### PR TITLE
Add --trusted-validator support for snapshot hash validation

### DIFF
--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -55,6 +55,7 @@ mod tests {
             snapshot_interval_slots,
             snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
             snapshot_path: PathBuf::from(snapshot_dir.path()),
+            trusted_validators: None,
         };
         bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
         SnapshotTestConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -537,6 +537,7 @@ fn load_bank_forks(
             snapshot_interval_slots: 0, // Value doesn't matter
             snapshot_package_output_path: ledger_path.clone(),
             snapshot_path: ledger_path.clone().join("snapshot"),
+            trusted_validators: None,
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -6,7 +6,7 @@ use log::*;
 use solana_measure::measure::Measure;
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::{bank::Bank, status_cache::MAX_CACHE_ENTRIES};
-use solana_sdk::{clock::Slot, timing};
+use solana_sdk::{clock::Slot, pubkey::Pubkey, timing};
 use std::{
     collections::{HashMap, HashSet},
     ops::Index,
@@ -26,6 +26,10 @@ pub struct SnapshotConfig {
 
     // Where to place the snapshots for recent slots
     pub snapshot_path: PathBuf,
+
+    // Validators that must vouch for a given snapshot hash before it's accepted
+    // None = accept any snapshot hash
+    pub trusted_validators: Option<HashSet<Pubkey>>,
 }
 
 #[derive(Error, Debug)]

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -139,6 +139,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --log ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 = --trusted-validator ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = -h ]]; then
       usage "$@"
     else


### PR DESCRIPTION
#### Problem

Validators cannot specify trusted validators to trust snapshot hashes from.

#### Summary of Changes

Add --trusted-validator argument to check in gossip the values they posted for the snapshot hash.

Fixes #
