### PR TITLE
Better error message for cli

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -75,7 +75,14 @@ pub fn signer_from_path(
                 false,
             )?))
         }
-        KeypairUrl::Filepath(path) => Ok(Box::new(read_keypair_file(&path)?)),
+        KeypairUrl::Filepath(path) => match read_keypair_file(&path) {
+            Err(e) => Err(Error::with_description(
+                &format!("Couldn't find keypair file: {:?} error: {:?}", path, e),
+                ErrorKind::InvalidValue,
+            )
+            .into()),
+            Ok(file) => Ok(Box::new(file)),
+        },
         KeypairUrl::Stdin => {
             let mut stdin = std::io::stdin();
             Ok(Box::new(read_keypair(&mut stdin)?))


### PR DESCRIPTION
#### Problem

If the user doesn't have a keypair, the only message for `solana address` is this error, which doesn't really give the user an indication on how to fix it:
`Os { code: 2, kind: NotFound, message: \"No such file or directory\"`

#### Summary of Changes

Add string in error message to indicate that it cannot find the keypair file and where it's looking.

New message:
```
Error: Error { message: "\u{1b}[1;31merror:\u{1b}[0m Couldn\'t find keypair file: \"foo.json\" error: O
s { code: 2, kind: NotFound, message: \"No such file or directory\" }", kind: InvalidValue, info: None
}
```

Fixes #
