### PR TITLE
Docs: Fix missing CLI `usage.md`

### DIFF
--- a/ci/publish-docs.sh
+++ b/ci/publish-docs.sh
@@ -15,6 +15,7 @@ if [[ -n $CI_BRANCH ]]; then
     )
     # make a local commit for the svgs
     git add -A -f docs/src/.gitbook/assets/.
+    git add -f docs/src/cli/usage.md
     if ! git diff-index --quiet HEAD; then
       git config user.email maintainers@solana.com
       git config user.name "$me"


### PR DESCRIPTION
#### Problem

Auto-generated `cli/usage.md` never makes it into the repo mirror that Gitbook pulls our doc sources from, leading to an empty page in the rendered output

#### Summary of Changes

Force add the ignored `.md` in publish automation

h/t: @danpaul000 