### PR TITLE
download-utils: Remove all snapshots not matching the desired hash

### DIFF
--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -173,20 +173,36 @@ pub fn download_genesis(
 pub fn download_snapshot(
     rpc_addr: &SocketAddr,
     ledger_path: &Path,
-    snapshot_hash: (Slot, Hash),
+    desired_snapshot_hash: (Slot, Hash),
 ) -> Result<(), String> {
-    let snapshot_package =
-        solana_ledger::snapshot_utils::get_snapshot_archive_path(ledger_path, &snapshot_hash);
-    if snapshot_package.exists() {
+    // Remove all snapshot not matching the desired hash
+    let snapshot_packages = solana_ledger::snapshot_utils::get_snapshot_archives(ledger_path);
+    for (snapshot_package, snapshot_hash) in snapshot_packages.iter() {
+        if *snapshot_hash != desired_snapshot_hash {
+            info!("Removing old snapshot: {:?}", snapshot_package);
+            fs::remove_file(snapshot_package)
+                .unwrap_or_else(|err| info!("Failed to remove old snapshot: {:}", err));
+        }
+    }
+
+    let desired_snapshot_package = solana_ledger::snapshot_utils::get_snapshot_archive_path(
+        ledger_path,
+        &desired_snapshot_hash,
+    );
+    if desired_snapshot_package.exists() {
         Ok(())
     } else {
         download_file(
             &format!(
                 "http://{}/{}",
                 rpc_addr,
-                snapshot_package.file_name().unwrap().to_str().unwrap()
+                desired_snapshot_package
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
             ),
-            &snapshot_package,
+            &desired_snapshot_package,
         )
     }
 }


### PR DESCRIPTION
If `solana-validator` encounters an error between the time that a snapshot is downloaded and the full validator boots up, old snapshots can pile up in the ledger/ directory.   Remove them.

As seen by @brianlong recently when his validator was in an a restart loop because the vote account check was failing (which occurs after snapshot download)