### PR TITLE
Do periodic inbound cleaning for rooted slots

### DIFF
--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -337,7 +337,7 @@ pub fn add_snapshot<P: AsRef<Path>>(
     bank: &Bank,
     snapshot_storages: &[SnapshotStorage],
 ) -> Result<SlotSnapshotPaths> {
-    bank.purge_zero_lamport_accounts();
+    bank.clean_accounts();
     bank.update_accounts_hash();
     let slot = bank.slot();
     // snapshot_path/slot

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -665,7 +665,7 @@ impl AccountsDB {
         let mut reclaims = Vec::new();
         for pubkey in all_pubkeys {
             if !purges.contains_key(&pubkey) {
-                accounts_index.eager_cleanup(&pubkey, &mut reclaims);
+                accounts_index.cleanup_rooted_entries(&pubkey, &mut reclaims);
             }
         }
         accounts_index.not_compacted_roots.clear();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -664,7 +664,7 @@ impl AccountsDB {
         }
         let mut reclaims = Vec::new();
         for pubkey in all_pubkeys {
-            if purges.get(&pubkey).is_none() {
+            if !purges.contains_key(&pubkey) {
                 accounts_index.eager_cleanup(&pubkey, &mut reclaims);
             }
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -640,7 +640,7 @@ impl AccountsDB {
 
     // Reclaim older states of rooted non-zero lamport accounts as a general
     // AccountsDB bloat mitigation and preprocess for better zero-lamport purging.
-    fn purge_old_normal_accounts(&self, purges: &HashMap<Pubkey, Vec<(Slot, AccountInfo)>>) {
+    fn clean_old_rooted_accounts(&self, purges: &HashMap<Pubkey, Vec<(Slot, AccountInfo)>>) {
         let mut accounts_index = self.accounts_index.write().unwrap();
         let mut all_pubkeys: HashSet<Pubkey> = HashSet::<Pubkey>::default();
         for root in accounts_index.uncleaned_roots.iter() {
@@ -688,7 +688,7 @@ impl AccountsDB {
         drop(accounts_index);
 
         if needs_to_clean_old_accounts {
-            self.purge_old_normal_accounts(&purges);
+            self.clean_old_rooted_accounts(&purges);
         }
 
         let accounts_index = self.accounts_index.read().unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -680,11 +680,11 @@ impl AccountsDB {
             reclaims
         });
         drop(accounts_index);
+        let reclaims: Vec<_> = reclaim_vecs.flatten().collect();
         measure.stop();
         inc_new_counter_info!("clean-old-root-par-clean-ms", measure.as_ms() as usize);
 
         let mut measure = Measure::start("clean_old_root-ms");
-        let reclaims: Vec<_> = reclaim_vecs.flatten().collect();
         self.handle_reclaims(&reclaims);
         measure.stop();
         inc_new_counter_info!("clean-old-root-reclaim-ms", measure.as_ms() as usize);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -642,7 +642,7 @@ impl AccountsDB {
     // AccountsDB bloat mitigation and preprocess for better zero-lamport purging.
     fn clean_old_rooted_accounts(&self, purges: &HashMap<Pubkey, Vec<(Slot, AccountInfo)>>) {
         let accounts_index = self.accounts_index.read().unwrap();
-        let mut all_pubkeys: HashSet<Pubkey> = HashSet::<Pubkey>::default();
+        let mut all_pubkeys: HashSet<Pubkey> = HashSet::new();
         for root in accounts_index.uncleaned_roots.iter() {
             let pubkey_sets: Vec<HashSet<Pubkey>> = self.scan_account_storage(
                 *root,
@@ -2024,6 +2024,15 @@ pub mod tests {
         //now old state is cleaned up
         assert_eq!(accounts.store_count_for_slot(0), 0);
         assert_eq!(accounts.store_count_for_slot(1), 1);
+        assert_eq!(
+            accounts
+                .accounts_index
+                .read()
+                .unwrap()
+                .uncleaned_roots
+                .len(),
+            0
+        );
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -638,6 +638,8 @@ impl AccountsDB {
         false
     }
 
+    // Reclaim older states of rooted non-zero lamports accounts as a general
+    // AccountsDB bloat mitigation and preprocess for better zero-lamport purging.
     fn compact_before_purge_zero_lamport_accounts(
         &self,
         purges: &HashMap<Pubkey, Vec<(Slot, AccountInfo)>>,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -56,7 +56,7 @@ impl<T: Clone> AccountsIndex<T> {
         let mut max = 0;
         let mut rv = None;
         for (i, (slot, _t)) in list.iter().rev().enumerate() {
-            if *slot >= max && (ancestors.get(slot).is_some() || self.is_root(*slot)) {
+            if *slot >= max && (ancestors.contains_key(slot) || self.is_root(*slot)) {
                 rv = Some((list.len() - 1) - i);
                 max = *slot;
             }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -120,7 +120,7 @@ impl<T: Clone> AccountsIndex<T> {
             slot_vec.retain(|(f, _)| *f != slot);
 
             slot_vec.push((slot, account_info));
-            // do lazy cleaclean
+            // now, do lazy clean
             self.purge_older_root_entries(&mut slot_vec, reclaims);
 
             None

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -174,6 +174,7 @@ impl<T: Clone> AccountsIndex<T> {
     /// Accounts no longer reference this slot.
     pub fn cleanup_dead_slot(&mut self, slot: Slot) {
         self.roots.remove(&slot);
+        self.not_compacted_roots.remove(&slot);
     }
 }
 
@@ -291,6 +292,16 @@ mod tests {
         index.cleanup_dead_slot(1);
         assert!(!index.is_root(1));
         assert!(index.is_root(0));
+    }
+
+    #[test]
+    fn test_cleanup_first_not_compacted_slot() {
+        let mut index = AccountsIndex::<bool>::default();
+        assert_eq!(0, index.not_compacted_roots.len());
+        index.add_root(1);
+        assert_eq!(1, index.not_compacted_roots.len());
+        index.cleanup_dead_slot(1);
+        assert_eq!(0, index.not_compacted_roots.len());
     }
 
     #[test]

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -121,7 +121,7 @@ impl<T: Clone> AccountsIndex<T> {
 
             slot_vec.push((slot, account_info));
             // do lazy cleanup
-            self.cleanup_root_entries(&mut slot_vec, reclaims);
+            self.purge_older_root_entries(&mut slot_vec, reclaims);
 
             None
         } else {
@@ -129,7 +129,7 @@ impl<T: Clone> AccountsIndex<T> {
         }
     }
 
-    fn cleanup_root_entries(&self, slot_vec: &mut Vec<(Slot, T)>, reclaims: &mut Vec<(Slot, T)>) {
+    fn purge_older_root_entries(&self, slot_vec: &mut Vec<(Slot, T)>, reclaims: &mut Vec<(Slot, T)>) {
         let roots = &self.roots;
 
         let max_root = Self::get_max_root(roots, &slot_vec);
@@ -143,10 +143,10 @@ impl<T: Clone> AccountsIndex<T> {
         slot_vec.retain(|(slot, _)| !Self::can_purge(max_root, *slot));
     }
 
-    pub fn eager_cleanup(&self, pubkey: &Pubkey, reclaims: &mut Vec<(Slot, T)>) {
+    pub fn cleanup_rooted_entries(&self, pubkey: &Pubkey, reclaims: &mut Vec<(Slot, T)>) {
         if let Some(lock) = self.account_maps.get(pubkey) {
             let mut slot_vec = lock.write().unwrap();
-            self.cleanup_root_entries(&mut slot_vec, reclaims);
+            self.purge_older_root_entries(&mut slot_vec, reclaims);
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2118,7 +2118,7 @@ impl Bank {
     }
 
     pub fn clean_accounts(&self) {
-        self.rc.accounts.accounts_db.clean_accounts(&self.ancestors);
+        self.rc.accounts.accounts_db.clean_accounts();
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1924,7 +1924,7 @@ impl Bank {
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self) -> bool {
-        self.purge_zero_lamport_accounts();
+        self.clean_accounts();
         // Order and short-circuiting is significant; verify_hash requires a valid bank hash
         self.verify_bank_hash() && self.verify_hash()
     }
@@ -2117,11 +2117,8 @@ impl Bank {
         );
     }
 
-    pub fn purge_zero_lamport_accounts(&self) {
-        self.rc
-            .accounts
-            .accounts_db
-            .purge_zero_lamport_accounts(&self.ancestors);
+    pub fn clean_accounts(&self) {
+        self.rc.accounts.accounts_db.clean_accounts(&self.ancestors);
     }
 }
 
@@ -3170,7 +3167,7 @@ mod tests {
         }
 
         let hash = bank.update_accounts_hash();
-        bank.purge_zero_lamport_accounts();
+        bank.clean_accounts();
         assert_eq!(bank.update_accounts_hash(), hash);
 
         let bank0 = Arc::new(new_from_parent(&bank));
@@ -3190,14 +3187,14 @@ mod tests {
 
         info!("bank0 purge");
         let hash = bank0.update_accounts_hash();
-        bank0.purge_zero_lamport_accounts();
+        bank0.clean_accounts();
         assert_eq!(bank0.update_accounts_hash(), hash);
 
         assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
 
         info!("bank1 purge");
-        bank1.purge_zero_lamport_accounts();
+        bank1.clean_accounts();
 
         assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
@@ -3215,7 +3212,7 @@ mod tests {
         // keypair should have 0 tokens on both forks
         assert_eq!(bank0.get_account(&keypair.pubkey()), None);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
-        bank1.purge_zero_lamport_accounts();
+        bank1.clean_accounts();
 
         assert!(bank1.verify_bank_hash());
     }


### PR DESCRIPTION
#### Problem

After much investigation, I've realized just removing storage entries with count being 0 nor tweaking the [purge logic](https://github.com/solana-labs/solana/blob/73a278dc647d12cf43a6c14dccfd1edb42cc0ee5/runtime/src/accounts_db.rs#L899) isn't enough.

The root cause of snapshot bloat is that we leak StorageEntry/AppendVec too easily, first of all. Even just running `solana ping` causes that situation.

In this regard, much like the zero-lamport accounts RAM exhaustion DOS attack, this behavior can be easily used to mount a DOS with rather small amount of SOL.

#### Summary of Changes

We were too lazy to GC older storage entries. Especially, we do literally nothing for any account states while not touched.

So, introduce a bit eager compaction for non-zero lamports accounts at the snapshot generation intervals.

#### Background

This is one of two PRs towards #8168. This is an inbound compaction. The other (#8337) is an outbound (when loading snapshot) compaction. To really fix enlarged snapshot on TdS, we need to land both.

Part of #8168
