### PR TITLE
Disable setLogFilter RPC API by default

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -48,6 +48,7 @@ fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
 #[derive(Debug, Default, Clone)]
 pub struct JsonRpcConfig {
     pub enable_validator_exit: bool,
+    pub enable_set_log_filter: bool,
     pub enable_get_confirmed_block: bool,
     pub identity_pubkey: Pubkey,
     pub faucet_addr: Option<SocketAddr>,
@@ -323,6 +324,13 @@ impl JsonRpcRequestProcessor {
             .map(|pubkey| pubkey.to_string())
             .collect();
         Ok(pubkeys)
+    }
+
+    pub fn set_log_filter(&self, filter: String) -> Result<()> {
+        if self.config.enable_set_log_filter {
+            solana_logger::setup_with(&filter);
+        }
+        Ok(())
     }
 
     pub fn validator_exit(&self) -> Result<bool> {
@@ -1098,9 +1106,11 @@ impl RpcSol for RpcSolImpl {
         })
     }
 
-    fn set_log_filter(&self, _meta: Self::Metadata, filter: String) -> Result<()> {
-        solana_logger::setup_with(&filter);
-        Ok(())
+    fn set_log_filter(&self, meta: Self::Metadata, filter: String) -> Result<()> {
+        meta.request_processor
+            .read()
+            .unwrap()
+            .set_log_filter(filter)
     }
 
     fn get_confirmed_block(

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -77,6 +77,7 @@ ledger_dir="$SOLANA_CONFIG_DIR"/bootstrap-validator
 
 args+=(
   --enable-rpc-exit
+  --enable-rpc-set-log-filter
   --ledger "$ledger_dir"
   --rpc-port 8899
   --snapshot-interval-slots 100

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -219,6 +219,8 @@ default_arg --voting-keypair "$voting_keypair_path"
 default_arg --storage-keypair "$storage_keypair_path"
 default_arg --ledger "$ledger_dir"
 default_arg --log -
+default_arg --enable-rpc-exit
+default_arg --enable-rpc-set-log-filter
 
 if [[ -n $SOLANA_CUDA ]]; then
   program=$solana_validator_cuda

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -293,7 +293,6 @@ EOF
         --enable-rpc-get-confirmed-block
       )
     else
-      args+=(--enable-rpc-exit)
       if [[ -n $internalNodesLamports ]]; then
         args+=(--node-lamports "$internalNodesLamports")
       fi

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -689,6 +689,12 @@ pub fn main() {
                 .help("Enable the JSON RPC 'validatorExit' API.  Only enable in a debug environment"),
         )
         .arg(
+            Arg::with_name("enable_rpc_set_log_filter")
+                .long("enable-rpc-set-log-filter")
+                .takes_value(false)
+                .help("Enable the JSON RPC 'setLogFilter' API.  Only enable in a debug environment"),
+        )
+        .arg(
             Arg::with_name("enable_rpc_get_confirmed_block")
                 .long("enable-rpc-get-confirmed-block")
                 .takes_value(false)
@@ -919,6 +925,7 @@ pub fn main() {
         new_hard_forks: hardforks_of(&matches, "hard_forks"),
         rpc_config: JsonRpcConfig {
             enable_validator_exit: matches.is_present("enable_rpc_exit"),
+            enable_set_log_filter: matches.is_present("enable_rpc_set_log_filter"),
             enable_get_confirmed_block: matches.is_present("enable_rpc_get_confirmed_block"),
             identity_pubkey: identity_keypair.pubkey(),
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {


### PR DESCRIPTION
If a node is running RPC, `curl`ing the following at it will cause it to log spam itself.   No need to make that available that outside of a dev environment
```
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"setLogFilter", "params":["*"]}' http://localhost:8899
```