### PR TITLE
CLI: collect and deduplicate signers

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -3,14 +3,14 @@ use crate::keypair::{
 };
 use chrono::DateTime;
 use clap::ArgMatches;
-use solana_remote_wallet::remote_wallet::DerivationPath;
+use solana_remote_wallet::remote_wallet::{DerivationPath, RemoteWalletManager};
 use solana_sdk::{
     clock::UnixTimestamp,
     native_token::sol_to_lamports,
     pubkey::Pubkey,
     signature::{read_keypair_file, Keypair, Signature, Signer},
 };
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
 // Return parsed values from matches at `name`
 pub fn values_of<T>(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<T>>
@@ -99,9 +99,10 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
 pub fn signer_of(
     name: &str,
     matches: &ArgMatches<'_>,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
 ) -> Result<Option<Box<dyn Signer>>, Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
-        signer_from_path(matches, location, name).map(Some)
+        signer_from_path(matches, location, name, wallet_manager).map(Some)
     } else {
         Ok(None)
     }

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -1,5 +1,5 @@
 use crate::keypair::{
-    keypair_from_seed_phrase, keypair_util_from_path, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
+    keypair_from_seed_phrase, signer_from_path, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
 };
 use chrono::DateTime;
 use clap::ArgMatches;
@@ -101,7 +101,7 @@ pub fn signer_of(
     matches: &ArgMatches<'_>,
 ) -> Result<Option<Box<dyn Signer>>, Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
-        keypair_util_from_path(matches, location, name).map(Some)
+        signer_from_path(matches, location, name).map(Some)
     } else {
         Ok(None)
     }

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -99,7 +99,7 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
 pub fn signer_of(
     name: &str,
     matches: &ArgMatches<'_>,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<Option<Box<dyn Signer>>, Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
         signer_from_path(matches, location, name, wallet_manager).map(Some)

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -96,15 +96,18 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
 }
 
 // Return a signer from matches at `name`
+#[allow(clippy::type_complexity)]
 pub fn signer_of(
-    name: &str,
     matches: &ArgMatches<'_>,
+    name: &str,
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
-) -> Result<Option<Box<dyn Signer>>, Box<dyn std::error::Error>> {
+) -> Result<(Option<Box<dyn Signer>>, Option<Pubkey>), Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
-        signer_from_path(matches, location, name, wallet_manager).map(Some)
+        let signer = signer_from_path(matches, location, name, wallet_manager)?;
+        let signer_pubkey = signer.pubkey();
+        Ok((Some(signer), Some(signer_pubkey)))
     } else {
-        Ok(None)
+        Ok((None, None))
     }
 }
 

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,6 +1,5 @@
 use crate::keypair::{parse_keypair_path, KeypairUrl, ASK_KEYWORD};
 use chrono::DateTime;
-use solana_remote_wallet::remote_keypair::generate_remote_keypair;
 use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
@@ -53,9 +52,6 @@ pub fn is_pubkey_or_keypair_or_ask_keyword(string: String) -> Result<(), String>
 
 pub fn is_valid_signer(string: String) -> Result<(), String> {
     match parse_keypair_path(&string) {
-        KeypairUrl::Usb(path) => generate_remote_keypair(path, None)
-            .map(|_| ())
-            .map_err(|err| format!("{:?}", err)),
         KeypairUrl::Filepath(path) => is_keypair(path),
         _ => Ok(()),
     }

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -64,7 +64,7 @@ pub fn signer_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     match parse_keypair_path(path) {
         KeypairUrl::Ask => {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -6,7 +6,10 @@ use crate::{
 use bip39::{Language, Mnemonic, Seed};
 use clap::{values_t, ArgMatches, Error, ErrorKind};
 use rpassword::prompt_password_stderr;
-use solana_remote_wallet::remote_keypair::generate_remote_keypair;
+use solana_remote_wallet::{
+    remote_keypair::generate_remote_keypair,
+    remote_wallet::{RemoteWalletError, RemoteWalletManager},
+};
 use solana_sdk::{
     pubkey::Pubkey,
     signature::{
@@ -19,6 +22,7 @@ use std::{
     io::{stdin, stdout, Write},
     process::exit,
     str::FromStr,
+    sync::Arc,
 };
 
 pub enum KeypairUrl {
@@ -60,6 +64,7 @@ pub fn signer_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     match parse_keypair_path(path) {
         KeypairUrl::Ask => {
@@ -75,10 +80,17 @@ pub fn signer_from_path(
             let mut stdin = std::io::stdin();
             Ok(Box::new(read_keypair(&mut stdin)?))
         }
-        KeypairUrl::Usb(path) => Ok(Box::new(generate_remote_keypair(
-            path,
-            derivation_of(matches, "derivation_path"),
-        )?)),
+        KeypairUrl::Usb(path) => {
+            if let Some(wallet_manager) = wallet_manager {
+                Ok(Box::new(generate_remote_keypair(
+                    path,
+                    derivation_of(matches, "derivation_path"),
+                    wallet_manager,
+                )?))
+            } else {
+                Err(RemoteWalletError::NoDeviceFound.into())
+            }
+        }
         KeypairUrl::Pubkey(pubkey) => {
             let presigner = pubkeys_sigs_of(matches, SIGNER_ARG.name)
                 .as_ref()

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -56,7 +56,7 @@ pub fn presigner_from_pubkey_sigs(
     })
 }
 
-pub fn keypair_util_from_path(
+pub fn signer_from_path(
     matches: &ArgMatches,
     path: &str,
     keypair_name: &str,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -434,7 +434,7 @@ pub struct CliConfig<'a> {
     pub command: CliCommand,
     pub json_rpc_url: String,
     pub signers: Vec<&'a dyn Signer>,
-    pub keypair_path: Option<String>,
+    pub keypair_path: String,
     pub derivation_path: Option<DerivationPath>,
     pub rpc_client: Option<RpcClient>,
     pub verbose: bool,
@@ -471,7 +471,7 @@ impl Default for CliConfig<'_> {
             },
             json_rpc_url: Self::default_json_rpc_url(),
             signers: Vec::new(),
-            keypair_path: Some(Self::default_keypair_path()),
+            keypair_path: Self::default_keypair_path(),
             derivation_path: None,
             rpc_client: None,
             verbose: false,
@@ -1416,11 +1416,9 @@ fn process_witness(
 pub fn process_command(config: &CliConfig) -> ProcessResult {
     if config.verbose {
         println_name_value("RPC URL:", &config.json_rpc_url);
-        if let Some(keypair_path) = &config.keypair_path {
-            println_name_value("Keypair Path:", keypair_path);
-            if keypair_path.starts_with("usb://") {
-                println_name_value("Pubkey:", &format!("{:?}", config.pubkey()?));
-            }
+        println_name_value("Default Signer Path:", &config.keypair_path);
+        if config.keypair_path.starts_with("usb://") {
+            println_name_value("Pubkey:", &format!("{:?}", config.pubkey()?));
         }
     }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -98,10 +98,6 @@ pub(crate) fn generate_unique_signers(
     })
 }
 
-pub(crate) fn signer_pubkey(signer: &Option<Box<dyn Signer>>) -> Option<Pubkey> {
-    signer.as_ref().map(|signer| signer.pubkey())
-}
-
 const DATA_CHUNK_SIZE: usize = 229; // Keep program chunks under PACKET_DATA_SIZE
 
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
@@ -655,7 +651,7 @@ pub fn parse_command(
             } else {
                 None
             };
-            let pubkey = pubkey_of(&matches, "to");
+            let pubkey = pubkey_of(matches, "to");
             let signers = if pubkey.is_some() {
                 vec![]
             } else {
@@ -678,7 +674,7 @@ pub fn parse_command(
             })
         }
         ("balance", Some(matches)) => {
-            let pubkey = pubkey_of(&matches, "pubkey");
+            let pubkey = pubkey_of(matches, "pubkey");
             let signers = if pubkey.is_some() {
                 vec![]
             } else {
@@ -719,7 +715,7 @@ pub fn parse_command(
         },
         ("pay", Some(matches)) => {
             let lamports = lamports_of_sol(matches, "amount").unwrap();
-            let to = pubkey_of(&matches, "to").unwrap();
+            let to = pubkey_of(matches, "to").unwrap();
             let timestamp = if matches.is_present("timestamp") {
                 // Parse input for serde_json
                 let date_string = if !matches.value_of("timestamp").unwrap().contains('Z') {
@@ -731,14 +727,14 @@ pub fn parse_command(
             } else {
                 None
             };
-            let timestamp_pubkey = value_of(&matches, "timestamp_pubkey");
-            let witnesses = values_of(&matches, "witness");
+            let timestamp_pubkey = value_of(matches, "timestamp_pubkey");
+            let witnesses = values_of(matches, "witness");
             let cancelable = matches.is_present("cancelable");
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-            let blockhash_query = BlockhashQuery::new_from_matches(&matches);
-            let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches, wallet_manager)?;
-            let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
+            let blockhash_query = BlockhashQuery::new_from_matches(matches);
+            let nonce_account = pubkey_of(matches, NONCE_ARG.name);
+            let (nonce_authority, nonce_authority_pubkey) =
+                signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
 
             let payer_provided = None;
             let signer_info = generate_unique_signers(
@@ -778,8 +774,8 @@ pub fn parse_command(
             })
         }
         ("send-signature", Some(matches)) => {
-            let to = value_of(&matches, "to").unwrap();
-            let process_id = value_of(&matches, "process_id").unwrap();
+            let to = value_of(matches, "to").unwrap();
+            let process_id = value_of(matches, "process_id").unwrap();
 
             let default_signer =
                 signer_from_path(matches, default_signer_path, "keypair", wallet_manager)?;
@@ -790,8 +786,8 @@ pub fn parse_command(
             })
         }
         ("send-timestamp", Some(matches)) => {
-            let to = value_of(&matches, "to").unwrap();
-            let process_id = value_of(&matches, "process_id").unwrap();
+            let to = value_of(matches, "to").unwrap();
+            let process_id = value_of(matches, "process_id").unwrap();
             let dt = if matches.is_present("datetime") {
                 // Parse input for serde_json
                 let date_string = if !matches.value_of("datetime").unwrap().contains('Z') {
@@ -813,16 +809,15 @@ pub fn parse_command(
         }
         ("transfer", Some(matches)) => {
             let lamports = lamports_of_sol(matches, "amount").unwrap();
-            let to = pubkey_of(&matches, "to").unwrap();
+            let to = pubkey_of(matches, "to").unwrap();
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(matches);
-            let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches, wallet_manager)?;
-            let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
-            let fee_payer = signer_of(FEE_PAYER_ARG.name, &matches, wallet_manager)?;
-            let fee_payer_pubkey = signer_pubkey(&fee_payer);
-            let from = signer_of("from", &matches, wallet_manager)?;
-            let from_pubkey = signer_pubkey(&from);
+            let nonce_account = pubkey_of(matches, NONCE_ARG.name);
+            let (nonce_authority, nonce_authority_pubkey) =
+                signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
+            let (fee_payer, fee_payer_pubkey) =
+                signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
+            let (from, from_pubkey) = signer_of(matches, "from", wallet_manager)?;
 
             let signer_info = generate_unique_signers(
                 vec![nonce_authority, fee_payer, from],

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -150,7 +150,7 @@ pub struct PayCommand {
     pub sign_only: bool,
     pub blockhash_query: BlockhashQuery,
     pub nonce_account: Option<Pubkey>,
-    pub nonce_authority: Option<Box<dyn Signer>>,
+    pub nonce_authority: SignerIndex,
 }
 
 #[derive(Debug, PartialEq)]
@@ -206,11 +206,11 @@ pub enum CliCommand {
     // Nonce commands
     AuthorizeNonceAccount {
         nonce_account: Pubkey,
-        nonce_authority: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
         new_authority: Pubkey,
     },
     CreateNonceAccount {
-        nonce_account: Rc<Box<dyn Signer>>,
+        nonce_account: SignerIndex,
         seed: Option<String>,
         nonce_authority: Option<Pubkey>,
         lamports: u64,
@@ -218,7 +218,7 @@ pub enum CliCommand {
     GetNonce(Pubkey),
     NewNonce {
         nonce_account: Pubkey,
-        nonce_authority: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
     },
     ShowNonceAccount {
         nonce_account_pubkey: Pubkey,
@@ -226,7 +226,7 @@ pub enum CliCommand {
     },
     WithdrawFromNonceAccount {
         nonce_account: Pubkey,
-        nonce_authority: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
         destination_account_pubkey: Pubkey,
         lamports: u64,
     },
@@ -234,7 +234,7 @@ pub enum CliCommand {
     Deploy(String),
     // Stake Commands
     CreateStakeAccount {
-        stake_account: Rc<Box<dyn Signer>>,
+        stake_account: SignerIndex,
         seed: Option<String>,
         staker: Option<Pubkey>,
         withdrawer: Option<Pubkey>,
@@ -243,41 +243,41 @@ pub enum CliCommand {
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<Box<dyn Signer>>,
-        fee_payer: Option<Box<dyn Signer>>,
-        from: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
+        fee_payer: SignerIndex,
+        from: SignerIndex,
     },
     DeactivateStake {
         stake_account_pubkey: Pubkey,
-        stake_authority: Option<Box<dyn Signer>>,
+        stake_authority: SignerIndex,
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<Box<dyn Signer>>,
-        fee_payer: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
+        fee_payer: SignerIndex,
     },
     DelegateStake {
         stake_account_pubkey: Pubkey,
         vote_account_pubkey: Pubkey,
-        stake_authority: Option<Box<dyn Signer>>,
+        stake_authority: SignerIndex,
         force: bool,
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<Box<dyn Signer>>,
-        fee_payer: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
+        fee_payer: SignerIndex,
     },
     SplitStake {
         stake_account_pubkey: Pubkey,
-        stake_authority: Option<Box<dyn Signer>>,
+        stake_authority: SignerIndex,
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<Box<dyn Signer>>,
-        split_stake_account: Rc<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
+        split_stake_account: SignerIndex,
         seed: Option<String>,
         lamports: u64,
-        fee_payer: Option<Box<dyn Signer>>,
+        fee_payer: SignerIndex,
     },
     ShowStakeHistory {
         use_lamports_unit: bool,
@@ -290,38 +290,37 @@ pub enum CliCommand {
         stake_account_pubkey: Pubkey,
         new_authorized_pubkey: Pubkey,
         stake_authorize: StakeAuthorize,
-        authority: Option<Box<dyn Signer>>,
+        authority: SignerIndex,
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<Box<dyn Signer>>,
-        fee_payer: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
+        fee_payer: SignerIndex,
     },
     StakeSetLockup {
         stake_account_pubkey: Pubkey,
         lockup: Lockup,
-        custodian: Option<Box<dyn Signer>>,
+        custodian: SignerIndex,
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<Box<dyn Signer>>,
-        fee_payer: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
+        fee_payer: SignerIndex,
     },
     WithdrawStake {
         stake_account_pubkey: Pubkey,
         destination_account_pubkey: Pubkey,
         lamports: u64,
-        withdraw_authority: Option<Box<dyn Signer>>,
+        withdraw_authority: SignerIndex,
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<Box<dyn Signer>>,
-        fee_payer: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
+        fee_payer: SignerIndex,
     },
     // Storage Commands
     CreateStorageAccount {
         account_owner: Pubkey,
-        storage_account: KeypairEq,
         account_type: StorageAccountType,
     },
     ClaimStorageReward {
@@ -338,7 +337,6 @@ pub enum CliCommand {
     },
     // Vote Commands
     CreateVoteAccount {
-        vote_account: KeypairEq,
         seed: Option<String>,
         node_pubkey: Pubkey,
         authorized_voter: Option<Pubkey>,
@@ -357,7 +355,6 @@ pub enum CliCommand {
     VoteUpdateValidator {
         vote_account_pubkey: Pubkey,
         new_identity_pubkey: Pubkey,
-        authorized_voter: KeypairEq,
     },
     // Wallet Commands
     Address,
@@ -383,12 +380,12 @@ pub enum CliCommand {
     Transfer {
         lamports: u64,
         to: Pubkey,
-        from: Option<Box<dyn Signer>>,
+        from: SignerIndex,
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
-        nonce_authority: Option<Box<dyn Signer>>,
-        fee_payer: Option<Box<dyn Signer>>,
+        nonce_authority: SignerIndex,
+        fee_payer: SignerIndex,
     },
     Witness(Pubkey, Pubkey), // Witness(to, process_id)
 }
@@ -396,7 +393,7 @@ pub enum CliCommand {
 #[derive(Debug, PartialEq)]
 pub struct CliCommandInfo {
     pub command: CliCommand,
-    pub require_keypair: bool,
+    pub signers: CliSigners,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -433,17 +430,17 @@ impl From<Box<dyn error::Error>> for CliError {
     }
 }
 
-pub struct CliConfig {
+pub struct CliConfig<'a> {
     pub command: CliCommand,
     pub json_rpc_url: String,
-    pub keypair: Box<dyn Signer>,
+    pub signers: Vec<&'a dyn Signer>,
     pub keypair_path: Option<String>,
     pub derivation_path: Option<DerivationPath>,
     pub rpc_client: Option<RpcClient>,
     pub verbose: bool,
 }
 
-impl CliConfig {
+impl CliConfig<'_> {
     pub fn default_keypair_path() -> String {
         let mut keypair_path = dirs::home_dir().expect("home directory");
         keypair_path.extend(&[".config", "solana", "id.json"]);
@@ -455,19 +452,25 @@ impl CliConfig {
     }
 
     pub(crate) fn pubkey(&self) -> Result<Pubkey, SignerError> {
-        self.keypair.try_pubkey()
+        if !self.signers.is_empty() {
+            self.signers[0].try_pubkey()
+        } else {
+            Err(SignerError::CustomError(
+                "Default keypair must be set if pubkey arg not provided".to_string(),
+            ))
+        }
     }
 }
 
-impl Default for CliConfig {
-    fn default() -> CliConfig {
+impl Default for CliConfig<'_> {
+    fn default() -> CliConfig<'static> {
         CliConfig {
             command: CliCommand::Balance {
                 pubkey: Some(Pubkey::default()),
                 use_lamports_unit: false,
             },
             json_rpc_url: Self::default_json_rpc_url(),
-            keypair: Box::new(Keypair::new()),
+            signers: Vec::new(),
             keypair_path: Some(Self::default_keypair_path()),
             derivation_path: None,
             rpc_client: None,
@@ -476,98 +479,150 @@ impl Default for CliConfig {
     }
 }
 
-pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn error::Error>> {
+pub fn parse_command(
+    matches: &ArgMatches<'_>,
+    default_signer_path: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+) -> Result<CliCommandInfo, Box<dyn error::Error>> {
     let response = match matches.subcommand() {
         // Cluster Query Commands
         ("catchup", Some(matches)) => parse_catchup(matches),
         ("cluster-version", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::ClusterVersion,
-            require_keypair: false,
+            signers: vec![],
         }),
         ("create-address-with-seed", Some(matches)) => parse_create_address_with_seed(matches),
         ("fees", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::Fees,
-            require_keypair: false,
+            signers: vec![],
         }),
         ("block-time", Some(matches)) => parse_get_block_time(matches),
         ("epoch-info", Some(matches)) => parse_get_epoch_info(matches),
         ("genesis-hash", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::GetGenesisHash,
-            require_keypair: false,
+            signers: vec![],
         }),
         ("slot", Some(matches)) => parse_get_slot(matches),
         ("transaction-count", Some(matches)) => parse_get_transaction_count(matches),
         ("leader-schedule", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::LeaderSchedule,
-            require_keypair: false,
+            signers: vec![],
         }),
-        ("ping", Some(matches)) => parse_cluster_ping(matches),
+        ("ping", Some(matches)) => parse_cluster_ping(matches, default_signer_path, wallet_manager),
         ("live-slots", Some(matches)) => parse_live_slots(matches),
         ("block-production", Some(matches)) => parse_show_block_production(matches),
         ("gossip", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::ShowGossip,
-            require_keypair: false,
+            signers: vec![],
         }),
         ("stakes", Some(matches)) => parse_show_stakes(matches),
         ("validators", Some(matches)) => parse_show_validators(matches),
         // Nonce Commands
-        ("authorize-nonce-account", Some(matches)) => parse_authorize_nonce_account(matches),
-        ("create-nonce-account", Some(matches)) => parse_nonce_create_account(matches),
+        ("authorize-nonce-account", Some(matches)) => {
+            parse_authorize_nonce_account(matches, default_signer_path, wallet_manager)
+        }
+        ("create-nonce-account", Some(matches)) => {
+            parse_nonce_create_account(matches, default_signer_path, wallet_manager)
+        }
         ("nonce", Some(matches)) => parse_get_nonce(matches),
-        ("new-nonce", Some(matches)) => parse_new_nonce(matches),
+        ("new-nonce", Some(matches)) => {
+            parse_new_nonce(matches, default_signer_path, wallet_manager)
+        }
         ("nonce-account", Some(matches)) => parse_show_nonce_account(matches),
         ("withdraw-from-nonce-account", Some(matches)) => {
-            parse_withdraw_from_nonce_account(matches)
+            parse_withdraw_from_nonce_account(matches, default_signer_path, wallet_manager)
         }
         // Program Deployment
         ("deploy", Some(matches)) => Ok(CliCommandInfo {
             command: CliCommand::Deploy(matches.value_of("program_location").unwrap().to_string()),
-            require_keypair: true,
+            signers: vec![signer_from_path(
+                matches,
+                default_signer_path,
+                "keypair",
+                wallet_manager,
+            )?],
         }),
         // Stake Commands
-        ("create-stake-account", Some(matches)) => parse_stake_create_account(matches),
-        ("delegate-stake", Some(matches)) => parse_stake_delegate_stake(matches),
-        ("withdraw-stake", Some(matches)) => parse_stake_withdraw_stake(matches),
-        ("deactivate-stake", Some(matches)) => parse_stake_deactivate_stake(matches),
-        ("split-stake", Some(matches)) => parse_split_stake(matches),
-        ("stake-authorize-staker", Some(matches)) => {
-            parse_stake_authorize(matches, StakeAuthorize::Staker)
+        ("create-stake-account", Some(matches)) => {
+            parse_stake_create_account(matches, default_signer_path, wallet_manager)
         }
-        ("stake-authorize-withdrawer", Some(matches)) => {
-            parse_stake_authorize(matches, StakeAuthorize::Withdrawer)
+        ("delegate-stake", Some(matches)) => {
+            parse_stake_delegate_stake(matches, default_signer_path, wallet_manager)
         }
-        ("stake-set-lockup", Some(matches)) => parse_stake_set_lockup(matches),
+        ("withdraw-stake", Some(matches)) => {
+            parse_stake_withdraw_stake(matches, default_signer_path, wallet_manager)
+        }
+        ("deactivate-stake", Some(matches)) => {
+            parse_stake_deactivate_stake(matches, default_signer_path, wallet_manager)
+        }
+        ("split-stake", Some(matches)) => {
+            parse_split_stake(matches, default_signer_path, wallet_manager)
+        }
+        ("stake-authorize-staker", Some(matches)) => parse_stake_authorize(
+            matches,
+            default_signer_path,
+            wallet_manager,
+            StakeAuthorize::Staker,
+        ),
+        ("stake-authorize-withdrawer", Some(matches)) => parse_stake_authorize(
+            matches,
+            default_signer_path,
+            wallet_manager,
+            StakeAuthorize::Withdrawer,
+        ),
+        ("stake-set-lockup", Some(matches)) => {
+            parse_stake_set_lockup(matches, default_signer_path, wallet_manager)
+        }
         ("stake-account", Some(matches)) => parse_show_stake_account(matches),
         ("stake-history", Some(matches)) => parse_show_stake_history(matches),
         // Storage Commands
         ("create-archiver-storage-account", Some(matches)) => {
-            parse_storage_create_archiver_account(matches)
+            parse_storage_create_archiver_account(matches, default_signer_path, wallet_manager)
         }
         ("create-validator-storage-account", Some(matches)) => {
-            parse_storage_create_validator_account(matches)
+            parse_storage_create_validator_account(matches, default_signer_path, wallet_manager)
         }
-        ("claim-storage-reward", Some(matches)) => parse_storage_claim_reward(matches),
+        ("claim-storage-reward", Some(matches)) => {
+            parse_storage_claim_reward(matches, default_signer_path, wallet_manager)
+        }
         ("storage-account", Some(matches)) => parse_storage_get_account_command(matches),
         // Validator Info Commands
         ("validator-info", Some(matches)) => match matches.subcommand() {
-            ("publish", Some(matches)) => parse_validator_info_command(matches),
+            ("publish", Some(matches)) => {
+                parse_validator_info_command(matches, default_signer_path, wallet_manager)
+            }
             ("get", Some(matches)) => parse_get_validator_info_command(matches),
             _ => unreachable!(),
         },
         // Vote Commands
-        ("create-vote-account", Some(matches)) => parse_vote_create_account(matches),
-        ("vote-update-validator", Some(matches)) => parse_vote_update_validator(matches),
-        ("vote-authorize-voter", Some(matches)) => {
-            parse_vote_authorize(matches, VoteAuthorize::Voter)
+        ("create-vote-account", Some(matches)) => {
+            parse_vote_create_account(matches, default_signer_path, wallet_manager)
         }
-        ("vote-authorize-withdrawer", Some(matches)) => {
-            parse_vote_authorize(matches, VoteAuthorize::Withdrawer)
+        ("vote-update-validator", Some(matches)) => {
+            parse_vote_update_validator(matches, default_signer_path, wallet_manager)
         }
+        ("vote-authorize-voter", Some(matches)) => parse_vote_authorize(
+            matches,
+            default_signer_path,
+            wallet_manager,
+            VoteAuthorize::Voter,
+        ),
+        ("vote-authorize-withdrawer", Some(matches)) => parse_vote_authorize(
+            matches,
+            default_signer_path,
+            wallet_manager,
+            VoteAuthorize::Withdrawer,
+        ),
         ("vote-account", Some(matches)) => parse_vote_get_account_command(matches),
         // Wallet Commands
         ("address", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::Address,
-            require_keypair: true,
+            signers: vec![signer_from_path(
+                matches,
+                default_signer_path,
+                "keypair",
+                wallet_manager,
+            )?],
         }),
         ("airdrop", Some(matches)) => {
             let faucet_port = matches
@@ -592,6 +647,16 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
                 None
             };
             let pubkey = pubkey_of(&matches, "to");
+            let signers = if pubkey.is_some() {
+                vec![]
+            } else {
+                vec![signer_from_path(
+                    matches,
+                    default_signer_path,
+                    "keypair",
+                    wallet_manager,
+                )?]
+            };
             let lamports = lamports_of_sol(matches, "amount").unwrap();
             Ok(CliCommandInfo {
                 command: CliCommand::Airdrop {
@@ -600,30 +665,43 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
                     pubkey,
                     lamports,
                 },
-                require_keypair: true,
+                signers,
             })
         }
         ("balance", Some(matches)) => {
             let pubkey = pubkey_of(&matches, "pubkey");
+            let signers = if pubkey.is_some() {
+                vec![]
+            } else {
+                vec![signer_from_path(
+                    matches,
+                    default_signer_path,
+                    "keypair",
+                    wallet_manager,
+                )?]
+            };
             Ok(CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey,
                     use_lamports_unit: matches.is_present("lamports"),
                 },
-                require_keypair: pubkey.is_none(),
+                signers,
             })
         }
         ("cancel", Some(matches)) => {
             let process_id = value_of(matches, "process_id").unwrap();
+            let default_signer =
+                signer_from_path(matches, default_signer_path, "keypair", wallet_manager)?;
+
             Ok(CliCommandInfo {
                 command: CliCommand::Cancel(process_id),
-                require_keypair: true,
+                signers: vec![default_signer],
             })
         }
         ("confirm", Some(matches)) => match matches.value_of("signature").unwrap().parse() {
             Ok(signature) => Ok(CliCommandInfo {
                 command: CliCommand::Confirm(signature),
-                require_keypair: false,
+                signers: vec![],
             }),
             _ => {
                 eprintln!("{}", matches.usage());
@@ -650,7 +728,15 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(&matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
+            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches, wallet_manager)?;
+
+            let payer_provided = None;
+            let CliSignerInfo { signers, indexes } = generate_unique_signers(
+                vec![payer_provided, nonce_authority],
+                matches,
+                default_signer_path,
+                wallet_manager,
+            )?;
 
             Ok(CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
@@ -663,9 +749,9 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
                     sign_only,
                     blockhash_query,
                     nonce_account,
-                    nonce_authority,
+                    nonce_authority: indexes[1],
                 }),
-                require_keypair: true,
+                signers,
             })
         }
         ("account", Some(matches)) => {
@@ -678,15 +764,19 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
                     output_file: output_file.map(ToString::to_string),
                     use_lamports_unit,
                 },
-                require_keypair: false,
+                signers: vec![],
             })
         }
         ("send-signature", Some(matches)) => {
             let to = value_of(&matches, "to").unwrap();
             let process_id = value_of(&matches, "process_id").unwrap();
+
+            let default_signer =
+                signer_from_path(matches, default_signer_path, "keypair", wallet_manager)?;
+
             Ok(CliCommandInfo {
                 command: CliCommand::Witness(to, process_id),
-                require_keypair: true,
+                signers: vec![default_signer],
             })
         }
         ("send-timestamp", Some(matches)) => {
@@ -703,9 +793,12 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             } else {
                 Utc::now()
             };
+            let default_signer =
+                signer_from_path(matches, default_signer_path, "keypair", wallet_manager)?;
+
             Ok(CliCommandInfo {
                 command: CliCommand::TimeElapsed(to, process_id, dt),
-                require_keypair: true,
+                signers: vec![default_signer],
             })
         }
         ("transfer", Some(matches)) => {
@@ -714,21 +807,29 @@ pub fn parse_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, Box<dyn
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
             let blockhash_query = BlockhashQuery::new_from_matches(matches);
             let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches)?;
-            let fee_payer = signer_of(FEE_PAYER_ARG.name, &matches)?;
-            let from = signer_of("from", &matches)?;
+            let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, &matches, wallet_manager)?;
+            let fee_payer = signer_of(FEE_PAYER_ARG.name, &matches, wallet_manager)?;
+            let from = signer_of("from", &matches, wallet_manager)?;
+
+            let CliSignerInfo { signers, indexes } = generate_unique_signers(
+                vec![nonce_authority, fee_payer, from],
+                matches,
+                default_signer_path,
+                wallet_manager,
+            )?;
+
             Ok(CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports,
                     to,
-                    from,
                     sign_only,
                     blockhash_query,
                     nonce_account,
-                    nonce_authority,
-                    fee_payer,
+                    nonce_authority: indexes[0],
+                    fee_payer: indexes[1],
+                    from: indexes[2],
                 },
-                require_keypair: true,
+                signers,
             })
         }
         //
@@ -824,8 +925,6 @@ pub fn parse_create_address_with_seed(
 ) -> Result<CliCommandInfo, CliError> {
     let from_pubkey = pubkey_of(matches, "from");
 
-    let require_keypair = from_pubkey.is_none();
-
     let program_id = match matches.value_of("program_id").unwrap() {
         "STAKE" => solana_stake_program::id(),
         "VOTE" => solana_vote_program::id(),
@@ -847,7 +946,7 @@ pub fn parse_create_address_with_seed(
             seed,
             program_id,
         },
-        require_keypair,
+        signers: vec![],
     })
 }
 
@@ -870,7 +969,11 @@ fn process_airdrop(
     pubkey: &Option<Pubkey>,
     lamports: u64,
 ) -> ProcessResult {
-    let pubkey = pubkey.unwrap_or(config.pubkey()?);
+    let pubkey = if let Some(pubkey) = pubkey {
+        *pubkey
+    } else {
+        config.pubkey()?
+    };
     println!(
         "Requesting airdrop of {} from {}",
         build_balance_message(lamports, false, true),
@@ -901,7 +1004,11 @@ fn process_balance(
     pubkey: &Option<Pubkey>,
     use_lamports_unit: bool,
 ) -> ProcessResult {
-    let pubkey = pubkey.unwrap_or(config.pubkey()?);
+    let pubkey = if let Some(pubkey) = pubkey {
+        *pubkey
+    } else {
+        config.pubkey()?
+    };
     let balance = rpc_client.retry_get_balance(&pubkey, 5)?;
     match balance {
         Some(lamports) => Ok(build_balance_message(lamports, use_lamports_unit, true)),
@@ -977,7 +1084,7 @@ fn process_deploy(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data.len())?;
     let ix = system_instruction::create_account(
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &program_id.pubkey(),
         minimum_balance.max(1),
         program_data.len() as u64,
@@ -985,9 +1092,9 @@ fn process_deploy(
     );
     let message = Message::new(vec![ix]);
     let mut create_account_tx = Transaction::new_unsigned(message);
-    create_account_tx.try_sign(&[config.keypair.as_ref(), &program_id], blockhash)?;
+    create_account_tx.try_sign(&[config.signers[0], &program_id], blockhash)?;
     messages.push(&create_account_tx.message);
-    let signers = [config.keypair.as_ref(), &program_id];
+    let signers = [config.signers[0], &program_id];
     let mut write_transactions = vec![];
     for (chunk, i) in program_data.chunks(DATA_CHUNK_SIZE).zip(0..) {
         let instruction = loader_instruction::write(
@@ -1013,7 +1120,7 @@ fn process_deploy(
 
     check_account_for_multiple_fees(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &messages,
     )?;
@@ -1052,36 +1159,31 @@ fn process_pay(
     sign_only: bool,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<Pubkey>,
-    nonce_authority: Option<&dyn Signer>,
+    nonce_authority: SignerIndex,
 ) -> ProcessResult {
     check_unique_pubkeys(
-        (&config.keypair.pubkey(), "cli keypair".to_string()),
+        (&config.signers[0].pubkey(), "cli keypair".to_string()),
         (to, "to".to_string()),
     )?;
 
     let (blockhash, fee_calculator) = blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
 
     let cancelable = if cancelable {
-        Some(config.keypair.pubkey())
+        Some(config.signers[0].pubkey())
     } else {
         None
     };
 
     if timestamp == None && *witnesses == None {
-        let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
-        let ix = system_instruction::transfer(&config.keypair.pubkey(), to, lamports);
-        let mut tx = if let Some(nonce_account) = &nonce_account {
-            let message =
-                Message::new_with_nonce(vec![ix], None, nonce_account, &nonce_authority.pubkey());
-            let mut tx = Transaction::new_unsigned(message);
-            tx.try_sign(&[config.keypair.as_ref(), nonce_authority], blockhash)?;
-            tx
+        let nonce_authority = config.signers[nonce_authority];
+        let ix = system_instruction::transfer(&config.signers[0].pubkey(), to, lamports);
+        let message = if let Some(nonce_account) = &nonce_account {
+            Message::new_with_nonce(vec![ix], None, nonce_account, &nonce_authority.pubkey())
         } else {
-            let message = Message::new(vec![ix]);
-            let mut tx = Transaction::new_unsigned(message);
-            tx.try_sign(&[config.keypair.as_ref()], blockhash)?;
-            tx
+            Message::new(vec![ix])
         };
+        let mut tx = Transaction::new_unsigned(message);
+        tx.try_sign(&config.signers, blockhash)?;
 
         if sign_only {
             return_signers(&tx)
@@ -1092,26 +1194,25 @@ fn process_pay(
             }
             check_account_for_fee(
                 rpc_client,
-                &config.keypair.pubkey(),
+                &config.signers[0].pubkey(),
                 &fee_calculator,
                 &tx.message,
             )?;
-            let result =
-                rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
+            let result = rpc_client.send_and_confirm_transaction(&mut tx, &config.signers);
             log_instruction_custom_error::<SystemError>(result)
         }
     } else if *witnesses == None {
         let dt = timestamp.unwrap();
         let dt_pubkey = match timestamp_pubkey {
             Some(pubkey) => pubkey,
-            None => config.keypair.pubkey(),
+            None => config.signers[0].pubkey(),
         };
 
         let contract_state = Keypair::new();
 
         // Initializing contract
         let ixs = budget_instruction::on_date(
-            &config.keypair.pubkey(),
+            &config.signers[0].pubkey(),
             to,
             &contract_state.pubkey(),
             dt,
@@ -1121,18 +1222,18 @@ fn process_pay(
         );
         let message = Message::new(ixs);
         let mut tx = Transaction::new_unsigned(message);
-        tx.try_sign(&[config.keypair.as_ref(), &contract_state], blockhash)?;
+        tx.try_sign(&[config.signers[0], &contract_state], blockhash)?;
         if sign_only {
             return_signers(&tx)
         } else {
             check_account_for_fee(
                 rpc_client,
-                &config.keypair.pubkey(),
+                &config.signers[0].pubkey(),
                 &fee_calculator,
                 &tx.message,
             )?;
             let result = rpc_client
-                .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), &contract_state]);
+                .send_and_confirm_transaction(&mut tx, &[config.signers[0], &contract_state]);
             let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
 
             Ok(json!({
@@ -1155,7 +1256,7 @@ fn process_pay(
 
         // Initializing contract
         let ixs = budget_instruction::when_signed(
-            &config.keypair.pubkey(),
+            &config.signers[0].pubkey(),
             to,
             &contract_state.pubkey(),
             &witness,
@@ -1164,15 +1265,15 @@ fn process_pay(
         );
         let message = Message::new(ixs);
         let mut tx = Transaction::new_unsigned(message);
-        tx.try_sign(&[config.keypair.as_ref(), &contract_state], blockhash)?;
+        tx.try_sign(&[config.signers[0], &contract_state], blockhash)?;
         if sign_only {
             return_signers(&tx)
         } else {
             let result = rpc_client
-                .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), &contract_state]);
+                .send_and_confirm_transaction(&mut tx, &[config.signers[0], &contract_state]);
             check_account_for_fee(
                 rpc_client,
-                &config.keypair.pubkey(),
+                &config.signers[0].pubkey(),
                 &fee_calculator,
                 &tx.message,
             )?;
@@ -1192,20 +1293,20 @@ fn process_pay(
 fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -> ProcessResult {
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ix = budget_instruction::apply_signature(
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         pubkey,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
     );
     let message = Message::new(vec![ix]);
     let mut tx = Transaction::new_unsigned(message);
-    tx.try_sign(&[config.keypair.as_ref()], blockhash)?;
+    tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.signers[0]]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 
@@ -1218,17 +1319,17 @@ fn process_time_elapsed(
 ) -> ProcessResult {
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let ix = budget_instruction::apply_timestamp(&config.keypair.pubkey(), pubkey, to, dt);
+    let ix = budget_instruction::apply_timestamp(&config.signers[0].pubkey(), pubkey, to, dt);
     let message = Message::new(vec![ix]);
     let mut tx = Transaction::new_unsigned(message);
-    tx.try_sign(&[config.keypair.as_ref()], blockhash)?;
+    tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.signers[0]]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 
@@ -1238,14 +1339,14 @@ fn process_transfer(
     config: &CliConfig,
     lamports: u64,
     to: &Pubkey,
-    from: Option<&(dyn Signer + 'static)>,
+    from: SignerIndex,
     sign_only: bool,
     blockhash_query: &BlockhashQuery,
     nonce_account: Option<&Pubkey>,
-    nonce_authority: Option<&(dyn Signer + 'static)>,
-    fee_payer: Option<&(dyn Signer + 'static)>,
+    nonce_authority: SignerIndex,
+    fee_payer: SignerIndex,
 ) -> ProcessResult {
-    let from = from.unwrap_or_else(|| config.keypair.as_ref());
+    let from = config.signers[from];
 
     check_unique_pubkeys(
         (&from.pubkey(), "cli keypair".to_string()),
@@ -1256,29 +1357,21 @@ fn process_transfer(
         blockhash_query.get_blockhash_fee_calculator(rpc_client)?;
     let ixs = vec![system_instruction::transfer(&from.pubkey(), to, lamports)];
 
-    let nonce_authority = nonce_authority.unwrap_or_else(|| config.keypair.as_ref());
-    let fee_payer = fee_payer.unwrap_or_else(|| config.keypair.as_ref());
-    let mut signers = vec![fee_payer];
-    if *fee_payer != *from {
-        signers.push(from)
-    }
-    let mut tx = if let Some(nonce_account) = &nonce_account {
-        signers.push(nonce_authority);
-        let message = Message::new_with_nonce(
+    let nonce_authority = config.signers[nonce_authority];
+    let fee_payer = config.signers[fee_payer];
+
+    let message = if let Some(nonce_account) = &nonce_account {
+        Message::new_with_nonce(
             ixs,
             Some(&fee_payer.pubkey()),
             nonce_account,
             &nonce_authority.pubkey(),
-        );
-        let mut tx = Transaction::new_unsigned(message);
-        tx.try_sign(&signers, recent_blockhash)?;
-        tx
+        )
     } else {
-        let message = Message::new_with_payer(ixs, Some(&fee_payer.pubkey()));
-        let mut tx = Transaction::new_unsigned(message);
-        tx.try_sign(&signers, recent_blockhash)?;
-        tx
+        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
     };
+    let mut tx = Transaction::new_unsigned(message);
+    tx.try_sign(&config.signers, recent_blockhash)?;
 
     if sign_only {
         return_signers(&tx)
@@ -1293,7 +1386,7 @@ fn process_transfer(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
+        let result = rpc_client.send_and_confirm_transaction(&mut tx, &config.signers);
         log_instruction_custom_error::<SystemError>(result)
     }
 }
@@ -1306,17 +1399,17 @@ fn process_witness(
 ) -> ProcessResult {
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let ix = budget_instruction::apply_signature(&config.keypair.pubkey(), pubkey, to);
+    let ix = budget_instruction::apply_signature(&config.signers[0].pubkey(), pubkey, to);
     let message = Message::new(vec![ix]);
     let mut tx = Transaction::new_unsigned(message);
-    tx.try_sign(&[config.keypair.as_ref()], blockhash)?;
+    tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.signers[0]]);
     log_instruction_custom_error::<BudgetError>(result)
 }
 
@@ -1403,13 +1496,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Assign authority to nonce account
         CliCommand::AuthorizeNonceAccount {
             nonce_account,
-            ref nonce_authority,
+            nonce_authority,
             new_authority,
         } => process_authorize_nonce_account(
             &rpc_client,
             config,
             nonce_account,
-            nonce_authority.as_deref(),
+            *nonce_authority,
             new_authority,
         ),
         // Create nonce account
@@ -1421,7 +1514,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_create_nonce_account(
             &rpc_client,
             config,
-            nonce_account.as_ref().as_ref(),
+            *nonce_account,
             seed.clone(),
             *nonce_authority,
             *lamports,
@@ -1433,13 +1526,8 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Get a new nonce
         CliCommand::NewNonce {
             nonce_account,
-            ref nonce_authority,
-        } => process_new_nonce(
-            &rpc_client,
-            config,
-            nonce_account,
-            nonce_authority.as_deref(),
-        ),
+            nonce_authority,
+        } => process_new_nonce(&rpc_client, config, nonce_account, *nonce_authority),
         // Show the contents of a nonce account
         CliCommand::ShowNonceAccount {
             nonce_account_pubkey,
@@ -1448,14 +1536,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Withdraw lamports from a nonce account
         CliCommand::WithdrawFromNonceAccount {
             nonce_account,
-            ref nonce_authority,
+            nonce_authority,
             destination_account_pubkey,
             lamports,
         } => process_withdraw_from_nonce_account(
             &rpc_client,
             config,
             &nonce_account,
-            nonce_authority.as_deref(),
+            *nonce_authority,
             &destination_account_pubkey,
             *lamports,
         ),
@@ -1471,7 +1559,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
 
         // Create stake account
         CliCommand::CreateStakeAccount {
-            ref stake_account,
+            stake_account,
             seed,
             staker,
             withdrawer,
@@ -1480,13 +1568,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             sign_only,
             blockhash_query,
             ref nonce_account,
-            ref nonce_authority,
-            ref fee_payer,
-            ref from,
+            nonce_authority,
+            fee_payer,
+            from,
         } => process_create_stake_account(
             &rpc_client,
             config,
-            stake_account.as_ref().as_ref(),
+            *stake_account,
             seed,
             staker,
             withdrawer,
@@ -1495,76 +1583,76 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *sign_only,
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_deref(),
-            fee_payer.as_deref(),
-            from.as_deref(),
+            *nonce_authority,
+            *fee_payer,
+            *from,
         ),
         CliCommand::DeactivateStake {
             stake_account_pubkey,
-            ref stake_authority,
+            stake_authority,
             sign_only,
             blockhash_query,
             nonce_account,
-            ref nonce_authority,
-            ref fee_payer,
+            nonce_authority,
+            fee_payer,
         } => process_deactivate_stake_account(
             &rpc_client,
             config,
             &stake_account_pubkey,
-            stake_authority.as_deref(),
+            *stake_authority,
             *sign_only,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_deref(),
-            fee_payer.as_deref(),
+            *nonce_authority,
+            *fee_payer,
         ),
         CliCommand::DelegateStake {
             stake_account_pubkey,
             vote_account_pubkey,
-            ref stake_authority,
+            stake_authority,
             force,
             sign_only,
             blockhash_query,
             nonce_account,
-            ref nonce_authority,
-            ref fee_payer,
+            nonce_authority,
+            fee_payer,
         } => process_delegate_stake(
             &rpc_client,
             config,
             &stake_account_pubkey,
             &vote_account_pubkey,
-            stake_authority.as_deref(),
+            *stake_authority,
             *force,
             *sign_only,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_deref(),
-            fee_payer.as_deref(),
+            *nonce_authority,
+            *fee_payer,
         ),
         CliCommand::SplitStake {
             stake_account_pubkey,
-            ref stake_authority,
+            stake_authority,
             sign_only,
             blockhash_query,
             nonce_account,
-            ref nonce_authority,
+            nonce_authority,
             split_stake_account,
             seed,
             lamports,
-            ref fee_payer,
+            fee_payer,
         } => process_split_stake(
             &rpc_client,
             config,
             &stake_account_pubkey,
-            stake_authority.as_deref(),
+            *stake_authority,
             *sign_only,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_deref(),
-            split_stake_account.as_ref().as_ref(),
+            *nonce_authority,
+            *split_stake_account,
             seed,
             *lamports,
-            fee_payer.as_deref(),
+            *fee_payer,
         ),
         CliCommand::ShowStakeAccount {
             pubkey: stake_account_pubkey,
@@ -1582,68 +1670,68 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             stake_account_pubkey,
             new_authorized_pubkey,
             stake_authorize,
-            ref authority,
+            authority,
             sign_only,
             blockhash_query,
             nonce_account,
-            ref nonce_authority,
-            ref fee_payer,
+            nonce_authority,
+            fee_payer,
         } => process_stake_authorize(
             &rpc_client,
             config,
             &stake_account_pubkey,
             &new_authorized_pubkey,
             *stake_authorize,
-            authority.as_deref(),
+            *authority,
             *sign_only,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_deref(),
-            fee_payer.as_deref(),
+            *nonce_authority,
+            *fee_payer,
         ),
         CliCommand::StakeSetLockup {
             stake_account_pubkey,
             mut lockup,
-            ref custodian,
+            custodian,
             sign_only,
             blockhash_query,
             nonce_account,
-            ref nonce_authority,
-            ref fee_payer,
+            nonce_authority,
+            fee_payer,
         } => process_stake_set_lockup(
             &rpc_client,
             config,
             &stake_account_pubkey,
             &mut lockup,
-            custodian.as_deref(),
+            *custodian,
             *sign_only,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_deref(),
-            fee_payer.as_deref(),
+            *nonce_authority,
+            *fee_payer,
         ),
         CliCommand::WithdrawStake {
             stake_account_pubkey,
             destination_account_pubkey,
             lamports,
-            ref withdraw_authority,
+            withdraw_authority,
             sign_only,
             blockhash_query,
             ref nonce_account,
-            ref nonce_authority,
-            ref fee_payer,
+            nonce_authority,
+            fee_payer,
         } => process_withdraw_stake(
             &rpc_client,
             config,
             &stake_account_pubkey,
             &destination_account_pubkey,
             *lamports,
-            withdraw_authority.as_deref(),
+            *withdraw_authority,
             *sign_only,
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_deref(),
-            fee_payer.as_deref(),
+            *nonce_authority,
+            *fee_payer,
         ),
 
         // Storage Commands
@@ -1651,15 +1739,8 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Create storage account
         CliCommand::CreateStorageAccount {
             account_owner,
-            storage_account,
             account_type,
-        } => process_create_storage_account(
-            &rpc_client,
-            config,
-            &account_owner,
-            storage_account,
-            *account_type,
-        ),
+        } => process_create_storage_account(&rpc_client, config, &account_owner, *account_type),
         CliCommand::ClaimStorageReward {
             node_account_pubkey,
             storage_account_pubkey,
@@ -1696,7 +1777,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
 
         // Create vote account
         CliCommand::CreateVoteAccount {
-            vote_account,
             seed,
             node_pubkey,
             authorized_voter,
@@ -1705,7 +1785,6 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_create_vote_account(
             &rpc_client,
             config,
-            vote_account,
             seed,
             &node_pubkey,
             authorized_voter,
@@ -1735,13 +1814,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::VoteUpdateValidator {
             vote_account_pubkey,
             new_identity_pubkey,
-            authorized_voter,
         } => process_vote_update_validator(
             &rpc_client,
             config,
             &vote_account_pubkey,
             &new_identity_pubkey,
-            authorized_voter,
         ),
 
         // Wallet Commands
@@ -1789,7 +1866,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             sign_only,
             blockhash_query,
             nonce_account,
-            ref nonce_authority,
+            nonce_authority,
         }) => process_pay(
             &rpc_client,
             config,
@@ -1802,7 +1879,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *sign_only,
             blockhash_query,
             *nonce_account,
-            nonce_authority.as_deref(),
+            *nonce_authority,
         ),
         CliCommand::ShowAccount {
             pubkey,
@@ -1822,23 +1899,23 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::Transfer {
             lamports,
             to,
-            ref from,
+            from,
             sign_only,
             ref blockhash_query,
             ref nonce_account,
-            ref nonce_authority,
-            ref fee_payer,
+            nonce_authority,
+            fee_payer,
         } => process_transfer(
             &rpc_client,
             config,
             *lamports,
             to,
-            from.as_deref(),
+            *from,
             *sign_only,
             blockhash_query,
             nonce_account.as_ref(),
-            nonce_authority.as_deref(),
-            fee_payer.as_deref(),
+            *nonce_authority,
+            *fee_payer,
         ),
         // Apply witness signature to contract
         CliCommand::Witness(to, pubkey) => process_witness(&rpc_client, config, &to, &pubkey),
@@ -2298,6 +2375,72 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_unique_signers() {
+        let CliSignerInfo {
+            signers,
+            indexes,
+            require_default_keypair,
+        } = generate_unique_signers(vec![]);
+        assert_eq!(signers.len(), 0);
+        assert_eq!(indexes.len(), 0);
+        assert_eq!(require_default_keypair, true);
+
+        let CliSignerInfo {
+            signers,
+            indexes,
+            require_default_keypair,
+        } = generate_unique_signers(vec![None, None]);
+        assert_eq!(signers.len(), 0);
+        assert_eq!(indexes, vec![0, 0]);
+        assert_eq!(require_default_keypair, true);
+
+        let keypair0 = keypair_from_seed(&[1u8; 32]).unwrap();
+        let keypair0_clone = keypair_from_seed(&[1u8; 32]).unwrap();
+        let signers = vec![None, Some(keypair0.into()), Some(keypair0_clone.into())];
+        let CliSignerInfo {
+            signers,
+            indexes,
+            require_default_keypair,
+        } = generate_unique_signers(signers);
+        assert_eq!(signers.len(), 1);
+        assert_eq!(indexes, vec![0, 1, 1]);
+        assert_eq!(require_default_keypair, true);
+
+        let keypair0 = keypair_from_seed(&[1u8; 32]).unwrap();
+        let keypair0_clone = keypair_from_seed(&[1u8; 32]).unwrap();
+        let signers = vec![Some(keypair0.into()), Some(keypair0_clone.into())];
+        let CliSignerInfo {
+            signers,
+            indexes,
+            require_default_keypair,
+        } = generate_unique_signers(signers);
+        assert_eq!(signers.len(), 1);
+        assert_eq!(indexes, vec![0, 0]);
+        assert_eq!(require_default_keypair, false);
+
+        // Signers with the same pubkey are not distinct
+        let keypair0 = Keypair::new();
+        let keypair1 = keypair_from_seed(&[1u8; 32]).unwrap();
+        let message = vec![0, 1, 2, 3];
+        let presigner0 = Presigner::new(&keypair0.pubkey(), &keypair0.sign_message(&message));
+        let presigner1 = Presigner::new(&keypair1.pubkey(), &keypair1.sign_message(&message));
+        let signers = vec![
+            Some(keypair0.into()),
+            Some(presigner0.into()),
+            Some(presigner1.into()),
+            Some(keypair1.into()),
+        ];
+        let CliSignerInfo {
+            signers,
+            indexes,
+            require_default_keypair,
+        } = generate_unique_signers(signers);
+        assert_eq!(signers.len(), 2);
+        assert_eq!(indexes, vec![0, 0, 1, 1]);
+        assert_eq!(require_default_keypair, false);
+    }
+
+    #[test]
     fn test_cli_parse_command() {
         let test_commands = app("test", "desc", "version");
 
@@ -2323,7 +2466,7 @@ mod tests {
                     pubkey: Some(pubkey),
                     lamports: 50_000_000_000,
                 },
-                require_keypair: true,
+                require_default_keypair: true,
             }
         );
 
@@ -2343,7 +2486,7 @@ mod tests {
                     pubkey: Some(keypair.pubkey()),
                     use_lamports_unit: false
                 },
-                require_keypair: false
+                require_default_keypair: false
             }
         );
         let test_balance = test_commands.clone().get_matches_from(vec![
@@ -2359,7 +2502,7 @@ mod tests {
                     pubkey: Some(keypair.pubkey()),
                     use_lamports_unit: true
                 },
-                require_keypair: false
+                require_default_keypair: false
             }
         );
         let test_balance =
@@ -2373,7 +2516,7 @@ mod tests {
                     pubkey: None,
                     use_lamports_unit: true
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2386,7 +2529,7 @@ mod tests {
             parse_command(&test_cancel).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Cancel(pubkey),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2401,7 +2544,7 @@ mod tests {
             parse_command(&test_confirm).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Confirm(signature),
-                require_keypair: false
+                require_default_keypair: false
             }
         );
         let test_bad_signature = test_commands
@@ -2433,7 +2576,7 @@ mod tests {
                         seed: "seed".to_string(),
                         program_id: *program_id
                     },
-                    require_keypair: false
+                    require_default_keypair: false
                 }
             );
         }
@@ -2451,7 +2594,7 @@ mod tests {
                     seed: "seed".to_string(),
                     program_id: solana_stake_program::id(),
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2464,7 +2607,7 @@ mod tests {
             parse_command(&test_deploy).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Deploy("/Users/test/program.o".to_string()),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2481,7 +2624,7 @@ mod tests {
                     to: pubkey,
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2505,7 +2648,7 @@ mod tests {
                     witnesses: Some(vec![witness0, witness1]),
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
         let test_pay_single_witness = test_commands.clone().get_matches_from(vec![
@@ -2525,7 +2668,7 @@ mod tests {
                     witnesses: Some(vec![witness0]),
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2550,7 +2693,7 @@ mod tests {
                     timestamp_pubkey: Some(witness0),
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2576,7 +2719,7 @@ mod tests {
                     sign_only: true,
                     ..PayCommand::default()
                 }),
-                require_keypair: true,
+                require_default_keypair: true,
             }
         );
 
@@ -2598,7 +2741,7 @@ mod tests {
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2625,7 +2768,7 @@ mod tests {
                     nonce_account: Some(pubkey),
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2656,7 +2799,7 @@ mod tests {
                     nonce_authority: Some(keypair.into()),
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2691,7 +2834,7 @@ mod tests {
                     nonce_authority: Some(Presigner::new(&authority_pubkey, &sig).into()),
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2729,7 +2872,7 @@ mod tests {
             parse_command(&test_send_signature).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Witness(pubkey, pubkey),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
         let test_pay_multiple_witnesses = test_commands.clone().get_matches_from(vec![
@@ -2757,7 +2900,7 @@ mod tests {
                     witnesses: Some(vec![witness0, witness1]),
                     ..PayCommand::default()
                 }),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -2774,7 +2917,7 @@ mod tests {
             parse_command(&test_send_timestamp).unwrap(),
             CliCommandInfo {
                 command: CliCommand::TimeElapsed(pubkey, pubkey, dt),
-                require_keypair: true
+                require_default_keypair: true
             }
         );
         let test_bad_timestamp = test_commands.clone().get_matches_from(vec![
@@ -2796,7 +2939,7 @@ mod tests {
 
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey().to_string();
-        config.keypair = keypair.into();
+        config.signers[0] = keypair.into();
         config.command = CliCommand::Address;
         assert_eq!(process_command(&config).unwrap(), pubkey);
 
@@ -2946,7 +3089,7 @@ mod tests {
             lamports: 10,
             to: bob_pubkey,
             timestamp: Some(dt),
-            timestamp_pubkey: Some(config.keypair.pubkey()),
+            timestamp_pubkey: Some(config.signers[0].pubkey()),
             ..PayCommand::default()
         });
         let result = process_command(&config);
@@ -2988,7 +3131,10 @@ mod tests {
             value: json!(RpcAccount::encode(
                 Account::new_data(
                     1,
-                    &NonceState::Initialized(NonceMeta::new(&config.keypair.pubkey()), blockhash),
+                    &NonceState::Initialized(
+                        NonceMeta::new(&config.signers[0].pubkey()),
+                        blockhash
+                    ),
                     &system_program::ID,
                 )
                 .unwrap()
@@ -3146,7 +3292,7 @@ mod tests {
             lamports: 10,
             to: bob_pubkey,
             timestamp: Some(dt),
-            timestamp_pubkey: Some(config.keypair.pubkey()),
+            timestamp_pubkey: Some(config.signers[0].pubkey()),
             ..PayCommand::default()
         });
         assert!(process_command(&config).is_err());
@@ -3222,7 +3368,7 @@ mod tests {
                     nonce_authority: None,
                     fee_payer: None,
                 },
-                require_keypair: true,
+                require_default_keypair: true,
             }
         );
 
@@ -3251,7 +3397,7 @@ mod tests {
                     nonce_authority: None,
                     fee_payer: None,
                 },
-                require_keypair: true,
+                require_default_keypair: true,
             }
         );
 
@@ -3285,7 +3431,7 @@ mod tests {
                     nonce_authority: None,
                     fee_payer: Some(Presigner::new(&from_pubkey, &from_sig).into()),
                 },
-                require_keypair: true,
+                require_default_keypair: true,
             }
         );
 
@@ -3320,7 +3466,7 @@ mod tests {
                     nonce_authority: Some(read_keypair_file(&nonce_authority_file).unwrap().into()),
                     fee_payer: None,
                 },
-                require_keypair: true,
+                require_default_keypair: true,
             }
         );
     }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -64,7 +64,7 @@ pub fn generate_unique_signers(
     bulk_signers: Vec<Option<Box<dyn Signer>>>,
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliSignerInfo, Box<dyn error::Error>> {
     let mut unique_signers = vec![];
     let mut indexes = vec![];
@@ -482,7 +482,7 @@ impl Default for CliConfig<'_> {
 pub fn parse_command(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, Box<dyn error::Error>> {
     let response = match matches.subcommand() {
         // Cluster Query Commands
@@ -2381,12 +2381,12 @@ mod tests {
         write_keypair_file(&default_keypair, &default_keypair_file).unwrap();
 
         let CliSignerInfo { signers, indexes } =
-            generate_unique_signers(vec![], &matches, &default_keypair_file, &None).unwrap();
+            generate_unique_signers(vec![], &matches, &default_keypair_file, None).unwrap();
         assert_eq!(signers.len(), 0);
         assert_eq!(indexes.len(), 0);
 
         let CliSignerInfo { signers, indexes } =
-            generate_unique_signers(vec![None, None], &matches, &default_keypair_file, &None)
+            generate_unique_signers(vec![None, None], &matches, &default_keypair_file, None)
                 .unwrap();
         assert_eq!(signers.len(), 1);
         assert_eq!(indexes, vec![0, 0]);
@@ -2395,7 +2395,7 @@ mod tests {
         let keypair0_clone = keypair_from_seed(&[1u8; 32]).unwrap();
         let signers = vec![None, Some(keypair0.into()), Some(keypair0_clone.into())];
         let CliSignerInfo { signers, indexes } =
-            generate_unique_signers(signers, &matches, &default_keypair_file, &None).unwrap();
+            generate_unique_signers(signers, &matches, &default_keypair_file, None).unwrap();
         assert_eq!(signers.len(), 2);
         assert_eq!(indexes, vec![0, 1, 1]);
 
@@ -2403,7 +2403,7 @@ mod tests {
         let keypair0_clone = keypair_from_seed(&[1u8; 32]).unwrap();
         let signers = vec![Some(keypair0.into()), Some(keypair0_clone.into())];
         let CliSignerInfo { signers, indexes } =
-            generate_unique_signers(signers, &matches, &default_keypair_file, &None).unwrap();
+            generate_unique_signers(signers, &matches, &default_keypair_file, None).unwrap();
         assert_eq!(signers.len(), 1);
         assert_eq!(indexes, vec![0, 0]);
 
@@ -2420,7 +2420,7 @@ mod tests {
             Some(keypair1.into()),
         ];
         let CliSignerInfo { signers, indexes } =
-            generate_unique_signers(signers, &matches, &default_keypair_file, &None).unwrap();
+            generate_unique_signers(signers, &matches, &default_keypair_file, None).unwrap();
         assert_eq!(signers.len(), 2);
         assert_eq!(indexes, vec![0, 0, 1, 1]);
     }
@@ -2443,7 +2443,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "airdrop", "50", &pubkey_string]);
         assert_eq!(
-            parse_command(&test_airdrop, "", &None).unwrap(),
+            parse_command(&test_airdrop, "", None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Airdrop {
                     faucet_host: None,
@@ -2466,7 +2466,7 @@ mod tests {
             &keypair.pubkey().to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_balance, "", &None).unwrap(),
+            parse_command(&test_balance, "", None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey: Some(keypair.pubkey()),
@@ -2482,7 +2482,7 @@ mod tests {
             "--lamports",
         ]);
         assert_eq!(
-            parse_command(&test_balance, "", &None).unwrap(),
+            parse_command(&test_balance, "", None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey: Some(keypair.pubkey()),
@@ -2496,7 +2496,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "balance", "--lamports"]);
         assert_eq!(
-            parse_command(&test_balance, &keypair_file, &None).unwrap(),
+            parse_command(&test_balance, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey: None,
@@ -2512,7 +2512,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "cancel", &pubkey_string]);
         assert_eq!(
-            parse_command(&test_cancel, &keypair_file, &None).unwrap(),
+            parse_command(&test_cancel, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Cancel(pubkey),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -2527,7 +2527,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "confirm", &signature_string]);
         assert_eq!(
-            parse_command(&test_confirm, "", &None).unwrap(),
+            parse_command(&test_confirm, "", None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Confirm(signature),
                 signers: vec![],
@@ -2536,7 +2536,7 @@ mod tests {
         let test_bad_signature = test_commands
             .clone()
             .get_matches_from(vec!["test", "confirm", "deadbeef"]);
-        assert!(parse_command(&test_bad_signature, "", &None).is_err());
+        assert!(parse_command(&test_bad_signature, "", None).is_err());
 
         // Test CreateAddressWithSeed
         let from_pubkey = Some(Pubkey::new_rand());
@@ -2555,7 +2555,7 @@ mod tests {
                 &from_str,
             ]);
             assert_eq!(
-                parse_command(&test_create_address_with_seed, "", &None).unwrap(),
+                parse_command(&test_create_address_with_seed, "", None).unwrap(),
                 CliCommandInfo {
                     command: CliCommand::CreateAddressWithSeed {
                         from_pubkey,
@@ -2573,7 +2573,7 @@ mod tests {
             "STAKE",
         ]);
         assert_eq!(
-            parse_command(&test_create_address_with_seed, "", &None).unwrap(),
+            parse_command(&test_create_address_with_seed, "", None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateAddressWithSeed {
                     from_pubkey: None,
@@ -2590,7 +2590,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "deploy", "/Users/test/program.o"]);
         assert_eq!(
-            parse_command(&test_deploy, &keypair_file, &None).unwrap(),
+            parse_command(&test_deploy, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Deploy("/Users/test/program.o".to_string()),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -2603,7 +2603,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "pay", &pubkey_string, "50"]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2626,7 +2626,7 @@ mod tests {
             &witness1_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay_multiple_witnesses, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay_multiple_witnesses, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2646,7 +2646,7 @@ mod tests {
             &witness0_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay_single_witness, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay_single_witness, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2670,7 +2670,7 @@ mod tests {
             &witness0_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay_timestamp, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay_timestamp, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2696,7 +2696,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2719,7 +2719,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2745,7 +2745,7 @@ mod tests {
             &pubkey_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2775,7 +2775,7 @@ mod tests {
             &keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2810,7 +2810,7 @@ mod tests {
             &signer_arg,
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2845,7 +2845,7 @@ mod tests {
             "--signer",
             &signer_arg,
         ]);
-        assert!(parse_command(&test_pay, &keypair_file, &None).is_err());
+        assert!(parse_command(&test_pay, &keypair_file, None).is_err());
 
         // Test Send-Signature Subcommand
         let test_send_signature = test_commands.clone().get_matches_from(vec![
@@ -2855,7 +2855,7 @@ mod tests {
             &pubkey_string,
         ]);
         assert_eq!(
-            parse_command(&test_send_signature, &keypair_file, &None).unwrap(),
+            parse_command(&test_send_signature, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Witness(pubkey, pubkey),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -2876,7 +2876,7 @@ mod tests {
             &witness1_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay_multiple_witnesses, &keypair_file, &None).unwrap(),
+            parse_command(&test_pay_multiple_witnesses, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2900,7 +2900,7 @@ mod tests {
             "2018-09-19T17:30:59",
         ]);
         assert_eq!(
-            parse_command(&test_send_timestamp, &keypair_file, &None).unwrap(),
+            parse_command(&test_send_timestamp, &keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::TimeElapsed(pubkey, pubkey, dt),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -2914,7 +2914,7 @@ mod tests {
             "--date",
             "20180919T17:30:59",
         ]);
-        assert!(parse_command(&test_bad_timestamp, &keypair_file, &None).is_err());
+        assert!(parse_command(&test_bad_timestamp, &keypair_file, None).is_err());
     }
 
     #[test]
@@ -3354,7 +3354,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "transfer", &to_string, "42"]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
@@ -3383,7 +3383,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
@@ -3417,7 +3417,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
@@ -3455,7 +3455,7 @@ mod tests {
             &nonce_authority_file,
         ]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -321,6 +321,7 @@ pub enum CliCommand {
     // Storage Commands
     CreateStorageAccount {
         account_owner: Pubkey,
+        storage_account: SignerIndex,
         account_type: StorageAccountType,
     },
     ClaimStorageReward {
@@ -1737,8 +1738,15 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         // Create storage account
         CliCommand::CreateStorageAccount {
             account_owner,
+            storage_account,
             account_type,
-        } => process_create_storage_account(&rpc_client, config, &account_owner, *account_type),
+        } => process_create_storage_account(
+            &rpc_client,
+            config,
+            *storage_account,
+            &account_owner,
+            *account_type,
+        ),
         CliCommand::ClaimStorageReward {
             node_account_pubkey,
             storage_account_pubkey,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2408,8 +2408,8 @@ mod tests {
         assert_eq!(indexes, vec![0, 0]);
 
         // Signers with the same pubkey are not distinct
-        let keypair0 = Keypair::new();
-        let keypair1 = keypair_from_seed(&[1u8; 32]).unwrap();
+        let keypair0 = keypair_from_seed(&[2u8; 32]).unwrap();
+        let keypair1 = keypair_from_seed(&[3u8; 32]).unwrap();
         let message = vec![0, 1, 2, 3];
         let presigner0 = Presigner::new(&keypair0.pubkey(), &keypair0.sign_message(&message));
         let presigner1 = Presigner::new(&keypair1.pubkey(), &keypair1.sign_message(&message));

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -737,8 +737,12 @@ pub fn parse_command(
                 signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
 
             let payer_provided = None;
+            let mut bulk_signers = vec![payer_provided];
+            if nonce_account.is_some() {
+                bulk_signers.push(nonce_authority);
+            }
             let signer_info = generate_unique_signers(
-                vec![payer_provided, nonce_authority],
+                bulk_signers,
                 matches,
                 default_signer_path,
                 wallet_manager,
@@ -819,8 +823,13 @@ pub fn parse_command(
                 signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
             let (from, from_pubkey) = signer_of(matches, "from", wallet_manager)?;
 
+            let mut bulk_signers = vec![fee_payer, from];
+            if nonce_account.is_some() {
+                bulk_signers.push(nonce_authority);
+            }
+
             let signer_info = generate_unique_signers(
-                vec![nonce_authority, fee_payer, from],
+                bulk_signers,
                 matches,
                 default_signer_path,
                 wallet_manager,
@@ -3449,17 +3458,14 @@ mod tests {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
                     to: to_pubkey,
-                    from: 1,
+                    from: 0,
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: None,
                     nonce_authority: 0,
-                    fee_payer: 1,
+                    fee_payer: 0,
                 },
-                signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&from_pubkey, &from_sig).into()
-                ],
+                signers: vec![Presigner::new(&from_pubkey, &from_sig).into()],
             }
         );
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -247,7 +247,7 @@ pub fn parse_catchup(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliErro
 pub fn parse_cluster_ping(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let lamports = value_t_or_exit!(matches, "lamports", u64);
     let interval = Duration::from_secs(value_t_or_exit!(matches, "interval", u64));
@@ -1134,7 +1134,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "cluster-version"]);
         assert_eq!(
-            parse_command(&test_cluster_version, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_cluster_version, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::ClusterVersion,
                 signers: vec![],
@@ -1143,7 +1143,7 @@ mod tests {
 
         let test_fees = test_commands.clone().get_matches_from(vec!["test", "fees"]);
         assert_eq!(
-            parse_command(&test_fees, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_fees, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Fees,
                 signers: vec![],
@@ -1156,7 +1156,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "block-time", &slot.to_string()]);
         assert_eq!(
-            parse_command(&test_get_block_time, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_get_block_time, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetBlockTime { slot },
                 signers: vec![],
@@ -1167,7 +1167,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "epoch-info"]);
         assert_eq!(
-            parse_command(&test_get_epoch_info, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_get_epoch_info, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetEpochInfo {
                     commitment_config: CommitmentConfig::recent(),
@@ -1180,7 +1180,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "genesis-hash"]);
         assert_eq!(
-            parse_command(&test_get_genesis_hash, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_get_genesis_hash, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetGenesisHash,
                 signers: vec![],
@@ -1189,7 +1189,7 @@ mod tests {
 
         let test_get_slot = test_commands.clone().get_matches_from(vec!["test", "slot"]);
         assert_eq!(
-            parse_command(&test_get_slot, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_get_slot, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetSlot {
                     commitment_config: CommitmentConfig::recent(),
@@ -1202,7 +1202,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "transaction-count"]);
         assert_eq!(
-            parse_command(&test_transaction_count, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_transaction_count, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetTransactionCount {
                     commitment_config: CommitmentConfig::recent(),
@@ -1223,7 +1223,7 @@ mod tests {
             "--confirmed",
         ]);
         assert_eq!(
-            parse_command(&test_ping, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_ping, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Ping {
                     lamports: 1,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -107,7 +107,7 @@ pub fn parse_args<'a>(
     };
 
     let CliCommandInfo { command, signers } =
-        parse_command(&matches, &default_signer_path, &wallet_manager)?;
+        parse_command(&matches, &default_signer_path, wallet_manager.as_ref())?;
 
     Ok((
         CliConfig {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,7 +114,7 @@ pub fn parse_args<'a>(
             command,
             json_rpc_url,
             signers: vec![],
-            keypair_path: Some(default_signer_path), // TODO: this isn't correct when default signer not used
+            keypair_path: default_signer_path,
             derivation_path: derivation_of(matches, "derivation_path"),
             rpc_client: None,
             verbose: matches.is_present("verbose"),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,15 +4,15 @@ use console::style;
 use solana_clap_utils::{
     input_parsers::derivation_of,
     input_validators::{is_derivation, is_url},
-    keypair::{keypair_util_from_path, SKIP_SEED_PHRASE_VALIDATION_ARG},
+    keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
 };
 use solana_cli::{
-    cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliError},
+    cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliSigners},
     display::{println_name_value, println_name_value_or},
 };
 use solana_cli_config::config::{Config, CONFIG_FILE};
-
-use std::error;
+use solana_remote_wallet::remote_wallet::{maybe_wallet_manager, RemoteWalletManager};
+use std::{error, sync::Arc};
 
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
     let parse_args = match matches.subcommand() {
@@ -80,7 +80,10 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
     Ok(parse_args)
 }
 
-pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::Error>> {
+pub fn parse_args<'a>(
+    matches: &ArgMatches<'_>,
+    wallet_manager: Option<Arc<RemoteWalletManager>>,
+) -> Result<(CliConfig<'a>, CliSigners), Box<dyn error::Error>> {
     let config = if let Some(config_file) = matches.value_of("config_file") {
         Config::load(config_file).unwrap_or_default()
     } else {
@@ -95,44 +98,29 @@ pub fn parse_args(matches: &ArgMatches<'_>) -> Result<CliConfig, Box<dyn error::
         default.json_rpc_url
     };
 
-    let CliCommandInfo {
-        command,
-        require_keypair,
-    } = parse_command(&matches)?;
-
-    let (keypair, keypair_path) = if require_keypair {
-        let path = if matches.is_present("keypair") {
-            matches.value_of("keypair").unwrap().to_string()
-        } else if config.keypair_path != "" {
-            config.keypair_path
-        } else {
-            let default_keypair_path = CliConfig::default_keypair_path();
-            if !std::path::Path::new(&default_keypair_path).exists() {
-                return Err(CliError::KeypairFileNotFound(format!(
-                    "Generate a new keypair at {} with `solana-keygen new`",
-                    default_keypair_path
-                ))
-                .into());
-            }
-            default_keypair_path
-        };
-
-        let keypair = keypair_util_from_path(matches, &path, "keypair")?;
-        (keypair, Some(path))
+    let default_signer_path = if matches.is_present("keypair") {
+        matches.value_of("keypair").unwrap().to_string()
+    } else if config.keypair_path != "" {
+        config.keypair_path
     } else {
-        let default = CliConfig::default();
-        (default.keypair, None)
+        CliConfig::default_keypair_path()
     };
 
-    Ok(CliConfig {
-        command,
-        json_rpc_url,
-        keypair,
-        keypair_path,
-        derivation_path: derivation_of(matches, "derivation_path"),
-        rpc_client: None,
-        verbose: matches.is_present("verbose"),
-    })
+    let CliCommandInfo { command, signers } =
+        parse_command(&matches, &default_signer_path, &wallet_manager)?;
+
+    Ok((
+        CliConfig {
+            command,
+            json_rpc_url,
+            signers: vec![],
+            keypair_path: Some(default_signer_path), // TODO: this isn't correct when default signer not used
+            derivation_path: derivation_of(matches, "derivation_path"),
+            rpc_client: None,
+            verbose: matches.is_present("verbose"),
+        },
+        signers,
+    ))
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
@@ -228,7 +216,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     .get_matches();
 
     if parse_settings(&matches)? {
-        let config = parse_args(&matches)?;
+        let wallet_manager = maybe_wallet_manager()?;
+
+        let (mut config, signers) = parse_args(&matches, wallet_manager)?;
+        config.signers = signers.iter().map(|s| s.as_ref()).collect();
         let result = process_command(&config)?;
         println!("{}", result);
     }

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -1,7 +1,7 @@
 use crate::cli::{
     build_balance_message, check_account_for_fee, check_unique_pubkeys, generate_unique_signers,
-    log_instruction_custom_error, signer_pubkey, CliCommand, CliCommandInfo, CliConfig, CliError,
-    ProcessResult, SignerIndex,
+    log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult,
+    SignerIndex,
 };
 use clap::{App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::{
@@ -225,8 +225,8 @@ pub fn parse_authorize_nonce_account(
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let new_authority = pubkey_of(matches, "new_authority").unwrap();
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
 
     let payer_provided = None;
     let signer_info = generate_unique_signers(
@@ -251,8 +251,8 @@ pub fn parse_nonce_create_account(
     default_signer_path: &str,
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
-    let nonce_account = signer_of("nonce_account_keypair", matches, wallet_manager)?;
-    let nonce_account_pubkey = signer_pubkey(&nonce_account);
+    let (nonce_account, nonce_account_pubkey) =
+        signer_of(matches, "nonce_account_keypair", wallet_manager)?;
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let nonce_authority = pubkey_of(matches, NONCE_AUTHORITY_ARG.name);
@@ -291,8 +291,8 @@ pub fn parse_new_nonce(
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
 
     let payer_provided = None;
     let signer_info = generate_unique_signers(
@@ -332,8 +332,8 @@ pub fn parse_withdraw_from_nonce_account(
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let destination_account_pubkey = pubkey_of(matches, "destination_account_pubkey").unwrap();
     let lamports = lamports_of_sol(matches, "amount").unwrap();
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
 
     let payer_provided = None;
     let signer_info = generate_unique_signers(

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -221,7 +221,7 @@ impl NonceSubCommands for App<'_, '_> {
 pub fn parse_authorize_nonce_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let new_authority = pubkey_of(matches, "new_authority").unwrap();
@@ -248,7 +248,7 @@ pub fn parse_authorize_nonce_account(
 pub fn parse_nonce_create_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = signer_of("nonce_account_keypair", matches, wallet_manager)?.unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
@@ -286,7 +286,7 @@ pub fn parse_get_nonce(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliEr
 pub fn parse_new_nonce(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
@@ -324,7 +324,7 @@ pub fn parse_show_nonce_account(matches: &ArgMatches<'_>) -> Result<CliCommandIn
 pub fn parse_withdraw_from_nonce_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
     let destination_account_pubkey = pubkey_of(matches, "destination_account_pubkey").unwrap();
@@ -658,7 +658,7 @@ mod tests {
             &Pubkey::default().to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_authorize_nonce_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize_nonce_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::AuthorizeNonceAccount {
                     nonce_account: nonce_account_pubkey,
@@ -679,7 +679,7 @@ mod tests {
             &authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_authorize_nonce_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize_nonce_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::AuthorizeNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
@@ -701,7 +701,7 @@ mod tests {
             "50",
         ]);
         assert_eq!(
-            parse_command(&test_create_nonce_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_nonce_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
                     nonce_account: 1,
@@ -726,7 +726,7 @@ mod tests {
             &authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_create_nonce_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_nonce_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
                     nonce_account: 1,
@@ -748,7 +748,7 @@ mod tests {
             &nonce_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_get_nonce, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_get_nonce, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetNonce(nonce_account_keypair.pubkey()),
                 signers: vec![],
@@ -762,7 +762,7 @@ mod tests {
                 .get_matches_from(vec!["test", "new-nonce", &keypair_file]);
         let nonce_account = read_keypair_file(&keypair_file).unwrap();
         assert_eq!(
-            parse_command(&test_new_nonce, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_new_nonce, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::NewNonce {
                     nonce_account: nonce_account.pubkey(),
@@ -782,7 +782,7 @@ mod tests {
         ]);
         let nonce_account = read_keypair_file(&keypair_file).unwrap();
         assert_eq!(
-            parse_command(&test_new_nonce, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_new_nonce, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::NewNonce {
                     nonce_account: nonce_account.pubkey(),
@@ -802,7 +802,7 @@ mod tests {
             &nonce_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_show_nonce_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_show_nonce_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::ShowNonceAccount {
                     nonce_account_pubkey: nonce_account_keypair.pubkey(),
@@ -824,7 +824,7 @@ mod tests {
             parse_command(
                 &test_withdraw_from_nonce_account,
                 &default_keypair_file,
-                &None
+                None
             )
             .unwrap(),
             CliCommandInfo {
@@ -849,7 +849,7 @@ mod tests {
             parse_command(
                 &test_withdraw_from_nonce_account,
                 &default_keypair_file,
-                &None
+                None
             )
             .unwrap(),
             CliCommandInfo {
@@ -877,7 +877,7 @@ mod tests {
             parse_command(
                 &test_withdraw_from_nonce_account,
                 &default_keypair_file,
-                &None
+                None
             )
             .unwrap(),
             CliCommandInfo {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2,8 +2,7 @@ use crate::{
     cli::{
         build_balance_message, check_account_for_fee, check_unique_pubkeys, fee_payer_arg,
         generate_unique_signers, log_instruction_custom_error, nonce_authority_arg, return_signers,
-        signer_pubkey, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult, SignerIndex,
-        FEE_PAYER_ARG,
+        CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult, SignerIndex, FEE_PAYER_ARG,
     },
     nonce::{check_nonce_account, nonce_arg, NONCE_ARG, NONCE_AUTHORITY_ARG},
     offline::*,
@@ -427,14 +426,12 @@ pub fn parse_stake_create_account(
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
-    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches, wallet_manager)?;
-    let fee_payer_pubkey = signer_pubkey(&fee_payer);
-    let from = signer_of("from", matches, wallet_manager)?;
-    let from_pubkey = signer_pubkey(&from);
-    let stake_account = signer_of("stake_account", matches, wallet_manager)?;
-    let stake_account_pubkey = signer_pubkey(&stake_account);
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
+    let (from, from_pubkey) = signer_of(matches, "from", wallet_manager)?;
+    let (stake_account, stake_account_pubkey) =
+        signer_of(matches, "stake_account", wallet_manager)?;
 
     let signer_info = generate_unique_signers(
         vec![nonce_authority, fee_payer, from, stake_account],
@@ -477,12 +474,11 @@ pub fn parse_stake_delegate_stake(
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let stake_authority_pubkey = signer_pubkey(&stake_authority);
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
-    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches, wallet_manager)?;
-    let fee_payer_pubkey = signer_pubkey(&fee_payer);
+    let (stake_authority, stake_authority_pubkey) =
+        signer_of(matches, STAKE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
     let signer_info = generate_unique_signers(
         vec![stake_authority, nonce_authority, fee_payer],
@@ -520,14 +516,12 @@ pub fn parse_stake_authorize(
         StakeAuthorize::Withdrawer => WITHDRAW_AUTHORITY_ARG.name,
     };
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
-    let authority = signer_of(authority_flag, matches, wallet_manager)?;
-    let authority_pubkey = signer_pubkey(&authority);
+    let (authority, authority_pubkey) = signer_of(matches, authority_flag, wallet_manager)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
-    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches, wallet_manager)?;
-    let fee_payer_pubkey = signer_pubkey(&fee_payer);
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
     let signer_info = generate_unique_signers(
         vec![authority, nonce_authority, fee_payer],
@@ -558,20 +552,19 @@ pub fn parse_split_stake(
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
-    let split_stake_account = signer_of("split_stake_account", matches, wallet_manager)?;
-    let split_stake_account_pubkey = signer_pubkey(&split_stake_account);
+    let (split_stake_account, split_stake_account_pubkey) =
+        signer_of(matches, "split_stake_account", wallet_manager)?;
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
 
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let stake_authority_pubkey = signer_pubkey(&stake_authority);
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
-    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches, wallet_manager)?;
-    let fee_payer_pubkey = signer_pubkey(&fee_payer);
+    let (stake_authority, stake_authority_pubkey) =
+        signer_of(matches, STAKE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
     let signer_info = generate_unique_signers(
         vec![
@@ -611,12 +604,11 @@ pub fn parse_stake_deactivate_stake(
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let stake_authority = signer_of(STAKE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let stake_authority_pubkey = signer_pubkey(&stake_authority);
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
-    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches, wallet_manager)?;
-    let fee_payer_pubkey = signer_pubkey(&fee_payer);
+    let (stake_authority, stake_authority_pubkey) =
+        signer_of(matches, STAKE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
     let signer_info = generate_unique_signers(
         vec![stake_authority, nonce_authority, fee_payer],
@@ -650,12 +642,11 @@ pub fn parse_stake_withdraw_stake(
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
-    let withdraw_authority = signer_of(WITHDRAW_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let withdraw_authority_pubkey = signer_pubkey(&withdraw_authority);
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
-    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches, wallet_manager)?;
-    let fee_payer_pubkey = signer_pubkey(&fee_payer);
+    let (withdraw_authority, withdraw_authority_pubkey) =
+        signer_of(matches, WITHDRAW_AUTHORITY_ARG.name, wallet_manager)?;
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
     let signer_info = generate_unique_signers(
         vec![withdraw_authority, nonce_authority, fee_payer],
@@ -694,12 +685,10 @@ pub fn parse_stake_set_lockup(
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
     let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
 
-    let custodian = signer_of("custodian", matches, wallet_manager)?;
-    let custodian_pubkey = signer_pubkey(&custodian);
-    let nonce_authority = signer_of(NONCE_AUTHORITY_ARG.name, matches, wallet_manager)?;
-    let nonce_authority_pubkey = signer_pubkey(&nonce_authority);
-    let fee_payer = signer_of(FEE_PAYER_ARG.name, matches, wallet_manager)?;
-    let fee_payer_pubkey = signer_pubkey(&fee_payer);
+    let (custodian, custodian_pubkey) = signer_of(matches, "custodian", wallet_manager)?;
+    let (nonce_authority, nonce_authority_pubkey) =
+        signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
+    let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
     let signer_info = generate_unique_signers(
         vec![custodian, nonce_authority, fee_payer],

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -415,7 +415,7 @@ impl StakeSubCommands for App<'_, '_> {
 pub fn parse_stake_create_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let epoch = value_of(&matches, "lockup_epoch").unwrap_or(0);
@@ -465,7 +465,7 @@ pub fn parse_stake_create_account(
 pub fn parse_stake_delegate_stake(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
     let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
@@ -503,7 +503,7 @@ pub fn parse_stake_delegate_stake(
 pub fn parse_stake_authorize(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
     stake_authorize: StakeAuthorize,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
@@ -545,7 +545,7 @@ pub fn parse_stake_authorize(
 pub fn parse_split_stake(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
     let split_stake_account = signer_of("split_stake_account", matches, wallet_manager)?.unwrap();
@@ -591,7 +591,7 @@ pub fn parse_split_stake(
 pub fn parse_stake_deactivate_stake(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
@@ -625,7 +625,7 @@ pub fn parse_stake_deactivate_stake(
 pub fn parse_stake_withdraw_stake(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
     let destination_account_pubkey = pubkey_of(matches, "destination_account_pubkey").unwrap();
@@ -663,7 +663,7 @@ pub fn parse_stake_withdraw_stake(
 pub fn parse_stake_set_lockup(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
     let epoch = value_of(&matches, "lockup_epoch").unwrap_or(0);
@@ -1473,7 +1473,7 @@ mod tests {
             &stake_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1499,7 +1499,7 @@ mod tests {
             &authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1531,7 +1531,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1565,7 +1565,7 @@ mod tests {
             &pubkey.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1609,7 +1609,7 @@ mod tests {
             &pubkey2.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1639,7 +1639,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1674,7 +1674,7 @@ mod tests {
             &nonce_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1708,7 +1708,7 @@ mod tests {
             &fee_payer_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1743,7 +1743,7 @@ mod tests {
             &signer,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1811,7 +1811,7 @@ mod tests {
             "43",
         ]);
         assert_eq!(
-            parse_command(&test_create_stake_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_stake_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
                     stake_account: 1,
@@ -1852,7 +1852,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_create_stake_account2, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_stake_account2, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
                     stake_account: 1,
@@ -1905,7 +1905,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_create_stake_account2, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_stake_account2, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
                     stake_account: 1,
@@ -1938,7 +1938,7 @@ mod tests {
             &vote_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -1967,7 +1967,7 @@ mod tests {
             &stake_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -1998,7 +1998,7 @@ mod tests {
             &vote_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2027,7 +2027,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2054,7 +2054,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2088,7 +2088,7 @@ mod tests {
             &key1.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2131,7 +2131,7 @@ mod tests {
             &key2.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2165,7 +2165,7 @@ mod tests {
             &fee_payer_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2195,7 +2195,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_withdraw_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_withdraw_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::WithdrawStake {
                     stake_account_pubkey,
@@ -2224,7 +2224,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_withdraw_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_withdraw_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::WithdrawStake {
                     stake_account_pubkey,
@@ -2268,7 +2268,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_withdraw_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_withdraw_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::WithdrawStake {
                     stake_account_pubkey,
@@ -2297,7 +2297,7 @@ mod tests {
             &stake_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2321,7 +2321,7 @@ mod tests {
             &stake_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2352,7 +2352,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2376,7 +2376,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2407,7 +2407,7 @@ mod tests {
             &key1.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2447,7 +2447,7 @@ mod tests {
             &key2.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2475,7 +2475,7 @@ mod tests {
             &fee_payer_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2509,7 +2509,7 @@ mod tests {
             "50",
         ]);
         assert_eq!(
-            parse_command(&test_split_stake_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_split_stake_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::SplitStake {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
@@ -2570,7 +2570,7 @@ mod tests {
             &stake_signer,
         ]);
         assert_eq!(
-            parse_command(&test_split_stake_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_split_stake_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::SplitStake {
                     stake_account_pubkey: stake_account_keypair.pubkey(),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -417,15 +417,15 @@ pub fn parse_stake_create_account(
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let seed = matches.value_of("seed").map(|s| s.to_string());
-    let epoch = value_of(&matches, "lockup_epoch").unwrap_or(0);
-    let unix_timestamp = unix_timestamp_from_rfc3339_datetime(&matches, "lockup_date").unwrap_or(0);
+    let epoch = value_of(matches, "lockup_epoch").unwrap_or(0);
+    let unix_timestamp = unix_timestamp_from_rfc3339_datetime(matches, "lockup_date").unwrap_or(0);
     let custodian = pubkey_of(matches, "custodian").unwrap_or_default();
     let staker = pubkey_of(matches, STAKE_AUTHORITY_ARG.name);
     let withdrawer = pubkey_of(matches, WITHDRAW_AUTHORITY_ARG.name);
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
-    let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
+    let nonce_account = pubkey_of(matches, NONCE_ARG.name);
     let (nonce_authority, nonce_authority_pubkey) =
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
@@ -473,7 +473,7 @@ pub fn parse_stake_delegate_stake(
     let force = matches.is_present("force");
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
-    let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
+    let nonce_account = pubkey_of(matches, NONCE_ARG.name);
     let (stake_authority, stake_authority_pubkey) =
         signer_of(matches, STAKE_AUTHORITY_ARG.name, wallet_manager)?;
     let (nonce_authority, nonce_authority_pubkey) =
@@ -518,7 +518,7 @@ pub fn parse_stake_authorize(
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let (authority, authority_pubkey) = signer_of(matches, authority_flag, wallet_manager)?;
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
-    let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
+    let nonce_account = pubkey_of(matches, NONCE_ARG.name);
     let (nonce_authority, nonce_authority_pubkey) =
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
@@ -559,7 +559,7 @@ pub fn parse_split_stake(
 
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
-    let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
+    let nonce_account = pubkey_of(matches, NONCE_ARG.name);
     let (stake_authority, stake_authority_pubkey) =
         signer_of(matches, STAKE_AUTHORITY_ARG.name, wallet_manager)?;
     let (nonce_authority, nonce_authority_pubkey) =
@@ -603,7 +603,7 @@ pub fn parse_stake_deactivate_stake(
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
-    let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
+    let nonce_account = pubkey_of(matches, NONCE_ARG.name);
     let (stake_authority, stake_authority_pubkey) =
         signer_of(matches, STAKE_AUTHORITY_ARG.name, wallet_manager)?;
     let (nonce_authority, nonce_authority_pubkey) =
@@ -641,7 +641,7 @@ pub fn parse_stake_withdraw_stake(
     let lamports = lamports_of_sol(matches, "amount").unwrap();
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
-    let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
+    let nonce_account = pubkey_of(matches, NONCE_ARG.name);
     let (withdraw_authority, withdraw_authority_pubkey) =
         signer_of(matches, WITHDRAW_AUTHORITY_ARG.name, wallet_manager)?;
     let (nonce_authority, nonce_authority_pubkey) =
@@ -677,13 +677,13 @@ pub fn parse_stake_set_lockup(
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey = pubkey_of(matches, "stake_account_pubkey").unwrap();
-    let epoch = value_of(&matches, "lockup_epoch").unwrap_or(0);
-    let unix_timestamp = unix_timestamp_from_rfc3339_datetime(&matches, "lockup_date").unwrap_or(0);
+    let epoch = value_of(matches, "lockup_epoch").unwrap_or(0);
+    let unix_timestamp = unix_timestamp_from_rfc3339_datetime(matches, "lockup_date").unwrap_or(0);
     let new_custodian = pubkey_of(matches, "new_custodian").unwrap_or_default();
 
     let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
     let blockhash_query = BlockhashQuery::new_from_matches(matches);
-    let nonce_account = pubkey_of(&matches, NONCE_ARG.name);
+    let nonce_account = pubkey_of(matches, NONCE_ARG.name);
 
     let (custodian, custodian_pubkey) = signer_of(matches, "custodian", wallet_manager)?;
     let (nonce_authority, nonce_authority_pubkey) =

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -433,12 +433,12 @@ pub fn parse_stake_create_account(
     let (stake_account, stake_account_pubkey) =
         signer_of(matches, "stake_account", wallet_manager)?;
 
-    let signer_info = generate_unique_signers(
-        vec![nonce_authority, fee_payer, from, stake_account],
-        matches,
-        default_signer_path,
-        wallet_manager,
-    )?;
+    let mut bulk_signers = vec![fee_payer, from, stake_account];
+    if nonce_account.is_some() {
+        bulk_signers.push(nonce_authority);
+    }
+    let signer_info =
+        generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateStakeAccount {
@@ -480,12 +480,12 @@ pub fn parse_stake_delegate_stake(
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
-    let signer_info = generate_unique_signers(
-        vec![stake_authority, nonce_authority, fee_payer],
-        matches,
-        default_signer_path,
-        wallet_manager,
-    )?;
+    let mut bulk_signers = vec![stake_authority, fee_payer];
+    if nonce_account.is_some() {
+        bulk_signers.push(nonce_authority);
+    }
+    let signer_info =
+        generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DelegateStake {
@@ -523,12 +523,12 @@ pub fn parse_stake_authorize(
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
-    let signer_info = generate_unique_signers(
-        vec![authority, nonce_authority, fee_payer],
-        matches,
-        default_signer_path,
-        wallet_manager,
-    )?;
+    let mut bulk_signers = vec![authority, fee_payer];
+    if nonce_account.is_some() {
+        bulk_signers.push(nonce_authority);
+    }
+    let signer_info =
+        generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeAuthorize {
@@ -566,17 +566,12 @@ pub fn parse_split_stake(
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
-    let signer_info = generate_unique_signers(
-        vec![
-            stake_authority,
-            nonce_authority,
-            fee_payer,
-            split_stake_account,
-        ],
-        matches,
-        default_signer_path,
-        wallet_manager,
-    )?;
+    let mut bulk_signers = vec![stake_authority, fee_payer, split_stake_account];
+    if nonce_account.is_some() {
+        bulk_signers.push(nonce_authority);
+    }
+    let signer_info =
+        generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::SplitStake {
@@ -610,12 +605,12 @@ pub fn parse_stake_deactivate_stake(
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
-    let signer_info = generate_unique_signers(
-        vec![stake_authority, nonce_authority, fee_payer],
-        matches,
-        default_signer_path,
-        wallet_manager,
-    )?;
+    let mut bulk_signers = vec![stake_authority, fee_payer];
+    if nonce_account.is_some() {
+        bulk_signers.push(nonce_authority);
+    }
+    let signer_info =
+        generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::DeactivateStake {
@@ -648,12 +643,12 @@ pub fn parse_stake_withdraw_stake(
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
-    let signer_info = generate_unique_signers(
-        vec![withdraw_authority, nonce_authority, fee_payer],
-        matches,
-        default_signer_path,
-        wallet_manager,
-    )?;
+    let mut bulk_signers = vec![withdraw_authority, fee_payer];
+    if nonce_account.is_some() {
+        bulk_signers.push(nonce_authority);
+    }
+    let signer_info =
+        generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::WithdrawStake {
@@ -690,12 +685,12 @@ pub fn parse_stake_set_lockup(
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;
     let (fee_payer, fee_payer_pubkey) = signer_of(matches, FEE_PAYER_ARG.name, wallet_manager)?;
 
-    let signer_info = generate_unique_signers(
-        vec![custodian, nonce_authority, fee_payer],
-        matches,
-        default_signer_path,
-        wallet_manager,
-    )?;
+    let mut bulk_signers = vec![custodian, fee_payer];
+    if nonce_account.is_some() {
+        bulk_signers.push(nonce_authority);
+    }
+    let signer_info =
+        generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
         command: CliCommand::StakeSetLockup {
@@ -1631,13 +1626,13 @@ mod tests {
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(nonce_account),
-                    nonce_authority: 1,
-                    fee_payer: 2,
+                    nonce_authority: 2,
+                    fee_payer: 1,
                 },
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&pubkey2, &sig2).into(),
                     Presigner::new(&pubkey, &sig).into(),
+                    Presigner::new(&pubkey2, &sig2).into(),
                 ],
             }
         );
@@ -2153,13 +2148,13 @@ mod tests {
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(nonce_account),
-                    nonce_authority: 1,
-                    fee_payer: 2,
+                    nonce_authority: 2,
+                    fee_payer: 1,
                 },
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Presigner::new(&key1, &sig1).into(),
                     Presigner::new(&key2, &sig2).into(),
-                    Presigner::new(&key1, &sig1).into()
                 ],
             }
         );
@@ -2467,13 +2462,13 @@ mod tests {
                     sign_only: false,
                     blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
                     nonce_account: Some(nonce_account),
-                    nonce_authority: 1,
-                    fee_payer: 2,
+                    nonce_authority: 2,
+                    fee_payer: 1,
                 },
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&key2, &sig2).into(),
                     Presigner::new(&key1, &sig1).into(),
+                    Presigner::new(&key2, &sig2).into(),
                 ],
             }
         );

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -101,7 +101,7 @@ impl StorageSubCommands for App<'_, '_> {
 pub fn parse_storage_create_archiver_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
     let storage_account = keypair_of(matches, "storage_account").unwrap();
@@ -120,7 +120,7 @@ pub fn parse_storage_create_archiver_account(
 pub fn parse_storage_create_validator_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
     let storage_account = keypair_of(matches, "storage_account").unwrap();
@@ -139,7 +139,7 @@ pub fn parse_storage_create_validator_account(
 pub fn parse_storage_claim_reward(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let node_account_pubkey = pubkey_of(matches, "node_account_pubkey").unwrap();
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
@@ -306,7 +306,7 @@ mod tests {
             parse_command(
                 &test_create_archiver_storage_account,
                 &default_keypair_file,
-                &None
+                None
             )
             .unwrap(),
             CliCommandInfo {
@@ -337,7 +337,7 @@ mod tests {
             parse_command(
                 &test_create_validator_storage_account,
                 &default_keypair_file,
-                &None
+                None
             )
             .unwrap(),
             CliCommandInfo {
@@ -359,7 +359,7 @@ mod tests {
             &storage_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_claim_storage_reward, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_claim_storage_reward, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::ClaimStorageReward {
                     node_account_pubkey: pubkey,

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -3,14 +3,15 @@ use crate::cli::{
     CliCommandInfo, CliConfig, CliError, ProcessResult,
 };
 use clap::{App, Arg, ArgMatches, SubCommand};
-use solana_clap_utils::{input_parsers::*, input_validators::*};
+use solana_clap_utils::{input_parsers::*, input_validators::*, keypair::signer_from_path};
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::signature::Keypair;
+use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
-    account_utils::StateMut, message::Message, pubkey::Pubkey, signature::Signer,
-    system_instruction::SystemError, transaction::Transaction,
+    account_utils::StateMut, message::Message, pubkey::Pubkey, system_instruction::SystemError,
+    transaction::Transaction,
 };
 use solana_storage_program::storage_instruction::{self, StorageAccountType};
+use std::sync::Arc;
 
 pub trait StorageSubCommands {
     fn storage_subcommands(self) -> Self;
@@ -99,35 +100,47 @@ impl StorageSubCommands for App<'_, '_> {
 
 pub fn parse_storage_create_archiver_account(
     matches: &ArgMatches<'_>,
+    default_signer_path: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
     let storage_account = keypair_of(matches, "storage_account").unwrap();
     Ok(CliCommandInfo {
         command: CliCommand::CreateStorageAccount {
             account_owner,
-            storage_account: storage_account.into(),
             account_type: StorageAccountType::Archiver,
         },
-        require_keypair: true,
+        signers: vec![
+            signer_from_path(matches, default_signer_path, "keypair", wallet_manager)?,
+            storage_account.into(),
+        ],
     })
 }
 
 pub fn parse_storage_create_validator_account(
     matches: &ArgMatches<'_>,
+    default_signer_path: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let account_owner = pubkey_of(matches, "storage_account_owner").unwrap();
     let storage_account = keypair_of(matches, "storage_account").unwrap();
     Ok(CliCommandInfo {
         command: CliCommand::CreateStorageAccount {
             account_owner,
-            storage_account: storage_account.into(),
             account_type: StorageAccountType::Validator,
         },
-        require_keypair: true,
+        signers: vec![
+            signer_from_path(matches, default_signer_path, "keypair", wallet_manager)?,
+            storage_account.into(),
+        ],
     })
 }
 
-pub fn parse_storage_claim_reward(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+pub fn parse_storage_claim_reward(
+    matches: &ArgMatches<'_>,
+    default_signer_path: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+) -> Result<CliCommandInfo, CliError> {
     let node_account_pubkey = pubkey_of(matches, "node_account_pubkey").unwrap();
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
     Ok(CliCommandInfo {
@@ -135,7 +148,12 @@ pub fn parse_storage_claim_reward(matches: &ArgMatches<'_>) -> Result<CliCommand
             node_account_pubkey,
             storage_account_pubkey,
         },
-        require_keypair: true,
+        signers: vec![signer_from_path(
+            matches,
+            default_signer_path,
+            "keypair",
+            wallet_manager,
+        )?],
     })
 }
 
@@ -145,7 +163,7 @@ pub fn parse_storage_get_account_command(
     let storage_account_pubkey = pubkey_of(matches, "storage_account_pubkey").unwrap();
     Ok(CliCommandInfo {
         command: CliCommand::ShowStorageAccount(storage_account_pubkey),
-        require_keypair: false,
+        signers: vec![],
     })
 }
 
@@ -153,12 +171,12 @@ pub fn process_create_storage_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
     account_owner: &Pubkey,
-    storage_account: &Keypair,
     account_type: StorageAccountType,
 ) -> ProcessResult {
+    let storage_account = config.signers[1];
     let storage_account_pubkey = storage_account.pubkey();
     check_unique_pubkeys(
-        (&config.keypair.pubkey(), "cli keypair".to_string()),
+        (&config.signers[0].pubkey(), "cli keypair".to_string()),
         (
             &storage_account_pubkey,
             "storage_account_pubkey".to_string(),
@@ -183,7 +201,7 @@ pub fn process_create_storage_account(
         .max(1);
 
     let ixs = storage_instruction::create_storage_account(
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &account_owner,
         &storage_account_pubkey,
         required_balance,
@@ -193,18 +211,14 @@ pub fn process_create_storage_account(
 
     let message = Message::new(ixs);
     let mut tx = Transaction::new_unsigned(message);
-    tx.try_sign(
-        &[config.keypair.as_ref(), storage_account],
-        recent_blockhash,
-    )?;
+    tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client
-        .send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref(), storage_account]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &config.signers);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -218,13 +232,13 @@ pub fn process_claim_storage_reward(
 
     let instruction =
         storage_instruction::claim_reward(node_account_pubkey, storage_account_pubkey);
-    let signers = [config.keypair.as_ref()];
+    let signers = [config.signers[0]];
     let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
@@ -292,7 +306,7 @@ mod tests {
                     storage_account: storage_account_keypair.into(),
                     account_type: StorageAccountType::Archiver,
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -316,7 +330,7 @@ mod tests {
                     storage_account: storage_account_keypair.into(),
                     account_type: StorageAccountType::Validator,
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -333,7 +347,7 @@ mod tests {
                     node_account_pubkey: pubkey,
                     storage_account_pubkey,
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
     }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::cli::{
     check_account_for_fee, check_unique_pubkeys, log_instruction_custom_error, CliCommand,
-    CliCommandInfo, CliConfig, CliError, ProcessResult,
+    CliCommandInfo, CliConfig, CliError, ProcessResult, SignerIndex,
 };
 use clap::{App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::{input_parsers::*, input_validators::*, keypair::signer_from_path};
@@ -108,6 +108,7 @@ pub fn parse_storage_create_archiver_account(
     Ok(CliCommandInfo {
         command: CliCommand::CreateStorageAccount {
             account_owner,
+            storage_account: 1,
             account_type: StorageAccountType::Archiver,
         },
         signers: vec![
@@ -127,6 +128,7 @@ pub fn parse_storage_create_validator_account(
     Ok(CliCommandInfo {
         command: CliCommand::CreateStorageAccount {
             account_owner,
+            storage_account: 1,
             account_type: StorageAccountType::Validator,
         },
         signers: vec![
@@ -170,10 +172,11 @@ pub fn parse_storage_get_account_command(
 pub fn process_create_storage_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
+    storage_account: SignerIndex,
     account_owner: &Pubkey,
     account_type: StorageAccountType,
 ) -> ProcessResult {
-    let storage_account = config.signers[1];
+    let storage_account = config.signers[storage_account];
     let storage_account_pubkey = storage_account.pubkey();
     check_unique_pubkeys(
         (&config.signers[0].pubkey(), "cli keypair".to_string()),
@@ -312,6 +315,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::CreateStorageAccount {
                     account_owner: pubkey,
+                    storage_account: 1,
                     account_type: StorageAccountType::Archiver,
                 },
                 signers: vec![
@@ -343,6 +347,7 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::CreateStorageAccount {
                     account_owner: pubkey,
+                    storage_account: 1,
                     account_type: StorageAccountType::Validator,
                 },
                 signers: vec![

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -11,9 +11,11 @@ use serde_json::{Map, Value};
 use solana_clap_utils::{
     input_parsers::pubkey_of,
     input_validators::{is_pubkey, is_url},
+    keypair::signer_from_path,
 };
 use solana_client::rpc_client::RpcClient;
 use solana_config_program::{config_instruction, get_config_data, ConfigKeys, ConfigState};
+use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     account::Account,
     commitment_config::CommitmentConfig,
@@ -22,7 +24,7 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
-use std::error;
+use std::{error, sync::Arc};
 use titlecase::titlecase;
 
 pub const MAX_SHORT_FIELD_LENGTH: usize = 70;
@@ -224,7 +226,11 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
     }
 }
 
-pub fn parse_validator_info_command(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+pub fn parse_validator_info_command(
+    matches: &ArgMatches<'_>,
+    default_signer_path: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+) -> Result<CliCommandInfo, CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
     // Prepare validator info
     let validator_info = parse_args(&matches);
@@ -234,7 +240,12 @@ pub fn parse_validator_info_command(matches: &ArgMatches<'_>) -> Result<CliComma
             force_keybase: matches.is_present("force"),
             info_pubkey,
         },
-        require_keypair: true,
+        signers: vec![signer_from_path(
+            matches,
+            default_signer_path,
+            "keypair",
+            wallet_manager,
+        )?],
     })
 }
 
@@ -244,7 +255,7 @@ pub fn parse_get_validator_info_command(
     let info_pubkey = pubkey_of(matches, "info_pubkey");
     Ok(CliCommandInfo {
         command: CliCommand::GetValidatorInfo(info_pubkey),
-        require_keypair: false,
+        signers: vec![],
     })
 }
 
@@ -257,7 +268,7 @@ pub fn process_set_validator_info(
 ) -> ProcessResult {
     // Validate keybase username
     if let Some(string) = validator_info.get("keybaseUsername") {
-        let result = verify_keybase(&config.keypair.pubkey(), &string);
+        let result = verify_keybase(&config.signers[0].pubkey(), &string);
         if result.is_err() {
             if force_keybase {
                 println!("--force supplied, ignoring: {:?}", result);
@@ -282,7 +293,7 @@ pub fn process_set_validator_info(
         })
         .find(|(pubkey, account)| {
             let (validator_pubkey, _) = parse_validator_info(&pubkey, &account).unwrap();
-            validator_pubkey == config.keypair.pubkey()
+            validator_pubkey == config.signers[0].pubkey()
         });
 
     // Create validator-info keypair to use if info_pubkey not provided or does not exist
@@ -300,7 +311,7 @@ pub fn process_set_validator_info(
         .poll_get_balance_with_commitment(&info_pubkey, CommitmentConfig::default())
         .unwrap_or(0);
 
-    let keys = vec![(id(), false), (config.keypair.pubkey(), true)];
+    let keys = vec![(id(), false), (config.signers[0].pubkey(), true)];
     let (message, signers): (Message, Vec<&dyn Signer>) = if balance == 0 {
         if info_pubkey != info_keypair.pubkey() {
             println!(
@@ -311,12 +322,12 @@ pub fn process_set_validator_info(
         }
         println!(
             "Publishing info for Validator {:?}",
-            config.keypair.pubkey()
+            config.signers[0].pubkey()
         );
         let lamports = rpc_client
             .get_minimum_balance_for_rent_exemption(ValidatorInfo::max_space() as usize)?;
         let mut instructions = config_instruction::create_account::<ValidatorInfo>(
-            &config.keypair.pubkey(),
+            &config.signers[0].pubkey(),
             &info_keypair.pubkey(),
             lamports,
             keys.clone(),
@@ -327,13 +338,13 @@ pub fn process_set_validator_info(
             keys,
             &validator_info,
         )]);
-        let signers = vec![config.keypair.as_ref(), &info_keypair];
+        let signers = vec![config.signers[0], &info_keypair];
         let message = Message::new(instructions);
         (message, signers)
     } else {
         println!(
             "Updating Validator {:?} info at: {:?}",
-            config.keypair.pubkey(),
+            config.signers[0].pubkey(),
             info_pubkey
         );
         let instructions = vec![config_instruction::store(
@@ -342,8 +353,8 @@ pub fn process_set_validator_info(
             keys,
             &validator_info,
         )];
-        let message = Message::new_with_payer(instructions, Some(&config.keypair.pubkey()));
-        let signers = vec![config.keypair.as_ref()];
+        let message = Message::new_with_payer(instructions, Some(&config.signers[0].pubkey()));
+        let signers = vec![config.signers[0]];
         (message, signers)
     };
 
@@ -353,7 +364,7 @@ pub fn process_set_validator_info(
     tx.try_sign(&signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -229,7 +229,7 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
 pub fn parse_validator_info_command(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
     // Prepare validator info

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -233,7 +233,7 @@ pub fn parse_validator_info_command(
 ) -> Result<CliCommandInfo, CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
     // Prepare validator info
-    let validator_info = parse_args(&matches);
+    let validator_info = parse_args(matches);
     Ok(CliCommandInfo {
         command: CliCommand::SetValidatorInfo {
             validator_info,

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -516,6 +516,10 @@ mod tests {
         let pubkey2 = keypair2.pubkey();
         let pubkey2_string = pubkey2.to_string();
 
+        let default_keypair = Keypair::new();
+        let (default_keypair_file, mut tmp_file) = make_tmp_file();
+        write_keypair(&default_keypair, tmp_file.as_file_mut()).unwrap();
+
         let test_authorize_voter = test_commands.clone().get_matches_from(vec![
             "test",
             "vote-authorize-voter",
@@ -523,14 +527,14 @@ mod tests {
             &pubkey2_string,
         ]);
         assert_eq!(
-            parse_command(&test_authorize_voter).unwrap(),
+            parse_command(&test_authorize_voter, &default_keypair_file, &None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::VoteAuthorize {
                     vote_account_pubkey: pubkey,
                     new_authorized_pubkey: pubkey2,
                     vote_authorize: VoteAuthorize::Voter
                 },
-                require_default_keypair: true
+                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
             }
         );
 
@@ -549,17 +553,19 @@ mod tests {
             "10",
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account).unwrap(),
+            parse_command(&test_create_vote_account, &default_keypair_file, &None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
-                    vote_account: keypair.into(),
                     seed: None,
                     node_pubkey,
                     authorized_voter: None,
                     authorized_withdrawer: None,
                     commission: 10,
                 },
-                require_default_keypair: true
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Box::new(keypair)
+                ],
             }
         );
 
@@ -574,17 +580,19 @@ mod tests {
             &node_pubkey_string,
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account2).unwrap(),
+            parse_command(&test_create_vote_account2, &default_keypair_file, &None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
-                    vote_account: keypair.into(),
                     seed: None,
                     node_pubkey,
                     authorized_voter: None,
                     authorized_withdrawer: None,
                     commission: 100,
                 },
-                require_default_keypair: true
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Box::new(keypair)
+                ],
             }
         );
 
@@ -603,17 +611,19 @@ mod tests {
             &authed.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account3).unwrap(),
+            parse_command(&test_create_vote_account3, &default_keypair_file, &None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
-                    vote_account: keypair.into(),
                     seed: None,
                     node_pubkey,
                     authorized_voter: Some(authed),
                     authorized_withdrawer: None,
                     commission: 100
                 },
-                require_default_keypair: true
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Box::new(keypair)
+                ],
             }
         );
 
@@ -630,17 +640,19 @@ mod tests {
             &authed.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account4).unwrap(),
+            parse_command(&test_create_vote_account4, &default_keypair_file, &None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
-                    vote_account: keypair.into(),
                     seed: None,
                     node_pubkey,
                     authorized_voter: None,
                     authorized_withdrawer: Some(authed),
                     commission: 100
                 },
-                require_default_keypair: true
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Box::new(keypair)
+                ],
             }
         );
 
@@ -652,16 +664,16 @@ mod tests {
             &keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_update_validator).unwrap(),
+            parse_command(&test_update_validator, &default_keypair_file, &None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::VoteUpdateValidator {
                     vote_account_pubkey: pubkey,
                     new_identity_pubkey: pubkey2,
-                    authorized_voter: solana_sdk::signature::read_keypair_file(&keypair_file)
-                        .unwrap()
-                        .into(),
                 },
-                require_default_keypair: true
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap())
+                ],
             }
         );
     }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -190,7 +190,7 @@ pub fn parse_vote_create_account(
     let authorized_withdrawer = pubkey_of(matches, "authorized_withdrawer");
 
     let payer_provided = None;
-    let CliSignerInfo { signers, .. } = generate_unique_signers(
+    let CliSignerInfo { signers } = generate_unique_signers(
         vec![payer_provided, Some(Box::new(vote_account))],
         matches,
         default_signer_path,
@@ -219,7 +219,7 @@ pub fn parse_vote_authorize(
     let new_authorized_pubkey = pubkey_of(matches, "new_authorized_pubkey").unwrap();
 
     let authorized_voter_provided = None;
-    let CliSignerInfo { signers, .. } = generate_unique_signers(
+    let CliSignerInfo { signers } = generate_unique_signers(
         vec![authorized_voter_provided],
         matches,
         default_signer_path,
@@ -246,7 +246,7 @@ pub fn parse_vote_update_validator(
     let authorized_voter = keypair_of(matches, "authorized_voter").unwrap();
 
     let payer_provided = None;
-    let CliSignerInfo { signers, .. } = generate_unique_signers(
+    let CliSignerInfo { signers } = generate_unique_signers(
         vec![payer_provided, Some(Box::new(authorized_voter))],
         matches,
         default_signer_path,

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -182,7 +182,7 @@ pub fn parse_vote_create_account(
     default_signer_path: &str,
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
-    let vote_account = keypair_of(matches, "vote_account").unwrap();
+    let (vote_account, _) = signer_of(matches, "vote_account", wallet_manager)?;
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let identity_pubkey = pubkey_of(matches, "identity_pubkey").unwrap();
     let commission = value_t_or_exit!(matches, "commission", u8);
@@ -191,7 +191,7 @@ pub fn parse_vote_create_account(
 
     let payer_provided = None;
     let CliSignerInfo { signers } = generate_unique_signers(
-        vec![payer_provided, Some(Box::new(vote_account))],
+        vec![payer_provided, vote_account],
         matches,
         default_signer_path,
         wallet_manager,
@@ -243,11 +243,11 @@ pub fn parse_vote_update_validator(
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
     let new_identity_pubkey = pubkey_of(matches, "new_identity_pubkey").unwrap();
-    let authorized_voter = keypair_of(matches, "authorized_voter").unwrap();
+    let (authorized_voter, _) = signer_of(matches, "authorized_voter", wallet_manager)?;
 
     let payer_provided = None;
     let CliSignerInfo { signers } = generate_unique_signers(
-        vec![payer_provided, Some(Box::new(authorized_voter))],
+        vec![payer_provided, authorized_voter],
         matches,
         default_signer_path,
         wallet_manager,

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -180,7 +180,7 @@ impl VoteSubCommands for App<'_, '_> {
 pub fn parse_vote_create_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account = keypair_of(matches, "vote_account").unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
@@ -212,7 +212,7 @@ pub fn parse_vote_create_account(
 pub fn parse_vote_authorize(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
     vote_authorize: VoteAuthorize,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
@@ -239,7 +239,7 @@ pub fn parse_vote_authorize(
 pub fn parse_vote_update_validator(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
     let new_identity_pubkey = pubkey_of(matches, "new_identity_pubkey").unwrap();
@@ -527,7 +527,7 @@ mod tests {
             &pubkey2_string,
         ]);
         assert_eq!(
-            parse_command(&test_authorize_voter, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_authorize_voter, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::VoteAuthorize {
                     vote_account_pubkey: pubkey,
@@ -553,7 +553,7 @@ mod tests {
             "10",
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_vote_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
                     seed: None,
@@ -580,7 +580,7 @@ mod tests {
             &node_pubkey_string,
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account2, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_vote_account2, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
                     seed: None,
@@ -611,7 +611,7 @@ mod tests {
             &authed.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account3, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_vote_account3, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
                     seed: None,
@@ -640,7 +640,7 @@ mod tests {
             &authed.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account4, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_create_vote_account4, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
                     seed: None,
@@ -664,7 +664,7 @@ mod tests {
             &keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_update_validator, &default_keypair_file, &None).unwrap(),
+            parse_command(&test_update_validator, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::VoteUpdateValidator {
                     vote_account_pubkey: pubkey,

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1,16 +1,16 @@
 use crate::cli::{
-    build_balance_message, check_account_for_fee, check_unique_pubkeys,
-    log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult,
+    build_balance_message, check_account_for_fee, check_unique_pubkeys, generate_unique_signers,
+    log_instruction_custom_error, CliCommand, CliCommandInfo, CliConfig, CliError, CliSignerInfo,
+    ProcessResult,
 };
 use clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::{input_parsers::*, input_validators::*};
 use solana_client::rpc_client::RpcClient;
+use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     account::Account,
     message::Message,
     pubkey::Pubkey,
-    signature::Keypair,
-    signature::Signer,
     system_instruction::{create_address_with_seed, SystemError},
     transaction::Transaction,
 };
@@ -18,6 +18,7 @@ use solana_vote_program::{
     vote_instruction::{self, VoteError},
     vote_state::{VoteAuthorize, VoteInit, VoteState},
 };
+use std::sync::Arc;
 
 pub trait VoteSubCommands {
     fn vote_subcommands(self) -> Self;
@@ -176,7 +177,11 @@ impl VoteSubCommands for App<'_, '_> {
     }
 }
 
-pub fn parse_vote_create_account(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+pub fn parse_vote_create_account(
+    matches: &ArgMatches<'_>,
+    default_signer_path: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+) -> Result<CliCommandInfo, CliError> {
     let vote_account = keypair_of(matches, "vote_account").unwrap();
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let identity_pubkey = pubkey_of(matches, "identity_pubkey").unwrap();
@@ -184,25 +189,42 @@ pub fn parse_vote_create_account(matches: &ArgMatches<'_>) -> Result<CliCommandI
     let authorized_voter = pubkey_of(matches, "authorized_voter");
     let authorized_withdrawer = pubkey_of(matches, "authorized_withdrawer");
 
+    let payer_provided = None;
+    let CliSignerInfo { signers, .. } = generate_unique_signers(
+        vec![payer_provided, Some(Box::new(vote_account))],
+        matches,
+        default_signer_path,
+        wallet_manager,
+    )?;
+
     Ok(CliCommandInfo {
         command: CliCommand::CreateVoteAccount {
-            vote_account: vote_account.into(),
             seed,
             node_pubkey: identity_pubkey,
             authorized_voter,
             authorized_withdrawer,
             commission,
         },
-        require_keypair: true,
+        signers,
     })
 }
 
 pub fn parse_vote_authorize(
     matches: &ArgMatches<'_>,
+    default_signer_path: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
     vote_authorize: VoteAuthorize,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
     let new_authorized_pubkey = pubkey_of(matches, "new_authorized_pubkey").unwrap();
+
+    let authorized_voter_provided = None;
+    let CliSignerInfo { signers, .. } = generate_unique_signers(
+        vec![authorized_voter_provided],
+        matches,
+        default_signer_path,
+        wallet_manager,
+    )?;
 
     Ok(CliCommandInfo {
         command: CliCommand::VoteAuthorize {
@@ -210,22 +232,33 @@ pub fn parse_vote_authorize(
             new_authorized_pubkey,
             vote_authorize,
         },
-        require_keypair: true,
+        signers,
     })
 }
 
-pub fn parse_vote_update_validator(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+pub fn parse_vote_update_validator(
+    matches: &ArgMatches<'_>,
+    default_signer_path: &str,
+    wallet_manager: &Option<Arc<RemoteWalletManager>>,
+) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey = pubkey_of(matches, "vote_account_pubkey").unwrap();
     let new_identity_pubkey = pubkey_of(matches, "new_identity_pubkey").unwrap();
     let authorized_voter = keypair_of(matches, "authorized_voter").unwrap();
+
+    let payer_provided = None;
+    let CliSignerInfo { signers, .. } = generate_unique_signers(
+        vec![payer_provided, Some(Box::new(authorized_voter))],
+        matches,
+        default_signer_path,
+        wallet_manager,
+    )?;
 
     Ok(CliCommandInfo {
         command: CliCommand::VoteUpdateValidator {
             vote_account_pubkey,
             new_identity_pubkey,
-            authorized_voter: authorized_voter.into(),
         },
-        require_keypair: true,
+        signers,
     })
 }
 
@@ -239,20 +272,20 @@ pub fn parse_vote_get_account_command(
             pubkey: vote_account_pubkey,
             use_lamports_unit,
         },
-        require_keypair: false,
+        signers: vec![],
     })
 }
 
 pub fn process_create_vote_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    vote_account: &Keypair,
     seed: &Option<String>,
     identity_pubkey: &Pubkey,
     authorized_voter: &Option<Pubkey>,
     authorized_withdrawer: &Option<Pubkey>,
     commission: u8,
 ) -> ProcessResult {
+    let vote_account = config.signers[1];
     let vote_account_pubkey = vote_account.pubkey();
     let vote_account_address = if let Some(seed) = seed {
         create_address_with_seed(&vote_account_pubkey, &seed, &solana_vote_program::id())?
@@ -260,7 +293,7 @@ pub fn process_create_vote_account(
         vote_account_pubkey
     };
     check_unique_pubkeys(
-        (&config.keypair.pubkey(), "cli keypair".to_string()),
+        (&config.signers[0].pubkey(), "cli keypair".to_string()),
         (&vote_account_address, "vote_account".to_string()),
     )?;
 
@@ -294,16 +327,16 @@ pub fn process_create_vote_account(
 
     let ixs = if let Some(seed) = seed {
         vote_instruction::create_account_with_seed(
-            &config.keypair.pubkey(), // from
-            &vote_account_address,    // to
-            &vote_account_pubkey,     // base
-            seed,                     // seed
+            &config.signers[0].pubkey(), // from
+            &vote_account_address,       // to
+            &vote_account_pubkey,        // base
+            seed,                        // seed
             &vote_init,
             required_balance,
         )
     } else {
         vote_instruction::create_account(
-            &config.keypair.pubkey(),
+            &config.signers[0].pubkey(),
             &vote_account_pubkey,
             &vote_init,
             required_balance,
@@ -311,22 +344,16 @@ pub fn process_create_vote_account(
     };
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let signers = if vote_account_pubkey != config.keypair.pubkey() {
-        vec![config.keypair.as_ref(), vote_account] // both must sign if `from` and `to` differ
-    } else {
-        vec![config.keypair.as_ref()] // when stake_account == config.keypair and there's a seed, we only need one signature
-    };
-
     let message = Message::new(ixs);
     let mut tx = Transaction::new_unsigned(message);
-    tx.try_sign(&signers, recent_blockhash)?;
+    tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &signers);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &config.signers);
     log_instruction_custom_error::<SystemError>(result)
 }
 
@@ -343,22 +370,22 @@ pub fn process_vote_authorize(
     )?;
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let ixs = vec![vote_instruction::authorize(
-        vote_account_pubkey,      // vote account to update
-        &config.keypair.pubkey(), // current authorized voter
-        new_authorized_pubkey,    // new vote signer/withdrawer
-        vote_authorize,           // vote or withdraw
+        vote_account_pubkey,         // vote account to update
+        &config.signers[0].pubkey(), // current authorized voter
+        new_authorized_pubkey,       // new vote signer/withdrawer
+        vote_authorize,              // vote or withdraw
     )];
 
-    let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
+    let message = Message::new_with_payer(ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.try_sign(&[config.keypair.as_ref()], recent_blockhash)?;
+    tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.signers[0]]);
     log_instruction_custom_error::<VoteError>(result)
 }
 
@@ -367,8 +394,8 @@ pub fn process_vote_update_validator(
     config: &CliConfig,
     vote_account_pubkey: &Pubkey,
     new_identity_pubkey: &Pubkey,
-    authorized_voter: &Keypair,
 ) -> ProcessResult {
+    let authorized_voter = config.signers[1];
     check_unique_pubkeys(
         (vote_account_pubkey, "vote_account_pubkey".to_string()),
         (new_identity_pubkey, "new_identity_pubkey".to_string()),
@@ -380,19 +407,16 @@ pub fn process_vote_update_validator(
         new_identity_pubkey,
     )];
 
-    let message = Message::new_with_payer(ixs, Some(&config.keypair.pubkey()));
+    let message = Message::new_with_payer(ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
-    tx.try_sign(
-        &[config.keypair.as_ref(), authorized_voter],
-        recent_blockhash,
-    )?;
+    tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(
         rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction(&mut tx, &[config.keypair.as_ref()]);
+    let result = rpc_client.send_and_confirm_transaction(&mut tx, &config.signers);
     log_instruction_custom_error::<VoteError>(result)
 }
 
@@ -474,7 +498,7 @@ pub fn process_show_vote_account(
 mod tests {
     use super::*;
     use crate::cli::{app, parse_command};
-    use solana_sdk::signature::write_keypair;
+    use solana_sdk::signature::{read_keypair_file, write_keypair, Keypair, Signer};
     use tempfile::NamedTempFile;
 
     fn make_tmp_file() -> (String, NamedTempFile) {
@@ -506,7 +530,7 @@ mod tests {
                     new_authorized_pubkey: pubkey2,
                     vote_authorize: VoteAuthorize::Voter
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -535,7 +559,7 @@ mod tests {
                     authorized_withdrawer: None,
                     commission: 10,
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -560,7 +584,7 @@ mod tests {
                     authorized_withdrawer: None,
                     commission: 100,
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -589,7 +613,7 @@ mod tests {
                     authorized_withdrawer: None,
                     commission: 100
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -616,7 +640,7 @@ mod tests {
                     authorized_withdrawer: Some(authed),
                     commission: 100
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
 
@@ -637,7 +661,7 @@ mod tests {
                         .unwrap()
                         .into(),
                 },
-                require_keypair: true
+                require_default_keypair: true
             }
         );
     }

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -3,7 +3,7 @@ use solana_cli::cli::{process_command, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::new_validator_for_tests;
 use solana_faucet::faucet::run_local_faucet;
-use solana_sdk::{bpf_loader, pubkey::Pubkey};
+use solana_sdk::{bpf_loader, pubkey::Pubkey, signature::Keypair};
 use std::{
     fs::{remove_dir_all, File},
     io::Read,
@@ -38,6 +38,7 @@ fn test_cli_deploy_program() {
         .unwrap();
 
     let mut config = CliConfig::default();
+    let keypair = Keypair::new();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
     config.command = CliCommand::Airdrop {
         faucet_host: None,
@@ -45,6 +46,7 @@ fn test_cli_deploy_program() {
         pubkey: None,
         lamports: minimum_balance_for_rent_exemption + 1, // min balance for rent exemption + leftover for tx processing
     };
+    config.signers = vec![&keypair];
     process_command(&config).unwrap();
 
     config.command = CliCommand::Deploy(pathbuf.to_str().unwrap().to_string());

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -12,22 +12,12 @@ use solana_sdk::{
     fee_calculator::FeeCalculator,
     nonce_state::NonceState,
     pubkey::Pubkey,
-    signature::{read_keypair_file, write_keypair, Keypair, Signer},
+    signature::{Keypair, Signer},
 };
-use std::fs::remove_dir_all;
-use std::sync::mpsc::channel;
+use std::{fs::remove_dir_all, sync::mpsc::channel, thread::sleep, time::Duration};
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests;
-use std::rc::Rc;
-use std::thread::sleep;
-use std::time::Duration;
-use tempfile::NamedTempFile;
-
-fn make_tmp_file() -> (String, NamedTempFile) {
-    let tmp_file = NamedTempFile::new().unwrap();
-    (String::from(tmp_file.path().to_str().unwrap()), tmp_file)
-}
 
 fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
     (0..5).for_each(|tries| {
@@ -52,32 +42,36 @@ fn test_cli_timestamp_tx() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer0 = Keypair::new();
+    let default_signer1 = Keypair::new();
 
     let mut config_payer = CliConfig::default();
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config_payer.signers = vec![&default_signer0];
 
     let mut config_witness = CliConfig::default();
     config_witness.json_rpc_url = config_payer.json_rpc_url.clone();
+    config_witness.signers = vec![&default_signer1];
 
     assert_ne!(
-        config_payer.keypair.pubkey(),
-        config_witness.keypair.pubkey()
+        config_payer.signers[0].pubkey(),
+        config_witness.signers[0].pubkey()
     );
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_payer.keypair.pubkey(),
+        &config_payer.signers[0].pubkey(),
         50,
     )
     .unwrap();
-    check_balance(50, &rpc_client, &config_payer.keypair.pubkey());
+    check_balance(50, &rpc_client, &config_payer.signers[0].pubkey());
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_witness.keypair.pubkey(),
+        &config_witness.signers[0].pubkey(),
         1,
     )
     .unwrap();
@@ -89,7 +83,7 @@ fn test_cli_timestamp_tx() {
         lamports: 10,
         to: bob_pubkey,
         timestamp: Some(dt),
-        timestamp_pubkey: Some(config_witness.keypair.pubkey()),
+        timestamp_pubkey: Some(config_witness.signers[0].pubkey()),
         ..PayCommand::default()
     });
     let sig_response = process_command(&config_payer);
@@ -101,7 +95,7 @@ fn test_cli_timestamp_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.signers[0].pubkey()); // config_payer balance
     check_balance(10, &rpc_client, &process_id); // contract balance
     check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -109,7 +103,7 @@ fn test_cli_timestamp_tx() {
     config_witness.command = CliCommand::TimeElapsed(bob_pubkey, process_id, dt);
     process_command(&config_witness).unwrap();
 
-    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.signers[0].pubkey()); // config_payer balance
     check_balance(0, &rpc_client, &process_id); // contract balance
     check_balance(10, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -127,30 +121,34 @@ fn test_cli_witness_tx() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer0 = Keypair::new();
+    let default_signer1 = Keypair::new();
 
     let mut config_payer = CliConfig::default();
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config_payer.signers = vec![&default_signer0];
 
     let mut config_witness = CliConfig::default();
     config_witness.json_rpc_url = config_payer.json_rpc_url.clone();
+    config_witness.signers = vec![&default_signer1];
 
     assert_ne!(
-        config_payer.keypair.pubkey(),
-        config_witness.keypair.pubkey()
+        config_payer.signers[0].pubkey(),
+        config_witness.signers[0].pubkey()
     );
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_payer.keypair.pubkey(),
+        &config_payer.signers[0].pubkey(),
         50,
     )
     .unwrap();
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_witness.keypair.pubkey(),
+        &config_witness.signers[0].pubkey(),
         1,
     )
     .unwrap();
@@ -159,7 +157,7 @@ fn test_cli_witness_tx() {
     config_payer.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        witnesses: Some(vec![config_witness.keypair.pubkey()]),
+        witnesses: Some(vec![config_witness.signers[0].pubkey()]),
         ..PayCommand::default()
     });
     let sig_response = process_command(&config_payer);
@@ -171,7 +169,7 @@ fn test_cli_witness_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.signers[0].pubkey()); // config_payer balance
     check_balance(10, &rpc_client, &process_id); // contract balance
     check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -179,7 +177,7 @@ fn test_cli_witness_tx() {
     config_witness.command = CliCommand::Witness(bob_pubkey, process_id);
     process_command(&config_witness).unwrap();
 
-    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.signers[0].pubkey()); // config_payer balance
     check_balance(0, &rpc_client, &process_id); // contract balance
     check_balance(10, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -197,23 +195,27 @@ fn test_cli_cancel_tx() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer0 = Keypair::new();
+    let default_signer1 = Keypair::new();
 
     let mut config_payer = CliConfig::default();
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config_payer.signers = vec![&default_signer0];
 
     let mut config_witness = CliConfig::default();
     config_witness.json_rpc_url = config_payer.json_rpc_url.clone();
+    config_witness.signers = vec![&default_signer1];
 
     assert_ne!(
-        config_payer.keypair.pubkey(),
-        config_witness.keypair.pubkey()
+        config_payer.signers[0].pubkey(),
+        config_witness.signers[0].pubkey()
     );
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_payer.keypair.pubkey(),
+        &config_payer.signers[0].pubkey(),
         50,
     )
     .unwrap();
@@ -222,7 +224,7 @@ fn test_cli_cancel_tx() {
     config_payer.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
-        witnesses: Some(vec![config_witness.keypair.pubkey()]),
+        witnesses: Some(vec![config_witness.signers[0].pubkey()]),
         cancelable: true,
         ..PayCommand::default()
     });
@@ -235,7 +237,7 @@ fn test_cli_cancel_tx() {
         .expect("base58-encoded public key");
     let process_id = Pubkey::new(&process_id_vec);
 
-    check_balance(40, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
+    check_balance(40, &rpc_client, &config_payer.signers[0].pubkey()); // config_payer balance
     check_balance(10, &rpc_client, &process_id); // contract balance
     check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -243,7 +245,7 @@ fn test_cli_cancel_tx() {
     config_payer.command = CliCommand::Cancel(process_id);
     process_command(&config_payer).unwrap();
 
-    check_balance(50, &rpc_client, &config_payer.keypair.pubkey()); // config_payer balance
+    check_balance(50, &rpc_client, &config_payer.signers[0].pubkey()); // config_payer balance
     check_balance(0, &rpc_client, &process_id); // contract balance
     check_balance(0, &rpc_client, &bob_pubkey); // recipient balance
 
@@ -261,22 +263,26 @@ fn test_offline_pay_tx() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer = Keypair::new();
+    let default_offline_signer = Keypair::new();
 
     let mut config_offline = CliConfig::default();
     config_offline.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config_offline.signers = vec![&default_offline_signer];
     let mut config_online = CliConfig::default();
     config_online.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config_online.signers = vec![&default_signer];
     assert_ne!(
-        config_offline.keypair.pubkey(),
-        config_online.keypair.pubkey()
+        config_offline.signers[0].pubkey(),
+        config_online.signers[0].pubkey()
     );
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_offline.keypair.pubkey(),
+        &config_offline.signers[0].pubkey(),
         50,
     )
     .unwrap();
@@ -284,12 +290,12 @@ fn test_offline_pay_tx() {
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_online.keypair.pubkey(),
+        &config_online.signers[0].pubkey(),
         50,
     )
     .unwrap();
-    check_balance(50, &rpc_client, &config_offline.keypair.pubkey());
-    check_balance(50, &rpc_client, &config_online.keypair.pubkey());
+    check_balance(50, &rpc_client, &config_offline.signers[0].pubkey());
+    check_balance(50, &rpc_client, &config_online.signers[0].pubkey());
 
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::Pay(PayCommand {
@@ -301,15 +307,15 @@ fn test_offline_pay_tx() {
     });
     let sig_response = process_command(&config_offline).unwrap();
 
-    check_balance(50, &rpc_client, &config_offline.keypair.pubkey());
-    check_balance(50, &rpc_client, &config_online.keypair.pubkey());
+    check_balance(50, &rpc_client, &config_offline.signers[0].pubkey());
+    check_balance(50, &rpc_client, &config_online.signers[0].pubkey());
     check_balance(0, &rpc_client, &bob_pubkey);
 
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner =
-        presigner_from_pubkey_sigs(&config_offline.keypair.pubkey(), &signers).unwrap();
-    let online_pubkey = config_online.keypair.pubkey();
-    config_online.keypair = offline_presigner.into();
+        presigner_from_pubkey_sigs(&config_offline.signers[0].pubkey(), &signers).unwrap();
+    let online_pubkey = config_online.signers[0].pubkey();
+    config_online.signers = vec![&offline_presigner];
     config_online.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,
@@ -318,7 +324,7 @@ fn test_offline_pay_tx() {
     });
     process_command(&config_online).unwrap();
 
-    check_balance(40, &rpc_client, &config_offline.keypair.pubkey());
+    check_balance(40, &rpc_client, &config_offline.signers[0].pubkey());
     check_balance(50, &rpc_client, &online_pubkey);
     check_balance(10, &rpc_client, &bob_pubkey);
 
@@ -336,9 +342,11 @@ fn test_nonced_pay_tx() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer = Keypair::new();
 
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config.signers = vec![&default_signer];
 
     let minimum_nonce_balance = rpc_client
         .get_minimum_balance_for_rent_exemption(NonceState::size())
@@ -359,14 +367,13 @@ fn test_nonced_pay_tx() {
 
     // Create nonce account
     let nonce_account = Keypair::new();
-    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
+        nonce_account: 1,
         seed: None,
         nonce_authority: Some(config.signers[0].pubkey()),
         lamports: minimum_nonce_balance,
     };
+    config.signers.push(&nonce_account);
     process_command(&config).unwrap();
 
     check_balance(50, &rpc_client, &config.signers[0].pubkey());
@@ -381,6 +388,7 @@ fn test_nonced_pay_tx() {
     };
 
     let bob_pubkey = Pubkey::new_rand();
+    config.signers = vec![&default_signer];
     config.command = CliCommand::Pay(PayCommand {
         lamports: 10,
         to: bob_pubkey,

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -347,14 +347,14 @@ fn test_nonced_pay_tx() {
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
         50 + minimum_nonce_balance,
     )
     .unwrap();
     check_balance(
         50 + minimum_nonce_balance,
         &rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
     );
 
     // Create nonce account
@@ -364,12 +364,12 @@ fn test_nonced_pay_tx() {
     config.command = CliCommand::CreateNonceAccount {
         nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed: None,
-        nonce_authority: Some(config.keypair.pubkey()),
+        nonce_authority: Some(config.signers[0].pubkey()),
         lamports: minimum_nonce_balance,
     };
     process_command(&config).unwrap();
 
-    check_balance(50, &rpc_client, &config.keypair.pubkey());
+    check_balance(50, &rpc_client, &config.signers[0].pubkey());
     check_balance(minimum_nonce_balance, &rpc_client, &nonce_account.pubkey());
 
     // Fetch nonce hash
@@ -390,7 +390,7 @@ fn test_nonced_pay_tx() {
     });
     process_command(&config).expect("failed to process pay command");
 
-    check_balance(40, &rpc_client, &config.keypair.pubkey());
+    check_balance(40, &rpc_client, &config.signers[0].pubkey());
     check_balance(10, &rpc_client, &bob_pubkey);
 
     // Verify that nonce has been used

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -27,7 +27,7 @@ fn test_cli_request_airdrop() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let balance = rpc_client
-        .retry_get_balance(&bob_config.keypair.pubkey(), 1)
+        .retry_get_balance(&bob_config.signers[0].pubkey(), 1)
         .unwrap()
         .unwrap();
     assert_eq!(balance, 50);

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -2,8 +2,8 @@ use solana_cli::cli::{process_command, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::new_validator_for_tests;
 use solana_faucet::faucet::run_local_faucet;
-use std::fs::remove_dir_all;
-use std::sync::mpsc::channel;
+use solana_sdk::signature::Keypair;
+use std::{fs::remove_dir_all, sync::mpsc::channel};
 
 #[test]
 fn test_cli_request_airdrop() {
@@ -20,6 +20,8 @@ fn test_cli_request_airdrop() {
         pubkey: None,
         lamports: 50,
     };
+    let keypair = Keypair::new();
+    bob_config.signers = vec![&keypair];
 
     let sig_response = process_command(&bob_config);
     sig_response.unwrap();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -57,8 +57,13 @@ fn test_stake_delegation_force() {
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config.keypair.pubkey(), 100_000)
-        .unwrap();
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.signers[0].pubkey(),
+        100_000,
+    )
+    .unwrap();
 
     // Create vote account
     let vote_keypair = Keypair::new();
@@ -67,7 +72,7 @@ fn test_stake_delegation_force() {
     config.command = CliCommand::CreateVoteAccount {
         vote_account: read_keypair_file(&vote_keypair_file).unwrap().into(),
         seed: None,
-        node_pubkey: config.keypair.pubkey(),
+        node_pubkey: config.signers[0].pubkey(),
         authorized_voter: None,
         authorized_withdrawer: None,
         commission: 0,
@@ -439,15 +444,20 @@ fn test_nonced_stake_delegation_and_deactivation() {
     let (config_keypair_file, mut tmp_file) = make_tmp_file();
     write_keypair(&config_keypair, tmp_file.as_file_mut()).unwrap();
     let mut config = CliConfig::default();
-    config.keypair = config_keypair.into();
+    config.signers[0] = config_keypair.into();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let minimum_nonce_balance = rpc_client
         .get_minimum_balance_for_rent_exemption(NonceState::size())
         .unwrap();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config.keypair.pubkey(), 100_000)
-        .unwrap();
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.signers[0].pubkey(),
+        100_000,
+    )
+    .unwrap();
 
     // Create stake account
     let stake_keypair = Keypair::new();
@@ -476,7 +486,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     config.command = CliCommand::CreateNonceAccount {
         nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
         seed: None,
-        nonce_authority: Some(config.keypair.pubkey()),
+        nonce_authority: Some(config.signers[0].pubkey()),
         lamports: minimum_nonce_balance,
     };
     process_command(&config).unwrap();
@@ -541,8 +551,13 @@ fn test_stake_authorize() {
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config.keypair.pubkey(), 100_000)
-        .unwrap();
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.signers[0].pubkey(),
+        100_000,
+    )
+    .unwrap();
 
     let offline_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
     let (offline_authority_file, mut tmp_file) = make_tmp_file();
@@ -779,9 +794,14 @@ fn test_stake_authorize_with_fee_payer() {
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config.keypair.pubkey(), 100_000)
-        .unwrap();
-    check_balance(100_000, &rpc_client, &config.keypair.pubkey());
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.signers[0].pubkey(),
+        100_000,
+    )
+    .unwrap();
+    check_balance(100_000, &rpc_client, &config.signers[0].pubkey());
 
     request_and_confirm_airdrop(&rpc_client, &faucet_addr, &payer_pubkey, 100_000).unwrap();
     check_balance(100_000, &rpc_client, &payer_pubkey);
@@ -813,7 +833,7 @@ fn test_stake_authorize_with_fee_payer() {
     check_balance(
         50_000 - SIG_FEE - SIG_FEE,
         &rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
     );
 
     // Assign authority with separate fee payer
@@ -833,7 +853,7 @@ fn test_stake_authorize_with_fee_payer() {
     check_balance(
         50_000 - SIG_FEE - SIG_FEE,
         &rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
     );
     // `config_payer` however has paid `config`'s authority sig
     // and `config_payer`'s fee sig
@@ -875,7 +895,7 @@ fn test_stake_authorize_with_fee_payer() {
     check_balance(
         50_000 - SIG_FEE - SIG_FEE,
         &rpc_client,
-        &config.keypair.pubkey(),
+        &config.signers[0].pubkey(),
     );
     // `config_offline` however has paid 1 sig due to being both authority
     // and fee payer
@@ -910,9 +930,14 @@ fn test_stake_split() {
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config.keypair.pubkey(), 500_000)
-        .unwrap();
-    check_balance(500_000, &rpc_client, &config.keypair.pubkey());
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.signers[0].pubkey(),
+        500_000,
+    )
+    .unwrap();
+    check_balance(500_000, &rpc_client, &config.signers[0].pubkey());
 
     request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
@@ -1040,9 +1065,14 @@ fn test_stake_set_lockup() {
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config.keypair.pubkey(), 500_000)
-        .unwrap();
-    check_balance(500_000, &rpc_client, &config.keypair.pubkey());
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.signers[0].pubkey(),
+        500_000,
+    )
+    .unwrap();
+    check_balance(500_000, &rpc_client, &config.signers[0].pubkey());
 
     request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
@@ -1058,7 +1088,7 @@ fn test_stake_set_lockup() {
     write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
 
     let mut lockup = Lockup::default();
-    lockup.custodian = config.keypair.pubkey();
+    lockup.custodian = config.signers[0].pubkey();
 
     config.command = CliCommand::CreateStakeAccount {
         stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
@@ -1104,7 +1134,7 @@ fn test_stake_set_lockup() {
         StakeState::Initialized(meta) => meta.lockup,
         _ => panic!("Unexpected stake state!"),
     };
-    lockup.custodian = config.keypair.pubkey(); // Default new_custodian is config.keypair
+    lockup.custodian = config.signers[0].pubkey(); // Default new_custodian is config.signers[0]
     assert_eq!(current_lockup, lockup);
 
     // Set custodian to another pubkey
@@ -1252,7 +1282,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config = CliConfig::default();
-    config.keypair = keypair_from_seed(&[1u8; 32]).unwrap().into();
+    config.signers[0] = keypair_from_seed(&[1u8; 32]).unwrap().into();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let mut config_offline = CliConfig::default();
@@ -1263,9 +1293,14 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     // Verfiy that we cannot reach the cluster
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &config.keypair.pubkey(), 200_000)
-        .unwrap();
-    check_balance(200_000, &rpc_client, &config.keypair.pubkey());
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.signers[0].pubkey(),
+        200_000,
+    )
+    .unwrap();
+    check_balance(200_000, &rpc_client, &config.signers[0].pubkey());
 
     request_and_confirm_airdrop(
         &rpc_client,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -10,27 +10,16 @@ use solana_sdk::{
     fee_calculator::FeeCalculator,
     nonce_state::NonceState,
     pubkey::Pubkey,
-    signature::{keypair_from_seed, read_keypair_file, write_keypair, Keypair, Signer},
+    signature::{keypair_from_seed, Keypair, Signer},
     system_instruction::create_address_with_seed,
 };
 use solana_stake_program::stake_state::{Lockup, StakeAuthorize, StakeState};
-use std::fs::remove_dir_all;
-use std::sync::mpsc::channel;
+use std::{fs::remove_dir_all, sync::mpsc::channel, thread::sleep, time::Duration};
 
 #[cfg(test)]
 use solana_core::validator::{
     new_validator_for_tests, new_validator_for_tests_ex, new_validator_for_tests_with_vote_pubkey,
 };
-use std::rc::Rc;
-use std::thread::sleep;
-use std::time::Duration;
-
-use tempfile::NamedTempFile;
-
-fn make_tmp_file() -> (String, NamedTempFile) {
-    let tmp_file = NamedTempFile::new().unwrap();
-    (String::from(tmp_file.path().to_str().unwrap()), tmp_file)
-}
 
 fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
     (0..5).for_each(|tries| {
@@ -53,9 +42,11 @@ fn test_stake_delegation_force() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer = Keypair::new();
 
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config.signers = vec![&default_signer];
 
     request_and_confirm_airdrop(
         &rpc_client,
@@ -67,10 +58,8 @@ fn test_stake_delegation_force() {
 
     // Create vote account
     let vote_keypair = Keypair::new();
-    let (vote_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&vote_keypair, tmp_file.as_file_mut()).unwrap();
+    config.signers = vec![&default_signer, &vote_keypair];
     config.command = CliCommand::CreateVoteAccount {
-        vote_account: read_keypair_file(&vote_keypair_file).unwrap().into(),
         seed: None,
         node_pubkey: config.signers[0].pubkey(),
         authorized_voter: None,
@@ -81,10 +70,9 @@ fn test_stake_delegation_force() {
 
     // Create stake account
     let stake_keypair = Keypair::new();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
+    config.signers = vec![&default_signer, &stake_keypair];
     config.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
         staker: None,
         withdrawer: None,
@@ -93,23 +81,24 @@ fn test_stake_delegation_force() {
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config).unwrap();
 
     // Delegate stake fails (vote account had never voted)
+    config.signers = vec![&default_signer];
     config.command = CliCommand::DelegateStake {
         stake_account_pubkey: stake_keypair.pubkey(),
         vote_account_pubkey: vote_keypair.pubkey(),
-        stake_authority: None,
+        stake_authority: 0,
         force: false,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap_err();
 
@@ -117,13 +106,13 @@ fn test_stake_delegation_force() {
     config.command = CliCommand::DelegateStake {
         stake_account_pubkey: stake_keypair.pubkey(),
         vote_account_pubkey: vote_keypair.pubkey(),
-        stake_authority: None,
+        stake_authority: 0,
         force: true,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
 
@@ -144,28 +133,22 @@ fn test_seed_stake_delegation_and_deactivation() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let validator_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
-    let (validator_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&validator_keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_validator = CliConfig::default();
-    config_validator.keypair = validator_keypair.into();
     config_validator.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-
-    let mut config_stake = CliConfig::default();
-    config_stake.json_rpc_url =
-        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config_validator.signers = vec![&validator_keypair];
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_validator.keypair.pubkey(),
+        &config_validator.signers[0].pubkey(),
         100_000,
     )
     .unwrap();
-    check_balance(100_000, &rpc_client, &config_validator.keypair.pubkey());
+    check_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
 
     let stake_address = create_address_with_seed(
-        &config_validator.keypair.pubkey(),
+        &config_validator.signers[0].pubkey(),
         "hi there",
         &solana_stake_program::id(),
     )
@@ -174,7 +157,7 @@ fn test_seed_stake_delegation_and_deactivation() {
     // Create stake account with a seed, uses the validator config as the base,
     //   which is nice ;)
     config_validator.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&validator_keypair_file).unwrap().into()),
+        stake_account: 0,
         seed: Some("hi there".to_string()),
         staker: None,
         withdrawer: None,
@@ -183,9 +166,9 @@ fn test_seed_stake_delegation_and_deactivation() {
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config_validator).unwrap();
 
@@ -193,25 +176,25 @@ fn test_seed_stake_delegation_and_deactivation() {
     config_validator.command = CliCommand::DelegateStake {
         stake_account_pubkey: stake_address,
         vote_account_pubkey: vote_pubkey,
-        stake_authority: None,
+        stake_authority: 0,
         force: false,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config_validator).unwrap();
 
     // Deactivate stake
     config_validator.command = CliCommand::DeactivateStake {
         stake_account_pubkey: stake_address,
-        stake_authority: None,
+        stake_authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config_validator).unwrap();
 
@@ -230,31 +213,28 @@ fn test_stake_delegation_and_deactivation() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let validator_keypair = Keypair::new();
 
     let mut config_validator = CliConfig::default();
     config_validator.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config_validator.signers = vec![&validator_keypair];
 
     let stake_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
-    let mut config_stake = CliConfig::default();
-    config_stake.keypair = stake_keypair.into();
-    config_stake.json_rpc_url =
-        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_validator.keypair.pubkey(),
+        &config_validator.signers[0].pubkey(),
         100_000,
     )
     .unwrap();
-    check_balance(100_000, &rpc_client, &config_validator.keypair.pubkey());
+    check_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
 
     // Create stake account
+    config_validator.signers.push(&stake_keypair);
     config_validator.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
         staker: None,
         withdrawer: None,
@@ -263,35 +243,36 @@ fn test_stake_delegation_and_deactivation() {
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config_validator).unwrap();
 
     // Delegate stake
+    config_validator.signers.pop();
     config_validator.command = CliCommand::DelegateStake {
-        stake_account_pubkey: config_stake.keypair.pubkey(),
+        stake_account_pubkey: stake_keypair.pubkey(),
         vote_account_pubkey: vote_pubkey,
-        stake_authority: None,
+        stake_authority: 0,
         force: false,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config_validator).unwrap();
 
     // Deactivate stake
     config_validator.command = CliCommand::DeactivateStake {
-        stake_account_pubkey: config_stake.keypair.pubkey(),
-        stake_authority: None,
+        stake_account_pubkey: stake_keypair.pubkey(),
+        stake_authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config_validator).unwrap();
 
@@ -314,113 +295,114 @@ fn test_offline_stake_delegation_and_deactivation() {
     let mut config_validator = CliConfig::default();
     config_validator.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    let validator_keypair = Keypair::new();
+    config_validator.signers = vec![&validator_keypair];
 
     let mut config_payer = CliConfig::default();
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let stake_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
-    let mut config_stake = CliConfig::default();
-    config_stake.keypair = stake_keypair.into();
-    config_stake.json_rpc_url =
-        format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let mut config_offline = CliConfig::default();
     config_offline.json_rpc_url = String::default();
     config_offline.command = CliCommand::ClusterVersion;
+    let offline_keypair = Keypair::new();
+    config_offline.signers = vec![&offline_keypair];
     // Verfiy that we cannot reach the cluster
     process_command(&config_offline).unwrap_err();
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_validator.keypair.pubkey(),
+        &config_validator.signers[0].pubkey(),
         100_000,
     )
     .unwrap();
-    check_balance(100_000, &rpc_client, &config_validator.keypair.pubkey());
+    check_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
 
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_offline.keypair.pubkey(),
+        &config_offline.signers[0].pubkey(),
         100_000,
     )
     .unwrap();
-    check_balance(100_000, &rpc_client, &config_offline.keypair.pubkey());
+    check_balance(100_000, &rpc_client, &config_offline.signers[0].pubkey());
 
     // Create stake account
+    config_validator.signers.push(&stake_keypair);
     config_validator.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
-        staker: Some(config_offline.keypair.pubkey().into()),
+        staker: Some(config_offline.signers[0].pubkey().into()),
         withdrawer: None,
         lockup: Lockup::default(),
         lamports: 50_000,
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config_validator).unwrap();
 
     // Delegate stake offline
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::DelegateStake {
-        stake_account_pubkey: config_stake.keypair.pubkey(),
+        stake_account_pubkey: stake_keypair.pubkey(),
         vote_account_pubkey: vote_pubkey,
-        stake_authority: None,
+        stake_authority: 0,
         force: false,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner =
-        presigner_from_pubkey_sigs(&config_offline.keypair.pubkey(), &signers).unwrap();
+        presigner_from_pubkey_sigs(&config_offline.signers[0].pubkey(), &signers).unwrap();
+    config_payer.signers = vec![&offline_presigner];
     config_payer.command = CliCommand::DelegateStake {
-        stake_account_pubkey: config_stake.keypair.pubkey(),
+        stake_account_pubkey: stake_keypair.pubkey(),
         vote_account_pubkey: vote_pubkey,
-        stake_authority: Some(offline_presigner.clone().into()),
+        stake_authority: 0,
         force: false,
         sign_only: false,
         blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config_payer).unwrap();
 
     // Deactivate stake offline
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::DeactivateStake {
-        stake_account_pubkey: config_stake.keypair.pubkey(),
-        stake_authority: None,
+        stake_account_pubkey: stake_keypair.pubkey(),
+        stake_authority: 0,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner =
-        presigner_from_pubkey_sigs(&config_offline.keypair.pubkey(), &signers).unwrap();
+        presigner_from_pubkey_sigs(&config_offline.signers[0].pubkey(), &signers).unwrap();
+    config_payer.signers = vec![&offline_presigner];
     config_payer.command = CliCommand::DeactivateStake {
-        stake_account_pubkey: config_stake.keypair.pubkey(),
-        stake_authority: Some(offline_presigner.clone().into()),
+        stake_account_pubkey: stake_keypair.pubkey(),
+        stake_authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config_payer).unwrap();
 
@@ -441,10 +423,8 @@ fn test_nonced_stake_delegation_and_deactivation() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let config_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
-    let (config_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&config_keypair, tmp_file.as_file_mut()).unwrap();
     let mut config = CliConfig::default();
-    config.signers[0] = config_keypair.into();
+    config.signers = vec![&config_keypair];
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let minimum_nonce_balance = rpc_client
@@ -461,10 +441,9 @@ fn test_nonced_stake_delegation_and_deactivation() {
 
     // Create stake account
     let stake_keypair = Keypair::new();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
+    config.signers.push(&stake_keypair);
     config.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
         staker: None,
         withdrawer: None,
@@ -473,18 +452,17 @@ fn test_nonced_stake_delegation_and_deactivation() {
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config).unwrap();
 
     // Create nonce account
     let nonce_account = Keypair::new();
-    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
+    config.signers[1] = &nonce_account;
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
+        nonce_account: 1,
         seed: None,
         nonce_authority: Some(config.signers[0].pubkey()),
         lamports: minimum_nonce_balance,
@@ -500,16 +478,17 @@ fn test_nonced_stake_delegation_and_deactivation() {
     };
 
     // Delegate stake
+    config.signers = vec![&config_keypair];
     config.command = CliCommand::DelegateStake {
         stake_account_pubkey: stake_keypair.pubkey(),
         vote_account_pubkey: vote_pubkey,
-        stake_authority: None,
+        stake_authority: 0,
         force: false,
         sign_only: false,
         blockhash_query: BlockhashQuery::None(nonce_hash, FeeCalculator::default()),
         nonce_account: Some(nonce_account.pubkey()),
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
 
@@ -524,12 +503,12 @@ fn test_nonced_stake_delegation_and_deactivation() {
     // Deactivate stake
     config.command = CliCommand::DeactivateStake {
         stake_account_pubkey: stake_keypair.pubkey(),
-        stake_authority: None,
+        stake_authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
         nonce_account: Some(nonce_account.pubkey()),
-        nonce_authority: Some(read_keypair_file(&config_keypair_file).unwrap().into()),
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
 
@@ -547,9 +526,11 @@ fn test_stake_authorize() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer = Keypair::new();
 
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config.signers = vec![&default_signer];
 
     request_and_confirm_airdrop(
         &rpc_client,
@@ -560,12 +541,10 @@ fn test_stake_authorize() {
     .unwrap();
 
     let offline_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
-    let (offline_authority_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&offline_keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_offline = CliConfig::default();
-    config_offline.keypair = offline_keypair.into();
+    config_offline.signers = vec![&offline_keypair];
     config_offline.json_rpc_url = String::default();
-    let offline_authority_pubkey = config_offline.keypair.pubkey();
+    let offline_authority_pubkey = config_offline.signers[0].pubkey();
     config_offline.command = CliCommand::ClusterVersion;
     // Verfiy that we cannot reach the cluster
     process_command(&config_offline).unwrap_err();
@@ -573,7 +552,7 @@ fn test_stake_authorize() {
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
-        &config_offline.keypair.pubkey(),
+        &config_offline.signers[0].pubkey(),
         100_000,
     )
     .unwrap();
@@ -581,10 +560,9 @@ fn test_stake_authorize() {
     // Create stake account, identity is authority
     let stake_keypair = Keypair::new();
     let stake_account_pubkey = stake_keypair.pubkey();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
+    config.signers.push(&stake_keypair);
     config.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
         staker: None,
         withdrawer: None,
@@ -593,27 +571,26 @@ fn test_stake_authorize() {
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config).unwrap();
 
     // Assign new online stake authority
     let online_authority = Keypair::new();
     let online_authority_pubkey = online_authority.pubkey();
-    let (online_authority_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&online_authority, tmp_file.as_file_mut()).unwrap();
+    config.signers.pop();
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: online_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: None,
+        authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -625,16 +602,17 @@ fn test_stake_authorize() {
     assert_eq!(current_authority, online_authority_pubkey);
 
     // Assign new offline stake authority
+    config.signers.push(&online_authority);
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: offline_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: Some(read_keypair_file(&online_authority_file).unwrap().into()),
+        authority: 1,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -648,34 +626,33 @@ fn test_stake_authorize() {
     // Offline assignment of new nonced stake authority
     let nonced_authority = Keypair::new();
     let nonced_authority_pubkey = nonced_authority.pubkey();
-    let (nonced_authority_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&nonced_authority, tmp_file.as_file_mut()).unwrap();
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: nonced_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: Some(read_keypair_file(&offline_authority_file).unwrap().into()),
+        authority: 0,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sign_reply = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sign_reply);
     let offline_presigner =
         presigner_from_pubkey_sigs(&offline_authority_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: nonced_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: Some(offline_presigner.clone().into()),
+        authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -691,12 +668,11 @@ fn test_stake_authorize() {
         .get_minimum_balance_for_rent_exemption(NonceState::size())
         .unwrap();
     let nonce_account = Keypair::new();
-    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
+    config.signers = vec![&default_signer, &nonce_account];
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
+        nonce_account: 1,
         seed: None,
-        nonce_authority: Some(config_offline.keypair.pubkey()),
+        nonce_authority: Some(offline_authority_pubkey),
         lamports: minimum_nonce_balance,
     };
     process_command(&config).unwrap();
@@ -712,18 +688,17 @@ fn test_stake_authorize() {
     // Nonced assignment of new online stake authority
     let online_authority = Keypair::new();
     let online_authority_pubkey = online_authority.pubkey();
-    let (_online_authority_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&online_authority, tmp_file.as_file_mut()).unwrap();
+    config_offline.signers.push(&nonced_authority);
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: online_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: Some(read_keypair_file(&nonced_authority_file).unwrap().into()),
+        authority: 1,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(nonce_hash, FeeCalculator::default()),
         nonce_account: Some(nonce_account.pubkey()),
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sign_reply = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sign_reply);
@@ -732,16 +707,17 @@ fn test_stake_authorize() {
         presigner_from_pubkey_sigs(&offline_authority_pubkey, &signers).unwrap();
     let nonced_authority_presigner =
         presigner_from_pubkey_sigs(&nonced_authority_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner, &nonced_authority_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: online_authority_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: Some(nonced_authority_presigner.clone().into()),
+        authority: 1,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: Some(nonce_account.pubkey()),
-        nonce_authority: Some(offline_presigner.clone().into()),
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -775,32 +751,29 @@ fn test_stake_authorize_with_fee_payer() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer = Keypair::new();
+    let default_pubkey = default_signer.pubkey();
 
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config.signers = vec![&default_signer];
 
     let payer_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
-    let (payer_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&payer_keypair, tmp_file.as_file_mut()).unwrap();
     let mut config_payer = CliConfig::default();
-    config_payer.keypair = payer_keypair.into();
+    config_payer.signers = vec![&payer_keypair];
     config_payer.json_rpc_url =
         format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
-    let payer_pubkey = config_payer.keypair.pubkey();
+    let payer_pubkey = config_payer.signers[0].pubkey();
 
     let mut config_offline = CliConfig::default();
-    let offline_pubkey = config_offline.keypair.pubkey();
+    let offline_signer = Keypair::new();
+    config_offline.signers = vec![&offline_signer];
+    let offline_pubkey = config_offline.signers[0].pubkey();
     // Verify we're offline
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(
-        &rpc_client,
-        &faucet_addr,
-        &config.signers[0].pubkey(),
-        100_000,
-    )
-    .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &default_pubkey, 100_000).unwrap();
     check_balance(100_000, &rpc_client, &config.signers[0].pubkey());
 
     request_and_confirm_airdrop(&rpc_client, &faucet_addr, &payer_pubkey, 100_000).unwrap();
@@ -812,10 +785,9 @@ fn test_stake_authorize_with_fee_payer() {
     // Create stake account, identity is authority
     let stake_keypair = Keypair::new();
     let stake_account_pubkey = stake_keypair.pubkey();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
+    config.signers.push(&stake_keypair);
     config.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
         staker: None,
         withdrawer: None,
@@ -824,44 +796,33 @@ fn test_stake_authorize_with_fee_payer() {
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config).unwrap();
     // `config` balance should be 50,000 - 1 stake account sig - 1 fee sig
-    check_balance(
-        50_000 - SIG_FEE - SIG_FEE,
-        &rpc_client,
-        &config.signers[0].pubkey(),
-    );
+    check_balance(50_000 - SIG_FEE - SIG_FEE, &rpc_client, &default_pubkey);
 
     // Assign authority with separate fee payer
+    config.signers = vec![&default_signer, &payer_keypair];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: offline_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: None,
+        authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: Some(read_keypair_file(&payer_keypair_file).unwrap().into()),
+        nonce_authority: 0,
+        fee_payer: 1,
     };
     process_command(&config).unwrap();
     // `config` balance has not changed, despite submitting the TX
-    check_balance(
-        50_000 - SIG_FEE - SIG_FEE,
-        &rpc_client,
-        &config.signers[0].pubkey(),
-    );
+    check_balance(50_000 - SIG_FEE - SIG_FEE, &rpc_client, &default_pubkey);
     // `config_payer` however has paid `config`'s authority sig
     // and `config_payer`'s fee sig
-    check_balance(
-        100_000 - SIG_FEE - SIG_FEE,
-        &rpc_client,
-        &config_payer.keypair.pubkey(),
-    );
+    check_balance(100_000 - SIG_FEE - SIG_FEE, &rpc_client, &payer_pubkey);
 
     // Assign authority with offline fee payer
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
@@ -869,41 +830,34 @@ fn test_stake_authorize_with_fee_payer() {
         stake_account_pubkey,
         new_authorized_pubkey: payer_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: None,
+        authority: 0,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sign_reply = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sign_reply);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorized_pubkey: payer_pubkey,
         stake_authorize: StakeAuthorize::Staker,
-        authority: Some(offline_presigner.clone().into()),
+        authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     // `config`'s balance again has not changed
-    check_balance(
-        50_000 - SIG_FEE - SIG_FEE,
-        &rpc_client,
-        &config.signers[0].pubkey(),
-    );
+    check_balance(50_000 - SIG_FEE - SIG_FEE, &rpc_client, &default_pubkey);
     // `config_offline` however has paid 1 sig due to being both authority
     // and fee payer
-    check_balance(
-        100_000 - SIG_FEE,
-        &rpc_client,
-        &config_offline.keypair.pubkey(),
-    );
+    check_balance(100_000 - SIG_FEE, &rpc_client, &offline_pubkey);
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();
@@ -919,13 +873,17 @@ fn test_stake_split() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer = Keypair::new();
+    let offline_signer = Keypair::new();
 
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config.signers = vec![&default_signer];
 
     let mut config_offline = CliConfig::default();
     config_offline.json_rpc_url = String::default();
-    let offline_pubkey = config_offline.keypair.pubkey();
+    config_offline.signers = vec![&offline_signer];
+    let offline_pubkey = config_offline.signers[0].pubkey();
     // Verify we're offline
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
@@ -948,10 +906,9 @@ fn test_stake_split() {
         .unwrap();
     let stake_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
     let stake_account_pubkey = stake_keypair.pubkey();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
+    config.signers.push(&stake_keypair);
     config.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
         staker: Some(offline_pubkey),
         withdrawer: Some(offline_pubkey),
@@ -960,9 +917,9 @@ fn test_stake_split() {
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config).unwrap();
     check_balance(
@@ -976,20 +933,18 @@ fn test_stake_split() {
         .get_minimum_balance_for_rent_exemption(NonceState::size())
         .unwrap();
     let nonce_account = keypair_from_seed(&[1u8; 32]).unwrap();
-    let nonce_account_pubkey = nonce_account.pubkey();
-    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
+    config.signers = vec![&default_signer, &nonce_account];
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
+        nonce_account: 1,
         seed: None,
         nonce_authority: Some(offline_pubkey),
         lamports: minimum_nonce_balance,
     };
     process_command(&config).unwrap();
-    check_balance(minimum_nonce_balance, &rpc_client, &nonce_account_pubkey);
+    check_balance(minimum_nonce_balance, &rpc_client, &nonce_account.pubkey());
 
     // Fetch nonce hash
-    let account = rpc_client.get_account(&nonce_account_pubkey).unwrap();
+    let account = rpc_client.get_account(&nonce_account.pubkey()).unwrap();
     let nonce_state: NonceState = account.state().unwrap();
     let nonce_hash = match nonce_state {
         NonceState::Initialized(_meta, hash) => hash,
@@ -998,35 +953,35 @@ fn test_stake_split() {
 
     // Nonced offline split
     let split_account = keypair_from_seed(&[2u8; 32]).unwrap();
-    let (split_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&split_account, tmp_file.as_file_mut()).unwrap();
     check_balance(0, &rpc_client, &split_account.pubkey());
+    config_offline.signers.push(&split_account);
     config_offline.command = CliCommand::SplitStake {
         stake_account_pubkey: stake_account_pubkey,
-        stake_authority: None,
+        stake_authority: 0,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(nonce_hash, FeeCalculator::default()),
-        nonce_account: Some(nonce_account_pubkey),
-        nonce_authority: None,
-        split_stake_account: Rc::new(read_keypair_file(&split_keypair_file).unwrap().into()),
+        nonce_account: Some(nonce_account.pubkey()),
+        nonce_authority: 0,
+        split_stake_account: 1,
         seed: None,
         lamports: 2 * minimum_stake_balance,
-        fee_payer: None,
+        fee_payer: 0,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner, &split_account];
     config.command = CliCommand::SplitStake {
         stake_account_pubkey: stake_account_pubkey,
-        stake_authority: Some(offline_presigner.clone().into()),
+        stake_authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
-        nonce_account: Some(nonce_account_pubkey),
-        nonce_authority: Some(offline_presigner.clone().into()),
-        split_stake_account: Rc::new(read_keypair_file(&split_keypair_file).unwrap().into()),
+        nonce_account: Some(nonce_account.pubkey()),
+        nonce_authority: 0,
+        split_stake_account: 1,
         seed: None,
         lamports: 2 * minimum_stake_balance,
-        fee_payer: Some(offline_presigner.clone().into()),
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     check_balance(
@@ -1054,13 +1009,17 @@ fn test_stake_set_lockup() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer = Keypair::new();
+    let offline_signer = Keypair::new();
 
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config.signers = vec![&default_signer];
 
     let mut config_offline = CliConfig::default();
     config_offline.json_rpc_url = String::default();
-    let offline_pubkey = config_offline.keypair.pubkey();
+    config_offline.signers = vec![&offline_signer];
+    let offline_pubkey = config_offline.signers[0].pubkey();
     // Verify we're offline
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
@@ -1084,14 +1043,13 @@ fn test_stake_set_lockup() {
 
     let stake_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
     let stake_account_pubkey = stake_keypair.pubkey();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
 
     let mut lockup = Lockup::default();
     lockup.custodian = config.signers[0].pubkey();
 
+    config.signers.push(&stake_keypair);
     config.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
         staker: Some(offline_pubkey),
         withdrawer: Some(offline_pubkey),
@@ -1100,9 +1058,9 @@ fn test_stake_set_lockup() {
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config).unwrap();
     check_balance(
@@ -1117,15 +1075,16 @@ fn test_stake_set_lockup() {
         epoch: 200,
         custodian: Pubkey::default(),
     };
+    config.signers.pop();
     config.command = CliCommand::StakeSetLockup {
         stake_account_pubkey,
         lockup,
-        custodian: None,
+        custodian: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -1140,8 +1099,6 @@ fn test_stake_set_lockup() {
     // Set custodian to another pubkey
     let online_custodian = Keypair::new();
     let online_custodian_pubkey = online_custodian.pubkey();
-    let (online_custodian_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&online_custodian, tmp_file.as_file_mut()).unwrap();
 
     let lockup = Lockup {
         unix_timestamp: 1581534571,
@@ -1151,12 +1108,12 @@ fn test_stake_set_lockup() {
     config.command = CliCommand::StakeSetLockup {
         stake_account_pubkey,
         lockup,
-        custodian: None,
+        custodian: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
 
@@ -1165,15 +1122,16 @@ fn test_stake_set_lockup() {
         epoch: 202,
         custodian: Pubkey::default(),
     };
+    config.signers = vec![&default_signer, &online_custodian];
     config.command = CliCommand::StakeSetLockup {
         stake_account_pubkey,
         lockup,
-        custodian: Some(read_keypair_file(&online_custodian_file).unwrap().into()),
+        custodian: 1,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -1194,12 +1152,12 @@ fn test_stake_set_lockup() {
     config.command = CliCommand::StakeSetLockup {
         stake_account_pubkey,
         lockup,
-        custodian: Some(online_custodian.into()),
+        custodian: 1,
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
 
@@ -1209,10 +1167,9 @@ fn test_stake_set_lockup() {
         .unwrap();
     let nonce_account = keypair_from_seed(&[1u8; 32]).unwrap();
     let nonce_account_pubkey = nonce_account.pubkey();
-    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
+    config.signers = vec![&default_signer, &nonce_account];
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
+        nonce_account: 1,
         seed: None,
         nonce_authority: Some(offline_pubkey),
         lamports: minimum_nonce_balance,
@@ -1237,25 +1194,26 @@ fn test_stake_set_lockup() {
     config_offline.command = CliCommand::StakeSetLockup {
         stake_account_pubkey,
         lockup,
-        custodian: None,
+        custodian: 0,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(nonce_hash, FeeCalculator::default()),
         nonce_account: Some(nonce_account_pubkey),
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner];
     config.command = CliCommand::StakeSetLockup {
         stake_account_pubkey,
         lockup,
-        custodian: Some(offline_presigner.clone().into()),
+        custodian: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: Some(nonce_account_pubkey),
-        nonce_authority: Some(offline_presigner.clone().into()),
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
@@ -1282,12 +1240,14 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
     let mut config = CliConfig::default();
-    config.signers[0] = keypair_from_seed(&[1u8; 32]).unwrap().into();
+    let default_signer = keypair_from_seed(&[1u8; 32]).unwrap();
+    config.signers = vec![&default_signer];
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
     let mut config_offline = CliConfig::default();
-    config_offline.keypair = keypair_from_seed(&[2u8; 32]).unwrap().into();
-    let offline_pubkey = config_offline.keypair.pubkey();
+    let offline_signer = keypair_from_seed(&[2u8; 32]).unwrap();
+    config_offline.signers = vec![&offline_signer];
+    let offline_pubkey = config_offline.signers[0].pubkey();
     config_offline.json_rpc_url = String::default();
     config_offline.command = CliCommand::ClusterVersion;
     // Verfiy that we cannot reach the cluster
@@ -1302,14 +1262,8 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     .unwrap();
     check_balance(200_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(
-        &rpc_client,
-        &faucet_addr,
-        &config_offline.keypair.pubkey(),
-        100_000,
-    )
-    .unwrap();
-    check_balance(100_000, &rpc_client, &config_offline.keypair.pubkey());
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
+    check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create nonce account
     let minimum_nonce_balance = rpc_client
@@ -1317,10 +1271,9 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         .unwrap();
     let nonce_account = keypair_from_seed(&[3u8; 32]).unwrap();
     let nonce_pubkey = nonce_account.pubkey();
-    let (nonce_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
+    config.signers.push(&nonce_account);
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: Rc::new(read_keypair_file(&nonce_keypair_file).unwrap().into()),
+        nonce_account: 1,
         seed: None,
         nonce_authority: Some(offline_pubkey),
         lamports: minimum_nonce_balance,
@@ -1338,10 +1291,9 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     // Create stake account offline
     let stake_keypair = keypair_from_seed(&[4u8; 32]).unwrap();
     let stake_pubkey = stake_keypair.pubkey();
-    let (stake_keypair_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&stake_keypair, tmp_file.as_file_mut()).unwrap();
+    config_offline.signers.push(&stake_keypair);
     config_offline.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(read_keypair_file(&stake_keypair_file).unwrap().into()),
+        stake_account: 1,
         seed: None,
         staker: None,
         withdrawer: None,
@@ -1350,17 +1302,17 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         sign_only: true,
         blockhash_query: BlockhashQuery::None(nonce_hash, FeeCalculator::default()),
         nonce_account: Some(nonce_pubkey),
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
+    let stake_presigner = presigner_from_pubkey_sigs(&stake_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner, &stake_presigner];
     config.command = CliCommand::CreateStakeAccount {
-        stake_account: presigner_from_pubkey_sigs(&stake_pubkey, &signers)
-            .map(|p| Rc::new(p.into()))
-            .unwrap(),
+        stake_account: 1,
         seed: None,
         staker: Some(offline_pubkey),
         withdrawer: None,
@@ -1369,9 +1321,9 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: Some(nonce_pubkey),
-        nonce_authority: Some(offline_presigner.clone().into()),
-        fee_payer: Some(offline_presigner.clone().into()),
-        from: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config).unwrap();
     check_balance(50_000, &rpc_client, &stake_pubkey);
@@ -1387,30 +1339,32 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     // Offline, nonced stake-withdraw
     let recipient = keypair_from_seed(&[5u8; 32]).unwrap();
     let recipient_pubkey = recipient.pubkey();
+    config_offline.signers.pop();
     config_offline.command = CliCommand::WithdrawStake {
         stake_account_pubkey: stake_pubkey,
         destination_account_pubkey: recipient_pubkey,
         lamports: 42,
-        withdraw_authority: None,
+        withdraw_authority: 0,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(nonce_hash, FeeCalculator::default()),
         nonce_account: Some(nonce_pubkey),
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner];
     config.command = CliCommand::WithdrawStake {
         stake_account_pubkey: stake_pubkey,
         destination_account_pubkey: recipient_pubkey,
         lamports: 42,
-        withdraw_authority: Some(offline_presigner.clone().into()),
+        withdraw_authority: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: Some(nonce_pubkey),
-        nonce_authority: Some(offline_presigner.clone().into()),
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     check_balance(42, &rpc_client, &recipient_pubkey);
@@ -1425,8 +1379,9 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
 
     // Create another stake account. This time with seed
     let seed = "seedy";
+    config_offline.signers = vec![&offline_signer, &stake_keypair];
     config_offline.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(Box::new(read_keypair_file(&stake_keypair_file).unwrap())),
+        stake_account: 1,
         seed: Some(seed.to_string()),
         staker: None,
         withdrawer: None,
@@ -1435,16 +1390,17 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         sign_only: true,
         blockhash_query: BlockhashQuery::None(nonce_hash, FeeCalculator::default()),
         nonce_account: Some(nonce_pubkey),
-        nonce_authority: None,
-        fee_payer: None,
-        from: None,
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     let sig_response = process_command(&config_offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
     let stake_presigner = presigner_from_pubkey_sigs(&stake_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner, &stake_presigner];
     config.command = CliCommand::CreateStakeAccount {
-        stake_account: Rc::new(stake_presigner.into()),
+        stake_account: 1,
         seed: Some(seed.to_string()),
         staker: Some(offline_pubkey.into()),
         withdrawer: Some(offline_pubkey.into()),
@@ -1453,9 +1409,9 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: Some(nonce_pubkey),
-        nonce_authority: Some(offline_presigner.clone().into()),
-        fee_payer: Some(offline_presigner.clone().into()),
-        from: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
+        from: 0,
     };
     process_command(&config).unwrap();
     let seed_address =

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -53,7 +53,7 @@ fn test_transfer() {
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
 
-    let sender_pubkey = config.keypair.pubkey();
+    let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::new(&[1u8; 32]);
     println!("sender: {:?}", sender_pubkey);
     println!("recipient: {:?}", recipient_pubkey);

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -10,22 +10,12 @@ use solana_sdk::{
     fee_calculator::FeeCalculator,
     nonce_state::NonceState,
     pubkey::Pubkey,
-    signature::{keypair_from_seed, read_keypair_file, write_keypair, Signer},
+    signature::{keypair_from_seed, Keypair, Signer},
 };
-use std::fs::remove_dir_all;
-use std::sync::mpsc::channel;
+use std::{fs::remove_dir_all, sync::mpsc::channel, thread::sleep, time::Duration};
 
 #[cfg(test)]
 use solana_core::validator::new_validator_for_tests_ex;
-use std::rc::Rc;
-use std::thread::sleep;
-use std::time::Duration;
-use tempfile::NamedTempFile;
-
-fn make_tmp_file() -> (String, NamedTempFile) {
-    let tmp_file = NamedTempFile::new().unwrap();
-    (String::from(tmp_file.path().to_str().unwrap()), tmp_file)
-}
 
 fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
     (0..5).for_each(|tries| {
@@ -50,13 +40,15 @@ fn test_transfer() {
 
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
 
+    let default_signer = Keypair::new();
+    let default_offline_signer = Keypair::new();
+
     let mut config = CliConfig::default();
     config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config.signers = vec![&default_signer];
 
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::new(&[1u8; 32]);
-    println!("sender: {:?}", sender_pubkey);
-    println!("recipient: {:?}", recipient_pubkey);
 
     request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000).unwrap();
     check_balance(50_000, &rpc_client, &sender_pubkey);
@@ -66,12 +58,12 @@ fn test_transfer() {
     config.command = CliCommand::Transfer {
         lamports: 10,
         to: recipient_pubkey,
-        from: None,
+        from: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::All,
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     check_balance(49_989, &rpc_client, &sender_pubkey);
@@ -79,12 +71,12 @@ fn test_transfer() {
 
     let mut offline = CliConfig::default();
     offline.json_rpc_url = String::default();
+    offline.signers = vec![&default_offline_signer];
     // Verify we cannot contact the cluster
     offline.command = CliCommand::ClusterVersion;
     process_command(&offline).unwrap_err();
 
-    let offline_pubkey = offline.keypair.pubkey();
-    println!("offline: {:?}", offline_pubkey);
+    let offline_pubkey = offline.signers[0].pubkey();
     request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 50).unwrap();
     check_balance(50, &rpc_client, &offline_pubkey);
 
@@ -93,25 +85,26 @@ fn test_transfer() {
     offline.command = CliCommand::Transfer {
         lamports: 10,
         to: recipient_pubkey,
-        from: None,
+        from: 0,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(blockhash, FeeCalculator::default()),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sign_only_reply = process_command(&offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sign_only_reply);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner];
     config.command = CliCommand::Transfer {
         lamports: 10,
         to: recipient_pubkey,
-        from: Some(offline_presigner.clone().into()),
+        from: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: None,
-        nonce_authority: None,
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     check_balance(39, &rpc_client, &offline_pubkey);
@@ -119,13 +112,12 @@ fn test_transfer() {
 
     // Create nonce account
     let nonce_account = keypair_from_seed(&[3u8; 32]).unwrap();
-    let (nonce_account_file, mut tmp_file) = make_tmp_file();
-    write_keypair(&nonce_account, tmp_file.as_file_mut()).unwrap();
     let minimum_nonce_balance = rpc_client
         .get_minimum_balance_for_rent_exemption(NonceState::size())
         .unwrap();
+    config.signers = vec![&default_signer, &nonce_account];
     config.command = CliCommand::CreateNonceAccount {
-        nonce_account: Rc::new(read_keypair_file(&nonce_account_file).unwrap().into()),
+        nonce_account: 1,
         seed: None,
         nonce_authority: None,
         lamports: minimum_nonce_balance,
@@ -142,15 +134,16 @@ fn test_transfer() {
     };
 
     // Nonced transfer
+    config.signers = vec![&default_signer];
     config.command = CliCommand::Transfer {
         lamports: 10,
         to: recipient_pubkey,
-        from: None,
+        from: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(nonce_hash),
         nonce_account: Some(nonce_account.pubkey()),
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     check_balance(49_976 - minimum_nonce_balance, &rpc_client, &sender_pubkey);
@@ -164,9 +157,10 @@ fn test_transfer() {
     assert_ne!(nonce_hash, new_nonce_hash);
 
     // Assign nonce authority to offline
+    config.signers = vec![&default_signer];
     config.command = CliCommand::AuthorizeNonceAccount {
         nonce_account: nonce_account.pubkey(),
-        nonce_authority: None,
+        nonce_authority: 0,
         new_authority: offline_pubkey,
     };
     process_command(&config).unwrap();
@@ -181,28 +175,30 @@ fn test_transfer() {
     };
 
     // Offline, nonced transfer
+    offline.signers = vec![&default_offline_signer];
     offline.command = CliCommand::Transfer {
         lamports: 10,
         to: recipient_pubkey,
-        from: None,
+        from: 0,
         sign_only: true,
         blockhash_query: BlockhashQuery::None(nonce_hash, FeeCalculator::default()),
         nonce_account: Some(nonce_account.pubkey()),
-        nonce_authority: None,
-        fee_payer: None,
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     let sign_only_reply = process_command(&offline).unwrap();
     let (blockhash, signers) = parse_sign_only_reply_string(&sign_only_reply);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
+    config.signers = vec![&offline_presigner];
     config.command = CliCommand::Transfer {
         lamports: 10,
         to: recipient_pubkey,
-        from: Some(offline_presigner.clone().into()),
+        from: 0,
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash),
         nonce_account: Some(nonce_account.pubkey()),
-        nonce_authority: Some(offline_presigner.clone().into()),
-        fee_payer: Some(offline_presigner.clone().into()),
+        nonce_authority: 0,
+        fee_payer: 0,
     };
     process_command(&config).unwrap();
     check_balance(28, &rpc_client, &offline_pubkey);

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -13,6 +13,7 @@ use solana_clap_utils::{
     },
 };
 use solana_cli_config::config::{Config, CONFIG_FILE};
+use solana_remote_wallet::remote_wallet::{maybe_wallet_manager, RemoteWalletManager};
 use solana_sdk::{
     pubkey::write_pubkey_file,
     signature::{keypair_from_seed, write_keypair, write_keypair_file, Keypair, Signer},
@@ -49,6 +50,7 @@ fn check_for_overwrite(outfile: &str, matches: &ArgMatches) {
 fn get_keypair_from_matches(
     matches: &ArgMatches,
     config: Config,
+    wallet_manager: Option<Arc<RemoteWalletManager>>,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     let mut path = dirs::home_dir().expect("home directory");
     let path = if matches.is_present("keypair") {
@@ -59,7 +61,7 @@ fn get_keypair_from_matches(
         path.extend(&[".config", "solana", "id.json"]);
         path.to_str().unwrap()
     };
-    signer_from_path(matches, path, "pubkey recovery")
+    signer_from_path(matches, path, "pubkey recovery", &wallet_manager)
 }
 
 fn output_keypair(
@@ -380,9 +382,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Config::default()
     };
 
+    let wallet_manager = maybe_wallet_manager()?;
+
     match matches.subcommand() {
         ("pubkey", Some(matches)) => {
-            let pubkey = get_keypair_from_matches(matches, config)?.try_pubkey()?;
+            let pubkey = get_keypair_from_matches(matches, config, wallet_manager)?.try_pubkey()?;
 
             if matches.is_present("outfile") {
                 let outfile = matches.value_of("outfile").unwrap();
@@ -559,7 +563,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             }
         }
         ("verify", Some(matches)) => {
-            let keypair = get_keypair_from_matches(matches, config)?;
+            let keypair = get_keypair_from_matches(matches, config, wallet_manager)?;
             let test_data = b"test";
             let signature = keypair.try_sign_message(test_data)?;
             let pubkey_bs58 = matches.value_of("pubkey").unwrap();

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -61,7 +61,7 @@ fn get_keypair_from_matches(
         path.extend(&[".config", "solana", "id.json"]);
         path.to_str().unwrap()
     };
-    signer_from_path(matches, path, "pubkey recovery", &wallet_manager)
+    signer_from_path(matches, path, "pubkey recovery", wallet_manager.as_ref())
 }
 
 fn output_keypair(

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -8,7 +8,7 @@ use num_cpus;
 use solana_clap_utils::{
     input_validators::is_derivation,
     keypair::{
-        keypair_from_seed_phrase, keypair_util_from_path, prompt_passphrase,
+        keypair_from_seed_phrase, prompt_passphrase, signer_from_path,
         SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
 };
@@ -59,7 +59,7 @@ fn get_keypair_from_matches(
         path.extend(&[".config", "solana", "id.json"]);
         path.to_str().unwrap()
     };
-    keypair_util_from_path(matches, path, "pubkey recovery")
+    signer_from_path(matches, path, "pubkey recovery")
 }
 
 fn output_keypair(

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -1,5 +1,5 @@
 use crate::remote_wallet::{
-    initialize_wallet_manager, DerivationPath, RemoteWallet, RemoteWalletError, RemoteWalletInfo,
+    DerivationPath, RemoteWallet, RemoteWalletError, RemoteWalletInfo, RemoteWalletManager,
 };
 use dialoguer::{theme::ColorfulTheme, Select};
 use log::*;
@@ -378,9 +378,8 @@ fn extend_and_serialize(derivation_path: &DerivationPath) -> Vec<u8> {
 /// Choose a Ledger wallet based on matching info fields
 pub fn get_ledger_from_info(
     info: RemoteWalletInfo,
+    wallet_manager: &RemoteWalletManager,
 ) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
-    let wallet_manager = initialize_wallet_manager()?;
-    let _device_count = wallet_manager.update_devices()?;
     let devices = wallet_manager.list_devices();
     let (pubkeys, device_paths): (Vec<Pubkey>, Vec<String>) = devices
         .iter()

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -1,7 +1,8 @@
 use crate::{
     ledger::get_ledger_from_info,
     remote_wallet::{
-        DerivationPath, RemoteWallet, RemoteWalletError, RemoteWalletInfo, RemoteWalletType,
+        DerivationPath, RemoteWallet, RemoteWalletError, RemoteWalletInfo, RemoteWalletManager,
+        RemoteWalletType,
     },
 };
 use solana_sdk::{
@@ -44,13 +45,14 @@ impl Signer for RemoteKeypair {
 pub fn generate_remote_keypair(
     path: String,
     explicit_derivation_path: Option<DerivationPath>,
+    wallet_manager: &RemoteWalletManager,
 ) -> Result<RemoteKeypair, RemoteWalletError> {
     let (remote_wallet_info, mut derivation_path) = RemoteWalletInfo::parse_path(path)?;
     if let Some(derivation) = explicit_derivation_path {
         derivation_path = derivation;
     }
     if remote_wallet_info.manufacturer == "ledger" {
-        let ledger = get_ledger_from_info(remote_wallet_info)?;
+        let ledger = get_ledger_from_info(remote_wallet_info, wallet_manager)?;
         Ok(RemoteKeypair {
             wallet_type: RemoteWalletType::Ledger(ledger),
             derivation_path,

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -299,6 +299,17 @@ pub fn initialize_wallet_manager() -> Result<Arc<RemoteWalletManager>, RemoteWal
     Ok(RemoteWalletManager::new(hidapi))
 }
 
+pub fn maybe_wallet_manager() -> Result<Option<Arc<RemoteWalletManager>>, RemoteWalletError> {
+    let wallet_manager = initialize_wallet_manager()?;
+    let device_count = wallet_manager.update_devices()?;
+    if device_count > 0 {
+        Ok(Some(wallet_manager))
+    } else {
+        drop(wallet_manager);
+        Ok(None)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -183,8 +183,8 @@ impl<T> From<T> for Box<dyn Signer>
 where
     T: Signer + 'static,
 {
-    fn from(keypair_util: T) -> Self {
-        Box::new(keypair_util)
+    fn from(signer: T) -> Self {
+        Box::new(signer)
     }
 }
 


### PR DESCRIPTION
#### Problem
Two problems involving CLI signers:
1. Hardware wallet users may want to sign transactions with multiple different keys. One appealing use case, for example, would be to make a transfer from one account, but pay the fees from another.
Currently, the CLI only supports using one RemoteKeypair to sign a CLI command. This is because the CLI tries to reinitialize the remote-wallet-manager on every RemoteKeypair parse, running into the existing handle on repeated attempts.

2. The CLI currently signs each transaction with every signer collected during the parse-command step. These Signer collections may contain duplicate keys when the same key is being used for multiple signing roles (for instance, when using the default signer for everything). The CLI happily signs the transaction repeatedly for each dupe. In most cases, this doesn't present as anything more than a performance hit. But in the case of remote wallets -- which require manual button-pushing for each signature -- it is very disruptive.

#### Summary of Changes
- Initialize the remote-wallet-manager once and only once per CLI call and provide it to argument parsers to enable multiple RemoteKeypairs
- Collect and deduplicate signers during command parsing, and pass by reference into `process_` methods. Identify various signing roles by index, rather than copying signers willy-nilly.

Most of the churn in this PR is updating tests to reflect: additional arg expected in `parse_command()`, and changes to the CliConfig and CliCommandInfo structs. The meat of this PR is in 86a9365 and cli/src/cli.rs in 9f431c0.