### PR TITLE
Have bank_slot_from_archive just call bank_from_archive

### DIFF
--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -83,6 +83,7 @@ mod tests {
                 .unwrap()
                 .snapshot_path,
             snapshot_utils::get_snapshot_archive_path(snapshot_package_output_path),
+            false,
         )
         .unwrap();
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -67,6 +67,7 @@ pub fn load(
                 &account_paths,
                 &snapshot_config.snapshot_path,
                 &tar,
+                false,
             )
             .expect("Load from snapshot failed");
 


### PR DESCRIPTION
### Problem

More code than necessary. Extra function is the same as bank_from_archive minus a few trivial things like not deserializing the status_cache. I don't think there is any reason not to do that.

#### Summary of Changes

Just call `bank_from_archive`.

Fixes #
