### PR TITLE
genesis: Add --enable-warmup-epochs flag

### DIFF
--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -27,6 +27,7 @@ $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/
 $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/storage-keypair.json
 
 args=("$@")
+default_arg --enable-warmup-epochs
 default_arg --bootstrap-validator-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity-keypair.json
 default_arg --bootstrap-vote-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-keypair.json
 default_arg --bootstrap-stake-pubkey "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-keypair.json


### PR DESCRIPTION
Warm-up epochs are great for development/test but without the ability to repair across older epochs (cc: https://github.com/solana-labs/solana/pull/8193), it's very hard for a node that never wants to accept a snapshot to catch up with a cluster (cc: https://github.com/solana-labs/solana/issues/8383)

This PR will:
1. Disable warm-up epochs by default in `solana-genesis`, so that all the production infra will not use warmup epochs
2. Explicitly enable warm-up epochs in `./multinode-demo/setup.sh` for local dev usage and `net/` usage
3. Deliberately keep warm-up epochs disabled in `./run.sh`, to ensure that periodically we'll still hit the warm-up epoch disabled configuration *before* an attempt to launch a production cluster.

Fixes: #8383