### PR TITLE
CLI: dynamic signing reboot

### DIFF
--- a/book/src/paper-wallet/usage.md
+++ b/book/src/paper-wallet/usage.md
@@ -251,10 +251,10 @@ Refer to the following page for a comprehensive guide on running a validator:
 Solana CLI tooling supports secure keypair input for stake delegation. To do so,
 first create a stake account with some SOL. Use the special `ASK` keyword to
 trigger a seed phrase input prompt for the stake account and use
-`--ask-seed-phrase keypair` to securely input the funding keypair.
+`--keypair ASK` to securely input the funding keypair.
 
 ```bash
-solana create-stake-account ASK 1 --ask-seed-phrase keypair
+solana create-stake-account ASK 1 --keypair ASK
 
 [stake_account] seed phrase: 🔒
 [stake_account] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
@@ -262,11 +262,11 @@ solana create-stake-account ASK 1 --ask-seed-phrase keypair
 [keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
 ```
 
-Then, to delegate that stake to a validator, use `--ask-seed-phrase keypair` to
+Then, to delegate that stake to a validator, use `--keypair ASK` to
 securely input the funding keypair.
 
 ```bash
-solana delegate-stake --ask-seed-phrase keypair <STAKE_ACCOUNT_PUBKEY> <VOTE_ACCOUNT_PUBKEY>
+solana delegate-stake --keypair ASK <STAKE_ACCOUNT_PUBKEY> <VOTE_ACCOUNT_PUBKEY>
 
 [keypair] seed phrase: 🔒
 [keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -99,7 +99,7 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
 pub fn signer_of(
     name: &str,
     matches: &ArgMatches<'_>,
-) -> Result<Option<Box<dyn KeypairUtil>>, Box<dyn std::error::Error>> {
+) -> Result<Option<Box<dyn Signer>>, Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
         keypair_util_from_path(matches, location, name).map(Some)
     } else {

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -1,4 +1,6 @@
-use crate::keypair::{keypair_from_seed_phrase, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG};
+use crate::keypair::{
+    keypair_from_seed_phrase, keypair_util_from_path, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
+};
 use chrono::DateTime;
 use clap::ArgMatches;
 use solana_remote_wallet::remote_wallet::DerivationPath;
@@ -91,6 +93,18 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
             })
             .collect()
     })
+}
+
+// Return a signer from matches at `name`
+pub fn signer_of(
+    name: &str,
+    matches: &ArgMatches<'_>,
+) -> Result<Option<Box<dyn KeypairUtil>>, Box<dyn std::error::Error>> {
+    if let Some(location) = matches.value_of(name) {
+        keypair_util_from_path(matches, location, name).map(Some)
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,5 +1,6 @@
-use crate::keypair::ASK_KEYWORD;
+use crate::keypair::{parse_keypair_path, KeypairUrl, ASK_KEYWORD};
 use chrono::DateTime;
+use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
@@ -48,6 +49,16 @@ pub fn is_pubkey_or_keypair(string: String) -> Result<(), String> {
 // Return an error if string cannot be parsed as pubkey or keypair file or keypair ask keyword
 pub fn is_pubkey_or_keypair_or_ask_keyword(string: String) -> Result<(), String> {
     is_pubkey(string.clone()).or_else(|_| is_keypair_or_ask_keyword(string))
+}
+
+pub fn is_valid_signer(string: String) -> Result<(), String> {
+    match parse_keypair_path(&string) {
+        KeypairUrl::Usb(path) => generate_remote_keypair(path, None)
+            .map(|_| ())
+            .map_err(|err| format!("{:?}", err)),
+        KeypairUrl::Filepath(path) => is_keypair(path),
+        _ => Ok(()),
+    }
 }
 
 // Return an error if string cannot be parsed as pubkey=signature string

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,5 +1,6 @@
 use crate::{
     input_parsers::{derivation_of, pubkeys_sigs_of},
+    offline::SIGNER_ARG,
     ArgConstant,
 };
 use bip39::{Language, Mnemonic, Seed};
@@ -79,7 +80,7 @@ pub fn keypair_util_from_path(
             derivation_of(matches, "derivation_path"),
         )?)),
         KeypairUrl::Pubkey(pubkey) => {
-            let presigner = pubkeys_sigs_of(matches, "signer")
+            let presigner = pubkeys_sigs_of(matches, SIGNER_ARG.name)
                 .as_ref()
                 .and_then(|presigners| presigner_from_pubkey_sigs(&pubkey, presigners));
             if let Some(presigner) = presigner {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,16 +1,23 @@
-use crate::{input_parsers::derivation_of, ArgConstant};
+use crate::{
+    input_parsers::{derivation_of, pubkeys_sigs_of},
+    ArgConstant,
+};
 use bip39::{Language, Mnemonic, Seed};
-use clap::{values_t, ArgMatches};
+use clap::{values_t, ArgMatches, Error, ErrorKind};
 use rpassword::prompt_password_stderr;
 use solana_remote_wallet::remote_keypair::generate_remote_keypair;
-use solana_sdk::signature::{
-    keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair, read_keypair_file,
-    Keypair, Signer,
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::{
+        keypair_from_seed, keypair_from_seed_phrase_and_passphrase, read_keypair,
+        read_keypair_file, Keypair, Presigner, Signer,
+    },
 };
 use std::{
     error,
     io::{stdin, stdout, Write},
     process::exit,
+    str::FromStr,
 };
 
 pub enum KeypairUrl {
@@ -18,6 +25,7 @@ pub enum KeypairUrl {
     Filepath(String),
     Usb(String),
     Stdin,
+    Pubkey(Pubkey),
 }
 
 pub fn parse_keypair_path(path: &str) -> KeypairUrl {
@@ -27,6 +35,8 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
         KeypairUrl::Ask
     } else if path.starts_with("usb://") {
         KeypairUrl::Usb(path.split_at(6).1.to_string())
+    } else if let Ok(pubkey) = Pubkey::from_str(path) {
+        KeypairUrl::Pubkey(pubkey)
     } else {
         KeypairUrl::Filepath(path.to_string())
     }
@@ -55,6 +65,26 @@ pub fn keypair_util_from_path(
             path,
             derivation_of(matches, "derivation_path"),
         )?)),
+        KeypairUrl::Pubkey(pubkey) => {
+            let presigner = pubkeys_sigs_of(matches, "signer").and_then(|presigners| {
+                presigners.iter().find_map(|(signer, sig)| {
+                    if *signer == pubkey {
+                        Some(Presigner::new(signer, sig))
+                    } else {
+                        None
+                    }
+                })
+            });
+            if let Some(presigner) = presigner {
+                Ok(Box::new(presigner))
+            } else {
+                Err(Error::with_description(
+                    "Missing signature for supplied pubkey",
+                    ErrorKind::MissingRequiredArgument,
+                )
+                .into())
+            }
+        }
     }
 }
 

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -26,3 +26,4 @@ pub struct ArgConstant<'a> {
 pub mod input_parsers;
 pub mod input_validators;
 pub mod keypair;
+pub mod offline;

--- a/clap-utils/src/offline.rs
+++ b/clap-utils/src/offline.rs
@@ -1,0 +1,19 @@
+use crate::ArgConstant;
+
+pub const BLOCKHASH_ARG: ArgConstant<'static> = ArgConstant {
+    name: "blockhash",
+    long: "blockhash",
+    help: "Use the supplied blockhash",
+};
+
+pub const SIGN_ONLY_ARG: ArgConstant<'static> = ArgConstant {
+    name: "sign_only",
+    long: "sign-only",
+    help: "Sign the transaction offline",
+};
+
+pub const SIGNER_ARG: ArgConstant<'static> = ArgConstant {
+    name: "signer",
+    long: "signer",
+    help: "Provide a public-key/signature pair for the transaction",
+};

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2250,7 +2250,7 @@ mod tests {
         system_program,
         transaction::TransactionError,
     };
-    use std::{collections::HashMap, path::PathBuf};
+    use std::{collections::HashMap, path::PathBuf, rc::Rc};
 
     fn make_tmp_path(name: &str) -> String {
         let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
@@ -2765,7 +2765,7 @@ mod tests {
 
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey().to_string();
-        config.keypair = keypair;
+        config.keypair = keypair.into();
         config.command = CliCommand::Address;
         assert_eq!(process_command(&config).unwrap(), pubkey);
 
@@ -2825,7 +2825,7 @@ mod tests {
         let bob_pubkey = bob_keypair.pubkey();
         let custodian = Pubkey::new_rand();
         config.command = CliCommand::CreateStakeAccount {
-            stake_account: bob_keypair.into(),
+            stake_account: Rc::new(bob_keypair.into()),
             seed: None,
             staker: None,
             withdrawer: None,
@@ -2883,7 +2883,7 @@ mod tests {
             blockhash_query: BlockhashQuery::default(),
             nonce_account: None,
             nonce_authority: None,
-            split_stake_account: split_stake_account.into(),
+            split_stake_account: Rc::new(split_stake_account.into()),
             seed: None,
             lamports: 1234,
             fee_payer: None,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -105,7 +105,6 @@ pub struct PayCommand {
     pub witnesses: Option<Vec<Pubkey>>,
     pub cancelable: bool,
     pub sign_only: bool,
-    pub signers: Option<Vec<(Pubkey, Signature)>>,
     pub blockhash_query: BlockhashQuery,
     pub nonce_account: Option<Pubkey>,
     pub nonce_authority: Option<Box<dyn Signer>>,
@@ -199,7 +198,6 @@ pub enum CliCommand {
         lockup: Lockup,
         lamports: u64,
         sign_only: bool,
-        signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
         nonce_authority: Option<Box<dyn Signer>>,
@@ -210,7 +208,6 @@ pub enum CliCommand {
         stake_account_pubkey: Pubkey,
         stake_authority: Option<Box<dyn Signer>>,
         sign_only: bool,
-        signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
         nonce_authority: Option<Box<dyn Signer>>,
@@ -222,7 +219,6 @@ pub enum CliCommand {
         stake_authority: Option<Box<dyn Signer>>,
         force: bool,
         sign_only: bool,
-        signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
         nonce_authority: Option<Box<dyn Signer>>,
@@ -232,7 +228,6 @@ pub enum CliCommand {
         stake_account_pubkey: Pubkey,
         stake_authority: Option<Box<dyn Signer>>,
         sign_only: bool,
-        signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
         nonce_authority: Option<Box<dyn Signer>>,
@@ -254,7 +249,6 @@ pub enum CliCommand {
         stake_authorize: StakeAuthorize,
         authority: Option<Box<dyn Signer>>,
         sign_only: bool,
-        signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
         nonce_authority: Option<Box<dyn Signer>>,
@@ -265,7 +259,6 @@ pub enum CliCommand {
         lockup: Lockup,
         custodian: Option<Box<dyn Signer>>,
         sign_only: bool,
-        signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
         nonce_authority: Option<Box<dyn Signer>>,
@@ -277,7 +270,6 @@ pub enum CliCommand {
         lamports: u64,
         withdraw_authority: Option<Box<dyn Signer>>,
         sign_only: bool,
-        signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
         nonce_authority: Option<Box<dyn Signer>>,
@@ -350,7 +342,6 @@ pub enum CliCommand {
         to: Pubkey,
         from: Option<Box<dyn Signer>>,
         sign_only: bool,
-        signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
         nonce_authority: Option<Box<dyn Signer>>,
@@ -614,7 +605,6 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let witnesses = values_of(&matches, "witness");
             let cancelable = matches.is_present("cancelable");
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-            let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(&matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
             let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
@@ -628,7 +618,6 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
                     witnesses,
                     cancelable,
                     sign_only,
-                    signers,
                     blockhash_query,
                     nonce_account,
                     nonce_authority,
@@ -680,7 +669,6 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let lamports = lamports_of_sol(matches, "amount").unwrap();
             let to = pubkey_of(&matches, "to").unwrap();
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-            let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
             let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
@@ -692,7 +680,6 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
                     to,
                     from,
                     sign_only,
-                    signers,
                     blockhash_query,
                     nonce_account,
                     nonce_authority,
@@ -1028,7 +1015,6 @@ fn process_pay(
     witnesses: &Option<Vec<Pubkey>>,
     cancelable: bool,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn Signer>,
@@ -1060,10 +1046,6 @@ fn process_pay(
         } else {
             system_transaction::transfer(config.keypair.as_ref(), to, lamports, blockhash)
         };
-
-        if let Some(signers) = signers {
-            replace_signatures(&mut tx, &signers)?;
-        }
 
         if sign_only {
             return_signers(&tx)
@@ -1106,9 +1088,6 @@ fn process_pay(
             ixs,
             blockhash,
         );
-        if let Some(signers) = signers {
-            replace_signatures(&mut tx, &signers)?;
-        }
         if sign_only {
             return_signers(&tx)
         } else {
@@ -1154,9 +1133,6 @@ fn process_pay(
             ixs,
             blockhash,
         );
-        if let Some(signers) = signers {
-            replace_signatures(&mut tx, &signers)?;
-        }
         if sign_only {
             return_signers(&tx)
         } else {
@@ -1230,7 +1206,6 @@ fn process_transfer(
     to: &Pubkey,
     from: Option<&(dyn Signer + 'static)>,
     sign_only: bool,
-    signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
     nonce_authority: Option<&(dyn Signer + 'static)>,
@@ -1266,10 +1241,6 @@ fn process_transfer(
             recent_blockhash,
         )
     };
-
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
 
     if sign_only {
         return_signers(&tx)
@@ -1468,7 +1439,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             lockup,
             lamports,
             sign_only,
-            ref signers,
             blockhash_query,
             ref nonce_account,
             ref nonce_authority,
@@ -1484,7 +1454,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             lockup,
             *lamports,
             *sign_only,
-            signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
             nonce_authority.as_deref(),
@@ -1495,7 +1464,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             stake_account_pubkey,
             ref stake_authority,
             sign_only,
-            ref signers,
             blockhash_query,
             nonce_account,
             ref nonce_authority,
@@ -1506,7 +1474,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &stake_account_pubkey,
             stake_authority.as_deref(),
             *sign_only,
-            signers,
             blockhash_query,
             *nonce_account,
             nonce_authority.as_deref(),
@@ -1518,7 +1485,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             ref stake_authority,
             force,
             sign_only,
-            ref signers,
             blockhash_query,
             nonce_account,
             ref nonce_authority,
@@ -1531,7 +1497,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             stake_authority.as_deref(),
             *force,
             *sign_only,
-            signers,
             blockhash_query,
             *nonce_account,
             nonce_authority.as_deref(),
@@ -1541,7 +1506,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             stake_account_pubkey,
             ref stake_authority,
             sign_only,
-            ref signers,
             blockhash_query,
             nonce_account,
             ref nonce_authority,
@@ -1555,7 +1519,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &stake_account_pubkey,
             stake_authority.as_deref(),
             *sign_only,
-            signers,
             blockhash_query,
             *nonce_account,
             nonce_authority.as_deref(),
@@ -1582,7 +1545,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             stake_authorize,
             ref authority,
             sign_only,
-            ref signers,
             blockhash_query,
             nonce_account,
             ref nonce_authority,
@@ -1595,7 +1557,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *stake_authorize,
             authority.as_deref(),
             *sign_only,
-            signers,
             blockhash_query,
             *nonce_account,
             nonce_authority.as_deref(),
@@ -1606,7 +1567,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             mut lockup,
             ref custodian,
             sign_only,
-            ref signers,
             blockhash_query,
             nonce_account,
             ref nonce_authority,
@@ -1618,7 +1578,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &mut lockup,
             custodian.as_deref(),
             *sign_only,
-            signers,
             blockhash_query,
             *nonce_account,
             nonce_authority.as_deref(),
@@ -1630,7 +1589,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             lamports,
             ref withdraw_authority,
             sign_only,
-            ref signers,
             blockhash_query,
             ref nonce_account,
             ref nonce_authority,
@@ -1643,7 +1601,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *lamports,
             withdraw_authority.as_deref(),
             *sign_only,
-            signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
             nonce_authority.as_deref(),
@@ -1791,7 +1748,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             ref witnesses,
             cancelable,
             sign_only,
-            ref signers,
             blockhash_query,
             nonce_account,
             ref nonce_authority,
@@ -1805,7 +1761,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             witnesses,
             *cancelable,
             *sign_only,
-            signers,
             blockhash_query,
             *nonce_account,
             nonce_authority.as_deref(),
@@ -1830,7 +1785,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             to,
             ref from,
             sign_only,
-            ref signers,
             ref blockhash_query,
             ref nonce_account,
             ref nonce_authority,
@@ -1842,7 +1796,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             to,
             from.as_deref(),
             *sign_only,
-            signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
             nonce_authority.as_deref(),
@@ -2755,7 +2708,6 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(pubkey),
                     nonce_authority: Some(Presigner::new(&authority_pubkey, &sig).into()),
-                    signers: Some(vec![(authority_pubkey, sig)]),
                     ..PayCommand::default()
                 }),
                 require_keypair: true
@@ -2934,7 +2886,6 @@ mod tests {
             },
             lamports: 1234,
             sign_only: false,
-            signers: None,
             blockhash_query: BlockhashQuery::All,
             nonce_account: None,
             nonce_authority: None,
@@ -2952,7 +2903,6 @@ mod tests {
             lamports: 100,
             withdraw_authority: None,
             sign_only: false,
-            signers: None,
             blockhash_query: BlockhashQuery::All,
             nonce_account: None,
             nonce_authority: None,
@@ -2966,7 +2916,6 @@ mod tests {
             stake_account_pubkey: stake_pubkey,
             stake_authority: None,
             sign_only: false,
-            signers: None,
             blockhash_query: BlockhashQuery::default(),
             nonce_account: None,
             nonce_authority: None,
@@ -2981,7 +2930,6 @@ mod tests {
             stake_account_pubkey: stake_pubkey,
             stake_authority: None,
             sign_only: false,
-            signers: None,
             blockhash_query: BlockhashQuery::default(),
             nonce_account: None,
             nonce_authority: None,
@@ -3288,7 +3236,6 @@ mod tests {
                     to: to_pubkey,
                     from: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -3318,7 +3265,6 @@ mod tests {
                     to: to_pubkey,
                     from: None,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -3353,7 +3299,6 @@ mod tests {
                     to: to_pubkey,
                     from: Some(Presigner::new(&from_pubkey, &from_sig).into()),
                     sign_only: false,
-                    signers: Some(vec![(from_pubkey, from_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -3389,7 +3334,6 @@ mod tests {
                     to: to_pubkey,
                     from: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(nonce_address.into()),
                     nonce_authority: Some(read_keypair_file(&nonce_authority_file).unwrap().into()),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -775,16 +775,6 @@ pub fn return_signers(tx: &Transaction) -> ProcessResult {
     .to_string())
 }
 
-pub fn replace_signatures(tx: &mut Transaction, signers: &[(Pubkey, Signature)]) -> ProcessResult {
-    tx.replace_signatures(signers).map_err(|_| {
-        CliError::BadParameter(
-            "Transaction construction failed, incorrect signature or public key provided"
-                .to_string(),
-        )
-    })?;
-    Ok("".to_string())
-}
-
 pub fn parse_create_address_with_seed(
     matches: &ArgMatches<'_>,
 ) -> Result<CliCommandInfo, CliError> {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -943,25 +943,22 @@ fn process_deploy(
     );
     let message = Message::new(vec![ix]);
     let mut create_account_tx = Transaction::new_unsigned(message);
-    create_account_tx.sign(&[config.keypair.as_ref(), &program_id], blockhash);
+    create_account_tx.try_sign(&[config.keypair.as_ref(), &program_id], blockhash)?;
     messages.push(&create_account_tx.message);
     let signers = [config.keypair.as_ref(), &program_id];
-    let write_transactions: Vec<_> = program_data
-        .chunks(DATA_CHUNK_SIZE)
-        .zip(0..)
-        .map(|(chunk, i)| {
-            let instruction = loader_instruction::write(
-                &program_id.pubkey(),
-                &bpf_loader::id(),
-                (i * DATA_CHUNK_SIZE) as u32,
-                chunk.to_vec(),
-            );
-            let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
-            let mut tx = Transaction::new_unsigned(message);
-            tx.sign(&signers, blockhash);
-            tx
-        })
-        .collect();
+    let mut write_transactions = vec![];
+    for (chunk, i) in program_data.chunks(DATA_CHUNK_SIZE).zip(0..) {
+        let instruction = loader_instruction::write(
+            &program_id.pubkey(),
+            &bpf_loader::id(),
+            (i * DATA_CHUNK_SIZE) as u32,
+            chunk.to_vec(),
+        );
+        let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
+        let mut tx = Transaction::new_unsigned(message);
+        tx.try_sign(&signers, blockhash)?;
+        write_transactions.push(tx);
+    }
     for transaction in write_transactions.iter() {
         messages.push(&transaction.message);
     }
@@ -969,7 +966,7 @@ fn process_deploy(
     let instruction = loader_instruction::finalize(&program_id.pubkey(), &bpf_loader::id());
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
     let mut finalize_tx = Transaction::new_unsigned(message);
-    finalize_tx.sign(&signers, blockhash);
+    finalize_tx.try_sign(&signers, blockhash)?;
     messages.push(&finalize_tx.message);
 
     check_account_for_multiple_fees(
@@ -1035,12 +1032,12 @@ fn process_pay(
             let message =
                 Message::new_with_nonce(vec![ix], None, nonce_account, &nonce_authority.pubkey());
             let mut tx = Transaction::new_unsigned(message);
-            tx.sign(&[config.keypair.as_ref(), nonce_authority], blockhash);
+            tx.try_sign(&[config.keypair.as_ref(), nonce_authority], blockhash)?;
             tx
         } else {
             let message = Message::new(vec![ix]);
             let mut tx = Transaction::new_unsigned(message);
-            tx.sign(&[config.keypair.as_ref()], blockhash);
+            tx.try_sign(&[config.keypair.as_ref()], blockhash)?;
             tx
         };
 
@@ -1082,7 +1079,7 @@ fn process_pay(
         );
         let message = Message::new(ixs);
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[config.keypair.as_ref(), &contract_state], blockhash);
+        tx.try_sign(&[config.keypair.as_ref(), &contract_state], blockhash)?;
         if sign_only {
             return_signers(&tx)
         } else {
@@ -1125,7 +1122,7 @@ fn process_pay(
         );
         let message = Message::new(ixs);
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[config.keypair.as_ref(), &contract_state], blockhash);
+        tx.try_sign(&[config.keypair.as_ref(), &contract_state], blockhash)?;
         if sign_only {
             return_signers(&tx)
         } else {
@@ -1159,7 +1156,7 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
     );
     let message = Message::new(vec![ix]);
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(&[config.keypair.as_ref()], blockhash);
+    tx.try_sign(&[config.keypair.as_ref()], blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -1182,7 +1179,7 @@ fn process_time_elapsed(
     let ix = budget_instruction::apply_timestamp(&config.keypair.pubkey(), pubkey, to, dt);
     let message = Message::new(vec![ix]);
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(&[config.keypair.as_ref()], blockhash);
+    tx.try_sign(&[config.keypair.as_ref()], blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -1232,12 +1229,12 @@ fn process_transfer(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&signers, recent_blockhash);
+        tx.try_sign(&signers, recent_blockhash)?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&signers, recent_blockhash);
+        tx.try_sign(&signers, recent_blockhash)?;
         tx
     };
 
@@ -1270,7 +1267,7 @@ fn process_witness(
     let ix = budget_instruction::apply_signature(&config.keypair.pubkey(), pubkey, to);
     let message = Message::new(vec![ix]);
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(&[config.keypair.as_ref()], blockhash);
+    tx.try_sign(&[config.keypair.as_ref()], blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2541,64 +2541,6 @@ mod tests {
             }
         );
 
-        // Test Pay Subcommand w/ signer
-        let key1 = Pubkey::new_rand();
-        let sig1 = Keypair::new().sign_message(&[0u8]);
-        let signer1 = format!("{}={}", key1, sig1);
-        let test_pay = test_commands.clone().get_matches_from(vec![
-            "test",
-            "pay",
-            &pubkey_string,
-            "50",
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer1,
-        ]);
-        assert_eq!(
-            parse_command(&test_pay).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Pay(PayCommand {
-                    lamports: 50_000_000_000,
-                    to: pubkey,
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    signers: Some(vec![(key1, sig1)]),
-                    ..PayCommand::default()
-                }),
-                require_keypair: true
-            }
-        );
-
-        // Test Pay Subcommand w/ signers
-        let key2 = Pubkey::new_rand();
-        let sig2 = Keypair::new().sign_message(&[1u8]);
-        let signer2 = format!("{}={}", key2, sig2);
-        let test_pay = test_commands.clone().get_matches_from(vec![
-            "test",
-            "pay",
-            &pubkey_string,
-            "50",
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer1,
-            "--signer",
-            &signer2,
-        ]);
-        assert_eq!(
-            parse_command(&test_pay).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Pay(PayCommand {
-                    lamports: 50_000_000_000,
-                    to: pubkey,
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    signers: Some(vec![(key1, sig1), (key2, sig2)]),
-                    ..PayCommand::default()
-                }),
-                require_keypair: true
-            }
-        );
-
         // Test Pay Subcommand w/ Blockhash
         let test_pay = test_commands.clone().get_matches_from(vec![
             "test",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -65,8 +65,8 @@ pub fn fee_payer_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(FEE_PAYER_ARG.name)
         .long(FEE_PAYER_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(FEE_PAYER_ARG.help)
 }
 
@@ -1975,7 +1975,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .index(1)
                         .value_name("PUBKEY")
                         .takes_value(true)
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_signer)
                         .help("The public key of the balance to check"),
                 )
                 .arg(
@@ -2184,8 +2184,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                     Arg::with_name("from")
                         .long("from")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Source account of funds (if different from client local account)"),
                 )
                 .offline_args()

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -14,7 +14,9 @@ use log::*;
 use num_traits::FromPrimitive;
 use serde_json::{self, json, Value};
 use solana_budget_program::budget_instruction::{self, BudgetError};
-use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
+use solana_clap_utils::{
+    input_parsers::*, input_validators::*, offline::SIGN_ONLY_ARG, ArgConstant,
+};
 use solana_client::{client_error::ClientError, rpc_client::RpcClient};
 #[cfg(not(test))]
 use solana_faucet::faucet::request_airdrop_transaction;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -20,10 +20,7 @@ use solana_client::{client_error::ClientError, rpc_client::RpcClient};
 use solana_faucet::faucet::request_airdrop_transaction;
 #[cfg(test)]
 use solana_faucet::faucet_mock::request_airdrop_transaction;
-use solana_remote_wallet::{
-    ledger::get_ledger_from_info,
-    remote_wallet::{DerivationPath, RemoteWallet, RemoteWalletInfo},
-};
+use solana_remote_wallet::remote_wallet::DerivationPath;
 use solana_sdk::{
     bpf_loader,
     clock::{Epoch, Slot},
@@ -496,19 +493,7 @@ impl CliConfig {
     }
 
     pub(crate) fn pubkey(&self) -> Result<Pubkey, Box<dyn std::error::Error>> {
-        if let Some(path) = &self.keypair_path {
-            if path.starts_with("usb://") {
-                let (remote_wallet_info, mut derivation_path) =
-                    RemoteWalletInfo::parse_path(path.to_string())?;
-                if let Some(derivation) = &self.derivation_path {
-                    let derivation = derivation.clone();
-                    derivation_path = derivation;
-                }
-                let ledger = get_ledger_from_info(remote_wallet_info)?;
-                return Ok(ledger.get_pubkey(&derivation_path)?);
-            }
-        }
-        Ok(self.keypair.pubkey())
+        self.keypair.try_pubkey()
     }
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -474,7 +474,7 @@ impl error::Error for CliError {
 pub struct CliConfig {
     pub command: CliCommand,
     pub json_rpc_url: String,
-    pub keypair: Keypair,
+    pub keypair: Box<dyn Signer>,
     pub keypair_path: Option<String>,
     pub derivation_path: Option<DerivationPath>,
     pub rpc_client: Option<RpcClient>,
@@ -492,7 +492,7 @@ impl CliConfig {
         "http://127.0.0.1:8899".to_string()
     }
 
-    pub(crate) fn pubkey(&self) -> Result<Pubkey, Box<dyn std::error::Error>> {
+    pub(crate) fn pubkey(&self) -> Result<Pubkey, SignerError> {
         self.keypair.try_pubkey()
     }
 }
@@ -505,7 +505,7 @@ impl Default for CliConfig {
                 use_lamports_unit: false,
             },
             json_rpc_url: Self::default_json_rpc_url(),
-            keypair: Keypair::new(),
+            keypair: Box::new(Keypair::new()),
             keypair_path: Some(Self::default_keypair_path()),
             derivation_path: None,
             rpc_client: None,
@@ -1041,7 +1041,7 @@ fn process_deploy(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data.len())?;
     let mut create_account_tx = system_transaction::create_account(
-        &config.keypair,
+        config.keypair.as_ref(),
         &program_id,
         blockhash,
         minimum_balance.max(1),
@@ -1049,7 +1049,7 @@ fn process_deploy(
         &bpf_loader::id(),
     );
     messages.push(&create_account_tx.message);
-    let signers = [&config.keypair, &program_id];
+    let signers = [config.keypair.as_ref(), &program_id];
     let write_transactions: Vec<_> = program_data
         .chunks(DATA_CHUNK_SIZE)
         .zip(0..)
@@ -1136,7 +1136,7 @@ fn process_pay(
                 .map(|authority| authority.keypair())
                 .unwrap_or(&config.keypair);
             system_transaction::nonced_transfer(
-                &config.keypair,
+                config.keypair.as_ref(),
                 to,
                 lamports,
                 nonce_account,
@@ -1144,7 +1144,7 @@ fn process_pay(
                 blockhash,
             )
         } else {
-            system_transaction::transfer(&config.keypair, to, lamports, blockhash)
+            system_transaction::transfer(config.keypair.as_ref(), to, lamports, blockhash)
         };
 
         if let Some(signers) = signers {
@@ -1167,7 +1167,8 @@ fn process_pay(
                 &fee_calculator,
                 &tx.message,
             )?;
-            let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+            let result =
+                rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
             log_instruction_custom_error::<SystemError>(result)
         }
     } else if *witnesses == None {
@@ -1190,7 +1191,7 @@ fn process_pay(
             lamports,
         );
         let mut tx = Transaction::new_signed_instructions(
-            &[&config.keypair, &contract_state],
+            &[config.keypair.as_ref(), &contract_state],
             ixs,
             blockhash,
         );
@@ -1207,7 +1208,7 @@ fn process_pay(
                 &tx.message,
             )?;
             let result = rpc_client
-                .send_and_confirm_transaction(&mut tx, &[&config.keypair, &contract_state]);
+                .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), &contract_state]);
             let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
 
             Ok(json!({
@@ -1238,7 +1239,7 @@ fn process_pay(
             lamports,
         );
         let mut tx = Transaction::new_signed_instructions(
-            &[&config.keypair, &contract_state],
+            &[config.keypair.as_ref(), &contract_state],
             ixs,
             blockhash,
         );
@@ -1249,7 +1250,7 @@ fn process_pay(
             return_signers(&tx)
         } else {
             let result = rpc_client
-                .send_and_confirm_transaction(&mut tx, &[&config.keypair, &contract_state]);
+                .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), &contract_state]);
             check_account_for_fee(
                 rpc_client,
                 &config.keypair.pubkey(),
@@ -1276,14 +1277,15 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
         pubkey,
         &config.keypair.pubkey(),
     );
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
+    let mut tx =
+        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 
@@ -1297,14 +1299,15 @@ fn process_time_elapsed(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_timestamp(&config.keypair.pubkey(), pubkey, to, dt);
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
+    let mut tx =
+        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 
@@ -1374,7 +1377,7 @@ fn process_transfer(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<SystemError>(result)
     }
 }
@@ -1388,14 +1391,15 @@ fn process_witness(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_signature(&config.keypair.pubkey(), pubkey, to);
-    let mut tx = Transaction::new_signed_instructions(&[&config.keypair], vec![ix], blockhash);
+    let mut tx =
+        Transaction::new_signed_instructions(&[config.keypair.as_ref()], vec![ix], blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1224,6 +1224,10 @@ fn process_transfer(
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
+    let mut signers = vec![fee_payer];
+    if *fee_payer != *from {
+        signers.push(from)
+    }
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1237,7 +1241,7 @@ fn process_transfer(
         Transaction::new_signed_with_payer(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer.as_ref(), from.as_ref()],
+            &signers,
             recent_blockhash,
         )
     };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -471,6 +471,12 @@ impl error::Error for CliError {
     }
 }
 
+impl From<Box<dyn error::Error>> for CliError {
+    fn from(error: Box<dyn error::Error>) -> Self {
+        CliError::DynamicProgramError(format!("{:?}", error))
+    }
+}
+
 pub struct CliConfig {
     pub command: CliCommand,
     pub json_rpc_url: String,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -33,7 +33,7 @@ use solana_sdk::{
     native_token::lamports_to_sol,
     program_utils::DecodeError,
     pubkey::Pubkey,
-    signature::{keypair_from_seed, Keypair, Signature, Signer, SignerError},
+    signature::{Keypair, Signature, Signer, SignerError},
     system_instruction::{self, create_address_with_seed, SystemError, MAX_ADDRESS_SEED_LEN},
     system_transaction,
     transaction::{Transaction, TransactionError},
@@ -45,6 +45,7 @@ use std::{
     fs::File,
     io::{Read, Write},
     net::{IpAddr, SocketAddr},
+    rc::Rc,
     thread::sleep,
     time::Duration,
     {error, fmt},
@@ -91,85 +92,6 @@ impl std::ops::Deref for KeypairEq {
     }
 }
 
-#[derive(Debug)]
-pub enum SigningAuthority {
-    Online(Keypair),
-    // We hold a random keypair alongside our legit pubkey in order
-    // to generate a placeholder signature in the transaction
-    Offline(Pubkey, Keypair),
-}
-
-impl SigningAuthority {
-    pub fn new_from_matches(
-        matches: &ArgMatches<'_>,
-        name: &str,
-        signers: Option<&[(Pubkey, Signature)]>,
-    ) -> Result<Option<Self>, CliError> {
-        if matches.is_present(name) {
-            keypair_of(matches, name)
-                .map(|keypair| keypair.into())
-                .or_else(|| {
-                    pubkey_of(matches, name)
-                        .filter(|pubkey| {
-                            signers
-                                .and_then(|signers| {
-                                    signers.iter().find(|(signer, _sig)| *signer == *pubkey)
-                                })
-                                .is_some()
-                        })
-                        .map(|pubkey| pubkey.into())
-                })
-                .ok_or_else(|| CliError::BadParameter("Invalid authority".to_string()))
-                .map(Some)
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub fn keypair(&self) -> &Keypair {
-        match self {
-            SigningAuthority::Online(keypair) => keypair,
-            SigningAuthority::Offline(_pubkey, keypair) => keypair,
-        }
-    }
-
-    pub fn pubkey(&self) -> Pubkey {
-        match self {
-            SigningAuthority::Online(keypair) => keypair.pubkey(),
-            SigningAuthority::Offline(pubkey, _keypair) => *pubkey,
-        }
-    }
-}
-
-impl From<Keypair> for SigningAuthority {
-    fn from(keypair: Keypair) -> Self {
-        SigningAuthority::Online(keypair)
-    }
-}
-
-impl From<Pubkey> for SigningAuthority {
-    fn from(pubkey: Pubkey) -> Self {
-        SigningAuthority::Offline(pubkey, keypair_from_seed(pubkey.as_ref()).unwrap())
-    }
-}
-
-impl PartialEq for SigningAuthority {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (SigningAuthority::Online(keypair1), SigningAuthority::Online(keypair2)) => {
-                keypair1.pubkey() == keypair2.pubkey()
-            }
-            (SigningAuthority::Online(keypair), SigningAuthority::Offline(pubkey, _))
-            | (SigningAuthority::Offline(pubkey, _), SigningAuthority::Online(keypair)) => {
-                keypair.pubkey() == *pubkey
-            }
-            (SigningAuthority::Offline(pubkey1, _), SigningAuthority::Offline(pubkey2, _)) => {
-                pubkey1 == pubkey2
-            }
-        }
-    }
-}
-
 pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     nonce::nonce_authority_arg().requires(NONCE_ARG.name)
 }
@@ -186,7 +108,7 @@ pub struct PayCommand {
     pub signers: Option<Vec<(Pubkey, Signature)>>,
     pub blockhash_query: BlockhashQuery,
     pub nonce_account: Option<Pubkey>,
-    pub nonce_authority: Option<SigningAuthority>,
+    pub nonce_authority: Option<Box<dyn Signer>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -242,11 +164,11 @@ pub enum CliCommand {
     // Nonce commands
     AuthorizeNonceAccount {
         nonce_account: Pubkey,
-        nonce_authority: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
         new_authority: Pubkey,
     },
     CreateNonceAccount {
-        nonce_account: KeypairEq,
+        nonce_account: Rc<Box<dyn Signer>>,
         seed: Option<String>,
         nonce_authority: Option<Pubkey>,
         lamports: u64,
@@ -254,7 +176,7 @@ pub enum CliCommand {
     GetNonce(Pubkey),
     NewNonce {
         nonce_account: Pubkey,
-        nonce_authority: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
     },
     ShowNonceAccount {
         nonce_account_pubkey: Pubkey,
@@ -262,7 +184,7 @@ pub enum CliCommand {
     },
     WithdrawFromNonceAccount {
         nonce_account: Pubkey,
-        nonce_authority: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
         destination_account_pubkey: Pubkey,
         lamports: u64,
     },
@@ -270,7 +192,7 @@ pub enum CliCommand {
     Deploy(String),
     // Stake Commands
     CreateStakeAccount {
-        stake_account: SigningAuthority,
+        stake_account: Rc<Box<dyn Signer>>,
         seed: Option<String>,
         staker: Option<Pubkey>,
         withdrawer: Option<Pubkey>,
@@ -280,44 +202,44 @@ pub enum CliCommand {
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
-        from: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
+        fee_payer: Option<Box<dyn Signer>>,
+        from: Option<Box<dyn Signer>>,
     },
     DeactivateStake {
         stake_account_pubkey: Pubkey,
-        stake_authority: Option<SigningAuthority>,
+        stake_authority: Option<Box<dyn Signer>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
+        fee_payer: Option<Box<dyn Signer>>,
     },
     DelegateStake {
         stake_account_pubkey: Pubkey,
         vote_account_pubkey: Pubkey,
-        stake_authority: Option<SigningAuthority>,
+        stake_authority: Option<Box<dyn Signer>>,
         force: bool,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
+        fee_payer: Option<Box<dyn Signer>>,
     },
     SplitStake {
         stake_account_pubkey: Pubkey,
-        stake_authority: Option<SigningAuthority>,
+        stake_authority: Option<Box<dyn Signer>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        split_stake_account: KeypairEq,
+        nonce_authority: Option<Box<dyn Signer>>,
+        split_stake_account: Rc<Box<dyn Signer>>,
         seed: Option<String>,
         lamports: u64,
-        fee_payer: Option<SigningAuthority>,
+        fee_payer: Option<Box<dyn Signer>>,
     },
     ShowStakeHistory {
         use_lamports_unit: bool,
@@ -330,36 +252,36 @@ pub enum CliCommand {
         stake_account_pubkey: Pubkey,
         new_authorized_pubkey: Pubkey,
         stake_authorize: StakeAuthorize,
-        authority: Option<SigningAuthority>,
+        authority: Option<Box<dyn Signer>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
+        fee_payer: Option<Box<dyn Signer>>,
     },
     StakeSetLockup {
         stake_account_pubkey: Pubkey,
         lockup: Lockup,
-        custodian: Option<SigningAuthority>,
+        custodian: Option<Box<dyn Signer>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
+        fee_payer: Option<Box<dyn Signer>>,
     },
     WithdrawStake {
         stake_account_pubkey: Pubkey,
         destination_account_pubkey: Pubkey,
         lamports: u64,
-        withdraw_authority: Option<SigningAuthority>,
+        withdraw_authority: Option<Box<dyn Signer>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
+        fee_payer: Option<Box<dyn Signer>>,
     },
     // Storage Commands
     CreateStorageAccount {
@@ -426,13 +348,13 @@ pub enum CliCommand {
     Transfer {
         lamports: u64,
         to: Pubkey,
-        from: Option<SigningAuthority>,
+        from: Option<Box<dyn Signer>>,
         sign_only: bool,
         signers: Option<Vec<(Pubkey, Signature)>>,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<SigningAuthority>,
-        fee_payer: Option<SigningAuthority>,
+        nonce_authority: Option<Box<dyn Signer>>,
+        fee_payer: Option<Box<dyn Signer>>,
     },
     Witness(Pubkey, Pubkey), // Witness(to, process_id)
 }
@@ -695,11 +617,7 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(&matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = SigningAuthority::new_from_matches(
-                &matches,
-                NONCE_AUTHORITY_ARG.name,
-                signers.as_deref(),
-            )?;
+            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
 
             Ok(CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
@@ -765,17 +683,9 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = SigningAuthority::new_from_matches(
-                &matches,
-                NONCE_AUTHORITY_ARG.name,
-                signers.as_deref(),
-            )?;
-            let fee_payer = SigningAuthority::new_from_matches(
-                &matches,
-                FEE_PAYER_ARG.name,
-                signers.as_deref(),
-            )?;
-            let from = SigningAuthority::new_from_matches(&matches, "from", signers.as_deref())?;
+            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
+            let fee_payer = signer_of(FEE_PAYER_ARG.name, &matches)?;
+            let from = signer_of("from", &matches)?;
             Ok(CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports,
@@ -1121,7 +1031,7 @@ fn process_pay(
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
@@ -1137,10 +1047,8 @@ fn process_pay(
     };
 
     if timestamp == None && *witnesses == None {
+        let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
         let mut tx = if let Some(nonce_account) = &nonce_account {
-            let nonce_authority: &Keypair = nonce_authority
-                .map(|authority| authority.keypair())
-                .unwrap_or(&config.keypair);
             system_transaction::nonced_transfer(
                 config.keypair.as_ref(),
                 to,
@@ -1161,11 +1069,8 @@ fn process_pay(
             return_signers(&tx)
         } else {
             if let Some(nonce_account) = &nonce_account {
-                let nonce_authority: Pubkey = nonce_authority
-                    .map(|authority| authority.pubkey())
-                    .unwrap_or_else(|| config.keypair.pubkey());
                 let nonce_account = rpc_client.get_account(nonce_account)?;
-                check_nonce_account(&nonce_account, &nonce_authority, &blockhash)?;
+                check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &blockhash)?;
             }
             check_account_for_fee(
                 rpc_client,
@@ -1323,20 +1228,18 @@ fn process_transfer(
     config: &CliConfig,
     lamports: u64,
     to: &Pubkey,
-    from: Option<&SigningAuthority>,
+    from: Option<&(dyn Signer + 'static)>,
     sign_only: bool,
     signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&(dyn Signer + 'static)>,
+    fee_payer: Option<&(dyn Signer + 'static)>,
 ) -> ProcessResult {
-    let (from_pubkey, from) = from
-        .map(|f| (f.pubkey(), f.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let from = from.unwrap_or_else(|| config.keypair.as_ref());
 
     check_unique_pubkeys(
-        (&from_pubkey, "cli keypair".to_string()),
+        (&from.pubkey(), "cli keypair".to_string()),
         (to, "to".to_string()),
     )?;
 
@@ -1344,10 +1247,8 @@ fn process_transfer(
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
     let ixs = vec![system_instruction::transfer(&from.pubkey(), to, lamports)];
 
-    let (nonce_authority_pubkey, nonce_authority) = nonce_authority
-        .map(|authority| (authority.pubkey(), authority.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
-    let fee_payer = fee_payer.map(|fp| fp.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1361,7 +1262,7 @@ fn process_transfer(
         Transaction::new_signed_with_payer(
             ixs,
             Some(&fee_payer.pubkey()),
-            &[fee_payer, from],
+            &[fee_payer.as_ref(), from.as_ref()],
             recent_blockhash,
         )
     };
@@ -1375,7 +1276,7 @@ fn process_transfer(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1498,7 +1399,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             nonce_account,
-            nonce_authority.as_ref(),
+            nonce_authority.as_deref(),
             new_authority,
         ),
         // Create nonce account
@@ -1510,7 +1411,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_create_nonce_account(
             &rpc_client,
             config,
-            nonce_account,
+            nonce_account.as_ref().as_ref(),
             seed.clone(),
             *nonce_authority,
             *lamports,
@@ -1523,7 +1424,12 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::NewNonce {
             nonce_account,
             ref nonce_authority,
-        } => process_new_nonce(&rpc_client, config, nonce_account, nonce_authority.as_ref()),
+        } => process_new_nonce(
+            &rpc_client,
+            config,
+            nonce_account,
+            nonce_authority.as_deref(),
+        ),
         // Show the contents of a nonce account
         CliCommand::ShowNonceAccount {
             nonce_account_pubkey,
@@ -1539,7 +1445,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             &nonce_account,
-            nonce_authority.as_ref(),
+            nonce_authority.as_deref(),
             &destination_account_pubkey,
             *lamports,
         ),
@@ -1571,7 +1477,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_create_stake_account(
             &rpc_client,
             config,
-            stake_account,
+            stake_account.as_ref().as_ref(),
             seed,
             staker,
             withdrawer,
@@ -1581,9 +1487,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
-            from.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
+            from.as_deref(),
         ),
         CliCommand::DeactivateStake {
             stake_account_pubkey,
@@ -1598,13 +1504,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             &stake_account_pubkey,
-            stake_authority.as_ref(),
+            stake_authority.as_deref(),
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::DelegateStake {
             stake_account_pubkey,
@@ -1622,14 +1528,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             &stake_account_pubkey,
             &vote_account_pubkey,
-            stake_authority.as_ref(),
+            stake_authority.as_deref(),
             *force,
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::SplitStake {
             stake_account_pubkey,
@@ -1647,16 +1553,16 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             &stake_account_pubkey,
-            stake_authority.as_ref(),
+            stake_authority.as_deref(),
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            split_stake_account,
+            nonce_authority.as_deref(),
+            split_stake_account.as_ref().as_ref(),
             seed,
             *lamports,
-            fee_payer.as_ref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::ShowStakeAccount {
             pubkey: stake_account_pubkey,
@@ -1687,13 +1593,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &stake_account_pubkey,
             &new_authorized_pubkey,
             *stake_authorize,
-            authority.as_ref(),
+            authority.as_deref(),
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::StakeSetLockup {
             stake_account_pubkey,
@@ -1710,13 +1616,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             &stake_account_pubkey,
             &mut lockup,
-            custodian.as_ref(),
+            custodian.as_deref(),
             *sign_only,
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         CliCommand::WithdrawStake {
             stake_account_pubkey,
@@ -1735,13 +1641,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &stake_account_pubkey,
             &destination_account_pubkey,
             *lamports,
-            withdraw_authority.as_ref(),
+            withdraw_authority.as_deref(),
             *sign_only,
             signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
 
         // Storage Commands
@@ -1902,7 +1808,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             signers,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_ref(),
+            nonce_authority.as_deref(),
         ),
         CliCommand::ShowAccount {
             pubkey,
@@ -1934,13 +1840,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             config,
             *lamports,
             to,
-            from.as_ref(),
+            from.as_deref(),
             *sign_only,
             signers.as_ref(),
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_ref(),
-            fee_payer.as_ref(),
+            nonce_authority.as_deref(),
+            fee_payer.as_deref(),
         ),
         // Apply witness signature to contract
         CliCommand::Witness(to, pubkey) => process_witness(&rpc_client, config, &to, &pubkey),
@@ -2379,7 +2285,7 @@ mod tests {
         account::Account,
         nonce_state::{Meta as NonceMeta, NonceState},
         pubkey::Pubkey,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair_file},
+        signature::{keypair_from_seed, read_keypair_file, write_keypair_file, Presigner},
         system_program,
         transaction::TransactionError,
     };
@@ -2397,13 +2303,6 @@ mod tests {
         let _ignored = std::fs::remove_file(&path);
 
         path
-    }
-
-    #[test]
-    fn test_signing_authority_dummy_keypairs() {
-        let signing_authority: SigningAuthority = Pubkey::new(&[1u8; 32]).into();
-        assert_eq!(signing_authority, Pubkey::new(&[1u8; 32]).into());
-        assert_ne!(signing_authority, Pubkey::new(&[2u8; 32]).into());
     }
 
     #[test]
@@ -2855,7 +2754,7 @@ mod tests {
                     to: pubkey,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(pubkey),
-                    nonce_authority: Some(authority_pubkey.into()),
+                    nonce_authority: Some(Presigner::new(&authority_pubkey, &sig).into()),
                     signers: Some(vec![(authority_pubkey, sig)]),
                     ..PayCommand::default()
                 }),
@@ -3452,13 +3351,13 @@ mod tests {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
                     to: to_pubkey,
-                    from: Some(from_pubkey.into()),
+                    from: Some(Presigner::new(&from_pubkey, &from_sig).into()),
                     sign_only: false,
                     signers: Some(vec![(from_pubkey, from_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: Some(from_pubkey.into()),
+                    fee_payer: Some(Presigner::new(&from_pubkey, &from_sig).into()),
                 },
                 require_keypair: true,
             }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -20,9 +20,11 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     epoch_schedule::Epoch,
     hash::Hash,
+    message::Message,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
-    system_transaction,
+    system_instruction,
+    transaction::Transaction,
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -743,8 +745,10 @@ pub fn process_ping(
         let (recent_blockhash, fee_calculator) = rpc_client.get_new_blockhash(&last_blockhash)?;
         last_blockhash = recent_blockhash;
 
-        let transaction =
-            system_transaction::transfer(config.keypair.as_ref(), &to, lamports, recent_blockhash);
+        let ix = system_instruction::transfer(&config.keypair.pubkey(), &to, lamports);
+        let message = Message::new(vec![ix]);
+        let mut transaction = Transaction::new_unsigned(message);
+        transaction.sign(&[config.keypair.as_ref()], recent_blockhash);
         check_account_for_fee(
             rpc_client,
             &config.keypair.pubkey(),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -744,7 +744,7 @@ pub fn process_ping(
         last_blockhash = recent_blockhash;
 
         let transaction =
-            system_transaction::transfer(&config.keypair, &to, lamports, recent_blockhash);
+            system_transaction::transfer(config.keypair.as_ref(), &to, lamports, recent_blockhash);
         check_account_for_fee(
             rpc_client,
             &config.keypair.pubkey(),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -748,7 +748,7 @@ pub fn process_ping(
         let ix = system_instruction::transfer(&config.keypair.pubkey(), &to, lamports);
         let message = Message::new(vec![ix]);
         let mut transaction = Transaction::new_unsigned(message);
-        transaction.sign(&[config.keypair.as_ref()], recent_blockhash);
+        transaction.try_sign(&[config.keypair.as_ref()], recent_blockhash)?;
         check_account_for_fee(
             rpc_client,
             &config.keypair.pubkey(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,17 +4,13 @@ use console::style;
 use solana_clap_utils::{
     input_parsers::derivation_of,
     input_validators::{is_derivation, is_url},
-    keypair::{
-        self, keypair_input, KeypairWithSource, ASK_SEED_PHRASE_ARG,
-        SKIP_SEED_PHRASE_VALIDATION_ARG,
-    },
+    keypair::{keypair_util_from_path, ASK_SEED_PHRASE_ARG, SKIP_SEED_PHRASE_VALIDATION_ARG},
 };
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliError},
     display::{println_name_value, println_name_value_or},
 };
 use solana_cli_config::config::{Config, CONFIG_FILE};
-use solana_sdk::signature::read_keypair_file;
 
 use std::error;
 
@@ -105,42 +101,24 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
     } = parse_command(&matches)?;
 
     let (keypair, keypair_path) = if require_keypair {
-        let KeypairWithSource { keypair, source } = keypair_input(&matches, "keypair")?;
-        match source {
-            keypair::Source::Path => (
-                keypair,
-                Some(matches.value_of("keypair").unwrap().to_string()),
-            ),
-            keypair::Source::SeedPhrase => (keypair, None),
-            keypair::Source::Generated => {
-                let keypair_path = if config.keypair_path != "" {
-                    config.keypair_path
-                } else {
-                    let default_keypair_path = CliConfig::default_keypair_path();
-                    if !std::path::Path::new(&default_keypair_path).exists() {
-                        return Err(CliError::KeypairFileNotFound(format!(
-                            "Generate a new keypair at {} with `solana-keygen new`",
-                            default_keypair_path
-                        ))
-                        .into());
-                    }
+        let path = if matches.is_present("keypair") {
+            matches.value_of("keypair").unwrap().to_string()
+        } else if config.keypair_path != "" {
+            config.keypair_path
+        } else {
+            let default_keypair_path = CliConfig::default_keypair_path();
+            if !std::path::Path::new(&default_keypair_path).exists() {
+                return Err(CliError::KeypairFileNotFound(format!(
+                    "Generate a new keypair at {} with `solana-keygen new`",
                     default_keypair_path
-                };
-
-                let keypair = if keypair_path.starts_with("usb://") {
-                    keypair
-                } else {
-                    read_keypair_file(&keypair_path).or_else(|err| {
-                        Err(CliError::BadParameter(format!(
-                            "{}: Unable to open keypair file: {}",
-                            err, keypair_path
-                        )))
-                    })?
-                };
-
-                (keypair, Some(keypair_path))
+                ))
+                .into());
             }
-        }
+            default_keypair_path
+        };
+
+        let keypair = keypair_util_from_path(matches, &path, "keypair")?;
+        (keypair, Some(path))
     } else {
         let default = CliConfig::default();
         (default.keypair, None)
@@ -201,6 +179,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Arg::with_name("derivation_path")
             .long("derivation-path")
             .value_name("ACCOUNT or ACCOUNT/CHANGE")
+            .global(true)
             .takes_value(true)
             .validator(is_derivation)
             .help("Derivation path to use: m/44'/501'/ACCOUNT'/CHANGE'; default key is device base pubkey: m/44'/501'/0'")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ use console::style;
 use solana_clap_utils::{
     input_parsers::derivation_of,
     input_validators::{is_derivation, is_url},
-    keypair::{keypair_util_from_path, ASK_SEED_PHRASE_ARG, SKIP_SEED_PHRASE_VALIDATION_ARG},
+    keypair::{keypair_util_from_path, SKIP_SEED_PHRASE_VALIDATION_ARG},
 };
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliError},
@@ -190,15 +190,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .short("v")
             .global(true)
             .help("Show extra information header"),
-    )
-    .arg(
-        Arg::with_name(ASK_SEED_PHRASE_ARG.name)
-            .long(ASK_SEED_PHRASE_ARG.long)
-            .value_name("KEYPAIR NAME")
-            .global(true)
-            .takes_value(true)
-            .possible_values(&["keypair"])
-            .help(ASK_SEED_PHRASE_ARG.help),
     )
     .arg(
         Arg::with_name(SKIP_SEED_PHRASE_VALIDATION_ARG.name)

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -348,7 +348,7 @@ pub fn process_authorize_nonce_account(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -357,8 +357,8 @@ pub fn process_authorize_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), nonce_authority]);
     log_instruction_custom_error::<NonceError>(result)
 }
 
@@ -428,9 +428,9 @@ pub fn process_create_nonce_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let signers = if nonce_account_pubkey != config.keypair.pubkey() {
-        vec![&config.keypair, nonce_account] // both must sign if `from` and `to` differ
+        vec![config.keypair.as_ref(), nonce_account] // both must sign if `from` and `to` differ
     } else {
-        vec![&config.keypair] // when stake_account == config.keypair and there's a seed, we only need one signature
+        vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
     let mut tx = Transaction::new_signed_with_payer(
@@ -495,7 +495,7 @@ pub fn process_new_nonce(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -504,8 +504,8 @@ pub fn process_new_nonce(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), nonce_authority]);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -580,7 +580,7 @@ pub fn process_withdraw_from_nonce_account(
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, nonce_authority],
+        &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -589,8 +589,8 @@ pub fn process_withdraw_from_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, nonce_authority]);
+    let result = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), nonce_authority]);
     log_instruction_custom_error::<NonceError>(result)
 }
 

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -2,9 +2,10 @@ use crate::cli::{
     build_balance_message, check_account_for_fee, check_unique_pubkeys,
     log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult,
 };
-use crate::offline::BLOCKHASH_ARG;
 use clap::{App, Arg, ArgMatches, SubCommand};
-use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
+use solana_clap_utils::{
+    input_parsers::*, input_validators::*, offline::BLOCKHASH_ARG, ArgConstant,
+};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     account::Account,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -592,9 +592,10 @@ mod tests {
         account::Account,
         hash::hash,
         nonce_state::{Meta as NonceMeta, NonceState},
-        signature::{read_keypair_file, write_keypair},
+        signature::{read_keypair_file, write_keypair, Keypair},
         system_program,
     };
+    use std::rc::Rc;
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -668,7 +669,7 @@ mod tests {
             parse_command(&test_create_nonce_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     nonce_authority: None,
                     lamports: 50_000_000_000,
@@ -690,7 +691,7 @@ mod tests {
             parse_command(&test_create_nonce_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    nonce_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     nonce_authority: Some(
                         read_keypair_file(&authority_keypair_file).unwrap().pubkey()

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -343,10 +343,10 @@ pub fn process_authorize_nonce_account(
     let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
     let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(
+    tx.try_sign(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
-    );
+    )?;
 
     check_account_for_fee(
         rpc_client,
@@ -432,7 +432,7 @@ pub fn process_create_nonce_account(
 
     let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(&signers, recent_blockhash);
+    tx.try_sign(&signers, recent_blockhash)?;
 
     check_account_for_fee(
         rpc_client,
@@ -487,10 +487,10 @@ pub fn process_new_nonce(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(
+    tx.try_sign(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
-    );
+    )?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -570,10 +570,10 @@ pub fn process_withdraw_from_nonce_account(
     );
     let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(
+    tx.try_sign(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
-    );
+    )?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -10,6 +10,7 @@ use solana_sdk::{
     account::Account,
     account_utils::StateMut,
     hash::Hash,
+    message::Message,
     nonce_state::{Meta, NonceState},
     pubkey::Pubkey,
     signature::Signer,
@@ -339,12 +340,13 @@ pub fn process_authorize_nonce_account(
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
-    let mut tx = Transaction::new_signed_with_payer(
-        vec![ix],
-        Some(&config.keypair.pubkey()),
+    let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
+
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -427,12 +429,10 @@ pub fn process_create_nonce_account(
         vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
-    let mut tx = Transaction::new_signed_with_payer(
-        ixs,
-        Some(&config.keypair.pubkey()),
-        &signers,
-        recent_blockhash,
-    );
+    let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(&signers, recent_blockhash);
+
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -484,9 +484,9 @@ pub fn process_new_nonce(
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = advance_nonce_account(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let mut tx = Transaction::new_signed_with_payer(
-        vec![ix],
-        Some(&config.keypair.pubkey()),
+    let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );
@@ -567,9 +567,9 @@ pub fn process_withdraw_from_nonce_account(
         destination_account_pubkey,
         lamports,
     );
-    let mut tx = Transaction::new_signed_with_payer(
-        vec![ix],
-        Some(&config.keypair.pubkey()),
+    let message = Message::new_with_payer(vec![ix], Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(
         &[config.keypair.as_ref(), nonce_authority],
         recent_blockhash,
     );

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -64,8 +64,8 @@ pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(NONCE_AUTHORITY_ARG.name)
         .long(NONCE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(NONCE_AUTHORITY_ARG.help)
 }
 

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -1,7 +1,6 @@
 use crate::cli::{
     build_balance_message, check_account_for_fee, check_unique_pubkeys,
     log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult,
-    SigningAuthority,
 };
 use crate::offline::BLOCKHASH_ARG;
 use clap::{App, Arg, ArgMatches, SubCommand};
@@ -13,7 +12,7 @@ use solana_sdk::{
     hash::Hash,
     nonce_state::{Meta, NonceState},
     pubkey::Pubkey,
-    signature::{Keypair, Signer},
+    signature::Signer,
     system_instruction::{
         advance_nonce_account, authorize_nonce_account, create_address_with_seed,
         create_nonce_account, create_nonce_account_with_seed, withdraw_nonce_account, NonceError,
@@ -218,8 +217,7 @@ impl NonceSubCommands for App<'_, '_> {
 pub fn parse_authorize_nonce_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let new_authority = pubkey_of(matches, "new_authority").unwrap();
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, None)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::AuthorizeNonceAccount {
@@ -232,7 +230,7 @@ pub fn parse_authorize_nonce_account(matches: &ArgMatches<'_>) -> Result<CliComm
 }
 
 pub fn parse_nonce_create_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let nonce_account = keypair_of(matches, "nonce_account_keypair").unwrap();
+    let nonce_account = signer_of("nonce_account_keypair", matches)?.unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let nonce_authority = pubkey_of(matches, NONCE_AUTHORITY_ARG.name);
@@ -259,8 +257,7 @@ pub fn parse_get_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliEr
 
 pub fn parse_new_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, None)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::NewNonce {
@@ -290,8 +287,7 @@ pub fn parse_withdraw_from_nonce_account(
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let destination_account_pubkey = pubkey_of(matches, "destination_account_pubkey").unwrap();
     let lamports = lamports_of_sol(matches, "amount").unwrap();
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, None)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawFromNonceAccount {
@@ -336,14 +332,12 @@ pub fn process_authorize_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
     new_authority: &Pubkey,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let nonce_authority = nonce_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
     let mut tx = Transaction::new_signed_with_payer(
         vec![ix],
@@ -365,7 +359,7 @@ pub fn process_authorize_nonce_account(
 pub fn process_create_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    nonce_account: &Keypair,
+    nonce_account: &dyn Signer,
     seed: Option<String>,
     nonce_authority: Option<Pubkey>,
     lamports: u64,
@@ -473,7 +467,7 @@ pub fn process_new_nonce(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
@@ -487,9 +481,7 @@ pub fn process_new_nonce(
         .into());
     }
 
-    let nonce_authority = nonce_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = advance_nonce_account(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_signed_with_payer(
@@ -562,15 +554,13 @@ pub fn process_withdraw_from_nonce_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     nonce_account: &Pubkey,
-    nonce_authority: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
     destination_account_pubkey: &Pubkey,
     lamports: u64,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let nonce_authority = nonce_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ix = withdraw_nonce_account(
         nonce_account,
         &nonce_authority.pubkey(),

--- a/cli/src/offline.rs
+++ b/cli/src/offline.rs
@@ -3,29 +3,11 @@ use serde_json::Value;
 use solana_clap_utils::{
     input_parsers::value_of,
     input_validators::{is_hash, is_pubkey_sig},
-    ArgConstant,
+    offline::{BLOCKHASH_ARG, SIGNER_ARG, SIGN_ONLY_ARG},
 };
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{fee_calculator::FeeCalculator, hash::Hash, pubkey::Pubkey, signature::Signature};
 use std::str::FromStr;
-
-pub const BLOCKHASH_ARG: ArgConstant<'static> = ArgConstant {
-    name: "blockhash",
-    long: "blockhash",
-    help: "Use the supplied blockhash",
-};
-
-pub const SIGN_ONLY_ARG: ArgConstant<'static> = ArgConstant {
-    name: "sign_only",
-    long: "sign-only",
-    help: "Sign the transaction offline",
-};
-
-pub const SIGNER_ARG: ArgConstant<'static> = ArgConstant {
-    name: "signer",
-    long: "signer",
-    help: "Provide a public-key/signature pair for the transaction",
-};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum BlockhashQuery {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use clap::{App, Arg, ArgMatches, SubCommand};
 use console::style;
-use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
+use solana_clap_utils::{input_parsers::*, input_validators::*, offline::*, ArgConstant};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     account_utils::StateMut,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -45,8 +45,8 @@ fn stake_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(STAKE_AUTHORITY_ARG.name)
         .long(STAKE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(STAKE_AUTHORITY_ARG.help)
 }
 
@@ -54,8 +54,8 @@ fn withdraw_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
         .long(WITHDRAW_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY")
-        .validator(is_pubkey_or_keypair_or_ask_keyword)
+        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .validator(is_valid_signer)
         .help(WITHDRAW_AUTHORITY_ARG.help)
 }
 
@@ -74,7 +74,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("STAKE ACCOUNT")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .validator(is_valid_signer)
                         .help("Signing authority of the stake address to fund")
                 )
                 .arg(
@@ -136,8 +136,8 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("from")
                         .long("from")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Source account of funds (if different from client local account)"),
                 )
                 .offline_args()
@@ -367,8 +367,8 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("custodian")
                         .long("custodian")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY")
-                        .validator(is_pubkey_or_keypair_or_ask_keyword)
+                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .validator(is_valid_signer)
                         .help("Public key of signing custodian (defaults to cli config pubkey)")
                 )
                 .offline_args()

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1590,7 +1590,7 @@ mod tests {
                     authority: None,
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
+                    nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&pubkey2, &sig2).into()),
                     fee_payer: Some(Presigner::new(&pubkey, &sig).into()),
                 },
@@ -2070,7 +2070,7 @@ mod tests {
             &key1.to_string(),
             "--nonce",
             &nonce_account.to_string(),
-            "--nonce_auhtority",
+            "--nonce-authority",
             &key2.to_string(),
         ]);
         assert_eq!(
@@ -2373,7 +2373,7 @@ mod tests {
             &key1.to_string(),
             "--nonce",
             &nonce_account.to_string(),
-            "--nonce-account",
+            "--nonce-authority",
             &key2.to_string(),
         ]);
         assert_eq!(
@@ -2384,7 +2384,7 @@ mod tests {
                     stake_authority: None,
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
+                    nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
                     fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -441,7 +441,6 @@ pub fn parse_stake_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
             },
             lamports,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -472,7 +471,6 @@ pub fn parse_stake_delegate_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
             stake_authority,
             force,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -493,7 +491,6 @@ pub fn parse_stake_authorize(
         StakeAuthorize::Withdrawer => WITHDRAW_AUTHORITY_ARG.name,
     };
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-    let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
     let authority = signer_of(authority_flag, matches)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
@@ -507,7 +504,6 @@ pub fn parse_stake_authorize(
             stake_authorize,
             authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -537,7 +533,6 @@ pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Cli
             stake_account_pubkey,
             stake_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -566,7 +561,6 @@ pub fn parse_stake_deactivate_stake(matches: &ArgMatches<'_>) -> Result<CliComma
             stake_account_pubkey,
             stake_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -596,7 +590,6 @@ pub fn parse_stake_withdraw_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
             lamports,
             withdraw_authority,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -632,7 +625,6 @@ pub fn parse_stake_set_lockup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
             },
             custodian,
             sign_only,
-            signers,
             blockhash_query,
             nonce_account,
             nonce_authority,
@@ -673,7 +665,6 @@ pub fn process_create_stake_account(
     lockup: &Lockup,
     lamports: u64,
     sign_only: bool,
-    signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
     nonce_authority: Option<&dyn Signer>,
@@ -779,9 +770,6 @@ pub fn process_create_stake_account(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -809,7 +797,6 @@ pub fn process_stake_authorize(
     stake_authorize: StakeAuthorize,
     authority: Option<&dyn Signer>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn Signer>,
@@ -848,9 +835,6 @@ pub fn process_stake_authorize(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -876,7 +860,6 @@ pub fn process_deactivate_stake_account(
     stake_account_pubkey: &Pubkey,
     stake_authority: Option<&dyn Signer>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn Signer>,
@@ -908,9 +891,6 @@ pub fn process_deactivate_stake_account(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -938,7 +918,6 @@ pub fn process_withdraw_stake(
     lamports: u64,
     withdraw_authority: Option<&dyn Signer>,
     sign_only: bool,
-    signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
     nonce_authority: Option<&dyn Signer>,
@@ -974,9 +953,6 @@ pub fn process_withdraw_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1002,7 +978,6 @@ pub fn process_split_stake(
     stake_account_pubkey: &Pubkey,
     stake_authority: Option<&dyn Signer>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn Signer>,
@@ -1116,9 +1091,6 @@ pub fn process_split_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1145,7 +1117,6 @@ pub fn process_stake_set_lockup(
     lockup: &mut Lockup,
     custodian: Option<&dyn Signer>,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
     nonce_authority: Option<&dyn Signer>,
@@ -1182,9 +1153,6 @@ pub fn process_stake_set_lockup(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1416,9 +1384,6 @@ pub fn process_delegate_stake(
             recent_blockhash,
         )
     };
-    if let Some(signers) = signers {
-        replace_signatures(&mut tx, &signers)?;
-    }
     if sign_only {
         return_signers(&tx)
     } else {
@@ -1482,7 +1447,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1509,7 +1473,6 @@ mod tests {
                     stake_authorize,
                     authority: Some(read_keypair_file(&authority_keypair_file).unwrap().into()),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1539,7 +1502,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1574,7 +1536,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(keypair.pubkey(), sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1616,7 +1577,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(keypair.pubkey(), sig), (keypair2.pubkey(), sig2),]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: Some(Presigner::new(&pubkey2, &sig2).into()),
@@ -1643,7 +1603,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1679,7 +1638,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(nonce_account_pubkey),
                     nonce_authority: Some(nonce_authority_keypair.into()),
@@ -1711,7 +1669,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1744,7 +1701,6 @@ mod tests {
                     stake_authorize,
                     authority: None,
                     sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1813,7 +1769,6 @@ mod tests {
                     },
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1848,7 +1803,6 @@ mod tests {
                     lockup: Lockup::default(),
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -1899,7 +1853,6 @@ mod tests {
                     lockup: Lockup::default(),
                     lamports: 50_000_000_000,
                     sign_only: false,
-                    signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
@@ -1928,7 +1881,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1962,7 +1914,6 @@ mod tests {
                     ),
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -1989,7 +1940,6 @@ mod tests {
                     stake_authority: None,
                     force: true,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2019,7 +1969,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2047,7 +1996,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2082,7 +2030,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2155,7 +2102,6 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2217,7 +2163,6 @@ mod tests {
                     lamports: 42_000_000_000,
                     withdraw_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2251,7 +2196,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2295,7 +2239,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
                     nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
@@ -2318,7 +2261,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2347,7 +2289,6 @@ mod tests {
                             .into()
                     ),
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2374,7 +2315,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2399,7 +2339,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: true,
-                    signers: None,
                     blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2431,7 +2370,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2469,7 +2407,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1), (key2, sig2)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
@@ -2494,7 +2431,6 @@ mod tests {
                     stake_account_pubkey,
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::All,
                     nonce_account: None,
                     nonce_authority: None,
@@ -2557,7 +2493,6 @@ mod tests {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
                     stake_authority: None,
                     sign_only: false,
-                    signers: None,
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
@@ -2616,10 +2551,6 @@ mod tests {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
                     stake_authority: Some(Presigner::new(&stake_auth_pubkey, &stake_sig).into()),
                     sign_only: false,
-                    signers: Some(vec![
-                        (nonce_auth_pubkey, nonce_sig),
-                        (stake_auth_pubkey, stake_sig)
-                    ]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account.into()),
                     nonce_authority: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1,9 +1,8 @@
 use crate::{
     cli::{
         build_balance_message, check_account_for_fee, check_unique_pubkeys, fee_payer_arg,
-        log_instruction_custom_error, nonce_authority_arg, replace_signatures, return_signers,
-        CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult, SigningAuthority,
-        FEE_PAYER_ARG,
+        log_instruction_custom_error, nonce_authority_arg, return_signers, CliCommand,
+        CliCommandInfo, CliConfig, CliError, ProcessResult, FEE_PAYER_ARG,
     },
     nonce::{check_nonce_account, nonce_arg, NONCE_ARG, NONCE_AUTHORITY_ARG},
     offline::*,
@@ -12,7 +11,6 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 use console::style;
 use solana_clap_utils::{input_parsers::*, input_validators::*, ArgConstant};
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::signature::{Keypair, Signature};
 use solana_sdk::{
     account_utils::StateMut,
     pubkey::Pubkey,
@@ -425,19 +423,14 @@ pub fn parse_stake_create_account(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
-    let from = SigningAuthority::new_from_matches(&matches, "from", signers.as_deref())?;
-    let stake_account =
-        SigningAuthority::new_from_matches(&matches, "stake_account", signers.as_deref())
-            .unwrap()
-            .unwrap();
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
+    let from = signer_of("from", matches)?;
+    let stake_account = signer_of("stake_account", matches)?.unwrap();
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateStakeAccount {
-            stake_account,
+            stake_account: stake_account.into(),
             seed,
             staker,
             withdrawer,
@@ -468,12 +461,9 @@ pub fn parse_stake_delegate_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        SigningAuthority::new_from_matches(&matches, STAKE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DelegateStake {
@@ -504,14 +494,11 @@ pub fn parse_stake_authorize(
     };
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let signers = pubkeys_sigs_of(&matches, SIGNER_ARG.name);
-    let authority =
-        SigningAuthority::new_from_matches(&matches, authority_flag, signers.as_deref())?;
+    let authority = signer_of(authority_flag, matches)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeAuthorize {
@@ -532,7 +519,7 @@ pub fn parse_stake_authorize(
 
 pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
-    let split_stake_account = keypair_of(matches, "split_stake_account").unwrap();
+    let split_stake_account = signer_of("split_stake_account", matches)?.unwrap();
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
 
@@ -541,12 +528,9 @@ pub fn parse_split_stake(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Cli
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        SigningAuthority::new_from_matches(&matches, STAKE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::SplitStake {
@@ -573,12 +557,9 @@ pub fn parse_stake_deactivate_stake(matches: &ArgMatches<'_>) -> Result<CliComma
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority =
-        SigningAuthority::new_from_matches(&matches, STAKE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DeactivateStake {
@@ -604,15 +585,9 @@ pub fn parse_stake_withdraw_stake(matches: &ArgMatches<'_>) -> Result<CliCommand
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let withdraw_authority = SigningAuthority::new_from_matches(
-        &matches,
-        WITHDRAW_AUTHORITY_ARG.name,
-        signers.as_deref(),
-    )?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let withdraw_authority = signer_of(WITHDRAW_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawStake {
@@ -643,11 +618,9 @@ pub fn parse_stake_set_lockup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
     let require_keypair = signers.is_none();
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
 
-    let custodian = SigningAuthority::new_from_matches(&matches, "custodian", signers.as_deref())?;
-    let nonce_authority =
-        SigningAuthority::new_from_matches(&matches, NONCE_AUTHORITY_ARG.name, signers.as_deref())?;
-    let fee_payer =
-        SigningAuthority::new_from_matches(&matches, FEE_PAYER_ARG.name, signers.as_deref())?;
+    let custodian = signer_of("custodian", matches)?;
+    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches)?;
+    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeSetLockup {
@@ -693,7 +666,7 @@ pub fn parse_show_stake_history(matches: &ArgMatches<'_>) -> Result<CliCommandIn
 pub fn process_create_stake_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    stake_account: &SigningAuthority,
+    stake_account: &dyn Signer,
     seed: &Option<String>,
     staker: &Option<Pubkey>,
     withdrawer: &Option<Pubkey>,
@@ -703,13 +676,13 @@ pub fn process_create_stake_account(
     signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
-    from: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
+    fee_payer: Option<&dyn Signer>,
+    from: Option<&dyn Signer>,
 ) -> ProcessResult {
     // Offline derived address creation currently is not possible
     // https://github.com/solana-labs/solana/pull/8252
-    if seed.is_some() && (sign_only || signers.is_some()) {
+    if seed.is_some() && sign_only {
         return Err(CliError::BadParameter(
             "Offline stake account creation with derived addresses are not yet supported"
                 .to_string(),
@@ -717,17 +690,14 @@ pub fn process_create_stake_account(
         .into());
     }
 
-    let (stake_account_pubkey, stake_account) = (stake_account.pubkey(), stake_account.keypair());
     let stake_account_address = if let Some(seed) = seed {
-        create_address_with_seed(&stake_account_pubkey, &seed, &solana_stake_program::id())?
+        create_address_with_seed(&stake_account.pubkey(), &seed, &solana_stake_program::id())?
     } else {
-        stake_account_pubkey
+        stake_account.pubkey()
     };
-    let (from_pubkey, from) = from
-        .map(|f| (f.pubkey(), f.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let from = from.unwrap_or_else(|| config.keypair.as_ref());
     check_unique_pubkeys(
-        (&from_pubkey, "from keypair".to_string()),
+        (&from.pubkey(), "from keypair".to_string()),
         (&stake_account_address, "stake_account".to_string()),
     )?;
 
@@ -757,8 +727,8 @@ pub fn process_create_stake_account(
     }
 
     let authorized = Authorized {
-        staker: staker.unwrap_or(from_pubkey),
-        withdrawer: withdrawer.unwrap_or(from_pubkey),
+        staker: staker.unwrap_or(from.pubkey()),
+        withdrawer: withdrawer.unwrap_or(from.pubkey()),
     };
 
     let ixs = if let Some(seed) = seed {
@@ -783,15 +753,13 @@ pub fn process_create_stake_account(
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
 
-    let fee_payer = fee_payer.map(|fp| fp.keypair()).unwrap_or(&config.keypair);
-    let mut tx_signers = if stake_account_pubkey != from_pubkey {
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
+    let mut tx_signers = if stake_account.pubkey() != from.pubkey() {
         vec![fee_payer, from, stake_account] // both must sign if `from` and `to` differ
     } else {
         vec![fee_payer, from] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
-    let (nonce_authority_pubkey, nonce_authority) = nonce_authority
-        .map(|na| (na.pubkey(), na.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let mut tx = if let Some(nonce_account) = &nonce_account {
         tx_signers.push(nonce_authority);
@@ -819,7 +787,7 @@ pub fn process_create_stake_account(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -839,19 +807,19 @@ pub fn process_stake_authorize(
     stake_account_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
     stake_authorize: StakeAuthorize,
-    authority: Option<&SigningAuthority>,
+    authority: Option<&dyn Signer>,
     sign_only: bool,
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
+    fee_payer: Option<&dyn Signer>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (stake_account_pubkey, "stake_account_pubkey".to_string()),
         (authorized_pubkey, "new_authorized_pubkey".to_string()),
     )?;
-    let authority = authority.map(|a| a.keypair()).unwrap_or(&config.keypair);
+    let authority = authority.unwrap_or_else(|| config.keypair.as_ref());
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
     let ixs = vec![stake_instruction::authorize(
@@ -861,10 +829,8 @@ pub fn process_stake_authorize(
         stake_authorize,      // stake or withdraw
     )];
 
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
-    let fee_payer = fee_payer.map(|f| f.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -890,7 +856,7 @@ pub fn process_stake_authorize(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -908,27 +874,23 @@ pub fn process_deactivate_stake_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
-    stake_authority: Option<&SigningAuthority>,
+    stake_authority: Option<&dyn Signer>,
     sign_only: bool,
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
+    fee_payer: Option<&dyn Signer>,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
-    let stake_authority = stake_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let stake_authority = stake_authority.unwrap_or_else(|| config.keypair.as_ref());
     let ixs = vec![stake_instruction::deactivate_stake(
         stake_account_pubkey,
         &stake_authority.pubkey(),
     )];
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
-    let fee_payer = fee_payer.map(|f| f.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -954,7 +916,7 @@ pub fn process_deactivate_stake_account(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -974,19 +936,17 @@ pub fn process_withdraw_stake(
     stake_account_pubkey: &Pubkey,
     destination_account_pubkey: &Pubkey,
     lamports: u64,
-    withdraw_authority: Option<&SigningAuthority>,
+    withdraw_authority: Option<&dyn Signer>,
     sign_only: bool,
     signers: Option<&Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
+    fee_payer: Option<&dyn Signer>,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
-    let withdraw_authority = withdraw_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let withdraw_authority = withdraw_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let ixs = vec![stake_instruction::withdraw(
         stake_account_pubkey,
@@ -995,10 +955,8 @@ pub fn process_withdraw_stake(
         lamports,
     )];
 
-    let fee_payer = fee_payer.map(|fp| fp.keypair()).unwrap_or(&config.keypair);
-    let (nonce_authority_pubkey, nonce_authority) = nonce_authority
-        .map(|na| (na.pubkey(), na.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1024,7 +982,7 @@ pub fn process_withdraw_stake(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1042,29 +1000,27 @@ pub fn process_split_stake(
     rpc_client: &RpcClient,
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
-    stake_authority: Option<&SigningAuthority>,
+    stake_authority: Option<&dyn Signer>,
     sign_only: bool,
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    split_stake_account: &Keypair,
+    nonce_authority: Option<&dyn Signer>,
+    split_stake_account: &dyn Signer,
     split_stake_account_seed: &Option<String>,
     lamports: u64,
-    fee_payer: Option<&SigningAuthority>,
+    fee_payer: Option<&dyn Signer>,
 ) -> ProcessResult {
-    let (fee_payer_pubkey, fee_payer) = fee_payer
-        .map(|f| (f.pubkey(), f.keypair()))
-        .unwrap_or((config.keypair.pubkey(), &config.keypair));
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     check_unique_pubkeys(
-        (&fee_payer_pubkey, "fee-payer keypair".to_string()),
+        (&fee_payer.pubkey(), "fee-payer keypair".to_string()),
         (
             &split_stake_account.pubkey(),
             "split_stake_account".to_string(),
         ),
     )?;
     check_unique_pubkeys(
-        (&fee_payer_pubkey, "fee-payer keypair".to_string()),
+        (&fee_payer.pubkey(), "fee-payer keypair".to_string()),
         (&stake_account_pubkey, "stake_account".to_string()),
     )?;
     check_unique_pubkeys(
@@ -1075,9 +1031,7 @@ pub fn process_split_stake(
         ),
     )?;
 
-    let stake_authority = stake_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let stake_authority = stake_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let split_stake_account_address = if let Some(seed) = split_stake_account_seed {
         create_address_with_seed(
@@ -1138,9 +1092,7 @@ pub fn process_split_stake(
         )
     };
 
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
@@ -1172,7 +1124,7 @@ pub fn process_split_stake(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1191,17 +1143,17 @@ pub fn process_stake_set_lockup(
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
     lockup: &mut Lockup,
-    custodian: Option<&SigningAuthority>,
+    custodian: Option<&dyn Signer>,
     sign_only: bool,
     signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
+    fee_payer: Option<&dyn Signer>,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
-    let custodian = custodian.map(|a| a.keypair()).unwrap_or(&config.keypair);
+    let custodian = custodian.unwrap_or_else(|| config.keypair.as_ref());
     // If new custodian is not explicitly set, default to current custodian
     if lockup.custodian == Pubkey::default() {
         lockup.custodian = custodian.pubkey();
@@ -1211,10 +1163,8 @@ pub fn process_stake_set_lockup(
         lockup,
         &custodian.pubkey(),
     )];
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
-    let fee_payer = fee_payer.map(|f| f.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1240,7 +1190,7 @@ pub fn process_stake_set_lockup(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1324,7 +1274,7 @@ pub fn process_show_stake_account(
     if stake_account.owner != solana_stake_program::id() {
         return Err(CliError::RpcRequestError(format!(
             "{:?} is not a stake account",
-            stake_account_pubkey
+            stake_account_pubkey,
         ))
         .into());
     }
@@ -1380,22 +1330,19 @@ pub fn process_delegate_stake(
     config: &CliConfig,
     stake_account_pubkey: &Pubkey,
     vote_account_pubkey: &Pubkey,
-    stake_authority: Option<&SigningAuthority>,
+    stake_authority: Option<&dyn Signer>,
     force: bool,
     sign_only: bool,
-    signers: &Option<Vec<(Pubkey, Signature)>>,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&SigningAuthority>,
-    fee_payer: Option<&SigningAuthority>,
+    nonce_authority: Option<&dyn Signer>,
+    fee_payer: Option<&dyn Signer>,
 ) -> ProcessResult {
     check_unique_pubkeys(
         (&config.keypair.pubkey(), "cli keypair".to_string()),
         (stake_account_pubkey, "stake_account_pubkey".to_string()),
     )?;
-    let stake_authority = stake_authority
-        .map(|a| a.keypair())
-        .unwrap_or(&config.keypair);
+    let stake_authority = stake_authority.unwrap_or_else(|| config.keypair.as_ref());
 
     if !sign_only {
         // Sanity check the vote account to ensure it is attached to a validator that has recently
@@ -1450,10 +1397,8 @@ pub fn process_delegate_stake(
         &stake_authority.pubkey(),
         vote_account_pubkey,
     )];
-    let (nonce_authority, nonce_authority_pubkey) = nonce_authority
-        .map(|a| (a.keypair(), a.pubkey()))
-        .unwrap_or((&config.keypair, config.keypair.pubkey()));
-    let fee_payer = fee_payer.map(|f| f.keypair()).unwrap_or(&config.keypair);
+    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
+    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
     let mut tx = if let Some(nonce_account) = &nonce_account {
         Transaction::new_signed_with_nonce(
             ixs,
@@ -1479,7 +1424,7 @@ pub fn process_delegate_stake(
     } else {
         if let Some(nonce_account) = &nonce_account {
             let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority_pubkey, &recent_blockhash)?;
+            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
         check_account_for_fee(
             rpc_client,
@@ -1499,7 +1444,7 @@ mod tests {
     use solana_sdk::{
         fee_calculator::FeeCalculator,
         hash::Hash,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair, Signer},
+        signature::{keypair_from_seed, read_keypair_file, write_keypair, Presigner, Signer},
     };
     use tempfile::NamedTempFile;
 
@@ -1603,8 +1548,9 @@ mod tests {
                 require_keypair: true
             }
         );
-        // Test Authorize Subcommand w/ signer
+        // Test Authorize Subcommand w/ offline feepayer
         let keypair = Keypair::new();
+        let pubkey = keypair.pubkey();
         let sig = keypair.sign_message(&[0u8]);
         let signer = format!("{}={}", keypair.pubkey(), sig);
         let test_authorize = test_commands.clone().get_matches_from(vec![
@@ -1616,6 +1562,8 @@ mod tests {
             &blockhash_string,
             "--signer",
             &signer,
+            "--fee-payer",
+            &pubkey.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_authorize).unwrap(),
@@ -1630,15 +1578,17 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: None,
+                    fee_payer: Some(Presigner::new(&pubkey, &sig).into()),
                 },
                 require_keypair: true
             }
         );
-        // Test Authorize Subcommand w/ signers
+        // Test Authorize Subcommand w/ offline fee payer and nonce authority
         let keypair2 = Keypair::new();
+        let pubkey2 = keypair2.pubkey();
         let sig2 = keypair.sign_message(&[0u8]);
         let signer2 = format!("{}={}", keypair2.pubkey(), sig2);
+        let nonce_account = Pubkey::new(&[1u8; 32]);
         let test_authorize = test_commands.clone().get_matches_from(vec![
             "test",
             &subcommand,
@@ -1650,6 +1600,12 @@ mod tests {
             &signer,
             "--signer",
             &signer2,
+            "--fee-payer",
+            &pubkey.to_string(),
+            "--nonce",
+            &nonce_account.to_string(),
+            "--nonce-authority",
+            &pubkey2.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_authorize).unwrap(),
@@ -1663,8 +1619,8 @@ mod tests {
                     signers: Some(vec![(keypair.pubkey(), sig), (keypair2.pubkey(), sig2),]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: None,
+                    nonce_authority: Some(Presigner::new(&pubkey2, &sig2).into()),
+                    fee_payer: Some(Presigner::new(&pubkey, &sig).into()),
                 },
                 require_keypair: true
             }
@@ -1792,7 +1748,7 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: Some(fee_payer_pubkey.into()),
+                    fee_payer: Some(Presigner::new(&fee_payer_pubkey, &sig).into()),
                 },
                 require_keypair: true
             }
@@ -1946,9 +1902,9 @@ mod tests {
                     signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
-                    nonce_authority: Some(offline_pubkey.into()),
-                    fee_payer: Some(offline_pubkey.into()),
-                    from: Some(offline_pubkey.into()),
+                    nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
+                    fee_payer: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
+                    from: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
                 },
                 require_keypair: false,
             }
@@ -2101,7 +2057,7 @@ mod tests {
             }
         );
 
-        // Test Delegate Subcommand w/ signer
+        // Test Delegate Subcommand w/ absent fee payer
         let key1 = Pubkey::new_rand();
         let sig1 = Keypair::new().sign_message(&[0u8]);
         let signer1 = format!("{}={}", key1, sig1);
@@ -2114,6 +2070,8 @@ mod tests {
             &blockhash_string,
             "--signer",
             &signer1,
+            "--fee-payer",
+            &key1.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_delegate_stake).unwrap(),
@@ -2128,13 +2086,13 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: None,
+                    fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },
                 require_keypair: false
             }
         );
 
-        // Test Delegate Subcommand w/ signers
+        // Test Delegate Subcommand w/ absent fee payer and absent nonce authority
         let key2 = Pubkey::new_rand();
         let sig2 = Keypair::new().sign_message(&[0u8]);
         let signer2 = format!("{}={}", key2, sig2);
@@ -2149,6 +2107,12 @@ mod tests {
             &signer1,
             "--signer",
             &signer2,
+            "--fee-payer",
+            &key1.to_string(),
+            "--nonce",
+            &nonce_account.to_string(),
+            "--nonce_auhtority",
+            &key2.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_delegate_stake).unwrap(),
@@ -2159,17 +2123,16 @@ mod tests {
                     stake_authority: None,
                     force: false,
                     sign_only: false,
-                    signers: Some(vec![(key1, sig1), (key2, sig2)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: None,
+                    nonce_account: Some(nonce_account),
+                    nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
+                    fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },
                 require_keypair: false
             }
         );
 
-        // Test Delegate Subcommand w/ fee-payer
+        // Test Delegate Subcommand w/ present fee-payer
         let (fee_payer_keypair_file, mut fee_payer_tmp_file) = make_tmp_file();
         let fee_payer_keypair = Keypair::new();
         write_keypair(&fee_payer_keypair, fee_payer_tmp_file.as_file_mut()).unwrap();
@@ -2335,8 +2298,8 @@ mod tests {
                     signers: Some(vec![(offline_pubkey, offline_sig)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account),
-                    nonce_authority: Some(offline_pubkey.into()),
-                    fee_payer: Some(offline_pubkey.into()),
+                    nonce_authority: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
+                    fee_payer: Some(Presigner::new(&offline_pubkey, &offline_sig).into()),
                 },
                 require_keypair: false,
             }
@@ -2446,7 +2409,7 @@ mod tests {
             }
         );
 
-        // Test Deactivate Subcommand w/ signers
+        // Test Deactivate Subcommand w/ absent fee payer
         let key1 = Pubkey::new_rand();
         let sig1 = Keypair::new().sign_message(&[0u8]);
         let signer1 = format!("{}={}", key1, sig1);
@@ -2458,6 +2421,8 @@ mod tests {
             &blockhash_string,
             "--signer",
             &signer1,
+            "--fee-payer",
+            &key1.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_deactivate_stake).unwrap(),
@@ -2470,13 +2435,13 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: None,
-                    fee_payer: None,
+                    fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },
                 require_keypair: false
             }
         );
 
-        // Test Deactivate Subcommand w/ signers
+        // Test Deactivate Subcommand w/ absent fee payer and nonce authority
         let key2 = Pubkey::new_rand();
         let sig2 = Keypair::new().sign_message(&[0u8]);
         let signer2 = format!("{}={}", key2, sig2);
@@ -2490,6 +2455,12 @@ mod tests {
             &signer1,
             "--signer",
             &signer2,
+            "--fee-payer",
+            &key1.to_string(),
+            "--nonce",
+            &nonce_account.to_string(),
+            "--nonce-account",
+            &key2.to_string(),
         ]);
         assert_eq!(
             parse_command(&test_deactivate_stake).unwrap(),
@@ -2501,8 +2472,8 @@ mod tests {
                     signers: Some(vec![(key1, sig1), (key2, sig2)]),
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: None,
+                    nonce_authority: Some(Presigner::new(&key2, &sig2).into()),
+                    fee_payer: Some(Presigner::new(&key1, &sig1).into()),
                 },
                 require_keypair: false
             }
@@ -2643,7 +2614,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::SplitStake {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
-                    stake_authority: Some(stake_auth_pubkey.into()),
+                    stake_authority: Some(Presigner::new(&stake_auth_pubkey, &stake_sig).into()),
                     sign_only: false,
                     signers: Some(vec![
                         (nonce_auth_pubkey, nonce_sig),
@@ -2651,13 +2622,13 @@ mod tests {
                     ]),
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account.into()),
-                    nonce_authority: Some(nonce_auth_pubkey.into()),
+                    nonce_authority: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),
                     split_stake_account: read_keypair_file(&split_stake_account_keypair_file)
                         .unwrap()
                         .into(),
                     seed: None,
                     lamports: 50_000_000_000,
-                    fee_payer: Some(nonce_auth_pubkey.into()),
+                    fee_payer: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),
                 },
                 require_keypair: false,
             }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2111,40 +2111,6 @@ mod tests {
             }
         );
 
-        // Test Delegate Subcommand w/ absentee fee-payer
-        let sig = fee_payer_keypair.sign_message(&[0u8]);
-        let signer = format!("{}={}", fee_payer_string, sig);
-        let test_delegate_stake = test_commands.clone().get_matches_from(vec![
-            "test",
-            "delegate-stake",
-            &stake_account_string,
-            &vote_account_string,
-            "--fee-payer",
-            &fee_payer_string,
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer,
-        ]);
-        assert_eq!(
-            parse_command(&test_delegate_stake).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::DelegateStake {
-                    stake_account_pubkey,
-                    vote_account_pubkey,
-                    stake_authority: None,
-                    force: false,
-                    sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: Some(fee_payer_pubkey.into()),
-                },
-                require_keypair: false
-            }
-        );
-
         // Test WithdrawStake Subcommand
         let test_withdraw_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2437,37 +2403,6 @@ mod tests {
                     fee_payer: Some(read_keypair_file(&fee_payer_keypair_file).unwrap().into()),
                 },
                 require_keypair: true
-            }
-        );
-
-        // Test Deactivate Subcommand w/ absentee fee-payer
-        let sig = fee_payer_keypair.sign_message(&[0u8]);
-        let signer = format!("{}={}", fee_payer_string, sig);
-        let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
-            "test",
-            "deactivate-stake",
-            &stake_account_string,
-            "--fee-payer",
-            &fee_payer_string,
-            "--blockhash",
-            &blockhash_string,
-            "--signer",
-            &signer,
-        ]);
-        assert_eq!(
-            parse_command(&test_deactivate_stake).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::DeactivateStake {
-                    stake_account_pubkey,
-                    stake_authority: None,
-                    sign_only: false,
-                    signers: Some(vec![(fee_payer_pubkey, sig)]),
-                    blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-                    nonce_account: None,
-                    nonce_authority: None,
-                    fee_payer: Some(fee_payer_pubkey.into()),
-                },
-                require_keypair: false
             }
         );
 

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -762,12 +762,12 @@ pub fn process_create_stake_account(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&tx_signers, recent_blockhash);
+        tx.try_sign(&tx_signers, recent_blockhash)?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&tx_signers, recent_blockhash);
+        tx.try_sign(&tx_signers, recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -826,12 +826,12 @@ pub fn process_stake_authorize(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[fee_payer, nonce_authority, authority], recent_blockhash);
+        tx.try_sign(&[fee_payer, nonce_authority, authority], recent_blockhash)?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[fee_payer, authority], recent_blockhash);
+        tx.try_sign(&[fee_payer, authority], recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -881,15 +881,15 @@ pub fn process_deactivate_stake_account(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(
+        tx.try_sign(
             &[fee_payer, nonce_authority, stake_authority],
             recent_blockhash,
-        );
+        )?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[fee_payer, stake_authority], recent_blockhash);
+        tx.try_sign(&[fee_payer, stake_authority], recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -945,15 +945,15 @@ pub fn process_withdraw_stake(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(
+        tx.try_sign(
             &[fee_payer, withdraw_authority, nonce_authority],
             recent_blockhash,
-        );
+        )?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[fee_payer, withdraw_authority], recent_blockhash);
+        tx.try_sign(&[fee_payer, withdraw_authority], recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -1080,7 +1080,7 @@ pub fn process_split_stake(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(
+        tx.try_sign(
             &[
                 fee_payer,
                 nonce_authority,
@@ -1088,15 +1088,15 @@ pub fn process_split_stake(
                 split_stake_account,
             ],
             recent_blockhash,
-        );
+        )?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(
+        tx.try_sign(
             &[fee_payer, stake_authority, split_stake_account],
             recent_blockhash,
-        );
+        )?;
         tx
     };
     if sign_only {
@@ -1152,12 +1152,12 @@ pub fn process_stake_set_lockup(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[fee_payer, nonce_authority, custodian], recent_blockhash);
+        tx.try_sign(&[fee_payer, nonce_authority, custodian], recent_blockhash)?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[fee_payer, custodian], recent_blockhash);
+        tx.try_sign(&[fee_payer, custodian], recent_blockhash)?;
         tx
     };
     if sign_only {
@@ -1382,15 +1382,15 @@ pub fn process_delegate_stake(
             &nonce_authority.pubkey(),
         );
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(
+        tx.try_sign(
             &[fee_payer, nonce_authority, stake_authority],
             recent_blockhash,
-        );
+        )?;
         tx
     } else {
         let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
         let mut tx = Transaction::new_unsigned(message);
-        tx.sign(&[fee_payer, stake_authority], recent_blockhash);
+        tx.try_sign(&[fee_payer, stake_authority], recent_blockhash)?;
         tx
     };
     if sign_only {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1418,8 +1418,11 @@ mod tests {
     use solana_sdk::{
         fee_calculator::FeeCalculator,
         hash::Hash,
-        signature::{keypair_from_seed, read_keypair_file, write_keypair, Presigner, Signer},
+        signature::{
+            keypair_from_seed, read_keypair_file, write_keypair, Keypair, Presigner, Signer,
+        },
     };
+    use std::rc::Rc;
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -1767,7 +1770,7 @@ mod tests {
             parse_command(&test_create_stake_account).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: stake_account_keypair.into(),
+                    stake_account: Rc::new(stake_account_keypair.into()),
                     seed: None,
                     staker: Some(authorized),
                     withdrawer: Some(authorized),
@@ -1805,7 +1808,7 @@ mod tests {
             parse_command(&test_create_stake_account2).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    stake_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     staker: None,
                     withdrawer: None,
@@ -1855,7 +1858,7 @@ mod tests {
             parse_command(&test_create_stake_account2).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
-                    stake_account: read_keypair_file(&keypair_file).unwrap().into(),
+                    stake_account: Rc::new(read_keypair_file(&keypair_file).unwrap().into()),
                     seed: None,
                     staker: None,
                     withdrawer: None,
@@ -2092,8 +2095,6 @@ mod tests {
         let (fee_payer_keypair_file, mut fee_payer_tmp_file) = make_tmp_file();
         let fee_payer_keypair = Keypair::new();
         write_keypair(&fee_payer_keypair, fee_payer_tmp_file.as_file_mut()).unwrap();
-        let fee_payer_pubkey = fee_payer_keypair.pubkey();
-        let fee_payer_string = fee_payer_pubkey.to_string();
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
             "test",
             "delegate-stake",
@@ -2440,9 +2441,11 @@ mod tests {
                     blockhash_query: BlockhashQuery::default(),
                     nonce_account: None,
                     nonce_authority: None,
-                    split_stake_account: read_keypair_file(&split_stake_account_keypair_file)
-                        .unwrap()
-                        .into(),
+                    split_stake_account: Rc::new(
+                        read_keypair_file(&split_stake_account_keypair_file)
+                            .unwrap()
+                            .into(),
+                    ),
                     seed: None,
                     lamports: 50_000_000_000,
                     fee_payer: None,
@@ -2498,9 +2501,11 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
                     nonce_account: Some(nonce_account.into()),
                     nonce_authority: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),
-                    split_stake_account: read_keypair_file(&split_stake_account_keypair_file)
-                        .unwrap()
-                        .into(),
+                    split_stake_account: Rc::new(
+                        read_keypair_file(&split_stake_account_keypair_file)
+                            .unwrap()
+                            .into(),
+                    ),
                     seed: None,
                     lamports: 50_000_000_000,
                     fee_payer: Some(Presigner::new(&nonce_auth_pubkey, &nonce_sig).into()),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -898,7 +898,7 @@ pub fn process_stake_authorize(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -962,7 +962,7 @@ pub fn process_deactivate_stake_account(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1032,7 +1032,7 @@ pub fn process_withdraw_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<SystemError>(result)
     }
 }
@@ -1180,7 +1180,7 @@ pub fn process_split_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1248,7 +1248,7 @@ pub fn process_stake_set_lockup(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }
@@ -1487,7 +1487,7 @@ pub fn process_delegate_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
         log_instruction_custom_error::<StakeError>(result)
     }
 }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -191,9 +191,10 @@ pub fn process_create_storage_account(
     );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let mut tx = Transaction::new_signed_instructions(
+    let message = Message::new(ixs);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(
         &[config.keypair.as_ref(), storage_account],
-        ixs,
         recent_blockhash,
     );
     check_account_for_fee(
@@ -219,8 +220,8 @@ pub fn process_claim_storage_reward(
         storage_instruction::claim_reward(node_account_pubkey, storage_account_pubkey);
     let signers = [config.keypair.as_ref()];
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
-
-    let mut tx = Transaction::new(&signers, message, recent_blockhash);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(&signers, recent_blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -193,10 +193,10 @@ pub fn process_create_storage_account(
 
     let message = Message::new(ixs);
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(
+    tx.try_sign(
         &[config.keypair.as_ref(), storage_account],
         recent_blockhash,
-    );
+    )?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -221,7 +221,7 @@ pub fn process_claim_storage_reward(
     let signers = [config.keypair.as_ref()];
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(&signers, recent_blockhash);
+    tx.try_sign(&signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -192,7 +192,7 @@ pub fn process_create_storage_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let mut tx = Transaction::new_signed_instructions(
-        &[&config.keypair, &storage_account],
+        &[config.keypair.as_ref(), storage_account],
         ixs,
         recent_blockhash,
     );
@@ -202,8 +202,8 @@ pub fn process_create_storage_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair, &storage_account]);
+    let result = rpc_client
+        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), storage_account]);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -217,7 +217,7 @@ pub fn process_claim_storage_reward(
 
     let instruction =
         storage_instruction::claim_reward(node_account_pubkey, storage_account_pubkey);
-    let signers = [&config.keypair];
+    let signers = [config.keypair.as_ref()];
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
 
     let mut tx = Transaction::new(&signers, message, recent_blockhash);

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -301,7 +301,7 @@ pub fn process_set_validator_info(
         .unwrap_or(0);
 
     let keys = vec![(id(), false), (config.keypair.pubkey(), true)];
-    let (message, signers): (Message, Vec<&Keypair>) = if balance == 0 {
+    let (message, signers): (Message, Vec<&dyn Signer>) = if balance == 0 {
         if info_pubkey != info_keypair.pubkey() {
             println!(
                 "Account {:?} does not exist. Generating new keypair...",
@@ -327,7 +327,7 @@ pub fn process_set_validator_info(
             keys,
             &validator_info,
         )]);
-        let signers = vec![&config.keypair, &info_keypair];
+        let signers = vec![config.keypair.as_ref(), &info_keypair];
         let message = Message::new(instructions);
         (message, signers)
     } else {
@@ -343,7 +343,7 @@ pub fn process_set_validator_info(
             &validator_info,
         )];
         let message = Message::new_with_payer(instructions, Some(&config.keypair.pubkey()));
-        let signers = vec![&config.keypair];
+        let signers = vec![config.keypair.as_ref()];
         (message, signers)
     };
 

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -349,7 +349,8 @@ pub fn process_set_validator_info(
 
     // Submit transaction
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let mut tx = Transaction::new(&signers, message, recent_blockhash);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(&signers, recent_blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -350,7 +350,7 @@ pub fn process_set_validator_info(
     // Submit transaction
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(&signers, recent_blockhash);
+    tx.try_sign(&signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -7,6 +7,7 @@ use solana_clap_utils::{input_parsers::*, input_validators::*};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     account::Account,
+    message::Message,
     pubkey::Pubkey,
     signature::Keypair,
     signature::Signer,
@@ -316,7 +317,9 @@ pub fn process_create_vote_account(
         vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
-    let mut tx = Transaction::new_signed_instructions(&signers, ixs, recent_blockhash);
+    let message = Message::new(ixs);
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(&signers, recent_blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -346,12 +349,9 @@ pub fn process_vote_authorize(
         vote_authorize,           // vote or withdraw
     )];
 
-    let mut tx = Transaction::new_signed_with_payer(
-        ixs,
-        Some(&config.keypair.pubkey()),
-        &[config.keypair.as_ref()],
-        recent_blockhash,
-    );
+    let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(&[config.keypair.as_ref()], recent_blockhash);
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -380,9 +380,9 @@ pub fn process_vote_update_validator(
         new_identity_pubkey,
     )];
 
-    let mut tx = Transaction::new_signed_with_payer(
-        ixs,
-        Some(&config.keypair.pubkey()),
+    let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
+    let mut tx = Transaction::new_unsigned(message);
+    tx.sign(
         &[config.keypair.as_ref(), authorized_voter],
         recent_blockhash,
     );

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -319,7 +319,7 @@ pub fn process_create_vote_account(
 
     let message = Message::new(ixs);
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(&signers, recent_blockhash);
+    tx.try_sign(&signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -351,7 +351,7 @@ pub fn process_vote_authorize(
 
     let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(&[config.keypair.as_ref()], recent_blockhash);
+    tx.try_sign(&[config.keypair.as_ref()], recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),
@@ -382,10 +382,10 @@ pub fn process_vote_update_validator(
 
     let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.sign(
+    tx.try_sign(
         &[config.keypair.as_ref(), authorized_voter],
         recent_blockhash,
-    );
+    )?;
     check_account_for_fee(
         rpc_client,
         &config.keypair.pubkey(),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -311,9 +311,9 @@ pub fn process_create_vote_account(
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let signers = if vote_account_pubkey != config.keypair.pubkey() {
-        vec![&config.keypair, vote_account] // both must sign if `from` and `to` differ
+        vec![config.keypair.as_ref(), vote_account] // both must sign if `from` and `to` differ
     } else {
-        vec![&config.keypair] // when stake_account == config.keypair and there's a seed, we only need one signature
+        vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
     };
 
     let mut tx = Transaction::new_signed_instructions(&signers, ixs, recent_blockhash);
@@ -349,7 +349,7 @@ pub fn process_vote_authorize(
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
         Some(&config.keypair.pubkey()),
-        &[&config.keypair],
+        &[config.keypair.as_ref()],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -358,7 +358,7 @@ pub fn process_vote_authorize(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<VoteError>(result)
 }
 
@@ -383,7 +383,7 @@ pub fn process_vote_update_validator(
     let mut tx = Transaction::new_signed_with_payer(
         ixs,
         Some(&config.keypair.pubkey()),
-        &[&config.keypair, authorized_voter],
+        &[config.keypair.as_ref(), authorized_voter],
         recent_blockhash,
     );
     check_account_for_fee(
@@ -392,7 +392,7 @@ pub fn process_vote_update_validator(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&config.keypair]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
     log_instruction_custom_error::<VoteError>(result)
 }
 

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -1,6 +1,4 @@
-use solana_cli::cli::{
-    process_command, request_and_confirm_airdrop, CliCommand, CliConfig, SigningAuthority,
-};
+use solana_cli::cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
@@ -15,6 +13,7 @@ use std::sync::mpsc::channel;
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests;
+use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -141,7 +140,7 @@ fn test_nonce_with_authority() {
     remove_dir_all(ledger_path).unwrap();
 }
 
-fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<SigningAuthority> {
+fn read_keypair_from_option(keypair_file: &Option<&str>) -> Option<Box<dyn Signer>> {
     keypair_file.map(|akf| read_keypair_file(&akf).unwrap().into())
 }
 
@@ -172,10 +171,9 @@ fn full_battery_tests(
 
     // Create nonce account
     config_payer.command = CliCommand::CreateNonceAccount {
-        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed,
-        nonce_authority: read_keypair_from_option(&authority_keypair_file)
-            .map(|na: SigningAuthority| na.pubkey()),
+        nonce_authority: read_keypair_from_option(&authority_keypair_file),
         lamports: 1000,
     };
 

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -18,6 +18,7 @@ use std::sync::mpsc::channel;
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests;
+use std::rc::Rc;
 use std::thread::sleep;
 use std::time::Duration;
 use tempfile::NamedTempFile;
@@ -303,11 +304,10 @@ fn test_offline_pay_tx() {
     check_balance(50, &rpc_client, &config_online.keypair.pubkey());
     check_balance(0, &rpc_client, &bob_pubkey);
 
-    let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
+    let (blockhash, _signers) = parse_sign_only_reply_string(&sig_response);
     config_online.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        signers: Some(signers),
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         ..PayCommand::default()
     });
@@ -357,7 +357,7 @@ fn test_nonced_pay_tx() {
     let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: read_keypair_file(&nonce_keypair_file).unwrap().into(),
+        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed: None,
         nonce_authority: Some(config.keypair.pubkey()),
         lamports: minimum_nonce_balance,

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -2,7 +2,6 @@ use solana_cli::cli::{process_command, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::new_validator_for_tests;
 use solana_faucet::faucet::run_local_faucet;
-use solana_sdk::signature::Signer;
 use std::fs::remove_dir_all;
 use std::sync::mpsc::channel;
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -6,21 +6,16 @@ use clap::{
 };
 use num_cpus;
 use solana_clap_utils::{
-    input_parsers::derivation_of,
     input_validators::is_derivation,
     keypair::{
-        keypair_from_seed_phrase, parse_keypair_path, prompt_passphrase, KeypairUrl,
+        keypair_from_seed_phrase, keypair_util_from_path, prompt_passphrase,
         SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
 };
 use solana_cli_config::config::{Config, CONFIG_FILE};
-use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     pubkey::write_pubkey_file,
-    signature::{
-        keypair_from_seed, read_keypair, read_keypair_file, write_keypair, write_keypair_file,
-        Keypair, Signer,
-    },
+    signature::{keypair_from_seed, write_keypair, write_keypair_file, Keypair, Signer},
 };
 use std::{
     collections::HashSet,
@@ -64,26 +59,7 @@ fn get_keypair_from_matches(
         path.extend(&[".config", "solana", "id.json"]);
         path.to_str().unwrap()
     };
-
-    match parse_keypair_path(path) {
-        KeypairUrl::Ask => {
-            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
-            Ok(Box::new(keypair_from_seed_phrase(
-                "pubkey recovery",
-                skip_validation,
-                false,
-            )?))
-        }
-        KeypairUrl::Filepath(path) => Ok(Box::new(read_keypair_file(&path)?)),
-        KeypairUrl::Stdin => {
-            let mut stdin = std::io::stdin();
-            Ok(Box::new(read_keypair(&mut stdin)?))
-        }
-        KeypairUrl::Usb(path) => Ok(Box::new(generate_remote_keypair(
-            path,
-            derivation_of(matches, "derivation_path"),
-        )?)),
-    }
+    keypair_util_from_path(matches, path, "pubkey recovery")
 }
 
 fn output_keypair(

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -341,7 +341,7 @@ fn extend_and_serialize(derivation_path: &DerivationPath) -> Vec<u8> {
 pub fn get_ledger_from_info(
     info: RemoteWalletInfo,
 ) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
-    let wallet_manager = initialize_wallet_manager();
+    let wallet_manager = initialize_wallet_manager()?;
     let _device_count = wallet_manager.update_devices()?;
     let devices = wallet_manager.list_devices();
     let (pubkeys, device_paths): (Vec<Pubkey>, Vec<String>) = devices

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -294,9 +294,9 @@ pub fn is_valid_hid_device(usage_page: u16, interface_number: i32) -> bool {
 }
 
 /// Helper to initialize hidapi and RemoteWalletManager
-pub fn initialize_wallet_manager() -> Arc<RemoteWalletManager> {
-    let hidapi = Arc::new(Mutex::new(hidapi::HidApi::new().unwrap()));
-    RemoteWalletManager::new(hidapi)
+pub fn initialize_wallet_manager() -> Result<Arc<RemoteWalletManager>, RemoteWalletError> {
+    let hidapi = Arc::new(Mutex::new(hidapi::HidApi::new()?));
+    Ok(RemoteWalletManager::new(hidapi))
 }
 
 #[cfg(test)]

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -221,8 +221,7 @@ pub struct Presigner {
 }
 
 impl Presigner {
-    #[allow(dead_code)]
-    fn new(pubkey: &Pubkey, signature: &Signature) -> Self {
+    pub fn new(pubkey: &Pubkey, signature: &Signature) -> Self {
         Self {
             pubkey: *pubkey,
             signature: *signature,

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -139,6 +139,18 @@ pub trait Signer {
     fn try_sign_message(&self, message: &[u8]) -> Result<Signature, SignerError>;
 }
 
+impl PartialEq for dyn Signer {
+    fn eq(&self, other: &dyn Signer) -> bool {
+        self.pubkey() == other.pubkey()
+    }
+}
+
+impl std::fmt::Debug for dyn Signer {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "Signer: {:?}", self.pubkey())
+    }
+}
+
 impl Signer for Keypair {
     /// Return the public key for the given keypair
     fn pubkey(&self) -> Pubkey {

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -179,6 +179,15 @@ where
     }
 }
 
+impl<T> From<T> for Box<dyn Signer>
+where
+    T: Signer + 'static,
+{
+    fn from(keypair_util: T) -> Self {
+        Box::new(keypair_util)
+    }
+}
+
 #[derive(Debug, Error, PartialEq)]
 pub enum SignerError {
     #[error("keypair-pubkey mismatch")]

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -223,7 +223,7 @@ pub enum SignerError {
     UserCancel,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Presigner {
     pubkey: Pubkey,
     signature: Signature,

--- a/sdk/src/signers.rs
+++ b/sdk/src/signers.rs
@@ -48,6 +48,34 @@ impl Signers for [Box<dyn Signer>] {
     default_keypairs_impl!();
 }
 
+impl Signers for Vec<&dyn Signer> {
+    default_keypairs_impl!();
+}
+
+impl Signers for [&dyn Signer] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [&dyn Signer; 0] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [&dyn Signer; 1] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [&dyn Signer; 2] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [&dyn Signer; 3] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [&dyn Signer; 4] {
+    default_keypairs_impl!();
+}
+
 impl<T: Signer> Signers for [&T; 0] {
     default_keypairs_impl!();
 }
@@ -106,6 +134,24 @@ mod tests {
 
         // Same as above, but less compiler magic.
         let xs_ref: &[Box<dyn Signer>] = &xs;
+        assert_eq!(
+            Signers::sign_message(xs_ref, b""),
+            vec![Signature::default(), Signature::default()],
+        );
+    }
+
+    #[test]
+    fn test_dyn_keypairs_by_ref_compile() {
+        let foo = Foo {};
+        let bar = Bar {};
+        let xs: Vec<&dyn Signer> = vec![&foo, &bar];
+        assert_eq!(
+            xs.sign_message(b""),
+            vec![Signature::default(), Signature::default()],
+        );
+
+        // Same as above, but less compiler magic.
+        let xs_ref: &[&dyn Signer] = &xs;
         assert_eq!(
             Signers::sign_message(xs_ref, b""),
             vec![Signature::default(), Signature::default()],


### PR DESCRIPTION
#### Problem
Our signer interfaces are too restrictive to accommodate a rich signing experience. It is impossible to mix signer types (which is a common use-case in offline/paper-wallet workflow), and remote wallets (like Ledger) are not supported at all.

#### Summary of Changes
Co-conspirator: @t-nelson 
- Consolidate CLI signer argument parsing and support remote-wallet paths
- Replace CLI Keypair structs with Box<dyn Signer>, to allow for various and mixed signer types
- Doc updates

A follow-up PR will streamline signer handling in the CLI, collecting and deduplicating signers before any processing occurs (and thus eliminating all of the `Option<Box<dyn Signer>>`s in this PR).
