### PR TITLE
Enable BPF in TdS epoch 17

### DIFF
--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -98,8 +98,10 @@ pub fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Option<Vec<(
                     solana_stake_program!(),
                     solana_system_program(),
                     solana_vote_program!(),
-                    solana_bpf_loader_program!(),
                 ])
+            } else if epoch == 17 {
+                // Enable BPF effective epoch 17 for TdS
+                Some(vec![solana_bpf_loader_program!()])
             } else if epoch == std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected to be reduced in a
                 // future hard fork.


### PR DESCRIPTION
Another sneaky change.  We will restart TdS on 0.23.6, and thanks to https://github.com/solana-labs/solana/pull/8369 TdS will switch operating mode from Stable to Preview when this happens.  

Next week when we upgrade TdS to 0.24.x we also want to enable BPF (which is enabled in Preview from genesis in 0.24.x), _but_ we're keeping the TdS ledger from 0.23.y during this upgrade so that code path won't be taken.   

The cleanest path I see is to enable BPF on the next TdS epoch while still on 0.23.6, *before* we upgrade to 0.24.x.   This does give a window when BPF is enabled earlier than desired but that functionality will be dormant unless somebody pokes it (fair notice for anybody watching this PR: attacking BPF in TdS before upgrading to 0.24.0 is out of bounds)