### PR TITLE
Lower error level of InvalidTickCount

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -629,11 +629,19 @@ impl ReplayStage {
             // errors related to the slot being purged
             let slot = bank.slot();
             warn!("Fatal replay error in slot: {}, err: {:?}", slot, err);
-            datapoint_error!(
-                "replay-stage-mark_dead_slot",
-                ("error", format!("error: {:?}", err), String),
-                ("slot", slot, i64)
-            );
+            if err.is_severity_error() {
+                datapoint_error!(
+                    "replay-stage-mark_dead_slot",
+                    ("error", format!("error: {:?}", err), String),
+                    ("slot", slot, i64)
+                );
+            } else {
+                datapoint_info!(
+                    "replay-stage-mark_dead_slot",
+                    ("error", format!("error: {:?}", err), String),
+                    ("slot", slot, i64)
+                );
+            }
             bank_progress.is_dead = true;
             blockstore
                 .set_dead_slot(slot)

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -630,10 +630,7 @@ impl ReplayStage {
             // errors related to the slot being purged
             let slot = bank.slot();
             warn!("Fatal replay error in slot: {}, err: {:?}", slot, err);
-            if matches!(
-                err,
-                BlockstoreProcessorError::InvalidBlock(BlockError::InvalidTickCount)
-            ) {
+            if let BlockstoreProcessorError::InvalidBlock(BlockError::InvalidTickCount) = err {
                 datapoint_info!(
                     "replay-stage-mark_dead_slot",
                     ("error", format!("error: {:?}", err), String),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -262,10 +262,10 @@ pub enum BlockstoreProcessorError {
 
 impl BlockstoreProcessorError {
     pub fn is_severity_error(&self) -> bool {
-        match self {
-            BlockstoreProcessorError::InvalidBlock(BlockError::InvalidTickCount) => false,
-            _ => true,
-        }
+        !matches!(
+            self,
+            BlockstoreProcessorError::InvalidBlock(BlockError::InvalidTickCount)
+        )
     }
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -260,6 +260,15 @@ pub enum BlockstoreProcessorError {
     InvalidHardFork(Slot),
 }
 
+impl BlockstoreProcessorError {
+    pub fn is_severity_error(&self) -> bool {
+        match self {
+            BlockstoreProcessorError::InvalidBlock(BlockError::InvalidTickCount) => false,
+            _ => true,
+        }
+    }
+}
+
 /// Callback for accessing bank state while processing the blockstore
 pub type ProcessCallback = Arc<dyn Fn(&Bank) -> () + Sync + Send>;
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -260,15 +260,6 @@ pub enum BlockstoreProcessorError {
     InvalidHardFork(Slot),
 }
 
-impl BlockstoreProcessorError {
-    pub fn is_severity_error(&self) -> bool {
-        !matches!(
-            self,
-            BlockstoreProcessorError::InvalidBlock(BlockError::InvalidTickCount)
-        )
-    }
-}
-
 /// Callback for accessing bank state while processing the blockstore
 pub type ProcessCallback = Arc<dyn Fn(&Bank) -> () + Sync + Send>;
 


### PR DESCRIPTION
#### Problem
`InvalidTickCount` is a block error that occurs as an expected part of the core protocol when blocks are interrupted, so should not show up as an "Error" in logs

#### Summary of Changes
Lower log severity of `InvalidTickCount` 
Fixes #
