### PR TITLE
Nit: Align Rust and C names

### DIFF
--- a/programs/bpf/c/src/dup_accounts/dup_accounts.c
+++ b/programs/bpf/c/src/dup_accounts/dup_accounts.c
@@ -9,7 +9,7 @@
  */
 
 extern uint64_t entrypoint(const uint8_t *input) {
-  SolKeyedAccount ka[4];
+  SolAccountInfo ka[4];
   SolParameters params = (SolParameters) { .ka = ka };
 
   if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {

--- a/programs/bpf/c/src/error_handling/error_handling.c
+++ b/programs/bpf/c/src/error_handling/error_handling.c
@@ -9,7 +9,7 @@
  */
 
 extern uint64_t entrypoint(const uint8_t *input) {
-  SolKeyedAccount ka[1];
+  SolAccountInfo ka[1];
   SolParameters params = (SolParameters) { .ka = ka };
 
   if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {

--- a/programs/bpf/c/src/move_funds/move_funds.c
+++ b/programs/bpf/c/src/move_funds/move_funds.c
@@ -11,7 +11,7 @@
 #define NUM_KA 3
 
 extern uint64_t entrypoint(const uint8_t *input) {
-  SolKeyedAccount ka[NUM_KA];
+  SolAccountInfo ka[NUM_KA];
   SolParameters params = (SolParameters) { .ka = ka };
 
   if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {

--- a/programs/bpf/c/src/noop++/noop++.cc
+++ b/programs/bpf/c/src/noop++/noop++.cc
@@ -10,7 +10,7 @@
 #define INVALID_INPUT 1
 
 extern uint64_t entrypoint(const uint8_t *input) {
-  SolKeyedAccount ka[1];
+  SolAccountInfo ka[1];
   SolParameters params = (SolParameters) { .ka = ka };
 
   sol_log(__FILE__);

--- a/programs/bpf/c/src/noop/noop.c
+++ b/programs/bpf/c/src/noop/noop.c
@@ -5,7 +5,7 @@
 #include <solana_sdk.h>
 
 extern uint64_t entrypoint(const uint8_t *input) {
-  SolKeyedAccount ka[1];
+  SolAccountInfo ka[1];
   SolParameters params = (SolParameters) { .ka = ka };
 
   sol_log(__FILE__);

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -4,7 +4,7 @@ mod bpf {
         bank::Bank,
         bank_client::BankClient,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        loader_utils::{load_program},
+        loader_utils::load_program,
     };
     use solana_sdk::{
         account::Account,
@@ -44,10 +44,10 @@ mod bpf {
         load_program(bank_client, payer_keypair, &bpf_loader::id(), elf)
     }
 
-        #[test]
-#[cfg(any(feature = "bpf_c", feature = "bpf_rust"))]
+    #[test]
+    #[cfg(any(feature = "bpf_c", feature = "bpf_rust"))]
     fn test_program_bpf_sanity() {
-            solana_logger::setup();
+        solana_logger::setup();
 
         let mut programs = Vec::new();
         #[cfg(feature = "bpf_c")]
@@ -63,7 +63,7 @@ mod bpf {
                 ("struct_ret", true),
             ]);
         }
-    #[cfg(feature = "bpf_rust")]
+        #[cfg(feature = "bpf_rust")]
         {
             programs.extend_from_slice(&[
                 ("solana_bpf_rust_128bit", true),
@@ -79,45 +79,45 @@ mod bpf {
             ]);
         }
 
-            for program in programs.iter() {
-                println!("Test program: {:?}", program.0);
+        for program in programs.iter() {
+            println!("Test program: {:?}", program.0);
 
-                let GenesisConfigInfo {
-                    genesis_config,
-                    mint_keypair,
-                    ..
-                } = create_genesis_config(50);
-                let bank = Arc::new(Bank::new(&genesis_config));
-                // Create bank with specific slot, used by solana_bpf_rust_sysvar test
-                let bank =
-                    Bank::new_from_parent(&bank, &Pubkey::default(), DEFAULT_SLOTS_PER_EPOCH + 1);
-                let bank_client = BankClient::new(bank);
+            let GenesisConfigInfo {
+                genesis_config,
+                mint_keypair,
+                ..
+            } = create_genesis_config(50);
+            let bank = Arc::new(Bank::new(&genesis_config));
+            // Create bank with specific slot, used by solana_bpf_rust_sysvar test
+            let bank =
+                Bank::new_from_parent(&bank, &Pubkey::default(), DEFAULT_SLOTS_PER_EPOCH + 1);
+            let bank_client = BankClient::new(bank);
 
-                // Call user program
-                let program_id = load_bpf_program(&bank_client, &mint_keypair, program.0);
-                let account_metas = vec![
-                    AccountMeta::new(mint_keypair.pubkey(), true),
-                    AccountMeta::new(Keypair::new().pubkey(), false),
-                    AccountMeta::new(clock::id(), false),
-                    AccountMeta::new(fees::id(), false),
-                    AccountMeta::new(rewards::id(), false),
-                    AccountMeta::new(slot_hashes::id(), false),
-                    AccountMeta::new(stake_history::id(), false),
-                    AccountMeta::new(rent::id(), false),
-                ];
-                let instruction = Instruction::new(program_id, &1u8, account_metas);
-                let result = bank_client.send_instruction(&mint_keypair, instruction);
-                if program.1 {
-                    assert!(result.is_ok());
-                } else {
-                    assert!(result.is_err());
-                }
+            // Call user program
+            let program_id = load_bpf_program(&bank_client, &mint_keypair, program.0);
+            let account_metas = vec![
+                AccountMeta::new(mint_keypair.pubkey(), true),
+                AccountMeta::new(Keypair::new().pubkey(), false),
+                AccountMeta::new(clock::id(), false),
+                AccountMeta::new(fees::id(), false),
+                AccountMeta::new(rewards::id(), false),
+                AccountMeta::new(slot_hashes::id(), false),
+                AccountMeta::new(stake_history::id(), false),
+                AccountMeta::new(rent::id(), false),
+            ];
+            let instruction = Instruction::new(program_id, &1u8, account_metas);
+            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            if program.1 {
+                assert!(result.is_ok());
+            } else {
+                assert!(result.is_err());
             }
         }
+    }
 
-        #[test]
+    #[test]
     fn test_program_bpf_duplicate_accounts() {
-            solana_logger::setup();
+        solana_logger::setup();
 
         let mut programs = Vec::new();
         #[cfg(feature = "bpf_c")]
@@ -197,9 +197,9 @@ mod bpf {
         }
     }
 
-        #[test]
+    #[test]
     fn test_program_bpf_error_handling() {
-            solana_logger::setup();
+        solana_logger::setup();
 
         let mut programs = Vec::new();
         #[cfg(feature = "bpf_c")]
@@ -279,10 +279,10 @@ mod bpf {
             if TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
                 != result
             {
-            assert_eq!(
+                assert_eq!(
                     result,
-                TransactionError::InstructionError(0, InstructionError::AccountBorrowFailed)
-            );
+                    TransactionError::InstructionError(0, InstructionError::AccountBorrowFailed)
+                );
             }
 
             let instruction = Instruction::new(program_id, &8u8, account_metas.clone());

--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -178,7 +178,7 @@ typedef struct {
   bool is_signer;      /** Transaction was signed by this account's key? */
   bool is_writable;    /** Is the account writable? */
   bool executable;     /** This account's data contains a loaded program (and is now read-only) */
-} SolKeyedAccount;
+} SolAccountInfo;
 
 /**
  * Copies memory
@@ -252,9 +252,9 @@ if (!(expr)) {          \
  * Structure that the program's entrypoint input data is deserialized into.
  */
 typedef struct {
-  SolKeyedAccount* ka; /** Pointer to an array of SolKeyedAccount, must already
-                           point to an array of SolKeyedAccounts */
-  uint64_t ka_num; /** Number of SolKeyedAccount entries in `ka` */
+  SolAccountInfo* ka; /** Pointer to an array of SolAccountInfo, must already
+                           point to an array of SolAccountInfos */
+  uint64_t ka_num; /** Number of SolAccountInfo entries in `ka` */
   const uint8_t *data; /** pointer to the instruction data */
   uint64_t data_len; /** Length in bytes of the instruction data */
   const SolPubkey *program_id; /** program_id of the currently executing program */
@@ -265,7 +265,7 @@ typedef struct {
  *
  * Use this function to deserialize the buffer passed to the program entrypoint
  * into usable types.  This function does not perform copy deserialization,
- * instead it populates the pointers and lengths in SolKeyedAccount and data so
+ * instead it populates the pointers and lengths in SolAccountInfo and data so
  * that any modification to lamports or account data take place on the original
  * buffer.  Doing so also eliminates the need to serialize back into the buffer
  * at program end.


### PR DESCRIPTION
#### Problem

BPF C definitions still referred to KeyedAccount when actually BPF programs are given something different (AccountInfo).

#### Summary of Changes

Align the C programs to the Rust programs and call the account structure AccountInfo

Fixes #
