### PR TITLE
Apply s/faucet-keypair/faucet renaming to net scripts

### DIFF
--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -77,7 +77,7 @@ solana-bench-exchange)
 idle)
   # Add the faucet keypair to idle clients for convenience
   net/scripts/rsync-retry.sh -vPrc \
-    "$entrypointIp":~/solana/config/faucet-keypair.json ~/solana/
+    "$entrypointIp":~/solana/config/faucet.json ~/solana/
   exit 0
   ;;
 *)

--- a/net/remote/remote-deploy-update.sh
+++ b/net/remote/remote-deploy-update.sh
@@ -36,5 +36,5 @@ PATH="$HOME"/.cargo/bin:"$PATH"
 
 set -x
 scripts/solana-install-deploy.sh \
-  --keypair config/faucet-keypair.json \
+  --keypair config/faucet.json \
   localhost "$releaseChannel" "$updatePlatform"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -310,13 +310,13 @@ EOF
     set -x
     # Add the faucet keypair to validators for convenient access from tools
     # like bench-tps and add to blocktreamers to run a faucet
-    scp "$entrypointIp":~/solana/config/faucet-keypair.json config/
+    scp "$entrypointIp":~/solana/config/faucet.json config/
     if [[ $nodeType = blockstreamer ]]; then
       # Run another faucet with the same keypair on the blockstreamer node.
       # Typically the blockstreamer node has a static IP/DNS name for hosting
       # the blockexplorer web app, and is a location that somebody would expect
       # to be able to airdrop from
-      scp "$entrypointIp":~/solana/config/faucet-keypair.json config/
+      scp "$entrypointIp":~/solana/config/faucet.json config/
       if [[ $airdropsEnabled = true ]]; then
 cat >> ~/solana/on-reboot <<EOF
         multinode-demo/faucet.sh > faucet.log 2>&1 &

--- a/run.sh
+++ b/run.sh
@@ -64,7 +64,7 @@ if [[ -e $leader_stake_account_keypair ]]; then
 else
   solana-keygen new --no-passphrase -so "$leader_stake_account_keypair"
 fi
-faucet_keypair="$dataDir"/faucet-keypair.json
+faucet_keypair="$dataDir"/faucet.json
 if [[ -e $faucet_keypair ]]; then
   echo "Use existing faucet keypair"
 else
@@ -76,7 +76,7 @@ if [[ -e "$ledgerDir"/genesis.bin ]]; then
 else
   solana-genesis \
     --hashes-per-tick sleep \
-    --faucet-pubkey "$dataDir"/faucet-keypair.json \
+    --faucet-pubkey "$dataDir"/faucet.json \
     --faucet-lamports 500000000000000000 \
     --bootstrap-validator \
       "$dataDir"/leader-keypair.json \
@@ -93,7 +93,7 @@ abort() {
 }
 trap abort INT TERM EXIT
 
-solana-faucet --keypair "$dataDir"/faucet-keypair.json &
+solana-faucet --keypair "$dataDir"/faucet.json &
 faucet=$!
 
 args=(


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/8837 missed a couple keypair file renames and broke the `/net` testnet scripts

#### Solution
Apply renaming of faucet-keypair.json to faucet.json