### PR TITLE
Accounts cleanup service and perf improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,6 +4511,7 @@ dependencies = [
  "solana-vote-program 1.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-priority 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5358,6 +5359,14 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-priority"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6667,6 +6676,7 @@ dependencies = [
 "checksum thiserror-impl 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a3ecbaa927a1d5a73d14a20af52463fa433c0727d07ef5e208f0546841d2efd"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+"checksum thread-priority 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52c084e908948709a7f7f6d44b5368e0134aa322e0e569431a92c989bf855188"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/core/src/accounts_cleanup_service.rs
+++ b/core/src/accounts_cleanup_service.rs
@@ -1,0 +1,38 @@
+// Service to clean up dead slots in accounts_db
+//
+// This can be expensive since we have to walk the append vecs being cleaned up.
+
+use solana_ledger::bank_forks::BankForks;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, RwLock,
+};
+use std::thread::{self, sleep, Builder, JoinHandle};
+use std::time::Duration;
+
+pub struct AccountsCleanupService {
+    t_cleanup: JoinHandle<()>,
+}
+
+impl AccountsCleanupService {
+    pub fn new(bank_forks: Arc<RwLock<BankForks>>, exit: &Arc<AtomicBool>) -> Self {
+        info!("AccountsCleanupService active");
+        let exit = exit.clone();
+        let t_cleanup = Builder::new()
+            .name("solana-accounts-cleanup".to_string())
+            .spawn(move || loop {
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+                let bank = bank_forks.read().unwrap().working_bank();
+                bank.clean_dead_slots();
+                sleep(Duration::from_millis(100));
+            })
+            .unwrap();
+        Self { t_cleanup }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.t_cleanup.join()
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@
 //! command-line tools to spin up validators and a Rust library
 //!
 
+pub mod accounts_cleanup_service;
 pub mod accounts_hash_verifier;
 pub mod banking_stage;
 pub mod broadcast_stage;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -37,6 +37,7 @@ solana-storage-program = { path = "../programs/storage", version = "1.1.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.1.0" }
 tempfile = "3.1.0"
 thiserror = "1.0"
+thread-priority = "0.1.1"
 
 
 [lib]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -884,10 +884,10 @@ impl AccountsDB {
         pubkey: &Pubkey,
     ) -> Option<(Account, Slot)> {
         let (lock, index) = accounts_index.get(pubkey, ancestors)?;
-        let slot = lock.1[index].0;
+        let slot = lock[index].0;
         //TODO: thread this as a ref
         if let Some(slot_storage) = storage.0.get(&slot) {
-            let info = &lock.1[index].1;
+            let info = &lock[index].1;
             slot_storage
                 .get(&info.store_id)
                 .and_then(|store| Some(store.accounts.get_account(info.offset)?.0.clone_account()))
@@ -1197,7 +1197,7 @@ impl AccountsDB {
             .par_iter()
             .filter_map(|pubkey| {
                 if let Some((list, index)) = accounts_index.get(pubkey, ancestors) {
-                    let (slot, account_info) = &list.1[index];
+                    let (slot, account_info) = &list[index];
                     if account_info.lamports != 0 {
                         storage
                             .0
@@ -1594,7 +1594,7 @@ impl AccountsDB {
 
         let mut counts = HashMap::new();
         for slot_list in accounts_index.account_maps.values() {
-            for (_slot, account_entry) in slot_list.read().unwrap().1.iter() {
+            for (_slot, account_entry) in slot_list.1.read().unwrap().iter() {
                 *counts.entry(account_entry.store_id).or_insert(0) += 1;
             }
         }
@@ -2084,7 +2084,7 @@ pub mod tests {
         let id = {
             let index = accounts.accounts_index.read().unwrap();
             let (list, idx) = index.get(&pubkey, &ancestors).unwrap();
-            list.1[idx].1.store_id
+            list[idx].1.store_id
         };
         accounts.add_root(1);
 
@@ -2270,7 +2270,7 @@ pub mod tests {
         info!("{}: accounts.accounts_index roots: {:?}", label, roots,);
         for (pubkey, list) in &accounts.accounts_index.read().unwrap().account_maps {
             info!("  key: {}", pubkey);
-            info!("      slots: {:?}", *list.read().unwrap());
+            info!("      slots: {:?}", *list.1.read().unwrap());
         }
     }
 
@@ -2477,9 +2477,9 @@ pub mod tests {
                 .account_maps
                 .get(&pubkey)
                 .unwrap()
+                .1
                 .read()
                 .unwrap()
-                .1
                 .len(),
             2
         );

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1,4 +1,5 @@
 use solana_sdk::pubkey::Pubkey;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
     collections::{HashMap, HashSet},
     sync::{RwLock, RwLockReadGuard},
@@ -7,11 +8,11 @@ use std::{
 pub type Slot = u64;
 type SlotList<T> = Vec<(Slot, T)>;
 pub type RefCount = u64;
-type AccountMapEntry<T> = (RefCount, SlotList<T>);
+type AccountMapEntry<T> = SlotList<T>;
 
 #[derive(Debug, Default)]
 pub struct AccountsIndex<T> {
-    pub account_maps: HashMap<Pubkey, RwLock<AccountMapEntry<T>>>,
+    pub account_maps: HashMap<Pubkey, (AtomicU64, RwLock<AccountMapEntry<T>>)>,
 
     pub roots: HashSet<Slot>,
     pub uncleaned_roots: HashSet<Slot>,
@@ -24,7 +25,7 @@ impl<T: Clone> AccountsIndex<T> {
         F: FnMut(&Pubkey, (&T, Slot)) -> (),
     {
         for (pubkey, list) in self.account_maps.iter() {
-            let list_r = &list.read().unwrap().1;
+            let list_r = &list.1.read().unwrap();
             if let Some(index) = self.latest_slot(ancestors, &list_r) {
                 func(pubkey, (&list_r[index].1, list_r[index].0));
             }
@@ -39,14 +40,14 @@ impl<T: Clone> AccountsIndex<T> {
     }
 
     pub fn would_purge(&self, pubkey: &Pubkey) -> Vec<(Slot, T)> {
-        let list = &self.account_maps.get(&pubkey).unwrap().read().unwrap().1;
+        let list = &self.account_maps.get(&pubkey).unwrap().1.read().unwrap();
         self.get_rooted_entries(&list)
     }
 
     // filter any rooted entries and return them along with a bool that indicates
     // if this account has no more entries.
     pub fn purge(&self, pubkey: &Pubkey) -> (Vec<(Slot, T)>, bool) {
-        let list = &mut self.account_maps.get(&pubkey).unwrap().write().unwrap().1;
+        let list = &mut self.account_maps.get(&pubkey).unwrap().1.write().unwrap();
         let reclaims = self.get_rooted_entries(&list);
         list.retain(|(slot, _)| !self.is_root(*slot));
         (reclaims, list.is_empty())
@@ -74,8 +75,8 @@ impl<T: Clone> AccountsIndex<T> {
         ancestors: &HashMap<Slot, usize>,
     ) -> Option<(RwLockReadGuard<AccountMapEntry<T>>, usize)> {
         self.account_maps.get(pubkey).and_then(|list| {
-            let list_r = list.read().unwrap();
-            let lock = &list_r.1;
+            let list_r = list.1.read().unwrap();
+            let lock = &list_r;
             let found_index = self.latest_slot(ancestors, &lock)?;
             Some((list_r, found_index))
         })
@@ -101,7 +102,7 @@ impl<T: Clone> AccountsIndex<T> {
         let _slot_vec = self
             .account_maps
             .entry(*pubkey)
-            .or_insert_with(|| RwLock::new((0 as RefCount, Vec::with_capacity(32))));
+            .or_insert_with(|| (AtomicU64::new(0), RwLock::new(Vec::with_capacity(32))));
         self.update(slot, pubkey, account_info, reclaims);
     }
 
@@ -117,15 +118,15 @@ impl<T: Clone> AccountsIndex<T> {
         reclaims: &mut Vec<(Slot, T)>,
     ) -> Option<T> {
         if let Some(lock) = self.account_maps.get(pubkey) {
-            let slot_vec = &mut lock.write().unwrap();
+            let mut slot_vec = &mut lock.1.write().unwrap();
             // filter out other dirty entries
-            reclaims.extend(slot_vec.1.iter().filter(|(f, _)| *f == slot).cloned());
-            slot_vec.1.retain(|(f, _)| *f != slot);
+            reclaims.extend(slot_vec.iter().filter(|(f, _)| *f == slot).cloned());
+            slot_vec.retain(|(f, _)| *f != slot);
 
-            slot_vec.0 += 1 as RefCount;
-            slot_vec.1.push((slot, account_info));
+            lock.0.fetch_add(1, Ordering::Relaxed);
+            slot_vec.push((slot, account_info));
             // now, do lazy clean
-            self.purge_older_root_entries(&mut slot_vec.1, reclaims);
+            self.purge_older_root_entries(&mut slot_vec, reclaims);
 
             None
         } else {
@@ -136,15 +137,14 @@ impl<T: Clone> AccountsIndex<T> {
     pub fn unref_from_storage(&self, pubkey: &Pubkey) {
         let locked_slot_vec = self.account_maps.get(pubkey);
         if let Some(slot_vec) = locked_slot_vec {
-            let mut slot_vec = slot_vec.write().unwrap();
-            slot_vec.0 -= 1 as RefCount;
+            slot_vec.0.fetch_sub(1, Ordering::Relaxed);
         }
     }
 
     pub fn ref_count_from_storage(&self, pubkey: &Pubkey) -> RefCount {
         let locked_slot_vec = self.account_maps.get(pubkey);
         if let Some(slot_vec) = locked_slot_vec {
-            slot_vec.read().unwrap().0
+            slot_vec.0.load(Ordering::Relaxed)
         } else {
             0
         }
@@ -170,8 +170,8 @@ impl<T: Clone> AccountsIndex<T> {
 
     pub fn clean_rooted_entries(&self, pubkey: &Pubkey, reclaims: &mut Vec<(Slot, T)>) {
         if let Some(lock) = self.account_maps.get(pubkey) {
-            let mut slot_vec = lock.write().unwrap();
-            self.purge_older_root_entries(&mut slot_vec.1, reclaims);
+            let mut slot_vec = lock.1.write().unwrap();
+            self.purge_older_root_entries(&mut slot_vec, reclaims);
         }
     }
 
@@ -179,8 +179,8 @@ impl<T: Clone> AccountsIndex<T> {
         let entry = self
             .account_maps
             .entry(*pubkey)
-            .or_insert_with(|| RwLock::new((1 as RefCount, vec![])));
-        entry.write().unwrap().1.push((slot, account_info));
+            .or_insert_with(|| (AtomicU64::new(1), RwLock::new(vec![])));
+        entry.1.write().unwrap().push((slot, account_info));
     }
 
     pub fn can_purge(max_root: Slot, slot: Slot) -> bool {
@@ -262,7 +262,7 @@ mod tests {
 
         let ancestors = vec![(0, 0)].into_iter().collect();
         let (list, idx) = index.get(&key.pubkey(), &ancestors).unwrap();
-        assert_eq!(list.1[idx], (0, true));
+        assert_eq!(list[idx], (0, true));
 
         let mut num = 0;
         let mut found_key = false;
@@ -295,7 +295,7 @@ mod tests {
         let ancestors = vec![].into_iter().collect();
         index.add_root(0);
         let (list, idx) = index.get(&key.pubkey(), &ancestors).unwrap();
-        assert_eq!(list.1[idx], (0, true));
+        assert_eq!(list[idx], (0, true));
     }
 
     #[test]
@@ -338,14 +338,14 @@ mod tests {
         index.insert(0, &key.pubkey(), true, &mut gc);
         assert!(gc.is_empty());
         let (list, idx) = index.get(&key.pubkey(), &ancestors).unwrap();
-        assert_eq!(list.1[idx], (0, true));
+        assert_eq!(list[idx], (0, true));
         drop(list);
 
         let mut gc = Vec::new();
         index.insert(0, &key.pubkey(), false, &mut gc);
         assert_eq!(gc, vec![(0, true)]);
         let (list, idx) = index.get(&key.pubkey(), &ancestors).unwrap();
-        assert_eq!(list.1[idx], (0, false));
+        assert_eq!(list[idx], (0, false));
     }
 
     #[test]
@@ -360,10 +360,10 @@ mod tests {
         index.insert(1, &key.pubkey(), false, &mut gc);
         assert!(gc.is_empty());
         let (list, idx) = index.get(&key.pubkey(), &ancestors).unwrap();
-        assert_eq!(list.1[idx], (0, true));
+        assert_eq!(list[idx], (0, true));
         let ancestors = vec![(1, 0)].into_iter().collect();
         let (list, idx) = index.get(&key.pubkey(), &ancestors).unwrap();
-        assert_eq!(list.1[idx], (1, false));
+        assert_eq!(list[idx], (1, false));
     }
 
     #[test]
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(gc, vec![(0, true), (1, false), (2, true)]);
         let ancestors = vec![].into_iter().collect();
         let (list, idx) = index.get(&key.pubkey(), &ancestors).unwrap();
-        assert_eq!(list.1[idx], (3, true));
+        assert_eq!(list[idx], (3, true));
 
         let mut num = 0;
         let mut found_key = false;

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -8,11 +8,11 @@ use std::{
 pub type Slot = u64;
 type SlotList<T> = Vec<(Slot, T)>;
 pub type RefCount = u64;
-type AccountMapEntry<T> = SlotList<T>;
+type AccountMapEntry<T> = (AtomicU64, RwLock<SlotList<T>>);
 
 #[derive(Debug, Default)]
 pub struct AccountsIndex<T> {
-    pub account_maps: HashMap<Pubkey, (AtomicU64, RwLock<AccountMapEntry<T>>)>,
+    pub account_maps: HashMap<Pubkey, AccountMapEntry<T>>,
 
     pub roots: HashSet<Slot>,
     pub uncleaned_roots: HashSet<Slot>,
@@ -73,7 +73,7 @@ impl<T: Clone> AccountsIndex<T> {
         &self,
         pubkey: &Pubkey,
         ancestors: &HashMap<Slot, usize>,
-    ) -> Option<(RwLockReadGuard<AccountMapEntry<T>>, usize)> {
+    ) -> Option<(RwLockReadGuard<SlotList<T>>, usize)> {
         self.account_maps.get(pubkey).and_then(|list| {
             let list_r = list.1.read().unwrap();
             let lock = &list_r;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2127,6 +2127,10 @@ impl Bank {
     pub fn clean_accounts(&self) {
         self.rc.accounts.accounts_db.clean_accounts();
     }
+
+    pub fn clean_dead_slots(&self) {
+        self.rc.accounts.accounts_db.handle_dead_slots();
+    }
 }
 
 impl Drop for Bank {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2129,7 +2129,7 @@ impl Bank {
     }
 
     pub fn clean_dead_slots(&self) {
-        self.rc.accounts.accounts_db.handle_dead_slots();
+        self.rc.accounts.accounts_db.process_dead_slots();
     }
 }
 


### PR DESCRIPTION
#### Problem

`set_root` taking 3-4 seconds with 1.4m accounts created by bench-tps. Also, clean_dead_slot called in the middle of banking can be very expensive since we have to walk all append-vecs in the slot to update the account ref counts.

#### Summary of Changes

Do async cleanup of dead roots.

Fixes #
