### PR TITLE
Use cluster information about slots to prioritize repair

### DIFF
--- a/core/src/cluster_slots.rs
+++ b/core/src/cluster_slots.rs
@@ -244,7 +244,7 @@ mod tests {
         c2.id = k2;
         assert_eq!(
             cs.compute_weights(0, &[c1, c2]),
-            vec![(std::u64::MAX / 2 + 1, 1), (1, 0)]
+            vec![(std::u64::MAX / 2 + 1, 0), (1, 1)]
         );
     }
 
@@ -265,7 +265,7 @@ mod tests {
         c2.id = k2;
         assert_eq!(
             cs.compute_weights(0, &[c1, c2]),
-            vec![(std::u64::MAX / 2 + 1, 1), (1, 0)]
+            vec![(std::u64::MAX / 2 + 1, 0), (1, 1)]
         );
     }
 

--- a/core/src/cluster_slots.rs
+++ b/core/src/cluster_slots.rs
@@ -224,6 +224,47 @@ mod tests {
     }
 
     #[test]
+    fn test_best_peer() {
+        let cs = ClusterSlots::default();
+        let ci = ContactInfo::default();
+        assert_eq!(cs.best_peer(0, &[ci]), 0);
+    }
+
+    #[test]
+    fn test_best_peer_2() {
+        let mut cs = ClusterSlots::default();
+        let mut c1 = ContactInfo::default();
+        let mut c2 = ContactInfo::default();
+        let mut map = HashMap::new();
+        let k1 = Pubkey::new_rand();
+        let k2 = Pubkey::new_rand();
+        map.insert(Rc::new(k1.clone()), std::u64::MAX / 2);
+        map.insert(Rc::new(k2.clone()), 0);
+        cs.cluster_slots.insert(0, map);
+        c1.id = k1;
+        c2.id = k2;
+        assert_eq!(cs.best_peer(0, &[c2, c1]), 1);
+    }
+
+    #[test]
+    fn test_best_peer_3() {
+        let mut cs = ClusterSlots::default();
+        let mut c1 = ContactInfo::default();
+        let mut c2 = ContactInfo::default();
+        let mut map = HashMap::new();
+        let k1 = Pubkey::new_rand();
+        let k2 = Pubkey::new_rand();
+        map.insert(Rc::new(k2.clone()), 0);
+        cs.cluster_slots.insert(0, map);
+        //make sure default weights are used as well
+        cs.validator_stakes
+            .insert(Rc::new(k1.clone()), std::u64::MAX / 2);
+        c1.id = k1;
+        c2.id = k2;
+        assert_eq!(cs.best_peer(0, &[c2, c1]), 1);
+    }
+
+    #[test]
     fn test_update_new_staked_slot() {
         let mut cs = ClusterSlots::default();
         let mut epoch_slot = EpochSlots::default();

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -12,6 +12,7 @@ use solana_ledger::{
 };
 use solana_sdk::{clock::Slot, epoch_schedule::EpochSchedule, pubkey::Pubkey};
 use std::{
+    collections::HashMap,
     iter::Iterator,
     net::SocketAddr,
     net::UdpSocket,
@@ -129,11 +130,12 @@ impl RepairService {
             };
 
             if let Ok(repairs) = repairs {
+                let mut cache = HashMap::new();
                 let reqs: Vec<((SocketAddr, Vec<u8>), RepairType)> = repairs
                     .into_iter()
                     .filter_map(|repair_request| {
                         serve_repair
-                            .repair_request(&cluster_slots, &repair_request)
+                            .repair_request(&cluster_slots, &repair_request, &mut cache)
                             .map(|result| (result, repair_request))
                             .ok()
                     })

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -133,7 +133,7 @@ impl RepairService {
                     .into_iter()
                     .filter_map(|repair_request| {
                         serve_repair
-                            .repair_request(&repair_request)
+                            .repair_request(&cluster_slots, &repair_request)
                             .map(|result| (result, repair_request))
                             .ok()
                     })

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -64,6 +64,8 @@ pub struct ServeRepair {
     cluster_info: Arc<RwLock<ClusterInfo>>,
 }
 
+type RepairCache = HashMap<Slot, (Vec<ContactInfo>, Vec<(u64, usize)>)>;
+
 impl ServeRepair {
     /// Without a valid keypair gossip will not function. Only useful for tests.
     pub fn new_with_invalid_keypair(contact_info: ContactInfo) -> Self {
@@ -276,7 +278,7 @@ impl ServeRepair {
         &self,
         cluster_slots: &ClusterSlots,
         repair_request: &RepairType,
-        cache: &mut HashMap<Slot, (Vec<ContactInfo>, Vec<(u64, usize)>)>,
+        cache: &mut RepairCache,
     ) -> Result<(SocketAddr, Vec<u8>)> {
         // find a peer that appears to be accepting replication and has the desired slot, as indicated
         // by a valid tvu port location


### PR DESCRIPTION
#### Problem

Repair requests clients are picked at random.

#### Summary of Changes

Use a stake weighted random selection to pick repair servers.  The servers who are advertising that their have the slot completed are prioritized 2x more than those who are in an unknown state.

Fixes #
