### PR TITLE
Cli: Enable any signer in various subcommands

### DIFF
--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -206,7 +206,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .value_name("NONCE ACCOUNT")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_keypair_or_ask_keyword)
+                        .validator(is_valid_signer)
                         .help("Nonce account to withdraw from"),
                 )
                 .arg(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -269,7 +269,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("SPLIT STAKE ACCOUNT")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_keypair_or_ask_keyword)
+                        .validator(is_valid_signer)
                         .help("Keypair of the new stake account to split funds into")
                 )
                 .arg(

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -36,7 +36,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("VOTE ACCOUNT KEYPAIR")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_keypair_or_ask_keyword)
+                        .validator(is_valid_signer)
                         .help("Vote account keypair to fund"),
                 )
                 .arg(
@@ -107,7 +107,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .value_name("AUTHORIZED VOTER KEYPAIR")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_keypair)
+                        .validator(is_valid_signer)
                         .help("Authorized voter keypair"),
                 )
         )


### PR DESCRIPTION
#### Problem
Some cli subcommands only support keypair/ASK signers, for no good reason.`solana split-stake` is a notable example. And in fact most of the plumbing exists to use any kind of signer already exists, but the clap validator is being overly restrictive.

#### Summary of Changes
- Convert `is_keypair_or_ask_keyword` validator in cli to `is_valid_signer` (archiver and validator uses remain until we support remote-keypair signers for these nodes)
- Update storage apis to use `signer_of`
