### PR TITLE
Ledger key path rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,6 +4390,7 @@ dependencies = [
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk 1.1.0",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -119,8 +119,8 @@ pub fn derivation_of(matches: &ArgMatches<'_>, name: &str) -> Option<DerivationP
     matches.value_of(name).map(|derivation_str| {
         let derivation_str = derivation_str.replace("'", "");
         let mut parts = derivation_str.split('/');
-        let account = parts.next().map(|account| account.parse::<u16>().unwrap());
-        let change = parts.next().map(|change| change.parse::<u16>().unwrap());
+        let account = parts.next().map(|account| account.parse::<u32>().unwrap());
+        let change = parts.next().map(|change| change.parse::<u32>().unwrap());
         DerivationPath { account, change }
     })
 }

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -142,7 +142,7 @@ pub fn is_derivation(value: String) -> Result<(), String> {
     let mut parts = value.split('/');
     let account = parts.next().unwrap();
     account
-        .parse::<u16>()
+        .parse::<u32>()
         .map_err(|e| {
             format!(
                 "Unable to parse derivation, provided: {}, err: {:?}",
@@ -151,7 +151,7 @@ pub fn is_derivation(value: String) -> Result<(), String> {
         })
         .and_then(|_| {
             if let Some(change) = parts.next() {
-                change.parse::<u16>().map_err(|e| {
+                change.parse::<u32>().map_err(|e| {
                     format!(
                         "Unable to parse derivation, provided: {}, err: {:?}",
                         change, e
@@ -172,11 +172,12 @@ mod tests {
     fn test_is_derivation() {
         assert_eq!(is_derivation("2".to_string()), Ok(()));
         assert_eq!(is_derivation("0".to_string()), Ok(()));
+        assert_eq!(is_derivation("65537".to_string()), Ok(()));
         assert_eq!(is_derivation("0/2".to_string()), Ok(()));
         assert_eq!(is_derivation("0'/2'".to_string()), Ok(()));
         assert!(is_derivation("a".to_string()).is_err());
-        assert!(is_derivation("65537".to_string()).is_err());
+        assert!(is_derivation("4294967296".to_string()).is_err());
         assert!(is_derivation("a/b".to_string()).is_err());
-        assert!(is_derivation("0/65537".to_string()).is_err());
+        assert!(is_derivation("0/4294967296".to_string()).is_err());
     }
 }

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -39,7 +39,7 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
     } else if path == ASK_KEYWORD {
         KeypairUrl::Ask
     } else if path.starts_with("usb://") {
-        KeypairUrl::Usb(path.split_at(6).1.to_string())
+        KeypairUrl::Usb(path.to_string())
     } else if let Ok(pubkey) = Pubkey::from_str(path) {
         KeypairUrl::Pubkey(pubkey)
     } else {

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -17,6 +17,7 @@ parking_lot = "0.10"
 semver = "0.9"
 solana-sdk = { path = "../sdk", version = "1.1.0" }
 thiserror = "1.0"
+url = "2.1.1"
 
 [features]
 default = ["linux-static-hidraw"]

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -7,6 +7,8 @@ use semver::Version as FirmwareVersion;
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use std::{cmp::min, fmt, sync::Arc};
 
+const HARDENED_BIT: u32 = 1 << 31;
+
 const APDU_TAG: u8 = 0x05;
 const APDU_CLA: u8 = 0xe0;
 const APDU_PAYLOAD_HEADER_LEN: usize = 8;
@@ -373,11 +375,11 @@ fn extend_and_serialize(derivation_path: &DerivationPath) -> Vec<u8> {
     let mut concat_derivation = vec![byte];
     concat_derivation.extend_from_slice(&SOL_DERIVATION_PATH_BE);
     if let Some(account) = derivation_path.account {
-        concat_derivation.extend_from_slice(&[0x80, 0]);
-        concat_derivation.extend_from_slice(&account.to_be_bytes());
+        let hardened_account = account | HARDENED_BIT;
+        concat_derivation.extend_from_slice(&hardened_account.to_be_bytes());
         if let Some(change) = derivation_path.change {
-            concat_derivation.extend_from_slice(&[0x80, 0]);
-            concat_derivation.extend_from_slice(&change.to_be_bytes());
+            let hardened_change = change | HARDENED_BIT;
+            concat_derivation.extend_from_slice(&hardened_change.to_be_bytes());
         }
     }
     concat_derivation

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -245,6 +245,7 @@ impl RemoteWalletInfo {
                 if let Some(mut pair) = query_pairs.next() {
                     if pair.0 == "key" {
                         let key_path = pair.1.to_mut();
+                        let _key_path = key_path.clone();
                         if key_path.ends_with('/') {
                             key_path.pop();
                         }
@@ -255,6 +256,12 @@ impl RemoteWalletInfo {
                         derivation_path.change = parts
                             .next()
                             .and_then(|change| change.replace("'", "").parse::<u32>().ok());
+                        if parts.next().is_some() {
+                            return Err(RemoteWalletError::InvalidDerivationPath(format!(
+                                "key path `{}` too deep, only <account>/<change> supported",
+                                _key_path
+                            )));
+                        }
                     }
                 }
             }
@@ -482,6 +489,7 @@ mod tests {
         assert!(RemoteWalletInfo::parse_path("usb://?key=1/2".to_string()).is_err());
         assert!(RemoteWalletInfo::parse_path("usb:/ledger?key=1/2".to_string()).is_err());
         assert!(RemoteWalletInfo::parse_path("ledger?key=1/2".to_string()).is_err());
+        assert!(RemoteWalletInfo::parse_path("usb://ledger?key=1/2/3".to_string()).is_err());
     }
 
     #[test]

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -242,10 +242,10 @@ impl RemoteWalletInfo {
                 }
                 derivation_path.account = parts
                     .next()
-                    .and_then(|account| account.replace("'", "").parse::<u16>().ok());
+                    .and_then(|account| account.replace("'", "").parse::<u32>().ok());
                 derivation_path.change = parts
                     .next()
-                    .and_then(|change| change.replace("'", "").parse::<u16>().ok());
+                    .and_then(|change| change.replace("'", "").parse::<u32>().ok());
             } else {
                 return Err(RemoteWalletError::InvalidDerivationPath(
                     "Derivation path too short, missing coin number".to_string(),
@@ -273,8 +273,8 @@ impl RemoteWalletInfo {
 
 #[derive(Default, PartialEq, Clone)]
 pub struct DerivationPath {
-    pub account: Option<u16>,
-    pub change: Option<u16>,
+    pub account: Option<u32>,
+    pub change: Option<u32>,
 }
 
 impl fmt::Debug for DerivationPath {


### PR DESCRIPTION
#### Problem
The required string path for remote wallets is frustrating to use, since it requires knowing the device's base key in order to construct a path to a specific key. 

#### Summary of Changes
- Use `key` query string instead of path segments for specifying key derivation; also don't require `44/501`

Before:
```
usb://ledger/nano-s/BsNsvfXqQTtJnagwFWdBS7FBXgnsK8VZ5CmuznN85swK/44/501/0
```

After:
```
usb://ledger?key=0
or
usb://ledger/nano-s?key=0
or
usb://ledger/nano-s/BsNsvfXqQTtJnagwFWdBS7FBXgnsK8VZ5CmuznN85swK?key=0
```

Also sneaks in a fix to open up all possible 31-bit account/change derivations.
