### PR TITLE
Call usage in delegate-stake.sh when getting incorrect arguments

### DIFF
--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -61,6 +61,7 @@ while [[ -n $1 ]]; do
       usage "$@"
     else
       echo "Unknown argument: $1"
+      usage
       exit 1
     fi
   else


### PR DESCRIPTION
#### Problem

When user gives bad arguments, usage is not printed to help them figure out which ones are correct.

#### Summary of Changes

Print usage when this happens.

Fixes #
