### PR TITLE
Cli: Fix create-with-seed

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -1,5 +1,6 @@
 use crate::keypair::{
-    keypair_from_seed_phrase, signer_from_path, ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
+    keypair_from_seed_phrase, pubkey_from_path, signer_from_path, ASK_KEYWORD,
+    SKIP_SEED_PHRASE_VALIDATION_ARG,
 };
 use chrono::DateTime;
 use clap::ArgMatches;
@@ -108,6 +109,23 @@ pub fn signer_of(
         Ok((Some(signer), Some(signer_pubkey)))
     } else {
         Ok((None, None))
+    }
+}
+
+pub fn pubkey_of_signer(
+    matches: &ArgMatches<'_>,
+    name: &str,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+) -> Result<Option<Pubkey>, Box<dyn std::error::Error>> {
+    if let Some(location) = matches.value_of(name) {
+        Ok(Some(pubkey_from_path(
+            matches,
+            location,
+            name,
+            wallet_manager,
+        )?))
+    } else {
+        Ok(None)
     }
 }
 

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -110,6 +110,18 @@ pub fn signer_from_path(
     }
 }
 
+pub fn pubkey_from_path(
+    matches: &ArgMatches,
+    path: &str,
+    keypair_name: &str,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+) -> Result<Pubkey, Box<dyn error::Error>> {
+    match parse_keypair_path(path) {
+        KeypairUrl::Pubkey(pubkey) => Ok(pubkey),
+        _ => Ok(signer_from_path(matches, path, keypair_name, wallet_manager)?.pubkey()),
+    }
+}
+
 // Keyword used to indicate that the user should be asked for a keypair seed phrase
 pub const ASK_KEYWORD: &str = "ASK";
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2303,7 +2303,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .required(false)
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_signer)
                         .help("From (base) key, defaults to client keypair."),
                 ),
         )

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -590,7 +590,9 @@ pub fn parse_command(
             command: CliCommand::ClusterVersion,
             signers: vec![],
         }),
-        ("create-address-with-seed", Some(matches)) => parse_create_address_with_seed(matches, default_signer_path, wallet_manager),
+        ("create-address-with-seed", Some(matches)) => {
+            parse_create_address_with_seed(matches, default_signer_path, wallet_manager)
+        }
         ("fees", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::Fees,
             signers: vec![],
@@ -1039,7 +1041,7 @@ pub fn parse_create_address_with_seed(
     default_signer_path: &str,
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
-    let from_pubkey = pubkey_of(matches, "from");
+    let from_pubkey = pubkey_of_signer(matches, "from", wallet_manager)?;
     let signers = if from_pubkey.is_some() {
         vec![]
     } else {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3332,8 +3332,22 @@ mod tests {
         let signature = process_command(&config);
         assert_eq!(signature.unwrap(), SIGNATURE.to_string());
 
+        // CreateAddressWithSeed
+        let from_pubkey = Pubkey::new_rand();
+        config.signers = vec![];
+        config.command = CliCommand::CreateAddressWithSeed {
+            from_pubkey: Some(from_pubkey),
+            seed: "seed".to_string(),
+            program_id: solana_stake_program::id(),
+        };
+        let address = process_command(&config);
+        let expected_address =
+            create_address_with_seed(&from_pubkey, "seed", &solana_stake_program::id()).unwrap();
+        assert_eq!(address.unwrap(), expected_address.to_string());
+
         // Need airdrop cases
         let to = Pubkey::new_rand();
+        config.signers = vec![&keypair];
         config.command = CliCommand::Airdrop {
             faucet_host: None,
             faucet_port: 1234,


### PR DESCRIPTION
#### Problem
`solana create-with-seed ...` errors our no matter what from or config keypair is provided.
Also, users might want to derive keys from any kind of signer, including hardware wallets or seed phrases, and there is currently no support for that.

#### Summary of Changes
- Handle `--from` and config keypair setting appropriately to fix subcommand
- Add `pubkey_of_signer()` method to generate a pubkey from any kind of acceptable signer and use to extend create-with-seed functionality (we may want to use this method in other cli subcommands; will examine and pr separately)

Fixes #8696
