### PR TITLE
Add --trusted-validator support for snapshot hash validation

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -344,8 +344,29 @@ impl Validator {
                 .set_entrypoint(entrypoint_info.clone());
         }
 
-        // If the node was loaded from a snapshot, advertise it in gossip
         if let Some(snapshot_hash) = snapshot_hash {
+            if let Some(ref trusted_validators) =
+                config.snapshot_config.as_ref().unwrap().trusted_validators
+            {
+                let trusted = cluster_info
+                    .read()
+                    .unwrap()
+                    .get_snapshot_hash(snapshot_hash.0)
+                    .iter()
+                    .any(|(pubkey, hash)| {
+                        trusted_validators.contains(pubkey) && snapshot_hash.1 == *hash
+                    });
+
+                if !trusted {
+                    error!(
+                        "The snapshot hash for slot {} is not published by your trusted validators: {:?}",
+                        snapshot_hash.0, trusted_validators
+                    );
+                    process::exit(1);
+                }
+            }
+
+            // If the node was loaded from a snapshot, advertise it in gossip
             cluster_info
                 .write()
                 .unwrap()

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -55,6 +55,7 @@ mod tests {
             snapshot_interval_slots,
             snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
             snapshot_path: PathBuf::from(snapshot_dir.path()),
+            trusted_validators: None,
         };
         bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
         SnapshotTestConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -537,6 +537,7 @@ fn load_bank_forks(
             snapshot_interval_slots: 0, // Value doesn't matter
             snapshot_package_output_path: ledger_path.clone(),
             snapshot_path: ledger_path.clone().join("snapshot"),
+            trusted_validators: None,
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -6,7 +6,7 @@ use log::*;
 use solana_measure::measure::Measure;
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::{bank::Bank, status_cache::MAX_CACHE_ENTRIES};
-use solana_sdk::{clock::Slot, timing};
+use solana_sdk::{clock::Slot, pubkey::Pubkey, timing};
 use std::{
     collections::{HashMap, HashSet},
     ops::Index,
@@ -26,6 +26,10 @@ pub struct SnapshotConfig {
 
     // Where to place the snapshots for recent slots
     pub snapshot_path: PathBuf,
+
+    // Validators that must vouch for a given snapshot hash before it's accepted
+    // None = accept any snapshot hash
+    pub trusted_validators: Option<HashSet<Pubkey>>,
 }
 
 #[derive(Error, Debug)]

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1000,6 +1000,7 @@ fn setup_snapshot_validator_config(
         snapshot_interval_slots,
         snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
         snapshot_path: PathBuf::from(snapshot_dir.path()),
+        trusted_validators: None,
     };
 
     // Create the account paths

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -139,6 +139,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --log ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 = --trusted-validator ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = -h ]]; then
       usage "$@"
     else


### PR DESCRIPTION
Spin off from https://github.com/solana-labs/solana/pull/8295


When a validator adds one or more `--trusted-validator PUBKEY` arguments, any snapshot that the validator loads must have a hash that matches one of the snapshot hashes published in gossip by the trusted set.   The actual snapshot itself will be download from any node that claims to have it though.
