### PR TITLE
Remove --derivation-path option

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -4,7 +4,7 @@ use crate::keypair::{
 };
 use chrono::DateTime;
 use clap::ArgMatches;
-use solana_remote_wallet::remote_wallet::{DerivationPath, RemoteWalletManager};
+use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     clock::UnixTimestamp,
     native_token::sol_to_lamports,
@@ -131,16 +131,6 @@ pub fn pubkey_of_signer(
 
 pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {
     value_of(matches, name).map(sol_to_lamports)
-}
-
-pub fn derivation_of(matches: &ArgMatches<'_>, name: &str) -> Option<DerivationPath> {
-    matches.value_of(name).map(|derivation_str| {
-        let derivation_str = derivation_str.replace("'", "");
-        let mut parts = derivation_str.split('/');
-        let account = parts.next().map(|account| account.parse::<u32>().unwrap());
-        let change = parts.next().map(|change| change.parse::<u32>().unwrap());
-        DerivationPath { account, change }
-    })
 }
 
 #[cfg(test)]
@@ -316,41 +306,5 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "--single", "0.03"]);
         assert_eq!(lamports_of_sol(&matches, "single"), Some(30000000));
-    }
-
-    #[test]
-    fn test_derivation_of() {
-        let matches = app()
-            .clone()
-            .get_matches_from(vec!["test", "--single", "2/3"]);
-        assert_eq!(
-            derivation_of(&matches, "single"),
-            Some(DerivationPath {
-                account: Some(2),
-                change: Some(3)
-            })
-        );
-        assert_eq!(derivation_of(&matches, "another"), None);
-        let matches = app()
-            .clone()
-            .get_matches_from(vec!["test", "--single", "2"]);
-        assert_eq!(
-            derivation_of(&matches, "single"),
-            Some(DerivationPath {
-                account: Some(2),
-                change: None
-            })
-        );
-        assert_eq!(derivation_of(&matches, "another"), None);
-        let matches = app()
-            .clone()
-            .get_matches_from(vec!["test", "--single", "2'/3'"]);
-        assert_eq!(
-            derivation_of(&matches, "single"),
-            Some(DerivationPath {
-                account: Some(2),
-                change: Some(3)
-            })
-        );
     }
 }

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,8 +1,4 @@
-use crate::{
-    input_parsers::{derivation_of, pubkeys_sigs_of},
-    offline::SIGNER_ARG,
-    ArgConstant,
-};
+use crate::{input_parsers::pubkeys_sigs_of, offline::SIGNER_ARG, ArgConstant};
 use bip39::{Language, Mnemonic, Seed};
 use clap::{ArgMatches, Error, ErrorKind};
 use rpassword::prompt_password_stderr;
@@ -91,7 +87,6 @@ pub fn signer_from_path(
             if let Some(wallet_manager) = wallet_manager {
                 Ok(Box::new(generate_remote_keypair(
                     path,
-                    derivation_of(matches, "derivation_path"),
                     wallet_manager,
                     matches.is_present("confirm_key"),
                     keypair_name,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -23,7 +23,7 @@ use solana_client::{client_error::ClientError, rpc_client::RpcClient};
 use solana_faucet::faucet::request_airdrop_transaction;
 #[cfg(test)]
 use solana_faucet::faucet_mock::request_airdrop_transaction;
-use solana_remote_wallet::remote_wallet::{DerivationPath, RemoteWalletManager};
+use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     bpf_loader,
     clock::{Epoch, Slot},
@@ -455,7 +455,6 @@ pub struct CliConfig<'a> {
     pub websocket_url: String,
     pub signers: Vec<&'a dyn Signer>,
     pub keypair_path: String,
-    pub derivation_path: Option<DerivationPath>,
     pub rpc_client: Option<RpcClient>,
     pub verbose: bool,
 }
@@ -547,7 +546,6 @@ impl Default for CliConfig<'_> {
             websocket_url: Self::default_websocket_url(),
             signers: Vec::new(),
             keypair_path: Self::default_keypair_path(),
-            derivation_path: None,
             rpc_client: None,
             verbose: false,
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,11 +1,7 @@
 use clap::{crate_description, crate_name, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand};
 use console::style;
 
-use solana_clap_utils::{
-    input_parsers::derivation_of,
-    input_validators::{is_derivation, is_url},
-    keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
-};
+use solana_clap_utils::{input_validators::is_url, keypair::SKIP_SEED_PHRASE_VALIDATION_ARG};
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliSigners},
     display::{println_name_value, println_name_value_or},
@@ -132,7 +128,6 @@ pub fn parse_args<'a>(
             websocket_url,
             signers: vec![],
             keypair_path: default_signer_path,
-            derivation_path: derivation_of(matches, "derivation_path"),
             rpc_client: None,
             verbose: matches.is_present("verbose"),
         },
@@ -188,15 +183,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .global(true)
             .takes_value(true)
             .help("/path/to/id.json or usb://remote/wallet/path"),
-    )
-    .arg(
-        Arg::with_name("derivation_path")
-            .long("derivation-path")
-            .value_name("ACCOUNT or ACCOUNT/CHANGE")
-            .global(true)
-            .takes_value(true)
-            .validator(is_derivation)
-            .help("Derivation path to use: m/44'/501'/ACCOUNT'/CHANGE'; default key is device base pubkey: m/44'/501'/0'")
     )
     .arg(
         Arg::with_name("verbose")

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -50,15 +50,11 @@ impl Signer for RemoteKeypair {
 
 pub fn generate_remote_keypair(
     path: String,
-    explicit_derivation_path: Option<DerivationPath>,
     wallet_manager: &RemoteWalletManager,
     confirm_key: bool,
     keypair_name: &str,
 ) -> Result<RemoteKeypair, RemoteWalletError> {
-    let (remote_wallet_info, mut derivation_path) = RemoteWalletInfo::parse_path(path)?;
-    if let Some(derivation) = explicit_derivation_path {
-        derivation_path = derivation;
-    }
+    let (remote_wallet_info, derivation_path) = RemoteWalletInfo::parse_path(path)?;
     if remote_wallet_info.manufacturer == "ledger" {
         let ledger = get_ledger_from_info(remote_wallet_info, keypair_name, wallet_manager)?;
         Ok(RemoteKeypair::new(


### PR DESCRIPTION
#### Problem

We added the `--derivation-path` option before we added the `?key=<DERIVATION_PATH>` feature.  The `--derivation-path` option is now redundant. It's also limited, as the option only applies to the keypair at `--keypair`.  To be consistent, we'd need to add a second option for each keypair option.

#### Summary of Changes

Remove `--derivation-path`.  Use `?key=<DERIVATION_PATH>` instead.
