### PR TITLE
Choose more appropriate options for pubsub websocket server

### DIFF
--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -37,6 +37,8 @@ impl PubSubService {
                         });
                         session
                 })
+                .max_connections(1000) // Arbitrary, default of 100 is too low
+                .max_payload(5 * 1024) // Arbitrary, default of 5MB is too high
                 .start(&pubsub_addr);
 
                 if let Err(e) = server {

--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -38,7 +38,7 @@ impl PubSubService {
                         session
                 })
                 .max_connections(1000) // Arbitrary, default of 100 is too low
-                .max_payload(5 * 1024) // Arbitrary, default of 5MB is too high
+                .max_payload(10 * 1024 * 1024 + 1024) // max account size (10MB) + extra (1K)
                 .start(&pubsub_addr);
 
                 if let Err(e) = server {


### PR DESCRIPTION
#### Problem
Default jsonrpc websocket server options are not very sensible for our network. Need more connections available for the "Break Solana" game

#### Summary of Changes
- Bumped max connections 100 -> 1000
- Increased max payload 5MB -> ~10MB (max account size)

_Note: these options are directly related to the max amount of memory that can build up inside the websocket server queue: 5 (default conn queue size) * max conns * max payload ~= 50GB_

Fixes #
