### PR TITLE
Remove unnecessary snapshot hash verification

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -352,34 +352,6 @@ impl Validator {
                 .set_entrypoint(entrypoint_info.clone());
         }
 
-        if let Some(ref snapshot_hash) = snapshot_hash {
-            if let Some(ref trusted_validators) = config.trusted_validators {
-                let mut trusted = false;
-                for _ in 0..10 {
-                    trusted = cluster_info
-                        .read()
-                        .unwrap()
-                        .get_snapshot_hash(snapshot_hash.0)
-                        .iter()
-                        .any(|(pubkey, hash)| {
-                            trusted_validators.contains(pubkey) && snapshot_hash.1 == *hash
-                        });
-                    if trusted {
-                        break;
-                    }
-                    sleep(Duration::from_secs(1));
-                }
-
-                if !trusted {
-                    error!(
-                        "The snapshot hash for slot {} is not published by your trusted validators: {:?}",
-                        snapshot_hash.0, trusted_validators
-                    );
-                    process::exit(1);
-                }
-            }
-        }
-
         let (snapshot_packager_service, snapshot_package_sender) =
             if config.snapshot_config.is_some() {
                 // Start a snapshot packaging service


### PR DESCRIPTION
The snapshot hash verification check performed by `Validator::new()` is unnecessary and undesirable.

_Unnecessary because:_
1. `validator/src/main.rs` refuses to download snapshot archives with hashes that are untrusted:  https://github.com/solana-labs/solana/blob/cb28ac3aed57dbc4d0719765e691a5bfb3beea8b/validator/src/main.rs#L338-L341
2. `bank_forks_utils::load()` ensures that one can't sneak a different snapshot hash into a downloaded snapshot archive:
https://github.com/solana-labs/solana/blob/cb28ac3aed57dbc4d0719765e691a5bfb3beea8b/ledger/src/bank_forks_utils.rs#L79-L85

_Undesirable because:_

When the `--no-snapshot-fetch` argument is used, the validator will never download a snapshot archive and only use locally produced archives.  However when a `--trusted-validator` argument also provided, the `Validator::new()` snapshot hash verification check will prevent the validator from booting when a locally produced archive is not in the snapshot hash list published by its trusted validator.  