### PR TITLE
validator: snapshot fetching cleanup

### DIFF
--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -520,7 +520,7 @@ pub fn untar_snapshot_in<P: AsRef<Path>, Q: AsRef<Path>>(
         archive.unpack(&unpack_dir)?;
     } else if let Err(e) = archive.unpack(&unpack_dir) {
         warn!(
-            "Trying to unpack as uncompressed tar because an error occured: {:?}",
+            "Trying to unpack as uncompressed tar because an error occurred: {:?}",
             e
         );
         let tar_bz2 = File::open(snapshot_tar)?;


### PR DESCRIPTION
* Break up `get_rpc_node()` into multiple functions before clippy attacks
* Reorder genesis fetching to occur after checking the genesis hash of the RPC node
* Groundwork for (1) surfacing the snapshot_hash of the downloaded snapshot for more verification in core/src/validator.rs, (2) rpc node blacklisting
* Fixed some speling