### PR TITLE
Print approved msg after Ledger device interaction

### DIFF
--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -229,8 +229,12 @@ impl LedgerWallet {
         self.write(command, p1, p2, data)?;
         if p1 == P1_CONFIRM && is_last_part(p2) {
             println!("Waiting for remote wallet to approve...");
+            let result = self.read()?;
+            println!("Approved");
+            Ok(result)
+        } else {
+            self.read()
         }
-        self.read()
     }
 
     fn _get_firmware_version(&self) -> Result<FirmwareVersion, RemoteWalletError> {


### PR DESCRIPTION
#### Problem
The cli prints a message when waiting for Ledger device approval/interaction, but it isn't clear when a transaction signature approval is successful and the cli progresses to waiting for the transaction to be confirmed.

#### Summary of Changes
Print an "Approved" message after approval is received
