### PR TITLE
Correct missing entry handling to avoid bad warns

### DIFF
--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -137,7 +137,7 @@ mod tests {
             5,
             vec![],
             link_snapshots_dir,
-            storage_entries.clone(),
+            vec![storage_entries],
             output_tar_path.clone(),
         );
 

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -128,6 +128,7 @@ mod tests {
         }
         // Generate a snapshot package for last bank
         let last_bank = bank_forks.get(last_slot).unwrap();
+        let storages: Vec<_> = last_bank.get_snapshot_storages();
         let slot_snapshot_paths =
             snapshot_utils::get_snapshot_paths(&snapshot_config.snapshot_path);
         let snapshot_package = snapshot_utils::package_snapshot(
@@ -140,6 +141,7 @@ mod tests {
             ),
             &snapshot_config.snapshot_path,
             &last_bank.src.roots(),
+            storages,
         )
         .unwrap();
 
@@ -199,7 +201,8 @@ mod tests {
 
         // Take snapshot of zeroth bank
         let bank0 = bank_forks.get(0).unwrap();
-        snapshot_utils::add_snapshot(&snapshot_config.snapshot_path, bank0).unwrap();
+        let storages: Vec<_> = bank0.get_snapshot_storages();
+        snapshot_utils::add_snapshot(&snapshot_config.snapshot_path, bank0, &storages).unwrap();
 
         // Set up snapshotting channels
         let (sender, receiver) = channel();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -903,7 +903,8 @@ fn main() {
                         exit(1);
                     });
 
-                    snapshot_utils::add_snapshot(&temp_dir, &bank)
+                    let storages: Vec<_> = bank.get_snapshot_storages();
+                    snapshot_utils::add_snapshot(&temp_dir, &bank, &storages)
                         .and_then(|slot_snapshot_paths| {
                             snapshot_utils::package_snapshot(
                                 &bank,
@@ -911,6 +912,7 @@ fn main() {
                                 snapshot_utils::get_snapshot_archive_path(output_directory),
                                 &temp_dir,
                                 &bank.src.roots(),
+                                storages,
                             )
                         })
                         .and_then(|package| {

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -251,8 +251,9 @@ impl BankForks {
             .cloned()
             .expect("root must exist in BankForks");
 
+        let storages: Vec<_> = bank.get_snapshot_storages();
         let mut add_snapshot_time = Measure::start("add-snapshot-ms");
-        snapshot_utils::add_snapshot(&config.snapshot_path, &bank)?;
+        snapshot_utils::add_snapshot(&config.snapshot_path, &bank, &storages)?;
         add_snapshot_time.stop();
         inc_new_counter_info!("add-snapshot-ms", add_snapshot_time.as_ms() as usize);
 
@@ -269,6 +270,7 @@ impl BankForks {
             tar_output_file,
             &config.snapshot_path,
             slots_to_snapshot,
+            storages,
         )?;
 
         // Send the package to the packaging thread

--- a/ledger/src/snapshot_package.rs
+++ b/ledger/src/snapshot_package.rs
@@ -1,4 +1,4 @@
-use solana_runtime::{accounts_db::SnapshotStorageCandidates, bank::BankSlotDelta};
+use solana_runtime::{accounts_db::SnapshotStorages, bank::BankSlotDelta};
 use solana_sdk::clock::Slot;
 use std::{
     path::PathBuf,
@@ -15,7 +15,7 @@ pub struct SnapshotPackage {
     pub root: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
-    pub storage_candidates: SnapshotStorageCandidates,
+    pub storages: SnapshotStorages,
     pub tar_output_file: PathBuf,
 }
 
@@ -24,14 +24,14 @@ impl SnapshotPackage {
         root: Slot,
         slot_deltas: Vec<BankSlotDelta>,
         snapshot_links: TempDir,
-        storage_candidates: SnapshotStorageCandidates,
+        storages: SnapshotStorages,
         tar_output_file: PathBuf,
     ) -> Self {
         Self {
             root,
             slot_deltas,
             snapshot_links,
-            storage_candidates,
+            storages,
             tar_output_file,
         }
     }

--- a/ledger/src/snapshot_package.rs
+++ b/ledger/src/snapshot_package.rs
@@ -1,11 +1,8 @@
-use solana_runtime::{accounts_db::AccountStorageEntry, bank::BankSlotDelta};
+use solana_runtime::{accounts_db::SnapshotStorageCandidates, bank::BankSlotDelta};
 use solana_sdk::clock::Slot;
 use std::{
     path::PathBuf,
-    sync::{
-        mpsc::{Receiver, SendError, Sender},
-        Arc,
-    },
+    sync::mpsc::{Receiver, SendError, Sender},
 };
 use tempfile::TempDir;
 
@@ -18,7 +15,7 @@ pub struct SnapshotPackage {
     pub root: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
-    pub storage_entries: Vec<Arc<AccountStorageEntry>>,
+    pub storage_candidates: SnapshotStorageCandidates,
     pub tar_output_file: PathBuf,
 }
 
@@ -27,14 +24,14 @@ impl SnapshotPackage {
         root: Slot,
         slot_deltas: Vec<BankSlotDelta>,
         snapshot_links: TempDir,
-        storage_entries: Vec<Arc<AccountStorageEntry>>,
+        storage_candidates: SnapshotStorageCandidates,
         tar_output_file: PathBuf,
     ) -> Self {
         Self {
             root,
             slot_deltas,
             snapshot_links,
-            storage_entries,
+            storage_candidates,
             tar_output_file,
         }
     }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1343,7 +1343,11 @@ mod tests {
         let mut writer = Cursor::new(vec![]);
         serialize_into(
             &mut writer,
-            &AccountsDBSerialize::new(&*accounts.accounts_db, 0),
+            &AccountsDBSerialize::new(
+                &*accounts.accounts_db,
+                0,
+                &accounts.accounts_db.get_snapshot_storages(0),
+            ),
         )
         .unwrap();
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1934,7 +1934,12 @@ pub mod tests {
 
     fn reconstruct_accounts_db_via_serialization(accounts: &AccountsDB, slot: Slot) -> AccountsDB {
         let mut writer = Cursor::new(vec![]);
-        serialize_into(&mut writer, &AccountsDBSerialize::new(&accounts, slot)).unwrap();
+        let snapshot_storages = accounts.get_snapshot_storages(slot);
+        serialize_into(
+            &mut writer,
+            &AccountsDBSerialize::new(&accounts, slot, &snapshot_storages),
+        )
+        .unwrap();
 
         let buf = writer.into_inner();
         let mut reader = BufReader::new(&buf[..]);
@@ -2277,7 +2282,7 @@ pub mod tests {
         accounts_db: &AccountsDB,
         output_dir: P,
     ) -> IOResult<()> {
-        let storage_entries = accounts_db.get_snapshot_storages(Slot::MAX);
+        let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value());
         for storage in storage_entries.iter().flatten() {
             let storage_path = storage.get_path();
             let output_path = output_dir.as_ref().join(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -134,7 +134,7 @@ impl<'a> Serialize for AccountStorageSerialize<'a> {
         let mut count = 0;
         let mut serialize_account_storage_timer = Measure::start("serialize_account_storage_ms");
         for storage_entries in self.account_storage_entries {
-            map.serialize_entry(&storage_entries.first().unwrap().slot_id, &storage_entries)?;
+            map.serialize_entry(&storage_entries.first().unwrap().slot_id, storage_entries)?;
             count += storage_entries.len();
         }
         serialize_account_storage_timer.stop();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4,7 +4,7 @@
 //! already been signed and verified.
 use crate::{
     accounts::{Accounts, TransactionAccounts, TransactionLoadResult, TransactionLoaders},
-    accounts_db::{AccountStorageEntry, AccountsDBSerialize, AppendVecId, ErrorCounters},
+    accounts_db::{AccountsDBSerialize, AppendVecId, ErrorCounters, SnapshotStorageCandidates},
     blockhash_queue::BlockhashQueue,
     hard_forks::HardForks,
     message_processor::{MessageProcessor, ProcessInstruction},
@@ -111,7 +111,7 @@ impl BankRc {
         Ok(())
     }
 
-    pub fn get_rooted_storage_entries(&self) -> Vec<Arc<AccountStorageEntry>> {
+    pub fn get_rooted_storage_entries(&self) -> SnapshotStorageCandidates {
         self.accounts.accounts_db.get_rooted_storage_entries()
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4,7 +4,9 @@
 //! already been signed and verified.
 use crate::{
     accounts::{Accounts, TransactionAccounts, TransactionLoadResult, TransactionLoaders},
-    accounts_db::{AccountsDBSerialize, AppendVecId, ErrorCounters, SnapshotStorageCandidates},
+    accounts_db::{
+        AccountsDBSerialize, AppendVecId, ErrorCounters, SnapshotStorage, SnapshotStorages,
+    },
     blockhash_queue::BlockhashQueue,
     hard_forks::HardForks,
     message_processor::{MessageProcessor, ProcessInstruction},
@@ -111,8 +113,8 @@ impl BankRc {
         Ok(())
     }
 
-    pub fn get_rooted_storage_entries(&self) -> SnapshotStorageCandidates {
-        self.accounts.accounts_db.get_rooted_storage_entries()
+    pub fn get_snapshot_storages(&self, slot: Slot) -> SnapshotStorages {
+        self.accounts.accounts_db.get_snapshot_storages(slot)
     }
 
     fn get_io_error(error: &str) -> IOError {
@@ -121,15 +123,23 @@ impl BankRc {
     }
 }
 
-impl Serialize for BankRc {
+pub struct BankRcSerialize<'a, 'b> {
+    pub bank_rc: &'a BankRc,
+    pub snapshot_storages: &'b [SnapshotStorage],
+}
+
+impl<'a, 'b> Serialize for BankRcSerialize<'a, 'b> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::ser::Serializer,
     {
         use serde::ser::Error;
         let mut wr = Cursor::new(Vec::new());
-        let accounts_db_serialize =
-            AccountsDBSerialize::new(&*self.accounts.accounts_db, self.slot);
+        let accounts_db_serialize = AccountsDBSerialize::new(
+            &*self.bank_rc.accounts.accounts_db,
+            self.bank_rc.slot,
+            self.snapshot_storages,
+        );
         serialize_into(&mut wr, &accounts_db_serialize).map_err(Error::custom)?;
         let len = wr.position() as usize;
         serializer.serialize_bytes(&wr.into_inner()[..len])
@@ -1855,6 +1865,13 @@ impl Bank {
         self.rc
             .accounts
             .verify_bank_hash(self.slot(), &self.ancestors)
+    }
+
+    pub fn get_snapshot_storages(&self) -> SnapshotStorages {
+        self.rc
+            .get_snapshot_storages(self.slot())
+            .into_iter()
+            .collect()
     }
 
     #[must_use]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4708,11 +4708,16 @@ mod tests {
 
         bank2.squash();
 
-        let len = serialized_size(&bank2).unwrap() + serialized_size(&bank2.rc).unwrap();
+        let snapshot_storages = bank2.get_snapshot_storages();
+        let rc_serialize = BankRcSerialize {
+            bank_rc: &bank2.rc,
+            snapshot_storages: &snapshot_storages,
+        };
+        let len = serialized_size(&bank2).unwrap() + serialized_size(&rc_serialize).unwrap();
         let mut buf = vec![0u8; len as usize];
         let mut writer = Cursor::new(&mut buf[..]);
         serialize_into(&mut writer, &bank2).unwrap();
-        serialize_into(&mut writer, &bank2.rc).unwrap();
+        serialize_into(&mut writer, &rc_serialize).unwrap();
 
         let mut rdr = Cursor::new(&buf[..]);
         let mut dbank: Bank = deserialize_from_snapshot(&mut rdr).unwrap();


### PR DESCRIPTION
#### Problem

Bogus warnings is introduced by #7281. Also this is needed for #8337 because compacting at `generate_index` causes a lot of missing storage entries.

#### Summary of Changes

~Put empty dummy files for missing storage entry's AppendVec in the snapshot file.~

=> Changed the design strategy to change `AccountStorageSerialize` as discussed on discord.

~*This changes ABI for snapshots.*~

=> this is not true anymore; this shouldn't introduce any ABI changes.