### PR TITLE
Patch bv for DoS due to malformed deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,8 +335,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bv"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.11.1-alpha.0"
+source = "git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants#ec84d9427ebc70fecb2d1997bc93893a16fe597e"
 dependencies = [
  "feature-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3894,7 +3894,7 @@ version = "1.1.0"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "core_affinity 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4440,7 +4440,7 @@ version = "1.1.0"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4485,7 +4485,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6200,7 +6200,7 @@ dependencies = [
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bstr 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e0a692f1c740e7e821ca71a22cf99b9b2322dfa94d10f71443befb1797b3946a"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
-"checksum bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cd4ae9e585e783756cd14b0ea21863acdfbb6383664ac2f7c9ef8d180a14727"
+"checksum bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)" = "<none>"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byte-unit 3.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6894a79550807490d9f19a138a6da0f8830e70c83e83402dd23f16fd6c479056"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,6 @@ exclude = [
     "programs/move_loader",
     "programs/librapay",
 ]
+
+[patch.crates-io]
+bv = { git = "https://github.com/Mrmaxmeier/bv-rs", branch = "deserialize-check-invariants", features = ["serde"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ codecov = { repository = "solana-labs/solana", branch = "master", service = "git
 
 [dependencies]
 bincode = "1.2.1"
-bv = { version = "0.11.0", features = ["serde"] }
+bv = { version = "0.11.1-alpha.0", features = ["serde"] }
 bs58 = "0.3.0"
 byteorder = "1.3.4"
 chrono = { version = "0.4.11", features = ["serde"] }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1943,7 +1943,7 @@ name = "solana-runtime"
 version = "1.1.0"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1979,7 +1979,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2771,7 +2771,7 @@ dependencies = [
 "checksum bloom 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4"
-"checksum bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cd4ae9e585e783756cd14b0ea21863acdfbb6383664ac2f7c9ef8d180a14727"
+"checksum bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)" = "<none>"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -49,3 +49,6 @@ members = [
     "rust/param_passing_dep",
     "rust/sysval",
 ]
+
+[patch.crates-io]
+bv = { git = "https://github.com/Mrmaxmeier/bv-rs", branch = "deserialize-check-invariants", features = ["serde"] }

--- a/programs/librapay/Cargo.lock
+++ b/programs/librapay/Cargo.lock
@@ -2730,7 +2730,7 @@ name = "solana-runtime"
 version = "1.0.0"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2766,7 +2766,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4090,7 +4090,7 @@ dependencies = [
 "checksum bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c95ee6bba9d950218b6cc910cf62bc9e0a171d0f4537e3627b0f54d08549b188"
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
-"checksum bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cd4ae9e585e783756cd14b0ea21863acdfbb6383664ac2f7c9ef8d180a14727"
+"checksum bv 0.11.1-alpha.0 (git+https://github.com/Mrmaxmeier/bv-rs?branch=deserialize-check-invariants)" = "<none>"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"

--- a/programs/librapay/Cargo.toml
+++ b/programs/librapay/Cargo.toml
@@ -20,3 +20,6 @@ types = { version = "0.0.1-sol4", package = "solana_libra_types" }
 [lib]
 crate-type = ["lib", "cdylib"]
 name = "solana_librapay"
+
+[patch.crates-io]
+bv = { git = "https://github.com/Mrmaxmeier/bv-rs", branch = "deserialize-check-invariants", features = ["serde"] }

--- a/programs/move_loader/Cargo.toml
+++ b/programs/move_loader/Cargo.toml
@@ -37,3 +37,6 @@ vm_runtime_types = { version = "0.0.1-sol4", package = "solana_libra_vm_runtime_
 [lib]
 crate-type = ["lib", "cdylib"]
 name = "solana_move_loader_program"
+
+[patch.crates-io]
+bv = { git = "https://github.com/Mrmaxmeier/bv-rs", branch = "deserialize-check-invariants", features = ["serde"] }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.2.1"
-bv = { version = "0.11.0", features = ["serde"] }
+bv = { version = "0.11.1-alpha.0", features = ["serde"] }
 byteorder = "1.3.4"
 fnv = "1.0.6"
 fs_extra = "1.1.0"
@@ -37,7 +37,6 @@ solana-vote-program = { path = "../programs/vote", version = "1.1.0" }
 sys-info = "0.5.10"
 tempfile = "3.1.0"
 thiserror = "1.0"
-
 
 [lib]
 crate-type = ["lib"]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -29,7 +29,7 @@ default = [
 assert_matches = { version = "1.3.0", optional = true }
 bincode = "1.2.1"
 bs58 = "0.3.0"
-bv = { version = "0.11.0", features = ["serde"] }
+bv = { version = "0.11.1-alpha.0", features = ["serde"] }
 byteorder = { version = "1.3.4", optional = true }
 chrono = { version = "0.4", optional = true }
 generic-array = { version = "0.13.2", default-features = false, features = ["serde", "more_lengths"] }

--- a/sdk/bpf/rust/test/Cargo.toml
+++ b/sdk/bpf/rust/test/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2018"
 
 [workspace]
 members = []
+
+[patch.crates-io]
+bv = { git = "https://github.com/Mrmaxmeier/bv-rs", branch = "deserialize-check-invariants", features = ["serde"] }


### PR DESCRIPTION
#### Problem

There is a remotely-exploitable DoS vulnerability in validator.

This is caused with `unsafe`s and a missing sanitization of the `bv` crate, which should catch the `BitVec`'s internal invariant violation from the desrialization code path.

The deserialization of `BitVec` in gossip packets are under our `limited_deserialize` protection. Nonetheless our `bincode`-based `limited_deserialize` protection is ineffective because the memory allocation per-se isn't abnormal but its future access is by a bad pointer offset `len`.

Affected `struct`s are `Bloom` (both master and v1.0 branches) and `EpochSlots` (only master).

Also, this is affects the sysvar `SlotHistory`, but which is usually protected by BankHash, so less severe than gossips.

#### Summary of Changes

- Cargo-`[patch]` a upstream's pending PR, thanks to @Mrmaxmeier's [PR](https://github.com/tov/bv-rs/pull/9) to address this.

Fixes #8873
