### PR TITLE
watchtower: send error message in notification

### DIFF
--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -55,7 +55,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let notifier = Notifier::new();
     let mut last_transaction_count = 0;
-    let mut last_check_notification_sent = false;
     loop {
         let mut notify_msg = String::from("solana-watchtower: undefined error");
         let ok = rpc_client
@@ -166,13 +165,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
         datapoint_info!("watchtower-sanity", ("ok", ok, bool));
         if !ok {
-            last_check_notification_sent = true;
             notifier.send(&notify_msg);
-        } else {
-            if last_check_notification_sent {
-                notifier.send("solana-watchtower: All Clear");
-            }
-            last_check_notification_sent = false;
         }
         sleep(interval);
     }

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -56,6 +56,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let notifier = Notifier::new();
     let mut last_transaction_count = 0;
     loop {
+        let mut notify_msg = String::from("solana-watchtower: undefined error");
         let ok = rpc_client
             .get_transaction_count()
             .and_then(|transaction_count| {
@@ -75,6 +76,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 }
             })
             .unwrap_or_else(|err| {
+                notify_msg = format!("solana-watchtower: {}", err.to_string());
                 datapoint_error!(
                     "watchtower-sanity-failure",
                     ("test", "transaction-count", String),
@@ -93,6 +95,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     Ok(true)
                 })
                 .unwrap_or_else(|err| {
+                    notify_msg = format!("solana-watchtower: {}", err.to_string());
                     datapoint_error!(
                         "watchtower-sanity-failure",
                         ("test", "blockhash", String),
@@ -149,6 +152,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     }
                 })
                 .unwrap_or_else(|err| {
+                    notify_msg = format!("solana-watchtower: {}", err.to_string());
                     datapoint_error!(
                         "watchtower-sanity-failure",
                         ("test", "delinquent-validators", String),
@@ -157,9 +161,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     false
                 });
 
+
+
         datapoint_info!("watchtower-sanity", ("ok", ok, bool));
         if !ok {
-            notifier.send("solana-watchtower sanity failure");
+            notifier.send(&notify_msg);
         }
         sleep(interval);
     }

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -55,6 +55,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let notifier = Notifier::new();
     let mut last_transaction_count = 0;
+    let mut last_check_notification_sent = false;
     loop {
         let mut notify_msg = String::from("solana-watchtower: undefined error");
         let ok = rpc_client
@@ -165,7 +166,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
         datapoint_info!("watchtower-sanity", ("ok", ok, bool));
         if !ok {
+            last_check_notification_sent = true;
             notifier.send(&notify_msg);
+        } else {
+            if last_check_notification_sent {
+                notifier.send("solana-watchtower: All Clear");
+            }
+            last_check_notification_sent = false;
         }
         sleep(interval);
     }


### PR DESCRIPTION
#### Problem

On failing a test, watchtower writes the error message to the log file, however the error message sent via the notification (telegram, discord) is always the same.

Sometimes a check fails just to have the subsequent check be ok, send All Clear to indicate everything is ok again.

#### Summary of Changes

Sends the error message as notification.

Sends All Clear on ok after fail.

Fixes #

Corresponds to https://github.com/solana-labs/solana/issues/8443 https://github.com/solana-labs/solana/issues/8444