### PR TITLE
Incorporate full accounts hash into voting hash every so often

### DIFF
--- a/core/src/generate_accounts_hash_service.rs
+++ b/core/src/generate_accounts_hash_service.rs
@@ -1,0 +1,56 @@
+// Service to generate the full accounts hash at some interval
+// to combine into the bank vote hash.
+use solana_ledger::bank_forks::BankForks;
+use solana_runtime::bank::Bank;
+use solana_sdk::pubkey::Pubkey;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Receiver;
+use std::sync::{Arc, RwLock};
+use std::thread::{self, Builder, JoinHandle};
+use std::time::Duration;
+
+pub struct GenerateAccountsHashService {
+    thread_hdls: Vec<JoinHandle<()>>,
+}
+
+impl GenerateAccountsHashService {
+    pub fn new(
+        receiver: Receiver<(u64, Pubkey)>,
+        bank_forks: &Arc<RwLock<BankForks>>,
+        exit: &Arc<AtomicBool>,
+    ) -> Self {
+        let exit = exit.clone();
+        let bank_forks = bank_forks.clone();
+        let thread_h = Builder::new()
+            .name("solana-generate-accounts-hash".to_string())
+            .spawn(move || loop {
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+                let timer = Duration::new(1, 0);
+                if let Ok((slot, pubkey)) = receiver.recv_timeout(timer) {
+                    info!("generate_accounts_hash processing: {:?} {}", slot, pubkey);
+                    let bank = bank_forks.read().unwrap()[slot].clone();
+                    Self::process_bank(&bank);
+                }
+            })
+            .unwrap();
+
+        GenerateAccountsHashService {
+            thread_hdls: vec![thread_h],
+        }
+    }
+
+    pub fn process_bank(bank: &Arc<Bank>) {
+        if bank.is_snapshotable() {
+            bank.update_accounts_hash();
+        }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        for thread_hdl in self.thread_hdls {
+            thread_hdl.join()?;
+        }
+        Ok(())
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod crds_gossip_push;
 pub mod crds_value;
 pub mod fetch_stage;
 pub mod gen_keys;
+pub mod generate_accounts_hash_service;
 pub mod genesis_utils;
 pub mod gossip_service;
 pub mod ledger_cleanup_service;

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -185,8 +185,14 @@ impl BankForks {
         // of banks since the last snapshot
         if self.snapshot_config.is_some() && snapshot_package_sender.is_some() {
             let config = self.snapshot_config.as_ref().unwrap();
-            info!("setting snapshot root: {}", root);
-            if root - self.last_snapshot_slot >= config.snapshot_interval_slots as Slot {
+            info!(
+                "setting snapshot root: {} block_height: {}",
+                root,
+                root_bank.block_height()
+            );
+            if root_bank.is_snapshotable()
+                && root - self.last_snapshot_slot >= config.snapshot_interval_slots as Slot
+            {
                 let mut snapshot_time = Measure::start("total-snapshot-ms");
                 let r = self.generate_snapshot(
                     root,

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -338,7 +338,7 @@ pub fn add_snapshot<P: AsRef<Path>>(
     snapshot_storages: &[SnapshotStorage],
 ) -> Result<SlotSnapshotPaths> {
     bank.purge_zero_lamport_accounts();
-    bank.update_accounts_hash();
+    assert_ne!(bank.get_accounts_hash(), Hash::default());
     let slot = bank.slot();
     // snapshot_path/slot
     let slot_snapshot_dir = get_bank_snapshot_dir(snapshot_path, slot);

--- a/sdk/src/accounts_epoch_hash.rs
+++ b/sdk/src/accounts_epoch_hash.rs
@@ -1,0 +1,7 @@
+use crate::hash::Hash;
+
+#[repr(C)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+pub struct AccountsEpochHash {
+    pub hash: Hash,
+}

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -55,6 +55,8 @@ pub const MAX_TRANSACTION_FORWARDING_DELAY_GPU: usize = 2;
 /// More delay is expected if CUDA is not enabled (as signature verification takes longer)
 pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 6;
 
+pub const DEFAULT_ACCOUNTS_HASH_EPOCH: u64 = 200;
+
 /// Converts a slot to a storage segment. Does not indicate that a segment is complete.
 pub fn get_segment_from_slot(rooted_slot: Slot, slots_per_segment: u64) -> Segment {
     (rooted_slot + (slots_per_segment - 1)) / slots_per_segment

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     account::Account,
-    clock::{UnixTimestamp, DEFAULT_SLOTS_PER_SEGMENT, DEFAULT_TICKS_PER_SLOT},
+    clock::{
+        UnixTimestamp, DEFAULT_ACCOUNTS_HASH_EPOCH, DEFAULT_SLOTS_PER_SEGMENT,
+        DEFAULT_TICKS_PER_SLOT,
+    },
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeCalculator,
     hash::{hash, Hash},
@@ -58,6 +61,8 @@ pub struct GenesisConfig {
     pub epoch_schedule: EpochSchedule,
     /// network runlevel
     pub operating_mode: OperatingMode,
+    /// Length of accounts hash epoch
+    pub accounts_hash_epoch: u64,
 }
 
 // useful for basic tests
@@ -93,6 +98,7 @@ impl Default for GenesisConfig {
             rent: Rent::default(),
             epoch_schedule: EpochSchedule::default(),
             operating_mode: OperatingMode::Development,
+            accounts_hash_epoch: DEFAULT_ACCOUNTS_HASH_EPOCH,
         }
     }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -3,6 +3,7 @@ extern crate self as solana_sdk;
 
 pub mod account;
 pub mod account_utils;
+pub mod accounts_epoch_hash;
 pub mod bpf_loader;
 pub mod clock;
 pub mod commitment_config;

--- a/sdk/src/sysvar/accounts_epoch_hash.rs
+++ b/sdk/src/sysvar/accounts_epoch_hash.rs
@@ -1,0 +1,12 @@
+//! This account contains the hash of the full accounts state at the accounts epoch
+//!
+
+pub use crate::accounts_epoch_hash::AccountsEpochHash;
+use crate::sysvar::Sysvar;
+
+crate::declare_sysvar_id!(
+    "AccountsEpochHash11111111111111111111111111",
+    AccountsEpochHash
+);
+
+impl Sysvar for AccountsEpochHash {}

--- a/sdk/src/sysvar/mod.rs
+++ b/sdk/src/sysvar/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     pubkey::Pubkey,
 };
 
+pub mod accounts_epoch_hash;
 pub mod clock;
 pub mod epoch_schedule;
 pub mod fees;


### PR DESCRIPTION
#### Problem

Full accounts hash is never incorporated into the voting bank hash so the accounts state could be inconsistent across nodes.

#### Summary of Changes

* Incorporate full accounts hash every ACCOUNTS_HASH_EPOCH slots to the bank hash.
* Add Generate accounts hash service to generate accounts hash

Fixes #8404 
