### PR TITLE
validator: Add --no-check-vote-account argument

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -592,6 +592,14 @@ pub fn main() {
                 .help("Launch node without voting"),
         )
         .arg(
+            Arg::with_name("no_check_vote_account")
+                .long("no-check-vote-account")
+                .takes_value(false)
+                .conflicts_with("no_voting")
+                .requires("entrypoint")
+                .help("Skip the RPC vote account sanity check")
+        )
+        .arg(
             Arg::with_name("dev_no_sigverify")
                 .long("dev-no-sigverify")
                 .takes_value(false)
@@ -795,6 +803,7 @@ pub fn main() {
     let cuda = matches.is_present("cuda");
     let no_genesis_fetch = matches.is_present("no_genesis_fetch");
     let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
+    let no_check_vote_account = matches.is_present("no_check_vote_account");
     let private_rpc = matches.is_present("private_rpc");
 
     // Canonicalize ledger path to avoid issues with symlink creation
@@ -1070,7 +1079,7 @@ pub fn main() {
             }
             validator_config.expected_genesis_hash = Some(genesis_hash);
 
-            if !validator_config.voting_disabled {
+            if !validator_config.voting_disabled && !no_check_vote_account {
                 check_vote_account(
                     &rpc_client,
                     &vote_account,


### PR DESCRIPTION
Alternative to https://github.com/solana-labs/solana/pull/8426

Turns out it's quite difficult to move the vote account check into core/src/validator.rs, so to help defend against the $5 wrench attack described in #8426, a validator can add the `--no-check-vote-account` argument if they're quite confident their vote account is fine and don't want the extra RPC exposure.