### PR TITLE
clap-utils/src/keypair.rs: Surface the missing pubkey

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -104,7 +104,7 @@ pub fn signer_from_path(
             } else {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    "missing signature for supplied pubkey".to_string(),
+                    format!("missing signature for supplied pubkey: {}", pubkey),
                 )
                 .into())
             }


### PR DESCRIPTION
`missing signature for supplied pubkey` is a super unhelpful error message without including the pubkey itself