### PR TITLE
Hack to skip cleanup_dead_slots upon snapshot load

### DIFF
--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -447,16 +447,18 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     let mut snapshot_version = String::new();
     File::open(unpacked_version_file).and_then(|mut f| f.read_to_string(&mut snapshot_version))?;
 
-    let bank = rebuild_bank_from_snapshots(
+    let mut bank = rebuild_bank_from_snapshots(
         snapshot_version.trim(),
         account_paths,
         &unpacked_snapshots_dir,
         unpacked_accounts_dir,
     )?;
 
+    bank.work_around_dead_slots_cleaning_bug(true);
     if !bank.verify_snapshot_bank() {
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());
     }
+    bank.work_around_dead_slots_cleaning_bug(false);
     measure.stop();
     info!("{}", measure);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1730,6 +1730,14 @@ impl Bank {
         self.rc.parent = RwLock::new(Some(parent.clone()));
     }
 
+    pub fn work_around_dead_slots_cleaning_bug(&mut self, flag: bool) {
+        self.rc
+            .accounts
+            .accounts_db
+            .dont_cleanup_dead_slots
+            .store(flag, Ordering::Relaxed);
+    }
+
     pub fn set_inflation(&self, inflation: Inflation) {
         *self.inflation.write().unwrap() = inflation;
     }


### PR DESCRIPTION
#### Problem

A validator started from snapshot may create bad snapshots, which cause bank hash mismatch error when consumed by other validators. This is because the validator internally removes too much AccountsStorage and bad snapshots don't include some necessary ones anymore.

#### Detail of problem

`generate_index` has been broken for long time about maintaining the correct count of storage's counts, which confuses `purge_zero_lamport_accounts()` (demonstrating assertion are currently disabled in this pr, real fix #8337 is pending).
This causes too many slots to be incorrectly marked as dead.
However, it hadn't caused problems because `cleanup_dead_slots()` had been broken too when called immediately after snapshot restoration. That function didn't remove `dead_slots` at all in that case.
In short, the caller wrongly requested too many `slot`s to remove and the callee wrongly didn't  anything. So, there had been a peace...

But it changed since #8148. This PR is needed as one of fixes for the enlarged snapshot issue #8168. And that PR was thought rather harmless..

After #8148, the callee started to remove actually. But things don't break immediately. Snapshots load successfully. And validator just works.
Its rather subtle ramification of unbalanced fix is at the future snapshot creation: Because `purge_zero_lamport_accounts()` incorrectly removes too many slots as dead in some corner case, newly-created snapshots silently start to omit to include that removed `storage`s backing that slots, causing the deadly `BankHashMismatch` error because of obvious incorrect view into the accounts set.

#### Summary of Changes

Until #8337 lands, just disable erroneous too eager removing behavior as an ugly hack...
This PR should have the same effect as reverting #8148, with better merge-conflict-free characteristics. #8337 should revert most of changes in this PR.

Fixes #8560  

Backport only to v1.0 because v0.23 was branched before #8148.
