### PR TITLE
Ledger: return specific error if ledger-app-solana is not running

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -87,6 +87,7 @@ pub fn signer_from_path(
                     derivation_of(matches, "derivation_path"),
                     wallet_manager,
                     matches.is_present("confirm_key"),
+                    keypair_name,
                 )?))
             } else {
                 Err(RemoteWalletError::NoDeviceFound.into())

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -190,7 +190,9 @@ impl LedgerWallet {
         #[allow(clippy::match_overlapping_arm)]
         match status {
             // These need to be aligned with solana Ledger app error codes, and clippy allowance removed
-            0x6700 => Err(RemoteWalletError::Protocol("Incorrect length")),
+            0x6700 => Err(RemoteWalletError::Protocol(
+                "Solana app not open on Ledger device",
+            )),
             0x6802 => Err(RemoteWalletError::Protocol("Invalid parameter")),
             0x6803 => Err(RemoteWalletError::Protocol(
                 "Overflow: message longer than MAX_MESSAGE_LENGTH",

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -402,6 +402,7 @@ fn extend_and_serialize(derivation_path: &DerivationPath) -> Vec<u8> {
 /// Choose a Ledger wallet based on matching info fields
 pub fn get_ledger_from_info(
     info: RemoteWalletInfo,
+    keypair_name: &str,
     wallet_manager: &RemoteWalletManager,
 ) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
     let devices = wallet_manager.list_devices();
@@ -426,7 +427,10 @@ pub fn get_ledger_from_info(
     }
     let wallet_base_pubkey = if pubkeys.len() > 1 {
         let selection = Select::with_theme(&ColorfulTheme::default())
-            .with_prompt("Multiple hardware wallets found. Please select a device")
+            .with_prompt(&format!(
+                "Multiple hardware wallets found. Please select a device for {:?}",
+                keypair_name
+            ))
             .default(0)
             .items(&device_paths[..])
             .interact()

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -53,13 +53,14 @@ pub fn generate_remote_keypair(
     explicit_derivation_path: Option<DerivationPath>,
     wallet_manager: &RemoteWalletManager,
     confirm_key: bool,
+    keypair_name: &str,
 ) -> Result<RemoteKeypair, RemoteWalletError> {
     let (remote_wallet_info, mut derivation_path) = RemoteWalletInfo::parse_path(path)?;
     if let Some(derivation) = explicit_derivation_path {
         derivation_path = derivation;
     }
     if remote_wallet_info.manufacturer == "ledger" {
-        let ledger = get_ledger_from_info(remote_wallet_info, wallet_manager)?;
+        let ledger = get_ledger_from_info(remote_wallet_info, keypair_name, wallet_manager)?;
         Ok(RemoteKeypair::new(
             RemoteWalletType::Ledger(ledger),
             derivation_path,


### PR DESCRIPTION
#### Problem
It is possible to detect when a Ledger device is unlocked, but the solana app is not running. However, we don't communicate anything useful to the user, just a generic `Error: NoDeviceFound`.

#### Summary of Changes
If a device returns an error on `RemoteWalletManager::update_devices()`, stash that error in RemoteWalletInfo. Then, when an application attempts to generate a RemoteKeypair for that device, return the error.
This two-step process enables a user to successfully access a Ledger device that is running the solana app via the generic `usb://ledger` even if there is another device plugged in that is not running the solana app.

This pr also adds the signer field name in multiple-device prompt, helping to disambiguate in cases where two devices are being used to sign one CLI command.
