### PR TITLE
Don't tell users to install unreleased software versions

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -67,6 +67,7 @@ ARGS+=(
   --env BUILDKITE_JOB_ID
   --env CI
   --env CI_BRANCH
+  --env CI_TAG
   --env CI_BUILD_ID
   --env CI_COMMIT
   --env CI_JOB_ID

--- a/docs/makefile
+++ b/docs/makefile
@@ -8,6 +8,7 @@ TARGET=html/index.html
 TEST_STAMP=src/tests.ok
 
 all: $(TARGET)
+	./set-solana-release-tag.sh
 
 svg: $(SVG_IMGS)
 

--- a/docs/set-solana-release-tag.sh
+++ b/docs/set-solana-release-tag.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [[ -n $CI_TAG ]]; then
+  LATEST_SOLANA_RELEASE_VERSION=$CI_TAG
+else
+  LATEST_SOLANA_RELEASE_VERSION=$(\
+    curl -sSfL https://api.github.com/repos/solana-labs/solana/releases/latest \
+    | grep -m 1 tag_name \
+    | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p' \
+  )
+fi
+
+set -x
+find html/ -name \*.html -exec sed -i "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;

--- a/docs/src/install-solana.md
+++ b/docs/src/install-solana.md
@@ -1,14 +1,14 @@
 # Install the Solana Tool Suite
 
 Install the Solana release
-[v1.1.0](https://github.com/solana-labs/solana/releases/tag/v1.1.0) on your
+[LATEST_SOLANA_RELEASE_VERSION](https://github.com/solana-labs/solana/releases/tag/LATEST_SOLANA_RELEASE_VERSION) on your
 machine by running:
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/solana-labs/solana/v1.1.0/install/solana-install-init.sh | sh -s - 1.1.0
+curl -sSf https://raw.githubusercontent.com/solana-labs/solana/LATEST_SOLANA_RELEASE_VERSION/install/solana-install-init.sh | sh -s - LATEST_SOLANA_RELEASE_VERSION
 ```
 
-If you are connecting to a different testnet, you can replace `1.1.0` with the
+If you are connecting to a different testnet, you can replace `LATEST_SOLANA_RELEASE_VERSION` with the
 release tag matching the software version of your desired testnet, or replace it
 with the named channel `stable`, `beta`, or `edge`.
 
@@ -16,11 +16,11 @@ The following output indicates a successful update:
 
 ```text
 looking for latest release
-downloading v1.1.0 installer
+downloading LATEST_SOLANA_RELEASE_VERSION installer
 Configuration: /home/solana/.config/solana/install/config.yml
 Active release directory: /home/solana/.local/share/solana/install/active_release
-* Release version: 1.1.0
-* Release URL: https://github.com/solana-labs/solana/releases/download/v1.1.0/solana-release-x86_64-unknown-linux-gnu.tar.bz2
+* Release version: LATEST_SOLANA_RELEASE_VERSION
+* Release URL: https://github.com/solana-labs/solana/releases/download/LATEST_SOLANA_RELEASE_VERSION/solana-release-x86_64-unknown-linux-gnu.tar.bz2
 Update successful
 ```
 

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -581,7 +581,7 @@ pub fn info(config_file: &str, local_info_only: bool) -> Result<Option<UpdateMan
     if let Some(explicit_release) = &config.explicit_release {
         match explicit_release {
             ExplicitRelease::Semver(release_semver) => {
-                println_name_value(&format!("{}Release version:", BULLET), &release_semver);
+                println_name_value(&format!("v{}Release version:", BULLET), &release_semver);
                 println_name_value(
                     &format!("{}Release URL:", BULLET),
                     &github_release_download_url(release_semver),


### PR DESCRIPTION
For edge/beta channel docs, we'll now suggest the user install the latest release.  For a release tag, we suggest they install that exact release

Fixes #8813
