### PR TITLE
Fix local cluster test, check for accounts hash

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -70,7 +70,10 @@ pub fn load(
             )
             .expect("Load from snapshot failed");
 
-            let snapshot_hash = (deserialized_bank.slot(), deserialized_bank.hash());
+            let snapshot_hash = (
+                deserialized_bank.slot(),
+                deserialized_bank.get_accounts_hash(),
+            );
             return to_loadresult(
                 blockstore_processor::process_blockstore_from_root(
                     genesis_config,


### PR DESCRIPTION
#### Problem

Using incorrect hash to compare with snapshot values.

#### Summary of Changes

Change search hash to the snapshot accounts hash, not the bank hash.

Fixes #
