### PR TITLE
Pass the correct program_id to programs

### DIFF
--- a/programs/bpf/rust/noop/src/lib.rs
+++ b/programs/bpf/rust/noop/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate solana_sdk;
 
 use solana_sdk::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, info, log::*, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, info, log::*, pubkey::Pubkey, bpf_loader,
 };
 
 #[derive(Debug, PartialEq)]
@@ -28,6 +28,8 @@ fn process_instruction(
 ) -> ProgramResult {
     info!("Program identifier:");
     program_id.log();
+
+    assert!(!bpf_loader::check_id(program_id));
 
     // Log the provided account keys and instruction input data.  In the case of
     // the no-op program, no account keys or input data are expected but real

--- a/programs/bpf/rust/noop/src/lib.rs
+++ b/programs/bpf/rust/noop/src/lib.rs
@@ -5,7 +5,8 @@
 extern crate solana_sdk;
 
 use solana_sdk::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, info, log::*, pubkey::Pubkey, bpf_loader,
+    account_info::AccountInfo, bpf_loader, entrypoint, entrypoint::ProgramResult, info, log::*,
+    pubkey::Pubkey,
 };
 
 #[derive(Debug, PartialEq)]

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -266,13 +266,13 @@ mod tests {
         // Case: Empty keyed accounts
         assert_eq!(
             Err(InstructionError::NotEnoughAccountKeys),
-            process_instruction(&program_id, &vec![], &instruction_data)
+            process_instruction(&bpf_loader::id(), &vec![], &instruction_data)
         );
 
         // Case: Not signed
         assert_eq!(
             Err(InstructionError::MissingRequiredSignature),
-            process_instruction(&program_id, &keyed_accounts, &instruction_data)
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &instruction_data)
         );
 
         // Case: Write bytes to an offset
@@ -280,7 +280,7 @@ mod tests {
         keyed_accounts[0].account.borrow_mut().data = vec![0; 6];
         assert_eq!(
             Ok(()),
-            process_instruction(&program_id, &keyed_accounts, &instruction_data)
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &instruction_data)
         );
         assert_eq!(
             vec![0, 0, 0, 1, 2, 3],
@@ -292,7 +292,7 @@ mod tests {
         keyed_accounts[0].account.borrow_mut().data = vec![0; 5];
         assert_eq!(
             Err(InstructionError::AccountDataTooSmall),
-            process_instruction(&program_id, &keyed_accounts, &instruction_data)
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &instruction_data)
         );
     }
 
@@ -313,7 +313,7 @@ mod tests {
         // Case: Empty keyed accounts
         assert_eq!(
             Err(InstructionError::NotEnoughAccountKeys),
-            process_instruction(&program_id, &vec![], &instruction_data)
+            process_instruction(&bpf_loader::id(), &vec![], &instruction_data)
         );
 
         let rent_account = RefCell::new(rent::create_account(1, &rent));
@@ -322,7 +322,7 @@ mod tests {
         // Case: Not signed
         assert_eq!(
             Err(InstructionError::MissingRequiredSignature),
-            process_instruction(&program_id, &keyed_accounts, &instruction_data)
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &instruction_data)
         );
 
         // Case: Finalize
@@ -332,7 +332,7 @@ mod tests {
         ];
         assert_eq!(
             Ok(()),
-            process_instruction(&program_id, &keyed_accounts, &instruction_data)
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &instruction_data)
         );
         assert!(keyed_accounts[0].account.borrow().executable);
 
@@ -346,7 +346,7 @@ mod tests {
         ];
         assert_eq!(
             Err(InstructionError::InvalidAccountData),
-            process_instruction(&program_id, &keyed_accounts, &instruction_data)
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &instruction_data)
         );
     }
 
@@ -370,20 +370,20 @@ mod tests {
         // Case: Empty keyed accounts
         assert_eq!(
             Err(InstructionError::NotEnoughAccountKeys),
-            process_instruction(&program_id, &vec![], &vec![])
+            process_instruction(&bpf_loader::id(), &vec![], &vec![])
         );
 
         // Case: Only a program account
         assert_eq!(
             Ok(()),
-            process_instruction(&program_id, &keyed_accounts, &vec![])
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &vec![])
         );
 
         // Case: Account not executable
         keyed_accounts[0].account.borrow_mut().executable = false;
         assert_eq!(
             Err(InstructionError::InvalidInstructionData),
-            process_instruction(&program_id, &keyed_accounts, &vec![])
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &vec![])
         );
         keyed_accounts[0].account.borrow_mut().executable = true;
 
@@ -392,7 +392,7 @@ mod tests {
         keyed_accounts.push(KeyedAccount::new(&program_key, false, &parameter_account));
         assert_eq!(
             Ok(()),
-            process_instruction(&program_id, &keyed_accounts, &vec![])
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &vec![])
         );
 
         // Case: With duplicate accounts
@@ -403,7 +403,7 @@ mod tests {
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
         assert_eq!(
             Ok(()),
-            process_instruction(&program_id, &keyed_accounts, &vec![])
+            process_instruction(&bpf_loader::id(), &keyed_accounts, &vec![])
         );
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4884,10 +4884,13 @@ mod tests {
         let mut bank = Bank::new(&genesis_config);
 
         fn mock_vote_processor(
-            _pubkey: &Pubkey,
-            _ka: &[KeyedAccount],
-            _data: &[u8],
+            program_id: &Pubkey,
+            _keyed_accounts: &[KeyedAccount],
+            _instruction_data: &[u8],
         ) -> std::result::Result<(), InstructionError> {
+            if !solana_vote_program::check_id(program_id) {
+                return Err(InstructionError::IncorrectProgramId);
+            }
             Err(InstructionError::CustomError(42))
         }
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -6,6 +6,7 @@ use solana_sdk::{
     entrypoint_native,
     instruction::{CompiledInstruction, InstructionError},
     message::Message,
+    native_loader::id as native_loader_id,
     pubkey::Pubkey,
     system_program,
     transaction::TransactionError,
@@ -172,7 +173,6 @@ impl MessageProcessor {
         executable_accounts: &[(Pubkey, RefCell<Account>)],
         program_accounts: &[Rc<RefCell<Account>>],
     ) -> Result<(), InstructionError> {
-        let program_id = instruction.program_id(&message.account_keys);
         let mut keyed_accounts = create_keyed_readonly_accounts(executable_accounts);
         let mut keyed_accounts2: Vec<_> = instruction
             .accounts
@@ -205,12 +205,16 @@ impl MessageProcessor {
         let root_program_id = keyed_accounts[0].unsigned_key();
         for (id, process_instruction) in &self.instruction_processors {
             if id == root_program_id {
-                return process_instruction(&program_id, &keyed_accounts[1..], &instruction.data);
+                return process_instruction(
+                    &root_program_id,
+                    &keyed_accounts[1..],
+                    &instruction.data,
+                );
             }
         }
 
         native_loader::invoke_entrypoint(
-            &program_id,
+            &native_loader_id(),
             &keyed_accounts,
             &instruction.data,
             &self.symbol_cache,

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -80,7 +80,7 @@ fn library_open(path: &PathBuf) -> std::io::Result<Library> {
 }
 
 pub fn invoke_entrypoint(
-    program_id: &Pubkey,
+    _program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
     symbol_cache: &SymbolCache,
@@ -90,7 +90,7 @@ pub fn invoke_entrypoint(
     let name_vec = &names[0].try_account_ref()?.data;
     if let Some(entrypoint) = symbol_cache.read().unwrap().get(name_vec) {
         unsafe {
-            return entrypoint(program_id, params, instruction_data);
+            return entrypoint(names[0].unsigned_key(), params, instruction_data);
         }
     }
     let name = match str::from_utf8(name_vec) {
@@ -116,7 +116,7 @@ pub fn invoke_entrypoint(
                         return Err(NativeLoaderError::EntrypointNotFound.into());
                     }
                 };
-            let ret = entrypoint(program_id, params, instruction_data);
+            let ret = entrypoint(names[0].unsigned_key(), params, instruction_data);
             symbol_cache
                 .write()
                 .unwrap()

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -3,6 +3,10 @@
 use crate::{account::KeyedAccount, instruction::InstructionError, pubkey::Pubkey};
 
 // Prototype of a native program entry point
+///
+/// program_id: Program ID of the currently executing program
+/// keyed_accounts: Accounts passed as part of the instruction
+/// instruction_data: Instruction data
 pub type Entrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],


### PR DESCRIPTION
#### Problem

Loader's are passed the program_id of the program they are loading and not their own in opposition to this documentation:

https://github.com/solana-labs/solana/blob/b85d7c1f70f317717e6f94ad58da334733b38099/sdk/src/entrypoint.rs#L19

#### Summary of Changes

Pass the program id of the currently running program to the program

Fixes #
