### PR TITLE
rpc: GET for /snapshot.tar.bz2 now redirects to the latest snapshot

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -237,6 +237,7 @@ impl Validator {
                 JsonRpcService::new(
                     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), rpc_port),
                     config.rpc_config.clone(),
+                    config.snapshot_config.clone(),
                     bank_forks.clone(),
                     block_commitment_cache.clone(),
                     blockstore.clone(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2,7 +2,7 @@ use bzip2::bufread::BzDecoder;
 use clap::{
     crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App, Arg, ArgMatches,
 };
-use console::{style, Emoji};
+use console::Emoji;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
 use rand::{thread_rng, Rng};
@@ -953,12 +953,6 @@ pub fn main() {
         warn!("--vote-signer-address ignored");
     }
 
-    println!(
-        "{} {}",
-        style(crate_name!()).bold(),
-        solana_clap_utils::version!()
-    );
-
     let _log_redirect = {
         #[cfg(unix)]
         {
@@ -996,6 +990,7 @@ pub fn main() {
         .join(","),
     );
 
+    info!("{} {}", crate_name!(), solana_clap_utils::version!());
     info!("Starting validator with: {:#?}", std::env::args_os());
 
     let vote_account = pubkey_of(&matches, "vote_account").unwrap_or_else(|| {


### PR DESCRIPTION
With the recent `snapshot-<slot>-<hash>.tar.bz2` change (#8482), we lost a convenient mechanism to fetch the latest snapshot from a node.    This PR restores this nicety by redirecting GETs for `/snapshot.tar.bz2` to the latest snapshot