### PR TITLE
[wip] Make generate_index 2-pass for dead slots cleanup

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2304,7 +2304,7 @@ pub mod tests {
     fn test_accounts_purge_chained_purge_after_snapshot_restore() {
         solana_logger::setup();
         test_with_chained_zero_lamport_accounts(|accounts, current_slot| {
-            let mut accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+            accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
             purge_zero_lamport_accounts(&accounts, current_slot);
             accounts
         });

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2304,7 +2304,7 @@ pub mod tests {
     fn test_accounts_purge_chained_purge_after_snapshot_restore() {
         solana_logger::setup();
         test_with_chained_zero_lamport_accounts(|accounts, current_slot| {
-            accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+            let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
             purge_zero_lamport_accounts(&accounts, current_slot);
             accounts
         });

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -191,6 +191,16 @@ pub struct AccountStorageEntry {
     count_and_status: RwLock<(usize, AccountStorageStatus)>,
 }
 
+impl Drop for AccountStorageEntry {
+    fn drop(&mut self) {
+        trace!(
+            "ryoqun: dropping AccountStorageEntry: {:?} {:?}",
+            self.slot_id,
+            self.count_and_status
+        );
+    }
+}
+
 impl AccountStorageEntry {
     pub fn new(path: &Path, slot_id: Slot, id: usize, file_size: u64) -> Self {
         let tail = AppendVec::new_relative_path(slot_id, id);
@@ -265,7 +275,7 @@ impl AccountStorageEntry {
 
     fn remove_account(&self) -> usize {
         let mut count_and_status = self.count_and_status.write().unwrap();
-        let (count, mut status) = *count_and_status;
+        let (mut count, mut status) = *count_and_status;
 
         if count == 1 && status == AccountStorageStatus::Full {
             // this case arises when we remove the last account from the
@@ -283,12 +293,20 @@ impl AccountStorageEntry {
             status = AccountStorageStatus::Available;
         }
 
-        if count > 0 {
-            *count_and_status = (count - 1, status);
-        } else {
-            warn!("count value 0 for slot {}", self.slot_id);
-        }
-        count_and_status.0
+        // This is really bad because some code path removing accounts too much,
+        // resulting in a highly likely disastrous event of an unintended reveal
+        // of old state of unrelated account. That means the very integrity of
+        // ledger consistency is broken hard.
+        assert!(
+            count > 0,
+            "double remove of account in slot: {}/store: {}!!",
+            self.slot_id,
+            self.id
+        );
+
+        count -= 1;
+        *count_and_status = (count, status);
+        count
     }
 
     pub fn set_file<P: AsRef<Path>>(&mut self, path: P) -> IOResult<()> {
@@ -616,9 +634,14 @@ impl AccountsDB {
     // can be purged because there are no live append vecs in the ancestors
     pub fn purge_zero_lamport_accounts(&self, ancestors: &HashMap<u64, usize>) {
         let accounts_index = self.accounts_index.read().unwrap();
-        info!(
-            "root counts (purge_zero, before): {}",
-            accounts_index.roots.len()
+        trace!(
+            "root counts (purge_zero, before): {:?}, {:?}",
+            accounts_index.roots,
+            ancestors
+        );
+        trace!(
+            "root counts (purge_zero, before): {:#?}",
+            accounts_index.account_maps,
         );
         self.report_store_stats();
 
@@ -635,9 +658,11 @@ impl AccountsDB {
         let storage = self.storage.read().unwrap();
         for (pubkey, account_infos) in purges.iter() {
             for (slot_id, account_info) in account_infos {
-                debug!(
+                trace!(
                     "checking account_info: slot: {} pubkey: {} {:?}",
-                    slot_id, pubkey, account_info
+                    slot_id,
+                    pubkey,
+                    account_info
                 );
                 let slot_storage = storage.0.get(&slot_id).unwrap();
                 let store = slot_storage.get(&account_info.store_id).unwrap();
@@ -672,7 +697,7 @@ impl AccountsDB {
         purges.retain(|pubkey, account_infos| {
             for (slot_id, account_info) in account_infos {
                 if *store_counts.get(&account_info.store_id).unwrap() != 0 {
-                    debug!("not purged: slot: {}, pubkey: {}", slot_id, pubkey);
+                    trace!("not purged: slot: {}, pubkey: {}", slot_id, pubkey);
                     return false;
                 }
             }
@@ -703,11 +728,51 @@ impl AccountsDB {
         self.handle_reclaims(&reclaims);
 
         let accounts_index = self.accounts_index.read().unwrap();
-        info!(
+        trace!(
             "root counts (purge_zero, after): {}",
             accounts_index.roots.len()
         );
         self.report_store_stats();
+    }
+
+    pub fn eager_cleanup(&self) {
+        trace!("root counts (eager_cleanup, before)",);
+        self.report_store_stats();
+
+        let mut reclaims = Vec::new();
+        self.accounts_index
+            .read()
+            .unwrap()
+            .eager_cleanup(&mut reclaims);
+        self.handle_reclaims(&reclaims);
+
+        trace!("root counts (eager_cleanup, after)",);
+        self.report_store_stats();
+    }
+
+    pub fn check_index_storage_consistency(&self) -> bool {
+        self.eager_cleanup();
+
+        let accounts_index = self.accounts_index.read().unwrap();
+        let storage = self.storage.read().unwrap();
+        let mut storage_account_count = 0;
+        for (_slot, slot_stores) in storage.0.iter() {
+            for store in slot_stores.values() {
+                let (c, _) = &*store.count_and_status.write().unwrap();
+                storage_account_count += c;
+            }
+        }
+
+        if storage_account_count == accounts_index.account_maps.len() {
+            trace!("total active account count is: {}", storage_account_count);
+            true
+        } else {
+            trace!(
+                "bad mismatch count {:?}",
+                &(storage_account_count, accounts_index.account_maps.len())
+            );
+            false
+        }
     }
 
     fn handle_reclaims(&self, reclaims: &[(Slot, AccountInfo)]) {
@@ -721,7 +786,7 @@ impl AccountsDB {
 
         let mut purge_slots = Measure::start("reclaims::purge_slots");
         for slot in dead_slots {
-            self.purge_slot(slot);
+            self.purge_dead_slot(slot);
         }
         purge_slots.stop();
     }
@@ -907,9 +972,20 @@ impl AccountsDB {
     pub fn purge_slot(&self, slot: Slot) {
         //add_root should be called first
         let is_root = self.accounts_index.read().unwrap().is_root(slot);
+        trace!("ryoqun purge_slot is requested: {} {}", is_root, slot);
         if !is_root {
             self.storage.write().unwrap().0.remove(&slot);
         }
+    }
+
+    pub fn purge_dead_slot(&self, slot: Slot) {
+        trace!(
+            "ryoqun purge_dead_slot is requested: {}, {}",
+            slot,
+            self.storage.write().unwrap().0.keys().len()
+        );
+        // add tests for this...
+        self.storage.write().unwrap().0.remove(&slot);
     }
 
     pub fn hash_stored_account(slot: Slot, account: &StoredAccount) -> Hash {
@@ -1078,9 +1154,12 @@ impl AccountsDB {
                         return;
                     }
                     let hash = BankHash::from_hash(&hash);
-                    debug!(
+                    trace!(
                         "xoring.. account: {:?} slot: {}, {} key: {}",
-                        account, slot, hash, pubkey
+                        account,
+                        slot,
+                        hash,
+                        pubkey
                     );
                     collector.push(hash);
                 }
@@ -1095,9 +1174,11 @@ impl AccountsDB {
         }
         let bank_hashes = self.bank_hashes.read().unwrap();
         if let Some(found_hash_info) = bank_hashes.get(&slot) {
-            warn!(
-                "ryoqun: bank hash for slot {}: {} (calculated) != {} (expected)",
-                slot, calculated_hash, found_hash_info.hash
+            trace!(
+                "ryoqun: bank hash for slot {}: {} (calculated) =?= {} (expected)",
+                slot,
+                calculated_hash,
+                found_hash_info.hash
             );
             if calculated_hash == found_hash_info.hash {
                 Ok(())
@@ -1161,6 +1242,7 @@ impl AccountsDB {
                         "AccountDB::accounts_index corrupted. Storage should only point to one slot"
                     );
                     let count = store.remove_account();
+                    trace!("remove dead account: {} {}", count, account_info.store_id);
                     if count == 0 {
                         dead_slots.insert(*slot_id);
                     }
@@ -1182,12 +1264,13 @@ impl AccountsDB {
         dead_slots
     }
 
+    // The caller must ensure given slots are actually dead (= older than the root)
     fn cleanup_dead_slots(&self, dead_slots: &mut HashSet<Slot>) {
         if !dead_slots.is_empty() {
             {
                 let mut index = self.accounts_index.write().unwrap();
                 for slot in dead_slots.iter() {
-                    debug!("cleanup_dead_slots: dead slot: {}", slot);
+                    trace!("cleanup_dead_slots: dead slot: {}", slot);
                     index.cleanup_dead_slot(*slot);
                 }
             }
@@ -1287,12 +1370,13 @@ impl AccountsDB {
         IOError::new(ErrorKind::Other, error)
     }
 
+    #[allow(clippy::cognitive_complexity)]
     fn generate_index(&self) {
         let storage = self.storage.read().unwrap();
         let mut slots: Vec<Slot> = storage.0.keys().cloned().collect();
         slots.sort();
         let mut accounts_index = self.accounts_index.write().unwrap();
-        info!(
+        trace!(
             "root counts (generate_index, before): {}",
             accounts_index.roots.len()
         );
@@ -1308,7 +1392,7 @@ impl AccountsDB {
                             offset: stored_account.offset,
                             lamports: stored_account.account_meta.lamports,
                         };
-                        debug!(
+                        trace!(
                             "ryoqun: slot_id: {}, pubkey: {:?}",
                             slot_id,
                             (stored_account.meta, &account_info)
@@ -1333,7 +1417,7 @@ impl AccountsDB {
             }
         }
 
-        info!(
+        trace!(
             "root counts (generate_index, middle): {}",
             accounts_index.roots.len()
         );
@@ -1345,7 +1429,6 @@ impl AccountsDB {
                 *counts.entry(account_entry.store_id).or_insert(0) += 1;
             }
         }
-        let mut dead_slots = vec![];
         let mut alive_slots = vec![];
         for (slot, slot_stores) in storage.0.iter() {
             let mut is_dead = true;
@@ -1378,51 +1461,59 @@ impl AccountsDB {
             }
             if is_dead {
                 trace!("slot: {}: clearing dead slot", slot);
-                dead_slots.push(*slot);
             } else {
                 trace!("slot: {}: NOT clearing dead slot", slot);
                 alive_slots.push(*slot);
             }
         }
 
-        let mut reclaims: Vec<(u64, AccountInfo)> = vec![];
         accounts_index.clear();
+        alive_slots.sort();
+        let mut reclaims: Vec<(u64, AccountInfo)> = vec![];
         for alive_slot in &alive_slots {
-            let mut accumulator: Vec<HashMap<Pubkey, (u64, AccountInfo)>> = self
+            let mut accumulator: Vec<HashMap<u64, (Pubkey, AccountInfo)>> = self
                 .scan_account_storage(
                     *alive_slot,
                     |stored_account: &StoredAccount,
                      store_id: AppendVecId,
-                     accum: &mut HashMap<Pubkey, (u64, AccountInfo)>| {
+                     accum: &mut HashMap<u64, (Pubkey, AccountInfo)>| {
                         let account_info = AccountInfo {
                             store_id,
                             offset: stored_account.offset,
                             lamports: stored_account.account_meta.lamports,
                         };
-                        debug!(
+                        trace!(
                             "ryoqun: alive_slot: {}, pubkey: {:?}",
                             *alive_slot,
                             (stored_account.meta, &account_info)
                         );
                         accum.insert(
-                            stored_account.meta.pubkey,
-                            (stored_account.meta.write_version, account_info),
+                            stored_account.meta.write_version,
+                            (stored_account.meta.pubkey, account_info),
                         );
                     },
                 );
 
-            let mut account_maps = accumulator.pop().unwrap();
+            let mut account_maps = std::collections::BTreeMap::new();
             while let Some(maps) = accumulator.pop() {
-                AccountsDB::merge(&mut account_maps, &maps);
+                for (write_version, value) in maps {
+                    account_maps.insert(write_version, value);
+                }
             }
-            for (pubkey, (_, account_info)) in account_maps.iter() {
+            for (_, (pubkey, account_info)) in account_maps.iter() {
+                trace!("reclaim count: {}", reclaims.len());
+                //if account_info.lamports != 0 && accounts_index.account_maps.get(pubkey).is_some() {
+                //    reclaims.extend(accounts_index.purge2(pubkey).0);
+                //} else {
+                //}
                 accounts_index.insert(*alive_slot, pubkey, account_info.clone(), &mut reclaims);
             }
-        }
-        for alive_slot in &alive_slots {
             accounts_index.roots.insert(*alive_slot);
         }
-        info!(
+        //for _alive_slot in &alive_slots {
+        //    accounts_index.roots.insert(*alive_slot);
+        //}
+        trace!(
             "root counts (generate_index, after): {}",
             accounts_index.roots.len()
         );
@@ -1431,6 +1522,12 @@ impl AccountsDB {
 
         //d b g!(&reclaims);
         self.handle_reclaims(&reclaims);
+        //self.purge_zero_lamport_accounts(&HashMap::<u64, usize>::new());
+
+        //let mut reclaims: Vec<(u64, AccountInfo)> = vec![];
+        //let mut accounts_index = self.accounts_index.write().unwrap();
+        //accounts_index.prune(&mut reclaims);
+        //self.handle_reclaims(&reclaims);
     }
 }
 
@@ -1950,7 +2047,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_accounts_db_serialize() {
+    fn test_accounts_db_serialize2() {
         solana_logger::setup();
         let accounts = AccountsDB::new_single();
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -1998,6 +2095,7 @@ pub mod tests {
         assert!(check_storage(&accounts, 2, 31));
 
         let daccounts = reconstruct_accounts_db_via_serialization(&accounts, latest_slot);
+        daccounts.eager_cleanup();
 
         assert_eq!(
             daccounts.write_version.load(Ordering::Relaxed),
@@ -2241,13 +2339,12 @@ pub mod tests {
         assert_load_account(&accounts, current_slot, pubkey, zero_lamport);
     }
 
-    fn test_with_chained_zero_lamport_accounts<F>(f: F)
+    fn with_chained_zero_lamport_accounts<F>(f: F)
     where
         F: Fn(AccountsDB, Slot) -> AccountsDB,
     {
         let some_lamport = 223;
         let zero_lamport = 0;
-        let dummy_lamport = 999;
         let no_data = 0;
         let owner = Account::default().owner;
 
@@ -2259,9 +2356,6 @@ pub mod tests {
         let pubkey = Pubkey::new_rand();
         let purged_pubkey1 = Pubkey::new_rand();
         let purged_pubkey2 = Pubkey::new_rand();
-
-        let dummy_account = Account::new(dummy_lamport, no_data, &owner);
-        let dummy_pubkey = Pubkey::default();
 
         let mut accounts = AccountsDB::new_single();
 
@@ -2279,23 +2373,20 @@ pub mod tests {
         accounts.store(current_slot, &[(&purged_pubkey2, &zero_lamport_account)]);
         accounts.add_root(current_slot);
 
-        current_slot += 1;
-        accounts.store(current_slot, &[(&dummy_pubkey, &dummy_account)]);
-        accounts.add_root(current_slot);
-
         accounts = f(accounts, current_slot);
 
         assert_load_account(&accounts, current_slot, pubkey, some_lamport);
         assert_load_account(&accounts, current_slot, purged_pubkey1, 0);
         assert_load_account(&accounts, current_slot, purged_pubkey2, 0);
-        assert_load_account(&accounts, current_slot, dummy_pubkey, dummy_lamport);
     }
 
     #[test]
     fn test_accounts_purge_chained_purge_before_snapshot_restore() {
         solana_logger::setup();
-        test_with_chained_zero_lamport_accounts(|accounts, current_slot| {
+        with_chained_zero_lamport_accounts(|accounts, current_slot| {
+            print_count_and_status("before purge zero", &accounts);
             purge_zero_lamport_accounts(&accounts, current_slot);
+            print_count_and_status("after purge zero", &accounts);
             reconstruct_accounts_db_via_serialization(&accounts, current_slot)
         });
     }
@@ -2303,9 +2394,12 @@ pub mod tests {
     #[test]
     fn test_accounts_purge_chained_purge_after_snapshot_restore() {
         solana_logger::setup();
-        test_with_chained_zero_lamport_accounts(|accounts, current_slot| {
+        with_chained_zero_lamport_accounts(|accounts, current_slot| {
+            print_count_and_status("before reconstruct", &accounts);
             let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
+            print_count_and_status("before purge zero", &accounts);
             purge_zero_lamport_accounts(&accounts, current_slot);
+            print_count_and_status("after purge zero", &accounts);
             accounts
         });
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1429,7 +1429,7 @@ impl AccountsDB {
         drop(storage);
         drop(accounts_index);
 
-        //dbg!(&reclaims);
+        //d b g!(&reclaims);
         self.handle_reclaims(&reclaims);
     }
 }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -47,6 +47,7 @@ impl<T: Clone> AccountsIndex<T> {
 
     // filter any rooted entries and return them along with a bool that indicates
     // if this account has no more entries.
+    #[must_use]
     pub fn purge(&self, pubkey: &Pubkey) -> (Vec<(Slot, T)>, bool) {
         let mut list = self.account_maps.get(&pubkey).unwrap().write().unwrap();
         let reclaims = self.get_rooted_entries(&list);
@@ -117,28 +118,39 @@ impl<T: Clone> AccountsIndex<T> {
         account_info: T,
         reclaims: &mut Vec<(Slot, T)>,
     ) -> Option<T> {
-        let roots = &self.roots;
         if let Some(lock) = self.account_maps.get(pubkey) {
             let mut slot_vec = lock.write().unwrap();
-            // filter out old entries
+            // filter out other dirty entries
             reclaims.extend(slot_vec.iter().filter(|(f, _)| *f == slot).cloned());
             slot_vec.retain(|(f, _)| *f != slot);
 
-            // add the new entry
             slot_vec.push((slot, account_info));
+            // do lazy cleanup
+            self.cleanup_root_entries(&mut slot_vec, reclaims);
 
-            let max_root = Self::get_max_root(roots, &slot_vec);
-
-            reclaims.extend(
-                slot_vec
-                    .iter()
-                    .filter(|(slot, _)| Self::can_purge(max_root, *slot))
-                    .cloned(),
-            );
-            slot_vec.retain(|(slot, _)| !Self::can_purge(max_root, *slot));
             None
         } else {
             Some(account_info)
+        }
+    }
+
+    fn cleanup_root_entries(&self, slot_vec: &mut Vec<(Slot, T)>, reclaims: &mut Vec<(Slot, T)>) {
+        let roots = &self.roots;
+
+        let max_root = Self::get_max_root(roots, &slot_vec);
+        reclaims.extend(
+            slot_vec
+                .iter()
+                .filter(|(slot, _)| Self::can_purge(max_root, *slot))
+                .cloned(),
+        );
+        slot_vec.retain(|(slot, _)| !Self::can_purge(max_root, *slot));
+    }
+
+    pub fn eager_cleanup(&self, reclaims: &mut Vec<(Slot, T)>) {
+        for lock in self.account_maps.values() {
+            let mut slot_vec = lock.write().unwrap();
+            self.cleanup_root_entries(&mut slot_vec, reclaims);
         }
     }
 

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -28,6 +28,11 @@ impl<T: Clone> AccountsIndex<T> {
         }
     }
 
+    pub fn clear(&mut self) {
+        self.roots.clear();
+        self.account_maps.clear();
+    }
+
     fn get_rooted_entries(&self, list: &[(Slot, T)]) -> Vec<(Slot, T)> {
         list.iter()
             .filter(|(slot, _)| self.is_root(*slot))

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -103,6 +103,7 @@ pub struct AppendVec {
 
 impl Drop for AppendVec {
     fn drop(&mut self) {
+        trace!("ryoqun: dropping AppendVec: {:?}", &self.path);
         let _ignored = remove_file(&self.path);
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1898,7 +1898,13 @@ impl Bank {
     pub fn verify_snapshot_bank(&self) -> bool {
         self.purge_zero_lamport_accounts();
         // Order and short-circuiting is significant; verify_hash requires a valid bank hash
-        self.verify_bank_hash() && self.verify_hash()
+        self.verify_bank_hash()
+            && self.verify_hash()
+            && self
+                .rc
+                .accounts
+                .accounts_db
+                .check_index_storage_consistency()
     }
 
     /// Return the number of hashes per tick


### PR DESCRIPTION
#### Problem

#8168 

#### Summary of Changes

This is still rough; but works.

*When backporting, do so in tandem with #8148. Only backporting with one of the two introduces bugs.*

Fixes #8168
