### PR TITLE
Cli: add subcommand to withdraw from vote account

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -364,6 +364,12 @@ pub enum CliCommand {
         use_lamports_unit: bool,
         commitment_config: CommitmentConfig,
     },
+    VoteAccountWithdraw {
+        vote_account_pubkey: Pubkey,
+        withdrawer_account_pubkey: Pubkey,
+        lamports: u64,
+        to_account_pubkey: Pubkey,
+    },
     VoteAuthorize {
         vote_account_pubkey: Pubkey,
         new_authorized_pubkey: Pubkey,
@@ -696,6 +702,9 @@ pub fn parse_command(
             VoteAuthorize::Withdrawer,
         ),
         ("vote-account", Some(matches)) => parse_vote_get_account_command(matches),
+        ("vote-account-withdraw", Some(matches)) => {
+            parse_vote_account_withdraw_command(matches, default_signer_path, wallet_manager)
+        }
         // Wallet Commands
         ("address", Some(matches)) => Ok(CliCommandInfo {
             command: CliCommand::Address,
@@ -1923,6 +1932,19 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &vote_account_pubkey,
             *use_lamports_unit,
             *commitment_config,
+        ),
+        CliCommand::VoteAccountWithdraw {
+            vote_account_pubkey,
+            withdrawer_account_pubkey,
+            lamports,
+            to_account_pubkey,
+        } => process_vote_account_withdraw(
+            &rpc_client,
+            config,
+            vote_account_pubkey,
+            withdrawer_account_pubkey,
+            *lamports,
+            to_account_pubkey,
         ),
         CliCommand::VoteAuthorize {
             vote_account_pubkey,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -366,9 +366,9 @@ pub enum CliCommand {
     },
     WithdrawFromVoteAccount {
         vote_account_pubkey: Pubkey,
-        authorized_withdrawer: Option<Pubkey>,
-        lamports: u64,
         destination_account_pubkey: Pubkey,
+        withdraw_authority: SignerIndex,
+        lamports: u64,
     },
     VoteAuthorize {
         vote_account_pubkey: Pubkey,
@@ -703,7 +703,7 @@ pub fn parse_command(
         ),
         ("vote-account", Some(matches)) => parse_vote_get_account_command(matches),
         ("withdraw-from-vote-account", Some(matches)) => {
-            parse_vote_account_withdraw(matches, default_signer_path, wallet_manager)
+            parse_withdraw_from_vote_account(matches, default_signer_path, wallet_manager)
         }
         // Wallet Commands
         ("address", Some(matches)) => Ok(CliCommandInfo {
@@ -1935,14 +1935,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         ),
         CliCommand::WithdrawFromVoteAccount {
             vote_account_pubkey,
-            authorized_withdrawer,
+            withdraw_authority,
             lamports,
             destination_account_pubkey,
-        } => process_vote_account_withdraw(
+        } => process_withdraw_from_vote_account(
             &rpc_client,
             config,
             vote_account_pubkey,
-            authorized_withdrawer,
+            *withdraw_authority,
             *lamports,
             destination_account_pubkey,
         ),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2310,7 +2310,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(true)
                         .required(false)
                         .validator(is_valid_signer)
-                        .help("From (base) key, defaults to client keypair."),
+                        .help("From (base) key, [default: cli config keypair]"),
                 ),
         )
         .subcommand(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -364,11 +364,11 @@ pub enum CliCommand {
         use_lamports_unit: bool,
         commitment_config: CommitmentConfig,
     },
-    VoteAccountWithdraw {
+    WithdrawFromVoteAccount {
         vote_account_pubkey: Pubkey,
-        withdrawer_account_pubkey: Pubkey,
+        authorized_withdrawer: Option<Pubkey>,
         lamports: u64,
-        to_account_pubkey: Pubkey,
+        destination_account_pubkey: Pubkey,
     },
     VoteAuthorize {
         vote_account_pubkey: Pubkey,
@@ -702,8 +702,8 @@ pub fn parse_command(
             VoteAuthorize::Withdrawer,
         ),
         ("vote-account", Some(matches)) => parse_vote_get_account_command(matches),
-        ("vote-account-withdraw", Some(matches)) => {
-            parse_vote_account_withdraw_command(matches, default_signer_path, wallet_manager)
+        ("withdraw-from-vote-account", Some(matches)) => {
+            parse_vote_account_withdraw(matches, default_signer_path, wallet_manager)
         }
         // Wallet Commands
         ("address", Some(matches)) => Ok(CliCommandInfo {
@@ -1933,18 +1933,18 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *use_lamports_unit,
             *commitment_config,
         ),
-        CliCommand::VoteAccountWithdraw {
+        CliCommand::WithdrawFromVoteAccount {
             vote_account_pubkey,
-            withdrawer_account_pubkey,
+            authorized_withdrawer,
             lamports,
-            to_account_pubkey,
+            destination_account_pubkey,
         } => process_vote_account_withdraw(
             &rpc_client,
             config,
             vote_account_pubkey,
-            withdrawer_account_pubkey,
+            authorized_withdrawer,
             *lamports,
-            to_account_pubkey,
+            destination_account_pubkey,
         ),
         CliCommand::VoteAuthorize {
             vote_account_pubkey,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -199,7 +199,7 @@ impl NonceSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("withdraw-from-nonce-account")
-                .about("Withdraw lamports from the nonce account")
+                .about("Withdraw SOL from the nonce account")
                 .arg(
                     Arg::with_name("nonce_account_keypair")
                         .index(1)
@@ -207,7 +207,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_keypair_or_ask_keyword)
-                        .help("Nonce account from to withdraw from"),
+                        .help("Nonce account to withdraw from"),
                 )
                 .arg(
                     Arg::with_name("destination_account_pubkey")
@@ -216,7 +216,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
-                        .help("The account to which the lamports should be transferred"),
+                        .help("The account to which the SOL should be transferred"),
                 )
                 .arg(
                     Arg::with_name("amount")

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -869,31 +869,6 @@ mod tests {
             }
         );
 
-        let test_withdraw_from_nonce_account = test_commands.clone().get_matches_from(vec![
-            "test",
-            "withdraw-from-nonce-account",
-            &keypair_file,
-            &nonce_account_string,
-            "42",
-        ]);
-        assert_eq!(
-            parse_command(
-                &test_withdraw_from_nonce_account,
-                &default_keypair_file,
-                None
-            )
-            .unwrap(),
-            CliCommandInfo {
-                command: CliCommand::WithdrawFromNonceAccount {
-                    nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
-                    nonce_authority: 0,
-                    destination_account_pubkey: nonce_account_pubkey,
-                    lamports: 42000000000
-                },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
-            }
-        );
-
         // Test WithdrawFromNonceAccount Subcommand with authority
         let test_withdraw_from_nonce_account = test_commands.clone().get_matches_from(vec![
             "test",

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -34,13 +34,13 @@ use std::{ops::Deref, sync::Arc};
 pub const STAKE_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {
     name: "stake_authority",
     long: "stake-authority",
-    help: "Public key of authorized staker (defaults to cli config pubkey)",
+    help: "Authorized staker (defaults to cli config keypair)",
 };
 
 pub const WITHDRAW_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {
     name: "withdraw_authority",
     long: "withdraw-authority",
-    help: "Public key of authorized withdrawer (defaults to cli config pubkey)",
+    help: "Authorized withdrawer (defaults to cli config keypair)",
 };
 
 fn stake_authority_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -34,13 +34,13 @@ use std::{ops::Deref, sync::Arc};
 pub const STAKE_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {
     name: "stake_authority",
     long: "stake-authority",
-    help: "Authorized staker (defaults to cli config keypair)",
+    help: "Authorized staker [default: cli config keypair]",
 };
 
 pub const WITHDRAW_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {
     name: "withdraw_authority",
     long: "withdraw-authority",
-    help: "Authorized withdrawer (defaults to cli config keypair)",
+    help: "Authorized withdrawer [default: cli config keypair]",
 };
 
 fn stake_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
@@ -374,7 +374,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
                         .validator(is_valid_signer)
-                        .help("Public key of signing custodian (defaults to cli config pubkey)")
+                        .help("Public key of signing custodian [default: cli config pubkey]")
                 )
                 .offline_args()
                 .arg(nonce_arg())

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -279,7 +279,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
-                        .help("The amount to move into the new stake account, in unit SOL")
+                        .help("The amount to move into the new stake account, in SOL")
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -296,7 +296,7 @@ impl StakeSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("withdraw-stake")
-                .about("Withdraw the unstaked lamports from the stake account")
+                .about("Withdraw the unstaked SOL from the stake account")
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
@@ -313,7 +313,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
-                        .help("The account to which the lamports should be transferred")
+                        .help("The account to which the SOL should be transferred")
                 )
                 .arg(
                     Arg::with_name("amount")

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -62,7 +62,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_pubkey_or_keypair)
-                        .help("Public key of the authorized voter (defaults to vote account)"),
+                        .help("Public key of the authorized voter [default: vote account]"),
                 )
                 .arg(
                     Arg::with_name("authorized_withdrawer")
@@ -70,7 +70,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_pubkey_or_keypair)
-                        .help("Public key of the authorized withdrawer (defaults to cli config pubkey)"),
+                        .help("Public key of the authorized withdrawer [default: cli config pubkey]"),
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -219,7 +219,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
                         .takes_value(true)
                         .validator(is_valid_signer)
-                        .help("Authorized withdrawer (defaults to cli config keypair)"),
+                        .help("Authorized withdrawer [default: cli config keypair]"),
                 )
         )
     }

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -1,0 +1,109 @@
+use solana_cli::cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig};
+use solana_client::rpc_client::RpcClient;
+use solana_core::validator::TestValidator;
+use solana_faucet::faucet::run_local_faucet;
+use solana_sdk::{
+    account_utils::StateMut,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+};
+use solana_vote_program::vote_state::{VoteAuthorize, VoteState, VoteStateVersions};
+use std::{fs::remove_dir_all, sync::mpsc::channel, thread::sleep, time::Duration};
+
+fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
+    (0..5).for_each(|tries| {
+        let balance = client.retry_get_balance(pubkey, 1).unwrap().unwrap();
+        if balance == expected_balance {
+            return;
+        }
+        if tries == 4 {
+            assert_eq!(balance, expected_balance);
+        }
+        sleep(Duration::from_millis(500));
+    });
+}
+
+#[test]
+fn test_vote_authorize_and_withdraw() {
+    let TestValidator {
+        server,
+        leader_data,
+        alice,
+        ledger_path,
+        ..
+    } = TestValidator::run();
+    let (sender, receiver) = channel();
+    run_local_faucet(alice, sender, None);
+    let faucet_addr = receiver.recv().unwrap();
+
+    let rpc_client = RpcClient::new_socket(leader_data.rpc);
+    let default_signer = Keypair::new();
+
+    let mut config = CliConfig::default();
+    config.json_rpc_url = format!("http://{}:{}", leader_data.rpc.ip(), leader_data.rpc.port());
+    config.signers = vec![&default_signer];
+
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &config.signers[0].pubkey(),
+        100_000,
+    )
+    .unwrap();
+
+    // Create vote account
+    let vote_account_keypair = Keypair::new();
+    let vote_account_pubkey = vote_account_keypair.pubkey();
+    config.signers = vec![&default_signer, &vote_account_keypair];
+    config.command = CliCommand::CreateVoteAccount {
+        seed: None,
+        node_pubkey: config.signers[0].pubkey(),
+        authorized_voter: None,
+        authorized_withdrawer: Some(config.signers[0].pubkey()),
+        commission: 0,
+    };
+    process_command(&config).unwrap();
+    let vote_account = rpc_client
+        .get_account(&vote_account_keypair.pubkey())
+        .unwrap();
+    let vote_state: VoteStateVersions = vote_account.state().unwrap();
+    let authorized_withdrawer = vote_state.convert_to_current().authorized_withdrawer;
+    assert_eq!(authorized_withdrawer, config.signers[0].pubkey());
+    let expected_balance = rpc_client
+        .get_minimum_balance_for_rent_exemption(VoteState::size_of())
+        .unwrap()
+        .max(1);
+    check_balance(expected_balance, &rpc_client, &vote_account_pubkey);
+
+    // Authorize vote account withdrawal to another signer
+    let withdraw_authority = Keypair::new();
+    config.signers = vec![&default_signer];
+    config.command = CliCommand::VoteAuthorize {
+        vote_account_pubkey,
+        new_authorized_pubkey: withdraw_authority.pubkey(),
+        vote_authorize: VoteAuthorize::Withdrawer,
+    };
+    process_command(&config).unwrap();
+    let vote_account = rpc_client
+        .get_account(&vote_account_keypair.pubkey())
+        .unwrap();
+    let vote_state: VoteStateVersions = vote_account.state().unwrap();
+    let authorized_withdrawer = vote_state.convert_to_current().authorized_withdrawer;
+    assert_eq!(authorized_withdrawer, withdraw_authority.pubkey());
+
+    // Withdraw from vote account
+    let destination_account = Pubkey::new_rand(); // Send withdrawal to new account to make balance check easy
+    config.signers = vec![&default_signer, &withdraw_authority];
+    config.command = CliCommand::WithdrawFromVoteAccount {
+        vote_account_pubkey,
+        withdraw_authority: 1,
+        lamports: 100,
+        destination_account_pubkey: destination_account,
+    };
+    process_command(&config).unwrap();
+    check_balance(expected_balance - 100, &rpc_client, &vote_account_pubkey);
+    check_balance(100, &rpc_client, &destination_account);
+
+    server.close().unwrap();
+    remove_dir_all(ledger_path).unwrap();
+}


### PR DESCRIPTION
#### Problem

The product's command line doesn't offer the ability to transfer rewards easily.

#### Summary of Changes

Add a vote account withdraw command.

Fixes #8095
