### PR TITLE
Convert Snapshot

### DIFF
--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -457,7 +457,7 @@ pub fn process_show_vote_account(
         build_balance_message(vote_account.lamports, use_lamports_unit, true)
     );
     println!("Validator Identity: {}", vote_state.node_pubkey);
-    println!("Authorized Voter: {}", vote_state.authorized_voter);
+    println!("Authorized Voter: {:?}", vote_state.authorized_voters());
     println!(
         "Authorized Withdrawer: {}",
         vote_state.authorized_withdrawer

--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -233,7 +233,7 @@ mod tests {
     use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_sdk::pubkey::Pubkey;
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state;
+    use solana_vote_program::vote_state::{self, VoteStateVersions};
 
     #[test]
     fn test_block_commitment() {
@@ -446,13 +446,15 @@ mod tests {
         let mut vote_state1 = VoteState::from(&vote_account1).unwrap();
         vote_state1.process_slot_vote_unchecked(3);
         vote_state1.process_slot_vote_unchecked(5);
-        vote_state1.to(&mut vote_account1).unwrap();
+        let versioned = VoteStateVersions::Current(Box::new(vote_state1));
+        VoteState::to(&versioned, &mut vote_account1).unwrap();
         bank.store_account(&pk1, &vote_account1);
 
         let mut vote_state2 = VoteState::from(&vote_account2).unwrap();
         vote_state2.process_slot_vote_unchecked(9);
         vote_state2.process_slot_vote_unchecked(10);
-        vote_state2.to(&mut vote_account2).unwrap();
+        let versioned = VoteStateVersions::Current(Box::new(vote_state2));
+        VoteState::to(&versioned, &mut vote_account2).unwrap();
         bank.store_account(&pk2, &vote_account2);
 
         let commitment = AggregateCommitmentService::aggregate_commitment(&ancestors, &bank);

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -489,8 +489,10 @@ pub mod test {
         transaction::Transaction,
     };
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state;
-    use solana_vote_program::{vote_instruction, vote_state::Vote};
+    use solana_vote_program::{
+        vote_instruction,
+        vote_state::{self, Vote, VoteStateVersions},
+    };
     use std::collections::{HashMap, VecDeque};
     use std::sync::RwLock;
     use std::{thread::sleep, time::Duration};
@@ -748,9 +750,11 @@ pub mod test {
             for slot in *votes {
                 vote_state.process_slot_vote_unchecked(*slot);
             }
-            vote_state
-                .serialize(&mut account.data)
-                .expect("serialize state");
+            VoteState::serialize(
+                &VoteStateVersions::Current(Box::new(vote_state)),
+                &mut account.data,
+            )
+            .expect("serialize state");
             stakes.push((Pubkey::new_rand(), (*lamports, account)));
         }
         stakes

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1080,7 +1080,7 @@ pub(crate) mod tests {
         transaction::TransactionError,
     };
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state::{self, Vote, VoteState};
+    use solana_vote_program::vote_state::{self, Vote, VoteState, VoteStateVersions};
     use std::{
         fs::remove_dir_all,
         iter,
@@ -1115,7 +1115,8 @@ pub(crate) mod tests {
             let mut vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(slot);
-            vote_state.to(&mut vote_account).unwrap();
+            let versioned = VoteStateVersions::Current(Box::new(vote_state));
+            VoteState::to(&versioned, &mut vote_account).unwrap();
             bank.store_account(&pubkey, &vote_account);
         }
 
@@ -1699,7 +1700,8 @@ pub(crate) mod tests {
             let mut leader_vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&leader_vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(bank.slot());
-            vote_state.to(&mut leader_vote_account).unwrap();
+            let versioned = VoteStateVersions::Current(Box::new(vote_state));
+            VoteState::to(&versioned, &mut leader_vote_account).unwrap();
             bank.store_account(&pubkey, &leader_vote_account);
         }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -36,6 +36,7 @@ use solana_metrics::datapoint_info;
 use solana_runtime::bank::Bank;
 use solana_sdk::{
     clock::{Slot, DEFAULT_SLOTS_PER_TURN},
+    epoch_schedule::MAX_LEADER_SCHEDULE_EPOCH_OFFSET,
     genesis_config::GenesisConfig,
     hash::Hash,
     pubkey::Pubkey,
@@ -564,6 +565,14 @@ fn new_banks_from_blockstore(
         error!("Failed to load genesis from {:?}: {}", blockstore_path, err);
         process::exit(1);
     });
+
+    // This needs to be limited otherwise the state in the VoteAccount data
+    // grows too large
+    let leader_schedule_slot_offset = genesis_config.epoch_schedule.leader_schedule_slot_offset;
+    let slots_per_epoch = genesis_config.epoch_schedule.slots_per_epoch;
+    let leader_epoch_offset = (leader_schedule_slot_offset + slots_per_epoch - 1) / slots_per_epoch;
+    assert!(leader_epoch_offset <= MAX_LEADER_SCHEDULE_EPOCH_OFFSET);
+
     let genesis_hash = genesis_config.hash();
     info!("genesis hash: {}", genesis_hash);
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -531,7 +531,12 @@ fn hardforks_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Slot>> {
     }
 }
 
-fn load_bank_from_snapshot(arg_matches: &ArgMatches, ledger_path: &PathBuf) -> Bank {
+fn load_bank_from_snapshot(
+    arg_matches: &ArgMatches,
+    ledger_path: &PathBuf,
+    should_verify: bool,
+    should_deserialize_bank_hash: bool,
+) -> Bank {
     let snapshot_config = SnapshotConfig {
         snapshot_interval_slots: 0, // Value doesn't matter
         snapshot_package_output_path: ledger_path.clone(),
@@ -543,7 +548,12 @@ fn load_bank_from_snapshot(arg_matches: &ArgMatches, ledger_path: &PathBuf) -> B
         vec![ledger_path.join("accounts")]
     };
 
-    bank_forks_utils::load_bank_from_archive(account_paths, &snapshot_config)
+    bank_forks_utils::load_bank_from_archive(
+        account_paths,
+        &snapshot_config,
+        should_verify,
+        should_deserialize_bank_hash,
+    )
 }
 
 fn load_bank_forks(
@@ -990,11 +1000,11 @@ fn main() {
             }
         }
         ("verify-snapshot", Some(arg_matches)) => {
-            load_bank_from_snapshot(arg_matches, &ledger_path);
+            load_bank_from_snapshot(arg_matches, &ledger_path, true, true);
         }
         ("convert-accounts", Some(arg_matches)) => {
             let output_directory = value_t_or_exit!(arg_matches, "output_directory", String);
-            let mut root_bank = load_bank_from_snapshot(arg_matches, &ledger_path);
+            let mut root_bank = load_bank_from_snapshot(arg_matches, &ledger_path, false, false);
             // Convert root_bank.EpochStakes
             for (_, stakes) in root_bank.epoch_stakes.iter_mut() {
                 for (pubkey, (_, vote_account)) in stakes.vote_accounts.iter_mut() {

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -122,6 +122,10 @@ impl BankForks {
         self.banks.get(&bank_slot)
     }
 
+    pub fn remove(&mut self, bank_slot: Slot) -> Arc<Bank> {
+        self.banks.remove(&bank_slot).unwrap()
+    }
+
     pub fn new_from_banks(initial_forks: &[Arc<Bank>], rooted_path: Vec<Slot>) -> Self {
         let mut banks = HashMap::new();
         let working_bank = initial_forks[0].clone();

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -9,6 +9,7 @@ use crate::{
     snapshot_utils,
 };
 use log::*;
+use solana_runtime::bank::Bank;
 use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash};
 use std::{fs, path::PathBuf, process, result, sync::Arc};
 
@@ -34,6 +35,18 @@ fn to_loadresult(
             snapshot_hash,
         )
     })
+}
+
+pub fn load_bank_from_archive(
+    account_paths: Vec<PathBuf>,
+    snapshot_config: &SnapshotConfig,
+) -> Bank {
+    let tar = snapshot_utils::get_highest_snapshot_archive_path(
+        &snapshot_config.snapshot_package_output_path,
+    )
+    .unwrap();
+    snapshot_utils::bank_from_archive(&account_paths, &snapshot_config.snapshot_path, &tar.0)
+        .unwrap()
 }
 
 pub fn load(

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -40,13 +40,21 @@ fn to_loadresult(
 pub fn load_bank_from_archive(
     account_paths: Vec<PathBuf>,
     snapshot_config: &SnapshotConfig,
+    should_verify: bool,
+    should_deserialize_bank_hash: bool,
 ) -> Bank {
     let tar = snapshot_utils::get_highest_snapshot_archive_path(
         &snapshot_config.snapshot_package_output_path,
     )
     .unwrap();
-    snapshot_utils::bank_from_archive(&account_paths, &snapshot_config.snapshot_path, &tar.0)
-        .unwrap()
+    snapshot_utils::bank_from_archive(
+        &account_paths,
+        &snapshot_config.snapshot_path,
+        &tar.0,
+        should_verify,
+        should_deserialize_bank_hash,
+    )
+    .unwrap()
 }
 
 pub fn load(
@@ -81,6 +89,8 @@ pub fn load(
                     &account_paths,
                     &snapshot_config.snapshot_path,
                     &archive_filename,
+                    false,
+                    true,
                 )
                 .expect("Load from snapshot failed");
 

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -338,6 +338,7 @@ pub fn add_snapshot<P: AsRef<Path>>(
     snapshot_storages: &[SnapshotStorage],
 ) -> Result<SlotSnapshotPaths> {
     bank.clean_accounts();
+    bank.update_accounts_hash();
     let slot = bank.slot();
     // snapshot_path/slot
     let slot_snapshot_dir = get_bank_snapshot_dir(snapshot_path, slot);

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -598,16 +598,8 @@ where
         &root_paths.snapshot_file_path,
         MAX_SNAPSHOT_DATA_FILE_SIZE,
         |stream| {
-            let mut bank: Bank = match snapshot_version {
-                SNAPSHOT_VERSION => deserialize_from_snapshot(stream.by_ref())?,
-                _ => {
-                    return Err(get_io_error(&format!(
-                        "unsupported snapshot version: {}",
-                        snapshot_version
-                    )));
-                }
-            };
-            info!("Rebuilding accounts...");
+            let mut bank: Bank = deserialize_from_snapshot(stream.by_ref())?;
+            println!("Rebuilding accounts...");
             bank.set_bank_rc(
                 bank::BankRc::new(account_paths.to_vec(), 0, bank.slot()),
                 bank::StatusCacheRc::default(),

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -18,7 +18,7 @@ use solana_sdk::{
     rent::Rent,
     stake_history::{StakeHistory, StakeHistoryEntry},
 };
-use solana_vote_program::vote_state::VoteState;
+use solana_vote_program::vote_state::{VoteState, VoteStateVersions};
 use std::collections::HashSet;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
@@ -615,7 +615,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                 let stake = Stake::new(
                     self.lamports()?.saturating_sub(meta.rent_exempt_reserve), // can't stake the rent ;)
                     vote_account.unsigned_key(),
-                    &vote_account.state()?,
+                    &State::<VoteStateVersions>::state(vote_account)?.convert_to_current(),
                     clock.epoch,
                     config,
                 );
@@ -625,7 +625,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                 meta.authorized.check(signers, StakeAuthorize::Staker)?;
                 stake.redelegate(
                     vote_account.unsigned_key(),
-                    &vote_account.state()?,
+                    &State::<VoteStateVersions>::state(vote_account)?.convert_to_current(),
                     clock,
                     stake_history,
                     config,
@@ -798,7 +798,8 @@ pub fn redeem_rewards(
     stake_history: Option<&StakeHistory>,
 ) -> Result<(u64, u64), InstructionError> {
     if let StakeState::Stake(meta, mut stake) = stake_account.state()? {
-        let vote_state = vote_account.state()?;
+        let vote_state: VoteState =
+            StateMut::<VoteStateVersions>::state(vote_account)?.convert_to_current();
 
         if let Some((voters_reward, stakers_reward)) =
             stake.redeem_rewards(point_value, &vote_state, stake_history)
@@ -1019,7 +1020,10 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&vote_state).unwrap();
+        let vote_state_credits = vote_state.credits();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(vote_state)))
+            .unwrap();
 
         let stake_pubkey = Pubkey::new_rand();
         let stake_lamports = 42;
@@ -1077,7 +1081,7 @@ mod tests {
                     deactivation_epoch: std::u64::MAX,
                     ..Delegation::default()
                 },
-                credits_observed: vote_state.credits(),
+                credits_observed: vote_state_credits,
                 ..Stake::default()
             }
         );
@@ -1125,7 +1129,7 @@ mod tests {
                     deactivation_epoch: std::u64::MAX,
                     ..Delegation::default()
                 },
-                credits_observed: vote_state.credits(),
+                credits_observed: vote_state_credits,
                 ..Stake::default()
             }
         );
@@ -1555,7 +1559,9 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&VoteState::default()).unwrap();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .unwrap();
         assert_eq!(
             stake_keyed_account.delegate(
                 &vote_keyed_account,
@@ -1644,7 +1650,9 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&VoteState::default()).unwrap();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .unwrap();
 
         stake_keyed_account
             .delegate(
@@ -1882,7 +1890,9 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&VoteState::default()).unwrap();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .unwrap();
         assert_eq!(
             stake_keyed_account.delegate(
                 &vote_keyed_account,
@@ -1991,7 +2001,9 @@ mod tests {
             100,
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
-        vote_keyed_account.set_state(&VoteState::default()).unwrap();
+        vote_keyed_account
+            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .unwrap();
         let signers = vec![stake_pubkey].into_iter().collect();
         assert_eq!(
             stake_keyed_account.delegate(

--- a/programs/vote/src/authorized_voters.rs
+++ b/programs/vote/src/authorized_voters.rs
@@ -1,0 +1,102 @@
+use log::*;
+use serde_derive::{Deserialize, Serialize};
+use solana_sdk::pubkey::Pubkey;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct AuthorizedVoters {
+    authorized_voters: BTreeMap<u64, Pubkey>,
+}
+
+impl AuthorizedVoters {
+    pub fn new(epoch: u64, pubkey: Pubkey) -> Self {
+        let mut authorized_voters = BTreeMap::new();
+        authorized_voters.insert(epoch, pubkey);
+        Self { authorized_voters }
+    }
+
+    pub fn get_authorized_voter(&self, epoch: u64) -> Option<Pubkey> {
+        self.get_or_calculate_authorized_voter_for_epoch(epoch)
+            .map(|(pubkey, _)| pubkey)
+    }
+
+    pub fn get_and_cache_authorized_voter_for_epoch(&mut self, epoch: u64) -> Option<Pubkey> {
+        let res = self.get_or_calculate_authorized_voter_for_epoch(epoch);
+
+        res.map(|(pubkey, existed)| {
+            if !existed {
+                self.authorized_voters.insert(epoch, pubkey);
+            }
+            pubkey
+        })
+    }
+
+    pub fn insert(&mut self, epoch: u64, authorized_voter: Pubkey) {
+        self.authorized_voters.insert(epoch, authorized_voter);
+    }
+
+    pub fn purge_authorized_voters(&mut self, current_epoch: u64) -> bool {
+        // Iterate through the keys in order, filtering out the ones
+        // less than the current epoch
+        let expired_keys: Vec<_> = self
+            .authorized_voters
+            .range(0..current_epoch)
+            .map(|(authorized_epoch, _)| *authorized_epoch)
+            .collect();
+
+        for key in expired_keys {
+            self.authorized_voters.remove(&key);
+        }
+
+        // Have to uphold this invariant b/c this is
+        // 1) The check for whether the vote state is initialized
+        // 2) How future authorized voters for uninitialized epochs are set
+        //    by this function
+        assert!(!self.authorized_voters.is_empty());
+        true
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.authorized_voters.is_empty()
+    }
+
+    pub fn first(&self) -> Option<(&u64, &Pubkey)> {
+        self.authorized_voters.iter().next()
+    }
+
+    pub fn last(&self) -> Option<(&u64, &Pubkey)> {
+        self.authorized_voters.iter().next_back()
+    }
+
+    pub fn len(&self) -> usize {
+        self.authorized_voters.len()
+    }
+
+    pub fn contains(&self, epoch: u64) -> bool {
+        self.authorized_voters.get(&epoch).is_some()
+    }
+
+    // Returns the authorized voter at the given epoch if the epoch is >= the
+    // current epoch, and a bool indicating whether the entry for this epoch
+    // exists in the self.authorized_voter map
+    fn get_or_calculate_authorized_voter_for_epoch(&self, epoch: u64) -> Option<(Pubkey, bool)> {
+        let res = self.authorized_voters.get(&epoch);
+        if res.is_none() {
+            // If no authorized voter has been set yet for this epoch,
+            // this must mean the authorized voter remains unchanged
+            // from the latest epoch before this one
+            let res = self.authorized_voters.range(0..epoch).next_back();
+
+            if res.is_none() {
+                warn!(
+                    "Tried to query for the authorized voter of an epoch earlier
+                    than the current epoch. Earlier epochs have been purged"
+                );
+            }
+
+            res.map(|(_, pubkey)| (*pubkey, false))
+        } else {
+            res.map(|pubkey| (*pubkey, true))
+        }
+    }
+}

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod authorized_voters;
 pub mod vote_instruction;
 pub mod vote_state;
 

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -17,6 +17,7 @@ use solana_sdk::{
     system_instruction,
     sysvar::{self, clock::Clock, slot_hashes::SlotHashes, Sysvar},
 };
+use std::collections::HashSet;
 use thiserror::Error;
 
 /// Reasons the stake might have had an error
@@ -187,7 +188,7 @@ pub fn process_instruction(
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 
-    let signers = get_signers(keyed_accounts);
+    let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
 
     let keyed_accounts = &mut keyed_accounts.iter();
     let me = &mut next_keyed_account(keyed_accounts)?;

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -20,7 +20,7 @@ use solana_sdk::{
 use std::boxed::Box;
 use std::collections::{HashSet, VecDeque};
 
-mod vote_state_0_23_5;
+pub mod vote_state_0_23_5;
 pub mod vote_state_versions;
 pub use vote_state_versions::*;
 

--- a/programs/vote/src/vote_state/vote_state_0_23_5.rs
+++ b/programs/vote/src/vote_state/vote_state_0_23_5.rs
@@ -1,0 +1,60 @@
+use super::*;
+
+const MAX_ITEMS: usize = 32;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct VoteState0_23_5 {
+    /// the node that votes in this account
+    pub node_pubkey: Pubkey,
+
+    /// the signer for vote transactions
+    pub authorized_voter: Pubkey,
+    /// when the authorized voter was set/initialized
+    pub authorized_voter_epoch: Epoch,
+
+    /// history of prior authorized voters and the epoch ranges for which
+    ///  they were set
+    pub prior_voters: CircBuf<(Pubkey, Epoch, Epoch, Slot)>,
+
+    /// the signer for withdrawals
+    pub authorized_withdrawer: Pubkey,
+    /// percentage (0-100) that represents what part of a rewards
+    ///  payout should be given to this VoteAccount
+    pub commission: u8,
+
+    pub votes: VecDeque<Lockout>,
+    pub root_slot: Option<u64>,
+
+    /// history of how many credits earned by the end of each epoch
+    ///  each tuple is (Epoch, credits, prev_credits)
+    pub epoch_credits: Vec<(Epoch, u64, u64)>,
+
+    /// most recent timestamp submitted with a vote
+    pub last_timestamp: BlockTimestamp,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct CircBuf<I> {
+    pub buf: [I; MAX_ITEMS],
+    /// next pointer
+    pub idx: usize,
+}
+
+impl<I: Default + Copy> Default for CircBuf<I> {
+    fn default() -> Self {
+        Self {
+            buf: [I::default(); MAX_ITEMS],
+            idx: MAX_ITEMS - 1,
+        }
+    }
+}
+
+impl<I> CircBuf<I> {
+    pub fn append(&mut self, item: I) {
+        // remember prior delegate and when we switched, to support later slashing
+        self.idx += 1;
+        self.idx %= MAX_ITEMS;
+
+        self.buf[self.idx] = item;
+    }
+}

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -1,0 +1,60 @@
+use super::*;
+use crate::vote_state::vote_state_0_23_5::VoteState0_23_5;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub enum VoteStateVersions {
+    V0_23_5(Box<VoteState0_23_5>),
+    Current(Box<VoteState>),
+}
+
+impl VoteStateVersions {
+    pub fn convert_to_current(self) -> VoteState {
+        match self {
+            VoteStateVersions::V0_23_5(state) => {
+                let authorized_voters =
+                    AuthorizedVoters::new(state.authorized_voter_epoch, state.authorized_voter);
+
+                VoteState {
+                    node_pubkey: state.node_pubkey,
+
+                    /// the signer for withdrawals
+                    authorized_withdrawer: state.authorized_withdrawer,
+
+                    /// percentage (0-100) that represents what part of a rewards
+                    ///  payout should be given to this VoteAccount
+                    commission: state.commission,
+
+                    votes: state.votes.clone(),
+
+                    root_slot: state.root_slot,
+
+                    /// the signer for vote transactions
+                    authorized_voters,
+
+                    /// history of prior authorized voters and the epochs for which
+                    /// they were set, the bottom end of the range is inclusive,
+                    /// the top of the range is exclusive
+                    prior_voters: CircBuf::default(),
+
+                    /// history of how many credits earned by the end of each epoch
+                    ///  each tuple is (Epoch, credits, prev_credits)
+                    epoch_credits: state.epoch_credits.clone(),
+
+                    /// most recent timestamp submitted with a vote
+                    last_timestamp: state.last_timestamp.clone(),
+                }
+            }
+            VoteStateVersions::Current(state) => *state,
+        }
+    }
+
+    pub fn is_uninitialized(&self) -> bool {
+        match self {
+            VoteStateVersions::V0_23_5(vote_state) => {
+                vote_state.authorized_voter == Pubkey::default()
+            }
+
+            VoteStateVersions::Current(vote_state) => vote_state.authorized_voters.is_empty(),
+        }
+    }
+}

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -72,7 +72,29 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 60000, 0);
     let ancestors = vec![(0, 0)].into_iter().collect();
+    accounts.accounts_db.update_accounts_hash(0, &ancestors);
+    bencher.iter(|| assert!(accounts.verify_bank_hash(0, &ancestors)));
+}
+
+#[bench]
+fn test_update_accounts_hash(bencher: &mut Bencher) {
+    solana_logger::setup();
+    let accounts = Accounts::new(vec![PathBuf::from("update_accounts_hash")]);
+    let mut pubkeys: Vec<Pubkey> = vec![];
+    create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
+    let ancestors = vec![(0, 0)].into_iter().collect();
     bencher.iter(|| {
-        accounts.verify_bank_hash(0, &ancestors);
+        accounts.accounts_db.update_accounts_hash(0, &ancestors);
+    });
+}
+
+#[bench]
+fn test_accounts_delta_hash(bencher: &mut Bencher) {
+    solana_logger::setup();
+    let accounts = Accounts::new(vec![PathBuf::from("accounts_delta_hash")]);
+    let mut pubkeys: Vec<Pubkey> = vec![];
+    create_test_accounts(&accounts, &mut pubkeys, 100_000, 0);
+    bencher.iter(|| {
+        accounts.accounts_db.get_accounts_delta_hash(0);
     });
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -85,9 +85,14 @@ impl Accounts {
         stream: &mut BufReader<R>,
         local_paths: &[PathBuf],
         append_vecs_path: P,
+        should_deserialize_bank_hash: bool,
     ) -> std::result::Result<(), IOError> {
-        self.accounts_db
-            .accounts_from_stream(stream, local_paths, append_vecs_path)
+        self.accounts_db.accounts_from_stream(
+            stream,
+            local_paths,
+            append_vecs_path,
+            should_deserialize_bank_hash,
+        )
     }
 
     /// Return true if the slice has any duplicate elements

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -317,14 +317,21 @@ impl Accounts {
         ancestors: &HashMap<Slot, usize>,
         pubkey: &Pubkey,
     ) -> Option<(Account, Slot)> {
-        let (account, slot) = self
-            .accounts_db
-            .load_slow(ancestors, pubkey)
-            .unwrap_or((Account::default(), self.slot));
+        let res = self.accounts_db.load_slow(ancestors, pubkey);
+
+        if res.is_none() {
+            panic!("Could not find pubkey");
+        }
+
+        let (account, slot) = res.unwrap_or((Account::default(), self.slot));
 
         if account.lamports > 0 {
             Some((account, slot))
         } else {
+            println!(
+                "0 lamports account owner: {}, {}",
+                account.owner, account.lamports
+            );
             None
         }
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -33,18 +33,20 @@ use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
 use solana_measure::measure::Measure;
 use solana_rayon_threadlimit::get_thread_count;
-use solana_sdk::account::Account;
-use solana_sdk::bank_hash::BankHash;
-use solana_sdk::clock::{Epoch, Slot};
-use solana_sdk::hash::{Hash, Hasher};
-use solana_sdk::pubkey::Pubkey;
-use std::collections::{HashMap, HashSet};
-use std::fmt;
-use std::io::{BufReader, Cursor, Error as IOError, ErrorKind, Read, Result as IOResult};
-use std::path::Path;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock};
+use solana_sdk::{
+    account::Account,
+    clock::{Epoch, Slot},
+    hash::{Hash, Hasher},
+    pubkey::Pubkey,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    io::{BufReader, Cursor, Error as IOError, ErrorKind, Read, Result as IOResult},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::{Arc, RwLock},
+};
 use tempfile::TempDir;
 
 pub const DEFAULT_FILE_SIZE: u64 = 4 * 1024 * 1024;
@@ -115,6 +117,22 @@ impl<'de> Visitor<'de> for AccountStorageVisitor {
     }
 }
 
+trait Versioned {
+    fn version(&self) -> u64;
+}
+
+impl Versioned for (u64, Hash) {
+    fn version(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Versioned for (u64, AccountInfo) {
+    fn version(&self) -> u64 {
+        self.0
+    }
+}
+
 struct AccountStorageSerialize<'a> {
     account_storage_entries: &'a [SnapshotStorage],
 }
@@ -160,7 +178,7 @@ pub enum AccountStorageStatus {
 }
 
 #[derive(Debug)]
-pub enum BankHashVerificatonError {
+pub enum BankHashVerificationError {
     MismatchedAccountHash,
     MismatchedBankHash,
     MissingBankHash,
@@ -396,7 +414,8 @@ impl BankHashStats {
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
 pub struct BankHashInfo {
-    pub hash: BankHash,
+    pub hash: Hash,
+    pub snapshot_hash: Hash,
     pub stats: BankHashStats,
 }
 
@@ -438,6 +457,8 @@ impl Default for AccountsDB {
     fn default() -> Self {
         let num_threads = get_thread_count();
 
+        let mut bank_hashes = HashMap::new();
+        bank_hashes.insert(0, BankHashInfo::default());
         AccountsDB {
             accounts_index: RwLock::new(AccountsIndex::default()),
             storage: RwLock::new(AccountStorage(HashMap::new())),
@@ -451,7 +472,7 @@ impl Default for AccountsDB {
                 .build()
                 .unwrap(),
             min_num_stores: num_threads,
-            bank_hashes: RwLock::new(HashMap::default()),
+            bank_hashes: RwLock::new(bank_hashes),
             dont_cleanup_dead_slots: AtomicBool::new(false),
         }
     }
@@ -828,9 +849,6 @@ impl AccountsDB {
 
     pub fn set_hash(&self, slot: Slot, parent_slot: Slot) {
         let mut bank_hashes = self.bank_hashes.write().unwrap();
-        let hash_info = bank_hashes
-            .get(&parent_slot)
-            .expect("accounts_db::set_hash::no parent slot");
         if bank_hashes.get(&slot).is_some() {
             error!(
                 "set_hash: already exists; multiple forks with shared slot {} as child (parent: {})!?",
@@ -839,9 +857,9 @@ impl AccountsDB {
             return;
         }
 
-        let hash = hash_info.hash;
         let new_hash_info = BankHashInfo {
-            hash,
+            hash: Hash::default(),
+            snapshot_hash: Hash::default(),
             stats: BankHashStats::default(),
         };
         bank_hashes.insert(slot, new_hash_info);
@@ -1096,46 +1114,137 @@ impl AccountsDB {
         datapoint_info!("accounts_db-stores", ("total_count", total_count, i64));
     }
 
+    pub fn compute_merkle_root(hashes: Vec<(Pubkey, Hash)>, fanout: usize) -> Hash {
+        let hashes: Vec<_> = hashes.into_iter().map(|(_pubkey, hash)| hash).collect();
+        let mut hashes: Vec<_> = hashes.chunks(fanout).map(|x| x.to_vec()).collect();
+        while hashes.len() > 1 {
+            let mut time = Measure::start("time");
+            let new_hashes: Vec<Hash> = hashes
+                .par_iter()
+                .map(|h| {
+                    let mut hasher = Hasher::default();
+                    for v in h.iter() {
+                        hasher.hash(v.as_ref());
+                    }
+                    hasher.result()
+                })
+                .collect();
+            time.stop();
+            debug!("hashing {} {}", hashes.len(), time);
+            hashes = new_hashes.chunks(fanout).map(|x| x.to_vec()).collect();
+        }
+        let mut hasher = Hasher::default();
+        hashes
+            .into_iter()
+            .flatten()
+            .map(|hash| hash)
+            .for_each(|hash| {
+                hasher.hash(hash.as_ref());
+            });
+        hasher.result()
+    }
+
+    fn accumulate_account_hashes(mut hashes: Vec<(Pubkey, Hash)>) -> Hash {
+        let mut sort = Measure::start("sort");
+        hashes.par_sort_by(|a, b| a.0.cmp(&b.0));
+        sort.stop();
+        let mut hash_time = Measure::start("hash");
+
+        let fanout = 16;
+
+        let res = Self::compute_merkle_root(hashes, fanout);
+
+        hash_time.stop();
+        debug!("{} {}", sort, hash_time);
+
+        res
+    }
+
+    fn calculate_accounts_hash(
+        &self,
+        ancestors: &HashMap<Slot, usize>,
+        check_hash: bool,
+    ) -> Result<Hash, BankHashVerificationError> {
+        use BankHashVerificationError::*;
+        let mut scan = Measure::start("scan");
+        let accounts_index = self.accounts_index.read().unwrap();
+        let storage = self.storage.read().unwrap();
+        let keys: Vec<_> = accounts_index.account_maps.keys().collect();
+        let mismatch_found = AtomicBool::new(false);
+        let hashes: Vec<_> = keys
+            .par_iter()
+            .filter_map(|pubkey| {
+                if let Some((list, index)) = accounts_index.get(pubkey, ancestors) {
+                    let (slot, account_info) = &list[index];
+                    if account_info.lamports != 0 {
+                        storage
+                            .0
+                            .get(&slot)
+                            .and_then(|storage_map| storage_map.get(&account_info.store_id))
+                            .and_then(|store| {
+                                let account = store.accounts.get_account(account_info.offset)?.0;
+
+                                if check_hash {
+                                    let hash = Self::hash_stored_account(*slot, &account);
+                                    if hash != *account.hash {
+                                        mismatch_found.store(true, Ordering::Relaxed);
+                                    }
+                                    if mismatch_found.load(Ordering::Relaxed) {
+                                        return None;
+                                    }
+                                }
+
+                                Some((**pubkey, *account.hash))
+                            })
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if mismatch_found.load(Ordering::Relaxed) {
+            return Err(MismatchedAccountHash);
+        }
+
+        scan.stop();
+        debug!("{}", scan);
+
+        Ok(Self::accumulate_account_hashes(hashes))
+    }
+
+    pub fn get_accounts_hash(&self, slot: Slot) -> Hash {
+        let bank_hashes = self.bank_hashes.read().unwrap();
+        let bank_hash_info = bank_hashes.get(&slot).unwrap();
+        bank_hash_info.snapshot_hash
+    }
+
+    pub fn update_accounts_hash(&self, slot: Slot, ancestors: &HashMap<Slot, usize>) -> Hash {
+        let hash = self.calculate_accounts_hash(ancestors, false).unwrap();
+        let mut bank_hashes = self.bank_hashes.write().unwrap();
+        let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
+        bank_hash_info.snapshot_hash = hash;
+        hash
+    }
+
     pub fn verify_bank_hash(
         &self,
         slot: Slot,
         ancestors: &HashMap<Slot, usize>,
-    ) -> Result<(), BankHashVerificatonError> {
-        use BankHashVerificatonError::*;
+    ) -> Result<(), BankHashVerificationError> {
+        use BankHashVerificationError::*;
 
-        let (hashes, mismatch_found) = self.scan_accounts(
-            ancestors,
-            |(collector, mismatch_found): &mut (Vec<BankHash>, bool),
-             option: Option<(&Pubkey, Account, Slot)>| {
-                if let Some((pubkey, account, slot)) = option {
-                    let hash = Self::hash_account(slot, &account, pubkey);
-                    if hash != account.hash {
-                        *mismatch_found = true;
-                    }
-                    if *mismatch_found {
-                        return;
-                    }
-                    let hash = BankHash::from_hash(&hash);
-                    debug!("xoring..{} key: {}", hash, pubkey);
-                    collector.push(hash);
-                }
-            },
-        );
-        if mismatch_found {
-            return Err(MismatchedAccountHash);
-        }
-        let mut calculated_hash = BankHash::default();
-        for hash in hashes {
-            calculated_hash.xor(hash);
-        }
+        let calculated_hash = self.calculate_accounts_hash(ancestors, true)?;
+
         let bank_hashes = self.bank_hashes.read().unwrap();
         if let Some(found_hash_info) = bank_hashes.get(&slot) {
-            if calculated_hash == found_hash_info.hash {
+            if calculated_hash == found_hash_info.snapshot_hash {
                 Ok(())
             } else {
                 warn!(
                     "mismatched bank hash for slot {}: {} (calculated) != {} (expected)",
-                    slot, calculated_hash, found_hash_info.hash
+                    slot, calculated_hash, found_hash_info.snapshot_hash
                 );
                 Err(MismatchedBankHash)
             }
@@ -1144,14 +1253,35 @@ impl AccountsDB {
         }
     }
 
-    pub fn xor_in_hash_state(&self, slot_id: Slot, hash: BankHash, stats: &BankHashStats) {
-        let mut bank_hashes = self.bank_hashes.write().unwrap();
-        let bank_hash = bank_hashes
-            .entry(slot_id)
-            .or_insert_with(BankHashInfo::default);
-        bank_hash.hash.xor(hash);
-
-        bank_hash.stats.merge(stats);
+    pub fn get_accounts_delta_hash(&self, slot_id: Slot) -> Hash {
+        let mut scan = Measure::start("scan");
+        let mut accumulator: Vec<HashMap<Pubkey, (u64, Hash)>> = self.scan_account_storage(
+            slot_id,
+            |stored_account: &StoredAccount,
+             _store_id: AppendVecId,
+             accum: &mut HashMap<Pubkey, (u64, Hash)>| {
+                accum.insert(
+                    stored_account.meta.pubkey,
+                    (stored_account.meta.write_version, *stored_account.hash),
+                );
+            },
+        );
+        scan.stop();
+        let mut merge = Measure::start("merge");
+        let mut account_maps = accumulator.pop().unwrap();
+        while let Some(maps) = accumulator.pop() {
+            AccountsDB::merge(&mut account_maps, &maps);
+        }
+        merge.stop();
+        let mut accumulate = Measure::start("accumulate");
+        let hashes: Vec<_> = account_maps
+            .into_iter()
+            .map(|(pubkey, (_, hash))| (pubkey, hash))
+            .collect();
+        let ret = Self::accumulate_account_hashes(hashes);
+        accumulate.stop();
+        info!("{} {} {}", scan, merge, accumulate);
+        ret
     }
 
     fn update_index(
@@ -1239,34 +1369,21 @@ impl AccountsDB {
     }
 
     fn hash_accounts(&self, slot_id: Slot, accounts: &[(&Pubkey, &Account)]) -> Vec<Hash> {
-        let mut hash_state = BankHash::default();
-        let mut had_account = false;
         let mut stats = BankHashStats::default();
         let hashes: Vec<_> = accounts
             .iter()
             .map(|(pubkey, account)| {
-                let hash = BankHash::from_hash(&account.hash);
                 stats.update(account);
-                let new_hash = Self::hash_account(slot_id, account, pubkey);
-                let new_bank_hash = BankHash::from_hash(&new_hash);
-                debug!(
-                    "hash_accounts: key: {} xor {} current: {}",
-                    pubkey, hash, hash_state
-                );
-                if !had_account {
-                    hash_state = hash;
-                    had_account = true;
-                } else {
-                    hash_state.xor(hash);
-                }
-                hash_state.xor(new_bank_hash);
-                new_hash
+                Self::hash_account(slot_id, account, pubkey)
             })
             .collect();
 
-        if had_account {
-            self.xor_in_hash_state(slot_id, hash_state, &stats);
-        }
+        let mut bank_hashes = self.bank_hashes.write().unwrap();
+        let slot_info = bank_hashes
+            .entry(slot_id)
+            .or_insert_with(BankHashInfo::default);
+        slot_info.stats.merge(&stats);
+
         hashes
     }
 
@@ -1306,17 +1423,17 @@ impl AccountsDB {
             .collect()
     }
 
-    fn merge(
-        dest: &mut HashMap<Pubkey, (u64, AccountInfo)>,
-        source: &HashMap<Pubkey, (u64, AccountInfo)>,
-    ) {
-        for (key, (source_version, source_info)) in source.iter() {
-            if let Some((dest_version, _)) = dest.get(key) {
-                if dest_version > source_version {
+    fn merge<X>(dest: &mut HashMap<Pubkey, X>, source: &HashMap<Pubkey, X>)
+    where
+        X: Versioned + Clone,
+    {
+        for (key, source_item) in source.iter() {
+            if let Some(dest_item) = dest.get(key) {
+                if dest_item.version() > source_item.version() {
                     continue;
                 }
             }
-            dest.insert(*key, (*source_version, source_info.clone()));
+            dest.insert(*key, source_item.clone());
         }
     }
 
@@ -1400,6 +1517,14 @@ pub mod tests {
     use std::fs;
     use std::str::FromStr;
     use tempfile::TempDir;
+
+    fn linear_ancestors(end_slot: u64) -> HashMap<Slot, usize> {
+        let mut ancestors: HashMap<Slot, usize> = vec![(0, 0)].into_iter().collect();
+        for i in 1..end_slot {
+            ancestors.insert(i, (i - 1) as usize);
+        }
+        ancestors
+    }
 
     #[test]
     fn test_accountsdb_add_root() {
@@ -1722,8 +1847,8 @@ pub mod tests {
             accounts.store(0, &[(&key, &account)]);
             keys.push(key);
         }
+        let ancestors = vec![(0, 0)].into_iter().collect();
         for (i, key) in keys.iter().enumerate() {
-            let ancestors = vec![(0, 0)].into_iter().collect();
             assert_eq!(
                 accounts.load_slow(&ancestors, &key).unwrap().0.lamports,
                 (i as u64) + 1
@@ -2014,11 +2139,16 @@ pub mod tests {
     }
 
     fn print_index(label: &'static str, accounts: &AccountsDB) {
-        info!(
-            "{}: accounts.accounts_index roots: {:?}",
-            label,
-            accounts.accounts_index.read().unwrap().roots
-        );
+        let mut roots: Vec<_> = accounts
+            .accounts_index
+            .read()
+            .unwrap()
+            .roots
+            .iter()
+            .cloned()
+            .collect();
+        roots.sort();
+        info!("{}: accounts.accounts_index roots: {:?}", label, roots,);
         for (pubkey, list) in &accounts.accounts_index.read().unwrap().account_maps {
             info!("  key: {}", pubkey);
             info!("      slots: {:?}", *list.read().unwrap());
@@ -2048,7 +2178,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_accounts_db_serialize() {
+    fn test_accounts_db_serialize1() {
         solana_logger::setup();
         let accounts = AccountsDB::new_single();
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -2109,7 +2239,7 @@ pub mod tests {
 
         // Get the hash for the latest slot, which should be the only hash in the
         // bank_hashes map on the deserialized AccountsDb
-        assert_eq!(daccounts.bank_hashes.read().unwrap().len(), 1);
+        assert_eq!(daccounts.bank_hashes.read().unwrap().len(), 2);
         assert_eq!(
             daccounts.bank_hashes.read().unwrap().get(&latest_slot),
             accounts.bank_hashes.read().unwrap().get(&latest_slot)
@@ -2123,6 +2253,12 @@ pub mod tests {
         assert!(check_storage(&daccounts, 0, 78));
         assert!(check_storage(&daccounts, 1, 11));
         assert!(check_storage(&daccounts, 2, 31));
+
+        let ancestors = linear_ancestors(latest_slot);
+        assert_eq!(
+            daccounts.update_accounts_hash(latest_slot, &ancestors),
+            accounts.update_accounts_hash(latest_slot, &ancestors)
+        );
     }
 
     fn assert_load_account(
@@ -2203,11 +2339,13 @@ pub mod tests {
         current_slot += 1;
         accounts.add_root(current_slot);
 
+        print_accounts("pre_purge", &accounts);
+
         accounts.clean_accounts();
 
         print_accounts("post_purge", &accounts);
 
-        // Make sure the index is for pubkey cleared
+        // Make sure the index is not touched
         assert_eq!(
             accounts
                 .accounts_index
@@ -2228,7 +2366,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_accounts_db_purge() {
+    fn test_accounts_db_purge1() {
         solana_logger::setup();
         let some_lamport = 223;
         let zero_lamport = 0;
@@ -2244,10 +2382,12 @@ pub mod tests {
         accounts.add_root(0);
 
         let mut current_slot = 1;
+        accounts.set_hash(current_slot, current_slot - 1);
         accounts.store(current_slot, &[(&pubkey, &account)]);
         accounts.add_root(current_slot);
 
         current_slot += 1;
+        accounts.set_hash(current_slot, current_slot - 1);
         accounts.store(current_slot, &[(&pubkey, &zero_lamport_account)]);
         accounts.add_root(current_slot);
 
@@ -2255,9 +2395,21 @@ pub mod tests {
 
         // Otherwise slot 2 will not be removed
         current_slot += 1;
+        accounts.set_hash(current_slot, current_slot - 1);
         accounts.add_root(current_slot);
 
+        print_accounts("pre_purge", &accounts);
+
+        let ancestors = linear_ancestors(current_slot);
+        info!("ancestors: {:?}", ancestors);
+        let hash = accounts.update_accounts_hash(current_slot, &ancestors);
+
         accounts.clean_accounts();
+
+        assert_eq!(
+            accounts.update_accounts_hash(current_slot, &ancestors),
+            hash
+        );
 
         print_accounts("post_purge", &accounts);
 
@@ -2603,7 +2755,7 @@ pub mod tests {
 
     #[test]
     fn test_verify_bank_hash() {
-        use BankHashVerificatonError::*;
+        use BankHashVerificationError::*;
         solana_logger::setup();
         let db = AccountsDB::new(Vec::new());
 
@@ -2615,6 +2767,7 @@ pub mod tests {
 
         db.store(some_slot, &[(&key, &account)]);
         db.add_root(some_slot);
+        db.update_accounts_hash(some_slot, &ancestors);
         assert_matches!(db.verify_bank_hash(some_slot, &ancestors), Ok(_));
 
         db.bank_hashes.write().unwrap().remove(&some_slot).unwrap();
@@ -2623,9 +2776,10 @@ pub mod tests {
             Err(MissingBankHash)
         );
 
-        let some_bank_hash = BankHash::from_hash(&Hash::new(&[0xca; HASH_BYTES]));
+        let some_bank_hash = Hash::new(&[0xca; HASH_BYTES]);
         let bank_hash_info = BankHashInfo {
             hash: some_bank_hash,
+            snapshot_hash: Hash::new(&[0xca; HASH_BYTES]),
             stats: BankHashStats::default(),
         };
         db.bank_hashes
@@ -2651,12 +2805,13 @@ pub mod tests {
             .unwrap()
             .insert(some_slot, BankHashInfo::default());
         db.add_root(some_slot);
+        db.update_accounts_hash(some_slot, &ancestors);
         assert_matches!(db.verify_bank_hash(some_slot, &ancestors), Ok(_));
     }
 
     #[test]
     fn test_verify_bank_hash_bad_account_hash() {
-        use BankHashVerificatonError::*;
+        use BankHashVerificationError::*;
         solana_logger::setup();
         let db = AccountsDB::new(Vec::new());
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -104,11 +104,16 @@ impl BankRc {
         mut stream: &mut BufReader<R>,
         local_paths: &[PathBuf],
         append_vecs_path: P,
+        should_deserialize_bank_hash: bool,
     ) -> std::result::Result<(), IOError> {
         let _len: usize =
             deserialize_from(&mut stream).map_err(|e| BankRc::get_io_error(&e.to_string()))?;
-        self.accounts
-            .accounts_from_stream(stream, local_paths, append_vecs_path)?;
+        self.accounts.accounts_from_stream(
+            stream,
+            local_paths,
+            append_vecs_path,
+            should_deserialize_bank_hash,
+        )?;
 
         Ok(())
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -76,7 +76,7 @@ type TransactionLoaderRefCells = Vec<Vec<(Pubkey, RefCell<Account>)>>;
 #[derive(Default)]
 pub struct BankRc {
     /// where all the Accounts are stored
-    accounts: Arc<Accounts>,
+    pub accounts: Arc<Accounts>,
 
     /// Previous checkpoint of this bank
     parent: RwLock<Option<Arc<Bank>>>,
@@ -317,14 +317,14 @@ pub struct Bank {
     inflation: Arc<RwLock<Inflation>>,
 
     /// cache of vote_account and stake_account state for this fork
-    stakes: RwLock<Stakes>,
+    pub stakes: RwLock<Stakes>,
 
     /// cache of validator and archiver storage accounts for this fork
     storage_accounts: RwLock<StorageAccounts>,
 
     /// staked nodes on epoch boundaries, saved off when a bank.slot() is at
     ///   a leader schedule calculation boundary
-    epoch_stakes: HashMap<Epoch, Stakes>,
+    pub epoch_stakes: HashMap<Epoch, Stakes>,
 
     /// A boolean reflecting whether any entries were recorded into the PoH
     /// stream for the slot == self.slot
@@ -764,6 +764,11 @@ impl Bank {
             // freeze is a one-way trip, idempotent
             *hash = self.hash_internal_state();
         }
+    }
+
+    pub fn recompute_hash(&self) {
+        let mut hash = self.hash.write().unwrap();
+        *hash = self.hash_internal_state();
     }
 
     pub fn epoch_schedule(&self) -> &EpochSchedule {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2178,6 +2178,7 @@ mod tests {
         stake_instruction,
         stake_state::{self, Authorized, Delegation, Lockup, Stake},
     };
+    use solana_vote_program::vote_state::VoteStateVersions;
     use solana_vote_program::{
         vote_instruction,
         vote_state::{self, Vote, VoteInit, VoteState, MAX_LOCKOUT_HISTORY},
@@ -3075,11 +3076,20 @@ mod tests {
         bank.store_account(&archiver_id, &archiver_account);
 
         // generate some rewards
-        let mut vote_state = VoteState::from(&vote_account).unwrap();
+        let mut vote_state = Some(VoteState::from(&vote_account).unwrap());
         for i in 0..MAX_LOCKOUT_HISTORY + 42 {
-            vote_state.process_slot_vote_unchecked(i as u64);
-            vote_state.to(&mut vote_account).unwrap();
+            vote_state
+                .as_mut()
+                .map(|v| v.process_slot_vote_unchecked(i as u64));
+            let versioned = VoteStateVersions::Current(Box::new(vote_state.take().unwrap()));
+            VoteState::to(&versioned, &mut vote_account).unwrap();
             bank.store_account(&vote_id, &vote_account);
+            match versioned {
+                VoteStateVersions::Current(v) => {
+                    vote_state = Some(*v);
+                }
+                _ => panic!("Has to be of type Current"),
+            };
         }
         bank.store_account(&vote_id, &vote_account);
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -196,7 +196,9 @@ pub mod tests {
     use super::*;
     use solana_sdk::{pubkey::Pubkey, rent::Rent};
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state::{self, VoteState, MAX_LOCKOUT_HISTORY};
+    use solana_vote_program::vote_state::{
+        self, VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY,
+    };
 
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
     pub fn create_staked_node_accounts(stake: u64) -> ((Pubkey, Account), (Pubkey, Account)) {
@@ -320,31 +322,55 @@ pub mod tests {
         assert_eq!(stakes.points(), 0);
         assert_eq!(stakes.claim_points(), 0);
 
-        let mut vote_state = VoteState::from(&vote_account).unwrap();
+        let mut vote_state = Some(VoteState::from(&vote_account).unwrap());
         for i in 0..MAX_LOCKOUT_HISTORY + 42 {
-            vote_state.process_slot_vote_unchecked(i as u64);
-            vote_state.to(&mut vote_account).unwrap();
+            vote_state
+                .as_mut()
+                .map(|v| v.process_slot_vote_unchecked(i as u64));
+            let versioned = VoteStateVersions::Current(Box::new(vote_state.take().unwrap()));
+            VoteState::to(&versioned, &mut vote_account).unwrap();
+            match versioned {
+                VoteStateVersions::Current(v) => {
+                    vote_state = Some(*v);
+                }
+                _ => panic!("Has to be of type Current"),
+            };
             stakes.store(&vote_pubkey, &vote_account);
-            assert_eq!(stakes.points(), vote_state.credits() * stake);
+            assert_eq!(
+                stakes.points(),
+                vote_state.as_ref().unwrap().credits() * stake
+            );
         }
         vote_account.lamports = 0;
         stakes.store(&vote_pubkey, &vote_account);
-        assert_eq!(stakes.points(), vote_state.credits() * stake);
+        assert_eq!(
+            stakes.points(),
+            vote_state.as_ref().unwrap().credits() * stake
+        );
 
-        assert_eq!(stakes.claim_points(), vote_state.credits() * stake);
+        assert_eq!(
+            stakes.claim_points(),
+            vote_state.as_ref().unwrap().credits() * stake
+        );
         assert_eq!(stakes.claim_points(), 0);
         assert_eq!(stakes.claim_points(), 0);
 
         // points come out of nowhere, but don't care here ;)
         vote_account.lamports = 1;
         stakes.store(&vote_pubkey, &vote_account);
-        assert_eq!(stakes.points(), vote_state.credits() * stake);
+        assert_eq!(
+            stakes.points(),
+            vote_state.as_ref().unwrap().credits() * stake
+        );
 
         // test going backwards, should never go backwards
         let old_vote_state = vote_state;
         let vote_account = vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 1);
         stakes.store(&vote_pubkey, &vote_account);
-        assert_eq!(stakes.points(), old_vote_state.credits() * stake);
+        assert_eq!(
+            stakes.points(),
+            old_vote_state.as_ref().unwrap().credits() * stake
+        );
     }
 
     #[test]

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 #[derive(Default, Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct Stakes {
     /// vote accounts
-    vote_accounts: HashMap<Pubkey, (u64, Account)>,
+    pub vote_accounts: HashMap<Pubkey, (u64, Account)>,
 
     /// stake_delegations
     stake_delegations: HashMap<Pubkey, Delegation>,

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -18,7 +18,7 @@ use solana_stake_program::{
 };
 use solana_vote_program::{
     vote_instruction,
-    vote_state::{Vote, VoteInit, VoteState},
+    vote_state::{Vote, VoteInit, VoteState, VoteStateVersions},
 };
 use std::sync::Arc;
 
@@ -254,7 +254,9 @@ fn test_stake_account_lifetime() {
 
     // Test that votes and credits are there
     let account = bank.get_account(&vote_pubkey).expect("account not found");
-    let vote_state: VoteState = account.state().expect("couldn't unpack account data");
+    let vote_state: VoteState = StateMut::<VoteStateVersions>::state(&account)
+        .expect("couldn't unpack account data")
+        .convert_to_current();
 
     // 1 less vote, as the first vote should have cleared the lockout
     assert_eq!(vote_state.votes.len(), 31);

--- a/sdk/src/epoch_schedule.rs
+++ b/sdk/src/epoch_schedule.rs
@@ -8,6 +8,11 @@ pub use crate::clock::{Epoch, Slot, DEFAULT_SLOTS_PER_EPOCH};
 ///  the beginning of epoch X - 1.
 pub const DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET: u64 = DEFAULT_SLOTS_PER_EPOCH;
 
+/// The maximum number of slots before an epoch starts to calculate the leader schedule.
+///  Default is an entire epoch, i.e. leader schedule for epoch X is calculated at
+///  the beginning of epoch X - 1.
+pub const MAX_LEADER_SCHEDULE_EPOCH_OFFSET: u64 = 3;
+
 /// based on MAX_LOCKOUT_HISTORY from vote_program
 pub const MINIMUM_SLOTS_PER_EPOCH: u64 = 32;
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -62,8 +62,6 @@ pub mod log;
 
 // Modules not usable by on-chain programs
 #[cfg(not(feature = "program"))]
-pub mod bank_hash;
-#[cfg(not(feature = "program"))]
 pub mod client;
 #[cfg(not(feature = "program"))]
 pub mod genesis_config;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -412,10 +412,32 @@ fn check_vote_account(
 
     let found_vote_account = solana_vote_program::vote_state::VoteState::from(&found_vote_account);
     if let Some(found_vote_account) = found_vote_account {
-        if found_vote_account.authorized_voter != *voting_pubkey {
+        if found_vote_account.authorized_voters().is_empty() {
+            return Err("Vote account not yet initialized".to_string());
+        }
+
+        let epoch_info = rpc_client
+            .get_epoch_info()
+            .map_err(|err| format!("Failed to get epoch info: {}", err.to_string()))?;
+
+        let mut authorized_voter;
+        authorized_voter = found_vote_account.get_authorized_voter(epoch_info.epoch);
+        if authorized_voter.is_none() {
+            // Must have gotten a clock on the boundary
+            authorized_voter = found_vote_account.get_authorized_voter(epoch_info.epoch + 1);
+        }
+
+        let authorized_voter = authorized_voter.expect(
+            "Could not get the authorized voter, which only happens if the
+            client gets an epoch earlier than the current epoch,
+            but the received epoch should not be off by more than
+            one epoch",
+        );
+
+        if authorized_voter != *voting_pubkey {
             return Err(format!(
                 "account's authorized voter ({}) does not match to the given voting keypair ({}).",
-                found_vote_account.authorized_voter, voting_pubkey
+                authorized_voter, voting_pubkey
             ));
         }
         if found_vote_account.node_pubkey != *node_pubkey {


### PR DESCRIPTION
#### Problem
No method exists to:
1) Upgrade accounts in old snapshot to newer versions of those accounts, specifically vote accounts
2) Convert to new bank hash

without breaking ABI compatibility

#### Summary of Changes

Fixes #
