### PR TITLE
cli: split-stake: Permit fee-payer/split-stake accounts to be the same when using --seed

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1041,13 +1041,16 @@ pub fn process_split_stake(
 ) -> ProcessResult {
     let split_stake_account = config.signers[split_stake_account];
     let fee_payer = config.signers[fee_payer];
-    check_unique_pubkeys(
-        (&fee_payer.pubkey(), "fee-payer keypair".to_string()),
-        (
-            &split_stake_account.pubkey(),
-            "split_stake_account".to_string(),
-        ),
-    )?;
+
+    if split_stake_account_seed.is_none() {
+        check_unique_pubkeys(
+            (&fee_payer.pubkey(), "fee-payer keypair".to_string()),
+            (
+                &split_stake_account.pubkey(),
+                "split_stake_account".to_string(),
+            ),
+        )?;
+    }
     check_unique_pubkeys(
         (&fee_payer.pubkey(), "fee-payer keypair".to_string()),
         (&stake_account_pubkey, "stake_account".to_string()),


### PR DESCRIPTION
This is ok:
```
$ solana --keypair ~/vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg.json \
  split-stake ~/stake16WnfUdP4uYZTuBr3ezc6MxS4GUd74jK6tkdDC.json \
  ~/vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg.json 1  --seed seed
```

I'm creating a derived stake account from `vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg` whilst also paying the transaction fee from `vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg`