### PR TITLE
Update getSignatureStatus rpc method to search historical statuses

### DIFF
--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -2,7 +2,7 @@ use crate::{
     client_error::Result,
     generic_rpc_client_request::GenericRpcClientRequest,
     rpc_request::RpcRequest,
-    rpc_response::{Response, RpcResponseContext},
+    rpc_response::{Response, RpcResponseContext, RpcTransactionStatus},
 };
 use serde_json::{Number, Value};
 use solana_sdk::{
@@ -87,19 +87,30 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                 value: serde_json::to_value(FeeRateGovernor::default()).unwrap(),
             })?,
             RpcRequest::GetSignatureStatus => {
-                let response: Option<transaction::Result<()>> = if self.url == "account_in_use" {
-                    Some(Err(TransactionError::AccountInUse))
+                let status: transaction::Result<()> = if self.url == "account_in_use" {
+                    Err(TransactionError::AccountInUse)
                 } else if self.url == "instruction_error" {
-                    Some(Err(TransactionError::InstructionError(
+                    Err(TransactionError::InstructionError(
                         0,
                         InstructionError::UninitializedAccount,
-                    )))
-                } else if self.url == "sig_not_found" {
+                    ))
+                } else {
+                    Ok(())
+                };
+                let value = if self.url == "sig_not_found" {
                     None
                 } else {
-                    Some(Ok(()))
+                    Some(RpcTransactionStatus {
+                        status,
+                        fee: 0,
+                        pre_balances: vec![],
+                        post_balances: vec![],
+                    })
                 };
-                serde_json::to_value(response).unwrap()
+                serde_json::to_value(vec![Response {
+                    context: RpcResponseContext { slot: 1 },
+                    value,
+                }])?
             }
             RpcRequest::GetTransactionCount => Value::Number(Number::from(1234)),
             RpcRequest::GetSlot => Value::Number(Number::from(0)),

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -2,7 +2,7 @@ use crate::{
     client_error::Result,
     generic_rpc_client_request::GenericRpcClientRequest,
     rpc_request::RpcRequest,
-    rpc_response::{Response, RpcResponseContext, RpcTransactionStatus},
+    rpc_response::{Response, RpcResponseContext, RpcTransactionStatusMeta},
 };
 use serde_json::{Number, Value};
 use solana_sdk::{
@@ -100,7 +100,7 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                 let value = if self.url == "sig_not_found" {
                     None
                 } else {
-                    Some(RpcTransactionStatus {
+                    Some(RpcTransactionStatusMeta {
                         status,
                         fee: 0,
                         pre_balances: vec![],

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -2,7 +2,7 @@ use crate::{
     client_error::Result,
     generic_rpc_client_request::GenericRpcClientRequest,
     rpc_request::RpcRequest,
-    rpc_response::{Response, RpcResponseContext, RpcTransactionStatusMeta},
+    rpc_response::{Response, RpcResponseContext, RpcTransactionStatus},
 };
 use serde_json::{Number, Value};
 use solana_sdk::{
@@ -97,20 +97,12 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                 } else {
                     Ok(())
                 };
-                let value = if self.url == "sig_not_found" {
+                let status = if self.url == "sig_not_found" {
                     None
                 } else {
-                    Some(RpcTransactionStatusMeta {
-                        status,
-                        fee: 0,
-                        pre_balances: vec![],
-                        post_balances: vec![],
-                    })
+                    Some(RpcTransactionStatus { status, slot: 1 })
                 };
-                serde_json::to_value(vec![Response {
-                    context: RpcResponseContext { slot: 1 },
-                    value,
-                }])?
+                serde_json::to_value(vec![status])?
             }
             RpcRequest::GetTransactionCount => Value::Number(Number::from(1234)),
             RpcRequest::GetSlot => Value::Number(Number::from(0)),

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -7,8 +7,7 @@ use crate::{
     rpc_response::{
         Response, RpcAccount, RpcBlockhashFeeCalculator, RpcConfirmedBlock, RpcContactInfo,
         RpcEpochInfo, RpcFeeCalculator, RpcFeeRateGovernor, RpcIdentity, RpcKeyedAccount,
-        RpcLeaderSchedule, RpcResult, RpcTransactionStatusMeta, RpcVersionInfo,
-        RpcVoteAccountStatus,
+        RpcLeaderSchedule, RpcResult, RpcTransactionStatus, RpcVersionInfo, RpcVoteAccountStatus,
     },
 };
 use bincode::serialize;
@@ -124,12 +123,9 @@ impl RpcClient {
             json!([[signature.to_string()], commitment_config]),
             5,
         )?;
-        let result: Vec<Response<Option<RpcTransactionStatusMeta>>> =
+        let result: Vec<Option<RpcTransactionStatus>> =
             serde_json::from_value(signature_status).unwrap();
-        Ok(result[0]
-            .value
-            .clone()
-            .map(|status_meta| status_meta.status))
+        Ok(result[0].clone().map(|status_meta| status_meta.status))
     }
 
     pub fn get_slot(&self) -> ClientResult<Slot> {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -7,7 +7,7 @@ use crate::{
     rpc_response::{
         Response, RpcAccount, RpcBlockhashFeeCalculator, RpcConfirmedBlock, RpcContactInfo,
         RpcEpochInfo, RpcFeeCalculator, RpcFeeRateGovernor, RpcIdentity, RpcKeyedAccount,
-        RpcLeaderSchedule, RpcResult, RpcVersionInfo, RpcVoteAccountStatus,
+        RpcLeaderSchedule, RpcResult, RpcTransactionStatus, RpcVersionInfo, RpcVoteAccountStatus,
     },
 };
 use bincode::serialize;
@@ -120,12 +120,15 @@ impl RpcClient {
     ) -> ClientResult<Option<transaction::Result<()>>> {
         let signature_status = self.client.send(
             &RpcRequest::GetSignatureStatus,
-            json!([signature.to_string(), commitment_config]),
+            json!([[signature.to_string()], commitment_config]),
             5,
         )?;
-        let result: Option<transaction::Result<()>> =
+        let result: Vec<Response<Option<RpcTransactionStatus>>> =
             serde_json::from_value(signature_status).unwrap();
-        Ok(result)
+        Ok(result[0]
+            .value
+            .clone()
+            .map(|status_meta| status_meta.status))
     }
 
     pub fn get_slot(&self) -> ClientResult<Slot> {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -7,7 +7,8 @@ use crate::{
     rpc_response::{
         Response, RpcAccount, RpcBlockhashFeeCalculator, RpcConfirmedBlock, RpcContactInfo,
         RpcEpochInfo, RpcFeeCalculator, RpcFeeRateGovernor, RpcIdentity, RpcKeyedAccount,
-        RpcLeaderSchedule, RpcResult, RpcTransactionStatus, RpcVersionInfo, RpcVoteAccountStatus,
+        RpcLeaderSchedule, RpcResult, RpcTransactionStatusMeta, RpcVersionInfo,
+        RpcVoteAccountStatus,
     },
 };
 use bincode::serialize;
@@ -123,7 +124,7 @@ impl RpcClient {
             json!([[signature.to_string()], commitment_config]),
             5,
         )?;
-        let result: Vec<Response<Option<RpcTransactionStatus>>> =
+        let result: Vec<Response<Option<RpcTransactionStatusMeta>>> =
             serde_json::from_value(signature_status).unwrap();
         Ok(result[0]
             .value

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -52,7 +52,7 @@ pub struct RpcConfirmedBlock {
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionWithStatusMeta {
     pub transaction: RpcEncodedTransaction,
-    pub meta: Option<RpcTransactionStatus>,
+    pub meta: Option<RpcTransactionStatusMeta>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -136,7 +136,7 @@ pub struct RpcCompiledInstruction {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcTransactionStatus {
+pub struct RpcTransactionStatusMeta {
     pub status: Result<()>,
     pub fee: u64,
     pub pre_balances: Vec<u64>,

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -143,6 +143,13 @@ pub struct RpcTransactionStatusMeta {
     pub post_balances: Vec<u64>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcTransactionStatus {
+    pub slot: Slot,
+    pub status: Result<()>,
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcBlockhashFeeCalculator {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -53,7 +53,7 @@ fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
 pub struct JsonRpcConfig {
     pub enable_validator_exit: bool,
     pub enable_set_log_filter: bool,
-    pub enable_get_confirmed_block: bool,
+    pub enable_rpc_transaction_history: bool,
     pub identity_pubkey: Pubkey,
     pub faucet_addr: Option<SocketAddr>,
 }
@@ -375,7 +375,7 @@ impl JsonRpcRequestProcessor {
         slot: Slot,
         encoding: Option<RpcTransactionEncoding>,
     ) -> Result<Option<RpcConfirmedBlock>> {
-        if self.config.enable_get_confirmed_block {
+        if self.config.enable_rpc_transaction_history {
             Ok(self.blockstore.get_confirmed_block(slot, encoding).ok())
         } else {
             Ok(None)
@@ -1383,7 +1383,7 @@ pub mod tests {
 
         let request_processor = Arc::new(RwLock::new(JsonRpcRequestProcessor::new(
             JsonRpcConfig {
-                enable_get_confirmed_block: true,
+                enable_rpc_transaction_history: true,
                 identity_pubkey: *pubkey,
                 ..JsonRpcConfig::default()
             },

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -433,9 +433,12 @@ impl JsonRpcRequestProcessor {
         let mut statuses: Vec<Option<RpcTransactionStatus>> = vec![];
 
         let (commitment, search_transaction_history) = if let Some(config) = config {
-            (config.commitment, config.search_transaction_history)
+            (
+                config.commitment,
+                config.search_transaction_history.unwrap_or(false),
+            )
         } else {
-            (None, None)
+            (None, false)
         };
         let bank = self.bank(commitment);
         let maximum_slot = bank.slot();
@@ -446,7 +449,7 @@ impl JsonRpcRequestProcessor {
                 bank.get_signature_confirmation_status(&signature)
             {
                 Some(RpcTransactionStatus { slot, status })
-            } else if search_transaction_history.is_some() && search_transaction_history.unwrap() {
+            } else if self.config.enable_rpc_transaction_history && search_transaction_history {
                 self.blockstore
                     .get_transaction_status(signature, maximum_slot, root)
                     .map_err(|_| Error::internal_error())?

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -19,7 +19,7 @@ use solana_ledger::{
     bank_forks::BankForks, blockstore::Blockstore, rooted_slot_iterator::RootedSlotIterator,
 };
 use solana_perf::packet::PACKET_DATA_SIZE;
-use solana_runtime::bank::Bank;
+use solana_runtime::{bank::Bank, status_cache::SignatureConfirmationStatus};
 use solana_sdk::{
     clock::{Slot, UnixTimestamp},
     commitment_config::{CommitmentConfig, CommitmentLevel},
@@ -204,7 +204,9 @@ impl JsonRpcRequestProcessor {
             Ok(sig) => {
                 let status = bank.get_signature_confirmation_status(&sig);
                 match status {
-                    Some((_, result)) => new_response(bank, result.is_ok()),
+                    Some(SignatureConfirmationStatus { status, .. }) => {
+                        new_response(bank, status.is_ok())
+                    }
                     None => new_response(bank, false),
                 }
             }
@@ -228,10 +230,16 @@ impl JsonRpcRequestProcessor {
     ) -> Option<RpcSignatureConfirmation> {
         self.bank(commitment)
             .get_signature_confirmation_status(&signature)
-            .map(|(confirmations, status)| RpcSignatureConfirmation {
-                confirmations,
-                status,
-            })
+            .map(
+                |SignatureConfirmationStatus {
+                     confirmations,
+                     status,
+                     ..
+                 }| RpcSignatureConfirmation {
+                    confirmations,
+                    status,
+                },
+            )
     }
 
     fn get_slot(&self, commitment: Option<CommitmentConfig>) -> Result<u64> {
@@ -423,9 +431,13 @@ impl JsonRpcRequestProcessor {
         let mut statuses: Vec<Response<Option<RpcTransactionStatus>>> = vec![];
         let root = self.bank_forks.read().unwrap().root();
         for signature in signatures {
+            let slot = self
+                .bank(Some(CommitmentConfig::recent()))
+                .get_signature_confirmation_status(&signature)
+                .map(|SignatureConfirmationStatus { slot, .. }| slot);
             let status = self
                 .blockstore
-                .get_transaction_status(signature, root)
+                .get_transaction_status(signature, slot, root)
                 .map_err(|_| Error::internal_error())?;
             let mut context = RpcResponseContext { slot: root };
             let value = status.and_then(|(slot, status)| {

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -11,7 +11,9 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use solana_chacha_cuda::chacha_cuda::chacha_cbc_encrypt_file_many_keys;
 use solana_ledger::{bank_forks::BankForks, blockstore::Blockstore};
-use solana_runtime::{bank::Bank, storage_utils::archiver_accounts};
+use solana_runtime::{
+    bank::Bank, status_cache::SignatureConfirmationStatus, storage_utils::archiver_accounts,
+};
 use solana_sdk::{
     account::Account,
     account_utils::StateMut,
@@ -343,8 +345,13 @@ impl StorageStage {
                 .unwrap()
                 .working_bank()
                 .get_signature_confirmation_status(signature);
-            if let Some((confirmations, res)) = response {
-                if res.is_ok() {
+            if let Some(SignatureConfirmationStatus {
+                confirmations,
+                status,
+                ..
+            }) = response
+            {
+                if status.is_ok() {
                     if confirmed_blocks != confirmations {
                         now = Instant::now();
                         confirmed_blocks = confirmations;

--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -1,5 +1,5 @@
 use crossbeam_channel::{Receiver, RecvTimeoutError};
-use solana_client::rpc_response::RpcTransactionStatus;
+use solana_client::rpc_response::RpcTransactionStatusMeta;
 use solana_ledger::{blockstore::Blockstore, blockstore_processor::TransactionStatusBatch};
 use solana_runtime::{
     bank::{Bank, HashAgeKind},
@@ -73,7 +73,7 @@ impl TransactionStatusService {
                 blockstore
                     .write_transaction_status(
                         (slot, transaction.signatures[0]),
-                        &RpcTransactionStatus {
+                        &RpcTransactionStatusMeta {
                             status,
                             fee,
                             pre_balances,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -264,7 +264,7 @@ impl Validator {
         });
 
         let (transaction_status_sender, transaction_status_service) =
-            if rpc_service.is_some() && config.rpc_config.enable_get_confirmed_block {
+            if rpc_service.is_some() && config.rpc_config.enable_rpc_transaction_history {
                 let (transaction_status_sender, transaction_status_receiver) = unbounded();
                 (
                     Some(transaction_status_sender),
@@ -279,7 +279,7 @@ impl Validator {
             };
 
         let (rewards_recorder_sender, rewards_recorder_service) =
-            if rpc_service.is_some() && config.rpc_config.enable_get_confirmed_block {
+            if rpc_service.is_some() && config.rpc_config.enable_rpc_transaction_history {
                 let (rewards_recorder_sender, rewards_receiver) = unbounded();
                 (
                     Some(rewards_recorder_sender),

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -693,24 +693,30 @@ Returns the status of a given signature. This method is similar to [confirmTrans
 
 #### Parameters:
 
-* `<string>` - Signature of Transaction to confirm, as base-58 encoded string
-* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+* `<array>` - An array of transaction signatures to confirm, as base-58 encoded strings
+* `<object>` - (optional) Extended Rpc configuration, containing the following optional fields:
+  * `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  * `searchTransactionHistory: <bool>` - whether to search the ledger transaction status cache, which may be expensive
 
 #### Results:
 
+An array of:
+
 * `<null>` - Unknown transaction
-* `<object>` - Transaction status:
-  * `"Ok": <null>` - Transaction was successful
-  * `"Err": <ERR>` - Transaction failed with TransactionError  [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
+* `<object>`
+  * `slot: <u64>` - The slot the transaction was processed
+  * `status: <object>` - Transaction status
+    * `"Ok": <null>` - Transaction was successful
+    * `"Err": <ERR>` - Transaction failed with TransactionError  [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
 
 #### Example:
 
 ```bash
 // Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatus", "params":["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"]}' http://localhost:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatus", "params":[["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW", "5j7s6NiJS3JAkvgkoc18WVAsiSaci2pxB2A6ueCJP4tprA2TFg9wSyTLeYouxPBJEMzJinENTkpA52YStRW5Dia7"]]]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"Ok": null},"id":1}
+{"jsonrpc":"2.0","result":[{"slot": 72, "status": {"Ok": null}}, null],"id":1}
 ```
 
 ### getSlot

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1536,23 +1536,17 @@ impl Blockstore {
     pub fn get_transaction_status(
         &self,
         signature: Signature,
-        slot: Option<Slot>,
         maximum_slot: Slot,
         root: Slot,
     ) -> Result<Option<(Slot, RpcTransactionStatusMeta)>> {
         let mut transaction_iter = self.transaction_status_cf.iter(IteratorMode::End)?;
         let status = transaction_iter
             .find(|((slot_index, sig), _)| {
-                if let Some(known_slot) = slot {
-                    slot_index == &known_slot && sig == &signature
-                } else {
-                    // If a slot is older than the root from bank_forks but not a root itself, it is a
-                    // dead fork and will never be rooted; disregard transaction statuses for these slots
-                    (self.is_root(*slot_index)
-                        || (*slot_index > root && !self.is_dead(*slot_index)))
-                        && slot_index <= &maximum_slot
-                        && sig == &signature
-                }
+                // If a slot is older than the root from bank_forks but not a root itself, it is a
+                // dead fork and will never be rooted; disregard transaction statuses for these slots
+                (self.is_root(*slot_index) || (*slot_index > root && !self.is_dead(*slot_index)))
+                    && slot_index <= &maximum_slot
+                    && sig == &signature
             })
             .map(|((slot, _), status_data)| (slot, deserialize(&status_data).unwrap()));
         Ok(status)
@@ -5364,76 +5358,47 @@ pub mod tests {
             // A transaction status should return the correct corresponding slot, regardless of
             // whether that slot is rooted yet
             assert_eq!(
-                blockstore
-                    .get_transaction_status(signature0, None, 5, 2)
-                    .unwrap(),
+                blockstore.get_transaction_status(signature0, 5, 2).unwrap(),
                 Some((0, status.clone()))
             );
             assert_eq!(
-                blockstore
-                    .get_transaction_status(signature2, None, 5, 2)
-                    .unwrap(),
+                blockstore.get_transaction_status(signature2, 5, 2).unwrap(),
                 Some((2, status.clone()))
             );
             assert_eq!(
-                blockstore
-                    .get_transaction_status(signature3, None, 5, 2)
-                    .unwrap(),
+                blockstore.get_transaction_status(signature3, 5, 2).unwrap(),
                 Some((3, status.clone()))
-            );
-            // If specific slot is specified, success depends on slot equality
-            assert_eq!(
-                blockstore
-                    .get_transaction_status(signature2, Some(2), 5, 2)
-                    .unwrap(),
-                Some((2, status.clone()))
-            );
-            assert_eq!(
-                blockstore
-                    .get_transaction_status(signature2, Some(3), 5, 2)
-                    .unwrap(),
-                None
             );
             // A transaction status in a slot greater than maximum should return None
             assert_eq!(
-                blockstore
-                    .get_transaction_status(signature2, None, 0, 2)
-                    .unwrap(),
+                blockstore.get_transaction_status(signature2, 0, 2).unwrap(),
                 None
             );
             // A transaction status in a slot that can never be rooted should return None
             assert_eq!(
-                blockstore
-                    .get_transaction_status(signature1, None, 5, 2)
-                    .unwrap(),
+                blockstore.get_transaction_status(signature1, 5, 2).unwrap(),
                 None
             );
             // If signature doesn't exist in column, should return None
             assert_eq!(
                 blockstore
-                    .get_transaction_status(Signature::default(), None, 5, 2)
+                    .get_transaction_status(Signature::default(), 5, 2)
                     .unwrap(),
                 None
             );
             // If duplicate signatures [root, old fork], return root
             assert_eq!(
-                blockstore
-                    .get_transaction_status(signature4, None, 5, 2)
-                    .unwrap(),
+                blockstore.get_transaction_status(signature4, 5, 2).unwrap(),
                 Some((2, status.clone()))
             );
             // If duplicate signatures [active slot, dead slot], return active slot
             assert_eq!(
-                blockstore
-                    .get_transaction_status(signature5, None, 5, 2)
-                    .unwrap(),
+                blockstore.get_transaction_status(signature5, 5, 2).unwrap(),
                 Some((3, status.clone()))
             );
             // If duplicate signatures [active slot, active slot], return most recent active slot
             assert_eq!(
-                blockstore
-                    .get_transaction_status(signature6, None, 5, 2)
-                    .unwrap(),
+                blockstore.get_transaction_status(signature6, 5, 2).unwrap(),
                 Some((5, status.clone()))
             );
         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1541,12 +1541,11 @@ impl Blockstore {
     ) -> Result<Option<(Slot, RpcTransactionStatusMeta)>> {
         let mut transaction_iter = self.transaction_status_cf.iter(IteratorMode::End)?;
         let status = transaction_iter
-            .find(|((slot_index, sig), _)| {
+            .find(|((slot, sig), _)| {
+                slot <= &maximum_slot && sig == &signature &&
                 // If a slot is older than the root from bank_forks but not a root itself, it is a
                 // dead fork and will never be rooted; disregard transaction statuses for these slots
-                (self.is_root(*slot_index) || (*slot_index > root && !self.is_dead(*slot_index)))
-                    && slot_index <= &maximum_slot
-                    && sig == &signature
+                (self.is_root(*slot) || (*slot > root && !self.is_dead(*slot)))
             })
             .map(|((slot, _), status_data)| (slot, deserialize(&status_data).unwrap()));
         Ok(status)

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -10,7 +10,7 @@ use rocksdb::{
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use solana_client::rpc_response::{RpcRewards, RpcTransactionStatus};
+use solana_client::rpc_response::{RpcRewards, RpcTransactionStatusMeta};
 use solana_sdk::{clock::Slot, signature::Signature};
 use std::{collections::HashMap, fs, marker::PhantomData, path::Path, sync::Arc};
 use thiserror::Error;
@@ -269,7 +269,7 @@ pub trait TypedColumn: Column {
 }
 
 impl TypedColumn for columns::TransactionStatus {
-    type Type = RpcTransactionStatus;
+    type Type = RpcTransactionStatusMeta;
 }
 
 pub trait SlotColumn<Index = u64> {}

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -39,7 +39,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --limit-ledger-size ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --enable-rpc-get-confirmed-block ]]; then
+    elif [[ $1 = --enable-rpc-transaction-history ]]; then
       args+=("$1")
       shift
     elif [[ $1 = --skip-poh-verify ]]; then

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -129,7 +129,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --limit-ledger-size ]]; then
       args+=("$1")
       shift
-    elif [[ $1 = --enable-rpc-get-confirmed-block ]]; then
+    elif [[ $1 = --enable-rpc-transaction-history ]]; then
       args+=("$1")
       shift
     elif [[ $1 = --skip-poh-verify ]]; then

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -290,7 +290,7 @@ EOF
         --blockstream /tmp/solana-blockstream.sock
         --no-voting
         --dev-no-sigverify
-        --enable-rpc-get-confirmed-block
+        --enable-rpc-transaction-history
       )
     else
       if [[ -n $internalNodesLamports ]]; then

--- a/run.sh
+++ b/run.sh
@@ -94,7 +94,7 @@ args=(
   --rpc-faucet-address 127.0.0.1:9900
   --log -
   --enable-rpc-exit
-  --enable-rpc-get-confirmed-block
+  --enable-rpc-transaction-history
   --init-complete-file "$dataDir"/init-completed
 )
 solana-validator "${args[@]}" &

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -13,7 +13,7 @@ use crate::{
         deserialize_atomicbool, deserialize_atomicu64, serialize_atomicbool, serialize_atomicu64,
     },
     stakes::Stakes,
-    status_cache::{SlotDelta, StatusCache},
+    status_cache::{SignatureConfirmationStatus, SlotDelta, StatusCache},
     storage_utils,
     storage_utils::StorageAccounts,
     system_instruction_processor::{get_system_account_kind, SystemAccountKind},
@@ -1826,14 +1826,14 @@ impl Bank {
     pub fn get_signature_confirmation_status(
         &self,
         signature: &Signature,
-    ) -> Option<(usize, Result<()>)> {
+    ) -> Option<SignatureConfirmationStatus<Result<()>>> {
         let rcache = self.src.status_cache.read().unwrap();
         rcache.get_signature_status_slow(signature, &self.ancestors)
     }
 
     pub fn get_signature_status(&self, signature: &Signature) -> Option<Result<()>> {
         self.get_signature_confirmation_status(signature)
-            .map(|v| v.1)
+            .map(|v| v.status)
     }
 
     pub fn has_signature(&self, signature: &Signature) -> bool {

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -1,4 +1,4 @@
-use crate::bank::Bank;
+use crate::{bank::Bank, status_cache::SignatureConfirmationStatus};
 use solana_sdk::{
     account::Account,
     client::{AsyncClient, Client, SyncClient},
@@ -188,8 +188,13 @@ impl SyncClient for BankClient {
         let mut confirmed_blocks = 0;
         loop {
             let response = self.bank.get_signature_confirmation_status(signature);
-            if let Some((confirmations, res)) = response {
-                if res.is_ok() {
+            if let Some(SignatureConfirmationStatus {
+                confirmations,
+                status,
+                ..
+            }) = response
+            {
+                if status.is_ok() {
                     if confirmed_blocks != confirmations {
                         now = Instant::now();
                         confirmed_blocks = confirmations;

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -32,6 +32,13 @@ type SlotDeltaMap<T> = HashMap<Slot, SignatureStatus<T>>;
 // construct a new one. Usually derived from a status cache's `SlotDeltaMap`
 pub type SlotDelta<T> = (Slot, bool, SignatureStatus<T>);
 
+#[derive(Debug, PartialEq)]
+pub struct SignatureConfirmationStatus<T> {
+    pub slot: Slot,
+    pub confirmations: usize,
+    pub status: T,
+}
+
 #[derive(Clone, Debug)]
 pub struct StatusCache<T: Serialize + Clone> {
     cache: StatusMap<T>,
@@ -100,7 +107,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         &self,
         sig: &Signature,
         ancestors: &HashMap<Slot, usize>,
-    ) -> Option<(usize, T)> {
+    ) -> Option<SignatureConfirmationStatus<T>> {
         trace!("get_signature_status_slow");
         let mut keys = vec![];
         let mut val: Vec<_> = self.cache.iter().map(|(k, _)| *k).collect();
@@ -112,8 +119,18 @@ impl<T: Serialize + Clone> StatusCache<T> {
                 trace!("get_signature_status_slow: got {}", forkid);
                 return ancestors
                     .get(&forkid)
-                    .map(|id| (*id, res.clone()))
-                    .or_else(|| Some((ancestors.len(), res)));
+                    .map(|id| SignatureConfirmationStatus {
+                        slot: forkid,
+                        confirmations: *id,
+                        status: res.clone(),
+                    })
+                    .or_else(|| {
+                        Some(SignatureConfirmationStatus {
+                            slot: forkid,
+                            confirmations: ancestors.len(),
+                            status: res,
+                        })
+                    });
             }
         }
         None
@@ -272,7 +289,11 @@ mod tests {
         );
         assert_eq!(
             status_cache.get_signature_status_slow(&sig, &ancestors),
-            Some((1, ()))
+            Some(SignatureConfirmationStatus {
+                slot: 0,
+                confirmations: 1,
+                status: ()
+            })
         );
     }
 
@@ -317,7 +338,11 @@ mod tests {
         status_cache.add_root(0);
         assert_eq!(
             status_cache.get_signature_status_slow(&sig, &ancestors),
-            Some((ancestors.len(), ()))
+            Some(SignatureConfirmationStatus {
+                slot: 0,
+                confirmations: ancestors.len(),
+                status: ()
+            })
         );
     }
 

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -117,20 +117,15 @@ impl<T: Serialize + Clone> StatusCache<T> {
             trace!("get_signature_status_slow: trying {}", blockhash);
             if let Some((forkid, res)) = self.get_signature_status(sig, blockhash, ancestors) {
                 trace!("get_signature_status_slow: got {}", forkid);
-                return ancestors
+                let confirmations = ancestors
                     .get(&forkid)
-                    .map(|id| SignatureConfirmationStatus {
-                        slot: forkid,
-                        confirmations: *id,
-                        status: res.clone(),
-                    })
-                    .or_else(|| {
-                        Some(SignatureConfirmationStatus {
-                            slot: forkid,
-                            confirmations: ancestors.len(),
-                            status: res,
-                        })
-                    });
+                    .copied()
+                    .unwrap_or_else(|| ancestors.len());
+                return Some(SignatureConfirmationStatus {
+                    slot: forkid,
+                    confirmations,
+                    status: res,
+                });
             }
         }
         None

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -500,10 +500,10 @@ pub fn main() {
                 .help("Enable the JSON RPC 'setLogFilter' API.  Only enable in a debug environment"),
         )
         .arg(
-            Arg::with_name("enable_rpc_get_confirmed_block")
-                .long("enable-rpc-get-confirmed-block")
+            Arg::with_name("enable_rpc_transaction_history")
+                .long("enable-rpc-transaction-history")
                 .takes_value(false)
-                .help("Enable the JSON RPC 'getConfirmedBlock' API.  This will cause an increase in disk usage and IOPS"),
+                .help("Enable historical transaction info over JSON RPC, including the 'getConfirmedBlock' and 'getSignatureStatus' APIs.  This will cause an increase in disk usage and IOPS"),
         )
         .arg(
             Arg::with_name("rpc_faucet_addr")
@@ -733,7 +733,7 @@ pub fn main() {
         rpc_config: JsonRpcConfig {
             enable_validator_exit: matches.is_present("enable_rpc_exit"),
             enable_set_log_filter: matches.is_present("enable_rpc_set_log_filter"),
-            enable_get_confirmed_block: matches.is_present("enable_rpc_get_confirmed_block"),
+            enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
             identity_pubkey: identity_keypair.pubkey(),
             faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")


### PR DESCRIPTION
#### Problem
Once a transaction signature has passed out of the bank status_cache (ie. it is older than MAX_CACHE_ENTRIES, currently 300), there is no way for a client to get the status of that transaction from a validator.

#### Summary of Changes
- Add getStatusHistory method that queries blockstore and returns an RpcTransactionStatus
The context reports the slot in which the transaction was processed.

```
curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getStatusHistory", "params":["2zxKRYbkn6FwwLKDFRqRgyWgWdf2TDmUMboeaswYB2iEwbVh4oPtgchM45n32TTALWU2Fp86zVcd25P38xMuDfX1"]}' 127.0.0.1:8899

{"jsonrpc":"2.0","result":{"context":{"slot":164},"value":{"fee":5000,"postBalances":[7999990000,2000000000,1],"preBalances":[8999995000,1000000000,1],"status":{"Ok":null}}},"id":1}
```

