### PR TITLE
Search for the validator with the highest snapshot

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -504,6 +504,14 @@ impl ClusterInfo {
             .collect()
     }
 
+    pub fn get_snapshot_hash_for_node(&self, pubkey: &Pubkey) -> Option<&Vec<(Slot, Hash)>> {
+        self.gossip
+            .crds
+            .table
+            .get(&CrdsValueLabel::SnapshotHash(*pubkey))
+            .map(|x| &x.value.snapshot_hash().unwrap().hashes)
+    }
+
     pub fn get_epoch_state_for_node(
         &self,
         pubkey: &Pubkey,


### PR DESCRIPTION
Snapshot selection is currently too dumb, an RPC node at random is selected.  In a cluster with delinquency, there's a chance that a new validator will fetch a snapshot from a delinquent validator and then likely go delinquent itself.   This can cause a delinquency chain and take down a cluster.

To avoid this validators now attempt to fetch the highest advertised snapshot

Fixes #8292