### PR TITLE
Add longer running performance tests and new partition testcase

### DIFF
--- a/system-test/netem-configs/complete-loss-two-partitions
+++ b/system-test/netem-configs/complete-loss-two-partitions
@@ -1,0 +1,18 @@
+{
+      "partitions":[
+         50,
+         50
+      ],
+      "interconnects":[
+         {
+            "a":0,
+            "b":1,
+            "config":"loss 100%"
+         },
+         {
+            "a":1,
+            "b":0,
+            "config":"loss 100%"
+         }
+      ]
+}

--- a/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
+++ b/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
@@ -1,11 +1,10 @@
 steps:
   - command: "system-test/testnet-automation.sh"
-    label: "GCE - 1 hour perf stability"
+    label: "GCE - 2 even partitions with full loss"
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "gce"
       TESTNET_TAG: "gce-perf-cpu-only"
-      TEST_DURATION_SECONDS: 3600
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
@@ -14,5 +13,10 @@ steps:
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"
+      APPLY_PARTITIONS: "true"
+      NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"
+      PARTITION_ACTIVE_DURATION: 60
+      PARTITION_INACTIVE_DURATION: 300
+      PARTITION_ITERATION_COUNT: 5
     agents:
       - "queue=gce-deploy"

--- a/system-test/stability-testcases/colo-long-duration-cpu-only-perf.yml
+++ b/system-test/stability-testcases/colo-long-duration-cpu-only-perf.yml
@@ -1,0 +1,15 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "COLO 1 hour performance & stability CPU only"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "colo"
+      TESTNET_TAG: "colo-perf-cpu-only"
+      ENABLE_GPU: "false"
+      TEST_DURATION_SECONDS: 3600
+      NUMBER_OF_VALIDATOR_NODES: 3
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 30000 --thread-batch-sleep-ms 250"
+      ADDITIONAL_FLAGS: ""
+    agents:
+      - "queue=colo-deploy"

--- a/system-test/stability-testcases/colo-long-duration-gpu-perf.yml
+++ b/system-test/stability-testcases/colo-long-duration-gpu-perf.yml
@@ -1,0 +1,15 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "COLO 1 hour performance & stability GPU enabled"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "colo"
+      TESTNET_TAG: "colo-perf-gpu-enabled"
+      ENABLE_GPU: "true"
+      TEST_DURATION_SECONDS: 3600
+      NUMBER_OF_VALIDATOR_NODES: 3
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 30000 --thread-batch-sleep-ms 250"
+      ADDITIONAL_FLAGS: ""
+    agents:
+      - "queue=colo-deploy"

--- a/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
+++ b/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
@@ -1,0 +1,18 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "GCE - 1 hour perf stability"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "gce"
+      TESTNET_TAG: "gce-perf-cpu-only"
+      TEST_DURATION_SECONDS: 3600
+      NUMBER_OF_VALIDATOR_NODES: 5
+      ENABLE_GPU: "false"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 20000 --thread-batch-sleep-ms 250"
+      TESTNET_ZONES: "us-west1-a"
+      USE_PUBLIC_IP_ADDRESSES: "true"
+      ADDITIONAL_FLAGS: "--dedicated"
+    agents:
+      - "queue=gce-deploy"


### PR DESCRIPTION
#### Problem
We haven't been running partition testcases in the nightly runs.
Should try running high tx cases longer than the standard ten minutes to try to expose more memory issues.

#### Summary of Changes
1. Add a new netem config that induces a full-loss partition across 50% of the network.

2. Add a GCE-based testcase that exercises the new netem partition config.

3. Add 1-hour long non-partitioned high throughput testcases to see what memory issues arise:
- 5 CPU-only nodes on GCE in a single zone with internal-only IP addressing
- Colo node test with GPUs disabled
- Colo node tesst with GPUs enabled
