### PR TITLE
Validate the genesis config downloaded over RPC before accepting it

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -44,6 +44,7 @@ use solana_sdk::{
     timing::timestamp,
 };
 use std::{
+    collections::HashSet,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     process,
@@ -73,6 +74,7 @@ pub struct ValidatorConfig {
     pub fixed_leader_schedule: Option<FixedSchedule>,
     pub wait_for_supermajority: bool,
     pub new_hard_forks: Option<Vec<Slot>>,
+    pub trusted_validators: Option<HashSet<Pubkey>>, // None = trust all
 }
 
 impl Default for ValidatorConfig {
@@ -95,6 +97,7 @@ impl Default for ValidatorConfig {
             fixed_leader_schedule: None,
             wait_for_supermajority: false,
             new_hard_forks: None,
+            trusted_validators: None,
         }
     }
 }
@@ -341,9 +344,7 @@ impl Validator {
         }
 
         if let Some(snapshot_hash) = snapshot_hash {
-            if let Some(ref trusted_validators) =
-                config.snapshot_config.as_ref().unwrap().trusted_validators
-            {
+            if let Some(ref trusted_validators) = config.trusted_validators {
                 let mut trusted = false;
                 for _ in 0..10 {
                     trusted = cluster_info

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -55,7 +55,6 @@ mod tests {
             snapshot_interval_slots,
             snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
             snapshot_path: PathBuf::from(snapshot_dir.path()),
-            trusted_validators: None,
         };
         bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
         SnapshotTestConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -536,7 +536,6 @@ fn load_bank_forks(
             snapshot_interval_slots: 0, // Value doesn't matter
             snapshot_package_output_path: ledger_path.clone(),
             snapshot_path: ledger_path.clone().join("snapshot"),
-            trusted_validators: None,
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -6,7 +6,7 @@ use log::*;
 use solana_measure::measure::Measure;
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::{bank::Bank, status_cache::MAX_CACHE_ENTRIES};
-use solana_sdk::{clock::Slot, pubkey::Pubkey, timing};
+use solana_sdk::{clock::Slot, timing};
 use std::{
     collections::{HashMap, HashSet},
     ops::Index,
@@ -26,10 +26,6 @@ pub struct SnapshotConfig {
 
     // Where to place the snapshots for recent slots
     pub snapshot_path: PathBuf,
-
-    // Validators that must vouch for a given snapshot hash before it's accepted
-    // None = accept any snapshot hash
-    pub trusted_validators: Option<HashSet<Pubkey>>,
 }
 
 #[derive(Error, Debug)]

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -726,12 +726,9 @@ fn test_snapshots_blockstore_floor() {
     let (cluster_nodes, _) = discover_cluster(&cluster.entry_point_info.gossip, 1).unwrap();
     let mut trusted_validators = HashSet::new();
     trusted_validators.insert(cluster_nodes[0].id);
-    if let Some(ref mut config) = validator_snapshot_test_config
+    validator_snapshot_test_config
         .validator_config
-        .snapshot_config
-    {
-        config.trusted_validators = Some(trusted_validators);
-    }
+        .trusted_validators = Some(trusted_validators);
 
     cluster.add_validator(
         &validator_snapshot_test_config.validator_config,
@@ -1012,7 +1009,6 @@ fn setup_snapshot_validator_config(
         snapshot_interval_slots,
         snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
         snapshot_path: PathBuf::from(snapshot_dir.path()),
-        trusted_validators: None,
     };
 
     // Create the account paths


### PR DESCRIPTION
This PR replaces #8467, and additionally adds verification of a downloaded genesis.tar.bz2 before accepting it.   If an RPC node serves a bad genesis, that node gets blacklisted and the validator tries another.  

This should be sufficient to prevent the Chorus One poisoned genesis attack during SLP2 boot from reoccurring.  However note that the Certus One bzip2 bomb as described by https://github.com/solana-labs/solana/issues/8427 is not fixed here.

* Progress towards #8406 and #8432
* <s>This also might be a fix for #7919, what do you think @ryoqun?</s> - update: no, because it doesn't consider genesis deserialization 
