### PR TITLE
watchtower: Increase buffer on low SOL fault to over a week

### DIFF
--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -225,7 +225,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                             .get_balance(&Pubkey::from_str(&validator_identity).unwrap_or_default())
                             .map(lamports_to_sol)
                             .map(|balance| {
-                                if balance < 1.0 {
+                                if balance < 10.0 {
+                                    // At 1 SOL/day for validator voting fees, this gives over a week to
+                                    // find some more SOL
                                     failures.push((
                                         "balance",
                                         format!("{} has {} SOL", validator_identity, balance),


### PR DESCRIPTION
At ~1 SOL /day for validator voting fees, raise the alarm when a validator is about 1 week away from running out 