### PR TITLE
increment-cargo-version.sh: Properly escape current version

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -50,7 +50,7 @@ SPECIAL=""
 semverParseInto "$(readCargoVariable version "${Cargo_tomls[0]}")" MAJOR MINOR PATCH SPECIAL
 [[ -n $MAJOR ]] || usage
 
-currentVersion="$MAJOR.$MINOR.$PATCH$SPECIAL"
+currentVersion="$MAJOR\.$MINOR\.$PATCH$SPECIAL"
 
 bump=$1
 if [[ -z $bump ]]; then


### PR DESCRIPTION
Fixes #8396
