### PR TITLE
Fixed reqwest json issue

### DIFF
--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://solana.com/"
 [dependencies]
 clap = "2.33.0"
 log = "0.4.8"
-reqwest = { version = "0.10.1", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.10.1", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 serde_json = "1.0"
 solana-clap-utils = { path = "../clap-utils", version = "0.23.7" }
 solana-client = { path = "../client", version = "0.23.7" }


### PR DESCRIPTION
#### Problem
```
error[E0599]: no method named `json` found for type `reqwest::blocking::request::RequestBuilder` in the current scope
  --> watchtower/src/notifier.rs:50:57
   |
50 |             if let Err(err) = self.client.post(webhook).json(&data).send() {
   |                                                         ^^^^ method not found in `reqwest::blocking::request::RequestBuilder`
```

#### Summary of Changes
Added the `json` feature to `reqwest` in Cargo.toml.
