### PR TITLE
Add ReplayStage changes for checking switch threshold

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -481,7 +481,6 @@ impl Tower {
 pub mod test {
     use super::*;
     use crate::replay_stage::{ForkProgress, HeaviestForkFailures, ReplayStage};
-    use bio::data_structures::interval_tree::IntervalTree;
     use solana_ledger::bank_forks::BankForks;
     use solana_runtime::{
         bank::Bank,
@@ -624,17 +623,17 @@ pub mod test {
             info!("lockouts: {:?}", fork_progress.fork_stats.stake_lockouts);
             let mut failures = vec![];
             if fork_progress.fork_stats.is_locked_out {
-                failures.push(VoteFailures::LockedOut(vote_slot));
+                failures.push(HeaviestForkFailures::LockedOut(vote_slot));
             }
             if !fork_progress.fork_stats.vote_threshold {
-                failures.push(VoteFailures::FailedThreshold(vote_slot));
+                failures.push(HeaviestForkFailures::FailedThreshold(vote_slot));
             }
             if !failures.is_empty() {
                 return failures;
             }
             let vote = tower.new_vote_from_bank(&bank, &my_vote_pubkey).0;
             if let Some(new_root) = tower.record_bank_vote(vote) {
-                ReplayStage::handle_new_root(new_root, bank_forks, progress, &None);
+                ReplayStage::handle_new_root(new_root, bank_forks, progress, &None, &mut 0);
             }
 
             // Mark the vote for this bank under this node's pubkey so it will be

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -315,10 +315,6 @@ impl ReplayStage {
                         );
                     }
 
-                    if vote_bank.is_none() && reset_bank.is_none() {
-                        break;
-                    }
-
                     info!(
                         "vote bank: {:?} reset bank: {:?}",
                         vote_bank.as_ref().map(|b| b.slot()),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -307,19 +307,16 @@ impl ReplayStage {
                             &tower,
                         );
 
-                    if !failure_reasons.is_empty() {
+                    if heaviest_bank.is_some()
+                        && tower.is_recent(heaviest_bank.as_ref().unwrap().slot())
+                        && !failure_reasons.is_empty()
+                    {
                         info!(
                             "Couldn't vote on heaviest fork: {:?}, failure_reasons: {:?}",
                             heaviest_bank.as_ref().map(|b| b.slot()),
                             failure_reasons
                         );
                     }
-
-                    info!(
-                        "vote bank: {:?} reset bank: {:?}",
-                        vote_bank.as_ref().map(|b| b.slot()),
-                        reset_bank.as_ref().map(|b| b.slot()),
-                    );
 
                     let start = allocated.get();
 
@@ -376,6 +373,11 @@ impl ReplayStage {
                         if last_reset != reset_bank.last_blockhash()
                             && (selected_same_fork || switch_threshold)
                         {
+                            info!(
+                                "vote bank: {:?} reset bank: {:?}",
+                                vote_bank.as_ref().map(|b| b.slot()),
+                                reset_bank.slot(),
+                            );
                             Self::reset_poh_recorder(
                                 &my_pubkey,
                                 &blockstore,


### PR DESCRIPTION
#### Problem
ReplayStage isn't structured to handle checking switch thresholds for 1-block confirmation

#### Summary of Changes
Restructure ReplayStage to check switch threshold for the earliest vote on the fork.

Fixes #
