### PR TITLE
Extend local-cluster CI timeout

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -29,7 +29,7 @@ steps:
     timeout_in_minutes: 20
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-local-cluster.sh"
     name: "local-cluster"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 45
     artifact_paths: "log-*.txt"
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
     name: "coverage"


### PR DESCRIPTION
#### Problem
local-cluster is timing out

#### Summary of Changes
Extend timeout from 30 to 45 minutes.  Longer runs are faster than re-runs.
