### PR TITLE
SDK: Allow `RecentBlockhashes` to hold the entire `BlockhashQueue`

### DIFF
--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -358,7 +358,11 @@ mod tests {
     fn create_default_recent_blockhashes_account() -> RefCell<Account> {
         RefCell::new(sysvar::recent_blockhashes::create_account_with_data(
             1,
-            vec![IterItem(0u64, &Hash::default(), &FeeCalculator::default()); 32].into_iter(),
+            vec![
+                IterItem(0u64, &Hash::default(), &FeeCalculator::default());
+                sysvar::recent_blockhashes::MAX_ENTRIES
+            ]
+            .into_iter(),
         ))
     }
     fn create_default_rent_account() -> RefCell<Account> {
@@ -1088,11 +1092,7 @@ mod tests {
             .iter()
             .map(|meta| {
                 RefCell::new(if sysvar::recent_blockhashes::check_id(&meta.pubkey) {
-                    sysvar::recent_blockhashes::create_account_with_data(
-                        1,
-                        vec![IterItem(0u64, &Hash::default(), &FeeCalculator::default()); 32]
-                            .into_iter(),
-                    )
+                    create_default_recent_blockhashes_account().into_inner()
                 } else if sysvar::rent::check_id(&meta.pubkey) {
                     sysvar::rent::create_account(1, &Rent::free())
                 } else {
@@ -1196,7 +1196,7 @@ mod tests {
                         &hash(&serialize(&0).unwrap()),
                         &FeeCalculator::default()
                     );
-                    32
+                    sysvar::recent_blockhashes::MAX_ENTRIES
                 ]
                 .into_iter(),
             ));

--- a/sdk/src/sysvar/recent_blockhashes.rs
+++ b/sdk/src/sysvar/recent_blockhashes.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use std::{cmp::Ordering, collections::BinaryHeap, iter::FromIterator, ops::Deref};
 
-pub const MAX_ENTRIES: usize = 300;
+pub const MAX_ENTRIES: usize = 150;
 
 declare_sysvar_id!(
     "SysvarRecentB1ockHashes11111111111111111111",
@@ -107,7 +107,7 @@ impl<T: Ord> Iterator for IntoIterSorted<T> {
 impl Sysvar for RecentBlockhashes {
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty
-        12008 // golden, update if MAX_ENTRIES changes
+        6008 // golden, update if MAX_ENTRIES changes
     }
 }
 
@@ -162,14 +162,14 @@ pub fn create_test_recent_blockhashes(start: usize) -> RecentBlockhashes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{clock::MAX_RECENT_BLOCKHASHES, hash::HASH_BYTES};
+    use crate::{clock::MAX_PROCESSING_AGE, hash::HASH_BYTES};
     use rand::seq::SliceRandom;
     use rand::thread_rng;
 
     #[test]
-    fn test_sysvar_can_hold_blockhash_queue() {
-        // Ensure we can still hold the entire `BlockhashQueue`
-        assert!(MAX_RECENT_BLOCKHASHES <= MAX_ENTRIES);
+    fn test_sysvar_can_hold_all_active_blockhashes() {
+        // Ensure we can still hold all of the active entries in `BlockhashQueue`
+        assert!(MAX_PROCESSING_AGE <= MAX_ENTRIES);
     }
 
     #[test]

--- a/sdk/src/sysvar/recent_blockhashes.rs
+++ b/sdk/src/sysvar/recent_blockhashes.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use std::{cmp::Ordering, collections::BinaryHeap, iter::FromIterator, ops::Deref};
 
-const MAX_ENTRIES: usize = 32;
+pub const MAX_ENTRIES: usize = 300;
 
 declare_sysvar_id!(
     "SysvarRecentB1ockHashes11111111111111111111",
@@ -107,7 +107,7 @@ impl<T: Ord> Iterator for IntoIterSorted<T> {
 impl Sysvar for RecentBlockhashes {
     fn size_of() -> usize {
         // hard-coded so that we don't have to construct an empty
-        1288 // golden, update if MAX_ENTRIES changes
+        12008 // golden, update if MAX_ENTRIES changes
     }
 }
 
@@ -162,9 +162,15 @@ pub fn create_test_recent_blockhashes(start: usize) -> RecentBlockhashes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hash::HASH_BYTES;
+    use crate::{clock::MAX_RECENT_BLOCKHASHES, hash::HASH_BYTES};
     use rand::seq::SliceRandom;
     use rand::thread_rng;
+
+    #[test]
+    fn test_sysvar_can_hold_blockhash_queue() {
+        // Ensure we can still hold the entire `BlockhashQueue`
+        assert!(MAX_RECENT_BLOCKHASHES <= MAX_ENTRIES);
+    }
 
     #[test]
     fn test_size_of() {


### PR DESCRIPTION
#### Problem

`RecentBlockhashes` sysvar only hold a subset of the `BlockhashQueue`, limiting its potential

#### Summary of Changes

Bump `recent_blockhashes::MAX_ENTRIES`
Add a test that `RecentBlockhashes` can hold the entire `BlockhashQueue`
Fix up some naughty users hardcoding the `MAX_ENTRIES` value