### PR TITLE
Automated tests should use dedicated colo nodes

### DIFF
--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -165,7 +165,7 @@ function launchTestnet() {
     # shellcheck disable=SC2086
       net/colo.sh create \
         -n "$NUMBER_OF_VALIDATOR_NODES" -c "$NUMBER_OF_CLIENT_NODES" $maybeEnableGpu \
-        -p "$TESTNET_TAG" $maybePublicIpAddresses \
+        -p "$TESTNET_TAG" $maybePublicIpAddresses --dedicated \
         ${ADDITIONAL_FLAGS[@]/#/" "}
       ;;
     *)


### PR DESCRIPTION
Now that colo tests can pre-empt reservations, make sure thee automation uses `--dedicated` reservations to protect it from itself running on a parallel job.