### PR TITLE
Rework validator vote account defaults to half voting fees

### DIFF
--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
         .arg(
             Arg::with_name("identity_keypair")
                 .short("i")
-                .long("identity-keypair")
+                .long("identity")
                 .value_name("PATH")
                 .takes_value(true)
                 .validator(is_keypair_or_ask_keyword)

--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -178,7 +178,7 @@ startNodes() {
 
       (
         set -x
-        $solana_cli --keypair config/bootstrap-validator/identity-keypair.json \
+        $solana_cli --keypair config/bootstrap-validator/identity.json \
           --url http://127.0.0.1:8899 genesis-hash
       ) | tee genesis-hash.log
       maybeExpectedGenesisHash="--expected-genesis-hash $(tail -n1 genesis-hash.log)"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -684,7 +684,7 @@ pub fn parse_command(
         },
         // Vote Commands
         ("create-vote-account", Some(matches)) => {
-            parse_vote_create_account(matches, default_signer_path, wallet_manager)
+            parse_create_vote_account(matches, default_signer_path, wallet_manager)
         }
         ("vote-update-validator", Some(matches)) => {
             parse_vote_update_validator(matches, default_signer_path, wallet_manager)

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -62,7 +62,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_pubkey_or_keypair)
-                        .help("Public key of the authorized voter [default: vote account]"),
+                        .help("Public key of the authorized voter [default: validator identity pubkey]"),
                 )
                 .arg(
                     Arg::with_name("authorized_withdrawer")
@@ -70,7 +70,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_pubkey_or_keypair)
-                        .help("Public key of the authorized withdrawer [default: cli config pubkey]"),
+                        .help("Public key of the authorized withdrawer [default: validator identity pubkey]"),
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -225,7 +225,7 @@ impl VoteSubCommands for App<'_, '_> {
     }
 }
 
-pub fn parse_vote_create_account(
+pub fn parse_create_vote_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
@@ -404,8 +404,8 @@ pub fn process_create_vote_account(
 
     let vote_init = VoteInit {
         node_pubkey: *identity_pubkey,
-        authorized_voter: authorized_voter.unwrap_or(vote_account_pubkey),
-        authorized_withdrawer: authorized_withdrawer.unwrap_or(vote_account_pubkey),
+        authorized_voter: authorized_voter.unwrap_or(*identity_pubkey),
+        authorized_withdrawer: authorized_withdrawer.unwrap_or(*identity_pubkey),
         commission,
     };
 

--- a/docs/src/paper-wallet/usage.md
+++ b/docs/src/paper-wallet/usage.md
@@ -233,25 +233,25 @@ done < public_keys.txt
 
 In order to run a validator, you will need to specify an "identity keypair"
 which will be used to fund all of the vote transactions signed by your validator.
-Rather than specifying a path with `--identity-keypair <PATH>` you can pass
+Rather than specifying a path with `--identity <PATH>` you can pass
 `ASK` to securely input the funding keypair.
 
 ```bash
-solana-validator --identity-keypair ASK --ledger ...
+solana-validator --identity ASK --ledger ...
 
-[identity-keypair] seed phrase: 🔒
-[identity-keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
+[identity] seed phrase: 🔒
+[identity] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
 ```
 
 You can use this input method for your voting keypair as well:
 
 ```bash
-solana-validator --identity-keypair ASK --voting-keypair ASK --ledger ...
+solana-validator --identity ASK --authorized-voter ASK --ledger ...
 
-[identity-keypair] seed phrase: 🔒
-[identity-keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
-[voting-keypair] seed phrase: 🔒
-[voting-keypair] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
+[identity] seed phrase: 🔒
+[identity] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
+[authorized-voter] seed phrase: 🔒
+[authorized-voter] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue:
 ```
 
 Refer to the following page for a comprehensive guide on running a validator:

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -137,16 +137,16 @@ Read more about the [difference between SOL and lamports here](../introduction.m
 
 If you haven’t already done so, create a vote-account keypair and create the
 vote account on the network. If you have completed this step, you should see the
-“validator-vote-keypair.json” in your Solana runtime directory:
+“vote-account-keypair.json” in your Solana runtime directory:
 
 ```bash
-solana-keygen new -o ~/validator-vote-keypair.json
+solana-keygen new -o ~/vote-account-keypair.json
 ```
 
 Create your vote account on the blockchain:
 
 ```bash
-solana create-vote-account ~/validator-vote-keypair.json ~/validator-keypair.json
+solana create-vote-account ~/vote-account-keypair.json ~/validator-keypair.json
 ```
 
 ## Connect Your Validator
@@ -154,7 +154,7 @@ solana create-vote-account ~/validator-vote-keypair.json ~/validator-keypair.jso
 Connect to a testnet cluster by running:
 
 ```bash
-solana-validator --identity-keypair ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json \
+solana-validator --identity ~/validator-keypair.json --vote-account ~/vote-account-keypair.json \
     --ledger ~/validator-ledger --rpc-port 8899 --entrypoint devnet.solana.com:8001 \
     --limit-ledger-size
 ```

--- a/docs/src/tour-de-sol/participation/steps-to-create-a-validator/connect-to-the-solana-network.md
+++ b/docs/src/tour-de-sol/participation/steps-to-create-a-validator/connect-to-the-solana-network.md
@@ -4,16 +4,16 @@
 
 Once you’ve confirmed the network is running, it’s time to connect your validator to the network.
 
-If you haven’t already done so, create a vote-account keypair and create the vote account on the network. If you have completed this step, you should see the “validator-vote-keypair.json” in your Solana runtime directory:
+If you haven’t already done so, create a vote-account keypair and create the vote account on the network. If you have completed this step, you should see the “vote-account-keypair.json” in your Solana runtime directory:
 
 ```bash
-solana-keygen new -o ~/validator-vote-keypair.json
+solana-keygen new -o ~/vote-account-keypair.json
 ```
 
 Create your vote account on the blockchain:
 
 ```bash
-solana create-vote-account ~/validator-vote-keypair.json ~/validator-keypair.json
+solana create-vote-account ~/vote-account-keypair.json ~/validator-keypair.json
 ```
 
 ## Connect Your Validator
@@ -25,7 +25,7 @@ export SOLANA_METRICS_CONFIG="host=https://metrics.solana.com:8086,db=tds,u=tds_
 ```
 
 ```bash
-solana-validator --identity-keypair ~/validator-keypair.json --voting-keypair ~/validator-vote-keypair.json \
+solana-validator --identity ~/validator-keypair.json --vote-account ~/vote-account-keypair.json \
     --ledger ~/validator-ledger --rpc-port 8899 --entrypoint tds.solana.com:8001 \
     --limit-ledger-size
 ```

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -467,8 +467,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             Account::new(bootstrap_validator_lamports, 0, &system_program::id()),
         );
 
-        let vote_account = vote_state::create_account(
-            &vote_pubkey,
+        let vote_account = vote_state::create_account_with_authorized(
+            &identity_pubkey,
+            &identity_pubkey,
             &identity_pubkey,
             100,
             VoteState::get_rent_exempt_reserve(&rent).max(1),

--- a/multinode-demo/archiver.sh
+++ b/multinode-demo/archiver.sh
@@ -18,10 +18,10 @@ while [[ -n $1 ]]; do
       entrypoint=$2
       args+=("$1" "$2")
       shift 2
-    elif [[ $1 = --identity-keypair ]]; then
-      identity_keypair=$2
-      [[ -r $identity_keypair ]] || {
-        echo "$identity_keypair does not exist"
+    elif [[ $1 = --identity ]]; then
+      identity=$2
+      [[ -r $identity ]] || {
+        echo "$identity does not exist"
         exit 1
       }
       args+=("$1" "$2")
@@ -52,29 +52,29 @@ while [[ -n $1 ]]; do
   fi
 done
 
-: "${identity_keypair:="$SOLANA_ROOT"/farf/archiver-identity-keypair"$label".json}"
+: "${identity:="$SOLANA_ROOT"/farf/archiver-identity"$label".json}"
 : "${storage_keypair:="$SOLANA_ROOT"/farf/archiver-storage-keypair"$label".json}"
 ledger="$SOLANA_ROOT"/farf/archiver-ledger"$label"
 
 rpc_url=$($solana_gossip rpc-url --entrypoint "$entrypoint")
 
-if [[ ! -r $identity_keypair ]]; then
-  $solana_keygen new --no-passphrase -so "$identity_keypair"
+if [[ ! -r $identity ]]; then
+  $solana_keygen new --no-passphrase -so "$identity"
 
   # See https://github.com/solana-labs/solana/issues/4344
-  $solana_cli --keypair "$identity_keypair" --url "$rpc_url" airdrop 1
+  $solana_cli --keypair "$identity" --url "$rpc_url" airdrop 1
 fi
-identity_pubkey=$($solana_keygen pubkey "$identity_keypair")
+identity_pubkey=$($solana_keygen pubkey "$identity")
 
 if [[ ! -r $storage_keypair ]]; then
   $solana_keygen new --no-passphrase -so "$storage_keypair"
 
-  $solana_cli --keypair "$identity_keypair" --url "$rpc_url" \
+  $solana_cli --keypair "$identity" --url "$rpc_url" \
     create-archiver-storage-account "$identity_pubkey" "$storage_keypair"
 fi
 
 default_arg --entrypoint "$entrypoint"
-default_arg --identity-keypair "$identity_keypair"
+default_arg --identity "$identity"
 default_arg --storage-keypair "$storage_keypair"
 default_arg --ledger "$ledger"
 

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -64,8 +64,8 @@ while [[ -n $1 ]]; do
 done
 
 # These keypairs are created by ./setup.sh and included in the genesis config
-identity_keypair=$SOLANA_CONFIG_DIR/bootstrap-validator/identity-keypair.json
-vote_keypair="$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-keypair.json
+identity=$SOLANA_CONFIG_DIR/bootstrap-validator/identity.json
+vote_account="$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-account.json
 
 ledger_dir="$SOLANA_CONFIG_DIR"/bootstrap-validator
 [[ -d "$ledger_dir" ]] || {
@@ -81,8 +81,8 @@ args+=(
   --ledger "$ledger_dir"
   --rpc-port 8899
   --snapshot-interval-slots 100
-  --identity-keypair "$identity_keypair"
-  --voting-keypair "$vote_keypair"
+  --identity "$identity"
+  --vote-account "$vote_account"
   --rpc-faucet-address 127.0.0.1:9900
 )
 default_arg --gossip-port 8001

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -80,16 +80,16 @@ if [[ -n ${positional_args[0]} ]]; then
 fi
 
 config_dir="$SOLANA_CONFIG_DIR/validator$label"
-vote_keypair_path="$config_dir"/vote-keypair.json
-stake_keypair_path="$config_dir"/stake-keypair.json
+vote_account="$config_dir"/vote-account.json
+stake_account="$config_dir"/stake-account.json
 
-if [[ ! -f $vote_keypair_path ]]; then
-  echo "Error: $vote_keypair_path not found"
+if [[ ! -f $vote_account ]]; then
+  echo "Error: $vote_account not found"
   exit 1
 fi
 
-if [[ -f $stake_keypair_path ]]; then
-  echo "Error: $stake_keypair_path already exists"
+if [[ -f $stake_account ]]; then
+  echo "Error: $stake_account already exists"
   exit 1
 fi
 
@@ -97,13 +97,13 @@ if ((airdrops_enabled)); then
   $solana_cli "${common_args[@]}" airdrop "$stake_sol"
 fi
 
-$solana_keygen new --no-passphrase -so "$stake_keypair_path"
+$solana_keygen new --no-passphrase -so "$stake_account"
 
 set -x
 $solana_cli "${common_args[@]}" \
-  vote-account "$vote_keypair_path"
+  vote-account "$vote_account"
 $solana_cli "${common_args[@]}" \
-  create-stake-account "$stake_keypair_path" "$stake_sol"
+  create-stake-account "$stake_account" "$stake_sol"
 $solana_cli "${common_args[@]}" \
-  delegate-stake $maybe_force "$stake_keypair_path" "$vote_keypair_path"
-$solana_cli "${common_args[@]}" stakes "$stake_keypair_path"
+  delegate-stake $maybe_force "$stake_account" "$vote_account"
+$solana_cli "${common_args[@]}" stakes "$stake_account"

--- a/multinode-demo/faucet.sh
+++ b/multinode-demo/faucet.sh
@@ -7,8 +7,8 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
-[[ -f "$SOLANA_CONFIG_DIR"/faucet-keypair.json ]] || {
-  echo "$SOLANA_CONFIG_DIR/faucet-keypair.json not found, create it by running:"
+[[ -f "$SOLANA_CONFIG_DIR"/faucet.json ]] || {
+  echo "$SOLANA_CONFIG_DIR/faucet.json not found, create it by running:"
   echo
   echo "  ${here}/setup.sh"
   exit 1
@@ -16,4 +16,4 @@ source "$here"/common.sh
 
 set -x
 # shellcheck disable=SC2086 # Don't want to double quote $solana_faucet
-exec $solana_faucet --keypair "$SOLANA_CONFIG_DIR"/faucet-keypair.json "$@"
+exec $solana_faucet --keypair "$SOLANA_CONFIG_DIR"/faucet.json "$@"

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -11,29 +11,29 @@ mkdir -p "$SOLANA_CONFIG_DIR"/bootstrap-validator
 
 # Create genesis ledger
 if [[ -r $FAUCET_KEYPAIR ]]; then
-  cp -f "$FAUCET_KEYPAIR" "$SOLANA_CONFIG_DIR"/faucet-keypair.json
+  cp -f "$FAUCET_KEYPAIR" "$SOLANA_CONFIG_DIR"/faucet.json
 else
-  $solana_keygen new --no-passphrase -fso "$SOLANA_CONFIG_DIR"/faucet-keypair.json
+  $solana_keygen new --no-passphrase -fso "$SOLANA_CONFIG_DIR"/faucet.json
 fi
 
 if [[ -f $BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR ]]; then
-  cp -f "$BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR" "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity-keypair.json
+  cp -f "$BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR" "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity.json
 else
-  $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity-keypair.json
+  $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity.json
 fi
 
-$solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-keypair.json
-$solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-keypair.json
+$solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-account.json
+$solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-account.json
 
 args=(
   "$@"
   --enable-warmup-epochs
-  --bootstrap-validator "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity-keypair.json
-                        "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-keypair.json
-                        "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-keypair.json
+  --bootstrap-validator "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity.json
+                        "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-account.json
+                        "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-account.json
 )
 default_arg --ledger "$SOLANA_CONFIG_DIR"/bootstrap-validator
-default_arg --faucet-pubkey "$SOLANA_CONFIG_DIR"/faucet-keypair.json
+default_arg --faucet-pubkey "$SOLANA_CONFIG_DIR"/faucet.json
 default_arg --faucet-lamports 500000000000000000
 default_arg --hashes-per-tick auto
 default_arg --operating-mode development

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -256,7 +256,7 @@ EOF
 
     if [[ $skipSetup != true ]]; then
       solana --url http://"$entrypointIp":8899 \
-        --keypair ~/solana/config/bootstrap-validator/identity-keypair.json \
+        --keypair ~/solana/config/bootstrap-validator/identity.json \
         validator-info publish "$(hostname)" -n team/solana --force || true
     fi
     ;;
@@ -301,7 +301,7 @@ EOF
     if [[ ! -f config/validator-identity.json ]]; then
       solana-keygen new --no-passphrase -so config/validator-identity.json
     fi
-    args+=(--identity-keypair config/validator-identity.json)
+    args+=(--identity config/validator-identity.json)
 
     if [[ $airdropsEnabled != true ]]; then
       args+=(--no-airdrop)
@@ -411,7 +411,7 @@ EOF
     )
 
     if [[ $airdropsEnabled != true ]]; then
-      # If this ever becomes a problem, we need to provide the `--identity-keypair`
+      # If this ever becomes a problem, we need to provide the `--identity`
       # argument to an existing system account with lamports in it
       echo "Error: archivers not supported without airdrops"
       exit 1

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -678,10 +678,10 @@ pub fn process_vote<S: std::hash::BuildHasher>(
     vote_account.set_state(&VoteStateVersions::Current(Box::new(vote_state)))
 }
 
-// utility function, used by Bank, tests
-pub fn create_account(
-    vote_pubkey: &Pubkey,
+pub fn create_account_with_authorized(
     node_pubkey: &Pubkey,
+    authorized_voter: &Pubkey,
+    authorized_withdrawer: &Pubkey,
     commission: u8,
     lamports: u64,
 ) -> Account {
@@ -690,8 +690,8 @@ pub fn create_account(
     let vote_state = VoteState::new(
         &VoteInit {
             node_pubkey: *node_pubkey,
-            authorized_voter: *vote_pubkey,
-            authorized_withdrawer: *vote_pubkey,
+            authorized_voter: *authorized_voter,
+            authorized_withdrawer: *authorized_withdrawer,
             commission,
         },
         &Clock::default(),
@@ -701,6 +701,16 @@ pub fn create_account(
     VoteState::to(&versioned, &mut vote_account).unwrap();
 
     vote_account
+}
+
+// create_account() should be removed, use create_account_with_authorized() instead
+pub fn create_account(
+    vote_pubkey: &Pubkey,
+    node_pubkey: &Pubkey,
+    commission: u8,
+    lamports: u64,
+) -> Account {
+    create_account_with_authorized(node_pubkey, vote_pubkey, vote_pubkey, commission, lamports)
 }
 
 #[cfg(test)]

--- a/run.sh
+++ b/run.sh
@@ -97,8 +97,8 @@ solana-faucet --keypair "$dataDir"/faucet-keypair.json &
 faucet=$!
 
 args=(
-  --identity-keypair "$dataDir"/leader-keypair.json
-  --voting-keypair "$dataDir"/leader-vote-account-keypair.json
+  --identity "$dataDir"/leader-keypair.json
+  --vote-account "$dataDir"/leader-vote-account-keypair.json
   --ledger "$ledgerDir"
   --gossip-port 8001
   --rpc-port 8899

--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -67,7 +67,7 @@ function wait_for_bootstrap_validator_stake_drop {
 
   while true; do
   # shellcheck disable=SC2154
-    bootstrap_validator_validator_info="$(ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana validators | grep "$($HOME/.cargo/bin/solana-keygen pubkey ~/solana/config/bootstrap-validator/identity-keypair.json)"')"
+    bootstrap_validator_validator_info="$(ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana validators | grep "$($HOME/.cargo/bin/solana-keygen pubkey ~/solana/config/bootstrap-validator/identity.json)"')"
     bootstrap_validator_stake_percentage="$(echo "$bootstrap_validator_validator_info" | awk '{gsub(/[\(,\),\%]/,""); print $9}')"
 
     if [[ $(echo "$bootstrap_validator_stake_percentage < $max_stake" | bc) -ne 0 ]]; then


### PR DESCRIPTION
The vote account default setup encourages a validator to spend 100% more lamports in transaction fees than it really needs to.   Rework the defaults so that a vote requires 1 signature instead of 2.

Note that I **intentionally** break the `solana-validator` command-line arguments here, as I want to alert our validators of this change.  Plus the original command-line arguments felt weird.

Changes:
* `solana-genesis` now authorizes the bootstrap validator's identity account to vote, instead of the bootstrap validator's vote account itself.
* `solana create-vote-account`  now authorizes the validator's identity account to vote, instead of the new vote account itself.
* `solana-validator` argument changes:
        1. `--identity-keypair` is now `--identity`
        2. `--voting-keypair` is now `--authorized-voter` (matching the cli), now optional, defaulting to `--identity` 
        3. `--vote-account` is now required to vote (and no longer defaults to `--voting-keypair`)

tl;dr - here's what this means to your validator: https://github.com/solana-labs/cluster/pull/18/files
