### PR TITLE
Remove holding Poh lock

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -325,7 +325,8 @@ impl ClusterInfoVoteListener {
             if exit.load(Ordering::Relaxed) {
                 return Ok(());
             }
-            if let Some(bank) = poh_recorder.lock().unwrap().bank() {
+            let poh_bank = poh_recorder.lock().unwrap().bank();
+            if let Some(bank) = poh_bank {
                 let last_ts = bank.last_vote_sync.load(Ordering::Relaxed);
                 let (votes, new_ts) = cluster_info.read().unwrap().get_votes(last_ts);
                 bank.last_vote_sync

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -445,7 +445,8 @@ impl ReplayStage {
                             rewards_recorder_sender.clone(),
                         );
 
-                        if let Some(bank) = poh_recorder.lock().unwrap().bank() {
+                        let poh_bank = poh_recorder.lock().unwrap().bank();
+                        if let Some(bank) = poh_bank {
                             Self::log_leader_change(
                                 &my_pubkey,
                                 bank.slot(),


### PR DESCRIPTION
#### Problem
Poh lock is held during expensive operations by statements of the type `if let Some(_) = poh.lock().unwrap()...`

#### Summary of Changes
Rework

Fixes #
