### PR TITLE
Remove granularity from genesis

### DIFF
--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -206,13 +206,10 @@ fn add_stakes(
     genesis_config: &mut GenesisConfig,
     staker_infos: &[StakerInfo],
     unlock_info: &UnlockInfo,
-    granularity: u64,
 ) -> u64 {
     staker_infos
         .iter()
-        .map(|staker_info| {
-            create_and_add_stakes(genesis_config, staker_info, unlock_info, granularity)
-        })
+        .map(|staker_info| create_and_add_stakes(genesis_config, staker_info, unlock_info, None))
         .sum::<u64>()
 }
 
@@ -224,23 +221,16 @@ pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig, mut issued_lampo
         genesis_config,
         &BATCH_FOUR_STAKER_INFOS,
         &UNLOCKS_ALL_AT_9_MONTHS,
-        1_000_000 * LAMPORTS_PER_SOL,
     ) + add_stakes(
         genesis_config,
         &FOUNDATION_STAKER_INFOS,
         &UNLOCKS_ALL_DAY_ZERO,
-        1_000_000 * LAMPORTS_PER_SOL,
-    ) + add_stakes(
-        genesis_config,
-        &GRANTS_STAKER_INFOS,
-        &UNLOCKS_ALL_DAY_ZERO,
-        1_000_000 * LAMPORTS_PER_SOL,
-    ) + add_stakes(
-        genesis_config,
-        &COMMUNITY_STAKER_INFOS,
-        &UNLOCKS_ALL_DAY_ZERO,
-        1_000_000 * LAMPORTS_PER_SOL,
-    );
+    ) + add_stakes(genesis_config, &GRANTS_STAKER_INFOS, &UNLOCKS_ALL_DAY_ZERO)
+        + add_stakes(
+            genesis_config,
+            &COMMUNITY_STAKER_INFOS,
+            &UNLOCKS_ALL_DAY_ZERO,
+        );
 
     // "one thanks" (community pool) gets 500_000_000SOL (total) - above distributions
     create_and_add_stakes(
@@ -252,7 +242,7 @@ pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig, mut issued_lampo
             withdrawer: Some("3FFaheyqtyAXZSYxDzsr5CVKvJuvZD1WE1VEsBtDbRqB"),
         },
         &UNLOCKS_ALL_DAY_ZERO,
-        1_000_000 * LAMPORTS_PER_SOL,
+        None,
     );
 }
 

--- a/genesis/src/stakes.rs
+++ b/genesis/src/stakes.rs
@@ -42,8 +42,9 @@ pub fn create_and_add_stakes(
     // description of how the stakes' lockups will expire
     unlock_info: &UnlockInfo,
     // the largest each stake account should be, in lamports
-    granularity: u64,
+    granularity: Option<u64>,
 ) -> u64 {
+    let granularity = granularity.unwrap_or(std::u64::MAX);
     let staker = &staker_info
         .staker
         .parse::<Pubkey>()
@@ -171,7 +172,7 @@ mod tests {
     ) {
         assert_eq!(
             total_lamports,
-            create_and_add_stakes(genesis_config, staker_info, unlock_info, granularity)
+            create_and_add_stakes(genesis_config, staker_info, unlock_info, Some(granularity))
         );
         assert_eq!(genesis_config.accounts.len(), len);
         assert_eq!(


### PR DESCRIPTION
#### Problem

The genesis granularity feature looks like it adds obfuscation at first glance, but all the information is in this genesis_accounts.rs file, so it only really obfuscates the accounts database, and makes it awkward to verify all the accounts are in the right place.

Breaking up stake accounts by granularity creates a handful of problems:
* Lots of Accounts, each requiring rent
* Lots of accounts with custodians, each which would need to be updated to change lockups
* The amount user wants to delegate may change, which would require at least the same number of commands to `withdraw-stake` and/or `split-stake`.

#### Summary of Changes

Don't use the granularity feature. Instead, put all tokens into each identity's stake account.

I good reason *not* to move forward with this PR is because `add_stakes` nicely ensures the stake account will be rent exempt.  That said, rent will still be a problem for the command-line user, so we need to ensure those tools exist anyway. Maybe they do already?

Regarding unit-tests, this case conveniently already tests exactly this scenario - using `std::u64::MAX` and verifying only the 2 accounts are created (System+Stake).