### PR TITLE
OperatingMode: Flip Stable and Preview enum values

### DIFF
--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -25,8 +25,8 @@ use std::{
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum OperatingMode {
-    Stable,      // Stable cluster features
     Preview,     // Next set of cluster features to be promoted to Stable
+    Stable,      // Stable cluster features
     Development, // All features (including experimental features)
 }
 


### PR DESCRIPTION
This is a sneaky change that'll move the current TdS ledger to the Preview operating mode in 0.23.6 and beyond.  We want Tds on Preview and SLP on Stable, and so can take advantage of the fact that the SLP genesis config is getting recreated next Monday whereas we're rolling forward with the existing TdS ledger.