### PR TITLE
Ledger messaging cleanup

### DIFF
--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -47,7 +47,7 @@ pub enum RemoteWalletError {
     #[error("pubkey not found for given address")]
     PubkeyNotFound,
 
-    #[error("operation has been cancelled")]
+    #[error("remote wallet operation rejected by the user")]
     UserCancel,
 }
 
@@ -62,7 +62,9 @@ impl From<RemoteWalletError> for SignerError {
             RemoteWalletError::InvalidInput(input) => SignerError::InvalidInput(input),
             RemoteWalletError::NoDeviceFound => SignerError::NoDeviceFound,
             RemoteWalletError::Protocol(e) => SignerError::Protocol(e.to_string()),
-            RemoteWalletError::UserCancel => SignerError::UserCancel,
+            RemoteWalletError::UserCancel => {
+                SignerError::UserCancel("remote wallet operation rejected by the user".to_string())
+            }
             _ => SignerError::CustomError(err.to_string()),
         }
     }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -219,8 +219,8 @@ pub enum SignerError {
     #[error("device protocol error: {0}")]
     Protocol(String),
 
-    #[error("operation has been cancelled")]
-    UserCancel,
+    #[error("{0}")]
+    UserCancel(String),
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
#### Problem
User doesn't know when a cli operation is waiting on remote-wallet interaction.
Also, the Ledger returned error is generic and unhelpful

#### Summary of Changes

- Add waiting-for-approval message to remote-wallet
- Update UserCancel error code to be correct
- ~~Also sneak in cli main.rs change to print `fmt::Display` for errors, which has been needed to fixup a lot of ugly CLI errors~~ This needs a different approach
