### PR TITLE
Update rust-bpf to include matching cargo

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -86,7 +86,7 @@ if [[ ! -f llvm-native-$machine-$version.md ]]; then
 fi
 
 # Install Rust-BPF
-version=v0.2.1
+version=v0.2.2
 if [[ ! -f rust-bpf-$machine-$version.md ]]; then
   (
     filename=solana-rust-bpf-$machine.tar.bz2


### PR DESCRIPTION
#### Problem

A newer version of cargo may pass options that an older rustc may not support

#### Summary of Changes

include a matching cargo along with the rust-bpf toolchain.

Fixes #
