### PR TITLE
Fix docs build

### DIFF
--- a/ci/publish-docs.sh
+++ b/ci/publish-docs.sh
@@ -11,7 +11,7 @@ if [[ -n $CI_BRANCH ]]; then
     set -x
     (
       . ci/rust-version.sh stable
-      ci/docker-run.sh "$rust_stable_docker_image" make -C docs -B svg
+      ci/docker-run.sh "$rust_stable_docker_image" make -C docs
     )
     # make a local commit for the svgs
     git add -A -f docs/src/.gitbook/assets/.


### PR DESCRIPTION
#### Problem

Only SVG targets were being built for gitbook, therefore missing any auto-generated markdown.

#### Summary of Changes

* Build the default target, `all`
* Remote `-B` option, which I don't think is needed
