### PR TITLE
Revert to a computed `websocket_url` value when `json_rpc_url` is changed

### DIFF
--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -31,7 +31,10 @@ impl Default for Config {
             keypair_path.to_str().unwrap().to_string()
         };
         let json_rpc_url = "http://127.0.0.1:8899".to_string();
-        let websocket_url = Self::compute_websocket_url(&json_rpc_url);
+
+        // Empty websocket_url string indicates the client should
+        // `Config::compute_websocket_url(&json_rpc_url)`
+        let websocket_url = "".to_string();
 
         Self {
             json_rpc_url,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -55,6 +55,9 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                     let mut config = Config::load(config_file).unwrap_or_default();
                     if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
                         config.json_rpc_url = url.to_string();
+                        // Revert to a computed `websocket_url` value when `json_rpc_url` is
+                        // changed
+                        config.websocket_url = "".to_string();
                     }
                     if let Some(url) = subcommand_matches.value_of("websocket_url") {
                         config.websocket_url = url.to_string();


### PR DESCRIPTION
When one runs, 'solana config set --url http://tds.solana.com/`, it's annoying that the websocket URL doesn't follow along (making it easy to have an RPC URL aimed at one cluster, while a websocket URL aimed at another).  Fix it