### PR TITLE
`catchup` now supports an optional RPC URL argument for validators with private RPC…

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -167,6 +167,7 @@ pub enum CliCommand {
     // Cluster Query Commands
     Catchup {
         node_pubkey: Pubkey,
+        node_json_rpc_url: Option<String>,
     },
     ClusterVersion,
     CreateAddressWithSeed {
@@ -1550,7 +1551,10 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::Address => Ok(format!("{}", config.pubkey()?)),
 
         // Return software version of solana-cli and cluster entrypoint node
-        CliCommand::Catchup { node_pubkey } => process_catchup(&rpc_client, node_pubkey),
+        CliCommand::Catchup {
+            node_pubkey,
+            node_json_rpc_url,
+        } => process_catchup(&rpc_client, node_pubkey, node_json_rpc_url),
         CliCommand::ClusterVersion => process_cluster_version(&rpc_client),
         CliCommand::CreateAddressWithSeed {
             from_pubkey,


### PR DESCRIPTION
`solana catchup` uses gossip to locate the RPC port of the validator of interest. 
 However validators using the `--private-rpc` flag will not publish an RPC port in gossip, and thus `solana catchup` can't find them.  But now this is possible by optionally supplying the RPC URL.

For example, a validator that uses `--rpc-bind-address 127.0.0.1` from #8628 can run
```
$ solana catchup ~/validator-identity.json http://127.0.0.1:8899
```
to monitor the catchup of their node.   Of course this only works if the `solana catchup` command is run from the same machine.

Fixes #8407