### PR TITLE
Add --bind-address and --rpc-bind-address validator arguments

### DIFF
--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -13,7 +13,12 @@ use solana_core::{
     contact_info::ContactInfo,
 };
 use solana_sdk::{commitment_config::CommitmentConfig, signature::Signer};
-use std::{net::SocketAddr, path::PathBuf, process::exit, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::PathBuf,
+    process::exit,
+    sync::Arc,
+};
 
 fn main() {
     solana_logger::setup();
@@ -116,6 +121,7 @@ fn main() {
         &identity_keypair.pubkey(),
         &gossip_addr,
         VALIDATOR_PORT_RANGE,
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
     );
 
     println!(

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -67,7 +67,8 @@ fn main() -> Result<()> {
     }
 
     let mut port = 0;
-    let mut addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
+    let ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+    let mut addr = SocketAddr::new(ip_addr, 0);
 
     let exit = Arc::new(AtomicBool::new(false));
 
@@ -75,7 +76,7 @@ fn main() -> Result<()> {
     let mut read_threads = Vec::new();
     let recycler = PacketsRecycler::default();
     for _ in 0..num_sockets {
-        let read = solana_net_utils::bind_to(port, false).unwrap();
+        let read = solana_net_utils::bind_to(ip_addr, port, false).unwrap();
         read.set_read_timeout(Some(Duration::new(1, 0))).unwrap();
 
         addr = read.local_addr().unwrap();

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -26,7 +26,7 @@ use solana_sdk::{
 };
 use std::{
     io,
-    net::{SocketAddr, UdpSocket},
+    net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         RwLock,
@@ -603,7 +603,8 @@ impl AsyncClient for ThinClient {
 }
 
 pub fn create_client((rpc, tpu): (SocketAddr, SocketAddr), range: (u16, u16)) -> ThinClient {
-    let (_, transactions_socket) = solana_net_utils::bind_in_range(range).unwrap();
+    let (_, transactions_socket) =
+        solana_net_utils::bind_in_range(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), range).unwrap();
     ThinClient::new(rpc, tpu, transactions_socket)
 }
 
@@ -612,7 +613,8 @@ pub fn create_client_with_timeout(
     range: (u16, u16),
     timeout: Duration,
 ) -> ThinClient {
-    let (_, transactions_socket) = solana_net_utils::bind_in_range(range).unwrap();
+    let (_, transactions_socket) =
+        solana_net_utils::bind_in_range(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), range).unwrap();
     ThinClient::new_socket_with_timeout(rpc, tpu, transactions_socket, timeout)
 }
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1635,8 +1635,9 @@ impl ClusterInfo {
         id: &Pubkey,
         gossip_addr: &SocketAddr,
     ) -> (ContactInfo, UdpSocket, Option<TcpListener>) {
+        let bind_ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let (port, (gossip_socket, ip_echo)) =
-            Node::get_gossip_port(gossip_addr, VALIDATOR_PORT_RANGE);
+            Node::get_gossip_port(gossip_addr, VALIDATOR_PORT_RANGE, bind_ip_addr);
         let contact_info = Self::gossip_contact_info(id, SocketAddr::new(gossip_addr.ip(), port));
 
         (contact_info, gossip_socket, Some(ip_echo))
@@ -1644,7 +1645,8 @@ impl ClusterInfo {
 
     /// A Node with dummy ports to spy on gossip via pull requests
     pub fn spy_node(id: &Pubkey) -> (ContactInfo, UdpSocket, Option<TcpListener>) {
-        let (_, gossip_socket) = bind_in_range(VALIDATOR_PORT_RANGE).unwrap();
+        let bind_ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+        let (_, gossip_socket) = bind_in_range(bind_ip_addr, VALIDATOR_PORT_RANGE).unwrap();
         let contact_info = Self::spy_contact_info(id);
 
         (contact_info, gossip_socket, None)
@@ -1759,16 +1761,18 @@ impl Node {
         }
     }
     pub fn new_localhost_with_pubkey(pubkey: &Pubkey) -> Self {
+        let bind_ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let tpu = UdpSocket::bind("127.0.0.1:0").unwrap();
-        let (gossip_port, (gossip, ip_echo)) = bind_common_in_range((1024, 65535)).unwrap();
+        let (gossip_port, (gossip, ip_echo)) =
+            bind_common_in_range(bind_ip_addr, (1024, 65535)).unwrap();
         let gossip_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), gossip_port);
         let tvu = UdpSocket::bind("127.0.0.1:0").unwrap();
         let tvu_forwards = UdpSocket::bind("127.0.0.1:0").unwrap();
         let tpu_forwards = UdpSocket::bind("127.0.0.1:0").unwrap();
         let repair = UdpSocket::bind("127.0.0.1:0").unwrap();
-        let rpc_port = find_available_port_in_range((1024, 65535)).unwrap();
+        let rpc_port = find_available_port_in_range(bind_ip_addr, (1024, 65535)).unwrap();
         let rpc_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), rpc_port);
-        let rpc_pubsub_port = find_available_port_in_range((1024, 65535)).unwrap();
+        let rpc_pubsub_port = find_available_port_in_range(bind_ip_addr, (1024, 65535)).unwrap();
         let rpc_pubsub_addr =
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), rpc_pubsub_port);
 
@@ -1811,45 +1815,52 @@ impl Node {
     fn get_gossip_port(
         gossip_addr: &SocketAddr,
         port_range: PortRange,
+        bind_ip_addr: IpAddr,
     ) -> (u16, (UdpSocket, TcpListener)) {
         if gossip_addr.port() != 0 {
             (
                 gossip_addr.port(),
-                bind_common(gossip_addr.port(), false).unwrap_or_else(|e| {
+                bind_common(bind_ip_addr, gossip_addr.port(), false).unwrap_or_else(|e| {
                     panic!("gossip_addr bind_to port {}: {}", gossip_addr.port(), e)
                 }),
             )
         } else {
-            bind_common_in_range(port_range).expect("Failed to bind")
+            bind_common_in_range(bind_ip_addr, port_range).expect("Failed to bind")
         }
     }
-    fn bind(port_range: PortRange) -> (u16, UdpSocket) {
-        bind_in_range(port_range).expect("Failed to bind")
+    fn bind(bind_ip_addr: IpAddr, port_range: PortRange) -> (u16, UdpSocket) {
+        bind_in_range(bind_ip_addr, port_range).expect("Failed to bind")
     }
+
     pub fn new_with_external_ip(
         pubkey: &Pubkey,
         gossip_addr: &SocketAddr,
         port_range: PortRange,
+        bind_ip_addr: IpAddr,
     ) -> Node {
-        let (gossip_port, (gossip, ip_echo)) = Self::get_gossip_port(gossip_addr, port_range);
+        let (gossip_port, (gossip, ip_echo)) =
+            Self::get_gossip_port(gossip_addr, port_range, bind_ip_addr);
 
-        let (tvu_port, tvu_sockets) = multi_bind_in_range(port_range, 8).expect("tvu multi_bind");
+        let (tvu_port, tvu_sockets) =
+            multi_bind_in_range(bind_ip_addr, port_range, 8).expect("tvu multi_bind");
 
         let (tvu_forwards_port, tvu_forwards_sockets) =
-            multi_bind_in_range(port_range, 8).expect("tvu_forwards multi_bind");
+            multi_bind_in_range(bind_ip_addr, port_range, 8).expect("tvu_forwards multi_bind");
 
-        let (tpu_port, tpu_sockets) = multi_bind_in_range(port_range, 32).expect("tpu multi_bind");
+        let (tpu_port, tpu_sockets) =
+            multi_bind_in_range(bind_ip_addr, port_range, 32).expect("tpu multi_bind");
 
         let (tpu_forwards_port, tpu_forwards_sockets) =
-            multi_bind_in_range(port_range, 8).expect("tpu_forwards multi_bind");
+            multi_bind_in_range(bind_ip_addr, port_range, 8).expect("tpu_forwards multi_bind");
 
         let (_, retransmit_sockets) =
-            multi_bind_in_range(port_range, 8).expect("retransmit multi_bind");
+            multi_bind_in_range(bind_ip_addr, port_range, 8).expect("retransmit multi_bind");
 
-        let (repair_port, repair) = Self::bind(port_range);
-        let (serve_repair_port, serve_repair) = Self::bind(port_range);
+        let (repair_port, repair) = Self::bind(bind_ip_addr, port_range);
+        let (serve_repair_port, serve_repair) = Self::bind(bind_ip_addr, port_range);
 
-        let (_, broadcast) = multi_bind_in_range(port_range, 4).expect("broadcast multi_bind");
+        let (_, broadcast) =
+            multi_bind_in_range(bind_ip_addr, port_range, 4).expect("broadcast multi_bind");
 
         let info = ContactInfo {
             id: *pubkey,
@@ -1889,9 +1900,10 @@ impl Node {
         pubkey: &Pubkey,
         gossip_addr: &SocketAddr,
         port_range: PortRange,
+        bind_ip_addr: IpAddr,
     ) -> Node {
-        let mut new = Self::new_with_external_ip(pubkey, gossip_addr, port_range);
-        let (storage_port, storage_socket) = Self::bind(port_range);
+        let mut new = Self::new_with_external_ip(pubkey, gossip_addr, port_range, bind_ip_addr);
+        let (storage_port, storage_socket) = Self::bind(bind_ip_addr, port_range);
 
         new.info.storage_addr = SocketAddr::new(gossip_addr.ip(), storage_port);
         new.sockets.storage = Some(storage_socket);
@@ -2025,6 +2037,7 @@ mod tests {
             &Pubkey::new_rand(),
             &socketaddr!(ip, 0),
             VALIDATOR_PORT_RANGE,
+            IpAddr::V4(ip),
         );
 
         check_node_sockets(&node, IpAddr::V4(ip), VALIDATOR_PORT_RANGE);
@@ -2034,7 +2047,7 @@ mod tests {
     fn new_with_external_ip_test_gossip() {
         let ip = IpAddr::V4(Ipv4Addr::from(0));
         let port = {
-            bind_in_range(VALIDATOR_PORT_RANGE)
+            bind_in_range(ip, VALIDATOR_PORT_RANGE)
                 .expect("Failed to bind")
                 .0
         };
@@ -2042,6 +2055,7 @@ mod tests {
             &Pubkey::new_rand(),
             &socketaddr!(0, port),
             VALIDATOR_PORT_RANGE,
+            ip,
         );
 
         check_node_sockets(&node, ip, VALIDATOR_PORT_RANGE);
@@ -2056,6 +2070,7 @@ mod tests {
             &Pubkey::new_rand(),
             &socketaddr!(ip, 0),
             VALIDATOR_PORT_RANGE,
+            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
         );
 
         let ip = IpAddr::V4(ip);

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -9,7 +9,7 @@ use solana_ledger::bank_forks::BankForks;
 use solana_perf::recycler::Recycler;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::{Keypair, Signer};
-use std::net::{SocketAddr, TcpListener, UdpSocket};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::channel;
 use std::sync::{Arc, RwLock};
@@ -163,7 +163,11 @@ pub fn get_multi_client(nodes: &[ContactInfo]) -> (ThinClient, usize) {
         .collect();
     let rpc_addrs: Vec<_> = addrs.iter().map(|addr| addr.0).collect();
     let tpu_addrs: Vec<_> = addrs.iter().map(|addr| addr.1).collect();
-    let (_, transactions_socket) = solana_net_utils::bind_in_range(VALIDATOR_PORT_RANGE).unwrap();
+    let (_, transactions_socket) = solana_net_utils::bind_in_range(
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+        VALIDATOR_PORT_RANGE,
+    )
+    .unwrap();
     let num_nodes = tpu_addrs.len();
     (
         ThinClient::new_from_addrs(rpc_addrs, tpu_addrs, transactions_socket),

--- a/core/src/local_vote_signer_service.rs
+++ b/core/src/local_vote_signer_service.rs
@@ -15,9 +15,12 @@ pub struct LocalVoteSignerService {
 impl LocalVoteSignerService {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(port_range: PortRange) -> (Self, SocketAddr) {
-        let addr = solana_net_utils::find_available_port_in_range(port_range)
-            .map(|port| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port))
-            .expect("Failed to find an available port for local vote signer service");
+        let ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+        let addr = SocketAddr::new(
+            ip_addr,
+            solana_net_utils::find_available_port_in_range(ip_addr, port_range)
+                .expect("Failed to find an available port for local vote signer service"),
+        );
         let exit = Arc::new(AtomicBool::new(false));
         let thread_exit = exit.clone();
         let thread = Builder::new()

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -284,6 +284,7 @@ mod tests {
     use solana_ledger::create_new_tmp_ledger;
     use solana_net_utils::find_available_port_in_range;
     use solana_sdk::pubkey::Pubkey;
+    use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
     fn test_skip_repair() {
@@ -300,11 +301,12 @@ mod tests {
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
         let mut me = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
-        let port = find_available_port_in_range((8000, 10000)).unwrap();
+        let ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
+        let port = find_available_port_in_range(ip_addr, (8000, 10000)).unwrap();
         let me_retransmit = UdpSocket::bind(format!("127.0.0.1:{}", port)).unwrap();
         // need to make sure tvu and tpu are valid addresses
         me.tvu_forwards = me_retransmit.local_addr().unwrap();
-        let port = find_available_port_in_range((8000, 10000)).unwrap();
+        let port = find_available_port_in_range(ip_addr, (8000, 10000)).unwrap();
         me.tvu = UdpSocket::bind(format!("127.0.0.1:{}", port))
             .unwrap()
             .local_addr()

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -262,9 +262,10 @@ mod tests {
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
             ContactInfo::default(),
         )));
+        let ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let rpc_addr = SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            solana_net_utils::find_available_port_in_range((10000, 65535)).unwrap(),
+            ip_addr,
+            solana_net_utils::find_available_port_in_range(ip_addr, (10000, 65535)).unwrap(),
         );
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank.slot(), bank)));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -197,8 +197,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let gossip_addr = SocketAddr::new(
                 gossip_host,
                 value_t!(matches, "gossip_port", u16).unwrap_or_else(|_| {
-                    solana_net_utils::find_available_port_in_range((0, 1))
-                        .expect("unable to find an available gossip port")
+                    solana_net_utils::find_available_port_in_range(
+                        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                        (0, 1),
+                    )
+                    .expect("unable to find an available gossip port")
                 }),
             );
 


### PR DESCRIPTION
By default the validator will bind to all network interfaces on the system (0.0.0.0) but that's not always desired.

Example of how to bind only to the 1.1.1.1 interface (assuming that exists on your machine)
```
$ solana-validator --bind-address 1.1.1.1 ...
```

There's an additional option specifically for RPC, ` --rpc-bind-address`.  Here's an example of how to ensure that RPC is only accessible on 127.0.0.1 while binding all other ports to 0.0.0.0:
```
$ solana-validator --rpc-bind-address 127.0.0.1 --rpc-port 8899 --private-rpc
```

Fixes #8623
