### PR TITLE
Cli: Add resolve-signer subcommand

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -1,6 +1,6 @@
 use crate::keypair::{
-    keypair_from_seed_phrase, pubkey_from_path, signer_from_path, ASK_KEYWORD,
-    SKIP_SEED_PHRASE_VALIDATION_ARG,
+    keypair_from_seed_phrase, pubkey_from_path, resolve_signer_from_path, signer_from_path,
+    ASK_KEYWORD, SKIP_SEED_PHRASE_VALIDATION_ARG,
 };
 use chrono::DateTime;
 use clap::ArgMatches;
@@ -127,6 +127,19 @@ pub fn pubkey_of_signer(
     } else {
         Ok(None)
     }
+}
+
+pub fn resolve_signer(
+    matches: &ArgMatches<'_>,
+    name: &str,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    Ok(resolve_signer_from_path(
+        matches,
+        matches.value_of(name).unwrap(),
+        name,
+        wallet_manager,
+    )?)
 }
 
 pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -124,6 +124,51 @@ pub fn pubkey_from_path(
     }
 }
 
+pub fn resolve_signer_from_path(
+    matches: &ArgMatches,
+    path: &str,
+    keypair_name: &str,
+    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+) -> Result<Option<String>, Box<dyn error::Error>> {
+    match parse_keypair_path(path) {
+        KeypairUrl::Ask => {
+            let skip_validation = matches.is_present(SKIP_SEED_PHRASE_VALIDATION_ARG.name);
+            // This method validates the seed phrase, but returns `None` because there is no path
+            // on disk or to a device
+            keypair_from_seed_phrase(keypair_name, skip_validation, false).map(|_| None)
+        }
+        KeypairUrl::Filepath(path) => match read_keypair_file(&path) {
+            Err(e) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("could not find keypair file: {} error: {}", path, e),
+            )
+            .into()),
+            Ok(_) => Ok(Some(path.to_string())),
+        },
+        KeypairUrl::Stdin => {
+            let mut stdin = std::io::stdin();
+            // This method validates the keypair from stdin, but returns `None` because there is no
+            // path on disk or to a device
+            read_keypair(&mut stdin).map(|_| None)
+        }
+        KeypairUrl::Usb(path) => {
+            if let Some(wallet_manager) = wallet_manager {
+                let path = generate_remote_keypair(
+                    path,
+                    wallet_manager,
+                    matches.is_present("confirm_key"),
+                    keypair_name,
+                )
+                .map(|keypair| keypair.path)?;
+                Ok(Some(path))
+            } else {
+                Err(RemoteWalletError::NoDeviceFound.into())
+            }
+        }
+        _ => Ok(Some(path.to_string())),
+    }
+}
+
 // Keyword used to indicate that the user should be asked for a keypair seed phrase
 pub const ASK_KEYWORD: &str = "ASK";
 

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -55,6 +55,7 @@ mod commands {
 /// Ledger Wallet device
 pub struct LedgerWallet {
     pub device: hidapi::HidDevice,
+    pub pretty_path: String,
 }
 
 impl fmt::Debug for LedgerWallet {
@@ -65,7 +66,10 @@ impl fmt::Debug for LedgerWallet {
 
 impl LedgerWallet {
     pub fn new(device: hidapi::HidDevice) -> Self {
-        Self { device }
+        Self {
+            device,
+            pretty_path: String::default(),
+        }
     }
 
     // Transport Protocol:

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -235,7 +235,10 @@ impl LedgerWallet {
     ) -> Result<Vec<u8>, RemoteWalletError> {
         self.write(command, p1, p2, data)?;
         if p1 == P1_CONFIRM && is_last_part(p2) {
-            println!("Waiting for remote wallet to approve...");
+            println!(
+                "Waiting for approval from remote wallet {}",
+                self.pretty_path
+            );
             let result = self.read()?;
             println!("{}Approved", CHECK_MARK);
             Ok(result)

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -14,6 +14,7 @@ pub struct RemoteKeypair {
     pub wallet_type: RemoteWalletType,
     pub derivation_path: DerivationPath,
     pub pubkey: Pubkey,
+    pub path: String,
 }
 
 impl RemoteKeypair {
@@ -21,6 +22,7 @@ impl RemoteKeypair {
         wallet_type: RemoteWalletType,
         derivation_path: DerivationPath,
         confirm_key: bool,
+        path: String,
     ) -> Result<Self, RemoteWalletError> {
         let pubkey = match &wallet_type {
             RemoteWalletType::Ledger(wallet) => wallet.get_pubkey(&derivation_path, confirm_key)?,
@@ -30,6 +32,7 @@ impl RemoteKeypair {
             wallet_type,
             derivation_path,
             pubkey,
+            path,
         })
     }
 }
@@ -57,10 +60,12 @@ pub fn generate_remote_keypair(
     let (remote_wallet_info, derivation_path) = RemoteWalletInfo::parse_path(path)?;
     if remote_wallet_info.manufacturer == "ledger" {
         let ledger = get_ledger_from_info(remote_wallet_info, keypair_name, wallet_manager)?;
+        let path = format!("{}{}", ledger.pretty_path, derivation_path.get_query());
         Ok(RemoteKeypair::new(
             RemoteWalletType::Ledger(ledger),
             derivation_path,
             confirm_key,
+            path,
         )?)
     } else {
         Err(RemoteWalletError::DeviceTypeMismatch)


### PR DESCRIPTION
#### Problem
When using more than one remote wallet, it's nice to be able to disambiguate them in commands by their specific usb path. But how do you get those paths? Currently, the only way is to plug them all in, and use something like `solana address --keypair usb://ledger` to generate the selection (disregarding the address/pubkey response).

#### Summary of Changes
- Add `solana resolve-signer` subcommand, which returns the specific path `usb://<manufacturer>/<model>/<base_pubkey>` of a selected device. While this subcommand will be most useful for remote wallet signers, it does support all the other signer types. In the case of keypair file-paths, keypair-from-seed-phrase, and keypair from stdin, this method confirms that the input can be parsed as a keypair.
- Also, updates remote-wallet "Waiting..." message to specify the specific device path it is waiting on... it turns out that fix for #8846 buildt on the remote-wallet changes in this pr, so I went ahead and lumped it in here.

Fixes #8851 
Fixes #8846 
