### PR TITLE
Always and fully deinitialize stored 0-lamport accts.

### DIFF
--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -334,6 +334,7 @@ mod tests {
         transaction::TransactionError,
     };
     use std::cell::RefCell;
+    use std::sync::Arc;
 
     impl From<Pubkey> for Address {
         fn from(address: Pubkey) -> Self {
@@ -931,6 +932,78 @@ mod tests {
         assert!(bank_client
             .send_instruction(&alice_keypair, allocate)
             .is_ok());
+    }
+
+    fn with_create_zero_lamport<F>(callback: F)
+    where
+        F: Fn(&Bank) -> (),
+    {
+        solana_logger::setup();
+
+        let alice_keypair = Keypair::new();
+        let bob_keypair = Keypair::new();
+
+        let alice_pubkey = alice_keypair.pubkey();
+        let bob_pubkey = bob_keypair.pubkey();
+
+        let program = Pubkey::new_rand();
+        let collector = Pubkey::new_rand();
+
+        let mint_lamports = 10000;
+        let len1 = 123;
+        let len2 = 456;
+
+        // create initial bank and fund the alice account
+        let (genesis_config, mint_keypair) = create_genesis_config(mint_lamports);
+        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank_client = BankClient::new_shared(&bank);
+        bank_client
+            .transfer(mint_lamports, &mint_keypair, &alice_pubkey)
+            .unwrap();
+
+        // create zero-lamports account to be cleaned
+        let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
+        let bank_client = BankClient::new_shared(&bank);
+        let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 0, len1, &program);
+        let message = Message::new(vec![ix]);
+        let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
+        assert!(r.is_ok());
+
+        // transfer some to bogus pubkey just to make previous bank (=slot) really cleanable
+        let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
+        let bank_client = BankClient::new_shared(&bank);
+        bank_client
+            .transfer(50, &alice_keypair, &Pubkey::new_rand())
+            .unwrap();
+
+        // super fun time; callback chooses to .clean_accounts() or not
+        callback(&*bank);
+
+        // create a normal account at the same pubkey as the zero-lamports account
+        let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
+        let bank_client = BankClient::new_shared(&bank);
+        let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 1, len2, &program);
+        let message = Message::new(vec![ix]);
+        let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn test_create_zero_lamport_with_clean() {
+        with_create_zero_lamport(|bank| {
+            bank.squash();
+            // do clean and assert that it actually did its job
+            assert_eq!(3, bank.get_snapshot_storages().len());
+            bank.clean_accounts();
+            assert_eq!(2, bank.get_snapshot_storages().len());
+        });
+    }
+
+    #[test]
+    fn test_create_zero_lamport_without_clean() {
+        with_create_zero_lamport(|_| {
+            // just do nothing; this should behave identically with test_create_zero_lamport_with_clean
+        });
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Recently, the TdS cluster died because of differing behavior in regards to handling a seemingly normal transaction, [resulting into two irreconcilable perpetual forks.](https://github.com/solana-labs/solana/issues/8590#issuecomment-594080164)

The direct cause is that `system_instruction_processor::allocate()`'s check differed in that it triggered and aborted the transaction or it processed the transaction normally.

The difference is caused by the fact that the state of the given account (with 0-lamport balance at the time) differed across the two forks. As a matter of fact, the transaction tried to recreate an account at the pubkey which recently got 0-lamport. Also note that the transaction should succeed because 0-lamport accounts should be equivalent to non-existing and shouldn't affect the succeeding transactions in any way.

Ultimately, the content of previous account differed because the one fork had called `Bank::clean_account()`, purged the 0-lamport account completely and passed a `Account::default()` to `system_instruction_processor::allocate()`. The other hadn't done so and 
passed an partially-deinitialized account to `system_instruction_processor::allocate()`, which was't same as `Account::default()` because there was lingering bad 0-lamport account index entry.

Currently, `Bank::clean_accounts()` could be called at any time while running validators because it's called as one of preparation steps of snapshot generation. In turn, snapshot timings are not synchronized across the cluster, meaning a validator can start to create a snapshot at any time.

#### Summary of Changes

Eliminate observable AccontsDB state difference depending on calling `Bank::clean_accounts()` or not by fully deinitializing accounts with 0-lamport before storing and indexing.

Originally, I thought tweaking `system_instruction_processor::allocate()` by adding `if account.lamports == 0`, but it created another error like this:

```
[2020-03-05T06:47:46.727369588Z DEBUG solana_runtime::bank] tx error: Err(InstructionError(0, AccountDataSizeChanged)) Transaction { signatures: [2V2NDFP5ztU28MEEk5suNEVoTdQhMCbxabx9zoT47BFnhezFo4CNLHjWWYJWLMSDFyaCUUaSdD9NBbwojpCQaHt4, 53dNNch84nZ2RMPnWeHRV1YpdaLetdanm45b4Udq3CvDuGyj85q38NpWVqW8HWe6NdFzULzYqpa1VJ9MUxtv9aas], message: Message { header: MessageHeader { num_required_signatures: 2, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 1 }, account_keys: [HPTqfUWRkjZSidPeTKKWS4JcicDjNp3jPuQtcSnLSNZj, G4NRURUNpx3VLDg7W88acurxVxspAdoTNacV7sHFvNPM, 11111111111111111111111111111111], recent_blockhash: Cid6k1HiuF883YfAHdSoZgF2b5TxPNBS3sNT2Ua84Hd, instructions: [CompiledInstruction { program_id_index: 2, accounts: [0, 1], data: [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 124, 0, 0, 0, 0, 0, 0, 0, 12, 155, 202, 84, 85, 242, 65, 121, 26, 152, 218, 87, 52, 59, 3, 36, 37, 164, 4, 23, 156, 202, 177, 215, 57, 234, 34, 173, 23, 218, 158, 238] }] } }
```

Ultimately, I've just noticed the stored 0-lamport account is of bad state:

```
[2020-03-05T05:52:39.322573307Z ERROR solana_runtime::system_instruction_processor] Account { lamports: 0 data.len: 0 owner: 6gtT3EUdxyDc2CR2wT6a9eDy6pLj8oi3LMFWeiukKPFo executable: false rent_epoch: 0 hash: 11111111111111111111111111111111 }
```

And I found that system_instruction level condition tweaking is fruiteless and found the root cause at the `AccountsDB::store()`.


Fixes #8590
