### PR TITLE
Use types for CLI value names

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -120,7 +120,7 @@ pub fn fee_payer_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(FEE_PAYER_ARG.name)
         .long(FEE_PAYER_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .value_name("KEYPAIR")
         .validator(is_valid_signer)
         .help(FEE_PAYER_ARG.help)
 }
@@ -2223,14 +2223,14 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("faucet_host")
                         .long("faucet-host")
-                        .value_name("HOST")
+                        .value_name("URL")
                         .takes_value(true)
                         .help("Faucet host to use [default: the --url host]"),
                 )
                 .arg(
                     Arg::with_name("faucet_port")
                         .long("faucet-port")
-                        .value_name("PORT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .default_value(solana_faucet::faucet::FAUCET_PORT_STR)
                         .help("Faucet port to use"),
@@ -2238,7 +2238,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("amount")
                         .index(1)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -2277,7 +2277,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(1)
-                        .value_name("PROCESS ID")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -2302,7 +2302,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("seed")
                         .index(1)
-                        .value_name("SEED_STRING")
+                        .value_name("STRING")
                         .takes_value(true)
                         .required(true)
                         .help("The seed.  Must not take more than 32 bytes to encode as utf-8"),
@@ -2310,7 +2310,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("program_id")
                         .index(2)
-                        .value_name("PROGRAM_ID")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help(
@@ -2334,7 +2334,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("program_location")
                         .index(1)
-                        .value_name("PATH TO BPF PROGRAM")
+                        .value_name("FILEPATH")
                         .takes_value(true)
                         .required(true)
                         .help("/path/to/program.o"),
@@ -2346,7 +2346,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("TO PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -2355,7 +2355,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -2402,7 +2402,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("signer")
                         .index(1)
-                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .value_name("URL")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -2424,7 +2424,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(2)
-                        .value_name("PROCESS ID")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help("The process id of the transfer to authorize"),
@@ -2445,7 +2445,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(2)
-                        .value_name("PROCESS ID")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help("The process id of the transfer to unlock"),
@@ -2464,7 +2464,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("TO PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -2473,7 +2473,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -2483,7 +2483,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                     Arg::with_name("from")
                         .long("from")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .value_name("KEYPAIR")
                         .validator(is_valid_signer)
                         .help("Source account of funds (if different from client local account)"),
                 )
@@ -2499,7 +2499,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -2509,7 +2509,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                     Arg::with_name("output_file")
                         .long("output")
                         .short("o")
-                        .value_name("FILE")
+                        .value_name("FILEPATH")
                         .takes_value(true)
                         .help("Write the account data to this file"),
                 )

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,7 +33,7 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                     if let Some(field) = subcommand_matches.value_of("specific_setting") {
                         let (field_name, value, setting_type) = match field {
                             "json_rpc_url" => ("RPC URL", json_rpc_url, url_setting_type),
-                            "websocket_url" => ("WS URL", websocket_url, ws_setting_type),
+                            "websocket_url" => ("WebSocket URL", websocket_url, ws_setting_type),
                             "keypair" => ("Key Path", keypair_path, keypair_setting_type),
                             _ => unreachable!(),
                         };
@@ -41,7 +41,7 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                     } else {
                         println_name_value("Config File:", config_file);
                         println_name_value_or("RPC URL:", &json_rpc_url, url_setting_type);
-                        println_name_value_or("WS URL:", &websocket_url, ws_setting_type);
+                        println_name_value_or("WebSocket URL:", &websocket_url, ws_setting_type);
                         println_name_value_or("Keypair Path:", &keypair_path, keypair_setting_type);
                     }
                 } else {
@@ -82,7 +82,7 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
 
                     println_name_value("Config File:", config_file);
                     println_name_value_or("RPC URL:", &json_rpc_url, url_setting_type);
-                    println_name_value_or("WS URL:", &websocket_url, ws_setting_type);
+                    println_name_value_or("WebSocket URL:", &websocket_url, ws_setting_type);
                     println_name_value_or("Keypair Path:", &keypair_path, keypair_setting_type);
                 } else {
                     println!(
@@ -151,7 +151,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         let arg = Arg::with_name("config_file")
             .short("C")
             .long("config")
-            .value_name("PATH")
+            .value_name("FILEPATH")
             .takes_value(true)
             .global(true)
             .help("Configuration file to use");
@@ -184,17 +184,17 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Arg::with_name("keypair")
             .short("k")
             .long("keypair")
-            .value_name("PATH")
+            .value_name("FILEPATH")
             .global(true)
             .takes_value(true)
-            .help("/path/to/id.json or usb://remote/wallet/path"),
+            .help("Filepath or URL to a keypair"),
     )
     .arg(
         Arg::with_name("verbose")
             .long("verbose")
             .short("v")
             .global(true)
-            .help("Show extra information header"),
+            .help("Show additional information"),
     )
     .arg(
         Arg::with_name(SKIP_SEED_PHRASE_VALIDATION_ARG.name)

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -93,12 +93,12 @@ impl NonceSubCommands for App<'_, '_> {
             SubCommand::with_name("authorize-nonce-account")
                 .about("Assign account authority to a new entity")
                 .arg(
-                    Arg::with_name("nonce_account_keypair")
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("KEYPAIR")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_valid_signer)
+                        .validator(is_pubkey_or_keypair)
                         .help("Address of the nonce account"),
                 )
                 .arg(
@@ -279,7 +279,7 @@ pub fn parse_authorize_nonce_account(
     default_signer_path: &str,
     wallet_manager: Option<&Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
-    let nonce_account = pubkey_of(matches, "nonce_account_keypair").unwrap();
+    let nonce_account = pubkey_of(matches, "nonce_account_pubkey").unwrap();
     let new_authority = pubkey_of(matches, "new_authority").unwrap();
     let (nonce_authority, nonce_authority_pubkey) =
         signer_of(matches, NONCE_AUTHORITY_ARG.name, wallet_manager)?;

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -82,7 +82,7 @@ pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(NONCE_AUTHORITY_ARG.name)
         .long(NONCE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .value_name("KEYPAIR")
         .validator(is_valid_signer)
         .help(NONCE_AUTHORITY_ARG.help)
 }
@@ -95,16 +95,16 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_keypair")
                         .index(1)
-                        .value_name("NONCE_ACCOUNT")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
-                        .validator(is_pubkey_or_keypair)
+                        .validator(is_valid_signer)
                         .help("Address of the nonce account"),
                 )
                 .arg(
                     Arg::with_name("new_authority")
                         .index(2)
-                        .value_name("NEW_AUTHORITY_PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -113,7 +113,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
-                        .value_name("SEED STRING")
+                        .value_name("STRING")
                         .takes_value(true)
                         .help("Seed for address generation; if specified, the resulting account will be at a derived address of the NONCE_ACCOUNT pubkey")
                 )
@@ -125,7 +125,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_keypair")
                         .index(1)
-                        .value_name("NONCE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -134,7 +134,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount)
@@ -144,7 +144,7 @@ impl NonceSubCommands for App<'_, '_> {
                     Arg::with_name(NONCE_AUTHORITY_ARG.name)
                         .long(NONCE_AUTHORITY_ARG.long)
                         .takes_value(true)
-                        .value_name("BASE58_PUBKEY")
+                        .value_name("PUBKEY")
                         .validator(is_pubkey_or_keypair)
                         .help("Assign noncing authority to another entity"),
                 ),
@@ -156,7 +156,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("NONCE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -169,7 +169,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_keypair")
                         .index(1)
-                        .value_name("NONCE ACCOUNT")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -184,7 +184,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("NONCE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -203,7 +203,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_keypair")
                         .index(1)
-                        .value_name("NONCE ACCOUNT")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -212,7 +212,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("DESTINATION ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -221,7 +221,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount)

--- a/cli/src/offline/mod.rs
+++ b/cli/src/offline/mod.rs
@@ -33,7 +33,7 @@ fn signer_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(SIGNER_ARG.name)
         .long(SIGNER_ARG.long)
         .takes_value(true)
-        .value_name("BASE58_PUBKEY=BASE58_SIG")
+        .value_name("PUBKEY=SIGNATURE")
         .validator(is_pubkey_sig)
         .requires(BLOCKHASH_ARG.name)
         .multiple(true)

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -47,7 +47,7 @@ fn stake_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(STAKE_AUTHORITY_ARG.name)
         .long(STAKE_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .value_name("KEYPAIR")
         .validator(is_valid_signer)
         .help(STAKE_AUTHORITY_ARG.help)
 }
@@ -56,7 +56,7 @@ fn withdraw_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
         .long(WITHDRAW_AUTHORITY_ARG.long)
         .takes_value(true)
-        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+        .value_name("KEYPAIR")
         .validator(is_valid_signer)
         .help(WITHDRAW_AUTHORITY_ARG.help)
 }
@@ -73,7 +73,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -82,7 +82,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -91,7 +91,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("custodian")
                         .long("custodian")
-                        .value_name("KEYPAIR or PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_pubkey_or_keypair)
                         .help("Identity of the custodian (can withdraw before lockup expires)")
@@ -99,21 +99,21 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
-                        .value_name("SEED STRING")
+                        .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account will be at a derived address of the STAKE ACCOUNT pubkey")
+                        .help("Seed for address generation; if specified, the resulting account will be at a derived address of the stake_account pubkey")
                 )
                 .arg(
                     Arg::with_name("lockup_epoch")
                         .long("lockup-epoch")
-                        .value_name("EPOCH")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .help("The epoch height at which this account will be available for withdrawal")
                 )
                 .arg(
                     Arg::with_name("lockup_date")
                         .long("lockup-date")
-                        .value_name("RFC3339 DATE TIME")
+                        .value_name("RFC3339 DATETIME")
                         .validator(is_rfc3339_datetime)
                         .takes_value(true)
                         .help("The date and time at which this account will be available for withdrawal")
@@ -138,7 +138,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("from")
                         .long("from")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .value_name("KEYPAIR")
                         .validator(is_valid_signer)
                         .help("Source account of funds (if different from client local account)"),
                 )
@@ -160,7 +160,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -169,7 +169,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(2)
-                        .value_name("VOTE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -187,7 +187,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -196,7 +196,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_pubkey")
                         .index(2)
-                        .value_name("AUTHORIZE PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -214,7 +214,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -223,7 +223,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_pubkey")
                         .index(2)
-                        .value_name("AUTHORIZE PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -241,7 +241,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help("Stake account to be deactivated.")
@@ -258,7 +258,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help("Stake account to be split")
@@ -266,7 +266,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("split_stake_account")
                         .index(2)
-                        .value_name("SPLIT STAKE ACCOUNT")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -275,7 +275,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -284,7 +284,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
-                        .value_name("SEED STRING")
+                        .value_name("STRING")
                         .takes_value(true)
                         .help("Seed for address generation; if specified, the resulting account will be at a derived address of the SPLIT STAKE ACCOUNT pubkey")
                 )
@@ -300,7 +300,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -309,7 +309,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("DESTINATION ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -318,7 +318,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -336,7 +336,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -345,14 +345,14 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("lockup_epoch")
                         .long("lockup-epoch")
-                        .value_name("EPOCH")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .help("The epoch height at which this account will be available for withdrawal")
                 )
                 .arg(
                     Arg::with_name("lockup_date")
                         .long("lockup-date")
-                        .value_name("RFC3339 DATE TIME")
+                        .value_name("RFC3339 DATETIME")
                         .validator(is_rfc3339_datetime)
                         .takes_value(true)
                         .help("The date and time at which this account will be available for withdrawal")
@@ -360,7 +360,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("new_custodian")
                         .long("new-custodian")
-                        .value_name("KEYPAIR or PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_pubkey_or_keypair)
                         .help("Identity of the new lockup custodian (can withdraw before lockup expires)")
@@ -372,7 +372,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("custodian")
                         .long("custodian")
                         .takes_value(true)
-                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .value_name("KEYPAIR")
                         .validator(is_valid_signer)
                         .help("Public key of signing custodian [default: cli config pubkey]")
                 )
@@ -388,7 +388,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("STAKE ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -26,7 +26,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_owner")
                         .index(1)
-                        .value_name("STORAGE ACCOUNT OWNER PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair),
@@ -34,7 +34,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account")
                         .index(2)
-                        .value_name("STORAGE ACCOUNT")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer),
@@ -46,7 +46,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_owner")
                         .index(1)
-                        .value_name("STORAGE ACCOUNT OWNER PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair),
@@ -54,7 +54,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account")
                         .index(2)
-                        .value_name("STORAGE ACCOUNT")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer),
@@ -66,7 +66,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("node_account_pubkey")
                         .index(1)
-                        .value_name("NODE PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -75,7 +75,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(2)
-                        .value_name("STORAGE ACCOUNT PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -89,7 +89,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(1)
-                        .value_name("STORAGE ACCOUNT PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -33,7 +33,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account")
                         .index(1)
-                        .value_name("VOTE ACCOUNT KEYPAIR")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -42,7 +42,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("identity_pubkey")
                         .index(2)
-                        .value_name("VALIDATOR IDENTITY PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -51,7 +51,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("commission")
                         .long("commission")
-                        .value_name("NUM")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .default_value("100")
                         .help("The commission taken on reward redemption (0-100)"),
@@ -75,7 +75,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
-                        .value_name("SEED STRING")
+                        .value_name("STRING")
                         .takes_value(true)
                         .help("Seed for address generation; if specified, the resulting account will be at a derived address of the VOTE ACCOUNT pubkey")
                 ),
@@ -86,7 +86,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -95,7 +95,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("new_identity_pubkey")
                         .index(2)
-                        .value_name("NEW VALIDATOR IDENTITY PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -104,7 +104,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_voter")
                         .index(3)
-                        .value_name("AUTHORIZED VOTER KEYPAIR")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -117,7 +117,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -126,7 +126,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("new_authorized_pubkey")
                         .index(2)
-                        .value_name("NEW VOTER PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -139,7 +139,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -148,7 +148,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("new_authorized_pubkey")
                         .index(2)
-                        .value_name("NEW WITHDRAWER PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -170,7 +170,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -189,7 +189,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -198,7 +198,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("DESTINATION ACCOUNT")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey_or_keypair)
@@ -207,7 +207,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
-                        .value_name("AMOUNT")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount)
@@ -216,7 +216,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_withdrawer")
                         .long("authorized-withdrawer")
-                        .value_name("KEYPAIR or PUBKEY or REMOTE WALLET PATH")
+                        .value_name("KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
                         .help("Authorized withdrawer [default: cli config keypair]"),

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -200,7 +200,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             let arg = Arg::with_name("config_file")
                 .short("C")
                 .long("config")
-                .value_name("PATH")
+                .value_name("FILEPATH")
                 .takes_value(true)
                 .global(true)
                 .help("Configuration file to use");
@@ -216,7 +216,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .arg(
                     Arg::with_name("pubkey")
                         .index(1)
-                        .value_name("BASE58_PUBKEY")
+                        .value_name("PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help("Public key"),
@@ -224,7 +224,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .arg(
                     Arg::with_name("keypair")
                         .index(2)
-                        .value_name("PATH")
+                        .value_name("FILEPATH")
                         .takes_value(true)
                         .help("Path to keypair file"),
                 )
@@ -237,7 +237,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     Arg::with_name("outfile")
                         .short("o")
                         .long("outfile")
-                        .value_name("PATH")
+                        .value_name("FILEPATH")
                         .takes_value(true)
                         .help("Path to generated file"),
                 )
@@ -252,7 +252,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .long("word-count")
                         .possible_values(&["12", "15", "18", "21", "24"])
                         .default_value("12")
-                        .value_name("NUM")
+                        .value_name("NUMBER")
                         .takes_value(true)
                         .help("Specify the number of words that will be present in the generated seed phrase"),
                 )
@@ -321,7 +321,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .arg(
                     Arg::with_name("keypair")
                         .index(1)
-                        .value_name("PATH")
+                        .value_name("FILEPATH")
                         .takes_value(true)
                         .help("Path to keypair file or remote wallet"),
                 )
@@ -334,7 +334,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     Arg::with_name("outfile")
                         .short("o")
                         .long("outfile")
-                        .value_name("PATH")
+                        .value_name("FILEPATH")
                         .takes_value(true)
                         .help("Path to generated file"),
                 )
@@ -361,7 +361,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     Arg::with_name("outfile")
                         .short("o")
                         .long("outfile")
-                        .value_name("PATH")
+                        .value_name("FILEPATH")
                         .takes_value(true)
                         .help("Path to generated file"),
                 )


### PR DESCRIPTION
#### Problem

CLI naming of "value names" inconsistent with typical command-line tools.

#### Summary of Changes

Use type names to hint what an acceptable value might be.

cc #8853
