### PR TITLE
Keep GenesisConfig binary compatible with v0.23

### DIFF
--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -48,6 +48,9 @@ pub struct GenesisConfig {
     pub slots_per_segment: u64,
     /// network speed configuration
     pub poh_config: PohConfig,
+    /// this field exists only to ensure that the binary layout of GenesisConfig remains compatible
+    /// with the Solana v0.23 release line
+    pub __backwards_compat_with_v0_23: u64,
     /// transaction fee config
     pub fee_rate_governor: FeeRateGovernor,
     /// rent config
@@ -89,6 +92,7 @@ impl Default for GenesisConfig {
             slots_per_segment: DEFAULT_SLOTS_PER_SEGMENT,
             poh_config: PohConfig::default(),
             inflation: Inflation::default(),
+            __backwards_compat_with_v0_23: 0,
             fee_rate_governor: FeeRateGovernor::default(),
             rent: Rent::default(),
             epoch_schedule: EpochSchedule::default(),


### PR DESCRIPTION
This, https://github.com/solana-labs/solana/blob/b83a0434a4d0a05aee027958be98e5ac290b88b8/sdk/src/fee_calculator.rs#L38, caused GenesisConfig to not longer be compatible with v0.23.   Rather than rewriting genesis for TdS and SLP and going into a long diatribe with busloads of people to justify why the genesis hash for TdS and SLP changed, sneak in a dummy `u64` field to make everything line up again.

cc: @t-nelson 