### PR TITLE
Convert snapshot

### DIFF
--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -433,7 +433,7 @@ pub fn process_show_vote_account(
         build_balance_message(vote_account.lamports, use_lamports_unit, true)
     );
     println!("Validator Identity: {}", vote_state.node_pubkey);
-    println!("Authorized Voter: {:?}", vote_state.authorized_voter());
+    println!("Authorized Voter: {:?}", vote_state.authorized_voters());
     println!(
         "Authorized Withdrawer: {}",
         vote_state.authorized_withdrawer

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -433,7 +433,7 @@ pub fn process_show_vote_account(
         build_balance_message(vote_account.lamports, use_lamports_unit, true)
     );
     println!("Validator Identity: {}", vote_state.node_pubkey);
-    println!("Authorized Voter: {}", vote_state.authorized_voter);
+    println!("Authorized Voter: {:?}", vote_state.authorized_voter());
     println!(
         "Authorized Withdrawer: {}",
         vote_state.authorized_withdrawer

--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -233,7 +233,7 @@ mod tests {
     use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_sdk::pubkey::Pubkey;
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state;
+    use solana_vote_program::vote_state::{self, VoteStateVersions};
 
     #[test]
     fn test_block_commitment() {
@@ -446,13 +446,15 @@ mod tests {
         let mut vote_state1 = VoteState::from(&vote_account1).unwrap();
         vote_state1.process_slot_vote_unchecked(3);
         vote_state1.process_slot_vote_unchecked(5);
-        vote_state1.to(&mut vote_account1).unwrap();
+        let versioned = VoteStateVersions::Current(vote_state1);
+        VoteState::to(&versioned, &mut vote_account1).unwrap();
         bank.store_account(&pk1, &vote_account1);
 
         let mut vote_state2 = VoteState::from(&vote_account2).unwrap();
         vote_state2.process_slot_vote_unchecked(9);
         vote_state2.process_slot_vote_unchecked(10);
-        vote_state2.to(&mut vote_account2).unwrap();
+        let versioned = VoteStateVersions::Current(vote_state2);
+        VoteState::to(&versioned, &mut vote_account2).unwrap();
         bank.store_account(&pk2, &vote_account2);
 
         let commitment = AggregateCommitmentService::aggregate_commitment(&ancestors, &bank);

--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -446,14 +446,14 @@ mod tests {
         let mut vote_state1 = VoteState::from(&vote_account1).unwrap();
         vote_state1.process_slot_vote_unchecked(3);
         vote_state1.process_slot_vote_unchecked(5);
-        let versioned = VoteStateVersions::Current(vote_state1);
+        let versioned = VoteStateVersions::Current(Box::new(vote_state1));
         VoteState::to(&versioned, &mut vote_account1).unwrap();
         bank.store_account(&pk1, &vote_account1);
 
         let mut vote_state2 = VoteState::from(&vote_account2).unwrap();
         vote_state2.process_slot_vote_unchecked(9);
         vote_state2.process_slot_vote_unchecked(10);
-        let versioned = VoteStateVersions::Current(vote_state2);
+        let versioned = VoteStateVersions::Current(Box::new(vote_state2));
         VoteState::to(&versioned, &mut vote_account2).unwrap();
         bank.store_account(&pk2, &vote_account2);
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -710,8 +710,11 @@ pub mod test {
             for slot in *votes {
                 vote_state.process_slot_vote_unchecked(*slot);
             }
-            VoteState::serialize(&VoteStateVersions::Current(vote_state), &mut account.data)
-                .expect("serialize state");
+            VoteState::serialize(
+                &VoteStateVersions::Current(Box::new(vote_state)),
+                &mut account.data,
+            )
+            .expect("serialize state");
             stakes.push((Pubkey::new_rand(), (*lamports, account)));
         }
         stakes

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -484,7 +484,10 @@ pub mod test {
         signature::{Keypair, Signer},
         transaction::Transaction,
     };
-    use solana_vote_program::{vote_instruction, vote_state::Vote};
+    use solana_vote_program::{
+        vote_instruction,
+        vote_state::{Vote, VoteStateVersions},
+    };
     use std::collections::{HashMap, VecDeque};
     use std::sync::RwLock;
     use std::{thread::sleep, time::Duration};
@@ -707,8 +710,7 @@ pub mod test {
             for slot in *votes {
                 vote_state.process_slot_vote_unchecked(*slot);
             }
-            vote_state
-                .serialize(&mut account.data)
+            VoteState::serialize(&VoteStateVersions::Current(vote_state), &mut account.data)
                 .expect("serialize state");
             stakes.push((Pubkey::new_rand(), (*lamports, account)));
         }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1087,7 +1087,7 @@ pub(crate) mod tests {
         transaction::TransactionError,
     };
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state::{self, Vote, VoteState};
+    use solana_vote_program::vote_state::{self, Vote, VoteState, VoteStateVersions};
     use std::{
         fs::remove_dir_all,
         iter,
@@ -1122,7 +1122,8 @@ pub(crate) mod tests {
             let mut vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(slot);
-            vote_state.to(&mut vote_account).unwrap();
+            let versioned = VoteStateVersions::Current(vote_state);
+            VoteState::to(&versioned, &mut vote_account).unwrap();
             bank.store_account(&pubkey, &vote_account);
         }
 
@@ -1706,7 +1707,8 @@ pub(crate) mod tests {
             let mut leader_vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&leader_vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(bank.slot());
-            vote_state.to(&mut leader_vote_account).unwrap();
+            let versioned = VoteStateVersions::Current(vote_state);
+            VoteState::to(&versioned, &mut leader_vote_account).unwrap();
             bank.store_account(&pubkey, &leader_vote_account);
         }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1122,7 +1122,7 @@ pub(crate) mod tests {
             let mut vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(slot);
-            let versioned = VoteStateVersions::Current(vote_state);
+            let versioned = VoteStateVersions::Current(Box::new(vote_state));
             VoteState::to(&versioned, &mut vote_account).unwrap();
             bank.store_account(&pubkey, &vote_account);
         }
@@ -1707,7 +1707,7 @@ pub(crate) mod tests {
             let mut leader_vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&leader_vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(bank.slot());
-            let versioned = VoteStateVersions::Current(vote_state);
+            let versioned = VoteStateVersions::Current(Box::new(vote_state));
             VoteState::to(&versioned, &mut leader_vote_account).unwrap();
             bank.store_account(&pubkey, &leader_vote_account);
         }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -988,6 +988,12 @@ fn main() {
                 }
             }
 
+            for (pubkey, (_, vote_account)) in
+                root_bank.stakes.write().unwrap().vote_accounts.iter_mut()
+            {
+                VoteStateVersions::convert_from_raw(vote_account, &pubkey);
+            }
+
             let index: Vec<_> = {
                 let index = root_bank
                     .rc
@@ -1027,7 +1033,8 @@ fn main() {
                     if account.owner == solana_vote_program::id() {
                         VoteStateVersions::convert_from_raw(&mut account, pubkey);
                         println!("loading3");
-                        root_bank.store_account_convert(*slot, pubkey, &account);
+                        root_bank.rc.accounts.store_slow(*slot, pubkey, &account);
+                        (*slot, pubkey, &account);
                     }
                 }
             }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -699,6 +699,20 @@ fn main() {
                     .help("Output directory for the snapshot"),
             )
         ).subcommand(
+            SubCommand::with_name("convert-accounts")
+            .about("Convert accounts in snapshot")
+            .arg(&no_snapshot_arg)
+            .arg(&account_paths_arg)
+            .arg(&halt_at_slot_arg)
+            .arg(&hard_forks_arg)
+            .arg(
+                Arg::with_name("output_directory")
+                    .index(1)
+                    .value_name("DIR")
+                    .takes_value(true)
+                    .help("Output directory for the snapshot"),
+            )
+        ).subcommand(
             SubCommand::with_name("print-accounts")
             .about("Print account contents after processing in the ledger")
             .arg(&no_snapshot_arg)
@@ -976,6 +990,7 @@ fn main() {
                         .unwrap();
 
                     // Write out the new accounts
+                    println!("Converting accounts");
                     for (pubkey, slot_list) in index.account_maps.iter() {
                         for (slot, _) in slot_list.read().unwrap().iter() {
                             let ancestors = vec![(*slot, 1)].into_iter().collect();
@@ -995,6 +1010,7 @@ fn main() {
                     }
 
                     // Update the bank hash
+                    println!("Updating bank hash");
                     root_bank
                         .rc
                         .accounts

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -714,6 +714,13 @@ fn main() {
                     .help("Output directory for the snapshot"),
             )
         ).subcommand(
+            SubCommand::with_name("verify-snapshot")
+            .about("Convert accounts in snapshot")
+            .arg(&no_snapshot_arg)
+            .arg(&account_paths_arg)
+            .arg(&halt_at_slot_arg)
+            .arg(&hard_forks_arg)
+        ).subcommand(
             SubCommand::with_name("convert-accounts")
             .about("Convert accounts in snapshot")
             .arg(&no_snapshot_arg)
@@ -976,6 +983,9 @@ fn main() {
                     exit(1);
                 }
             }
+        }
+        ("verify-snapshot", Some(arg_matches)) => {
+            load_bank_from_snapshot(arg_matches, &ledger_path);
         }
         ("convert-accounts", Some(arg_matches)) => {
             let output_directory = value_t_or_exit!(arg_matches, "output_directory", String);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -975,6 +975,7 @@ fn main() {
                         .read()
                         .unwrap();
 
+                    // Write out the new accounts
                     for (pubkey, slot_list) in index.account_maps.iter() {
                         for (slot, _) in slot_list.read().unwrap().iter() {
                             let ancestors = vec![(*slot, 1)].into_iter().collect();
@@ -992,6 +993,16 @@ fn main() {
                             }
                         }
                     }
+
+                    // Update the bank hash
+                    root_bank
+                        .rc
+                        .accounts
+                        .accounts_db
+                        .recompute_bank_hash(root_bank.slot())
+                        .expect("Failed to recompute bank hash");
+
+                    root_bank.recompute_hash();
 
                     let temp_dir = tempfile::TempDir::new().unwrap_or_else(|err| {
                         eprintln!("Unable to create temporary directory: {}", err);

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -122,6 +122,10 @@ impl BankForks {
         self.banks.get(&bank_slot)
     }
 
+    pub fn remove(&mut self, bank_slot: Slot) -> Arc<Bank> {
+        self.banks.remove(&bank_slot).unwrap()
+    }
+
     pub fn new_from_banks(initial_forks: &[Arc<Bank>], rooted_path: Vec<Slot>) -> Self {
         let mut banks = HashMap::new();
         let working_bank = initial_forks[0].clone();

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -9,6 +9,7 @@ use crate::{
     snapshot_utils,
 };
 use log::*;
+use solana_runtime::bank::Bank;
 use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash};
 use std::{fs, path::PathBuf, result, sync::Arc};
 
@@ -34,6 +35,15 @@ fn to_loadresult(
             snapshot_hash,
         )
     })
+}
+
+pub fn load_bank_from_archive(
+    account_paths: Vec<PathBuf>,
+    snapshot_config: &SnapshotConfig,
+) -> Bank {
+    let tar =
+        snapshot_utils::get_snapshot_archive_path(&snapshot_config.snapshot_package_output_path);
+    snapshot_utils::bank_from_archive(&account_paths, &snapshot_config.snapshot_path, &tar).unwrap()
 }
 
 pub fn load(

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -556,15 +556,7 @@ where
         &root_paths.snapshot_file_path,
         MAX_SNAPSHOT_DATA_FILE_SIZE,
         |stream| {
-            let mut bank: Bank = match snapshot_version {
-                env!("CARGO_PKG_VERSION") => deserialize_from_snapshot(stream.by_ref())?,
-                _ => {
-                    return Err(get_io_error(&format!(
-                        "unsupported snapshot version: {}",
-                        snapshot_version
-                    )));
-                }
-            };
+            let mut bank: Bank = deserialize_from_snapshot(stream.by_ref())?;
             info!("Rebuilding accounts...");
             bank.set_bank_rc(
                 bank::BankRc::new(account_paths.to_vec(), 0, bank.slot()),

--- a/programs/vote/src/authorized_voters.rs
+++ b/programs/vote/src/authorized_voters.rs
@@ -1,8 +1,9 @@
 use log::*;
+use serde_derive::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 use std::collections::BTreeMap;
 
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct AuthorizedVoters {
     authorized_voters: BTreeMap<u64, Pubkey>,
 }

--- a/programs/vote/src/authorized_voters.rs
+++ b/programs/vote/src/authorized_voters.rs
@@ -1,0 +1,101 @@
+use log::*;
+use solana_sdk::pubkey::Pubkey;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct AuthorizedVoters {
+    authorized_voters: BTreeMap<u64, Pubkey>,
+}
+
+impl AuthorizedVoters {
+    pub fn new(epoch: u64, pubkey: Pubkey) -> Self {
+        let mut authorized_voters = BTreeMap::new();
+        authorized_voters.insert(epoch, pubkey);
+        Self { authorized_voters }
+    }
+
+    pub fn get_authorized_voter(&self, epoch: u64) -> Option<Pubkey> {
+        self.get_or_calculate_authorized_voter_for_epoch(epoch)
+            .map(|(pubkey, _)| pubkey)
+    }
+
+    pub fn get_and_cache_authorized_voter_for_epoch(&mut self, epoch: u64) -> Option<Pubkey> {
+        let res = self.get_or_calculate_authorized_voter_for_epoch(epoch);
+
+        res.map(|(pubkey, existed)| {
+            if !existed {
+                self.authorized_voters.insert(epoch, pubkey);
+            }
+            pubkey
+        })
+    }
+
+    pub fn insert(&mut self, epoch: u64, authorized_voter: Pubkey) {
+        self.authorized_voters.insert(epoch, authorized_voter);
+    }
+
+    pub fn purge_authorized_voters(&mut self, current_epoch: u64) -> bool {
+        // Iterate through the keys in order, filtering out the ones
+        // less than the current epoch
+        let expired_keys: Vec<_> = self
+            .authorized_voters
+            .range(0..current_epoch)
+            .map(|(authorized_epoch, _)| *authorized_epoch)
+            .collect();
+
+        for key in expired_keys {
+            self.authorized_voters.remove(&key);
+        }
+
+        // Have to uphold this invariant b/c this is
+        // 1) The check for whether the vote state is initialized
+        // 2) How future authorized voters for uninitialized epochs are set
+        //    by this function
+        assert!(!self.authorized_voters.is_empty());
+        true
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.authorized_voters.is_empty()
+    }
+
+    pub fn first(&self) -> Option<(&u64, &Pubkey)> {
+        self.authorized_voters.iter().next()
+    }
+
+    pub fn last(&self) -> Option<(&u64, &Pubkey)> {
+        self.authorized_voters.iter().next_back()
+    }
+
+    pub fn len(&self) -> usize {
+        self.authorized_voters.len()
+    }
+
+    pub fn contains(&self, epoch: u64) -> bool {
+        self.authorized_voters.get(&epoch).is_some()
+    }
+
+    // Returns the authorized voter at the given epoch if the epoch is >= the
+    // current epoch, and a bool indicating whether the entry for this epoch
+    // exists in the self.authorized_voter map
+    fn get_or_calculate_authorized_voter_for_epoch(&self, epoch: u64) -> Option<(Pubkey, bool)> {
+        let res = self.authorized_voters.get(&epoch);
+        if res.is_none() {
+            // If no authorized voter has been set yet for this epoch,
+            // this must mean the authorized voter remains unchanged
+            // from the latest epoch before this one
+            let res = self.authorized_voters.range(0..epoch).next_back();
+
+            if res.is_none() {
+                warn!(
+                    "Tried to query for the authorized voter of an epoch earlier
+                    than the current epoch. Earlier epochs have been purged"
+                );
+            }
+
+            res.map(|(_, pubkey)| (*pubkey, false))
+        } else {
+            res.map(|pubkey| (*pubkey, true))
+        }
+    }
+}

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod authorized_voters;
 pub mod vote_instruction;
 pub mod vote_state;
 

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -17,6 +17,7 @@ use solana_sdk::{
     system_instruction,
     sysvar::{self, clock::Clock, slot_hashes::SlotHashes, Sysvar},
 };
+use std::collections::HashSet;
 use thiserror::Error;
 
 /// Reasons the stake might have had an error
@@ -187,7 +188,7 @@ pub fn process_instruction(
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 
-    let signers = get_signers(keyed_accounts);
+    let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
 
     let keyed_accounts = &mut keyed_accounts.iter();
     let me = &mut next_keyed_account(keyed_accounts)?;

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -39,9 +39,6 @@ pub enum VoteError {
 
     #[error("authorized voter has already been changed this epoch")]
     TooSoonToReauthorize,
-
-    #[error("cannot set same authorized voter as latest authorized voter")]
-    ReauthorizedSameVoter,
 }
 
 impl<E> DecodeError<E> for VoteError {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -625,10 +625,13 @@ pub fn initialize_account(
     vote_init: &VoteInit,
     clock: &Clock,
 ) -> Result<(), InstructionError> {
-    let vote_state: VoteState =
-        State::<VoteStateVersions>::state(vote_account)?.convert_to_current();
-
-    if !vote_state.authorized_voters.is_empty() {
+    if !vote_account
+        .try_account_ref()
+        .unwrap()
+        .data
+        .iter()
+        .all(|x| *x == 0)
+    {
         return Err(InstructionError::AccountAlreadyInitialized);
     }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -20,6 +20,7 @@ use solana_sdk::{
 use std::boxed::Box;
 use std::collections::{HashSet, VecDeque};
 
+mod vote_state_0_23_5;
 pub mod vote_state_versions;
 pub use vote_state_versions::*;
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -213,7 +213,7 @@ impl VoteState {
         vote_state.votes = VecDeque::from(vec![Lockout::default(); MAX_LOCKOUT_HISTORY]);
         vote_state.root_slot = Some(std::u64::MAX);
         vote_state.epoch_credits = vec![(0, 0, 0); MAX_EPOCH_CREDITS_HISTORY];
-        serialized_size(&vote_state).unwrap() as usize
+        serialized_size(&VoteStateVersions::Current(Box::new(vote_state))).unwrap() as usize
     }
 
     // utility function, used by Stakes, tests

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -19,7 +19,7 @@ use solana_sdk::{
 use std::boxed::Box;
 use std::collections::{HashSet, VecDeque};
 
-mod vote_state_0_23_5;
+pub mod vote_state_0_23_5;
 pub mod vote_state_versions;
 pub use vote_state_versions::*;
 

--- a/programs/vote/src/vote_state/vote_state_0_23_5.rs
+++ b/programs/vote/src/vote_state/vote_state_0_23_5.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+const MAX_ITEMS: usize = 32;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct VoteState0_23_5 {
+    /// the node that votes in this account
+    pub node_pubkey: Pubkey,
+
+    /// the signer for vote transactions
+    pub authorized_voter: Pubkey,
+    /// when the authorized voter was set/initialized
+    pub authorized_voter_epoch: Epoch,
+
+    /// history of prior authorized voters and the epoch ranges for which
+    ///  they were set
+    pub prior_voters: CircBuf<(Pubkey, Epoch, Epoch, Slot)>,
+
+    /// the signer for withdrawals
+    pub authorized_withdrawer: Pubkey,
+    /// percentage (0-100) that represents what part of a rewards
+    ///  payout should be given to this VoteAccount
+    pub commission: u8,
+
+    pub votes: VecDeque<Lockout>,
+    pub root_slot: Option<u64>,
+
+    /// history of how many credits earned by the end of each epoch
+    ///  each tuple is (Epoch, credits, prev_credits)
+    pub epoch_credits: Vec<(Epoch, u64, u64)>,
+
+    /// most recent timestamp submitted with a vote
+    pub last_timestamp: BlockTimestamp,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct CircBuf<I> {
+    pub buf: [I; MAX_ITEMS],
+    /// next pointer
+    pub idx: usize,
+}
+
+impl<I: Default + Copy> Default for CircBuf<I> {
+    fn default() -> Self {
+        Self {
+            buf: [I::default(); MAX_ITEMS],
+            idx: MAX_ITEMS - 1,
+        }
+    }
+}
+
+impl<I> CircBuf<I> {
+    pub fn append(&mut self, item: I) {
+        // remember prior delegate and when we switched, to support later slashing
+        self.idx += 1;
+        self.idx %= MAX_ITEMS;
+
+        self.buf[self.idx] = item;
+    }
+}

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::vote_state::vote_state_0_23_5::VoteState0_23_5;
+use solana_sdk::account_utils::StateMut;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum VoteStateVersions {
@@ -46,5 +47,18 @@ impl VoteStateVersions {
             }
             VoteStateVersions::Current(state) => *state,
         }
+    }
+
+    pub fn convert_from_raw(account: &mut Account, pubkey: &Pubkey) {
+        let vote_state: VoteState0_23_5 = account
+            .state()
+            .unwrap_or_else(|e| panic!("Couldn't deserialize vote account {}, error: {:?}", pubkey, e));
+
+        let current_vote_state =
+            VoteStateVersions::V0_23_5(Box::new(vote_state)).convert_to_current();
+        VoteState::to(
+            &VoteStateVersions::Current(Box::new(current_vote_state)),
+            account,
+        );
     }
 }

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -8,7 +8,7 @@ pub enum VoteStateVersions {
 }
 
 impl VoteStateVersions {
-    pub fn to_current(&self) -> VoteStateVersions {
+    pub fn convert_to_current(self) -> VoteState {
         match self {
             VoteStateVersions::V0_23_5(state) => {
                 let authorized_voters =
@@ -43,9 +43,9 @@ impl VoteStateVersions {
                     /// most recent timestamp submitted with a vote
                     last_timestamp: state.last_timestamp.clone(),
                 };
-                VoteStateVersions::Current(Box::new(current_state))
+                current_state
             }
-            VoteStateVersions::Current(state) => VoteStateVersions::Current(state.clone()),
+            VoteStateVersions::Current(state) => *state,
         }
     }
 }

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -5,12 +5,12 @@ use solana_vote_program_0_23_5::vote_state::VoteState as VoteState_0_23_5;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum VoteStateVersions {
-    V0_23_5(VoteState_0_23_5),
-    Current(VoteState),
+    V0_23_5(Box<VoteState_0_23_5>),
+    Current(Box<VoteState>),
 }
 
 impl VoteStateVersions {
-    pub fn to_current(self) -> VoteStateVersions {
+    pub fn to_current(&self) -> VoteStateVersions {
         match self {
             VoteStateVersions::V0_23_5(state) => {
                 let authorized_voter = Pubkey::new(state.authorized_withdrawer.as_ref());
@@ -59,9 +59,9 @@ impl VoteStateVersions {
                     /// most recent timestamp submitted with a vote
                     last_timestamp,
                 };
-                VoteStateVersions::Current(current_state)
+                VoteStateVersions::Current(Box::new(current_state))
             }
-            VoteStateVersions::Current(state) => VoteStateVersions::Current(state),
+            VoteStateVersions::Current(state) => VoteStateVersions::Current(state.clone()),
         }
     }
 }

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -14,7 +14,7 @@ impl VoteStateVersions {
                 let authorized_voters =
                     AuthorizedVoters::new(state.authorized_voter_epoch, state.authorized_voter);
 
-                let current_state = VoteState {
+                VoteState {
                     node_pubkey: state.node_pubkey,
 
                     /// the signer for withdrawals
@@ -42,8 +42,7 @@ impl VoteStateVersions {
 
                     /// most recent timestamp submitted with a vote
                     last_timestamp: state.last_timestamp.clone(),
-                };
-                current_state
+                }
             }
             VoteStateVersions::Current(state) => *state,
         }

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -50,9 +50,12 @@ impl VoteStateVersions {
     }
 
     pub fn convert_from_raw(account: &mut Account, pubkey: &Pubkey) {
-        let vote_state: VoteState0_23_5 = account
-            .state()
-            .unwrap_or_else(|e| panic!("Couldn't deserialize vote account {}, error: {:?}", pubkey, e));
+        let vote_state: VoteState0_23_5 = account.state().unwrap_or_else(|e| {
+            panic!(
+                "Couldn't deserialize vote account {}, error: {:?}",
+                pubkey, e
+            )
+        });
 
         let current_vote_state =
             VoteStateVersions::V0_23_5(Box::new(vote_state)).convert_to_current();

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -1,0 +1,67 @@
+extern crate solana_vote_program_0_23_5;
+
+use super::*;
+use solana_vote_program_0_23_5::vote_state::VoteState as VoteState_0_23_5;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub enum VoteStateVersions {
+    V0_23_5(VoteState_0_23_5),
+    Current(VoteState),
+}
+
+impl VoteStateVersions {
+    pub fn to_current(self) -> VoteStateVersions {
+        match self {
+            VoteStateVersions::V0_23_5(state) => {
+                let authorized_voter = Pubkey::new(state.authorized_withdrawer.as_ref());
+                let authorized_voters =
+                    AuthorizedVoters::new(state.authorized_voter_epoch, authorized_voter);
+                let last_timestamp = BlockTimestamp {
+                    slot: state.last_timestamp.slot,
+                    timestamp: state.last_timestamp.timestamp,
+                };
+                let votes: VecDeque<_> = state
+                    .votes
+                    .iter()
+                    .map(|lockout| {
+                        let mut current_lockout = Lockout::new(lockout.slot);
+                        current_lockout.confirmation_count = lockout.confirmation_count;
+                        current_lockout
+                    })
+                    .collect();
+
+                let current_state = VoteState {
+                    node_pubkey: Pubkey::new(state.node_pubkey.as_ref()),
+
+                    /// the signer for withdrawals
+                    authorized_withdrawer: Pubkey::new(state.authorized_withdrawer.as_ref()),
+
+                    /// percentage (0-100) that represents what part of a rewards
+                    ///  payout should be given to this VoteAccount
+                    commission: state.commission,
+
+                    votes,
+
+                    root_slot: state.root_slot,
+
+                    /// the signer for vote transactions
+                    authorized_voters,
+
+                    /// history of prior authorized voters and the epochs for which
+                    /// they were set, the bottom end of the range is inclusive,
+                    /// the top of the range is exclusive
+                    prior_voters: CircBuf::default(),
+
+                    /// history of how many credits earned by the end of each epoch
+                    ///  each tuple is (Epoch, credits, prev_credits)
+                    epoch_credits: state.epoch_credits().clone(),
+
+                    /// most recent timestamp submitted with a vote
+                    last_timestamp,
+                };
+                VoteStateVersions::Current(current_state)
+            }
+            VoteStateVersions::Current(state) => VoteStateVersions::Current(state),
+        }
+    }
+}

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -318,14 +318,21 @@ impl Accounts {
         ancestors: &HashMap<Slot, usize>,
         pubkey: &Pubkey,
     ) -> Option<(Account, Slot)> {
-        let (account, slot) = self
-            .accounts_db
-            .load_slow(ancestors, pubkey)
-            .unwrap_or((Account::default(), self.slot));
+        let res = self.accounts_db.load_slow(ancestors, pubkey);
+
+        if res.is_none() {
+            panic!("Could not find pubkey");
+        }
+
+        let (account, slot) = res.unwrap_or((Account::default(), self.slot));
 
         if account.lamports > 0 {
             Some((account, slot))
         } else {
+            println!(
+                "0 lamports account owner: {}, {}",
+                account.owner, account.lamports
+            );
             None
         }
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1089,8 +1089,8 @@ impl AccountsDB {
         }
     }
 
-    pub fn recompute_bank_hash(&self, slot: Slot) -> Result<BankHash, BankHashVerificationError> {
-        use BankHashVerificationError::*;
+    pub fn recompute_bank_hash(&self, slot: Slot) -> Result<BankHash, BankHashVerificatonError> {
+        use BankHashVerificatonError::*;
 
         let ancestors = vec![(slot, 1)].into_iter().collect();
         let (hashes, mismatch_found) = self.scan_accounts(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -317,7 +317,7 @@ pub struct Bank {
     inflation: Arc<RwLock<Inflation>>,
 
     /// cache of vote_account and stake_account state for this fork
-    stakes: RwLock<Stakes>,
+    pub stakes: RwLock<Stakes>,
 
     /// cache of validator and archiver storage accounts for this fork
     storage_accounts: RwLock<StorageAccounts>,
@@ -1680,21 +1680,6 @@ impl Bank {
                 .write()
                 .unwrap()
                 .store(pubkey, account);
-        }
-    }
-
-    pub fn store_account_convert(&self, slot: u64, pubkey: &Pubkey, account: &Account) {
-        self.rc.accounts.store_slow(slot, pubkey, account);
-
-        if slot == self.slot() {
-            if Stakes::is_stake(account) {
-                self.stakes.write().unwrap().store(pubkey, account);
-            } else if storage_utils::is_storage(account) {
-                self.storage_accounts
-                    .write()
-                    .unwrap()
-                    .store(pubkey, account);
-            }
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -766,6 +766,11 @@ impl Bank {
         }
     }
 
+    pub fn recompute_hash(&self) {
+        let mut hash = self.hash.write().unwrap();
+        *hash = self.hash_internal_state();
+    }
+
     pub fn epoch_schedule(&self) -> &EpochSchedule {
         &self.epoch_schedule
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3064,12 +3064,12 @@ mod tests {
             vote_state
                 .as_mut()
                 .map(|v| v.process_slot_vote_unchecked(i as u64));
-            let versioned = VoteStateVersions::Current(vote_state.take().unwrap());
+            let versioned = VoteStateVersions::Current(Box::new(vote_state.take().unwrap()));
             VoteState::to(&versioned, &mut vote_account).unwrap();
             bank.store_account(&vote_id, &vote_account);
             match versioned {
                 VoteStateVersions::Current(v) => {
-                    vote_state = Some(v);
+                    vote_state = Some(*v);
                 }
                 _ => panic!("Has to be of type Current"),
             };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2161,6 +2161,7 @@ mod tests {
         stake_instruction,
         stake_state::{self, Authorized, Delegation, Lockup, Stake},
     };
+    use solana_vote_program::vote_state::VoteStateVersions;
     use solana_vote_program::{
         vote_instruction,
         vote_state::{self, Vote, VoteInit, VoteState, MAX_LOCKOUT_HISTORY},
@@ -3058,11 +3059,20 @@ mod tests {
         bank.store_account(&archiver_id, &archiver_account);
 
         // generate some rewards
-        let mut vote_state = VoteState::from(&vote_account).unwrap();
+        let mut vote_state = Some(VoteState::from(&vote_account).unwrap());
         for i in 0..MAX_LOCKOUT_HISTORY + 42 {
-            vote_state.process_slot_vote_unchecked(i as u64);
-            vote_state.to(&mut vote_account).unwrap();
+            vote_state
+                .as_mut()
+                .map(|v| v.process_slot_vote_unchecked(i as u64));
+            let versioned = VoteStateVersions::Current(vote_state.take().unwrap());
+            VoteState::to(&versioned, &mut vote_account).unwrap();
             bank.store_account(&vote_id, &vote_account);
+            match versioned {
+                VoteStateVersions::Current(v) => {
+                    vote_state = Some(v);
+                }
+                _ => panic!("Has to be of type Current"),
+            };
         }
         bank.store_account(&vote_id, &vote_account);
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 #[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct Stakes {
     /// vote accounts
-    vote_accounts: HashMap<Pubkey, (u64, Account)>,
+    pub vote_accounts: HashMap<Pubkey, (u64, Account)>,
 
     /// stake_delegations
     stake_delegations: HashMap<Pubkey, Delegation>,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -326,11 +326,11 @@ pub mod tests {
             vote_state
                 .as_mut()
                 .map(|v| v.process_slot_vote_unchecked(i as u64));
-            let versioned = VoteStateVersions::Current(vote_state.take().unwrap());
+            let versioned = VoteStateVersions::Current(Box::new(vote_state.take().unwrap()));
             VoteState::to(&versioned, &mut vote_account).unwrap();
             match versioned {
                 VoteStateVersions::Current(v) => {
-                    vote_state = Some(v);
+                    vote_state = Some(*v);
                 }
                 _ => panic!("Has to be of type Current"),
             };

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -195,7 +195,9 @@ pub mod tests {
     use super::*;
     use solana_sdk::{pubkey::Pubkey, rent::Rent};
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state::{self, VoteState, MAX_LOCKOUT_HISTORY};
+    use solana_vote_program::vote_state::{
+        self, VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+    };
 
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
     pub fn create_staked_node_accounts(stake: u64) -> ((Pubkey, Account), (Pubkey, Account)) {
@@ -319,31 +321,55 @@ pub mod tests {
         assert_eq!(stakes.points(), 0);
         assert_eq!(stakes.claim_points(), 0);
 
-        let mut vote_state = VoteState::from(&vote_account).unwrap();
+        let mut vote_state = Some(VoteState::from(&vote_account).unwrap());
         for i in 0..MAX_LOCKOUT_HISTORY + 42 {
-            vote_state.process_slot_vote_unchecked(i as u64);
-            vote_state.to(&mut vote_account).unwrap();
+            vote_state
+                .as_mut()
+                .map(|v| v.process_slot_vote_unchecked(i as u64));
+            let versioned = VoteStateVersions::Current(vote_state.take().unwrap());
+            VoteState::to(&versioned, &mut vote_account).unwrap();
+            match versioned {
+                VoteStateVersions::Current(v) => {
+                    vote_state = Some(v);
+                }
+                _ => panic!("Has to be of type Current"),
+            };
             stakes.store(&vote_pubkey, &vote_account);
-            assert_eq!(stakes.points(), vote_state.credits() * stake);
+            assert_eq!(
+                stakes.points(),
+                vote_state.as_ref().unwrap().credits() * stake
+            );
         }
         vote_account.lamports = 0;
         stakes.store(&vote_pubkey, &vote_account);
-        assert_eq!(stakes.points(), vote_state.credits() * stake);
+        assert_eq!(
+            stakes.points(),
+            vote_state.as_ref().unwrap().credits() * stake
+        );
 
-        assert_eq!(stakes.claim_points(), vote_state.credits() * stake);
+        assert_eq!(
+            stakes.claim_points(),
+            vote_state.as_ref().unwrap().credits() * stake
+        );
         assert_eq!(stakes.claim_points(), 0);
         assert_eq!(stakes.claim_points(), 0);
 
         // points come out of nowhere, but don't care here ;)
         vote_account.lamports = 1;
         stakes.store(&vote_pubkey, &vote_account);
-        assert_eq!(stakes.points(), vote_state.credits() * stake);
+        assert_eq!(
+            stakes.points(),
+            vote_state.as_ref().unwrap().credits() * stake
+        );
 
         // test going backwards, should never go backwards
         let old_vote_state = vote_state;
         let vote_account = vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 1);
         stakes.store(&vote_pubkey, &vote_account);
-        assert_eq!(stakes.points(), old_vote_state.credits() * stake);
+        assert_eq!(
+            stakes.points(),
+            old_vote_state.as_ref().unwrap().credits() * stake
+        );
     }
 
     #[test]

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -18,7 +18,7 @@ use solana_stake_program::{
 };
 use solana_vote_program::{
     vote_instruction,
-    vote_state::{Vote, VoteInit, VoteState},
+    vote_state::{Vote, VoteInit, VoteState, VoteStateVersions},
 };
 use std::sync::Arc;
 
@@ -254,7 +254,9 @@ fn test_stake_account_lifetime() {
 
     // Test that votes and credits are there
     let account = bank.get_account(&vote_pubkey).expect("account not found");
-    let vote_state: VoteState = account.state().expect("couldn't unpack account data");
+    let vote_state: VoteState = StateMut::<VoteStateVersions>::state(&account)
+        .expect("couldn't unpack account data")
+        .convert_to_current();
 
     // 1 less vote, as the first vote should have cleared the lockout
     assert_eq!(vote_state.votes.len(), 31);

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -350,7 +350,7 @@ fn check_vote_account(
 
     let found_vote_account = solana_vote_program::vote_state::VoteState::from(&found_vote_account);
     if let Some(found_vote_account) = found_vote_account {
-        if found_vote_account.authorized_voter().is_empty() {
+        if found_vote_account.authorized_voters().is_empty() {
             return Err("Vote account not yet initialized".to_string());
         }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -350,10 +350,32 @@ fn check_vote_account(
 
     let found_vote_account = solana_vote_program::vote_state::VoteState::from(&found_vote_account);
     if let Some(found_vote_account) = found_vote_account {
-        if found_vote_account.authorized_voter != *voting_pubkey {
+        if found_vote_account.authorized_voter().is_empty() {
+            return Err("Vote account not yet initialized".to_string());
+        }
+
+        let epoch_info = rpc_client
+            .get_epoch_info()
+            .map_err(|err| format!("Failed to get epoch info: {}", err.to_string()))?;
+
+        let mut authorized_voter;
+        authorized_voter = found_vote_account.get_authorized_voter(epoch_info.epoch);
+        if authorized_voter.is_none() {
+            // Must have gotten a clock on the boundary
+            authorized_voter = found_vote_account.get_authorized_voter(epoch_info.epoch + 1);
+        }
+
+        let authorized_voter = authorized_voter.expect(
+            "Could not get the authorized voter, which only happens if the
+            client gets an epoch earlier than the current epoch,
+            but the received epoch should not be off by more than
+            one epoch",
+        );
+
+        if authorized_voter != *voting_pubkey {
             return Err(format!(
                 "account's authorized voter ({}) does not match to the given voting keypair ({}).",
-                found_vote_account.authorized_voter, voting_pubkey
+                authorized_voter, voting_pubkey
             ));
         }
         if found_vote_account.node_pubkey != *node_pubkey {


### PR DESCRIPTION
#### Problem
No method exists to upgrade accounts in old snapshot to newer versions of those accounts, specifically vote accounts

Note: The only relevant changes are in ledger-tool/main.rs, all other changes are from: https://github.com/solana-labs/solana/pull/8348

#### Summary of Changes
Hack together some throwaway code to try and achieve above.

Note: Nothing has been tested or even run yet 😛 
Fixes #
