### PR TITLE
`solana catchup` now detects when you try to catchup to yourself

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -394,6 +394,19 @@ pub fn process_catchup(
         )
     };
 
+    let reported_node_pubkey = node_client.get_identity()?;
+    if reported_node_pubkey != *node_pubkey {
+        return Err(format!(
+            "The identity reported by node RPC URL does not match.  Expected: {:?}.  Reported: {:?}",
+            node_pubkey, reported_node_pubkey
+        )
+        .into());
+    }
+
+    if rpc_client.get_identity()? == *node_pubkey {
+        return Err("Both RPC URLs reference the same node, unable to monitor for catchup.  Try a different --url".into());
+    }
+
     let progress_bar = new_spinner_progress_bar();
     progress_bar.set_message("Connecting...");
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -6,8 +6,8 @@ use crate::{
     rpc_request::RpcRequest,
     rpc_response::{
         Response, RpcAccount, RpcBlockhashFeeCalculator, RpcConfirmedBlock, RpcContactInfo,
-        RpcEpochInfo, RpcFeeRateGovernor, RpcKeyedAccount, RpcLeaderSchedule, RpcResponse,
-        RpcVersionInfo, RpcVoteAccountStatus,
+        RpcEpochInfo, RpcFeeRateGovernor, RpcIdentity, RpcKeyedAccount, RpcLeaderSchedule,
+        RpcResponse, RpcVersionInfo, RpcVoteAccountStatus,
     },
 };
 use bincode::serialize;
@@ -354,6 +354,34 @@ impl RpcClient {
                 format!("GetEpochSchedule parse failure: {:?}", err),
             )
         })
+    }
+
+    pub fn get_identity(&self) -> io::Result<Pubkey> {
+        let response = self
+            .client
+            .send(&RpcRequest::GetIdentity, Value::Null, 0)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("GetIdentity request failure: {:?}", err),
+                )
+            })?;
+
+        serde_json::from_value(response)
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("GetIdentity failure: {:?}", err),
+                )
+            })
+            .and_then(|rpc_identity: RpcIdentity| {
+                rpc_identity.identity.parse::<Pubkey>().map_err(|err| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("GetIdentity invalid pubkey failure: {:?}", err),
+                    )
+                })
+            })
     }
 
     pub fn get_inflation(&self) -> io::Result<Inflation> {

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -15,6 +15,7 @@ pub enum RpcRequest {
     GetEpochInfo,
     GetEpochSchedule,
     GetGenesisHash,
+    GetIdentity,
     GetInflation,
     GetLeaderSchedule,
     GetNumBlocksSinceSignatureConfirmation,
@@ -55,6 +56,7 @@ impl RpcRequest {
             RpcRequest::GetEpochInfo => "getEpochInfo",
             RpcRequest::GetEpochSchedule => "getEpochSchedule",
             RpcRequest::GetGenesisHash => "getGenesisHash",
+            RpcRequest::GetIdentity => "getIdentity",
             RpcRequest::GetInflation => "getInflation",
             RpcRequest::GetLeaderSchedule => "getLeaderSchedule",
             RpcRequest::GetNumBlocksSinceSignatureConfirmation => {

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -242,6 +242,13 @@ pub struct RpcVersionInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct RpcIdentity {
+    /// The current node identity pubkey
+    pub identity: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcVoteAccountStatus {
     pub current: Vec<RpcVoteAccountInfo>,

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -26,6 +26,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getEpochSchedule](jsonrpc-api.md#getepochschedule)
 * [getFeeRateGovernor](jsonrpc-api.md#getfeerategovernor)
 * [getGenesisHash](jsonrpc-api.md#getgenesishash)
+* [getIdentity](jsonrpc-api.md#getidentity)
 * [getInflation](jsonrpc-api.md#getinflation)
 * [getLeaderSchedule](jsonrpc-api.md#getleaderschedule)
 * [getMinimumBalanceForRentExemption](jsonrpc-api.md#getminimumbalanceforrentexemption)
@@ -452,6 +453,29 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":"GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC","id":1}
+```
+
+### getIdentity
+
+Returns the identity pubkey for the current node
+
+#### Parameters:
+
+None
+
+#### Results:
+
+The result field will be a JSON object with the following fields:
+
+* `identity`, the identity pubkey of the current node \(as a base-58 encoded string\)
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getIdentity"}' http://localhost:8899
+// Result
+{"jsonrpc":"2.0","result":{"identity": "2r1F4iWqVcb8M1DbAjQuFpebkQHY9hcVU4WuW2DJBppN"},"id":1}
 ```
 
 ### getInflation

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -903,6 +903,7 @@ pub fn main() {
         rpc_config: JsonRpcConfig {
             enable_validator_exit: matches.is_present("enable_rpc_exit"),
             enable_get_confirmed_block: matches.is_present("enable_rpc_get_confirmed_block"),
+            identity_pubkey: identity_keypair.pubkey(),
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")
             }),


### PR DESCRIPTION
A common pothole in TdS is:
```
$ solana set --url http://127.0.0.1:8899
$ solana catchup ~/validator-identity.json
```

`solana catchup` will always succeed because you are caught up with yourself.  

This PR addresses that issue by detecting when you're talking to yourself and reporting an error.

Fixes #8084
