### PR TITLE
Do not compress small incomplete slot list

### DIFF
--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -63,9 +63,23 @@ pub enum CrdsData {
     EpochSlots(EpochSlotIndex, EpochSlots),
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum CompressionType {
+    Uncompressed,
+    GZip,
+    BZip2,
+}
+
+impl Default for CompressionType {
+    fn default() -> Self {
+        Self::Uncompressed
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct EpochIncompleteSlots {
     pub first: Slot,
+    pub compression: CompressionType,
     pub compressed_list: Vec<u8>,
 }
 


### PR DESCRIPTION
#### Problem
GZip compression has overheads (at least 18 bytes). So  if EpochIncompleteSlots has only a few bytes worth of slots, it'll get compressed to larger size than the input. That defeats the purpose of compression.

#### Summary of Changes
Do not compress small sized input list (say if size < 64 bytes). Added a flag to EpochIncompleteSlots that denotes the compression algorithm used. It also allows us to move to a different compression in future without breaking ABI.
