### PR TITLE
validator: --wait-for-supermajority now requires a SLOT

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,6 +1,7 @@
 use crate::keypair::{parse_keypair_path, KeypairUrl, ASK_KEYWORD};
 use chrono::DateTime;
 use solana_sdk::{
+    clock::Slot,
     hash::Hash,
     pubkey::Pubkey,
     signature::{read_keypair_file, Signature},
@@ -91,6 +92,12 @@ pub fn is_url(string: String) -> Result<(), String> {
         }
         Err(err) => Err(format!("{:?}", err)),
     }
+}
+
+pub fn is_slot(slot: String) -> Result<(), String> {
+    slot.parse::<Slot>()
+        .map(|_| ())
+        .map_err(|e| format!("{:?}", e))
 }
 
 pub fn is_port(port: String) -> Result<(), String> {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -72,7 +72,7 @@ pub struct ValidatorConfig {
     pub broadcast_stage_type: BroadcastStageType,
     pub enable_partition: Option<Arc<AtomicBool>>,
     pub fixed_leader_schedule: Option<FixedSchedule>,
-    pub wait_for_supermajority: bool,
+    pub wait_for_supermajority: Option<Slot>,
     pub new_hard_forks: Option<Vec<Slot>>,
     pub trusted_validators: Option<HashSet<Pubkey>>, // None = trust all
 }
@@ -95,7 +95,7 @@ impl Default for ValidatorConfig {
             broadcast_stage_type: BroadcastStageType::Standard,
             enable_partition: None,
             fixed_leader_schedule: None,
-            wait_for_supermajority: false,
+            wait_for_supermajority: None,
             new_hard_forks: None,
             trusted_validators: None,
         }
@@ -631,7 +631,7 @@ fn wait_for_supermajority(
     bank: &Arc<Bank>,
     cluster_info: &Arc<RwLock<ClusterInfo>>,
 ) {
-    if !config.wait_for_supermajority {
+    if config.wait_for_supermajority != Some(bank.slot()) {
         return;
     }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -4,6 +4,7 @@ use clap::{
 };
 use histogram;
 use serde_json::json;
+use solana_clap_utils::input_validators::is_slot;
 use solana_ledger::{
     bank_forks::{BankForks, SnapshotConfig},
     bank_forks_utils,
@@ -576,11 +577,13 @@ fn main() {
     let halt_at_slot_arg = Arg::with_name("halt_at_slot")
         .long("halt-at-slot")
         .value_name("SLOT")
+        .validator(is_slot)
         .takes_value(true)
         .help("Halt processing at the given slot");
     let hard_forks_arg = Arg::with_name("hard_forks")
         .long("hard-fork")
         .value_name("SLOT")
+        .validator(is_slot)
         .multiple(true)
         .takes_value(true)
         .help("Add a hard fork at this slot");
@@ -609,6 +612,7 @@ fn main() {
                 Arg::with_name("slots")
                     .index(1)
                     .value_name("SLOTS")
+                    .validator(is_slot)
                     .takes_value(true)
                     .multiple(true)
                     .required(true)
@@ -685,6 +689,7 @@ fn main() {
                 Arg::with_name("snapshot_slot")
                     .index(1)
                     .value_name("SLOT")
+                    .validator(is_slot)
                     .takes_value(true)
                     .help("Slot at which to create the snapshot"),
             )

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -158,7 +158,7 @@ fn test_validator_exit_2() {
     let num_nodes = 2;
     let mut validator_config = ValidatorConfig::default();
     validator_config.rpc_config.enable_validator_exit = true;
-    validator_config.wait_for_supermajority = true;
+    validator_config.wait_for_supermajority = Some(0);
 
     let config = ClusterConfig {
         cluster_lamports: 10_000,


### PR DESCRIPTION
Rework ` --wait-for-supermajority` to avoid a death spiral from 75% active stake to 66%.   

This increases the burden on validators during a cluster restart as they must now manually and correctly add the ` --wait-for-supermajority <RESTART_SLOT>` argument to their validator, but that seems like a small ask

Fixes #8563
