### PR TITLE
Corrected the CLI argument name in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -97,7 +97,7 @@ solana-faucet --keypair "$dataDir"/faucet.json &
 faucet=$!
 
 args=(
-  --identity "$dataDir"/leader-keypair.json
+  --identity-keypair "$dataDir"/leader-keypair.json
   --vote-account "$dataDir"/leader-vote-account-keypair.json
   --ledger "$ledgerDir"
   --gossip-port 8001


### PR DESCRIPTION
#### Problem

The CLI argument name `--identity` has changed to `--identity-keypair` but `run.sh` hasn't been updated to reflect that.

#### Summary of Changes

Updated `run.sh` to reflect the change.