### PR TITLE
Automated test framework can run scripts on launched clusters.  Add offline stake operations test case and script.

### DIFF
--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -112,11 +112,7 @@ function upload_results_to_slack() {
     BUILDKITE_BUILD_URL="https://buildkite.com/solana-labs/"
   fi
 
-<<<<<<< HEAD
   GRAFANA_URL="https://metrics.solana.com:3000/d/monitor-${CHANNEL:-edge}/cluster-telemetry-${CHANNEL:-edge}?var-testnet=${TESTNET_TAG:-testnet-automation}&from=${TESTNET_START_UNIX_MSECS:-0}&to=${TESTNET_FINISH_UNIX_MSECS:-0}"
-=======
-  GRAFANA_URL="https://metrics.solana.com:3000/d/testnet-${CHANNEL:-edge}/testnet-monitor-${CHANNEL:-edge}?var-testnet=${TESTNET_TAG:-testnet-automation}&from=${TESTNET_START_UNIX_MSECS:-0}&to=${TESTNET_FINISH_UNIX_MSECS:-0}"
->>>>>>> Refactor automation utilities
 
   [[ -n $RESULT_DETAILS ]] || RESULT_DETAILS="Undefined"
   [[ -n $TEST_CONFIGURATION ]] || TEST_CONFIGURATION="Undefined"
@@ -124,11 +120,7 @@ function upload_results_to_slack() {
   payLoad="$(cat <<EOF
 {
 "blocks": [
-<<<<<<< HEAD
         {
-=======
-  	{
->>>>>>> Refactor automation utilities
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
@@ -180,11 +172,7 @@ function upload_results_to_slack() {
 		{
 			"type": "divider"
 		},
-<<<<<<< HEAD
-                {
-=======
-  	{
->>>>>>> Refactor automation utilities
+    {
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",

--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -85,6 +85,12 @@ function get_slot {
   ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana slot'
 }
 
+function get_bootstrap_validator_ip_address {
+  source "${REPO_ROOT}"/net/common.sh
+  loadConfigFile
+  echo ${validatorIpList[0]}
+}
+
 function upload_results_to_slack() {
   echo --- Uploading results to Slack Performance Results App
 

--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -62,6 +62,10 @@ function analyze_packet_loss {
 
 function wait_for_bootstrap_validator_stake_drop {
   max_stake="$1"
+  if [[ $max_stake -eq 100 ]]; then
+    return
+  fi
+
   source "${REPO_ROOT}"/net/common.sh
   loadConfigFile
 
@@ -88,7 +92,63 @@ function get_slot {
 function get_bootstrap_validator_ip_address {
   source "${REPO_ROOT}"/net/common.sh
   loadConfigFile
-  echo ${validatorIpList[0]}
+  echo "${validatorIpList[0]}"
+}
+
+function collect_performance_statistics {
+  execution_step "Collect performance statistics about run"
+  declare q_mean_tps='
+    SELECT ROUND(MEAN("median_sum")) as "mean_tps" FROM (
+      SELECT MEDIAN(sum_count) AS "median_sum" FROM (
+        SELECT SUM("count") AS "sum_count"
+          FROM "'$TESTNET_TAG'"."autogen"."bank-process_transactions"
+          WHERE time > now() - '"$TEST_DURATION_SECONDS"'s AND count > 0
+          GROUP BY time(1s), host_id)
+      GROUP BY time(1s)
+    )'
+
+  declare q_max_tps='
+    SELECT MAX("median_sum") as "max_tps" FROM (
+      SELECT MEDIAN(sum_count) AS "median_sum" FROM (
+        SELECT SUM("count") AS "sum_count"
+          FROM "'$TESTNET_TAG'"."autogen"."bank-process_transactions"
+          WHERE time > now() - '"$TEST_DURATION_SECONDS"'s AND count > 0
+          GROUP BY time(1s), host_id)
+      GROUP BY time(1s)
+    )'
+
+  declare q_mean_confirmation='
+    SELECT round(mean("duration_ms")) as "mean_confirmation_ms"
+      FROM "'$TESTNET_TAG'"."autogen"."validator-confirmation"
+      WHERE time > now() - '"$TEST_DURATION_SECONDS"'s'
+
+  declare q_max_confirmation='
+    SELECT round(max("duration_ms")) as "max_confirmation_ms"
+      FROM "'$TESTNET_TAG'"."autogen"."validator-confirmation"
+      WHERE time > now() - '"$TEST_DURATION_SECONDS"'s'
+
+  declare q_99th_confirmation='
+    SELECT round(percentile("duration_ms", 99)) as "99th_percentile_confirmation_ms"
+      FROM "'$TESTNET_TAG'"."autogen"."validator-confirmation"
+      WHERE time > now() - '"$TEST_DURATION_SECONDS"'s'
+
+  declare q_max_tower_distance_observed='
+    SELECT MAX("tower_distance") as "max_tower_distance" FROM (
+      SELECT last("slot") - last("root") as "tower_distance"
+        FROM "'$TESTNET_TAG'"."autogen"."tower-observed"
+        WHERE time > now() - '"$TEST_DURATION_SECONDS"'s
+        GROUP BY time(1s), host_id)'
+
+  declare q_last_tower_distance_observed='
+      SELECT MEAN("tower_distance") as "last_tower_distance" FROM (
+            SELECT last("slot") - last("root") as "tower_distance"
+              FROM "'$TESTNET_TAG'"."autogen"."tower-observed"
+              GROUP BY host_id)'
+
+  curl -G "${INFLUX_HOST}/query?u=ro&p=topsecret" \
+    --data-urlencode "db=${TESTNET_TAG}" \
+    --data-urlencode "q=$q_mean_tps;$q_max_tps;$q_mean_confirmation;$q_max_confirmation;$q_99th_confirmation;$q_max_tower_distance_observed;$q_last_tower_distance_observed" |
+    python "${REPO_ROOT}"/system-test/testnet-automation-json-parser.py >>"$RESULT_FILE"
 }
 
 function upload_results_to_slack() {

--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -106,7 +106,11 @@ function upload_results_to_slack() {
     BUILDKITE_BUILD_URL="https://buildkite.com/solana-labs/"
   fi
 
+<<<<<<< HEAD
   GRAFANA_URL="https://metrics.solana.com:3000/d/monitor-${CHANNEL:-edge}/cluster-telemetry-${CHANNEL:-edge}?var-testnet=${TESTNET_TAG:-testnet-automation}&from=${TESTNET_START_UNIX_MSECS:-0}&to=${TESTNET_FINISH_UNIX_MSECS:-0}"
+=======
+  GRAFANA_URL="https://metrics.solana.com:3000/d/testnet-${CHANNEL:-edge}/testnet-monitor-${CHANNEL:-edge}?var-testnet=${TESTNET_TAG:-testnet-automation}&from=${TESTNET_START_UNIX_MSECS:-0}&to=${TESTNET_FINISH_UNIX_MSECS:-0}"
+>>>>>>> Refactor automation utilities
 
   [[ -n $RESULT_DETAILS ]] || RESULT_DETAILS="Undefined"
   [[ -n $TEST_CONFIGURATION ]] || TEST_CONFIGURATION="Undefined"
@@ -114,7 +118,11 @@ function upload_results_to_slack() {
   payLoad="$(cat <<EOF
 {
 "blocks": [
+<<<<<<< HEAD
         {
+=======
+  	{
+>>>>>>> Refactor automation utilities
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",
@@ -166,7 +174,11 @@ function upload_results_to_slack() {
 		{
 			"type": "divider"
 		},
+<<<<<<< HEAD
                 {
+=======
+  	{
+>>>>>>> Refactor automation utilities
 			"type": "section",
 			"text": {
 				"type": "mrkdwn",

--- a/system-test/deprecated-testcases/colo-cpu-only-perf.yml
+++ b/system-test/deprecated-testcases/colo-cpu-only-perf.yml
@@ -11,5 +11,6 @@ steps:
       NUMBER_OF_CLIENT_NODES: 2
       CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/deprecated-testcases/colo-gpu-perf-high-txcount.yml
+++ b/system-test/deprecated-testcases/colo-gpu-perf-high-txcount.yml
@@ -11,5 +11,6 @@ steps:
       NUMBER_OF_CLIENT_NODES: 2
       CLIENT_OPTIONS: "bench-tps=2=--tx_count 30000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/deprecated-testcases/colo-gpu-perf.yml
+++ b/system-test/deprecated-testcases/colo-gpu-perf.yml
@@ -11,5 +11,6 @@ steps:
       NUMBER_OF_CLIENT_NODES: 2
       CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/deprecated-testcases/gce-gpu-perf-100-node.yml
+++ b/system-test/deprecated-testcases/gce-gpu-perf-100-node.yml
@@ -15,5 +15,6 @@ steps:
       ALLOW_BOOT_FAILURES: "true"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=gce-deploy"

--- a/system-test/offline_stake_operations.sh
+++ b/system-test/offline_stake_operations.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -n "$1" ]]; then
+  url="$1"
+fi
+
+if [[ -z "$url" ]]; then
+  echo Provide complete URL, ex: "$0" http://testnet.solana.com:8899
+  exit 1
+fi
+solana config set --url $url
+
+# Create a dummy keypair file with no balance for operations that require a "client keypair file" to exist even if they don't touch it
+dummy_keypair=dummy.json
+solana-keygen new -o "$dummy_keypair" --no-passphrase --force --silent
+solana config set --keypair $dummy_keypair
+
+### Offline stake account creation
+
+# The nonce account and the system account funding its creation are online
+online_nonce_account_keypair=nonce_keypair.json
+online_system_account_keypair=online_system_account_keypair.json
+
+solana-keygen new -o "$online_system_account_keypair" --no-passphrase --force --silent
+solana-keygen new -o "$online_nonce_account_keypair" --no-passphrase --force --silent
+
+online_system_account_pubkey="$(solana-keygen pubkey $online_system_account_keypair)"
+nonce_account_pubkey="$(solana-keygen pubkey $online_nonce_account_keypair)"
+
+# System account funding the stake account is offline, and the auth staker and withdrawer keypairs are offline
+offline_system_account_keypair=offline_system_account_keypair.json
+offline_staker_keypair=offline_staker_keypair.json
+offline_withdrawer_keypair=offline_withdrawer_keypair.json
+offline_custodian_keypair=offline_custodian_keypair.json
+
+solana-keygen new -o "$offline_system_account_keypair" --no-passphrase --force --silent
+solana-keygen new -o "$offline_staker_keypair" --no-passphrase --force --silent
+solana-keygen new -o "$offline_withdrawer_keypair" --no-passphrase --force --silent
+solana-keygen new -o "$offline_custodian_keypair" --no-passphrase --force --silent
+
+offline_system_account_pubkey="$(solana-keygen pubkey $offline_system_account_keypair)"
+offline_withdrawer_pubkey="$(solana-keygen pubkey $offline_withdrawer_keypair)"
+offline_staker_pubkey="$(solana-keygen pubkey $offline_staker_keypair)"
+offline_custodian_pubkey="$(solana-keygen pubkey $offline_custodian_keypair)"
+
+# Airdrop some funds to the offline account.
+solana airdrop 100 $offline_system_account_pubkey
+solana airdrop 2 $online_system_account_pubkey
+
+# Create a nonce account funded by the online account, with the authority given to the offline account
+solana create-nonce-account $online_nonce_account_keypair 1 --nonce-authority $offline_system_account_pubkey --keypair $online_system_account_keypair
+nonce="$(solana nonce $nonce_account_pubkey)"
+
+echo --- OFFLINE SYSTEM ACCOUNT BALANCE BEFORE CREATING STAKE ACCOUNTS ---
+(
+  set -x
+  solana balance $offline_system_account_pubkey
+)
+
+################################
+echo +++ OFFLINE STAKE ACCOUNT CREATION +++
+################################
+
+# Create a stake account funded by the offline system account
+
+stake_account_keypair=stake_account_keypair.json
+solana-keygen new -o "$stake_account_keypair" --no-passphrase --force --silent
+stake_account_address="$(solana-keygen pubkey $stake_account_keypair)"
+
+sign_only="$(solana create-stake-account $stake_account_keypair 50 \
+  --sign-only --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_keypair \
+  --stake-authority $offline_staker_pubkey --withdraw-authority $offline_withdrawer_pubkey \
+  --custodian $offline_custodian_pubkey \
+  --lockup-epoch 999 \
+  --keypair $offline_system_account_keypair --url http://0.0.0.0)"
+
+signers=()
+while read LINE; do
+  signers+=( --signer $LINE )
+done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+
+solana create-stake-account $stake_account_keypair 50 \
+  --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
+  --stake-authority $offline_staker_pubkey --withdraw-authority $offline_withdrawer_pubkey \
+  --custodian $offline_custodian_pubkey \
+  --lockup-epoch 999 \
+  --from $offline_system_account_pubkey --fee-payer $offline_system_account_pubkey ${signers[@]}
+
+echo --- STAKE ACCOUNT AFTER CREATION ---
+(
+  set -x
+  solana stake-account $stake_account_address
+)
+
+
+echo --- OFFLINE SYSTEM ACCOUNT BALANCE AFTER CREATING FIRST STAKE ACCOUNT ---
+(
+  set -x
+  solana balance $offline_system_account_pubkey
+)
+
+#####################
+echo +++ OFFLINE STAKE SPLIT +++
+#####################
+
+# Split the original stake account before delegating
+
+split_stake_account_keypair=split_stake_account_keypair.json
+solana-keygen new -o $split_stake_account_keypair --no-passphrase --force --silent
+split_stake_account_address=$(solana-keygen pubkey $split_stake_account_keypair)
+
+nonce="$(solana nonce $nonce_account_pubkey)"
+
+sign_only="$(solana split-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_keypair \
+  --stake-authority $offline_staker_keypair $stake_account_address $split_stake_account_keypair 10 \
+  --keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
+
+signers=()
+while read LINE; do
+  signers+=( --signer $LINE )
+done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+
+solana split-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
+  --stake-authority $offline_staker_pubkey $stake_account_address $split_stake_account_keypair 10 \
+  --fee-payer $offline_system_account_pubkey ${signers[@]}
+
+echo --- ORIGINAL STAKE ACCOUNT AFTER SPLITTING ---
+(
+  set -x
+  solana stake-account $stake_account_address
+)
+
+echo --- NEW STAKE ACCOUNT CREATED FROM SPLITTING ORIGINAL ---
+(
+  set -x
+  solana stake-account $split_stake_account_address
+)
+
+#####################
+echo +++ CUSTODIAN CHANGE LOCKUP +++
+#####################
+
+# Set the lockup epoch to 0 to allow stake to be withdrawn
+
+nonce="$(solana nonce $nonce_account_pubkey)"
+
+sign_only="$(solana stake-set-lockup --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_keypair \
+  $split_stake_account_address --custodian $offline_custodian_keypair --lockup-epoch 0 \
+  --keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
+
+signers=()
+while read LINE; do
+  signers+=( --signer $LINE )
+done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+
+solana stake-set-lockup --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_keypair \
+  $split_stake_account_address --custodian $offline_custodian_pubkey --lockup-epoch 0 \
+  --fee-payer $offline_system_account_pubkey ${signers[@]}
+
+echo --- SPLIT STAKE ACCOUNT AFTER CHANGING LOCKUP ---
+(
+  set -x
+  solana stake-account $split_stake_account_address
+)
+
+##########################
+echo +++ OFFLINE STAKE WITHDRAWAL +++
+##########################
+
+# Withdraw the lamports from the stake account that was split off and return them to the offline system account
+
+nonce="$(solana nonce $nonce_account_pubkey)"
+
+sign_only="$(solana withdraw-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_keypair \
+   $split_stake_account_address $offline_system_account_pubkey 10 \
+  --withdraw-authority $offline_withdrawer_keypair \
+  --keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
+
+signers=()
+while read LINE; do
+  signers+=( --signer $LINE )
+done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+
+solana withdraw-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
+  $split_stake_account_address $offline_system_account_pubkey 10 \
+  --withdraw-authority $offline_withdrawer_pubkey \
+  --fee-payer $offline_system_account_pubkey ${signers[@]}
+
+echo --- OFFLINE SYSTEM ACCOUNT BALANCE AFTER WITHDRAWING SPLIT STAKE ---
+(
+  set -x
+  solana balance $offline_system_account_pubkey
+)
+
+##########################
+echo +++ OFFLINE STAKE DELEGATION +++
+##########################
+
+# Delegate stake from the original account to a vote account
+
+vote_account_pubkey="$(awk '{if(NR==4) print $2}'<<<"$(solana show-validators)")"
+nonce="$(solana nonce $nonce_account_pubkey)"
+
+# Sign a stake delegation, assuming the authorized staker is held offline
+sign_only="$(solana delegate-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_keypair \
+--stake-authority $offline_staker_keypair $stake_account_address $vote_account_pubkey \
+--keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
+
+signers=()
+while read LINE; do
+  signers+=( --signer $LINE )
+done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+
+# Send the signed transaction on the cluster
+solana delegate-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
+--stake-authority $offline_staker_pubkey $stake_account_address $vote_account_pubkey \
+--fee-payer $offline_system_account_pubkey ${signers[@]}
+
+echo --- ORIGINAL STAKE ACCOUNT AFTER DELEGATION ---
+(
+  set -x
+  solana stake-account $stake_account_address
+)
+
+##########################
+ echo +++ OFFLINE STAKE DEACTIVATION +++
+##########################
+
+# Deactivate delegated stake
+
+nonce="$(solana nonce $nonce_account_pubkey)"
+
+# Sign a stake delegation, assuming the authorized staker is held offline
+sign_only="$(solana deactivate-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_keypair \
+--stake-authority $offline_staker_keypair $stake_account_address \
+--keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
+
+signers=()
+while read LINE; do
+  signers+=( --signer $LINE )
+done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+
+# Send the signed transaction on the cluster
+solana deactivate-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
+--stake-authority $offline_staker_pubkey $stake_account_address \
+--fee-payer $offline_system_account_pubkey ${signers[@]}
+
+echo --- ORIGINAL STAKE ACCOUNT AFTER DEACTIVATION ---
+(
+   set -x
+   solana stake-account $stake_account_address
+)

--- a/system-test/offline_stake_operations.sh
+++ b/system-test/offline_stake_operations.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2086
+# shellcheck disable=SC2068
+# shellcheck disable=SC2206
+# shellcheck disable=SC2162
+
 set -e
 
 if [[ -n "$1" ]]; then

--- a/system-test/partition-testcases/colo-3-partition.yml
+++ b/system-test/partition-testcases/colo-3-partition.yml
@@ -15,5 +15,6 @@ steps:
       PARTITION_ACTIVE_DURATION: 30
       PARTITION_INACTIVE_DURATION: 30
       PARTITION_ITERATION_COUNT: 5
+      TEST_TYPE: "partition"
     agents:
       - "queue=colo-deploy"

--- a/system-test/partition-testcases/colo-partition-long-sanity-test.yml
+++ b/system-test/partition-testcases/colo-partition-long-sanity-test.yml
@@ -15,5 +15,6 @@ steps:
       PARTITION_ACTIVE_DURATION: 60
       PARTITION_INACTIVE_DURATION: 60
       PARTITION_ITERATION_COUNT: 10
+      TEST_TYPE: "partition"
     agents:
       - "queue=colo-deploy"

--- a/system-test/partition-testcases/colo-partition-once-then-stabilize.yml
+++ b/system-test/partition-testcases/colo-partition-once-then-stabilize.yml
@@ -15,5 +15,6 @@ steps:
       PARTITION_ACTIVE_DURATION: 60
       PARTITION_INACTIVE_DURATION: 300
       PARTITION_ITERATION_COUNT: 1
+      TEST_TYPE: "partition"
     agents:
       - "queue=colo-deploy"

--- a/system-test/partition-testcases/gce-5-node-3-partition.yml
+++ b/system-test/partition-testcases/gce-5-node-3-partition.yml
@@ -18,5 +18,6 @@ steps:
       PARTITION_ACTIVE_DURATION: 30
       PARTITION_INACTIVE_DURATION: 30
       PARTITION_ITERATION_COUNT: 5
+      TEST_TYPE: "partition"
     agents:
       - "queue=testnet-deploy"

--- a/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
+++ b/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
@@ -18,5 +18,6 @@ steps:
       PARTITION_ACTIVE_DURATION: 60
       PARTITION_INACTIVE_DURATION: 300
       PARTITION_ITERATION_COUNT: 5
+      TEST_TYPE: "partition"
     agents:
       - "queue=gce-deploy"

--- a/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
+++ b/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
@@ -18,5 +18,6 @@ steps:
       PARTITION_ACTIVE_DURATION: 60
       PARTITION_INACTIVE_DURATION: 300
       PARTITION_ITERATION_COUNT: 1
+      TEST_TYPE: "partition"
     agents:
       - "queue=gce-deploy"

--- a/system-test/performance-testcases/aws-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/aws-cpu-only-perf-10-node.yml
@@ -15,5 +15,6 @@ steps:
       TESTNET_ZONES: "us-west-1a,us-west-1c,us-east-1a,eu-west-1a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=aws-deploy"

--- a/system-test/performance-testcases/aws-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/aws-cpu-only-perf-5-node.yml
@@ -15,5 +15,6 @@ steps:
       TESTNET_ZONES: "us-west-1a,us-west-1c,us-east-1a,eu-west-1a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=aws-deploy"

--- a/system-test/performance-testcases/azure-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/azure-cpu-only-perf-5-node.yml
@@ -14,5 +14,6 @@ steps:
       TESTNET_ZONES: "westus"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=azure-deploy"

--- a/system-test/performance-testcases/colo-cpu-only-perf-4-val-1-client.yml
+++ b/system-test/performance-testcases/colo-cpu-only-perf-4-val-1-client.yml
@@ -11,5 +11,6 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 40000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/performance-testcases/colo-gpu-perf-4-val-1-client.yml
+++ b/system-test/performance-testcases/colo-gpu-perf-4-val-1-client.yml
@@ -11,5 +11,6 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 40000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/performance-testcases/colo-gpu-perf-high-txcount-4-val-1-client.yml
+++ b/system-test/performance-testcases/colo-gpu-perf-high-txcount-4-val-1-client.yml
@@ -11,5 +11,6 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 60000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
@@ -14,5 +14,6 @@ steps:
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
@@ -14,5 +14,6 @@ steps:
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node.yml
@@ -14,5 +14,6 @@ steps:
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-25-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node.yml
@@ -14,5 +14,6 @@ steps:
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node.yml
@@ -14,5 +14,6 @@ steps:
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-50-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node.yml
@@ -15,5 +15,6 @@ steps:
       ALLOW_BOOT_FAILURES: "true"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=gce-deploy"

--- a/system-test/sanity-testcases/colo-cpu-only-quick-sanity-test.yml
+++ b/system-test/sanity-testcases/colo-cpu-only-quick-sanity-test.yml
@@ -12,5 +12,6 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 40000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 100
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/sanity-testcases/colo-cpu-only-quick-sanity-test.yml
+++ b/system-test/sanity-testcases/colo-cpu-only-quick-sanity-test.yml
@@ -6,12 +6,12 @@ steps:
       CLOUD_PROVIDER: "colo"
       TESTNET_TAG: "colo-perf-cpu-only"
       ENABLE_GPU: "false"
-      TEST_DURATION_SECONDS: 30
+      TEST_DURATION_SECONDS: 60
       NUMBER_OF_VALIDATOR_NODES: 1
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 40000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
-      BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 100
+      BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 99
       TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/sanity-testcases/colo-partition-sanity-test.yml
+++ b/system-test/sanity-testcases/colo-partition-sanity-test.yml
@@ -5,7 +5,7 @@ steps:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "colo"
       TESTNET_TAG: "colo-perf-cpu-only"
-      NUMBER_OF_VALIDATOR_NODES: 4
+      NUMBER_OF_VALIDATOR_NODES: 3
       ENABLE_GPU: "false"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 15000 --thread-batch-sleep-ms 250"
@@ -15,7 +15,7 @@ steps:
       PARTITION_ACTIVE_DURATION: 30
       PARTITION_INACTIVE_DURATION: 30
       PARTITION_ITERATION_COUNT: 2
-      BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 100
+      BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 66
       TEST_TYPE: "partition"
     agents:
       - "queue=colo-deploy"

--- a/system-test/sanity-testcases/colo-partition-sanity-test.yml
+++ b/system-test/sanity-testcases/colo-partition-sanity-test.yml
@@ -16,5 +16,6 @@ steps:
       PARTITION_INACTIVE_DURATION: 30
       PARTITION_ITERATION_COUNT: 2
       BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 100
+      TEST_TYPE: "partition"
     agents:
       - "queue=colo-deploy"

--- a/system-test/stability-testcases/colo-long-duration-cpu-only-perf.yml
+++ b/system-test/stability-testcases/colo-long-duration-cpu-only-perf.yml
@@ -11,5 +11,6 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 30000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/stability-testcases/colo-long-duration-gpu-perf.yml
+++ b/system-test/stability-testcases/colo-long-duration-gpu-perf.yml
@@ -11,5 +11,6 @@ steps:
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 30000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=colo-deploy"

--- a/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
+++ b/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
@@ -14,5 +14,6 @@ steps:
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=gce-deploy"

--- a/system-test/stability-testcases/gce-stability-5-node.yml
+++ b/system-test/stability-testcases/gce-stability-5-node.yml
@@ -13,5 +13,6 @@ steps:
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
     agents:
       - "queue=stability-deploy"

--- a/system-test/stake-operations-testcases/offline_stake_colo.yml
+++ b/system-test/stake-operations-testcases/offline_stake_colo.yml
@@ -1,0 +1,5 @@
+steps:
+  - command: "system-test/stake-operations-testcases/stake_test_automation.sh"
+    label: "Running Offline Stake Operations Tests"
+    agents:
+      - "queue=colo-deploy"

--- a/system-test/stake-operations-testcases/offline_stake_colo.yml
+++ b/system-test/stake-operations-testcases/offline_stake_colo.yml
@@ -1,18 +1,17 @@
 steps:
   - command: "system-test/testnet-automation.sh"
-    label: "Running Offline Stake Operations Tests on GCE"
+    label: "Running Offline Stake Operations Tests on Colo"
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
-      CLOUD_PROVIDER: "gce"
+      CLOUD_PROVIDER: "colo"
       ENABLE_GPU: "false"
       TEST_DURATION_SECONDS: 30
       NUMBER_OF_VALIDATOR_NODES: 1
-      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
       NUMBER_OF_CLIENT_NODES: 0
-      ADDITIONAL_FLAGS: "--dedicated"
+      ADDITIONAL_FLAGS: ""
       BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 100
       SKIP_PERF_RESULTS: "true"
       TEST_TYPE: "script"
       CUSTOM_SCRIPT: "system-test/stake-operations-testcases/stake_test_automation.sh"
     agents:
-      - "queue=gce-deploy"
+      - "queue=colo-deploy"

--- a/system-test/stake-operations-testcases/offline_stake_colo.yml
+++ b/system-test/stake-operations-testcases/offline_stake_colo.yml
@@ -1,5 +1,0 @@
-steps:
-  - command: "system-test/stake-operations-testcases/stake_test_automation.sh"
-    label: "Running Offline Stake Operations Tests"
-    agents:
-      - "queue=colo-deploy"

--- a/system-test/stake-operations-testcases/offline_stake_gce.yml
+++ b/system-test/stake-operations-testcases/offline_stake_gce.yml
@@ -1,0 +1,18 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "Running Offline Stake Operations Tests"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "gce"
+      TESTNET_TAG: "gce-perf-cpu-only"
+      ENABLE_GPU: "false"
+      TEST_DURATION_SECONDS: 30
+      NUMBER_OF_VALIDATOR_NODES: 1
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      NUMBER_OF_CLIENT_NODES: 0
+      ADDITIONAL_FLAGS: ""
+      BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 100
+      TEST_TYPE: "script"
+      CUSTOM_SCRIPT: "system-test/stake-operations-testcases/stake_test_automation.sh"
+    agents:
+      - "queue=gce-deploy"

--- a/system-test/stake-operations-testcases/offline_stake_gce.yml
+++ b/system-test/stake-operations-testcases/offline_stake_gce.yml
@@ -12,6 +12,7 @@ steps:
       NUMBER_OF_CLIENT_NODES: 0
       ADDITIONAL_FLAGS: ""
       BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 100
+      SKIP_PERF_RESULTS: "true"
       TEST_TYPE: "script"
       CUSTOM_SCRIPT: "system-test/stake-operations-testcases/stake_test_automation.sh"
     agents:

--- a/system-test/stake-operations-testcases/offline_stake_operations.sh
+++ b/system-test/stake-operations-testcases/offline_stake_operations.sh
@@ -4,12 +4,25 @@
 # shellcheck disable=SC2068
 # shellcheck disable=SC2206
 # shellcheck disable=SC2162
+# shellcheck disable=SC2178
+# shellcheck disable=SC2145
 
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091
 source "$(dirname "$0")"/../automation_utils.sh
 
 set -e
+
+function get_signers_string() {
+  sign_only_output="$1"
+
+  signers=()
+  while read LINE; do
+    signers+=( --signer $LINE )
+  done <<<"$(sed -Ee $'s/^  ([a-km-zA-HJ-NP-Z1-9]{32,44}=[a-km-zA-HJ-NP-Z1-9]{64,88})$/\\1/\nt\nd' <<<"$sign_only_output")"
+
+  echo "${signers[@]}"
+}
 
 if [[ -n "$1" ]]; then
   url="$1"
@@ -85,10 +98,7 @@ sign_only="$(solana create-stake-account $stake_account_keypair 50 \
   --lockup-epoch 999 \
   --keypair $offline_system_account_keypair --url http://0.0.0.0)"
 
-signers=()
-while read LINE; do
-  signers+=( --signer $LINE )
-done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+signers="$(get_signers_string "${sign_only[@]})")"
 
 solana create-stake-account $stake_account_keypair 50 \
   --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
@@ -126,10 +136,7 @@ sign_only="$(solana split-stake --blockhash $nonce --nonce $nonce_account_pubkey
   --stake-authority $offline_staker_keypair $stake_account_address $split_stake_account_keypair 10 \
   --keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
 
-signers=()
-while read LINE; do
-  signers+=( --signer $LINE )
-done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+signers="$(get_signers_string "${sign_only[@]})")"
 
 solana split-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
   --stake-authority $offline_staker_pubkey $stake_account_address $split_stake_account_keypair 10 \
@@ -159,10 +166,7 @@ sign_only="$(solana stake-set-lockup --blockhash $nonce --nonce $nonce_account_p
   $split_stake_account_address --custodian $offline_custodian_keypair --lockup-epoch 0 \
   --keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
 
-signers=()
-while read LINE; do
-  signers+=( --signer $LINE )
-done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+signers="$(get_signers_string "${sign_only[@]})")"
 
 solana stake-set-lockup --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_keypair \
   $split_stake_account_address --custodian $offline_custodian_pubkey --lockup-epoch 0 \
@@ -187,10 +191,7 @@ sign_only="$(solana withdraw-stake --blockhash $nonce --nonce $nonce_account_pub
   --withdraw-authority $offline_withdrawer_keypair \
   --keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
 
-signers=()
-while read LINE; do
-  signers+=( --signer $LINE )
-done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+signers="$(get_signers_string "${sign_only[@]})")"
 
 solana withdraw-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
   $split_stake_account_address $offline_system_account_pubkey 10 \
@@ -217,10 +218,7 @@ sign_only="$(solana delegate-stake --blockhash $nonce --nonce $nonce_account_pub
 --stake-authority $offline_staker_keypair $stake_account_address $vote_account_pubkey \
 --keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
 
-signers=()
-while read LINE; do
-  signers+=( --signer $LINE )
-done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+signers="$(get_signers_string "${sign_only[@]})")"
 
 # Send the signed transaction on the cluster
 solana delegate-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \
@@ -246,10 +244,7 @@ sign_only="$(solana deactivate-stake --blockhash $nonce --nonce $nonce_account_p
 --stake-authority $offline_staker_keypair $stake_account_address \
 --keypair $offline_system_account_keypair --sign-only --url http://0.0.0.0)"
 
-signers=()
-while read LINE; do
-  signers+=( --signer $LINE )
-done <<<"$(sed -Ee $'s/^  ([a-zA-Z0-9]+=[a-zA-Z0-9]+)/\\1/\nt\nd' <<<"$sign_only")"
+signers="$(get_signers_string "${sign_only[@]})")"
 
 # Send the signed transaction on the cluster
 solana deactivate-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-authority $offline_system_account_pubkey \

--- a/system-test/stake-operations-testcases/offline_stake_operations.sh
+++ b/system-test/stake-operations-testcases/offline_stake_operations.sh
@@ -58,14 +58,14 @@ solana airdrop 2 $online_system_account_pubkey
 solana create-nonce-account $online_nonce_account_keypair 1 --nonce-authority $offline_system_account_pubkey --keypair $online_system_account_keypair
 nonce="$(solana nonce $nonce_account_pubkey)"
 
-echo --- OFFLINE SYSTEM ACCOUNT BALANCE BEFORE CREATING STAKE ACCOUNTS ---
+echo --- OFFLINE SYSTEM ACCOUNT BALANCE BEFORE CREATING STAKE ACCOUNTS
 (
   set -x
   solana balance $offline_system_account_pubkey
 )
 
 ################################
-echo +++ OFFLINE STAKE ACCOUNT CREATION +++
+echo --- OFFLINE STAKE ACCOUNT CREATION
 ################################
 
 # Create a stake account funded by the offline system account
@@ -93,21 +93,21 @@ solana create-stake-account $stake_account_keypair 50 \
   --lockup-epoch 999 \
   --from $offline_system_account_pubkey --fee-payer $offline_system_account_pubkey ${signers[@]}
 
-echo --- STAKE ACCOUNT AFTER CREATION ---
+echo --- STAKE ACCOUNT AFTER CREATION
 (
   set -x
   solana stake-account $stake_account_address
 )
 
 
-echo --- OFFLINE SYSTEM ACCOUNT BALANCE AFTER CREATING FIRST STAKE ACCOUNT ---
+echo --- OFFLINE SYSTEM ACCOUNT BALANCE AFTER CREATING FIRST STAKE ACCOUNT
 (
   set -x
   solana balance $offline_system_account_pubkey
 )
 
 #####################
-echo +++ OFFLINE STAKE SPLIT +++
+echo --- OFFLINE STAKE SPLIT
 #####################
 
 # Split the original stake account before delegating
@@ -131,20 +131,20 @@ solana split-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-auth
   --stake-authority $offline_staker_pubkey $stake_account_address $split_stake_account_keypair 10 \
   --fee-payer $offline_system_account_pubkey ${signers[@]}
 
-echo --- ORIGINAL STAKE ACCOUNT AFTER SPLITTING ---
+echo --- ORIGINAL STAKE ACCOUNT AFTER SPLITTING
 (
   set -x
   solana stake-account $stake_account_address
 )
 
-echo --- NEW STAKE ACCOUNT CREATED FROM SPLITTING ORIGINAL ---
+echo --- NEW STAKE ACCOUNT CREATED FROM SPLITTING ORIGINAL
 (
   set -x
   solana stake-account $split_stake_account_address
 )
 
 #####################
-echo +++ CUSTODIAN CHANGE LOCKUP +++
+echo --- CUSTODIAN CHANGE LOCKUP
 #####################
 
 # Set the lockup epoch to 0 to allow stake to be withdrawn
@@ -164,14 +164,14 @@ solana stake-set-lockup --blockhash $nonce --nonce $nonce_account_pubkey --nonce
   $split_stake_account_address --custodian $offline_custodian_pubkey --lockup-epoch 0 \
   --fee-payer $offline_system_account_pubkey ${signers[@]}
 
-echo --- SPLIT STAKE ACCOUNT AFTER CHANGING LOCKUP ---
+echo --- SPLIT STAKE ACCOUNT AFTER CHANGING LOCKUP
 (
   set -x
   solana stake-account $split_stake_account_address
 )
 
 ##########################
-echo +++ OFFLINE STAKE WITHDRAWAL +++
+echo --- OFFLINE STAKE WITHDRAWAL
 ##########################
 
 # Withdraw the lamports from the stake account that was split off and return them to the offline system account
@@ -193,14 +193,14 @@ solana withdraw-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-a
   --withdraw-authority $offline_withdrawer_pubkey \
   --fee-payer $offline_system_account_pubkey ${signers[@]}
 
-echo --- OFFLINE SYSTEM ACCOUNT BALANCE AFTER WITHDRAWING SPLIT STAKE ---
+echo --- OFFLINE SYSTEM ACCOUNT BALANCE AFTER WITHDRAWING SPLIT STAKE
 (
   set -x
   solana balance $offline_system_account_pubkey
 )
 
 ##########################
-echo +++ OFFLINE STAKE DELEGATION +++
+echo --- OFFLINE STAKE DELEGATION
 ##########################
 
 # Delegate stake from the original account to a vote account
@@ -223,14 +223,14 @@ solana delegate-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce-a
 --stake-authority $offline_staker_pubkey $stake_account_address $vote_account_pubkey \
 --fee-payer $offline_system_account_pubkey ${signers[@]}
 
-echo --- ORIGINAL STAKE ACCOUNT AFTER DELEGATION ---
+echo --- ORIGINAL STAKE ACCOUNT AFTER DELEGATION
 (
   set -x
   solana stake-account $stake_account_address
 )
 
 ##########################
- echo +++ OFFLINE STAKE DEACTIVATION +++
+ echo --- OFFLINE STAKE DEACTIVATION
 ##########################
 
 # Deactivate delegated stake
@@ -252,7 +252,7 @@ solana deactivate-stake --blockhash $nonce --nonce $nonce_account_pubkey --nonce
 --stake-authority $offline_staker_pubkey $stake_account_address \
 --fee-payer $offline_system_account_pubkey ${signers[@]}
 
-echo --- ORIGINAL STAKE ACCOUNT AFTER DEACTIVATION ---
+echo --- ORIGINAL STAKE ACCOUNT AFTER DEACTIVATION
 (
    set -x
    solana stake-account $stake_account_address

--- a/system-test/stake-operations-testcases/offline_stake_operations.sh
+++ b/system-test/stake-operations-testcases/offline_stake_operations.sh
@@ -12,7 +12,7 @@ if [[ -n "$1" ]]; then
 fi
 
 if [[ -z "$url" ]]; then
-  echo Provide complete URL, ex: "$0" http://testnet.solana.com:8899
+  echo Provide complete URL, ex: "$0" http://devnet.solana.com:8899
   exit 1
 fi
 solana config set --url $url

--- a/system-test/stake-operations-testcases/stake_test_automation.sh
+++ b/system-test/stake-operations-testcases/stake_test_automation.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+# shellcheck disable=SC1091
+source "$(dirname "$0")"/../automation_utils.sh
+
+curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v1.0.5/install/solana-install-init.sh | sh -s - 1.0.5
+
+# Create a single node cluster on colo, then call offline_stake_operations.sh against that cluster
+"${REPO_ROOT}"/net/colo.sh delete --reclaim-preemptible-reservations
+"${REPO_ROOT}"/net/colo.sh create -n 1 -c 0 -p stake-ops-testnet --dedicated
+"${REPO_ROOT}"/net/net.sh start -t edge
+
+bootstrapper_ip_address="$(get_bootstrap_validator_ip_address)"
+entrypoint=http://"${bootstrapper_ip_address}":8899
+
+"${REPO_ROOT}"/system-test/stake-operations-testcases/offline_stake_operations.sh "$entrypoint"

--- a/system-test/stake-operations-testcases/stake_test_automation.sh
+++ b/system-test/stake-operations-testcases/stake_test_automation.sh
@@ -6,9 +6,11 @@ set -ex
 # shellcheck disable=SC1091
 source "$(dirname "$0")"/../automation_utils.sh
 
-# Runs offline stake operations tests against a running cluster launched from the automation framework
+RESULT_FILE="$1"
 
+# Runs offline stake operations tests against a running cluster launched from the automation framework
 bootstrapper_ip_address="$(get_bootstrap_validator_ip_address)"
 entrypoint=http://"${bootstrapper_ip_address}":8899
-
 PATH="$REPO_ROOT"/solana-release/bin:$PATH "$REPO_ROOT"/system-test/stake-operations-testcases/offline_stake_operations.sh "$entrypoint"
+
+echo "Offline Stake Operations Test Succeeded" >>"$RESULT_FILE"

--- a/system-test/stake-operations-testcases/stake_test_automation.sh
+++ b/system-test/stake-operations-testcases/stake_test_automation.sh
@@ -1,19 +1,14 @@
 #!/usr/bin/env bash
 
-set -e
-set -x
+set -ex
 
+# shellcheck disable=SC1090
 # shellcheck disable=SC1091
 source "$(dirname "$0")"/../automation_utils.sh
 
-curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v1.0.5/install/solana-install-init.sh | sh -s - 1.0.5
-
-# Create a single node cluster on colo, then call offline_stake_operations.sh against that cluster
-"${REPO_ROOT}"/net/colo.sh delete --reclaim-preemptible-reservations
-"${REPO_ROOT}"/net/colo.sh create -n 1 -c 0 -p stake-ops-testnet --dedicated
-"${REPO_ROOT}"/net/net.sh start -t edge
+# Runs offline stake operations tests against a running cluster launched from the automation framework
 
 bootstrapper_ip_address="$(get_bootstrap_validator_ip_address)"
 entrypoint=http://"${bootstrapper_ip_address}":8899
 
-"${REPO_ROOT}"/system-test/stake-operations-testcases/offline_stake_operations.sh "$entrypoint"
+PATH="$REPO_ROOT"/solana-release/bin:$PATH "$REPO_ROOT"/system-test/stake-operations-testcases/offline_stake_operations.sh "$entrypoint"

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# shellcheck disable=SC2034
+# shellcheck disable=SC1090
 # shellcheck disable=SC1091
 source "$(dirname "$0")"/automation_utils.sh
 

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -185,7 +185,7 @@ function launch_testnet() {
   SLOTS_PER_SECOND="$(bc <<< "scale=3; ($END_SLOT - $START_SLOT)/($SLOT_COUNT_END_SECONDS - $SLOT_COUNT_START_SECONDS)")"
   execution_step "Average slot rate: $SLOTS_PER_SECOND slots/second over $((SLOT_COUNT_END_SECONDS - SLOT_COUNT_START_SECONDS)) seconds"
 
-  [[ -n $SKIP_PERF_RESULTS ]] || collect_performance_statistics
+  [[ "$SKIP_PERF_RESULTS" = "false" ]] || collect_performance_statistics
 
   echo "slots_per_second: $SLOTS_PER_SECOND" >>"$RESULT_FILE"
 
@@ -201,6 +201,7 @@ execution_step "Initialize Environment"
 [[ -n $TESTNET_TAG ]] || TESTNET_TAG=testnet-automation
 [[ -n $INFLUX_HOST ]] || INFLUX_HOST=https://metrics.solana.com:8086
 [[ -n $BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD ]] || BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD=66
+[[ -n $SKIP_PERF_RESULTS ]] || SKIP_PERF_RESULTS=false
 
 if [[ -z $NUMBER_OF_VALIDATOR_NODES ]]; then
   echo NUMBER_OF_VALIDATOR_NODES not defined

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC2034
 # shellcheck disable=SC1091
 source "$(dirname "$0")"/automation_utils.sh
 

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -147,30 +147,36 @@ function launch_testnet() {
   SLOT_COUNT_START_SECONDS=$SECONDS
   execution_step "Marking beginning of slot rate test - Slot: $START_SLOT, Seconds: $SLOT_COUNT_START_SECONDS"
 
-  if [[ -n $TEST_DURATION_SECONDS ]]; then
-    execution_step "Wait ${TEST_DURATION_SECONDS} seconds to complete test"
-    sleep "$TEST_DURATION_SECONDS"
-  elif [[ "$APPLY_PARTITIONS" = "true" ]]; then
-    STATS_START_SECONDS=$SECONDS
-    execution_step "Wait $PARTITION_INACTIVE_DURATION before beginning to apply partitions"
-    sleep "$PARTITION_INACTIVE_DURATION"
-    for (( i=1; i<=PARTITION_ITERATION_COUNT; i++ )); do
-      execution_step "Partition Iteration $i of $PARTITION_ITERATION_COUNT"
-      execution_step "Applying netem config $NETEM_CONFIG_FILE for $PARTITION_ACTIVE_DURATION seconds"
-      "${REPO_ROOT}"/net/net.sh netem --config-file "$NETEM_CONFIG_FILE"
-      sleep "$PARTITION_ACTIVE_DURATION"
-
-      execution_step "Resolving partitions for $PARTITION_INACTIVE_DURATION seconds"
-      "${REPO_ROOT}"/net/net.sh netem --config-file "$NETEM_CONFIG_FILE" --netem-cmd cleanup
+  case $TEST_TYPE in
+    fixed_duration)
+      execution_step "Wait ${TEST_DURATION_SECONDS} seconds to complete test"
+      sleep "$TEST_DURATION_SECONDS"
+      ;;
+    partition)
+      STATS_START_SECONDS=$SECONDS
+      execution_step "Wait $PARTITION_INACTIVE_DURATION before beginning to apply partitions"
       sleep "$PARTITION_INACTIVE_DURATION"
-    done
-    STATS_FINISH_SECONDS=$SECONDS
-    TEST_DURATION_SECONDS=$((STATS_FINISH_SECONDS - STATS_START_SECONDS))
-  else
-    # We should never get here
-    echo Test duration and partition config not defined
-    exit 1
-  fi
+      for (( i=1; i<=PARTITION_ITERATION_COUNT; i++ )); do
+        execution_step "Partition Iteration $i of $PARTITION_ITERATION_COUNT"
+        execution_step "Applying netem config $NETEM_CONFIG_FILE for $PARTITION_ACTIVE_DURATION seconds"
+        "${REPO_ROOT}"/net/net.sh netem --config-file "$NETEM_CONFIG_FILE"
+        sleep "$PARTITION_ACTIVE_DURATION"
+
+        execution_step "Resolving partitions for $PARTITION_INACTIVE_DURATION seconds"
+        "${REPO_ROOT}"/net/net.sh netem --config-file "$NETEM_CONFIG_FILE" --netem-cmd cleanup
+        sleep "$PARTITION_INACTIVE_DURATION"
+      done
+      STATS_FINISH_SECONDS=$SECONDS
+      TEST_DURATION_SECONDS=$((STATS_FINISH_SECONDS - STATS_START_SECONDS))
+      ;;
+    script)
+      execution_step "Running custom script: ${REPO_ROOT}/${CUSTOM_SCRIPT}"
+      "$REPO_ROOT"/"$CUSTOM_SCRIPT"
+      ;;
+    *)
+      echo "Error: Unsupported test type: $TEST_TYPE"
+      ;;
+  esac
 
   END_SLOT=$(get_slot)
   SLOT_COUNT_END_SECONDS=$SECONDS
@@ -179,63 +185,10 @@ function launch_testnet() {
   SLOTS_PER_SECOND="$(bc <<< "scale=3; ($END_SLOT - $START_SLOT)/($SLOT_COUNT_END_SECONDS - $SLOT_COUNT_START_SECONDS)")"
   execution_step "Average slot rate: $SLOTS_PER_SECOND slots/second over $((SLOT_COUNT_END_SECONDS - SLOT_COUNT_START_SECONDS)) seconds"
 
-  execution_step "Collect statistics about run"
-  declare q_mean_tps='
-    SELECT ROUND(MEAN("median_sum")) as "mean_tps" FROM (
-      SELECT MEDIAN(sum_count) AS "median_sum" FROM (
-        SELECT SUM("count") AS "sum_count"
-          FROM "'$TESTNET_TAG'"."autogen"."bank-process_transactions"
-          WHERE time > now() - '"$TEST_DURATION_SECONDS"'s AND count > 0
-          GROUP BY time(1s), host_id)
-      GROUP BY time(1s)
-    )'
-
-  declare q_max_tps='
-    SELECT MAX("median_sum") as "max_tps" FROM (
-      SELECT MEDIAN(sum_count) AS "median_sum" FROM (
-        SELECT SUM("count") AS "sum_count"
-          FROM "'$TESTNET_TAG'"."autogen"."bank-process_transactions"
-          WHERE time > now() - '"$TEST_DURATION_SECONDS"'s AND count > 0
-          GROUP BY time(1s), host_id)
-      GROUP BY time(1s)
-    )'
-
-  declare q_mean_confirmation='
-    SELECT round(mean("duration_ms")) as "mean_confirmation_ms"
-      FROM "'$TESTNET_TAG'"."autogen"."validator-confirmation"
-      WHERE time > now() - '"$TEST_DURATION_SECONDS"'s'
-
-  declare q_max_confirmation='
-    SELECT round(max("duration_ms")) as "max_confirmation_ms"
-      FROM "'$TESTNET_TAG'"."autogen"."validator-confirmation"
-      WHERE time > now() - '"$TEST_DURATION_SECONDS"'s'
-
-  declare q_99th_confirmation='
-    SELECT round(percentile("duration_ms", 99)) as "99th_percentile_confirmation_ms"
-      FROM "'$TESTNET_TAG'"."autogen"."validator-confirmation"
-      WHERE time > now() - '"$TEST_DURATION_SECONDS"'s'
-
-  declare q_max_tower_distance_observed='
-    SELECT MAX("tower_distance") as "max_tower_distance" FROM (
-      SELECT last("slot") - last("root") as "tower_distance"
-        FROM "'$TESTNET_TAG'"."autogen"."tower-observed"
-        WHERE time > now() - '"$TEST_DURATION_SECONDS"'s
-        GROUP BY time(1s), host_id)'
-
-  declare q_last_tower_distance_observed='
-      SELECT MEAN("tower_distance") as "last_tower_distance" FROM (
-            SELECT last("slot") - last("root") as "tower_distance"
-              FROM "'$TESTNET_TAG'"."autogen"."tower-observed"
-              GROUP BY host_id)'
-
-  curl -G "${INFLUX_HOST}/query?u=ro&p=topsecret" \
-    --data-urlencode "db=${TESTNET_TAG}" \
-    --data-urlencode "q=$q_mean_tps;$q_max_tps;$q_mean_confirmation;$q_max_confirmation;$q_99th_confirmation;$q_max_tower_distance_observed;$q_last_tower_distance_observed" |
-    python "${REPO_ROOT}"/system-test/testnet-automation-json-parser.py >>"$RESULT_FILE"
+  [[ -n $SKIP_PERF_RESULTS ]] || collect_performance_statistics
 
   echo "slots_per_second: $SLOTS_PER_SECOND" >>"$RESULT_FILE"
 
-  execution_step "Writing test results to ${RESULT_FILE}"
   RESULT_DETAILS=$(<"$RESULT_FILE")
   upload-ci-artifact "$RESULT_FILE"
 }
@@ -292,18 +245,35 @@ if [[ "$USE_PUBLIC_IP_ADDRESSES" = "true" ]]; then
   maybePublicIpAddresses="-P"
 fi
 
-: "${CLIENT_DELAY_START:=0}"
+execution_step "Checking for required parameters"
+testTypeRequiredParameters=
+case $TEST_TYPE in
+  fixed_duration)
+    testTypeRequiredParameters+=TEST_DURATION_SECONDS
+    ;;
+  partition)
+    testTypeRequiredParameters+=NETEM_CONFIG_FILE
+    testTypeRequiredParameters+=PARTITION_ACTIVE_DURATION
+    testTypeRequiredParameters+=PARTITION_INACTIVE_DURATION
+    testTypeRequiredParameters+=PARTITION_ITERATION_COUNT
+    ;;
+  script)
+    testTypeRequiredParameters+=CUSTOM_SCRIPT
+    ;;
+  *)
+    echo "Error: Unsupported test type: $TEST_TYPE"
+    ;;
+esac
 
-if [[ -z $APPLY_PARTITIONS ]]; then
-  APPLY_PARTITIONS=false
-fi
-if [[ "$APPLY_PARTITIONS" = "true" ]]; then
-  if [[ -n $TEST_DURATION_SECONDS ]]; then
-    echo Cannot accept TEST_DURATION_SECONDS and a parition looping config
-    exit 1
+missingParameters=
+for i in "${testTypeRequiredParameters[@]}"; do
+  if [[ -z ${!i} ]]; then
+    missingParameters+="${i} "
   fi
-elif [[ -z $TEST_DURATION_SECONDS ]]; then
-  echo TEST_DURATION_SECONDS not defined
+done
+
+if [[ -n $missingParameters ]]; then
+  echo "Error: For test type $TEST_TYPE, the following required parameters are missing: ${missingParameters[*]}"
   exit 1
 fi
 


### PR DESCRIPTION
#### Problem
 -  Cluster framework needs greater flexibility as we add more flavors of test cases.
 -  We don't have test/example scripts for the various staking operations, particularly the offline signing maneuvers.

#### Summary of Changes
 1) Re-factor the automation framework to be able to run arbitrary scripts on a configurable testnet after the cluster has launched. (`system-test/stake-operations-testcases/offline_stake_colo.yml` is an example of a testcase that calls a `CUSTOM_SCRIPT` after successful cluster launch.)

 2) Distinguish between testcases that should run a sleep time, partition looping logic, or a script

 3) Create test script (`system-test/stake-operations-testcases/offline_stake_operations.sh`) that points at a running cluster and uses a nonce account and the offline signing workflow to do all staking operations.  This can be run from the automation framework or manually without any environment dependencies, other than having `solana` and `solana-keygen` in your `PATH`.

 4) Add a buildkite-readable testcase to wrap up the creation of a colo or GCE testnet and run the stake operations against it. 

5) Add `SKIP_PERF_RESULTS` flag to buildkite testcases to skip printing TPS, confirmation time and slot rate for non-performance (ie staking ops) cases where we don't care about those values.  Reducing output clutter.

Fixes #6194 
