### PR TITLE
Rename deactivate-stake and split-stake

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -251,7 +251,7 @@ pub enum CliCommand {
         fee_payer: SignerIndex,
         from: SignerIndex,
     },
-    DeactivateStake {
+    DeactivateStakeAccount {
         stake_account_pubkey: Pubkey,
         stake_authority: SignerIndex,
         sign_only: bool,
@@ -271,7 +271,7 @@ pub enum CliCommand {
         nonce_authority: SignerIndex,
         fee_payer: SignerIndex,
     },
-    SplitStake {
+    SplitStakeAccount {
         stake_account_pubkey: Pubkey,
         stake_authority: SignerIndex,
         sign_only: bool,
@@ -557,10 +557,10 @@ pub fn parse_command(
         ("withdraw-stake", Some(matches)) => {
             parse_stake_withdraw_stake(matches, default_signer_path, wallet_manager)
         }
-        ("deactivate-stake", Some(matches)) => {
+        ("deactivate-stake-account", Some(matches)) => {
             parse_stake_deactivate_stake(matches, default_signer_path, wallet_manager)
         }
-        ("split-stake", Some(matches)) => {
+        ("split-stake-account", Some(matches)) => {
             parse_split_stake(matches, default_signer_path, wallet_manager)
         }
         ("stake-authorize-staker", Some(matches)) => parse_stake_authorize(
@@ -1602,7 +1602,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *fee_payer,
             *from,
         ),
-        CliCommand::DeactivateStake {
+        CliCommand::DeactivateStakeAccount {
             stake_account_pubkey,
             stake_authority,
             sign_only,
@@ -1644,7 +1644,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *nonce_authority,
             *fee_payer,
         ),
-        CliCommand::SplitStake {
+        CliCommand::SplitStakeAccount {
             stake_account_pubkey,
             stake_authority,
             sign_only,
@@ -3070,7 +3070,7 @@ mod tests {
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
         let stake_pubkey = Pubkey::new_rand();
-        config.command = CliCommand::DeactivateStake {
+        config.command = CliCommand::DeactivateStakeAccount {
             stake_account_pubkey: stake_pubkey,
             stake_authority: 0,
             sign_only: false,
@@ -3084,7 +3084,7 @@ mod tests {
 
         let stake_pubkey = Pubkey::new_rand();
         let split_stake_account = Keypair::new();
-        config.command = CliCommand::SplitStake {
+        config.command = CliCommand::SplitStakeAccount {
             stake_account_pubkey: stake_pubkey,
             stake_authority: 0,
             sign_only: false,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -235,7 +235,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(fee_payer_arg())
         )
         .subcommand(
-            SubCommand::with_name("deactivate-stake")
+            SubCommand::with_name("deactivate-stake-account")
                 .about("Deactivate the delegated stake from the stake account")
                 .arg(
                     Arg::with_name("stake_account_pubkey")
@@ -252,7 +252,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(fee_payer_arg())
         )
         .subcommand(
-            SubCommand::with_name("split-stake")
+            SubCommand::with_name("split-stake-account")
                 .about("Split a stake account")
                 .arg(
                     Arg::with_name("stake_account_pubkey")
@@ -574,7 +574,7 @@ pub fn parse_split_stake(
         generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
-        command: CliCommand::SplitStake {
+        command: CliCommand::SplitStakeAccount {
             stake_account_pubkey,
             stake_authority: signer_info.index_of(stake_authority_pubkey).unwrap(),
             sign_only,
@@ -613,7 +613,7 @@ pub fn parse_stake_deactivate_stake(
         generate_unique_signers(bulk_signers, matches, default_signer_path, wallet_manager)?;
 
     Ok(CliCommandInfo {
-        command: CliCommand::DeactivateStake {
+        command: CliCommand::DeactivateStakeAccount {
             stake_account_pubkey,
             stake_authority: signer_info.index_of(stake_authority_pubkey).unwrap(),
             sign_only,
@@ -2297,16 +2297,16 @@ mod tests {
             }
         );
 
-        // Test DeactivateStake Subcommand
+        // Test DeactivateStakeAccount Subcommand
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
-            "deactivate-stake",
+            "deactivate-stake-account",
             &stake_account_string,
         ]);
         assert_eq!(
             parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::DeactivateStake {
+                command: CliCommand::DeactivateStakeAccount {
                     stake_account_pubkey,
                     stake_authority: 0,
                     sign_only: false,
@@ -2319,10 +2319,10 @@ mod tests {
             }
         );
 
-        // Test DeactivateStake Subcommand w/ authority
+        // Test DeactivateStakeAccount Subcommand w/ authority
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
-            "deactivate-stake",
+            "deactivate-stake-account",
             &stake_account_string,
             "--stake-authority",
             &stake_authority_keypair_file,
@@ -2330,7 +2330,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::DeactivateStake {
+                command: CliCommand::DeactivateStakeAccount {
                     stake_account_pubkey,
                     stake_authority: 1,
                     sign_only: false,
@@ -2353,7 +2353,7 @@ mod tests {
         let blockhash_string = format!("{}", blockhash);
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
-            "deactivate-stake",
+            "deactivate-stake-account",
             &stake_account_string,
             "--blockhash",
             &blockhash_string,
@@ -2361,7 +2361,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::DeactivateStake {
+                command: CliCommand::DeactivateStakeAccount {
                     stake_account_pubkey,
                     stake_authority: 0,
                     sign_only: false,
@@ -2376,7 +2376,7 @@ mod tests {
 
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
-            "deactivate-stake",
+            "deactivate-stake-account",
             &stake_account_string,
             "--blockhash",
             &blockhash_string,
@@ -2385,7 +2385,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::DeactivateStake {
+                command: CliCommand::DeactivateStakeAccount {
                     stake_account_pubkey,
                     stake_authority: 0,
                     sign_only: true,
@@ -2404,7 +2404,7 @@ mod tests {
         let signer1 = format!("{}={}", key1, sig1);
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
-            "deactivate-stake",
+            "deactivate-stake-account",
             &stake_account_string,
             "--blockhash",
             &blockhash_string,
@@ -2416,7 +2416,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::DeactivateStake {
+                command: CliCommand::DeactivateStakeAccount {
                     stake_account_pubkey,
                     stake_authority: 0,
                     sign_only: false,
@@ -2438,7 +2438,7 @@ mod tests {
         let signer2 = format!("{}={}", key2, sig2);
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
-            "deactivate-stake",
+            "deactivate-stake-account",
             &stake_account_string,
             "--blockhash",
             &blockhash_string,
@@ -2456,7 +2456,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::DeactivateStake {
+                command: CliCommand::DeactivateStakeAccount {
                     stake_account_pubkey,
                     stake_authority: 0,
                     sign_only: false,
@@ -2476,7 +2476,7 @@ mod tests {
         // Test Deactivate Subcommand w/ fee-payer
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
             "test",
-            "deactivate-stake",
+            "deactivate-stake-account",
             &stake_account_string,
             "--fee-payer",
             &fee_payer_keypair_file,
@@ -2484,7 +2484,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::DeactivateStake {
+                command: CliCommand::DeactivateStakeAccount {
                     stake_account_pubkey,
                     stake_authority: 0,
                     sign_only: false,
@@ -2500,7 +2500,7 @@ mod tests {
             }
         );
 
-        // Test SplitStake SubCommand
+        // Test SplitStakeAccount SubCommand
         let (keypair_file, mut tmp_file) = make_tmp_file();
         let stake_account_keypair = Keypair::new();
         write_keypair(&stake_account_keypair, tmp_file.as_file_mut()).unwrap();
@@ -2510,7 +2510,7 @@ mod tests {
 
         let test_split_stake_account = test_commands.clone().get_matches_from(vec![
             "test",
-            "split-stake",
+            "split-stake-account",
             &keypair_file,
             &split_stake_account_keypair_file,
             "50",
@@ -2518,7 +2518,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_split_stake_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::SplitStake {
+                command: CliCommand::SplitStakeAccount {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
                     stake_authority: 0,
                     sign_only: false,
@@ -2557,7 +2557,7 @@ mod tests {
 
         let test_split_stake_account = test_commands.clone().get_matches_from(vec![
             "test",
-            "split-stake",
+            "split-stake-account",
             &keypair_file,
             &split_stake_account_keypair_file,
             "50",
@@ -2579,7 +2579,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_split_stake_account, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::SplitStake {
+                command: CliCommand::SplitStakeAccount {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
                     stake_authority: 0,
                     sign_only: false,

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -195,7 +195,7 @@ fn test_seed_stake_delegation_and_deactivation() {
     process_command(&config_validator).unwrap();
 
     // Deactivate stake
-    config_validator.command = CliCommand::DeactivateStake {
+    config_validator.command = CliCommand::DeactivateStakeAccount {
         stake_account_pubkey: stake_address,
         stake_authority: 0,
         sign_only: false,
@@ -279,7 +279,7 @@ fn test_stake_delegation_and_deactivation() {
     process_command(&config_validator).unwrap();
 
     // Deactivate stake
-    config_validator.command = CliCommand::DeactivateStake {
+    config_validator.command = CliCommand::DeactivateStakeAccount {
         stake_account_pubkey: stake_keypair.pubkey(),
         stake_authority: 0,
         sign_only: false,
@@ -401,7 +401,7 @@ fn test_offline_stake_delegation_and_deactivation() {
 
     // Deactivate stake offline
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
-    config_offline.command = CliCommand::DeactivateStake {
+    config_offline.command = CliCommand::DeactivateStakeAccount {
         stake_account_pubkey: stake_keypair.pubkey(),
         stake_authority: 0,
         sign_only: true,
@@ -415,7 +415,7 @@ fn test_offline_stake_delegation_and_deactivation() {
     let offline_presigner =
         presigner_from_pubkey_sigs(&config_offline.signers[0].pubkey(), &signers).unwrap();
     config_payer.signers = vec![&offline_presigner];
-    config_payer.command = CliCommand::DeactivateStake {
+    config_payer.command = CliCommand::DeactivateStakeAccount {
         stake_account_pubkey: stake_keypair.pubkey(),
         stake_authority: 0,
         sign_only: false,
@@ -527,7 +527,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     };
 
     // Deactivate stake
-    config.command = CliCommand::DeactivateStake {
+    config.command = CliCommand::DeactivateStakeAccount {
         stake_account_pubkey: stake_keypair.pubkey(),
         stake_authority: 0,
         sign_only: false,
@@ -1004,7 +1004,7 @@ fn test_stake_split() {
     let split_account = keypair_from_seed(&[2u8; 32]).unwrap();
     check_balance(0, &rpc_client, &split_account.pubkey());
     config_offline.signers.push(&split_account);
-    config_offline.command = CliCommand::SplitStake {
+    config_offline.command = CliCommand::SplitStakeAccount {
         stake_account_pubkey: stake_account_pubkey,
         stake_authority: 0,
         sign_only: true,
@@ -1020,7 +1020,7 @@ fn test_stake_split() {
     let (blockhash, signers) = parse_sign_only_reply_string(&sig_response);
     let offline_presigner = presigner_from_pubkey_sigs(&offline_pubkey, &signers).unwrap();
     config.signers = vec![&offline_presigner, &split_account];
-    config.command = CliCommand::SplitStake {
+    config.command = CliCommand::SplitStakeAccount {
         stake_account_pubkey: stake_account_pubkey,
         stake_authority: 0,
         sign_only: false,

--- a/docs/src/cli/usage.md
+++ b/docs/src/cli/usage.md
@@ -223,7 +223,7 @@ SUBCOMMANDS:
     create-stake-account                Create a stake account
     create-validator-storage-account    Create a validator storage account
     create-vote-account                 Create a vote account
-    deactivate-stake                    Deactivate the delegated stake from the stake account
+    deactivate-stake-account            Deactivate the delegated stake from the stake account
     delegate-stake                      Delegate stake to a vote account
     deploy                              Deploy a program
     epoch-info                          Get information about the current epoch
@@ -241,7 +241,7 @@ SUBCOMMANDS:
     send-signature                      Send a signature to authorize a transfer
     send-timestamp                      Send a timestamp to unlock a transfer
     slot                                Get current slot
-    split-stake                         Split a stake account
+    split-stake-account                 Split a stake account
     stake-account                       Show the contents of a stake account
     stake-authorize-staker              Authorize a new stake signing keypair for the given stake account
     stake-authorize-withdrawer          Authorize a new withdraw signing keypair for the given stake account
@@ -830,13 +830,13 @@ ARGS:
     <VALIDATOR IDENTITY PUBKEY>    Validator that will vote with this account
 ```
 
-#### solana-deactivate-stake
+#### solana-deactivate-stake-account
 ```text
-solana-deactivate-stake
+solana-deactivate-stake-account
 Deactivate the delegated stake from the stake account
 
 USAGE:
-    solana deactivate-stake [FLAGS] [OPTIONS] <STAKE ACCOUNT>
+    solana deactivate-stake-account [FLAGS] [OPTIONS] <STAKE ACCOUNT>
 
 FLAGS:
     -h, --help                           Prints help information
@@ -1349,13 +1349,13 @@ OPTIONS:
     -k, --keypair <PATH>                    /path/to/id.json or usb://remote/wallet/path
 ```
 
-#### solana-split-stake
+#### solana-split-stake-account
 ```text
-solana-split-stake
+solana-split-stake-account
 Split a stake account
 
 USAGE:
-    solana split-stake [FLAGS] [OPTIONS] <STAKE ACCOUNT> <SPLIT STAKE ACCOUNT> <AMOUNT>
+    solana split-stake-account [FLAGS] [OPTIONS] <STAKE ACCOUNT> <SPLIT STAKE ACCOUNT> <AMOUNT>
 
 FLAGS:
     -h, --help                           Prints help information

--- a/docs/src/offline-signing/README.md
+++ b/docs/src/offline-signing/README.md
@@ -15,7 +15,7 @@ transaction.
 
 At present, the following commands support offline signing:
   * [`delegate-stake`](../api-reference/cli.md#solana-delegate-stake)
-  * [`deactivate-stake`](../api-reference/cli.md#solana-deactivate-stake)
+  * [`deactivate-stake-account`](../api-reference/cli.md#solana-deactivate-stake-account)
   * [`pay`](../api-reference/cli.md#solana-pay)
 
 ## Signing Transactions Offline

--- a/docs/src/offline-signing/durable-nonce.md
+++ b/docs/src/offline-signing/durable-nonce.md
@@ -174,7 +174,7 @@ supported.
 The following subcommands have received this treatment so far
 * [`pay`](../api-reference/cli.md#solana-pay)
 * [`delegate-stake`](../api-reference/cli.md#solana-delegate-stake)
-* [`deactivate-stake`](../api-reference/cli.md#solana-deactivate-stake)
+* [`deactivate-stake-account`](../api-reference/cli.md#solana-deactivate-stake-account)
 
 ### Example Pay Using Durable Nonce
 

--- a/docs/src/running-validator/validator-stake.md
+++ b/docs/src/running-validator/validator-stake.md
@@ -115,7 +115,7 @@ Before detaching your validator from the cluster, you should deactivate the
 stake that was previously delegated by running:
 
 ```bash
-solana deactivate-stake ~/validator-stake-keypair.json
+solana deactivate-stake-account ~/validator-stake-keypair.json
 ```
 
 Stake is not deactivated immediately and instead cools down in a similar fashion

--- a/docs/src/tour-de-sol/participation/steps-to-create-a-validator/delegating-stake.md
+++ b/docs/src/tour-de-sol/participation/steps-to-create-a-validator/delegating-stake.md
@@ -76,7 +76,7 @@ Helpful JSON-RPC methods:
 Before detaching your validator from the TdS cluster, you should deactivate the stake that was previously delegated by running:
 
 ```bash
-solana deactivate-stake ~/validator-stake-keypair.json
+solana deactivate-stake-account ~/validator-stake-keypair.json
 ```
 
 Stake is not deactivated immediately and instead cools down in a similar fashion as stake warm up.  Your validator should remain attached to the cluster while the stake is cooling down. More information about the stake cool down can be found [here](../../../running-validator/validator-stake.md)


### PR DESCRIPTION
#### Problem

Misleading names in the CLI. While indeed they deactivate stake and split stake, respectively, their primary side-effect is on the account, not the stake.  The name deactivate-stake is problematic, because there's no way to delegate stake after the command is called. The account itself has been deactivated. In the case of split-stake, the issue is more subtle - the current name might imply configuring the account to split its stake across two vote accounts.

#### Summary of Changes

* Rename `solana deactivate-stake` to `solana deactivate-stake-account`
* Rename `solana split-stake` to `solana split-stake-account`
