### PR TITLE
Validators now run a full gossip node while looking for a snapshot

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1601,7 +1601,7 @@ impl ClusterInfo {
             .unwrap()
     }
 
-    fn gossip_contact_info(id: &Pubkey, gossip: SocketAddr) -> ContactInfo {
+    pub fn gossip_contact_info(id: &Pubkey, gossip: SocketAddr) -> ContactInfo {
         ContactInfo {
             id: *id,
             gossip,


### PR DESCRIPTION
When a validator starts up and looks for a snapshot it was running a spy node (no gossip socket address) instead of a full gossip node, which prevented gossip pushes from other nodes.  There's no reason for this limitation, and in fact might be causing an issue for one of the TdS validators.   This PR brings `solana-validator` in line with `solana-gossip spy`