### PR TITLE
CLI: Error message cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,6 +4130,7 @@ dependencies = [
  "solana-cli-config 1.1.0",
  "solana-remote-wallet 1.1.0",
  "solana-sdk 1.1.0",
+ "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,6 +3792,7 @@ dependencies = [
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-remote-wallet 1.1.0",
  "solana-sdk 1.1.0",
+ "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4130,7 +4131,6 @@ dependencies = [
  "solana-cli-config 1.1.0",
  "solana-remote-wallet 1.1.0",
  "solana-sdk 1.1.0",
- "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/archiver-lib/src/archiver.rs
+++ b/archiver-lib/src/archiver.rs
@@ -612,6 +612,7 @@ impl Archiver {
                         ErrorKind::Other,
                         "setup_mining_account: signature not found",
                     ),
+                    TransportError::Custom(e) => io::Error::new(ErrorKind::Other, e),
                 })?;
         }
         Ok(())

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -13,6 +13,7 @@ clap = "2.33.0"
 rpassword = "4.0"
 solana-remote-wallet = { path = "../remote-wallet", version = "1.1.0" }
 solana-sdk = { path = "../sdk", version = "1.1.0" }
+thiserror = "1.0.11"
 tiny-bip39 = "0.7.0"
 url = "2.1.0"
 chrono = "0.4"

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 pub fn is_pubkey(string: String) -> Result<(), String> {
     match string.parse::<Pubkey>() {
         Ok(_) => Ok(()),
-        Err(err) => Err(format!("{:?}", err)),
+        Err(err) => Err(format!("{}", err)),
     }
 }
 
@@ -20,7 +20,7 @@ pub fn is_pubkey(string: String) -> Result<(), String> {
 pub fn is_hash(string: String) -> Result<(), String> {
     match string.parse::<Hash>() {
         Ok(_) => Ok(()),
-        Err(err) => Err(format!("{:?}", err)),
+        Err(err) => Err(format!("{}", err)),
     }
 }
 
@@ -28,7 +28,7 @@ pub fn is_hash(string: String) -> Result<(), String> {
 pub fn is_keypair(string: String) -> Result<(), String> {
     read_keypair_file(&string)
         .map(|_| ())
-        .map_err(|err| format!("{:?}", err))
+        .map_err(|err| format!("{}", err))
 }
 
 // Return an error if a keypair file cannot be parsed
@@ -38,7 +38,7 @@ pub fn is_keypair_or_ask_keyword(string: String) -> Result<(), String> {
     }
     read_keypair_file(&string)
         .map(|_| ())
-        .map_err(|err| format!("{:?}", err))
+        .map_err(|err| format!("{}", err))
 }
 
 // Return an error if string cannot be parsed as pubkey string or keypair file location
@@ -73,10 +73,10 @@ pub fn is_pubkey_sig(string: String) -> Result<(), String> {
                     .ok_or_else(|| "Malformed signer string".to_string())?,
             ) {
                 Ok(_) => Ok(()),
-                Err(err) => Err(format!("{:?}", err)),
+                Err(err) => Err(format!("{}", err)),
             }
         }
-        Err(err) => Err(format!("{:?}", err)),
+        Err(err) => Err(format!("{}", err)),
     }
 }
 
@@ -90,20 +90,20 @@ pub fn is_url(string: String) -> Result<(), String> {
                 Err("no host provided".to_string())
             }
         }
-        Err(err) => Err(format!("{:?}", err)),
+        Err(err) => Err(format!("{}", err)),
     }
 }
 
 pub fn is_slot(slot: String) -> Result<(), String> {
     slot.parse::<Slot>()
         .map(|_| ())
-        .map_err(|e| format!("{:?}", e))
+        .map_err(|e| format!("{}", e))
 }
 
 pub fn is_port(port: String) -> Result<(), String> {
     port.parse::<u16>()
         .map(|_| ())
-        .map_err(|e| format!("{:?}", e))
+        .map_err(|e| format!("{}", e))
 }
 
 pub fn is_valid_percentage(percentage: String) -> Result<(), String> {
@@ -111,7 +111,7 @@ pub fn is_valid_percentage(percentage: String) -> Result<(), String> {
         .parse::<u8>()
         .map_err(|e| {
             format!(
-                "Unable to parse input percentage, provided: {}, err: {:?}",
+                "Unable to parse input percentage, provided: {}, err: {}",
                 percentage, e
             )
         })
@@ -141,7 +141,7 @@ pub fn is_amount(amount: String) -> Result<(), String> {
 pub fn is_rfc3339_datetime(value: String) -> Result<(), String> {
     DateTime::parse_from_rfc3339(&value)
         .map(|_| ())
-        .map_err(|e| format!("{:?}", e))
+        .map_err(|e| format!("{}", e))
 }
 
 pub fn is_derivation(value: String) -> Result<(), String> {
@@ -152,7 +152,7 @@ pub fn is_derivation(value: String) -> Result<(), String> {
         .parse::<u32>()
         .map_err(|e| {
             format!(
-                "Unable to parse derivation, provided: {}, err: {:?}",
+                "Unable to parse derivation, provided: {}, err: {}",
                 account, e
             )
         })
@@ -160,7 +160,7 @@ pub fn is_derivation(value: String) -> Result<(), String> {
             if let Some(change) = parts.next() {
                 change.parse::<u32>().map_err(|e| {
                     format!(
-                        "Unable to parse derivation, provided: {}, err: {:?}",
+                        "Unable to parse derivation, provided: {}, err: {}",
                         change, e
                     )
                 })

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -73,7 +73,7 @@ pub fn signer_from_path(
         }
         KeypairUrl::Filepath(path) => match read_keypair_file(&path) {
             Err(e) => Err(Error::with_description(
-                &format!("Couldn't find keypair file: {:?} error: {:?}", path, e),
+                &format!("Couldn't find keypair file: {} error: {}", path, e),
                 ErrorKind::InvalidValue,
             )
             .into()),

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -1,6 +1,6 @@
 use crate::{input_parsers::pubkeys_sigs_of, offline::SIGNER_ARG, ArgConstant};
 use bip39::{Language, Mnemonic, Seed};
-use clap::{ArgMatches, Error, ErrorKind};
+use clap::ArgMatches;
 use rpassword::prompt_password_stderr;
 use solana_remote_wallet::{
     remote_keypair::generate_remote_keypair,
@@ -72,9 +72,9 @@ pub fn signer_from_path(
             )?))
         }
         KeypairUrl::Filepath(path) => match read_keypair_file(&path) {
-            Err(e) => Err(Error::with_description(
-                &format!("Couldn't find keypair file: {} error: {}", path, e),
-                ErrorKind::InvalidValue,
+            Err(e) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("could not find keypair file: {} error: {}", path, e),
             )
             .into()),
             Ok(file) => Ok(Box::new(file)),
@@ -102,9 +102,9 @@ pub fn signer_from_path(
             if let Some(presigner) = presigner {
                 Ok(Box::new(presigner))
             } else {
-                Err(Error::with_description(
-                    "Missing signature for supplied pubkey",
-                    ErrorKind::MissingRequiredArgument,
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "missing signature for supplied pubkey".to_string(),
                 )
                 .into())
             }

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -1,3 +1,5 @@
+use thiserror::Error;
+
 #[macro_export]
 macro_rules! version {
     () => {
@@ -21,6 +23,23 @@ pub struct ArgConstant<'a> {
     pub long: &'a str,
     pub name: &'a str,
     pub help: &'a str,
+}
+
+/// Error type for forwarding Errors out of `main()` of a `clap` app
+/// and still using the `Display` formatter
+#[derive(Error)]
+#[error("{0}")]
+pub struct DisplayError(Box<dyn std::error::Error>);
+impl DisplayError {
+    pub fn new_as_boxed(inner: Box<dyn std::error::Error>) -> Box<Self> {
+        DisplayError(inner).into()
+    }
+}
+
+impl std::fmt::Debug for DisplayError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "{}", self.0)
+    }
 }
 
 pub mod input_parsers;

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -433,16 +433,14 @@ pub enum CliError {
 
 impl From<Box<dyn error::Error>> for CliError {
     fn from(error: Box<dyn error::Error>) -> Self {
-        CliError::DynamicProgramError(format!("{:?}", error))
+        CliError::DynamicProgramError(error.to_string())
     }
 }
 
 impl From<CliNonceError> for CliError {
     fn from(error: CliNonceError) -> Self {
         match error {
-            CliNonceError::Client(client_error) => {
-                Self::RpcRequestError(format!("{:?}", client_error))
-            }
+            CliNonceError::Client(client_error) => Self::RpcRequestError(client_error),
             _ => Self::InvalidNonce(error),
         }
     }
@@ -715,7 +713,7 @@ pub fn parse_command(
                 .parse()
                 .or_else(|err| {
                     Err(CliError::BadParameter(format!(
-                        "Invalid faucet port: {:?}",
+                        "Invalid faucet port: {}",
                         err
                     )))
                 })?;
@@ -723,7 +721,7 @@ pub fn parse_command(
             let faucet_host = if let Some(faucet_host) = matches.value_of("faucet_host") {
                 Some(solana_net_utils::parse_host(faucet_host).or_else(|err| {
                     Err(CliError::BadParameter(format!(
-                        "Invalid faucet host: {:?}",
+                        "Invalid faucet host: {}",
                         err
                     )))
                 })?)
@@ -1135,13 +1133,13 @@ fn process_confirm(rpc_client: &RpcClient, signature: &Signature) -> ProcessResu
             if let Some(result) = status {
                 match result {
                     Ok(_) => Ok("Confirmed".to_string()),
-                    Err(err) => Ok(format!("Transaction failed with error {:?}", err)),
+                    Err(err) => Ok(format!("Transaction failed with error: {}", err)),
                 }
             } else {
                 Ok("Not found".to_string())
             }
         }
-        Err(err) => Err(CliError::RpcRequestError(format!("Unable to confirm: {:?}", err)).into()),
+        Err(err) => Err(CliError::RpcRequestError(format!("Unable to confirm: {}", err)).into()),
     }
 }
 
@@ -3326,7 +3324,7 @@ mod tests {
         assert_eq!(
             process_command(&config).unwrap(),
             format!(
-                "Transaction failed with error {:?}",
+                "Transaction failed with error: {}",
                 TransactionError::AccountInUse
             )
         );

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -19,7 +19,7 @@ use solana_clap_utils::{
     ArgConstant,
 };
 use solana_client::{
-    client_error::{ClientError, Result as ClientResult},
+    client_error::{ClientErrorKind, Result as ClientResult},
     rpc_client::RpcClient,
 };
 #[cfg(not(test))]
@@ -2127,12 +2127,12 @@ where
 {
     match result {
         Err(err) => {
-            if let ClientError::TransactionError(TransactionError::InstructionError(
+            if let ClientErrorKind::TransactionError(TransactionError::InstructionError(
                 _,
                 InstructionError::CustomError(code),
-            )) = err
+            )) = err.kind()
             {
-                if let Some(specific_error) = E::decode_custom_error_to_enum(code) {
+                if let Some(specific_error) = E::decode_custom_error_to_enum(*code) {
                     error!("{}::{:?}", E::type_of(), specific_error);
                     eprintln!(
                         "Program Error ({}::{:?}): {}",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -18,7 +18,10 @@ use solana_clap_utils::{
     input_parsers::*, input_validators::*, keypair::signer_from_path, offline::SIGN_ONLY_ARG,
     ArgConstant,
 };
-use solana_client::{client_error::ClientError, rpc_client::RpcClient};
+use solana_client::{
+    client_error::{ClientError, Result as ClientResult},
+    rpc_client::RpcClient,
+};
 #[cfg(not(test))]
 use solana_faucet::faucet::request_airdrop_transaction;
 #[cfg(test)]
@@ -2118,7 +2121,7 @@ pub fn request_and_confirm_airdrop(
     log_instruction_custom_error::<SystemError>(result)
 }
 
-pub fn log_instruction_custom_error<E>(result: Result<String, ClientError>) -> ProcessResult
+pub fn log_instruction_custom_error<E>(result: ClientResult<String>) -> ProcessResult
 where
     E: 'static + std::error::Error + DecodeError<E> + FromPrimitive,
 {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -50,14 +50,15 @@ use solana_stake_program::{
 use solana_storage_program::storage_instruction::StorageAccountType;
 use solana_vote_program::vote_state::VoteAuthorize;
 use std::{
+    error,
     fs::File,
     io::{Read, Write},
     net::{IpAddr, SocketAddr},
     sync::Arc,
     thread::sleep,
     time::Duration,
-    {error, fmt},
 };
+use thiserror::Error;
 use url::Url;
 
 pub type CliSigners = Vec<Box<dyn Signer>>;
@@ -412,32 +413,22 @@ pub struct CliCommandInfo {
     pub signers: CliSigners,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Error, PartialEq)]
 pub enum CliError {
+    #[error("bad parameter: {0}")]
     BadParameter(String),
+    #[error("command not recognized: {0}")]
     CommandNotRecognized(String),
+    #[error("insuficient funds for fee")]
     InsufficientFundsForFee,
+    #[error(transparent)]
     InvalidNonce(CliNonceError),
+    #[error("dynamic program error: {0}")]
     DynamicProgramError(String),
+    #[error("rpc request error: {0}")]
     RpcRequestError(String),
+    #[error("keypair file not found: {0}")]
     KeypairFileNotFound(String),
-}
-
-impl fmt::Display for CliError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid")
-    }
-}
-
-impl error::Error for CliError {
-    fn description(&self) -> &str {
-        "invalid"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        // Generic error, underlying cause isn't tracked.
-        None
-    }
 }
 
 impl From<Box<dyn error::Error>> for CliError {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1011,7 +1011,7 @@ pub fn process_live_slots(url: &str) -> ProcessResult {
                 current = Some(new_info);
             }
             Err(err) => {
-                eprintln!("disconnected: {:?}", err);
+                eprintln!("disconnected: {}", err);
                 break;
             }
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -230,6 +230,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     )
     .get_matches();
 
+    if let Err(e) = do_main(&matches) {
+        eprintln!("error: {}", e);
+    }
+    Ok(())
+}
+
+fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
     if parse_settings(&matches)? {
         let wallet_manager = maybe_wallet_manager()?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -231,7 +231,19 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     .get_matches();
 
     if let Err(e) = do_main(&matches) {
-        eprintln!("error: {}", e);
+        use thiserror::Error;
+
+        #[derive(Error)]
+        #[error("")]
+        struct PrettyError(String);
+
+        impl std::fmt::Debug for PrettyError {
+            fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(fmt, "{}", self.0)
+            }
+        }
+
+        return Err(PrettyError(e.to_string()).into());
     }
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -241,7 +241,8 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
 
         let (mut config, signers) = parse_args(&matches, wallet_manager)?;
         config.signers = signers.iter().map(|s| s.as_ref()).collect();
-        process_command(&config)?;
+        let result = process_command(&config)?;
+        println!("{}", result);
     };
     Ok(())
 }

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -238,7 +238,7 @@ pub fn get_account(
 ) -> Result<Account, CliNonceError> {
     rpc_client
         .get_account(nonce_pubkey)
-        .map_err(|e| CliNonceError::Client(format!("{:?}", e)))
+        .map_err(|e| CliNonceError::Client(format!("{}", e)))
         .and_then(|a| match account_identity_ok(&a) {
             Ok(()) => Ok(a),
             Err(e) => Err(e),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1300,7 +1300,7 @@ pub fn process_show_stake_account(
             Ok("".to_string())
         }
         Err(err) => Err(CliError::RpcRequestError(format!(
-            "Account data could not be deserialized to stake state: {:?}",
+            "Account data could not be deserialized to stake state: {}",
             err
         ))
         .into()),
@@ -1396,11 +1396,11 @@ pub fn process_delegate_stake(
             }
         };
 
-        if sanity_check_result.is_err() {
+        if let Err(err) = &sanity_check_result {
             if !force {
                 sanity_check_result?;
             } else {
-                println!("--force supplied, ignoring: {:?}", sanity_check_result);
+                println!("--force supplied, ignoring: {}", err);
             }
         }
     }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -266,7 +266,7 @@ pub fn process_show_storage_account(
 
     use solana_storage_program::storage_contract::StorageContract;
     let storage_contract: StorageContract = account.state().map_err(|err| {
-        CliError::RpcRequestError(format!("Unable to deserialize storage account: {:?}", err))
+        CliError::RpcRequestError(format!("Unable to deserialize storage account: {}", err))
     })?;
     println!("{:#?}", storage_contract);
     println!("Account Lamports: {}", account.lamports);

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -274,7 +274,7 @@ pub fn process_set_validator_info(
                 println!("--force supplied, ignoring: {:?}", result);
             } else {
                 result.map_err(|err| {
-                    CliError::BadParameter(format!("Invalid validator keybase username: {:?}", err))
+                    CliError::BadParameter(format!("Invalid validator keybase username: {}", err))
                 })?;
             }
         }

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -48,7 +48,7 @@ impl Into<TransportError> for ClientErrorKind {
 }
 
 #[derive(Error, Debug)]
-#[error("client error: kind({kind})")]
+#[error("{kind}")]
 pub struct ClientError {
     command: Option<&'static str>,
     #[source]

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -2,7 +2,7 @@ use crate::rpc_request;
 use solana_sdk::{
     signature::SignerError, transaction::TransactionError, transport::TransportError,
 };
-use std::{fmt, io};
+use std::io;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -19,13 +19,8 @@ pub enum ClientErrorKind {
     SigningError(#[from] SignerError),
     #[error(transparent)]
     TransactionError(#[from] TransactionError),
+    #[error("Custom: {0}")]
     Custom(String),
-}
-
-impl fmt::Display for ClientErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "solana client error")
-    }
 }
 
 impl From<TransportError> for ClientErrorKind {

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -55,12 +55,31 @@ impl Into<TransportError> for ClientErrorKind {
 #[derive(Error, Debug)]
 #[error("client error: kind({kind})")]
 pub struct ClientError {
+    command: Option<&'static str>,
     #[source]
     #[error(transparent)]
     kind: ClientErrorKind,
 }
 
 impl ClientError {
+    pub fn new_with_command(kind: ClientErrorKind, command: &'static str) -> Self {
+        Self {
+            command: Some(command),
+            kind,
+        }
+    }
+
+    pub fn into_with_command(self, command: &'static str) -> Self {
+        Self {
+            command: Some(command),
+            ..self
+        }
+    }
+
+    pub fn command(&self) -> Option<&'static str> {
+        self.command
+    }
+
     pub fn kind(&self) -> &ClientErrorKind {
         &self.kind
     }
@@ -68,13 +87,17 @@ impl ClientError {
 
 impl From<ClientErrorKind> for ClientError {
     fn from(kind: ClientErrorKind) -> Self {
-        Self { kind }
+        Self {
+            command: None,
+            kind,
+        }
     }
 }
 
 impl From<TransportError> for ClientError {
     fn from(err: TransportError) -> Self {
         Self {
+            command: None,
             kind: err.into(),
         }
     }
@@ -89,6 +112,7 @@ impl Into<TransportError> for ClientError {
 impl From<std::io::Error> for ClientError {
     fn from(err: std::io::Error) -> Self {
         Self {
+            command: None,
             kind: err.into(),
         }
     }
@@ -97,6 +121,7 @@ impl From<std::io::Error> for ClientError {
 impl From<reqwest::Error> for ClientError {
     fn from(err: reqwest::Error) -> Self {
         Self {
+            command: None,
             kind: err.into(),
         }
     }
@@ -105,6 +130,7 @@ impl From<reqwest::Error> for ClientError {
 impl From<rpc_request::RpcError> for ClientError {
     fn from(err: rpc_request::RpcError) -> Self {
         Self {
+            command: None,
             kind: err.into(),
         }
     }
@@ -113,6 +139,7 @@ impl From<rpc_request::RpcError> for ClientError {
 impl From<serde_json::error::Error> for ClientError {
     fn from(err: serde_json::error::Error) -> Self {
         Self {
+            command: None,
             kind: err.into(),
         }
     }
@@ -121,6 +148,7 @@ impl From<serde_json::error::Error> for ClientError {
 impl From<SignerError> for ClientError {
     fn from(err: SignerError) -> Self {
         Self {
+            command: None,
             kind: err.into(),
         }
     }
@@ -129,6 +157,7 @@ impl From<SignerError> for ClientError {
 impl From<TransactionError> for ClientError {
     fn from(err: TransactionError) -> Self {
         Self {
+            command: None,
             kind: err.into(),
         }
     }

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -6,23 +6,29 @@ use std::{fmt, io};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum ClientError {
+pub enum ClientErrorKind {
+    #[error(transparent)]
     Io(#[from] io::Error),
+    #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
     RpcError(#[from] rpc_request::RpcError),
+    #[error(transparent)]
     SerdeJson(#[from] serde_json::error::Error),
+    #[error(transparent)]
     SigningError(#[from] SignerError),
+    #[error(transparent)]
     TransactionError(#[from] TransactionError),
     Custom(String),
 }
 
-impl fmt::Display for ClientError {
+impl fmt::Display for ClientErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "solana client error")
     }
 }
 
-impl From<TransportError> for ClientError {
+impl From<TransportError> for ClientErrorKind {
     fn from(err: TransportError) -> Self {
         match err {
             TransportError::IoError(err) => Self::Io(err),
@@ -32,7 +38,7 @@ impl From<TransportError> for ClientError {
     }
 }
 
-impl Into<TransportError> for ClientError {
+impl Into<TransportError> for ClientErrorKind {
     fn into(self) -> TransportError {
         match self {
             Self::Io(err) => TransportError::IoError(err),
@@ -42,6 +48,88 @@ impl Into<TransportError> for ClientError {
             Self::SerdeJson(err) => TransportError::Custom(format!("{:?}", err)),
             Self::SigningError(err) => TransportError::Custom(format!("{:?}", err)),
             Self::Custom(err) => TransportError::Custom(format!("{:?}", err)),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("client error: kind({kind})")]
+pub struct ClientError {
+    #[source]
+    #[error(transparent)]
+    kind: ClientErrorKind,
+}
+
+impl ClientError {
+    pub fn kind(&self) -> &ClientErrorKind {
+        &self.kind
+    }
+}
+
+impl From<ClientErrorKind> for ClientError {
+    fn from(kind: ClientErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
+impl From<TransportError> for ClientError {
+    fn from(err: TransportError) -> Self {
+        Self {
+            kind: err.into(),
+        }
+    }
+}
+
+impl Into<TransportError> for ClientError {
+    fn into(self) -> TransportError {
+        self.kind.into()
+    }
+}
+
+impl From<std::io::Error> for ClientError {
+    fn from(err: std::io::Error) -> Self {
+        Self {
+            kind: err.into(),
+        }
+    }
+}
+
+impl From<reqwest::Error> for ClientError {
+    fn from(err: reqwest::Error) -> Self {
+        Self {
+            kind: err.into(),
+        }
+    }
+}
+
+impl From<rpc_request::RpcError> for ClientError {
+    fn from(err: rpc_request::RpcError) -> Self {
+        Self {
+            kind: err.into(),
+        }
+    }
+}
+
+impl From<serde_json::error::Error> for ClientError {
+    fn from(err: serde_json::error::Error) -> Self {
+        Self {
+            kind: err.into(),
+        }
+    }
+}
+
+impl From<SignerError> for ClientError {
+    fn from(err: SignerError) -> Self {
+        Self {
+            kind: err.into(),
+        }
+    }
+}
+
+impl From<TransactionError> for ClientError {
+    fn from(err: TransactionError) -> Self {
+        Self {
+            kind: err.into(),
         }
     }
 }

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -45,3 +45,5 @@ impl Into<TransportError> for ClientError {
         }
     }
 }
+
+pub type Result<T> = std::result::Result<T, ClientError>;

--- a/client/src/generic_rpc_client_request.rs
+++ b/client/src/generic_rpc_client_request.rs
@@ -1,4 +1,4 @@
-use crate::{client_error::ClientError, rpc_request::RpcRequest};
+use crate::{client_error::Result, rpc_request::RpcRequest};
 
 pub(crate) trait GenericRpcClientRequest {
     fn send(
@@ -6,5 +6,5 @@ pub(crate) trait GenericRpcClientRequest {
         request: &RpcRequest,
         params: serde_json::Value,
         retries: usize,
-    ) -> Result<serde_json::Value, ClientError>;
+    ) -> Result<serde_json::Value>;
 }

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client_error::ClientError,
+    client_error::Result,
     generic_rpc_client_request::GenericRpcClientRequest,
     rpc_request::RpcRequest,
     rpc_response::{Response, RpcResponseContext},
@@ -41,7 +41,7 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
         request: &RpcRequest,
         params: serde_json::Value,
         _retries: usize,
-    ) -> Result<serde_json::Value, ClientError> {
+    ) -> Result<serde_json::Value> {
         if let Some(value) = self.mocks.write().unwrap().remove(request) {
             return Ok(value);
         }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1260,7 +1260,7 @@ pub fn get_rpc_request_str(rpc_addr: SocketAddr, tls: bool) -> String {
 mod tests {
     use super::*;
     use crate::{
-        client_error::ClientError,
+        client_error::ClientErrorKind,
         mock_rpc_client_request::{PUBKEY, SIGNATURE},
     };
     use assert_matches::assert_matches;
@@ -1433,8 +1433,8 @@ mod tests {
         let rpc_client = RpcClient::new_mock("instruction_error".to_string());
         let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&key]);
         assert_matches!(
-            result.unwrap_err(),
-            ClientError::TransactionError(TransactionError::InstructionError(
+            result.unwrap_err().kind(),
+            ClientErrorKind::TransactionError(TransactionError::InstructionError(
                 0,
                 InstructionError::UninitializedAccount
             ))
@@ -1442,7 +1442,7 @@ mod tests {
 
         let rpc_client = RpcClient::new_mock("sig_not_found".to_string());
         let result = rpc_client.send_and_confirm_transaction(&mut tx, &[&key]);
-        if let ClientError::Io(err) = result.unwrap_err() {
+        if let ClientErrorKind::Io(err) = result.unwrap_err().kind() {
             assert_eq!(err.kind(), io::ErrorKind::Other);
         }
     }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -7,7 +7,7 @@ use crate::{
     rpc_response::{
         Response, RpcAccount, RpcBlockhashFeeCalculator, RpcConfirmedBlock, RpcContactInfo,
         RpcEpochInfo, RpcFeeCalculator, RpcFeeRateGovernor, RpcIdentity, RpcKeyedAccount,
-        RpcLeaderSchedule, RpcResponse, RpcVersionInfo, RpcVoteAccountStatus,
+        RpcLeaderSchedule, RpcResult, RpcVersionInfo, RpcVoteAccountStatus,
     },
 };
 use bincode::serialize;
@@ -77,7 +77,7 @@ impl RpcClient {
         &self,
         signature: &str,
         commitment_config: CommitmentConfig,
-    ) -> RpcResponse<bool> {
+    ) -> RpcResult<bool> {
         let response = self
             .client
             .send(
@@ -643,7 +643,7 @@ impl RpcClient {
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResponse<Option<Account>> {
+    ) -> RpcResult<Option<Account>> {
         let response = self.client.send(
             &RpcRequest::GetAccountInfo,
             json!([pubkey.to_string(), commitment_config]),
@@ -724,7 +724,7 @@ impl RpcClient {
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResponse<u64> {
+    ) -> RpcResult<u64> {
         let balance_json = self
             .client
             .send(
@@ -823,7 +823,7 @@ impl RpcClient {
     pub fn get_recent_blockhash_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> RpcResponse<(Hash, FeeCalculator)> {
+    ) -> RpcResult<(Hash, FeeCalculator)> {
         let response = self
             .client
             .send(
@@ -894,7 +894,7 @@ impl RpcClient {
         Ok(value.map(|rf| rf.fee_calculator))
     }
 
-    pub fn get_fee_rate_governor(&self) -> RpcResponse<FeeRateGovernor> {
+    pub fn get_fee_rate_governor(&self) -> RpcResult<FeeRateGovernor> {
         let response = self
             .client
             .send(&RpcRequest::GetFeeRateGovernor, Value::Null, 0)

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -85,20 +85,10 @@ impl RpcClient {
                 json!([signature, commitment_config]),
                 0,
             )
-            .map_err(|err| {
-                Into::<ClientError>::into(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("ConfirmTransaction request failure {:?}", err),
-                ))
-            })?;
+            .map_err(|err| err.into_with_command("ConfirmTransaction"))?;
 
-        serde_json::from_value::<Response<bool>>(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("Received result of an unexpected type {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value::<Response<bool>>(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "ConfirmTransaction"))
     }
 
     pub fn send_transaction(&self, transaction: &Transaction) -> ClientResult<String> {
@@ -150,20 +140,10 @@ impl RpcClient {
         let response = self
             .client
             .send(&RpcRequest::GetSlot, json!([commitment_config]), 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetSlot request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetSlot"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetSlot parse failure: {}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetSlot"))
     }
 
     pub fn total_supply(&self) -> ClientResult<u64> {
@@ -177,20 +157,10 @@ impl RpcClient {
         let response = self
             .client
             .send(&RpcRequest::GetTotalSupply, json!([commitment_config]), 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetTotalSupply request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetTotalSupply"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetTotalSupply parse failure: {}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetTotalSupply"))
     }
 
     pub fn get_vote_accounts(&self) -> ClientResult<RpcVoteAccountStatus> {
@@ -204,60 +174,30 @@ impl RpcClient {
         let response = self
             .client
             .send(&RpcRequest::GetVoteAccounts, json!([commitment_config]), 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetVoteAccounts request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetVoteAccounts"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetVoteAccounts parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetVoteAccounts"))
     }
 
     pub fn get_cluster_nodes(&self) -> ClientResult<Vec<RpcContactInfo>> {
         let response = self
             .client
             .send(&RpcRequest::GetClusterNodes, Value::Null, 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetClusterNodes request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetClusterNodes"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetClusterNodes parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetClusterNodes"))
     }
 
     pub fn get_confirmed_block(&self, slot: Slot) -> ClientResult<RpcConfirmedBlock> {
         let response = self
             .client
             .send(&RpcRequest::GetConfirmedBlock, json!([slot]), 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetConfirmedBlock request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetConfirmedBlock"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetConfirmedBlock parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetConfirmedBlock"))
     }
 
     pub fn get_confirmed_blocks(
@@ -272,20 +212,10 @@ impl RpcClient {
                 json!([start_slot, end_slot]),
                 0,
             )
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetConfirmedBlocks request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetConfirmedBlocks"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetConfirmedBlocks parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetConfirmedBlocks"))
     }
 
     pub fn get_block_time(&self, slot: Slot) -> ClientResult<UnixTimestamp> {
@@ -302,16 +232,12 @@ impl RpcClient {
                     )
                     .into());
                 }
-                let result = serde_json::from_value(result_json)?;
+                let result = serde_json::from_value(result_json)
+                    .map_err(|err| ClientError::new_with_command(err.into(), "GetBlockTime"))?;
                 trace!("Response block timestamp {:?} {:?}", slot, result);
                 Ok(result)
             })
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetBlockTime request failure: {:?}", err),
-                )
-            })?
+            .map_err(|err| err.into_with_command("GetBlockTime"))?
     }
 
     pub fn get_epoch_info(&self) -> ClientResult<RpcEpochInfo> {
@@ -325,20 +251,10 @@ impl RpcClient {
         let response = self
             .client
             .send(&RpcRequest::GetEpochInfo, json!([commitment_config]), 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetEpochInfo request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetEpochInfo"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetEpochInfo parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetEpochInfo"))
     }
 
     pub fn get_leader_schedule(
@@ -360,61 +276,30 @@ impl RpcClient {
                 json!([slot, commitment_config]),
                 0,
             )
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetLeaderSchedule request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetLeaderSchedule"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetLeaderSchedule failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetLeaderSchedule"))
     }
 
     pub fn get_epoch_schedule(&self) -> ClientResult<EpochSchedule> {
         let response = self
             .client
             .send(&RpcRequest::GetEpochSchedule, Value::Null, 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetEpochSchedule request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetEpochSchedule"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetEpochSchedule parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetEpochSchedule"))
     }
 
     pub fn get_identity(&self) -> ClientResult<Pubkey> {
         let response = self
             .client
             .send(&RpcRequest::GetIdentity, Value::Null, 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetIdentity request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetIdentity"))?;
 
         serde_json::from_value(response)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetIdentity failure: {:?}", err),
-                )
-                .into()
-            })
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetIdentity"))
             .and_then(|rpc_identity: RpcIdentity| {
                 rpc_identity.identity.parse::<Pubkey>().map_err(|err| {
                     io::Error::new(
@@ -430,60 +315,30 @@ impl RpcClient {
         let response = self
             .client
             .send(&RpcRequest::GetInflation, Value::Null, 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetInflation request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetInflation"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetInflation parse failure: {}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetInflation"))
     }
 
     pub fn get_version(&self) -> ClientResult<RpcVersionInfo> {
         let response = self
             .client
             .send(&RpcRequest::GetVersion, Value::Null, 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetVersion request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetVersion"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetVersion parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetVersion"))
     }
 
     pub fn minimum_ledger_slot(&self) -> ClientResult<Slot> {
         let response = self
             .client
             .send(&RpcRequest::MinimumLedgerSlot, Value::Null, 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("MinimumLedgerSlot request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("MinimumLedgerSlot"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("MinimumLedgerSlot parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "MinimumLedgerSlot"))
     }
 
     pub fn send_and_confirm_transaction<T: Signers>(
@@ -628,21 +483,11 @@ impl RpcClient {
                 json!([pubkey.to_string()]),
                 retries,
             )
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("RetryGetBalance request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("RetryGetBalance"))?;
 
         Ok(Some(
             serde_json::from_value::<Response<u64>>(balance_json)
-                .map_err(|err| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("RetryGetBalance parse failure: {:?}", err),
-                    )
-                })?
+                .map_err(|err| ClientError::new_with_command(err.into(), "RetryGetBalance"))?
                 .value,
         ))
     }
@@ -710,21 +555,10 @@ impl RpcClient {
                 json!([data_len]),
                 0,
             )
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "GetMinimumBalanceForRentExemption request failure: {:?}",
-                        err
-                    ),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetMinimumBalanceForRentExemption"))?;
 
         let minimum_balance: u64 = serde_json::from_value(minimum_balance_json).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetMinimumBalanceForRentExemption parse failure: {:?}", err),
-            )
+            ClientError::new_with_command(err.into(), "GetMinimumBalanceForRentExemption")
         })?;
         trace!(
             "Response minimum balance {:?} {:?}",
@@ -753,20 +587,10 @@ impl RpcClient {
                 json!([pubkey.to_string(), commitment_config]),
                 0,
             )
-            .map_err(|err| {
-                Into::<ClientError>::into(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetBalance request failure: {:?}", err),
-                ))
-            })?;
+            .map_err(|err| err.into_with_command("GetBalance"))?;
 
-        serde_json::from_value::<Response<u64>>(balance_json).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetBalance parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value::<Response<u64>>(balance_json)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetBalance"))
     }
 
     pub fn get_program_accounts(&self, pubkey: &Pubkey) -> ClientResult<Vec<(Pubkey, Account)>> {
@@ -785,12 +609,8 @@ impl RpcClient {
             })?;
 
         let accounts: Vec<RpcKeyedAccount> =
-            serde_json::from_value::<Vec<RpcKeyedAccount>>(response).map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetProgramAccounts parse failure: {:?}", err),
-                )
-            })?;
+            serde_json::from_value::<Vec<RpcKeyedAccount>>(response)
+                .map_err(|err| ClientError::new_with_command(err.into(), "GetProgramAccounts"))?;
 
         let mut pubkey_accounts: Vec<(Pubkey, Account)> = Vec::new();
         for RpcKeyedAccount { pubkey, account } in accounts.into_iter() {
@@ -821,20 +641,10 @@ impl RpcClient {
                 json!([commitment_config]),
                 0,
             )
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetTransactionCount request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetTransactionCount"))?;
 
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetTransactionCount parse failure: {:?}", err),
-            )
-            .into()
-        })
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetTransactionCount"))
     }
 
     pub fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
@@ -854,12 +664,7 @@ impl RpcClient {
                 json!([commitment_config]),
                 0,
             )
-            .map_err(|err| {
-                Into::<ClientError>::into(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetRecentBlockhash request failure: {:?}", err),
-                ))
-            })?;
+            .map_err(|err| err.into_with_command("GetRecentBlockhash"))?;
 
         let Response {
             context,
@@ -868,14 +673,8 @@ impl RpcClient {
                     blockhash,
                     fee_calculator,
                 },
-        } = serde_json::from_value::<Response<RpcBlockhashFeeCalculator>>(response).map_err(
-            |err| {
-                Into::<ClientError>::into(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetRecentBlockhash parse failure: {:?}", err),
-                ))
-            },
-        )?;
+        } = serde_json::from_value::<Response<RpcBlockhashFeeCalculator>>(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetRecentBlockhash"))?;
         let blockhash = blockhash.parse().map_err(|err| {
             Into::<ClientError>::into(io::Error::new(
                 io::ErrorKind::Other,
@@ -899,21 +698,11 @@ impl RpcClient {
                 json!([blockhash.to_string()]),
                 0,
             )
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetFeeCalculatorForBlockhash request failure: {:?}", e),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetFeeCalculatorForBlockhash"))?;
         let Response { value, .. } = serde_json::from_value::<Response<Option<RpcFeeCalculator>>>(
             response,
         )
-        .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetFeeCalculatorForBlockhash parse failure: {:?}", e),
-            )
-        })?;
+        .map_err(|e| ClientError::new_with_command(e.into(), "GetFeeCalculatorForBlockhash"))?;
         Ok(value.map(|rf| rf.fee_calculator))
     }
 
@@ -921,21 +710,12 @@ impl RpcClient {
         let response = self
             .client
             .send(&RpcRequest::GetFeeRateGovernor, Value::Null, 0)
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetFeeRateGovernor request failure: {:?}", e),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetFeeRateGovernor"))?;
         let Response {
             context,
             value: RpcFeeRateGovernor { fee_rate_governor },
-        } = serde_json::from_value::<Response<RpcFeeRateGovernor>>(response).map_err(|e| {
-            Into::<ClientError>::into(io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetFeeRateGovernor parse failure: {:?}", e),
-            ))
-        })?;
+        } = serde_json::from_value::<Response<RpcFeeRateGovernor>>(response)
+            .map_err(|e| ClientError::new_with_command(e.into(), "GetFeeRateGovernor"))?;
         Ok(Response {
             context,
             value: fee_rate_governor,
@@ -975,19 +755,10 @@ impl RpcClient {
         let response = self
             .client
             .send(&RpcRequest::GetGenesisHash, Value::Null, 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetGenesisHash request failure: {:?}", err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetGenesisHash"))?;
 
-        let hash = serde_json::from_value::<String>(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetGenesisHash parse failure: {:?}", err),
-            )
-        })?;
+        let hash = serde_json::from_value::<String>(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetGenesisHash"))?;
 
         let hash = hash.parse().map_err(|err| {
             io::Error::new(
@@ -1202,24 +973,9 @@ impl RpcClient {
                 json!([signature.to_string(), CommitmentConfig::recent().ok()]),
                 1,
             )
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "GetNumBlocksSinceSignatureConfirmation request failure: {}",
-                        err
-                    ),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetNumBlocksSinceSignatureConfirmation"))?;
         serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!(
-                    "GetNumBlocksSinceSignatureConfirmation parse failure: {}",
-                    err
-                ),
-            )
-            .into()
+            ClientError::new_with_command(err.into(), "GetNumBlocksSinceSignatureConfirmation")
         })
     }
 
@@ -1227,19 +983,9 @@ impl RpcClient {
         let response = self
             .client
             .send(&RpcRequest::ValidatorExit, Value::Null, 0)
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("ValidatorExit request failure: {:?}", err),
-                )
-            })?;
-        serde_json::from_value(response).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("ValidatorExit parse failure: {:?}", err),
-            )
-            .into()
-        })
+            .map_err(|err| err.into_with_command("ValidatorExit"))?;
+        serde_json::from_value(response)
+            .map_err(|err| ClientError::new_with_command(err.into(), "ValidatorExit"))
     }
 
     pub fn send(&self, request: &RpcRequest, params: Value, retries: usize) -> ClientResult<Value> {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -374,7 +374,7 @@ impl RpcClient {
                     return Err(err.unwrap_err().into());
                 } else {
                     return Err(
-                        RpcError::ForUser(format!("Transaction {} failed", signature_str)).into(),
+                        RpcError::ForUser("unable to confirm transaction. This can happen in situations such as transaction expiration and insufficient fee-payer funds".to_string()).into(),
                     );
                 }
             }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client_error::ClientError,
+    client_error::Result as ClientResult,
     generic_rpc_client_request::GenericRpcClientRequest,
     mock_rpc_client_request::{MockRpcClientRequest, Mocks},
     rpc_client_request::RpcClientRequest,
@@ -100,7 +100,7 @@ impl RpcClient {
         })
     }
 
-    pub fn send_transaction(&self, transaction: &Transaction) -> Result<String, ClientError> {
+    pub fn send_transaction(&self, transaction: &Transaction) -> ClientResult<String> {
         let serialized_encoded = bs58::encode(serialize(transaction).unwrap()).into_string();
         let signature =
             self.client
@@ -119,7 +119,7 @@ impl RpcClient {
     pub fn get_signature_status(
         &self,
         signature: &str,
-    ) -> Result<Option<transaction::Result<()>>, ClientError> {
+    ) -> ClientResult<Option<transaction::Result<()>>> {
         self.get_signature_status_with_commitment(signature, CommitmentConfig::default())
     }
 
@@ -127,7 +127,7 @@ impl RpcClient {
         &self,
         signature: &str,
         commitment_config: CommitmentConfig,
-    ) -> Result<Option<transaction::Result<()>>, ClientError> {
+    ) -> ClientResult<Option<transaction::Result<()>>> {
         let signature_status = self.client.send(
             &RpcRequest::GetSignatureStatus,
             json!([signature.to_string(), commitment_config]),
@@ -471,7 +471,7 @@ impl RpcClient {
         &self,
         transaction: &mut Transaction,
         signer_keys: &T,
-    ) -> Result<String, ClientError> {
+    ) -> ClientResult<String> {
         let mut send_retries = 20;
         loop {
             let mut status_retries = 15;
@@ -590,7 +590,7 @@ impl RpcClient {
         &self,
         tx: &mut Transaction,
         signer_keys: &T,
-    ) -> Result<(), ClientError> {
+    ) -> ClientResult<()> {
         let (blockhash, _fee_calculator) =
             self.get_new_blockhash(&tx.message().recent_blockhash)?;
         tx.try_sign(signer_keys, blockhash)?;
@@ -1214,12 +1214,7 @@ impl RpcClient {
         })
     }
 
-    pub fn send(
-        &self,
-        request: &RpcRequest,
-        params: Value,
-        retries: usize,
-    ) -> Result<Value, ClientError> {
+    pub fn send(&self, request: &RpcRequest, params: Value, retries: usize) -> ClientResult<Value> {
         assert!(params.is_array() || params.is_null());
         self.client.send(request, params, retries)
     }
@@ -1236,7 +1231,10 @@ pub fn get_rpc_request_str(rpc_addr: SocketAddr, tls: bool) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mock_rpc_client_request::{PUBKEY, SIGNATURE};
+    use crate::{
+        client_error::ClientError,
+        mock_rpc_client_request::{PUBKEY, SIGNATURE},
+    };
     use assert_matches::assert_matches;
     use jsonrpc_core::{Error, IoHandler, Params};
     use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder};

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client_error::Result as ClientResult,
+    client_error::{ClientError, Result as ClientResult},
     generic_rpc_client_request::GenericRpcClientRequest,
     mock_rpc_client_request::{MockRpcClientRequest, Mocks},
     rpc_client_request::RpcClientRequest,
@@ -67,7 +67,7 @@ impl RpcClient {
         }
     }
 
-    pub fn confirm_transaction(&self, signature: &str) -> io::Result<bool> {
+    pub fn confirm_transaction(&self, signature: &str) -> ClientResult<bool> {
         Ok(self
             .confirm_transaction_with_commitment(signature, CommitmentConfig::default())?
             .value)
@@ -86,10 +86,10 @@ impl RpcClient {
                 0,
             )
             .map_err(|err| {
-                io::Error::new(
+                Into::<ClientError>::into(io::Error::new(
                     io::ErrorKind::Other,
                     format!("ConfirmTransaction request failure {:?}", err),
-                )
+                ))
             })?;
 
         serde_json::from_value::<Response<bool>>(response).map_err(|err| {
@@ -97,6 +97,7 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("Received result of an unexpected type {:?}", err),
             )
+            .into()
         })
     }
 
@@ -138,14 +139,14 @@ impl RpcClient {
         Ok(result)
     }
 
-    pub fn get_slot(&self) -> io::Result<Slot> {
+    pub fn get_slot(&self) -> ClientResult<Slot> {
         self.get_slot_with_commitment(CommitmentConfig::default())
     }
 
     pub fn get_slot_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<Slot> {
+    ) -> ClientResult<Slot> {
         let response = self
             .client
             .send(&RpcRequest::GetSlot, json!([commitment_config]), 0)
@@ -161,17 +162,18 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetSlot parse failure: {}", err),
             )
+            .into()
         })
     }
 
-    pub fn total_supply(&self) -> io::Result<u64> {
+    pub fn total_supply(&self) -> ClientResult<u64> {
         self.total_supply_with_commitment(CommitmentConfig::default())
     }
 
     pub fn total_supply_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<u64> {
+    ) -> ClientResult<u64> {
         let response = self
             .client
             .send(&RpcRequest::GetTotalSupply, json!([commitment_config]), 0)
@@ -187,17 +189,18 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetTotalSupply parse failure: {}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_vote_accounts(&self) -> io::Result<RpcVoteAccountStatus> {
+    pub fn get_vote_accounts(&self) -> ClientResult<RpcVoteAccountStatus> {
         self.get_vote_accounts_with_commitment(CommitmentConfig::default())
     }
 
     pub fn get_vote_accounts_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<RpcVoteAccountStatus> {
+    ) -> ClientResult<RpcVoteAccountStatus> {
         let response = self
             .client
             .send(&RpcRequest::GetVoteAccounts, json!([commitment_config]), 0)
@@ -213,10 +216,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetVoteAccounts parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_cluster_nodes(&self) -> io::Result<Vec<RpcContactInfo>> {
+    pub fn get_cluster_nodes(&self) -> ClientResult<Vec<RpcContactInfo>> {
         let response = self
             .client
             .send(&RpcRequest::GetClusterNodes, Value::Null, 0)
@@ -232,10 +236,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetClusterNodes parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_confirmed_block(&self, slot: Slot) -> io::Result<RpcConfirmedBlock> {
+    pub fn get_confirmed_block(&self, slot: Slot) -> ClientResult<RpcConfirmedBlock> {
         let response = self
             .client
             .send(&RpcRequest::GetConfirmedBlock, json!([slot]), 0)
@@ -251,6 +256,7 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetConfirmedBlock parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
@@ -258,7 +264,7 @@ impl RpcClient {
         &self,
         start_slot: Slot,
         end_slot: Option<Slot>,
-    ) -> io::Result<Vec<Slot>> {
+    ) -> ClientResult<Vec<Slot>> {
         let response = self
             .client
             .send(
@@ -278,10 +284,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetConfirmedBlocks parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_block_time(&self, slot: Slot) -> io::Result<UnixTimestamp> {
+    pub fn get_block_time(&self, slot: Slot) -> ClientResult<UnixTimestamp> {
         let response = self
             .client
             .send(&RpcRequest::GetBlockTime, json!([slot]), 0);
@@ -292,7 +299,8 @@ impl RpcClient {
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
                         format!("Block Not Found: slot={}", slot),
-                    ));
+                    )
+                    .into());
                 }
                 let result = serde_json::from_value(result_json)?;
                 trace!("Response block timestamp {:?} {:?}", slot, result);
@@ -306,14 +314,14 @@ impl RpcClient {
             })?
     }
 
-    pub fn get_epoch_info(&self) -> io::Result<RpcEpochInfo> {
+    pub fn get_epoch_info(&self) -> ClientResult<RpcEpochInfo> {
         self.get_epoch_info_with_commitment(CommitmentConfig::default())
     }
 
     pub fn get_epoch_info_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<RpcEpochInfo> {
+    ) -> ClientResult<RpcEpochInfo> {
         let response = self
             .client
             .send(&RpcRequest::GetEpochInfo, json!([commitment_config]), 0)
@@ -329,10 +337,14 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetEpochInfo parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_leader_schedule(&self, slot: Option<Slot>) -> io::Result<Option<RpcLeaderSchedule>> {
+    pub fn get_leader_schedule(
+        &self,
+        slot: Option<Slot>,
+    ) -> ClientResult<Option<RpcLeaderSchedule>> {
         self.get_leader_schedule_with_commitment(slot, CommitmentConfig::default())
     }
 
@@ -340,7 +352,7 @@ impl RpcClient {
         &self,
         slot: Option<Slot>,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<Option<RpcLeaderSchedule>> {
+    ) -> ClientResult<Option<RpcLeaderSchedule>> {
         let response = self
             .client
             .send(
@@ -360,10 +372,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetLeaderSchedule failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_epoch_schedule(&self) -> io::Result<EpochSchedule> {
+    pub fn get_epoch_schedule(&self) -> ClientResult<EpochSchedule> {
         let response = self
             .client
             .send(&RpcRequest::GetEpochSchedule, Value::Null, 0)
@@ -379,10 +392,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetEpochSchedule parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_identity(&self) -> io::Result<Pubkey> {
+    pub fn get_identity(&self) -> ClientResult<Pubkey> {
         let response = self
             .client
             .send(&RpcRequest::GetIdentity, Value::Null, 0)
@@ -399,6 +413,7 @@ impl RpcClient {
                     io::ErrorKind::Other,
                     format!("GetIdentity failure: {:?}", err),
                 )
+                .into()
             })
             .and_then(|rpc_identity: RpcIdentity| {
                 rpc_identity.identity.parse::<Pubkey>().map_err(|err| {
@@ -406,11 +421,12 @@ impl RpcClient {
                         io::ErrorKind::Other,
                         format!("GetIdentity invalid pubkey failure: {:?}", err),
                     )
+                    .into()
                 })
             })
     }
 
-    pub fn get_inflation(&self) -> io::Result<Inflation> {
+    pub fn get_inflation(&self) -> ClientResult<Inflation> {
         let response = self
             .client
             .send(&RpcRequest::GetInflation, Value::Null, 0)
@@ -426,10 +442,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetInflation parse failure: {}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_version(&self) -> io::Result<RpcVersionInfo> {
+    pub fn get_version(&self) -> ClientResult<RpcVersionInfo> {
         let response = self
             .client
             .send(&RpcRequest::GetVersion, Value::Null, 0)
@@ -445,10 +462,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetVersion parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn minimum_ledger_slot(&self) -> io::Result<Slot> {
+    pub fn minimum_ledger_slot(&self) -> ClientResult<Slot> {
         let response = self
             .client
             .send(&RpcRequest::MinimumLedgerSlot, Value::Null, 0)
@@ -464,6 +482,7 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("MinimumLedgerSlot parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
@@ -628,7 +647,7 @@ impl RpcClient {
         ))
     }
 
-    pub fn get_account(&self, pubkey: &Pubkey) -> io::Result<Account> {
+    pub fn get_account(&self, pubkey: &Pubkey) -> ClientResult<Account> {
         self.get_account_with_commitment(pubkey, CommitmentConfig::default())?
             .value
             .ok_or_else(|| {
@@ -636,6 +655,7 @@ impl RpcClient {
                     io::ErrorKind::Other,
                     format!("AccountNotFound: pubkey={}", pubkey),
                 )
+                .into()
             })
     }
 
@@ -656,7 +676,8 @@ impl RpcClient {
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
                         format!("AccountNotFound: pubkey={}", pubkey),
-                    ));
+                    )
+                    .into());
                 }
                 let Response {
                     context,
@@ -670,18 +691,18 @@ impl RpcClient {
                 })
             })
             .map_err(|err| {
-                io::Error::new(
+                Into::<ClientError>::into(io::Error::new(
                     io::ErrorKind::Other,
                     format!("AccountNotFound: pubkey={}: {:?}", pubkey, err),
-                )
+                ))
             })?
     }
 
-    pub fn get_account_data(&self, pubkey: &Pubkey) -> io::Result<Vec<u8>> {
+    pub fn get_account_data(&self, pubkey: &Pubkey) -> ClientResult<Vec<u8>> {
         Ok(self.get_account(pubkey)?.data)
     }
 
-    pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> io::Result<u64> {
+    pub fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> ClientResult<u64> {
         let minimum_balance_json = self
             .client
             .send(
@@ -714,7 +735,7 @@ impl RpcClient {
     }
 
     /// Request the balance of the account `pubkey`.
-    pub fn get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
+    pub fn get_balance(&self, pubkey: &Pubkey) -> ClientResult<u64> {
         Ok(self
             .get_balance_with_commitment(pubkey, CommitmentConfig::default())?
             .value)
@@ -733,10 +754,10 @@ impl RpcClient {
                 0,
             )
             .map_err(|err| {
-                io::Error::new(
+                Into::<ClientError>::into(io::Error::new(
                     io::ErrorKind::Other,
                     format!("GetBalance request failure: {:?}", err),
-                )
+                ))
             })?;
 
         serde_json::from_value::<Response<u64>>(balance_json).map_err(|err| {
@@ -744,10 +765,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetBalance parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_program_accounts(&self, pubkey: &Pubkey) -> io::Result<Vec<(Pubkey, Account)>> {
+    pub fn get_program_accounts(&self, pubkey: &Pubkey) -> ClientResult<Vec<(Pubkey, Account)>> {
         let response = self
             .client
             .send(
@@ -784,14 +806,14 @@ impl RpcClient {
     }
 
     /// Request the transaction count.
-    pub fn get_transaction_count(&self) -> io::Result<u64> {
+    pub fn get_transaction_count(&self) -> ClientResult<u64> {
         self.get_transaction_count_with_commitment(CommitmentConfig::default())
     }
 
     pub fn get_transaction_count_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<u64> {
+    ) -> ClientResult<u64> {
         let response = self
             .client
             .send(
@@ -811,10 +833,11 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("GetTransactionCount parse failure: {:?}", err),
             )
+            .into()
         })
     }
 
-    pub fn get_recent_blockhash(&self) -> io::Result<(Hash, FeeCalculator)> {
+    pub fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
         Ok(self
             .get_recent_blockhash_with_commitment(CommitmentConfig::default())?
             .value)
@@ -832,10 +855,10 @@ impl RpcClient {
                 0,
             )
             .map_err(|err| {
-                io::Error::new(
+                Into::<ClientError>::into(io::Error::new(
                     io::ErrorKind::Other,
                     format!("GetRecentBlockhash request failure: {:?}", err),
-                )
+                ))
             })?;
 
         let Response {
@@ -847,17 +870,17 @@ impl RpcClient {
                 },
         } = serde_json::from_value::<Response<RpcBlockhashFeeCalculator>>(response).map_err(
             |err| {
-                io::Error::new(
+                Into::<ClientError>::into(io::Error::new(
                     io::ErrorKind::Other,
                     format!("GetRecentBlockhash parse failure: {:?}", err),
-                )
+                ))
             },
         )?;
         let blockhash = blockhash.parse().map_err(|err| {
-            io::Error::new(
+            Into::<ClientError>::into(io::Error::new(
                 io::ErrorKind::Other,
                 format!("GetRecentBlockhash hash parse failure: {:?}", err),
-            )
+            ))
         })?;
         Ok(Response {
             context,
@@ -868,7 +891,7 @@ impl RpcClient {
     pub fn get_fee_calculator_for_blockhash(
         &self,
         blockhash: &Hash,
-    ) -> io::Result<Option<FeeCalculator>> {
+    ) -> ClientResult<Option<FeeCalculator>> {
         let response = self
             .client
             .send(
@@ -908,10 +931,10 @@ impl RpcClient {
             context,
             value: RpcFeeRateGovernor { fee_rate_governor },
         } = serde_json::from_value::<Response<RpcFeeRateGovernor>>(response).map_err(|e| {
-            io::Error::new(
+            Into::<ClientError>::into(io::Error::new(
                 io::ErrorKind::Other,
                 format!("GetFeeRateGovernor parse failure: {:?}", e),
-            )
+            ))
         })?;
         Ok(Response {
             context,
@@ -919,7 +942,7 @@ impl RpcClient {
         })
     }
 
-    pub fn get_new_blockhash(&self, blockhash: &Hash) -> io::Result<(Hash, FeeCalculator)> {
+    pub fn get_new_blockhash(&self, blockhash: &Hash) -> ClientResult<(Hash, FeeCalculator)> {
         let mut num_retries = 0;
         let start = Instant::now();
         while start.elapsed().as_secs() < 5 {
@@ -944,10 +967,11 @@ impl RpcClient {
                 num_retries,
                 blockhash
             ),
-        ))
+        )
+        .into())
     }
 
-    pub fn get_genesis_hash(&self) -> io::Result<Hash> {
+    pub fn get_genesis_hash(&self) -> ClientResult<Hash> {
         let response = self
             .client
             .send(&RpcRequest::GetGenesisHash, Value::Null, 0)
@@ -980,7 +1004,7 @@ impl RpcClient {
         polling_frequency: &Duration,
         timeout: &Duration,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<u64> {
+    ) -> ClientResult<u64> {
         let now = Instant::now();
         loop {
             match self.get_balance_with_commitment(&pubkey, commitment_config.clone()) {
@@ -1001,7 +1025,7 @@ impl RpcClient {
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<u64> {
+    ) -> ClientResult<u64> {
         self.poll_balance_with_timeout_and_commitment(
             pubkey,
             &Duration::from_millis(100),
@@ -1040,7 +1064,7 @@ impl RpcClient {
     }
 
     /// Poll the server to confirm a transaction.
-    pub fn poll_for_signature(&self, signature: &Signature) -> io::Result<()> {
+    pub fn poll_for_signature(&self, signature: &Signature) -> ClientResult<()> {
         self.poll_for_signature_with_commitment(signature, CommitmentConfig::default())
     }
 
@@ -1049,7 +1073,7 @@ impl RpcClient {
         &self,
         signature: &Signature,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<()> {
+    ) -> ClientResult<()> {
         let now = Instant::now();
         loop {
             if let Ok(Some(_)) = self.get_signature_status_with_commitment(
@@ -1065,7 +1089,8 @@ impl RpcClient {
                         "signature not found after {} seconds",
                         now.elapsed().as_secs()
                     ),
-                ));
+                )
+                .into());
             }
             sleep(Duration::from_millis(250));
         }
@@ -1114,7 +1139,7 @@ impl RpcClient {
         &self,
         signature: &Signature,
         min_confirmed_blocks: usize,
-    ) -> io::Result<usize> {
+    ) -> ClientResult<usize> {
         let mut now = Instant::now();
         let mut confirmed_blocks = 0;
         loop {
@@ -1157,7 +1182,8 @@ impl RpcClient {
                             "signature not found after {} seconds",
                             now.elapsed().as_secs()
                         ),
-                    ));
+                    )
+                    .into());
                 }
             }
             sleep(Duration::from_millis(250));
@@ -1168,7 +1194,7 @@ impl RpcClient {
     pub fn get_num_blocks_since_signature_confirmation(
         &self,
         signature: &Signature,
-    ) -> io::Result<usize> {
+    ) -> ClientResult<usize> {
         let response = self
             .client
             .send(
@@ -1193,10 +1219,11 @@ impl RpcClient {
                     err
                 ),
             )
+            .into()
         })
     }
 
-    pub fn validator_exit(&self) -> io::Result<bool> {
+    pub fn validator_exit(&self) -> ClientResult<bool> {
         let response = self
             .client
             .send(&RpcRequest::ValidatorExit, Value::Null, 0)
@@ -1211,6 +1238,7 @@ impl RpcClient {
                 io::ErrorKind::Other,
                 format!("ValidatorExit parse failure: {:?}", err),
             )
+            .into()
         })
     }
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -3,7 +3,7 @@ use crate::{
     generic_rpc_client_request::GenericRpcClientRequest,
     mock_rpc_client_request::{MockRpcClientRequest, Mocks},
     rpc_client_request::RpcClientRequest,
-    rpc_request::RpcRequest,
+    rpc_request::{RpcError, RpcRequest},
     rpc_response::{
         Response, RpcAccount, RpcBlockhashFeeCalculator, RpcConfirmedBlock, RpcContactInfo,
         RpcEpochInfo, RpcFeeCalculator, RpcFeeRateGovernor, RpcIdentity, RpcKeyedAccount,
@@ -27,7 +27,7 @@ use solana_sdk::{
     transaction::{self, Transaction, TransactionError},
 };
 use std::{
-    error, io,
+    error,
     net::SocketAddr,
     thread::sleep,
     time::{Duration, Instant},
@@ -97,11 +97,7 @@ impl RpcClient {
             self.client
                 .send(&RpcRequest::SendTransaction, json!([serialized_encoded]), 5)?;
         if signature.as_str().is_none() {
-            Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Received result of an unexpected type",
-            )
-            .into())
+            Err(RpcError::ForUser("Received result of an unexpected type".to_string()).into())
         } else {
             Ok(signature.as_str().unwrap().to_string())
         }
@@ -226,11 +222,7 @@ impl RpcClient {
         response
             .map(|result_json| {
                 if result_json.is_null() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("Block Not Found: slot={}", slot),
-                    )
-                    .into());
+                    return Err(RpcError::ForUser(format!("Block Not Found: slot={}", slot)).into());
                 }
                 let result = serde_json::from_value(result_json)
                     .map_err(|err| ClientError::new_with_command(err.into(), "GetBlockTime"))?;
@@ -301,12 +293,11 @@ impl RpcClient {
         serde_json::from_value(response)
             .map_err(|err| ClientError::new_with_command(err.into(), "GetIdentity"))
             .and_then(|rpc_identity: RpcIdentity| {
-                rpc_identity.identity.parse::<Pubkey>().map_err(|err| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("GetIdentity invalid pubkey failure: {:?}", err),
+                rpc_identity.identity.parse::<Pubkey>().map_err(|_| {
+                    ClientError::new_with_command(
+                        RpcError::ParseError("Pubkey".to_string()).into(),
+                        "GetIdentity",
                     )
-                    .into()
                 })
             })
     }
@@ -382,11 +373,9 @@ impl RpcClient {
                 if let Some(err) = status {
                     return Err(err.unwrap_err().into());
                 } else {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("Transaction {:?} failed: {:?}", signature_str, status),
-                    )
-                    .into());
+                    return Err(
+                        RpcError::ForUser(format!("Transaction {} failed", signature_str)).into(),
+                    );
                 }
             }
         }
@@ -445,7 +434,7 @@ impl RpcClient {
             }
 
             if send_retries == 0 {
-                return Err(io::Error::new(io::ErrorKind::Other, "Transactions failed").into());
+                return Err(RpcError::ForUser("Transactions failed".to_string()).into());
             }
             send_retries -= 1;
 
@@ -495,13 +484,7 @@ impl RpcClient {
     pub fn get_account(&self, pubkey: &Pubkey) -> ClientResult<Account> {
         self.get_account_with_commitment(pubkey, CommitmentConfig::default())?
             .value
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("AccountNotFound: pubkey={}", pubkey),
-                )
-                .into()
-            })
+            .ok_or_else(|| RpcError::ForUser(format!("AccountNotFound: pubkey={}", pubkey)).into())
     }
 
     pub fn get_account_with_commitment(
@@ -518,11 +501,9 @@ impl RpcClient {
         response
             .map(|result_json| {
                 if result_json.is_null() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("AccountNotFound: pubkey={}", pubkey),
-                    )
-                    .into());
+                    return Err(
+                        RpcError::ForUser(format!("AccountNotFound: pubkey={}", pubkey)).into(),
+                    );
                 }
                 let Response {
                     context,
@@ -536,10 +517,10 @@ impl RpcClient {
                 })
             })
             .map_err(|err| {
-                Into::<ClientError>::into(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("AccountNotFound: pubkey={}: {:?}", pubkey, err),
-                ))
+                Into::<ClientError>::into(RpcError::ForUser(format!(
+                    "AccountNotFound: pubkey={}: {}",
+                    pubkey, err
+                )))
             })?
     }
 
@@ -601,12 +582,7 @@ impl RpcClient {
                 json!([pubkey.to_string()]),
                 0,
             )
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("AccountNotFound: pubkey={}: {:?}", pubkey, err),
-                )
-            })?;
+            .map_err(|err| err.into_with_command("GetProgramAccounts"))?;
 
         let accounts: Vec<RpcKeyedAccount> =
             serde_json::from_value::<Vec<RpcKeyedAccount>>(response)
@@ -614,10 +590,10 @@ impl RpcClient {
 
         let mut pubkey_accounts: Vec<(Pubkey, Account)> = Vec::new();
         for RpcKeyedAccount { pubkey, account } in accounts.into_iter() {
-            let pubkey = pubkey.parse().map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("GetProgramAccounts parse failure: {:?}", err),
+            let pubkey = pubkey.parse().map_err(|_| {
+                ClientError::new_with_command(
+                    RpcError::ParseError("Pubkey".to_string()).into(),
+                    "GetProgramAccounts",
                 )
             })?;
             pubkey_accounts.push((pubkey, account.decode().unwrap()));
@@ -675,11 +651,11 @@ impl RpcClient {
                 },
         } = serde_json::from_value::<Response<RpcBlockhashFeeCalculator>>(response)
             .map_err(|err| ClientError::new_with_command(err.into(), "GetRecentBlockhash"))?;
-        let blockhash = blockhash.parse().map_err(|err| {
-            Into::<ClientError>::into(io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetRecentBlockhash hash parse failure: {:?}", err),
-            ))
+        let blockhash = blockhash.parse().map_err(|_| {
+            ClientError::new_with_command(
+                RpcError::ParseError("Hash".to_string()).into(),
+                "GetRecentBlockhash",
+            )
         })?;
         Ok(Response {
             context,
@@ -739,15 +715,12 @@ impl RpcClient {
             ));
             num_retries += 1;
         }
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "Unable to get new blockhash after {}ms (retried {} times), stuck at {}",
-                start.elapsed().as_millis(),
-                num_retries,
-                blockhash
-            ),
-        )
+        Err(RpcError::ForUser(format!(
+            "Unable to get new blockhash after {}ms (retried {} times), stuck at {}",
+            start.elapsed().as_millis(),
+            num_retries,
+            blockhash
+        ))
         .into())
     }
 
@@ -760,10 +733,10 @@ impl RpcClient {
         let hash = serde_json::from_value::<String>(response)
             .map_err(|err| ClientError::new_with_command(err.into(), "GetGenesisHash"))?;
 
-        let hash = hash.parse().map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("GetGenesisHash hash parse failure: {:?}", err),
+        let hash = hash.parse().map_err(|_| {
+            ClientError::new_with_command(
+                RpcError::ParseError("Hash".to_string()).into(),
+                "GetGenesisHash",
             )
         })?;
         Ok(hash)
@@ -854,13 +827,10 @@ impl RpcClient {
                 break;
             }
             if now.elapsed().as_secs() > 15 {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    format!(
-                        "signature not found after {} seconds",
-                        now.elapsed().as_secs()
-                    ),
-                )
+                return Err(RpcError::ForUser(format!(
+                    "signature not found after {} seconds",
+                    now.elapsed().as_secs()
+                ))
                 .into());
             }
             sleep(Duration::from_millis(250));
@@ -947,13 +917,10 @@ impl RpcClient {
                 if confirmed_blocks > 0 {
                     return Ok(confirmed_blocks);
                 } else {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!(
-                            "signature not found after {} seconds",
-                            now.elapsed().as_secs()
-                        ),
-                    )
+                    return Err(RpcError::ForUser(format!(
+                        "signature not found after {} seconds",
+                        now.elapsed().as_secs()
+                    ))
                     .into());
                 }
             }
@@ -1018,7 +985,7 @@ mod tests {
         instruction::InstructionError, signature::Keypair, system_transaction,
         transaction::TransactionError,
     };
-    use std::{sync::mpsc::channel, thread};
+    use std::{io, sync::mpsc::channel, thread};
 
     #[test]
     fn test_send() {

--- a/client/src/rpc_client_request.rs
+++ b/client/src/rpc_client_request.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client_error::ClientError,
+    client_error::Result,
     generic_rpc_client_request::GenericRpcClientRequest,
     rpc_request::{RpcError, RpcRequest},
 };
@@ -34,7 +34,7 @@ impl GenericRpcClientRequest for RpcClientRequest {
         request: &RpcRequest,
         params: serde_json::Value,
         mut retries: usize,
-    ) -> Result<serde_json::Value, ClientError> {
+    ) -> Result<serde_json::Value> {
         // Concurrent requests are not supported so reuse the same request id for all requests
         let request_id = 1;
 

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -1,5 +1,5 @@
 use serde_json::{json, Value};
-use std::{error, fmt};
+use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum RpcRequest {
@@ -95,26 +95,16 @@ impl RpcRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Error)]
 pub enum RpcError {
+    #[error("rpc reques error: {0}")]
     RpcRequestError(String),
-}
-
-impl fmt::Display for RpcError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid")
-    }
-}
-
-impl error::Error for RpcError {
-    fn description(&self) -> &str {
-        "invalid"
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        // Generic error, underlying cause isn't tracked.
-        None
-    }
+    #[error("parse error: expected {0}")]
+    ParseError(String), /* "expected" */
+    // Anything in a `ForUser` needs to die.  The caller should be
+    // deciding what to tell their user
+    #[error("{0}")]
+    ForUser(String), /* "direct-to-user message" */
 }
 
 #[cfg(test)]

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
 };
 use std::{collections::HashMap, io, net::SocketAddr, str::FromStr};
 
-pub type RpcResponse<T> = io::Result<Response<T>>;
+pub type RpcResult<T> = io::Result<Response<T>>;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RpcResponseContext {

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -1,4 +1,4 @@
-use crate::rpc_request::RpcError;
+use crate::{client_error, rpc_request::RpcError};
 use bincode::serialize;
 use solana_sdk::{
     account::Account,
@@ -8,9 +8,9 @@ use solana_sdk::{
     pubkey::Pubkey,
     transaction::{Result, Transaction},
 };
-use std::{collections::HashMap, io, net::SocketAddr, str::FromStr};
+use std::{collections::HashMap, net::SocketAddr, str::FromStr};
 
-pub type RpcResult<T> = io::Result<Response<T>>;
+pub type RpcResult<T> = client_error::Result<Response<T>>;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RpcResponseContext {

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -1,6 +1,5 @@
 use crate::rpc_request::RpcError;
 use bincode::serialize;
-use jsonrpc_core::Result as JsonResult;
 use solana_sdk::{
     account::Account,
     clock::{Epoch, Slot},
@@ -11,7 +10,6 @@ use solana_sdk::{
 };
 use std::{collections::HashMap, io, net::SocketAddr, str::FromStr};
 
-pub type RpcResponseIn<T> = JsonResult<Response<T>>;
 pub type RpcResponse<T> = io::Result<Response<T>>;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -571,7 +571,7 @@ impl SyncClient for ThinClient {
 }
 
 impl AsyncClient for ThinClient {
-    fn async_send_transaction(&self, transaction: Transaction) -> io::Result<Signature> {
+    fn async_send_transaction(&self, transaction: Transaction) -> TransportResult<Signature> {
         let mut buf = vec![0; serialized_size(&transaction).unwrap() as usize];
         let mut wr = std::io::Cursor::new(&mut buf[..]);
         serialize_into(&mut wr, &transaction)
@@ -586,7 +586,7 @@ impl AsyncClient for ThinClient {
         keypairs: &T,
         message: Message,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature> {
+    ) -> TransportResult<Signature> {
         let transaction = Transaction::new(keypairs, message, recent_blockhash);
         self.async_send_transaction(transaction)
     }
@@ -595,7 +595,7 @@ impl AsyncClient for ThinClient {
         keypair: &Keypair,
         instruction: Instruction,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature> {
+    ) -> TransportResult<Signature> {
         let message = Message::new(&[instruction]);
         self.async_send_message(&[keypair], message, recent_blockhash)
     }
@@ -605,7 +605,7 @@ impl AsyncClient for ThinClient {
         keypair: &Keypair,
         pubkey: &Pubkey,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature> {
+    ) -> TransportResult<Signature> {
         let transfer_instruction =
             system_instruction::transfer(&keypair.pubkey(), pubkey, lamports);
         self.async_send_instruction(keypair, transfer_instruction, recent_blockhash)

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -188,7 +188,7 @@ impl ThinClient {
         transaction: &mut Transaction,
         tries: usize,
         min_confirmed_blocks: usize,
-    ) -> io::Result<Signature> {
+    ) -> TransportResult<Signature> {
         self.send_and_confirm_transaction(&[keypair], transaction, tries, min_confirmed_blocks)
     }
 
@@ -198,7 +198,7 @@ impl ThinClient {
         keypair: &Keypair,
         transaction: &mut Transaction,
         tries: usize,
-    ) -> io::Result<Signature> {
+    ) -> TransportResult<Signature> {
         self.send_and_confirm_transaction(&[keypair], transaction, tries, 0)
     }
 
@@ -209,7 +209,7 @@ impl ThinClient {
         transaction: &mut Transaction,
         tries: usize,
         pending_confirmations: usize,
-    ) -> io::Result<Signature> {
+    ) -> TransportResult<Signature> {
         for x in 0..tries {
             let now = Instant::now();
             let mut buf = vec![0; serialized_size(&transaction).unwrap() as usize];
@@ -243,13 +243,14 @@ impl ThinClient {
                 }
             }
             info!("{} tries failed transfer to {}", x, self.tpu_addr());
-            let (blockhash, _fee_calculator) = self.rpc_client().get_recent_blockhash()?;
+            let (blockhash, _fee_calculator) = self.get_recent_blockhash()?;
             transaction.sign(keypairs, blockhash);
         }
         Err(io::Error::new(
             io::ErrorKind::Other,
             format!("retry_transfer failed in {} retries", tries),
-        ))
+        )
+        .into())
     }
 
     pub fn poll_balance_with_timeout_and_commitment(
@@ -258,13 +259,15 @@ impl ThinClient {
         polling_frequency: &Duration,
         timeout: &Duration,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<u64> {
-        self.rpc_client().poll_balance_with_timeout_and_commitment(
-            pubkey,
-            polling_frequency,
-            timeout,
-            commitment_config,
-        )
+    ) -> TransportResult<u64> {
+        self.rpc_client()
+            .poll_balance_with_timeout_and_commitment(
+                pubkey,
+                polling_frequency,
+                timeout,
+                commitment_config,
+            )
+            .map_err(|e| e.into())
     }
 
     pub fn poll_balance_with_timeout(
@@ -272,8 +275,8 @@ impl ThinClient {
         pubkey: &Pubkey,
         polling_frequency: &Duration,
         timeout: &Duration,
-    ) -> io::Result<u64> {
-        self.rpc_client().poll_balance_with_timeout_and_commitment(
+    ) -> TransportResult<u64> {
+        self.poll_balance_with_timeout_and_commitment(
             pubkey,
             polling_frequency,
             timeout,
@@ -281,18 +284,18 @@ impl ThinClient {
         )
     }
 
-    pub fn poll_get_balance(&self, pubkey: &Pubkey) -> io::Result<u64> {
-        self.rpc_client()
-            .poll_get_balance_with_commitment(pubkey, CommitmentConfig::default())
+    pub fn poll_get_balance(&self, pubkey: &Pubkey) -> TransportResult<u64> {
+        self.poll_get_balance_with_commitment(pubkey, CommitmentConfig::default())
     }
 
     pub fn poll_get_balance_with_commitment(
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> io::Result<u64> {
+    ) -> TransportResult<u64> {
         self.rpc_client()
             .poll_get_balance_with_commitment(pubkey, commitment_config)
+            .map_err(|e| e.into())
     }
 
     pub fn wait_for_balance(&self, pubkey: &Pubkey, expected_balance: Option<u64>) -> Option<u64> {
@@ -321,9 +324,9 @@ impl ThinClient {
         signature: &Signature,
         commitment_config: CommitmentConfig,
     ) -> TransportResult<()> {
-        Ok(self
-            .rpc_client()
-            .poll_for_signature_with_commitment(signature, commitment_config)?)
+        self.rpc_client()
+            .poll_for_signature_with_commitment(signature, commitment_config)
+            .map_err(|e| e.into())
     }
 
     /// Check a signature in the bank. This method blocks
@@ -332,16 +335,17 @@ impl ThinClient {
         self.rpc_client().check_signature(signature)
     }
 
-    pub fn validator_exit(&self) -> io::Result<bool> {
-        self.rpc_client().validator_exit()
+    pub fn validator_exit(&self) -> TransportResult<bool> {
+        self.rpc_client().validator_exit().map_err(|e| e.into())
     }
 
     pub fn get_num_blocks_since_signature_confirmation(
         &mut self,
         sig: &Signature,
-    ) -> io::Result<usize> {
+    ) -> TransportResult<usize> {
         self.rpc_client()
             .get_num_blocks_since_signature_confirmation(sig)
+            .map_err(|e| e.into())
     }
 }
 
@@ -400,14 +404,14 @@ impl SyncClient for ThinClient {
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> TransportResult<Option<Account>> {
-        Ok(self
-            .rpc_client()
-            .get_account_with_commitment(pubkey, commitment_config)?
-            .value)
+        self.rpc_client()
+            .get_account_with_commitment(pubkey, commitment_config)
+            .map_err(|e| e.into())
+            .map(|r| r.value)
     }
 
     fn get_balance(&self, pubkey: &Pubkey) -> TransportResult<u64> {
-        Ok(self.rpc_client().get_balance(pubkey)?)
+        self.rpc_client().get_balance(pubkey).map_err(|e| e.into())
     }
 
     fn get_balance_with_commitment(
@@ -415,10 +419,10 @@ impl SyncClient for ThinClient {
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
     ) -> TransportResult<u64> {
-        let balance = self
-            .rpc_client()
-            .get_balance_with_commitment(pubkey, commitment_config)?;
-        Ok(balance.value)
+        self.rpc_client()
+            .get_balance_with_commitment(pubkey, commitment_config)
+            .map_err(|e| e.into())
+            .map(|r| r.value)
     }
 
     fn get_recent_blockhash(&self) -> TransportResult<(Hash, FeeCalculator)> {
@@ -449,15 +453,16 @@ impl SyncClient for ThinClient {
         &self,
         blockhash: &Hash,
     ) -> TransportResult<Option<FeeCalculator>> {
-        let fee_calculator = self
-            .rpc_client()
-            .get_fee_calculator_for_blockhash(blockhash)?;
-        Ok(fee_calculator)
+        self.rpc_client()
+            .get_fee_calculator_for_blockhash(blockhash)
+            .map_err(|e| e.into())
     }
 
     fn get_fee_rate_governor(&self) -> TransportResult<FeeRateGovernor> {
-        let fee_rate_governor = self.rpc_client().get_fee_rate_governor()?;
-        Ok(fee_rate_governor.value)
+        self.rpc_client()
+            .get_fee_rate_governor()
+            .map_err(|e| e.into())
+            .map(|r| r.value)
     }
 
     fn get_signature_status(
@@ -555,18 +560,21 @@ impl SyncClient for ThinClient {
         signature: &Signature,
         min_confirmed_blocks: usize,
     ) -> TransportResult<usize> {
-        Ok(self
-            .rpc_client()
-            .poll_for_signature_confirmation(signature, min_confirmed_blocks)?)
+        self.rpc_client()
+            .poll_for_signature_confirmation(signature, min_confirmed_blocks)
+            .map_err(|e| e.into())
     }
 
     fn poll_for_signature(&self, signature: &Signature) -> TransportResult<()> {
-        Ok(self.rpc_client().poll_for_signature(signature)?)
+        self.rpc_client()
+            .poll_for_signature(signature)
+            .map_err(|e| e.into())
     }
 
     fn get_new_blockhash(&self, blockhash: &Hash) -> TransportResult<(Hash, FeeCalculator)> {
-        let new_blockhash = self.rpc_client().get_new_blockhash(blockhash)?;
-        Ok(new_blockhash)
+        self.rpc_client()
+            .get_new_blockhash(blockhash)
+            .map_err(|e| e.into())
     }
 }
 

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -17,6 +17,7 @@ solana-clap-utils = { path = "../clap-utils", version = "1.1.0" }
 solana-cli-config = { path = "../cli-config", version = "1.1.0" }
 solana-remote-wallet = { path = "../remote-wallet", version = "1.1.0" }
 solana-sdk = { path = "../sdk", version = "1.1.0" }
+thiserror = "1.0.11"
 tiny-bip39 = "0.7.0"
 
 [[bin]]

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -17,7 +17,6 @@ solana-clap-utils = { path = "../clap-utils", version = "1.1.0" }
 solana-cli-config = { path = "../cli-config", version = "1.1.0" }
 solana-remote-wallet = { path = "../remote-wallet", version = "1.1.0" }
 solana-sdk = { path = "../sdk", version = "1.1.0" }
-thiserror = "1.0.11"
 tiny-bip39 = "0.7.0"
 
 [[bin]]

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -193,7 +193,19 @@ fn grind_parse_args(
 fn main() -> Result<(), Box<dyn error::Error>> {
     let result = do_main().err();
     if let Some(err) = result {
-        eprintln!("hi! {}", err);
+        use thiserror::Error;
+
+        #[derive(Error)]
+        #[error("")]
+        struct PrettyError(String);
+
+        impl std::fmt::Debug for PrettyError {
+            fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(fmt, "{}", self.0)
+            }
+        }
+
+        return Err(PrettyError(err.to_string()).into());
     }
     Ok(())
 }

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -191,6 +191,14 @@ fn grind_parse_args(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
+    let result = do_main().err();
+    if let Some(err) = result {
+        eprintln!("hi! {}", err);
+    }
+    Ok(())
+}
+
+fn do_main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_clap_utils::version!())

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -262,7 +262,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
                 );
                 match sig {
                     Err(e) => {
-                        result = Err(TransportError::IoError(e));
+                        result = Err(e);
                         continue;
                     }
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -23,6 +23,7 @@ use solana_sdk::{
     signature::{Keypair, Signer},
     system_transaction,
     transaction::Transaction,
+    transport::Result as TransportResult,
 };
 use solana_stake_program::{
     config as stake_config, stake_instruction,
@@ -607,7 +608,7 @@ impl LocalCluster {
         storage_keypair: &Keypair,
         from_keypair: &Arc<Keypair>,
         archiver: bool,
-    ) -> Result<()> {
+    ) -> TransportResult<()> {
         let storage_account_type = if archiver {
             StorageAccountType::Archiver
         } else {

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -36,7 +36,7 @@ impl Client for BankClient {
 }
 
 impl AsyncClient for BankClient {
-    fn async_send_transaction(&self, transaction: Transaction) -> io::Result<Signature> {
+    fn async_send_transaction(&self, transaction: Transaction) -> Result<Signature> {
         let signature = transaction.signatures.get(0).cloned().unwrap_or_default();
         let transaction_sender = self.transaction_sender.lock().unwrap();
         transaction_sender.send(transaction).unwrap();
@@ -48,7 +48,7 @@ impl AsyncClient for BankClient {
         keypairs: &T,
         message: Message,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature> {
+    ) -> Result<Signature> {
         let transaction = Transaction::new(keypairs, message, recent_blockhash);
         self.async_send_transaction(transaction)
     }
@@ -58,7 +58,7 @@ impl AsyncClient for BankClient {
         keypair: &Keypair,
         instruction: Instruction,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature> {
+    ) -> Result<Signature> {
         let message = Message::new(&[instruction]);
         self.async_send_message(&[keypair], message, recent_blockhash)
     }
@@ -70,7 +70,7 @@ impl AsyncClient for BankClient {
         keypair: &Keypair,
         pubkey: &Pubkey,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature> {
+    ) -> Result<Signature> {
         let transfer_instruction =
             system_instruction::transfer(&keypair.pubkey(), pubkey, lamports);
         self.async_send_instruction(keypair, transfer_instruction, recent_blockhash)

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -21,7 +21,6 @@ use crate::{
     transaction,
     transport::Result,
 };
-use std::io;
 
 pub trait Client: SyncClient + AsyncClient {
     fn tpu_addr(&self) -> String;
@@ -122,10 +121,7 @@ pub trait SyncClient {
 
 pub trait AsyncClient {
     /// Send a signed transaction, but don't wait to see if the server accepted it.
-    fn async_send_transaction(
-        &self,
-        transaction: transaction::Transaction,
-    ) -> io::Result<Signature>;
+    fn async_send_transaction(&self, transaction: transaction::Transaction) -> Result<Signature>;
 
     /// Create a transaction from the given message, and send it to the
     /// server, but don't wait for to see if the server accepted it.
@@ -134,7 +130,7 @@ pub trait AsyncClient {
         keypairs: &T,
         message: Message,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature>;
+    ) -> Result<Signature>;
 
     /// Create a transaction from a single instruction that only requires
     /// a single signer. Then send it to the server, but don't wait for a reply.
@@ -143,7 +139,7 @@ pub trait AsyncClient {
         keypair: &Keypair,
         instruction: Instruction,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature>;
+    ) -> Result<Signature>;
 
     /// Attempt to transfer lamports from `keypair` to `pubkey`, but don't wait to confirm.
     fn async_transfer(
@@ -152,5 +148,5 @@ pub trait AsyncClient {
         keypair: &Keypair,
         pubkey: &Pubkey,
         recent_blockhash: Hash,
-    ) -> io::Result<Signature>;
+    ) -> Result<Signature>;
 }

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -2,6 +2,7 @@
 
 use sha2::{Digest, Sha256};
 use std::{convert::TryFrom, fmt, mem, str::FromStr};
+use thiserror::Error;
 
 pub const HASH_BYTES: usize = 32;
 #[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -47,9 +48,11 @@ impl fmt::Display for Hash {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ParseHashError {
+    #[error("string decoded to wrong size for hash")]
     WrongSize,
+    #[error("failed to decoded string to hash")]
     Invalid,
 }
 

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -3,96 +3,124 @@
 use crate::{pubkey::Pubkey, short_vec, system_instruction::SystemError};
 use bincode::serialize;
 use serde::Serialize;
+use thiserror::Error;
 
 /// Reasons the runtime might have rejected an instruction.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Error, PartialEq, Eq, Clone)]
 pub enum InstructionError {
     /// Deprecated! Use CustomError instead!
     /// The program instruction returned an error
+    #[error("generic instruction error")]
     GenericError,
 
     /// The arguments provided to a program instruction where invalid
+    #[error("invalid instruction argument")]
     InvalidArgument,
 
     /// An instruction's data contents was invalid
+    #[error("invalid instruction data")]
     InvalidInstructionData,
 
     /// An account's data contents was invalid
+    #[error("invalid account data for instruction")]
     InvalidAccountData,
 
     /// An account's data was too small
+    #[error("account data too small for instruction")]
     AccountDataTooSmall,
 
     /// An account's balance was too small to complete the instruction
+    #[error("insufficient funds for instruction")]
     InsufficientFunds,
 
     /// The account did not have the expected program id
+    #[error("incorrect program id for instruction")]
     IncorrectProgramId,
 
     /// A signature was required but not found
+    #[error("missing required signature for instruction")]
     MissingRequiredSignature,
 
     /// An initialize instruction was sent to an account that has already been initialized.
+    #[error("already initialized account for instruction")]
     AccountAlreadyInitialized,
 
     /// An attempt to operate on an account that hasn't been initialized.
+    #[error("uninitialized account for instruction")]
     UninitializedAccount,
 
     /// Program's instruction lamport balance does not equal the balance after the instruction
+    #[error("balance mismatch after instruction")]
     UnbalancedInstruction,
 
     /// Program modified an account's program id
+    #[error("instruction modified program id")]
     ModifiedProgramId,
 
     /// Program spent the lamports of an account that doesn't belong to it
+    #[error("instruction spent from account it does not own")]
     ExternalAccountLamportSpend,
 
     /// Program modified the data of an account that doesn't belong to it
+    #[error("instruction modified data of account it does not own")]
     ExternalAccountDataModified,
 
     /// Read-only account modified lamports
+    #[error("instruction changed balance of read-only account")]
     ReadonlyLamportChange,
 
     /// Read-only account modified data
+    #[error("instruction modified data of read-only account")]
     ReadonlyDataModified,
 
     /// An account was referenced more than once in a single instruction
     // Deprecated, instructions can now contain duplicate accounts
+    #[error("instruction contains duplicate accounts")]
     DuplicateAccountIndex,
 
     /// Executable bit on account changed, but shouldn't have
+    #[error("instrcution changed executable bit")]
     ExecutableModified,
 
     /// Rent_epoch account changed, but shouldn't have
+    #[error("instruction modified rent epoch")]
     RentEpochModified,
 
     /// The instruction expected additional account keys
+    #[error("Insufficient account keys for instruction")]
     NotEnoughAccountKeys,
 
     /// A non-system program changed the size of the account data
+    #[error("non-system instruction changed account size")]
     AccountDataSizeChanged,
 
     /// The instruction expected an executable account
+    #[error("instruction expected an executable account")]
     AccountNotExecutable,
 
     /// Failed to borrow a reference to account data, already borrowed
+    #[error("instruction attempted to borrow already borrowed account")]
     AccountBorrowFailed,
 
     /// Account data has an outstanding reference after a program's execution
+    #[error("instruction left account data with outstanding borrow")]
     AccountBorrowOutstanding,
 
     /// The same account was multiply passed to an on-chain program's entrypoint, but the program
     /// modified them differently.  A program can only modify one instance of the account because
     /// the runtime cannot determine which changes to pick or how to merge them if both are modified
+    #[error("instruction modifications of multiply-passed account differ")]
     DuplicateAccountOutOfSync,
 
     /// Allows on-chain programs to implement program-specific error types and see them returned
     /// by the Solana runtime. A program-specific error may be any type that is represented as
     /// or serialized to a u32 integer.
+    #[error("custom instruction error: {0}")]
     CustomError(u32),
 
     /// The return value from the program was invalid.  Valid errors are either a defined builtin
     /// error value or a user-defined error in the lower 32 bits.
+    #[error("instruction error is invalid")]
     InvalidError,
 }
 

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -13,11 +13,11 @@ pub enum InstructionError {
     #[error("generic instruction error")]
     GenericError,
 
-    /// The arguments provided to a program instruction where invalid
-    #[error("invalid instruction argument")]
+    /// The arguments provided to a program were invalid
+    #[error("invalid program argument")]
     InvalidArgument,
 
-    /// An instruction's data contents was invalid
+    /// An instruction's data contents were invalid
     #[error("invalid instruction data")]
     InvalidInstructionData,
 
@@ -42,35 +42,35 @@ pub enum InstructionError {
     MissingRequiredSignature,
 
     /// An initialize instruction was sent to an account that has already been initialized.
-    #[error("already initialized account for instruction")]
+    #[error("instruction requires an uninitialized account")]
     AccountAlreadyInitialized,
 
     /// An attempt to operate on an account that hasn't been initialized.
-    #[error("uninitialized account for instruction")]
+    #[error("instruction requires an initialized account")]
     UninitializedAccount,
 
     /// Program's instruction lamport balance does not equal the balance after the instruction
-    #[error("balance mismatch after instruction")]
+    #[error("sum of account balances before and after instruction do not match")]
     UnbalancedInstruction,
 
     /// Program modified an account's program id
-    #[error("instruction modified program id")]
+    #[error("instruction modified the program id of an account")]
     ModifiedProgramId,
 
     /// Program spent the lamports of an account that doesn't belong to it
-    #[error("instruction spent from account it does not own")]
+    #[error("instruction spent from the balance of an account it does not own")]
     ExternalAccountLamportSpend,
 
     /// Program modified the data of an account that doesn't belong to it
-    #[error("instruction modified data of account it does not own")]
+    #[error("instruction modified data of an account it does not own")]
     ExternalAccountDataModified,
 
     /// Read-only account modified lamports
-    #[error("instruction changed balance of read-only account")]
+    #[error("instruction changed balance of a read-only account")]
     ReadonlyLamportChange,
 
     /// Read-only account modified data
-    #[error("instruction modified data of read-only account")]
+    #[error("instruction modified data of a read-only account")]
     ReadonlyDataModified,
 
     /// An account was referenced more than once in a single instruction
@@ -79,15 +79,15 @@ pub enum InstructionError {
     DuplicateAccountIndex,
 
     /// Executable bit on account changed, but shouldn't have
-    #[error("instrcution changed executable bit")]
+    #[error("instruction changed executable bit of an account")]
     ExecutableModified,
 
     /// Rent_epoch account changed, but shouldn't have
-    #[error("instruction modified rent epoch")]
+    #[error("instruction modified rent epoch of an account")]
     RentEpochModified,
 
     /// The instruction expected additional account keys
-    #[error("Insufficient account keys for instruction")]
+    #[error("insufficient account key count for instruction")]
     NotEnoughAccountKeys,
 
     /// A non-system program changed the size of the account data
@@ -99,11 +99,11 @@ pub enum InstructionError {
     AccountNotExecutable,
 
     /// Failed to borrow a reference to account data, already borrowed
-    #[error("instruction attempted to borrow already borrowed account")]
+    #[error("instruction tries to borrow reference for an account which is already borrowed")]
     AccountBorrowFailed,
 
     /// Account data has an outstanding reference after a program's execution
-    #[error("instruction left account data with outstanding borrow")]
+    #[error("instruction left account with an outstanding reference borrowed")]
     AccountBorrowOutstanding,
 
     /// The same account was multiply passed to an on-chain program's entrypoint, but the program
@@ -115,12 +115,12 @@ pub enum InstructionError {
     /// Allows on-chain programs to implement program-specific error types and see them returned
     /// by the Solana runtime. A program-specific error may be any type that is represented as
     /// or serialized to a u32 integer.
-    #[error("custom instruction error: {0}")]
+    #[error("program error: {0}")]
     CustomError(u32),
 
     /// The return value from the program was invalid.  Valid errors are either a defined builtin
     /// error value or a user-defined error in the lower 32 bits.
-    #[error("instruction error is invalid")]
+    #[error("program returned invalid error code")]
     InvalidError,
 }
 

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -107,9 +107,11 @@ impl Into<[u8; 64]> for Signature {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ParseSignatureError {
+    #[error("string decoded to wrong size for signature")]
     WrongSize,
+    #[error("failed to decode string to signature")]
     Invalid,
 }
 

--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -1,20 +1,13 @@
 use crate::transaction::TransactionError;
-use std::{error, fmt, io};
+use std::io;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TransportError {
-    IoError(io::Error),
-    TransactionError(TransactionError),
-}
-
-impl error::Error for TransportError {}
-impl fmt::Display for TransportError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            TransportError::IoError(err) => write!(formatter, "{:?}", err),
-            TransportError::TransactionError(err) => write!(formatter, "{:?}", err),
-        }
-    }
+    #[error("transport io error: {0}")]
+    IoError(#[from] io::Error),
+    #[error("transport transaction error: {0}")]
+    TransactionError(#[from] TransactionError),
 }
 
 impl TransportError {
@@ -24,18 +17,6 @@ impl TransportError {
         } else {
             panic!("unexpected transport error")
         }
-    }
-}
-
-impl From<io::Error> for TransportError {
-    fn from(err: io::Error) -> TransportError {
-        TransportError::IoError(err)
-    }
-}
-
-impl From<TransactionError> for TransportError {
-    fn from(err: TransactionError) -> TransportError {
-        TransportError::TransactionError(err)
     }
 }
 

--- a/sdk/src/transport.rs
+++ b/sdk/src/transport.rs
@@ -8,6 +8,8 @@ pub enum TransportError {
     IoError(#[from] io::Error),
     #[error("transport transaction error: {0}")]
     TransactionError(#[from] TransactionError),
+    #[error("transport custom error: {0}")]
+    Custom(String),
 }
 
 impl TransportError {

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -14,7 +14,7 @@ use solana_client::{
 };
 use solana_metrics::{datapoint_error, datapoint_info};
 use solana_sdk::{hash::Hash, native_token::lamports_to_sol, pubkey::Pubkey};
-use std::{error, io, str::FromStr, thread::sleep, time::Duration};
+use std::{error, str::FromStr, thread::sleep, time::Duration};
 
 struct Config {
     interval: Duration,

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -9,7 +9,9 @@ use solana_clap_utils::{
     input_parsers::pubkeys_of,
     input_validators::{is_pubkey_or_keypair, is_url},
 };
-use solana_client::{rpc_client::RpcClient, rpc_response::RpcVoteAccountStatus};
+use solana_client::{
+    client_error::Result as ClientResult, rpc_client::RpcClient, rpc_response::RpcVoteAccountStatus,
+};
 use solana_metrics::{datapoint_error, datapoint_info};
 use solana_sdk::{hash::Hash, native_token::lamports_to_sol, pubkey::Pubkey};
 use std::{error, io, str::FromStr, thread::sleep, time::Duration};
@@ -115,7 +117,7 @@ fn get_config() -> Config {
     config
 }
 
-fn get_cluster_info(rpc_client: &RpcClient) -> io::Result<(u64, Hash, RpcVoteAccountStatus)> {
+fn get_cluster_info(rpc_client: &RpcClient) -> ClientResult<(u64, Hash, RpcVoteAccountStatus)> {
     let transaction_count = rpc_client.get_transaction_count()?;
     let recent_blockhash = rpc_client.get_recent_blockhash()?.0;
     let vote_accounts = rpc_client.get_vote_accounts()?;


### PR DESCRIPTION
#### Problem

CLI produces error message that expose implementation details and are generally unfriendly to the user

#### Summary of Changes

- Consistent return types throughout client interface
- Stop abusing `io::Error`
- Surface full error stack to callers rather than squashing to a string

#### TODO
- [x] Handle remaining `io::Error` abusers in `RpcClient`
- [ ] ~Extend return type consistency to CLI~ `Box<dyn error::Error>` will do for now
- [x] Pretty error messages

Fixes #7722 
