### PR TITLE
Docs: Use correct flag in keypair verification instructions

### DIFF
--- a/docs/src/paper-wallet/usage.md
+++ b/docs/src/paper-wallet/usage.md
@@ -125,7 +125,7 @@ Command
 
 ```text
 solana transfer 11111111111111111111111111111111 0 --sign-only \
-    --ask-seed-phrase keypair --blockhash 11111111111111111111111111111111
+    --keypair ASK --blockhash 11111111111111111111111111111111
 ```
 
 Prompt for seed phrase


### PR DESCRIPTION
#### Problem

Paper wallet keypair verification instructions still reference old `--ask-seed-phrase keypair` flag.

#### Summary of Changes

Update with current `--keypair ASK` flag