### PR TITLE
Upgrade VoteState

### DIFF
--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -233,7 +233,7 @@ mod tests {
     use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_sdk::pubkey::Pubkey;
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state;
+    use solana_vote_program::vote_state::{self, VoteStateVersions};
 
     #[test]
     fn test_block_commitment() {
@@ -446,13 +446,15 @@ mod tests {
         let mut vote_state1 = VoteState::from(&vote_account1).unwrap();
         vote_state1.process_slot_vote_unchecked(3);
         vote_state1.process_slot_vote_unchecked(5);
-        vote_state1.to(&mut vote_account1).unwrap();
+        let versioned = VoteStateVersions::Current(Box::new(vote_state1));
+        VoteState::to(&versioned, &mut vote_account1).unwrap();
         bank.store_account(&pk1, &vote_account1);
 
         let mut vote_state2 = VoteState::from(&vote_account2).unwrap();
         vote_state2.process_slot_vote_unchecked(9);
         vote_state2.process_slot_vote_unchecked(10);
-        vote_state2.to(&mut vote_account2).unwrap();
+        let versioned = VoteStateVersions::Current(Box::new(vote_state2));
+        VoteState::to(&versioned, &mut vote_account2).unwrap();
         bank.store_account(&pk2, &vote_account2);
 
         let commitment = AggregateCommitmentService::aggregate_commitment(&ancestors, &bank);

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -483,7 +483,10 @@ pub mod test {
         signature::{Keypair, Signer},
         transaction::Transaction,
     };
-    use solana_vote_program::{vote_instruction, vote_state::Vote};
+    use solana_vote_program::{
+        vote_instruction,
+        vote_state::{Vote, VoteStateVersions},
+    };
     use std::collections::{HashMap, VecDeque};
     use std::sync::RwLock;
     use std::{thread::sleep, time::Duration};
@@ -706,9 +709,11 @@ pub mod test {
             for slot in *votes {
                 vote_state.process_slot_vote_unchecked(*slot);
             }
-            vote_state
-                .serialize(&mut account.data)
-                .expect("serialize state");
+            VoteState::serialize(
+                &VoteStateVersions::Current(Box::new(vote_state)),
+                &mut account.data,
+            )
+            .expect("serialize state");
             stakes.push((Pubkey::new_rand(), (*lamports, account)));
         }
         stakes

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1087,7 +1087,7 @@ pub(crate) mod tests {
         transaction::TransactionError,
     };
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state::{self, Vote, VoteState};
+    use solana_vote_program::vote_state::{self, Vote, VoteState, VoteStateVersions};
     use std::{
         fs::remove_dir_all,
         iter,
@@ -1122,7 +1122,8 @@ pub(crate) mod tests {
             let mut vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(slot);
-            vote_state.to(&mut vote_account).unwrap();
+            let versioned = VoteStateVersions::Current(Box::new(vote_state));
+            VoteState::to(&versioned, &mut vote_account).unwrap();
             bank.store_account(&pubkey, &vote_account);
         }
 
@@ -1706,7 +1707,8 @@ pub(crate) mod tests {
             let mut leader_vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&leader_vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(bank.slot());
-            vote_state.to(&mut leader_vote_account).unwrap();
+            let versioned = VoteStateVersions::Current(Box::new(vote_state));
+            VoteState::to(&versioned, &mut leader_vote_account).unwrap();
             bank.store_account(&pubkey, &leader_vote_account);
         }
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
     rent::Rent,
     stake_history::{StakeHistory, StakeHistoryEntry},
 };
-use solana_vote_program::vote_state::VoteState;
+use solana_vote_program::vote_state::{VoteState, VoteStateVersions};
 use std::collections::HashSet;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
@@ -595,7 +595,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                 let stake = Stake::new(
                     self.lamports()?.saturating_sub(meta.rent_exempt_reserve), // can't stake the rent ;)
                     vote_account.unsigned_key(),
-                    &vote_account.state()?,
+                    &State::<VoteStateVersions>::state(vote_account)?.convert_to_current(),
                     clock.epoch,
                     config,
                 );
@@ -605,7 +605,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                 meta.authorized.check(signers, StakeAuthorize::Staker)?;
                 stake.redelegate(
                     vote_account.unsigned_key(),
-                    &vote_account.state()?,
+                    &State::<VoteStateVersions>::state(vote_account)?.convert_to_current(),
                     clock,
                     stake_history,
                     config,
@@ -778,7 +778,8 @@ pub fn redeem_rewards(
     stake_history: Option<&StakeHistory>,
 ) -> Result<(u64, u64), InstructionError> {
     if let StakeState::Stake(meta, mut stake) = stake_account.state()? {
-        let vote_state = vote_account.state()?;
+        let vote_state: VoteState =
+            StateMut::<VoteStateVersions>::state(vote_account)?.convert_to_current();
 
         if let Some((voters_reward, stakers_reward)) =
             stake.redeem_rewards(point_value, &vote_state, stake_history)
@@ -999,7 +1000,10 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&vote_state).unwrap();
+        let vote_state_credits = vote_state.credits();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(vote_state)))
+            .unwrap();
 
         let stake_pubkey = Pubkey::new_rand();
         let stake_lamports = 42;
@@ -1057,7 +1061,7 @@ mod tests {
                     deactivation_epoch: std::u64::MAX,
                     ..Delegation::default()
                 },
-                credits_observed: vote_state.credits(),
+                credits_observed: vote_state_credits,
                 ..Stake::default()
             }
         );
@@ -1105,7 +1109,7 @@ mod tests {
                     deactivation_epoch: std::u64::MAX,
                     ..Delegation::default()
                 },
-                credits_observed: vote_state.credits(),
+                credits_observed: vote_state_credits,
                 ..Stake::default()
             }
         );
@@ -1535,7 +1539,9 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&VoteState::default()).unwrap();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .unwrap();
         assert_eq!(
             stake_keyed_account.delegate(
                 &vote_keyed_account,
@@ -1624,7 +1630,9 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&VoteState::default()).unwrap();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .unwrap();
 
         stake_keyed_account
             .delegate(
@@ -1748,7 +1756,9 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&VoteState::default()).unwrap();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .unwrap();
         assert_eq!(
             stake_keyed_account.delegate(
                 &vote_keyed_account,
@@ -1857,7 +1867,9 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&VoteState::default()).unwrap();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .unwrap();
         let signers = vec![stake_pubkey].into_iter().collect();
         assert_eq!(
             stake_keyed_account.delegate(

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -17,6 +17,7 @@ use solana_sdk::{
     system_instruction,
     sysvar::{self, clock::Clock, slot_hashes::SlotHashes, Sysvar},
 };
+use std::collections::HashSet;
 use thiserror::Error;
 
 /// Reasons the stake might have had an error
@@ -187,7 +188,7 @@ pub fn process_instruction(
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 
-    let signers = get_signers(keyed_accounts);
+    let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
 
     let keyed_accounts = &mut keyed_accounts.iter();
     let me = &mut next_keyed_account(keyed_accounts)?;

--- a/programs/vote/src/vote_state/vote_state_0_23_5.rs
+++ b/programs/vote/src/vote_state/vote_state_0_23_5.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+const MAX_ITEMS: usize = 32;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct VoteState0_23_5 {
+    /// the node that votes in this account
+    pub node_pubkey: Pubkey,
+
+    /// the signer for vote transactions
+    pub authorized_voter: Pubkey,
+    /// when the authorized voter was set/initialized
+    pub authorized_voter_epoch: Epoch,
+
+    /// history of prior authorized voters and the epoch ranges for which
+    ///  they were set
+    pub prior_voters: CircBuf<(Pubkey, Epoch, Epoch, Slot)>,
+
+    /// the signer for withdrawals
+    pub authorized_withdrawer: Pubkey,
+    /// percentage (0-100) that represents what part of a rewards
+    ///  payout should be given to this VoteAccount
+    pub commission: u8,
+
+    pub votes: VecDeque<Lockout>,
+    pub root_slot: Option<u64>,
+
+    /// history of how many credits earned by the end of each epoch
+    ///  each tuple is (Epoch, credits, prev_credits)
+    pub epoch_credits: Vec<(Epoch, u64, u64)>,
+
+    /// most recent timestamp submitted with a vote
+    pub last_timestamp: BlockTimestamp,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct CircBuf<I> {
+    pub buf: [I; MAX_ITEMS],
+    /// next pointer
+    pub idx: usize,
+}
+
+impl<I: Default + Copy> Default for CircBuf<I> {
+    fn default() -> Self {
+        Self {
+            buf: [I::default(); MAX_ITEMS],
+            idx: MAX_ITEMS - 1,
+        }
+    }
+}
+
+impl<I> CircBuf<I> {
+    pub fn append(&mut self, item: I) {
+        // remember prior delegate and when we switched, to support later slashing
+        self.idx += 1;
+        self.idx %= MAX_ITEMS;
+
+        self.buf[self.idx] = item;
+    }
+}

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -1,0 +1,60 @@
+use super::*;
+use crate::vote_state::vote_state_0_23_5::VoteState0_23_5;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub enum VoteStateVersions {
+    V0_23_5(Box<VoteState0_23_5>),
+    Current(Box<VoteState>),
+}
+
+impl VoteStateVersions {
+    pub fn convert_to_current(self) -> VoteState {
+        match self {
+            VoteStateVersions::V0_23_5(state) => {
+                let authorized_voters =
+                    AuthorizedVoters::new(state.authorized_voter_epoch, state.authorized_voter);
+
+                VoteState {
+                    node_pubkey: state.node_pubkey,
+
+                    /// the signer for withdrawals
+                    authorized_withdrawer: state.authorized_withdrawer,
+
+                    /// percentage (0-100) that represents what part of a rewards
+                    ///  payout should be given to this VoteAccount
+                    commission: state.commission,
+
+                    votes: state.votes.clone(),
+
+                    root_slot: state.root_slot,
+
+                    /// the signer for vote transactions
+                    authorized_voters,
+
+                    /// history of prior authorized voters and the epochs for which
+                    /// they were set, the bottom end of the range is inclusive,
+                    /// the top of the range is exclusive
+                    prior_voters: CircBuf::default(),
+
+                    /// history of how many credits earned by the end of each epoch
+                    ///  each tuple is (Epoch, credits, prev_credits)
+                    epoch_credits: state.epoch_credits.clone(),
+
+                    /// most recent timestamp submitted with a vote
+                    last_timestamp: state.last_timestamp.clone(),
+                }
+            }
+            VoteStateVersions::Current(state) => *state,
+        }
+    }
+
+    pub fn is_uninitialized(&self) -> bool {
+        match self {
+            VoteStateVersions::V0_23_5(vote_state) => {
+                vote_state.authorized_voter == Pubkey::default()
+            }
+
+            VoteStateVersions::Current(vote_state) => vote_state.authorized_voters.is_empty(),
+        }
+    }
+}

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -18,7 +18,7 @@ use solana_stake_program::{
 };
 use solana_vote_program::{
     vote_instruction,
-    vote_state::{Vote, VoteInit, VoteState},
+    vote_state::{Vote, VoteInit, VoteState, VoteStateVersions},
 };
 use std::sync::Arc;
 
@@ -254,7 +254,9 @@ fn test_stake_account_lifetime() {
 
     // Test that votes and credits are there
     let account = bank.get_account(&vote_pubkey).expect("account not found");
-    let vote_state: VoteState = account.state().expect("couldn't unpack account data");
+    let vote_state: VoteState = StateMut::<VoteStateVersions>::state(&account)
+        .expect("couldn't unpack account data")
+        .convert_to_current();
 
     // 1 less vote, as the first vote should have cleared the lockout
     assert_eq!(vote_state.votes.len(), 31);


### PR DESCRIPTION
#### Problem
No way to upgrade to new VoteState without breaking ABI

Depends on and includes changes from https://github.com/solana-labs/solana/pull/8303

#### Summary of Changes
Convert VoteState's between different releases using an enum to differentiate the types

TODO: convert snapshots to include new VoteStates

Fixes #
