### PR TITLE
Fix c/p error. We want a rent sysvar account here

### DIFF
--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -354,10 +354,7 @@ mod tests {
         ))
     }
     fn create_default_rent_account() -> RefCell<Account> {
-        RefCell::new(sysvar::recent_blockhashes::create_account_with_data(
-            1,
-            vec![(0u64, &Hash::default()); 32].into_iter(),
-        ))
+        RefCell::new(sysvar::rent::create_account(1, &Rent::free()))
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

`Rent` sysvar test account helper is creating a `RecentBlockhashes` sysvar account

#### Summary of Changes

Create the expected account type

Fixes #
