### PR TITLE
Fix windows build by removing sys-info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3915,6 +3924,7 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3945,7 +3955,6 @@ dependencies = [
  "solana-sys-tuner 1.1.0",
  "solana-vote-program 1.1.0",
  "solana-vote-signer 1.1.0",
- "sys-info 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "systemstat 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4152,6 +4161,7 @@ dependencies = [
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4175,7 +4185,6 @@ dependencies = [
  "solana-stake-program 1.1.0",
  "solana-vote-program 1.1.0",
  "symlink 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sys-info 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4289,6 +4298,7 @@ name = "solana-metrics"
 version = "1.1.0"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gethostname 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4296,7 +4306,6 @@ dependencies = [
  "serial_test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-sdk 1.1.0",
- "sys-info 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4405,7 +4414,7 @@ name = "solana-rayon-threadlimit"
 version = "1.1.0"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sys-info 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4465,7 +4474,6 @@ dependencies = [
  "solana-stake-program 1.1.0",
  "solana-storage-program 1.1.0",
  "solana-vote-program 1.1.0",
- "sys-info 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5165,15 +5173,6 @@ dependencies = [
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6318,6 +6317,7 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
 "checksum get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
+"checksum gethostname 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
 "checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -6603,7 +6603,6 @@ dependencies = [
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
-"checksum sys-info 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "58283a48c9212afcade2069f8bbf7ded6a7bdbf4888d2defba72244c8e5f423c"
 "checksum sysctl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0501f0d0c2aa64b419abff97c209f4b82c4e67caa63e8dc5b222ecc1b574cb5c"
 "checksum systemstat 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2078da8d09c6202bffd5e075946e65bfad5ce2cfa161edb15c5f014a8440adee"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,6 +34,7 @@ jsonrpc-ws-server = "14.0.6"
 libc = "0.2.67"
 log = "0.4.8"
 nix = "0.17.0"
+num_cpus = "1.0.0"
 num-traits = "0.2"
 rand = "0.6.5"
 rand_chacha = "0.1.1"
@@ -62,7 +63,6 @@ solana-storage-program = { path = "../programs/storage", version = "1.1.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.1.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.1.0" }
 solana-sys-tuner = { path = "../sys-tuner", version = "1.1.0" }
-sys-info = "0.5.10"
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = "0.1"

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 type Nodes = HashMap<Pubkey, (bool, HashSet<i32>, Receiver<(i32, bool)>)>;
 
 fn num_threads() -> usize {
-    sys_info::cpu_num().unwrap_or(10) as usize
+    num_cpus::get()
 }
 
 /// Search for the a node with the given balance

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -20,6 +20,7 @@ fs_extra = "1.1.0"
 itertools = "0.9.0"
 libc = "0.2.67"
 log = { version = "0.4.8" }
+num_cpus = "1.0.0"
 rand = "0.6.5"
 rand_chacha = "0.1.1"
 rayon = "1.3.0"
@@ -40,7 +41,6 @@ solana-runtime = { path = "../runtime", version = "1.1.0" }
 solana-sdk = { path = "../sdk", version = "1.1.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.1.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.1.0" }
-sys-info = "0.5.10"
 symlink = "0.1.0"
 tar = "0.4.26"
 thiserror = "1.0"

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -754,6 +754,6 @@ fn get_db_options() -> Options {
     options.create_if_missing(true);
     options.create_missing_column_families(true);
     // A good value for this is the number of cores on the machine
-    options.increase_parallelism(sys_info::cpu_num().unwrap() as i32);
+    options.increase_parallelism(num_cpus::get() as i32);
     options
 }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 
 [dependencies]
 env_logger = "0.7.1"
+gethostname = "0.2.1"
 lazy_static = "1.4.0"
 log = "0.4.8"
 reqwest = { version = "0.10.4", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 solana-sdk = { path = "../sdk", version = "1.1.0" }
-sys-info = "0.5.10"
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -1,6 +1,7 @@
 //! The `metrics` module enables sending measurements to an `InfluxDB` instance
 
 use crate::{counter::CounterPoint, datapoint::DataPoint};
+use gethostname::gethostname;
 use lazy_static::lazy_static;
 use log::*;
 use solana_sdk::hash::hash;
@@ -11,7 +12,6 @@ use std::sync::{Arc, Barrier, Mutex, Once, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 use std::{cmp, env};
-use sys_info::hostname;
 
 type CounterMap = HashMap<(&'static str, u64), CounterPoint>;
 
@@ -317,7 +317,9 @@ fn get_singleton_agent() -> Arc<Mutex<MetricsAgent>> {
 lazy_static! {
     static ref HOST_ID: Arc<RwLock<String>> = {
         Arc::new(RwLock::new({
-            let hostname: String = hostname().unwrap_or_else(|_| "".to_string());
+            let hostname: String = gethostname()
+                .into_string()
+                .unwrap_or_else(|_| "".to_string());
             format!("{}", hash(hostname.as_bytes()))
         }))
     };

--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -10,5 +10,5 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+num_cpus = "1.0.0"
 lazy_static = "1.4.0"
-sys-info = "0.5.10"

--- a/rayon-threadlimit/src/lib.rs
+++ b/rayon-threadlimit/src/lib.rs
@@ -6,7 +6,7 @@ extern crate lazy_static;
 lazy_static! {
     // reduce the number of threads each pool is allowed to half the cpu core count, to avoid rayon
     // hogging cpu
-    static ref MAX_RAYON_THREADS: usize = sys_info::cpu_num().unwrap() as usize / 2;
+    static ref MAX_RAYON_THREADS: usize = num_cpus::get() as usize / 2;
 }
 
 pub fn get_thread_count() -> usize {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -34,7 +34,6 @@ solana-sdk = { path = "../sdk", version = "1.1.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.1.0" }
 solana-storage-program = { path = "../programs/storage", version = "1.1.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.1.0" }
-sys-info = "0.5.10"
 tempfile = "3.1.0"
 thiserror = "1.0"
 


### PR DESCRIPTION
#### Problem

sys_info crate doesn't build on windows.

#### Summary of Changes

Remove it for the functionally equivalent num_cpus and gethostname.rs

Fixes #
