### PR TITLE
Fix Gitbook's markdown rendering

### DIFF
--- a/docs/src/remote-wallet/ledger.md
+++ b/docs/src/remote-wallet/ledger.md
@@ -49,6 +49,7 @@ OSError: open failed
 ```
 
 To fix, check the following:
+
 1. Ensure your Ledger device is connected to USB
 2. Ensure your Ledger device is unlocked and not waiting for you to enter your pin
 3. Ensure the Ledger Live application is not open


### PR DESCRIPTION
#### Problem

Gitbook renders markdown differently than mdbook, which is what we run locally.

#### Summary of Changes

Add a newline, so that Gitbook will render the list correctly.
