### PR TITLE
RPC: Add `getFeeCalculatorForBlockhash` method call

### DIFF
--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -71,6 +71,17 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                     serde_json::to_value(FeeCalculator::default()).unwrap(),
                 ),
             })?,
+            RpcRequest::GetFeeCalculatorForBlockhash => {
+                let value = if self.url == "blockhash_expired" {
+                    Value::Null
+                } else {
+                    serde_json::to_value(Some(FeeCalculator::default())).unwrap()
+                };
+                serde_json::to_value(Response {
+                    context: RpcResponseContext { slot: 1 },
+                    value,
+                })?
+            }
             RpcRequest::GetFeeRateGovernor => serde_json::to_value(Response {
                 context: RpcResponseContext { slot: 1 },
                 value: serde_json::to_value(FeeRateGovernor::default()).unwrap(),

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -21,6 +21,7 @@ pub enum RpcRequest {
     GetNumBlocksSinceSignatureConfirmation,
     GetProgramAccounts,
     GetRecentBlockhash,
+    GetFeeCalculatorForBlockhash,
     GetFeeRateGovernor,
     GetSignatureStatus,
     GetSlot,
@@ -64,6 +65,7 @@ impl RpcRequest {
             }
             RpcRequest::GetProgramAccounts => "getProgramAccounts",
             RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
+            RpcRequest::GetFeeCalculatorForBlockhash => "getFeeCalculatorForBlockhash",
             RpcRequest::GetFeeRateGovernor => "getFeeRateGovernor",
             RpcRequest::GetSignatureStatus => "getSignatureStatus",
             RpcRequest::GetSlot => "getSlot",
@@ -127,7 +129,7 @@ mod tests {
         assert_eq!(request["params"], json!([addr]));
 
         let test_request = RpcRequest::GetBalance;
-        let request = test_request.build_request_json(1, json!([addr]));
+        let request = test_request.build_request_json(1, json!([addr.clone()]));
         assert_eq!(request["method"], "getBalance");
 
         let test_request = RpcRequest::GetEpochInfo;
@@ -141,6 +143,10 @@ mod tests {
         let test_request = RpcRequest::GetRecentBlockhash;
         let request = test_request.build_request_json(1, Value::Null);
         assert_eq!(request["method"], "getRecentBlockhash");
+
+        let test_request = RpcRequest::GetFeeCalculatorForBlockhash;
+        let request = test_request.build_request_json(1, json!([addr.clone()]));
+        assert_eq!(request["method"], "getFeeCalculatorForBlockhash");
 
         let test_request = RpcRequest::GetFeeRateGovernor;
         let request = test_request.build_request_json(1, Value::Null);

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -154,6 +154,12 @@ pub struct RpcBlockhashFeeCalculator {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct RpcFeeCalculator {
+    pub fee_calculator: FeeCalculator,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcFeeRateGovernor {
     pub fee_rate_governor: FeeRateGovernor,
 }

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -445,6 +445,16 @@ impl SyncClient for ThinClient {
         }
     }
 
+    fn get_fee_calculator_for_blockhash(
+        &self,
+        blockhash: &Hash,
+    ) -> TransportResult<Option<FeeCalculator>> {
+        let fee_calculator = self
+            .rpc_client()
+            .get_fee_calculator_for_blockhash(blockhash)?;
+        Ok(fee_calculator)
+    }
+
     fn get_fee_rate_governor(&self) -> TransportResult<FeeRateGovernor> {
         let fee_rate_governor = self.rpc_client().get_fee_rate_governor()?;
         Ok(fee_rate_governor.value)

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -24,6 +24,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getConfirmedBlocks](jsonrpc-api.md#getconfirmedblocks)
 * [getEpochInfo](jsonrpc-api.md#getepochinfo)
 * [getEpochSchedule](jsonrpc-api.md#getepochschedule)
+* [getFeeCalculatorForBlockhash](jsonrpc-api.md#getfeecalculatorforblockhash)
 * [getFeeRateGovernor](jsonrpc-api.md#getfeerategovernor)
 * [getGenesisHash](jsonrpc-api.md#getgenesishash)
 * [getIdentity](jsonrpc-api.md#getidentity)
@@ -403,6 +404,30 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":{"firstNormalEpoch":8,"firstNormalSlot":8160,"leaderScheduleSlotOffset":8192,"slotsPerEpoch":8192,"warmup":true},"id":1}
+```
+
+### getFeeCalculatorForBlockhash
+
+Returns the fee calculator associated with the query blockhash, or `null` if the blockhash has expired
+
+#### Parameters:
+
+* `blockhash: <string>`, query blockhash as a Base58 encoded string
+
+#### Results:
+
+The `result` field will be `null` if the query blockhash has expired, otherwise an `object` with the following fields:
+
+* `feeCalculator: <object>`, `FeeCalculator` object describing the cluster fee rate at the queried blockhash
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getFeeCalculatorForBlockhash", "params":["GJxqhuxcgfn5Tcj6y3f8X4FeCDd2RQ6SnEMo1AAxrPRZ"]}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":{"context":{"slot":221},"value":{"feeCalculator":{"lamportsPerSignature":5000}}},"id":1}
 ```
 
 ### getFeeRateGovernor

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -137,6 +137,10 @@ impl SyncClient for BankClient {
         Ok(self.bank.last_blockhash_with_fee_calculator())
     }
 
+    fn get_fee_calculator_for_blockhash(&self, blockhash: &Hash) -> Result<Option<FeeCalculator>> {
+        Ok(self.bank.get_fee_calculator(blockhash))
+    }
+
     fn get_fee_rate_governor(&self) -> Result<FeeRateGovernor> {
         Ok(self.bank.get_fee_rate_governor().clone())
     }

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -72,6 +72,10 @@ pub trait SyncClient {
         commitment_config: CommitmentConfig,
     ) -> Result<(Hash, FeeCalculator)>;
 
+    /// Get `Some(FeeCalculator)` associated with `blockhash` if it is still in
+    /// the BlockhashQueue`, otherwise `None`
+    fn get_fee_calculator_for_blockhash(&self, blockhash: &Hash) -> Result<Option<FeeCalculator>>;
+
     /// Get recent fee rate governor
     fn get_fee_rate_governor(&self) -> Result<FeeRateGovernor>;
 


### PR DESCRIPTION
#### Problem

There is no RPC method for querying the cluster for a `FeeCalculator` by blockhash

#### Summary of Changes

Add `getFeeCalculatorForBlockhash`