### PR TITLE
Collapse verbose buildkite logging

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -621,7 +621,7 @@ deploy() {
   $metricsWriteDatapoint "testnet-deploy version=\"${networkVersion:0:9}\""
 
   echo
-  echo "+++ Deployment Successful"
+  echo "--- Deployment Successful"
   echo "Bootstrap validator deployment took $bootstrapNodeDeployTime seconds"
   echo "Additional validator deployment (${#validatorIpList[@]} validators, ${#blockstreamerIpList[@]} blockstreamer nodes, ${#archiverIpList[@]} archivers) took $additionalNodeDeployTime seconds"
   echo "Client deployment (${#clientIpList[@]} instances) took $clientDeployTime seconds"

--- a/net/remote/remote-sanity.sh
+++ b/net/remote/remote-sanity.sh
@@ -82,13 +82,13 @@ else
   fi
 fi
 
-echo "+++ $sanityTargetIp: validators"
+echo "--- $sanityTargetIp: validators"
 (
   set -x
   $solana_cli --url http://"$sanityTargetIp":8899 validators
 )
 
-echo "+++ $sanityTargetIp: node count ($numSanityNodes expected)"
+echo "--- $sanityTargetIp: node count ($numSanityNodes expected)"
 (
   set -x
 


### PR DESCRIPTION
Collapse auto-expanding log messages in the buildkite log display, so failure expansions and log headlines can be more easily seen at a glance.
