### PR TITLE
Don't use move semantics if not needed

### DIFF
--- a/archiver-lib/src/archiver.rs
+++ b/archiver-lib/src/archiver.rs
@@ -379,8 +379,7 @@ impl Archiver {
                         &archiver_keypair.pubkey(),
                         &storage_keypair.pubkey(),
                     );
-                    let message =
-                        Message::new_with_payer(vec![ix], Some(&archiver_keypair.pubkey()));
+                    let message = Message::new_with_payer(&[ix], Some(&archiver_keypair.pubkey()));
                     if let Err(e) = client.send_message(&[archiver_keypair.as_ref()], message) {
                         error!("unable to redeem reward, tx failed: {:?}", e);
                     } else {
@@ -655,7 +654,7 @@ impl Archiver {
             Signature::new(&meta.signature.as_ref()),
             meta.blockhash,
         );
-        let message = Message::new_with_payer(vec![instruction], Some(&archiver_keypair.pubkey()));
+        let message = Message::new_with_payer(&[instruction], Some(&archiver_keypair.pubkey()));
         let mut transaction = Transaction::new(
             &[archiver_keypair.as_ref(), storage_keypair.as_ref()],
             message,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1225,7 +1225,7 @@ fn process_deploy(
         program_data.len() as u64,
         &bpf_loader::id(),
     );
-    let message = Message::new(vec![ix]);
+    let message = Message::new(&[ix]);
     let mut create_account_tx = Transaction::new_unsigned(message);
     create_account_tx.try_sign(&[config.signers[0], &program_id], blockhash)?;
     messages.push(&create_account_tx.message);
@@ -1238,7 +1238,7 @@ fn process_deploy(
             (i * DATA_CHUNK_SIZE) as u32,
             chunk.to_vec(),
         );
-        let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
+        let message = Message::new_with_payer(&[instruction], Some(&signers[0].pubkey()));
         let mut tx = Transaction::new_unsigned(message);
         tx.try_sign(&signers, blockhash)?;
         write_transactions.push(tx);
@@ -1248,7 +1248,7 @@ fn process_deploy(
     }
 
     let instruction = loader_instruction::finalize(&program_id.pubkey(), &bpf_loader::id());
-    let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
+    let message = Message::new_with_payer(&[instruction], Some(&signers[0].pubkey()));
     let mut finalize_tx = Transaction::new_unsigned(message);
     finalize_tx.try_sign(&signers, blockhash)?;
     messages.push(&finalize_tx.message);
@@ -1315,7 +1315,7 @@ fn process_pay(
         let message = if let Some(nonce_account) = &nonce_account {
             Message::new_with_nonce(vec![ix], None, nonce_account, &nonce_authority.pubkey())
         } else {
-            Message::new(vec![ix])
+            Message::new(&[ix])
         };
         let mut tx = Transaction::new_unsigned(message);
         tx.try_sign(&config.signers, blockhash)?;
@@ -1355,7 +1355,7 @@ fn process_pay(
             cancelable,
             lamports,
         );
-        let message = Message::new(ixs);
+        let message = Message::new(&ixs);
         let mut tx = Transaction::new_unsigned(message);
         tx.try_sign(&[config.signers[0], &contract_state], blockhash)?;
         if sign_only {
@@ -1398,7 +1398,7 @@ fn process_pay(
             cancelable,
             lamports,
         );
-        let message = Message::new(ixs);
+        let message = Message::new(&ixs);
         let mut tx = Transaction::new_unsigned(message);
         tx.try_sign(&[config.signers[0], &contract_state], blockhash)?;
         if sign_only {
@@ -1432,7 +1432,7 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
         pubkey,
         &config.signers[0].pubkey(),
     );
-    let message = Message::new(vec![ix]);
+    let message = Message::new(&[ix]);
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee(
@@ -1455,7 +1455,7 @@ fn process_time_elapsed(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_timestamp(&config.signers[0].pubkey(), pubkey, to, dt);
-    let message = Message::new(vec![ix]);
+    let message = Message::new(&[ix]);
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee(
@@ -1503,7 +1503,7 @@ fn process_transfer(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
+        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
@@ -1535,7 +1535,7 @@ fn process_witness(
     let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let ix = budget_instruction::apply_signature(&config.signers[0].pubkey(), pubkey, to);
-    let message = Message::new(vec![ix]);
+    let message = Message::new(&[ix]);
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee(

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -828,7 +828,7 @@ pub fn process_ping(
         last_blockhash = recent_blockhash;
 
         let ix = system_instruction::transfer(&config.signers[0].pubkey(), &to, lamports);
-        let message = Message::new(vec![ix]);
+        let message = Message::new(&[ix]);
         let mut transaction = Transaction::new_unsigned(message);
         transaction.try_sign(&config.signers, recent_blockhash)?;
         check_account_for_fee(

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -391,7 +391,7 @@ pub fn process_authorize_nonce_account(
 
     let nonce_authority = config.signers[nonce_authority];
     let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
-    let message = Message::new_with_payer(vec![ix], Some(&config.signers[0].pubkey()));
+    let message = Message::new_with_payer(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
 
@@ -470,7 +470,7 @@ pub fn process_create_nonce_account(
 
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let message = Message::new_with_payer(ixs, Some(&config.signers[0].pubkey()));
+    let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
 
@@ -526,7 +526,7 @@ pub fn process_new_nonce(
     let nonce_authority = config.signers[nonce_authority];
     let ix = advance_nonce_account(&nonce_account, &nonce_authority.pubkey());
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let message = Message::new_with_payer(vec![ix], Some(&config.signers[0].pubkey()));
+    let message = Message::new_with_payer(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(
@@ -612,7 +612,7 @@ pub fn process_withdraw_from_nonce_account(
         destination_account_pubkey,
         lamports,
     );
-    let message = Message::new_with_payer(vec![ix], Some(&config.signers[0].pubkey()));
+    let message = Message::new_with_payer(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -827,7 +827,7 @@ pub fn process_create_stake_account(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
+        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
@@ -889,7 +889,7 @@ pub fn process_stake_authorize(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
+        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
@@ -942,7 +942,7 @@ pub fn process_deactivate_stake_account(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
+        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
@@ -1001,7 +1001,7 @@ pub fn process_withdraw_stake(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
+        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
@@ -1131,7 +1131,7 @@ pub fn process_split_stake(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
+        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
@@ -1187,7 +1187,7 @@ pub fn process_stake_set_lockup(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
+        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
@@ -1421,7 +1421,7 @@ pub fn process_delegate_stake(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(ixs, Some(&fee_payer.pubkey()))
+        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -212,7 +212,7 @@ pub fn process_create_storage_account(
     );
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let message = Message::new(ixs);
+    let message = Message::new(&ixs);
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(
@@ -236,7 +236,7 @@ pub fn process_claim_storage_reward(
     let instruction =
         storage_instruction::claim_reward(node_account_pubkey, storage_account_pubkey);
     let signers = [config.signers[0]];
-    let message = Message::new_with_payer(vec![instruction], Some(&signers[0].pubkey()));
+    let message = Message::new_with_payer(&[instruction], Some(&signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&signers, recent_blockhash)?;
     check_account_for_fee(

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -339,7 +339,7 @@ pub fn process_set_validator_info(
             &validator_info,
         )]);
         let signers = vec![config.signers[0], &info_keypair];
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         (message, signers)
     } else {
         println!(
@@ -353,7 +353,7 @@ pub fn process_set_validator_info(
             keys,
             &validator_info,
         )];
-        let message = Message::new_with_payer(instructions, Some(&config.signers[0].pubkey()));
+        let message = Message::new_with_payer(&instructions, Some(&config.signers[0].pubkey()));
         let signers = vec![config.signers[0]];
         (message, signers)
     };

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -359,7 +359,7 @@ pub fn process_create_vote_account(
     };
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
-    let message = Message::new(ixs);
+    let message = Message::new(&ixs);
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(
@@ -391,7 +391,7 @@ pub fn process_vote_authorize(
         vote_authorize,              // vote or withdraw
     )];
 
-    let message = Message::new_with_payer(ixs, Some(&config.signers[0].pubkey()));
+    let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(
@@ -422,7 +422,7 @@ pub fn process_vote_update_validator(
         new_identity_pubkey,
     )];
 
-    let message = Message::new_with_payer(ixs, Some(&config.signers[0].pubkey()));
+    let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee(

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -368,7 +368,7 @@ impl SyncClient for ThinClient {
         keypair: &Keypair,
         instruction: Instruction,
     ) -> TransportResult<Signature> {
-        let message = Message::new(vec![instruction]);
+        let message = Message::new(&[instruction]);
         self.send_message(&[keypair], message)
     }
 
@@ -596,7 +596,7 @@ impl AsyncClient for ThinClient {
         instruction: Instruction,
         recent_blockhash: Hash,
     ) -> io::Result<Signature> {
-        let message = Message::new(vec![instruction]);
+        let message = Message::new(&[instruction]);
         self.async_send_message(&[keypair], message, recent_blockhash)
     }
     fn async_transfer(

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -312,7 +312,7 @@ impl StorageStage {
         }
 
         let signer_keys = vec![keypair.as_ref(), storage_keypair.as_ref()];
-        let message = Message::new_with_payer(vec![instruction], Some(&signer_keys[0].pubkey()));
+        let message = Message::new_with_payer(&[instruction], Some(&signer_keys[0].pubkey()));
         let transaction = Transaction::new(&signer_keys, message, blockhash);
         // try sending the transaction upto 5 times
         for _ in 0..5 {

--- a/core/tests/storage_stage.rs
+++ b/core/tests/storage_stage.rs
@@ -120,7 +120,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let message = Message::new_with_payer(vec![mining_proof_ix], Some(&mint_keypair.pubkey()));
+        let message = Message::new_with_payer(&[mining_proof_ix], Some(&mint_keypair.pubkey()));
         let mining_proof_tx = Transaction::new(
             &[&mint_keypair, archiver_keypair.as_ref()],
             message,

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -127,7 +127,7 @@ impl Faucet {
 
                     let create_instruction =
                         system_instruction::transfer(&self.mint_keypair.pubkey(), &to, lamports);
-                    let message = Message::new(vec![create_instruction]);
+                    let message = Message::new(&[create_instruction]);
                     Ok(Transaction::new(&[&self.mint_keypair], message, blockhash))
                 } else {
                     Err(Error::new(
@@ -413,7 +413,7 @@ mod tests {
 
         let keypair = Keypair::new();
         let expected_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);
-        let message = Message::new(vec![expected_instruction]);
+        let message = Message::new(&[expected_instruction]);
         let expected_tx = Transaction::new(&[&keypair], message, blockhash);
         let expected_bytes = serialize(&expected_tx).unwrap();
         let mut expected_vec_with_length = vec![0; 2];

--- a/faucet/tests/local-faucet.rs
+++ b/faucet/tests/local-faucet.rs
@@ -16,7 +16,7 @@ fn test_local_faucet() {
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
     let create_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);
-    let message = Message::new(vec![create_instruction]);
+    let message = Message::new(&[create_instruction]);
     let expected_tx = Transaction::new(&[&keypair], message, blockhash);
 
     let (sender, receiver) = channel();

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -244,7 +244,7 @@ fn store_update_manifest(
         update_manifest,
     );
 
-    let message = Message::new_with_payer(vec![instruction], Some(&from_keypair.pubkey()));
+    let message = Message::new_with_payer(&[instruction], Some(&from_keypair.pubkey()));
     let mut transaction = Transaction::new(&signers, message, recent_blockhash);
     rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
     Ok(())

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -566,7 +566,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         }
         ("verify", Some(matches)) => {
             let keypair = get_keypair_from_matches(matches, config, wallet_manager)?;
-            let simple_message = Message::new(vec![Instruction::new(
+            let simple_message = Message::new(&[Instruction::new(
                 Pubkey::default(),
                 &0,
                 vec![AccountMeta::new(keypair.pubkey(), true)],

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -685,8 +685,7 @@ mod tests {
     fn test_verify_tick_hash_count() {
         let hashes_per_tick = 10;
         let keypairs: Vec<&Keypair> = Vec::new();
-        let tx: Transaction =
-            Transaction::new(&keypairs, Message::new(Vec::new()), Hash::default());
+        let tx: Transaction = Transaction::new(&keypairs, Message::new(&[]), Hash::default());
         let tx_entry = Entry::new(&Hash::default(), 1, vec![tx]);
         let full_tick_entry = Entry::new_tick(hashes_per_tick, &Hash::default());
         let partial_tick_entry = Entry::new_tick(hashes_per_tick - 1, &Hash::default());

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -614,7 +614,7 @@ impl LocalCluster {
             StorageAccountType::Validator
         };
         let message = Message::new_with_payer(
-            storage_instruction::create_storage_account(
+            &storage_instruction::create_storage_account(
                 &from_keypair.pubkey(),
                 &from_keypair.pubkey(),
                 &storage_keypair.pubkey(),

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -256,7 +256,7 @@ mod tests {
             budget_instruction::payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 1);
         instructions[1].accounts = vec![]; // <!-- Attack! Prevent accounts from being passed into processor.
 
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         assert_eq!(
             bank_client
                 .send_message(&[&alice_keypair, &budget_keypair], message)
@@ -276,7 +276,7 @@ mod tests {
         let budget_pubkey = budget_keypair.pubkey();
         let instructions =
             budget_instruction::payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 100);
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -302,7 +302,7 @@ mod tests {
             None,
             1,
         );
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -315,7 +315,7 @@ mod tests {
             .unwrap();
         let instruction =
             budget_instruction::apply_signature(&mallory_pubkey, &budget_pubkey, &bob_pubkey);
-        let mut message = Message::new(vec![instruction]);
+        let mut message = Message::new(&[instruction]);
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         message.account_keys.insert(3, alice_pubkey);
@@ -352,7 +352,7 @@ mod tests {
             None,
             1,
         );
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -365,7 +365,7 @@ mod tests {
             .unwrap();
         let instruction =
             budget_instruction::apply_timestamp(&mallory_pubkey, &budget_pubkey, &bob_pubkey, dt);
-        let mut message = Message::new(vec![instruction]);
+        let mut message = Message::new(&[instruction]);
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         message.account_keys.insert(3, alice_pubkey);
@@ -402,7 +402,7 @@ mod tests {
             None,
             1,
         );
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -472,7 +472,7 @@ mod tests {
             Some(alice_pubkey),
             1,
         );
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -550,7 +550,7 @@ mod tests {
             game_hash,
             41,
         );
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -570,7 +570,7 @@ mod tests {
 
         // Anyone can sign the message, but presumably it's Bob, since he's the
         // one claiming the payout.
-        let message = Message::new_with_payer(vec![instruction], Some(&bob_pubkey));
+        let message = Message::new_with_payer(&[instruction], Some(&bob_pubkey));
         bank_client.send_message(&[&bob_keypair], message).unwrap();
 
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 0);

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -603,7 +603,7 @@ mod test {
         );
 
         client
-            .send_message(&[owner, &new], Message::new(vec![instruction]))
+            .send_message(&[owner, &new], Message::new(&[instruction]))
             .expect(&format!("{}:{}", line!(), file!()));
         new.pubkey()
     }

--- a/programs/librapay/src/lib.rs
+++ b/programs/librapay/src/lib.rs
@@ -32,11 +32,11 @@ pub fn create_genesis<T: Client>(from: &Keypair, client: &T, amount: u64) -> Key
     );
 
     client
-        .send_message(&[&from, &genesis], Message::new(vec![instruction]))
+        .send_message(&[&from, &genesis], Message::new(&[instruction]))
         .unwrap();
 
     let instruction = librapay_instruction::genesis(&genesis.pubkey(), amount);
-    let message = Message::new_with_payer(vec![instruction], Some(&from.pubkey()));
+    let message = Message::new_with_payer(&[instruction], Some(&from.pubkey()));
     client.send_message(&[from, &genesis], message).unwrap();
 
     genesis

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -93,7 +93,7 @@ mod tests {
             owner_pubkey,
             lamports,
         );
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client.send_message(&[payer_keypair, account_keypair], message)
     }
 
@@ -109,7 +109,7 @@ mod tests {
             &old_owner_keypair.pubkey(),
             new_owner_pubkey,
         );
-        let message = Message::new_with_payer(vec![instruction], Some(&payer_keypair.pubkey()));
+        let message = Message::new_with_payer(&[instruction], Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair, old_owner_keypair], message)
     }
 

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -187,7 +187,7 @@ mod tests {
             date_instruction::create_account(&payer_keypair.pubkey(), &date_pubkey, 1);
         instructions.push(date_instruction::store(&date_pubkey, date));
 
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client.send_message(&[payer_keypair, date_keypair], message)
     }
 
@@ -199,7 +199,7 @@ mod tests {
     ) -> Result<Signature> {
         let date_pubkey = date_keypair.pubkey();
         let instruction = date_instruction::store(&date_pubkey, date);
-        let message = Message::new_with_payer(vec![instruction], Some(&payer_keypair.pubkey()));
+        let message = Message::new_with_payer(&[instruction], Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair, date_keypair], message)
     }
 
@@ -222,7 +222,7 @@ mod tests {
             &date_pubkey,
             lamports,
         );
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         bank_client.send_message(&[payer_keypair, contract_keypair], message)
     }
 
@@ -257,7 +257,7 @@ mod tests {
     ) -> Result<Signature> {
         let instruction =
             vest_instruction::redeem_tokens(&contract_pubkey, &date_pubkey, &payee_pubkey);
-        let message = Message::new_with_payer(vec![instruction], Some(&payer_keypair.pubkey()));
+        let message = Message::new_with_payer(&[instruction], Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair], message)
     }
 
@@ -353,7 +353,7 @@ mod tests {
         );
         instructions[1].accounts = vec![]; // <!-- Attack! Prevent accounts from being passed into processor.
 
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         assert_eq!(
             bank_client
                 .send_message(&[&alice_keypair, &contract_keypair], message)

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -59,7 +59,7 @@ impl AsyncClient for BankClient {
         instruction: Instruction,
         recent_blockhash: Hash,
     ) -> io::Result<Signature> {
-        let message = Message::new(vec![instruction]);
+        let message = Message::new(&[instruction]);
         self.async_send_message(&[keypair], message, recent_blockhash)
     }
 
@@ -87,7 +87,7 @@ impl SyncClient for BankClient {
 
     /// Create and process a transaction from a single instruction.
     fn send_instruction(&self, keypair: &Keypair, instruction: Instruction) -> Result<Signature> {
-        let message = Message::new(vec![instruction]);
+        let message = Message::new(&[instruction]);
         self.send_message(&[keypair], message)
     }
 
@@ -302,7 +302,7 @@ mod tests {
             .accounts
             .push(AccountMeta::new(jane_pubkey, true));
 
-        let message = Message::new(vec![transfer_instruction]);
+        let message = Message::new(&[transfer_instruction]);
         bank_client.send_message(&doe_keypairs, message).unwrap();
         assert_eq!(bank_client.get_balance(&bob_pubkey).unwrap(), 42);
     }

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -28,7 +28,7 @@ pub fn load_program<T: Client>(
     bank_client
         .send_message(
             &[from_keypair, &program_keypair],
-            Message::new(vec![instruction]),
+            Message::new(&[instruction]),
         )
         .unwrap();
 
@@ -37,7 +37,7 @@ pub fn load_program<T: Client>(
     for chunk in program.chunks(chunk_size) {
         let instruction =
             loader_instruction::write(&program_pubkey, loader_pubkey, offset, chunk.to_vec());
-        let message = Message::new_with_payer(vec![instruction], Some(&from_keypair.pubkey()));
+        let message = Message::new_with_payer(&[instruction], Some(&from_keypair.pubkey()));
         bank_client
             .send_message(&[from_keypair, &program_keypair], message)
             .unwrap();
@@ -45,7 +45,7 @@ pub fn load_program<T: Client>(
     }
 
     let instruction = loader_instruction::finalize(&program_pubkey, loader_pubkey);
-    let message = Message::new_with_payer(vec![instruction], Some(&from_keypair.pubkey()));
+    let message = Message::new_with_payer(&[instruction], Some(&from_keypair.pubkey()));
     bank_client
         .send_message(&[from_keypair, &program_keypair], message)
         .unwrap();

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -798,7 +798,7 @@ mod tests {
             AccountMeta::new(from_pubkey, true),
             AccountMeta::new_readonly(to_pubkey, false),
         ];
-        let message = Message::new(vec![Instruction::new(
+        let message = Message::new(&[Instruction::new(
             mock_system_program_id,
             &MockSystemInstruction::Correct,
             account_metas.clone(),
@@ -809,7 +809,7 @@ mod tests {
         assert_eq!(accounts[0].borrow().lamports, 100);
         assert_eq!(accounts[1].borrow().lamports, 0);
 
-        let message = Message::new(vec![Instruction::new(
+        let message = Message::new(&[Instruction::new(
             mock_system_program_id,
             &MockSystemInstruction::AttemptCredit { lamports: 50 },
             account_metas.clone(),
@@ -824,7 +824,7 @@ mod tests {
             ))
         );
 
-        let message = Message::new(vec![Instruction::new(
+        let message = Message::new(&[Instruction::new(
             mock_system_program_id,
             &MockSystemInstruction::AttemptDataChange { data: 50 },
             account_metas,
@@ -921,7 +921,7 @@ mod tests {
         ];
 
         // Try to borrow mut the same account
-        let message = Message::new(vec![Instruction::new(
+        let message = Message::new(&[Instruction::new(
             mock_program_id,
             &MockSystemInstruction::BorrowFail,
             account_metas.clone(),
@@ -936,7 +936,7 @@ mod tests {
         );
 
         // Try to borrow mut the same account in a safe way
-        let message = Message::new(vec![Instruction::new(
+        let message = Message::new(&[Instruction::new(
             mock_program_id,
             &MockSystemInstruction::MultiBorrowMut,
             account_metas.clone(),
@@ -945,7 +945,7 @@ mod tests {
         assert_eq!(result, Ok(()));
 
         // Do work on the same account but at different location in keyed_accounts[]
-        let message = Message::new(vec![Instruction::new(
+        let message = Message::new(&[Instruction::new(
             mock_program_id,
             &MockSystemInstruction::DoWork {
                 lamports: 10,

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -111,7 +111,7 @@ pub(crate) mod tests {
         let bank = Arc::new(bank);
         let bank_client = BankClient::new_shared(&bank);
 
-        let message = Message::new(storage_instruction::create_storage_account(
+        let message = Message::new(&storage_instruction::create_storage_account(
             &mint_pubkey,
             &Pubkey::default(),
             &archiver_pubkey,
@@ -122,7 +122,7 @@ pub(crate) mod tests {
             .send_message(&[&mint_keypair, &archiver_keypair], message)
             .unwrap();
 
-        let message = Message::new(storage_instruction::create_storage_account(
+        let message = Message::new(&storage_instruction::create_storage_account(
             &mint_pubkey,
             &Pubkey::default(),
             &validator_pubkey,

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -926,7 +926,7 @@ mod tests {
             .unwrap();
 
         let allocate_with_seed = Message::new_with_payer(
-            vec![system_instruction::allocate_with_seed(
+            &[system_instruction::allocate_with_seed(
                 &alice_with_seed,
                 &alice_pubkey,
                 seed,
@@ -978,7 +978,7 @@ mod tests {
         let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
         let bank_client = BankClient::new_shared(&bank);
         let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 0, len1, &program);
-        let message = Message::new(vec![ix]);
+        let message = Message::new(&[ix]);
         let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
         assert!(r.is_ok());
 
@@ -996,7 +996,7 @@ mod tests {
         let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
         let bank_client = BankClient::new_shared(&bank);
         let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 1, len2, &program);
-        let message = Message::new(vec![ix]);
+        let message = Message::new(&[ix]);
         let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
         assert!(r.is_ok());
     }
@@ -1036,7 +1036,7 @@ mod tests {
             .unwrap();
 
         let assign_with_seed = Message::new_with_payer(
-            vec![system_instruction::assign_with_seed(
+            &[system_instruction::assign_with_seed(
                 &alice_with_seed,
                 &alice_pubkey,
                 seed,

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -53,7 +53,7 @@ fn fill_epoch_with_votes(
         let parent = bank.parent().unwrap();
 
         let message = Message::new_with_payer(
-            vec![vote_instruction::vote(
+            &[vote_instruction::vote(
                 &vote_pubkey,
                 &vote_pubkey,
                 Vote::new(vec![parent.slot() as u64], parent.hash()),
@@ -121,7 +121,7 @@ fn test_stake_create_and_split_single_signature() {
     let lamports = 1_000_000;
 
     // Create stake account with seed
-    let message = Message::new(stake_instruction::create_account_with_seed(
+    let message = Message::new(&stake_instruction::create_account_with_seed(
         &staker_pubkey, // from
         &stake_address, // to
         &staker_pubkey, // base
@@ -141,7 +141,7 @@ fn test_stake_create_and_split_single_signature() {
         create_address_with_seed(&staker_pubkey, "split_stake", &solana_stake_program::id())
             .unwrap();
     // Test split
-    let message = Message::new(stake_instruction::split_with_seed(
+    let message = Message::new(&stake_instruction::split_with_seed(
         &stake_address, // original
         &staker_pubkey, // authorized
         lamports / 2,
@@ -179,7 +179,7 @@ fn test_stake_account_lifetime() {
     let bank_client = BankClient::new_shared(&bank);
 
     // Create Vote Account
-    let message = Message::new(vote_instruction::create_account(
+    let message = Message::new(&vote_instruction::create_account(
         &mint_pubkey,
         &vote_pubkey,
         &VoteInit {
@@ -196,7 +196,7 @@ fn test_stake_account_lifetime() {
 
     let authorized = stake_state::Authorized::auto(&stake_pubkey);
     // Create stake account and delegate to vote account
-    let message = Message::new(stake_instruction::create_account_and_delegate_stake(
+    let message = Message::new(&stake_instruction::create_account_and_delegate_stake(
         &mint_pubkey,
         &stake_pubkey,
         &vote_pubkey,
@@ -219,7 +219,7 @@ fn test_stake_account_lifetime() {
 
     // Test that we cannot withdraw anything until deactivation
     let message = Message::new_with_payer(
-        vec![stake_instruction::withdraw(
+        &[stake_instruction::withdraw(
             &stake_pubkey,
             &stake_pubkey,
             &Pubkey::new_rand(),
@@ -282,7 +282,7 @@ fn test_stake_account_lifetime() {
     let bank_client = BankClient::new_shared(&bank);
     // Test split
     let message = Message::new_with_payer(
-        stake_instruction::split(
+        &stake_instruction::split(
             &stake_pubkey,
             &stake_pubkey,
             lamports / 2,
@@ -299,7 +299,7 @@ fn test_stake_account_lifetime() {
 
     // Deactivate the split
     let message = Message::new_with_payer(
-        vec![stake_instruction::deactivate_stake(
+        &[stake_instruction::deactivate_stake(
             &split_stake_pubkey,
             &stake_pubkey,
         )],
@@ -313,7 +313,7 @@ fn test_stake_account_lifetime() {
 
     // Test that we cannot withdraw above what's staked
     let message = Message::new_with_payer(
-        vec![stake_instruction::withdraw(
+        &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
             &Pubkey::new_rand(),
@@ -334,7 +334,7 @@ fn test_stake_account_lifetime() {
 
     // withdrawal in cooldown
     let message = Message::new_with_payer(
-        vec![stake_instruction::withdraw(
+        &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
             &Pubkey::new_rand(),
@@ -349,7 +349,7 @@ fn test_stake_account_lifetime() {
 
     // but we can withdraw unstaked
     let message = Message::new_with_payer(
-        vec![stake_instruction::withdraw(
+        &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
             &Pubkey::new_rand(),
@@ -373,7 +373,7 @@ fn test_stake_account_lifetime() {
 
     // Test that we can withdraw everything else out of the split
     let message = Message::new_with_payer(
-        vec![stake_instruction::withdraw(
+        &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
             &Pubkey::new_rand(),
@@ -414,7 +414,7 @@ fn test_create_stake_account_from_seed() {
         create_address_with_seed(&mint_pubkey, seed, &solana_stake_program::id()).unwrap();
 
     // Create Vote Account
-    let message = Message::new(vote_instruction::create_account(
+    let message = Message::new(&vote_instruction::create_account(
         &mint_pubkey,
         &vote_pubkey,
         &VoteInit {
@@ -432,7 +432,7 @@ fn test_create_stake_account_from_seed() {
     let authorized = stake_state::Authorized::auto(&mint_pubkey);
     // Create stake account and delegate to vote account
     let message = Message::new(
-        stake_instruction::create_account_with_seed_and_delegate_stake(
+        &stake_instruction::create_account_with_seed_and_delegate_stake(
             &mint_pubkey,
             &stake_pubkey,
             &mint_pubkey,

--- a/runtime/tests/storage.rs
+++ b/runtime/tests/storage.rs
@@ -49,7 +49,7 @@ fn test_account_owner() {
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 
-    let message = Message::new(storage_instruction::create_storage_account(
+    let message = Message::new(&storage_instruction::create_storage_account(
         &mint_pubkey,
         &account_owner,
         &validator_storage_pubkey,
@@ -69,7 +69,7 @@ fn test_account_owner() {
         assert!(false, "wrong account type found")
     }
 
-    let message = Message::new(storage_instruction::create_storage_account(
+    let message = Message::new(&storage_instruction::create_storage_account(
         &mint_pubkey,
         &account_owner,
         &archiver_storage_pubkey,
@@ -137,7 +137,7 @@ fn test_validate_mining() {
 
     // advertise for storage segment 1
     let message = Message::new_with_payer(
-        vec![storage_instruction::advertise_recent_blockhash(
+        &[storage_instruction::advertise_recent_blockhash(
             &validator_storage_id,
             Hash::default(),
             1,
@@ -172,7 +172,7 @@ fn test_validate_mining() {
             ));
     }
     let message = Message::new_with_payer(
-        vec![storage_instruction::advertise_recent_blockhash(
+        &[storage_instruction::advertise_recent_blockhash(
             &validator_storage_id,
             Hash::default(),
             2,
@@ -195,7 +195,7 @@ fn test_validate_mining() {
     );
 
     let message = Message::new_with_payer(
-        vec![storage_instruction::proof_validation(
+        &[storage_instruction::proof_validation(
             &validator_storage_id,
             proof_segment as u64,
             checked_proofs.into_iter().map(|entry| entry).collect(),
@@ -209,7 +209,7 @@ fn test_validate_mining() {
     );
 
     let message = Message::new_with_payer(
-        vec![storage_instruction::advertise_recent_blockhash(
+        &[storage_instruction::advertise_recent_blockhash(
             &validator_storage_id,
             Hash::default(),
             3,
@@ -244,7 +244,7 @@ fn test_validate_mining() {
         .map(|account| Rewards::from_account(&account).unwrap())
         .unwrap();
     let message = Message::new_with_payer(
-        vec![storage_instruction::claim_reward(
+        &[storage_instruction::claim_reward(
             &owner_pubkey,
             &validator_storage_id,
         )],
@@ -264,7 +264,7 @@ fn test_validate_mining() {
     assert_eq!(bank_client.get_balance(&archiver_1_storage_id).unwrap(), 10);
 
     let message = Message::new_with_payer(
-        vec![storage_instruction::claim_reward(
+        &[storage_instruction::claim_reward(
             &owner_pubkey,
             &archiver_1_storage_id,
         )],
@@ -278,7 +278,7 @@ fn test_validate_mining() {
     );
 
     let message = Message::new_with_payer(
-        vec![storage_instruction::claim_reward(
+        &[storage_instruction::claim_reward(
             &owner_pubkey,
             &archiver_2_storage_id,
         )],
@@ -328,7 +328,7 @@ fn init_storage_accounts(
             StorageAccountType::Archiver,
         ))
     });
-    let message = Message::new(ixs);
+    let message = Message::new(&ixs);
     client.send_message(&signers, message).unwrap();
 }
 
@@ -360,7 +360,7 @@ fn submit_proof(
 ) -> ProofStatus {
     let sha_state = Hash::new(Pubkey::new_rand().as_ref());
     let message = Message::new_with_payer(
-        vec![storage_instruction::mining_proof(
+        &[storage_instruction::mining_proof(
             &storage_keypair.pubkey(),
             sha_state,
             segment_index,
@@ -422,7 +422,7 @@ fn test_bank_storage() {
     let x2 = x * 2;
     let storage_blockhash = hash(&[x2]);
 
-    let message = Message::new(storage_instruction::create_storage_account(
+    let message = Message::new(&storage_instruction::create_storage_account(
         &mint_pubkey,
         &Pubkey::default(),
         &archiver_pubkey,
@@ -433,7 +433,7 @@ fn test_bank_storage() {
         .send_message(&[&mint_keypair, &archiver_keypair], message)
         .unwrap();
 
-    let message = Message::new(storage_instruction::create_storage_account(
+    let message = Message::new(&storage_instruction::create_storage_account(
         &mint_pubkey,
         &Pubkey::default(),
         &validator_pubkey,
@@ -445,7 +445,7 @@ fn test_bank_storage() {
         .unwrap();
 
     let message = Message::new_with_payer(
-        vec![storage_instruction::advertise_recent_blockhash(
+        &[storage_instruction::advertise_recent_blockhash(
             &validator_pubkey,
             storage_blockhash,
             1,
@@ -460,7 +460,7 @@ fn test_bank_storage() {
 
     let slot = 0;
     let message = Message::new_with_payer(
-        vec![storage_instruction::mining_proof(
+        &[storage_instruction::mining_proof(
             &archiver_pubkey,
             Hash::default(),
             slot,

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn test_fee_calculator_calculate_fee() {
         // Default: no fee.
-        let message = Message::new(vec![]);
+        let message = Message::new(&[]);
         assert_eq!(FeeCalculator::default().calculate_fee(&message), 0);
 
         // No signature, no fee.
@@ -193,13 +193,13 @@ mod tests {
         let pubkey0 = Pubkey::new(&[0; 32]);
         let pubkey1 = Pubkey::new(&[1; 32]);
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
-        let message = Message::new(vec![ix0]);
+        let message = Message::new(&[ix0]);
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 2);
 
         // Two signatures, double the fee.
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
         let ix1 = system_instruction::transfer(&pubkey1, &pubkey0, 1);
-        let message = Message::new(vec![ix0, ix1]);
+        let message = Message::new(&[ix0, ix1]);
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 4);
     }
 

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -193,10 +193,10 @@ impl Message {
             unsigned_keys,
             num_readonly_signed_accounts,
             num_readonly_unsigned_accounts,
-        } = get_keys(&instructions, payer);
+        } = get_keys(instructions, payer);
         let num_required_signatures = signed_keys.len() as u8;
         signed_keys.extend(&unsigned_keys);
-        let instructions = compile_instructions(&instructions, &signed_keys);
+        let instructions = compile_instructions(instructions, &signed_keys);
         Self::new_with_compiled_instructions(
             num_required_signatures,
             num_readonly_signed_accounts,

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -13,7 +13,7 @@ fn position(keys: &[Pubkey], key: &Pubkey) -> u8 {
     keys.iter().position(|k| k == key).unwrap() as u8
 }
 
-fn compile_instruction(ix: Instruction, keys: &[Pubkey]) -> CompiledInstruction {
+fn compile_instruction(ix: &Instruction, keys: &[Pubkey]) -> CompiledInstruction {
     let accounts: Vec<_> = ix
         .accounts
         .iter()
@@ -27,10 +27,8 @@ fn compile_instruction(ix: Instruction, keys: &[Pubkey]) -> CompiledInstruction 
     }
 }
 
-fn compile_instructions(ixs: Vec<Instruction>, keys: &[Pubkey]) -> Vec<CompiledInstruction> {
-    ixs.into_iter()
-        .map(|ix| compile_instruction(ix, keys))
-        .collect()
+fn compile_instructions(ixs: &[Instruction], keys: &[Pubkey]) -> Vec<CompiledInstruction> {
+    ixs.iter().map(|ix| compile_instruction(ix, keys)).collect()
 }
 
 /// A helper struct to collect pubkeys referenced by a set of instructions and read-only counts
@@ -185,11 +183,11 @@ impl Message {
         }
     }
 
-    pub fn new(instructions: Vec<Instruction>) -> Self {
+    pub fn new(instructions: &[Instruction]) -> Self {
         Self::new_with_payer(instructions, None)
     }
 
-    pub fn new_with_payer(instructions: Vec<Instruction>, payer: Option<&Pubkey>) -> Self {
+    pub fn new_with_payer(instructions: &[Instruction], payer: Option<&Pubkey>) -> Self {
         let InstructionKeys {
             mut signed_keys,
             unsigned_keys,
@@ -198,7 +196,7 @@ impl Message {
         } = get_keys(&instructions, payer);
         let num_required_signatures = signed_keys.len() as u8;
         signed_keys.extend(&unsigned_keys);
-        let instructions = compile_instructions(instructions, &signed_keys);
+        let instructions = compile_instructions(&instructions, &signed_keys);
         Self::new_with_compiled_instructions(
             num_required_signatures,
             num_readonly_signed_accounts,
@@ -220,7 +218,7 @@ impl Message {
             &nonce_authority_pubkey,
         );
         instructions.insert(0, nonce_ix);
-        Self::new_with_payer(instructions, payer)
+        Self::new_with_payer(&instructions, payer)
     }
 
     pub fn serialize(&self) -> Vec<u8> {
@@ -426,11 +424,11 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]);
-        let message = Message::new(vec![ix]);
+        let message = Message::new(&[ix]);
         assert_eq!(message.header.num_required_signatures, 0);
 
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
-        let message = Message::new(vec![ix]);
+        let message = Message::new(&[ix]);
         assert_eq!(message.header.num_required_signatures, 1);
     }
 
@@ -463,7 +461,7 @@ mod tests {
         let id0 = Pubkey::default();
         let keypair1 = Keypair::new();
         let id1 = keypair1.pubkey();
-        let message = Message::new(vec![
+        let message = Message::new(&[
             Instruction::new(program_id0, &0, vec![AccountMeta::new(id0, false)]),
             Instruction::new(program_id1, &0, vec![AccountMeta::new(id1, true)]),
             Instruction::new(program_id0, &0, vec![AccountMeta::new(id1, false)]),
@@ -489,11 +487,11 @@ mod tests {
         let id0 = Pubkey::default();
 
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]);
-        let message = Message::new_with_payer(vec![ix], Some(&payer));
+        let message = Message::new_with_payer(&[ix], Some(&payer));
         assert_eq!(message.header.num_required_signatures, 1);
 
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
-        let message = Message::new_with_payer(vec![ix], Some(&payer));
+        let message = Message::new_with_payer(&[ix], Some(&payer));
         assert_eq!(message.header.num_required_signatures, 2);
 
         let ix = Instruction::new(
@@ -501,7 +499,7 @@ mod tests {
             &0,
             vec![AccountMeta::new(payer, true), AccountMeta::new(id0, true)],
         );
-        let message = Message::new_with_payer(vec![ix], Some(&payer));
+        let message = Message::new_with_payer(&[ix], Some(&payer));
         assert_eq!(message.header.num_required_signatures, 2);
     }
 
@@ -528,7 +526,7 @@ mod tests {
         let program_id0 = Pubkey::default();
         let program_id1 = Pubkey::new_rand();
         let id = Pubkey::new_rand();
-        let message = Message::new(vec![
+        let message = Message::new(&[
             Instruction::new(program_id0, &0, vec![AccountMeta::new(id, false)]),
             Instruction::new(program_id1, &0, vec![AccountMeta::new(id, true)]),
         ]);
@@ -571,7 +569,7 @@ mod tests {
         let id1 = Pubkey::new_rand();
         let id2 = Pubkey::new_rand();
         let id3 = Pubkey::new_rand();
-        let message = Message::new(vec![
+        let message = Message::new(&[
             Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
             Instruction::new(program_id, &0, vec![AccountMeta::new(id1, true)]),
             Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id2, false)]),

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -92,7 +92,7 @@ impl Transaction {
     }
 
     pub fn new_with_payer(instructions: Vec<Instruction>, payer: Option<&Pubkey>) -> Self {
-        let message = Message::new_with_payer(instructions, payer);
+        let message = Message::new_with_payer(&instructions, payer);
         Self::new_unsigned(message)
     }
 
@@ -102,7 +102,7 @@ impl Transaction {
         signing_keypairs: &T,
         recent_blockhash: Hash,
     ) -> Self {
-        let message = Message::new_with_payer(instructions, payer);
+        let message = Message::new_with_payer(&instructions, payer);
         Self::new(signing_keypairs, message, recent_blockhash)
     }
 
@@ -123,7 +123,7 @@ impl Transaction {
     }
 
     pub fn new_unsigned_instructions(instructions: Vec<Instruction>) -> Self {
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         Self::new_unsigned(message)
     }
 
@@ -142,7 +142,7 @@ impl Transaction {
         instructions: Vec<Instruction>,
         recent_blockhash: Hash,
     ) -> Transaction {
-        let message = Message::new(instructions);
+        let message = Message::new(&instructions);
         Self::new(from_keypairs, message, recent_blockhash)
     }
 
@@ -482,7 +482,7 @@ mod tests {
             AccountMeta::new(to, false),
         ];
         let instruction = Instruction::new(program_id, &(1u8, 2u8, 3u8), account_metas);
-        let message = Message::new(vec![instruction]);
+        let message = Message::new(&[instruction]);
         Transaction::new(&[&keypair], message, Hash::default())
     }
 
@@ -513,7 +513,7 @@ mod tests {
         let expected_instruction_size = 1 + 1 + ix.accounts.len() + 1 + expected_data_size;
         assert_eq!(expected_instruction_size, 17);
 
-        let message = Message::new(vec![ix]);
+        let message = Message::new(&[ix]);
         assert_eq!(
             serialized_size(&message.instructions[0]).unwrap() as usize,
             expected_instruction_size,


### PR DESCRIPTION
#### Problem

Lots of unnecessary vector allocations due to functions taking vectors instead of slices

#### Summary of Changes

Take a slice

Fixes #
