### PR TITLE
Add snapshot hashes to gossip

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -20,7 +20,7 @@ use crate::{
     crds_gossip::CrdsGossip,
     crds_gossip_error::CrdsGossipError,
     crds_gossip_pull::{CrdsFilter, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS},
-    crds_value::{self, CrdsData, CrdsValue, CrdsValueLabel, EpochSlots, Vote},
+    crds_value::{self, CrdsData, CrdsValue, CrdsValueLabel, EpochSlots, SnapshotHash, Vote},
     packet::{Packet, PACKET_DATA_SIZE},
     result::{Error, Result},
     sendmmsg::{multicast, send_mmsg},
@@ -42,6 +42,7 @@ use solana_net_utils::{
 };
 use solana_perf::packet::{to_packets_with_destination, Packets, PacketsRecycler};
 use solana_rayon_threadlimit::get_thread_count;
+use solana_sdk::hash::Hash;
 use solana_sdk::{
     clock::{Slot, DEFAULT_MS_PER_SLOT},
     pubkey::Pubkey,
@@ -403,6 +404,16 @@ impl ClusterInfo {
             .process_push_message(&self.id(), vec![entry], now);
     }
 
+    pub fn push_snapshot_hashes(&mut self, snapshot_hashes: Vec<(Slot, Hash)>) {
+        let now = timestamp();
+        let entry = CrdsValue::new_signed(
+            CrdsData::SnapshotHash(SnapshotHash::new(self.id(), snapshot_hashes, now)),
+            &self.keypair,
+        );
+        self.gossip
+            .process_push_message(&self.id(), vec![entry], now);
+    }
+
     pub fn push_vote(&mut self, tower_index: usize, vote: Transaction) {
         let now = timestamp();
         let vote = Vote::new(&self.id(), vote, now);
@@ -441,6 +452,23 @@ impl ClusterInfo {
         let txs: Vec<Transaction> = votes.into_iter().map(|x| x.1).collect();
         inc_new_counter_info!("cluster_info-get_votes-count", txs.len());
         (txs, max_ts)
+    }
+
+    pub fn get_snapshot_hash(&self, slot: Slot) -> Vec<(Pubkey, Hash)> {
+        self.gossip
+            .crds
+            .table
+            .values()
+            .filter_map(|x| x.value.snapshot_hash().map(|v| v))
+            .filter_map(|x| {
+                for (table_slot, hash) in &x.hashes {
+                    if *table_slot == slot {
+                        return Some((x.from, *hash));
+                    }
+                }
+                None
+            })
+            .collect()
     }
 
     pub fn get_epoch_state_for_node(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -153,7 +153,8 @@ impl Tvu {
             if snapshot_config.is_some() {
                 // Start a snapshot packaging service
                 let (sender, receiver) = channel();
-                let snapshot_packager_service = SnapshotPackagerService::new(receiver, exit);
+                let snapshot_packager_service =
+                    SnapshotPackagerService::new(receiver, exit, &cluster_info.clone());
                 (Some(snapshot_packager_service), Some(sender))
             } else {
                 (None, None)

--- a/ledger/src/snapshot_package.rs
+++ b/ledger/src/snapshot_package.rs
@@ -1,5 +1,6 @@
 use solana_runtime::{accounts_db::AccountStorageEntry, bank::BankSlotDelta};
 use solana_sdk::clock::Slot;
+use solana_sdk::hash::Hash;
 use std::{
     path::PathBuf,
     sync::{
@@ -20,6 +21,7 @@ pub struct SnapshotPackage {
     pub snapshot_links: TempDir,
     pub storage_entries: Vec<Arc<AccountStorageEntry>>,
     pub tar_output_file: PathBuf,
+    pub hash: Hash,
 }
 
 impl SnapshotPackage {
@@ -29,6 +31,7 @@ impl SnapshotPackage {
         snapshot_links: TempDir,
         storage_entries: Vec<Arc<AccountStorageEntry>>,
         tar_output_file: PathBuf,
+        hash: Hash,
     ) -> Self {
         Self {
             root,
@@ -36,6 +39,7 @@ impl SnapshotPackage {
             snapshot_links,
             storage_entries,
             tar_output_file,
+            hash,
         }
     }
 }

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -106,6 +106,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
         snapshot_hard_links_dir,
         account_storage_entries,
         snapshot_package_output_file.as_ref().to_path_buf(),
+        bank.hash(),
     );
 
     Ok(package)


### PR DESCRIPTION
#### Problem

Validators wanting to download a snapshot don't know the hash or age of snapshots created by the validators in the network, so cannot make a good decision on which one to download.

#### Summary of Changes

Add the last 24 snapshot slots and hashes to gossip to give the validator a better idea who to download from.

Fixes #
