### PR TITLE
Add handling for fallible signers

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -36,7 +36,7 @@ use solana_sdk::{
     native_token::lamports_to_sol,
     program_utils::DecodeError,
     pubkey::Pubkey,
-    signature::{keypair_from_seed, Keypair, Signature, Signer},
+    signature::{keypair_from_seed, Keypair, Signature, Signer, SignerError},
     system_instruction::{self, create_address_with_seed, SystemError, MAX_ADDRESS_SEED_LEN},
     system_transaction,
     transaction::{Transaction, TransactionError},
@@ -1980,7 +1980,7 @@ impl Signer for FaucetKeypair {
         self.transaction.message().account_keys[0]
     }
 
-    fn try_pubkey(&self) -> Result<Pubkey, Box<dyn error::Error>> {
+    fn try_pubkey(&self) -> Result<Pubkey, SignerError> {
         Ok(self.pubkey())
     }
 
@@ -1988,7 +1988,7 @@ impl Signer for FaucetKeypair {
         self.transaction.signatures[0]
     }
 
-    fn try_sign_message(&self, message: &[u8]) -> Result<Signature, Box<dyn error::Error>> {
+    fn try_sign_message(&self, message: &[u8]) -> Result<Signature, SignerError> {
         Ok(self.sign_message(message))
     }
 }

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -1,5 +1,5 @@
 use crate::rpc_request;
-use solana_sdk::transaction::TransactionError;
+use solana_sdk::{signature::SignerError, transaction::TransactionError};
 use std::{fmt, io};
 use thiserror::Error;
 
@@ -9,7 +9,7 @@ pub enum ClientError {
     Reqwest(#[from] reqwest::Error),
     RpcError(#[from] rpc_request::RpcError),
     SerdeJson(#[from] serde_json::error::Error),
-    SigningError(String),
+    SigningError(#[from] SignerError),
     TransactionError(#[from] TransactionError),
 }
 

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -1,50 +1,20 @@
 use crate::rpc_request;
 use solana_sdk::transaction::TransactionError;
 use std::{fmt, io};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ClientError {
-    Io(io::Error),
-    Reqwest(reqwest::Error),
-    RpcError(rpc_request::RpcError),
-    SerdeJson(serde_json::error::Error),
-    TransactionError(TransactionError),
+    Io(#[from] io::Error),
+    Reqwest(#[from] reqwest::Error),
+    RpcError(#[from] rpc_request::RpcError),
+    SerdeJson(#[from] serde_json::error::Error),
+    SigningError(String),
+    TransactionError(#[from] TransactionError),
 }
 
 impl fmt::Display for ClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "solana client error")
-    }
-}
-
-impl std::error::Error for ClientError {}
-
-impl From<io::Error> for ClientError {
-    fn from(err: io::Error) -> ClientError {
-        ClientError::Io(err)
-    }
-}
-
-impl From<reqwest::Error> for ClientError {
-    fn from(err: reqwest::Error) -> ClientError {
-        ClientError::Reqwest(err)
-    }
-}
-
-impl From<rpc_request::RpcError> for ClientError {
-    fn from(err: rpc_request::RpcError) -> ClientError {
-        ClientError::RpcError(err)
-    }
-}
-
-impl From<serde_json::error::Error> for ClientError {
-    fn from(err: serde_json::error::Error) -> ClientError {
-        ClientError::SerdeJson(err)
-    }
-}
-
-impl From<TransactionError> for ClientError {
-    fn from(err: TransactionError) -> ClientError {
-        ClientError::TransactionError(err)
     }
 }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -517,13 +517,13 @@ impl RpcClient {
             // Re-sign any failed transactions with a new blockhash and retry
             let (blockhash, _fee_calculator) =
                 self.get_new_blockhash(&transactions_signatures[0].0.message().recent_blockhash)?;
-            transactions = transactions_signatures
-                .into_iter()
-                .map(|(mut transaction, _)| {
-                    transaction.sign(signer_keys, blockhash);
-                    transaction
-                })
-                .collect();
+            transactions = vec![];
+            for (mut transaction, _) in transactions_signatures.into_iter() {
+                transaction
+                    .try_sign(signer_keys, blockhash)
+                    .map_err(|e| ClientError::SigningError(format!("{:?}", e)))?;
+                transactions.push(transaction);
+            }
         }
     }
 
@@ -534,7 +534,8 @@ impl RpcClient {
     ) -> Result<(), ClientError> {
         let (blockhash, _fee_calculator) =
             self.get_new_blockhash(&tx.message().recent_blockhash)?;
-        tx.sign(signer_keys, blockhash);
+        tx.try_sign(signer_keys, blockhash)
+            .map_err(|e| ClientError::SigningError(format!("{:?}", e)))?;
         Ok(())
     }
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -519,9 +519,7 @@ impl RpcClient {
                 self.get_new_blockhash(&transactions_signatures[0].0.message().recent_blockhash)?;
             transactions = vec![];
             for (mut transaction, _) in transactions_signatures.into_iter() {
-                transaction
-                    .try_sign(signer_keys, blockhash)
-                    .map_err(|e| ClientError::SigningError(format!("{:?}", e)))?;
+                transaction.try_sign(signer_keys, blockhash)?;
                 transactions.push(transaction);
             }
         }
@@ -534,8 +532,7 @@ impl RpcClient {
     ) -> Result<(), ClientError> {
         let (blockhash, _fee_calculator) =
             self.get_new_blockhash(&tx.message().recent_blockhash)?;
-        tx.try_sign(signer_keys, blockhash)
-            .map_err(|e| ClientError::SigningError(format!("{:?}", e)))?;
+        tx.try_sign(signer_keys, blockhash)?;
         Ok(())
     }
 

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -6,9 +6,8 @@ use crate::{
 };
 use solana_sdk::{
     pubkey::Pubkey,
-    signature::{Signature, Signer},
+    signature::{Signature, Signer, SignerError},
 };
-use std::error;
 
 pub struct RemoteKeypair {
     pub wallet_type: RemoteWalletType,
@@ -25,7 +24,7 @@ impl RemoteKeypair {
 }
 
 impl Signer for RemoteKeypair {
-    fn try_pubkey(&self) -> Result<Pubkey, Box<dyn error::Error>> {
+    fn try_pubkey(&self) -> Result<Pubkey, SignerError> {
         match &self.wallet_type {
             RemoteWalletType::Ledger(wallet) => wallet
                 .get_pubkey(&self.derivation_path)
@@ -33,7 +32,7 @@ impl Signer for RemoteKeypair {
         }
     }
 
-    fn try_sign_message(&self, message: &[u8]) -> Result<Signature, Box<dyn error::Error>> {
+    fn try_sign_message(&self, message: &[u8]) -> Result<Signature, SignerError> {
         match &self.wallet_type {
             RemoteWalletType::Ledger(wallet) => wallet
                 .sign_message(&self.derivation_path, message)

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -4,7 +4,7 @@ use crate::{
     hash::Hash,
     instruction::{AccountMeta, CompiledInstruction, Instruction},
     pubkey::Pubkey,
-    short_vec,
+    short_vec, system_instruction,
 };
 use itertools::Itertools;
 
@@ -206,6 +206,20 @@ impl Message {
             Hash::default(),
             instructions,
         )
+    }
+
+    pub fn new_with_nonce(
+        mut instructions: Vec<Instruction>,
+        payer: Option<&Pubkey>,
+        nonce_account_pubkey: &Pubkey,
+        nonce_authority_pubkey: &Pubkey,
+    ) -> Self {
+        let nonce_ix = system_instruction::advance_nonce_account(
+            &nonce_account_pubkey,
+            &nonce_authority_pubkey,
+        );
+        instructions.insert(0, nonce_ix);
+        Self::new_with_payer(instructions, payer)
     }
 
     pub fn serialize(&self) -> Vec<u8> {

--- a/sdk/src/signers.rs
+++ b/sdk/src/signers.rs
@@ -2,10 +2,13 @@ use crate::{
     pubkey::Pubkey,
     signature::{Signature, Signer},
 };
+use std::error;
 
 pub trait Signers {
     fn pubkeys(&self) -> Vec<Pubkey>;
+    fn try_pubkeys(&self) -> Result<Vec<Pubkey>, Box<dyn error::Error>>;
     fn sign_message(&self, message: &[u8]) -> Vec<Signature>;
+    fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, Box<dyn error::Error>>;
 }
 
 macro_rules! default_keypairs_impl {
@@ -14,10 +17,26 @@ macro_rules! default_keypairs_impl {
                 self.iter().map(|keypair| keypair.pubkey()).collect()
             }
 
+            fn try_pubkeys(&self) -> Result<Vec<Pubkey>, Box<dyn error::Error>> {
+                let mut pubkeys = Vec::new();
+                for keypair in self.iter() {
+                    pubkeys.push(keypair.try_pubkey()?);
+                }
+                Ok(pubkeys)
+            }
+
             fn sign_message(&self, message: &[u8]) -> Vec<Signature> {
                 self.iter()
                     .map(|keypair| keypair.sign_message(message))
                     .collect()
+            }
+
+            fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, Box<dyn error::Error>> {
+                let mut signatures = Vec::new();
+                for keypair in self.iter() {
+                    signatures.push(keypair.try_sign_message(message)?);
+                }
+                Ok(signatures)
             }
     );
 }

--- a/sdk/src/signers.rs
+++ b/sdk/src/signers.rs
@@ -1,14 +1,13 @@
 use crate::{
     pubkey::Pubkey,
-    signature::{Signature, Signer},
+    signature::{Signature, Signer, SignerError},
 };
-use std::error;
 
 pub trait Signers {
     fn pubkeys(&self) -> Vec<Pubkey>;
-    fn try_pubkeys(&self) -> Result<Vec<Pubkey>, Box<dyn error::Error>>;
+    fn try_pubkeys(&self) -> Result<Vec<Pubkey>, SignerError>;
     fn sign_message(&self, message: &[u8]) -> Vec<Signature>;
-    fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, Box<dyn error::Error>>;
+    fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, SignerError>;
 }
 
 macro_rules! default_keypairs_impl {
@@ -17,7 +16,7 @@ macro_rules! default_keypairs_impl {
                 self.iter().map(|keypair| keypair.pubkey()).collect()
             }
 
-            fn try_pubkeys(&self) -> Result<Vec<Pubkey>, Box<dyn error::Error>> {
+            fn try_pubkeys(&self) -> Result<Vec<Pubkey>, SignerError> {
                 let mut pubkeys = Vec::new();
                 for keypair in self.iter() {
                     pubkeys.push(keypair.try_pubkey()?);
@@ -31,7 +30,7 @@ macro_rules! default_keypairs_impl {
                     .collect()
             }
 
-            fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, Box<dyn error::Error>> {
+            fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, SignerError> {
                 let mut signatures = Vec::new();
                 for keypair in self.iter() {
                     signatures.push(keypair.try_sign_message(message)?);
@@ -76,24 +75,23 @@ impl<T: Signer> Signers for Vec<&T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::error;
 
     struct Foo;
     impl Signer for Foo {
-        fn try_pubkey(&self) -> Result<Pubkey, Box<dyn error::Error>> {
+        fn try_pubkey(&self) -> Result<Pubkey, SignerError> {
             Ok(Pubkey::default())
         }
-        fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, Box<dyn error::Error>> {
+        fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
             Ok(Signature::default())
         }
     }
 
     struct Bar;
     impl Signer for Bar {
-        fn try_pubkey(&self) -> Result<Pubkey, Box<dyn error::Error>> {
+        fn try_pubkey(&self) -> Result<Pubkey, SignerError> {
             Ok(Pubkey::default())
         }
-        fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, Box<dyn error::Error>> {
+        fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
             Ok(Signature::default())
         }
     }


### PR DESCRIPTION
#### Problem
Some structs that implement Signer may fail in signing (or more rarely, in returning a pubkey). If such a signer is used in a Signers collection with current methods, errors will get silently dropped. This is terrible UX.

#### Summary of Changes
- Add fallible methods to Signers trait
- Add minimal fallible signing methods to Transaction struct
- Update RpcClient to use fallible signing methods, since these methods already return an error

A SigningError enum to capture errors from specific fallible Signers (Presigner, RemoteKeypair) was considered as a replacement for `Box<dyn error::Error>`, but the variants would have to strip out useful upstream information or wrap as String due to circular-dependency issues. Neither seemed like a better option than Box.
