### PR TITLE
Override GCE self-destruct timer in automation

### DIFF
--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -136,6 +136,7 @@ function launchTestnet() {
         $maybeCustomMachineType "$VALIDATOR_NODE_MACHINE_TYPE" $maybeEnableGpu \
         -p "$TESTNET_TAG" $maybeCreateAllowBootFailures $maybePublicIpAddresses \
         ${TESTNET_CLOUD_ZONES[@]/#/"-z "} \
+        --self-destruct-hours 0 \
         ${ADDITIONAL_FLAGS[@]/#/" "}
       ;;
     ec2)


### PR DESCRIPTION
#### Problem
Overnight test nodes are getting self-destructed just before the end of the test and resulting cleanup

#### Summary of Changes
Disable automatic self-destruct on GCE VMs for automated testing.

Fixes #8681 
