### PR TITLE
CLI: Fix `create-nonce-account` with seed

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1067,10 +1067,10 @@ pub fn parse_create_address_with_seed(
     };
 
     let program_id = match matches.value_of("program_id").unwrap() {
-        "STAKE" => solana_stake_program::id(),
-        "VOTE" => solana_vote_program::id(),
-        "STORAGE" => solana_storage_program::id(),
         "NONCE" => system_program::id(),
+        "STAKE" => solana_stake_program::id(),
+        "STORAGE" => solana_storage_program::id(),
+        "VOTE" => solana_vote_program::id(),
         _ => pubkey_of(matches, "program_id").unwrap(),
     };
 
@@ -2347,7 +2347,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .required(true)
                         .help(
                             "The program_id that the address will ultimately be used for, \n\
-                             or one of NONCE, STAKE, VOTE, and STORAGE keywords",
+                             or one of NONCE, STAKE, STORAGE, and VOTE keywords",
                         ),
                 )
                 .arg(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -41,6 +41,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, Signature, Signer, SignerError},
     system_instruction::{self, create_address_with_seed, SystemError, MAX_ADDRESS_SEED_LEN},
+    system_program,
     transaction::{Transaction, TransactionError},
 };
 use solana_stake_program::{
@@ -1069,6 +1070,7 @@ pub fn parse_create_address_with_seed(
         "STAKE" => solana_stake_program::id(),
         "VOTE" => solana_vote_program::id(),
         "STORAGE" => solana_storage_program::id(),
+        "NONCE" => system_program::id(),
         _ => pubkey_of(matches, "program_id").unwrap(),
     };
 
@@ -2345,7 +2347,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .required(true)
                         .help(
                             "The program_id that the address will ultimately be used for, \n\
-                             or one of STAKE, VOTE, and STORAGE keywords",
+                             or one of NONCE, STAKE, VOTE, and STORAGE keywords",
                         ),
                 )
                 .arg(
@@ -2767,6 +2769,7 @@ mod tests {
             ("STAKE", solana_stake_program::id()),
             ("VOTE", solana_vote_program::id()),
             ("STORAGE", solana_storage_program::id()),
+            ("NONCE", system_program::id()),
         ] {
             let test_create_address_with_seed = test_commands.clone().get_matches_from(vec![
                 "test",

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -110,13 +110,6 @@ impl NonceSubCommands for App<'_, '_> {
                         .validator(is_valid_pubkey)
                         .help("Account to be granted authority of the nonce account"),
                 )
-                .arg(
-                    Arg::with_name("seed")
-                        .long("seed")
-                        .value_name("STRING")
-                        .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account will be at a derived address of the NONCE_ACCOUNT pubkey")
-                )
                 .arg(nonce_authority_arg()),
         )
         .subcommand(
@@ -147,6 +140,13 @@ impl NonceSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .validator(is_valid_pubkey)
                         .help("Assign noncing authority to another entity"),
+                )
+                .arg(
+                    Arg::with_name("seed")
+                        .long("seed")
+                        .value_name("STRING")
+                        .takes_value(true)
+                        .help("Seed for address generation; if specified, the resulting account will be at a derived address of the NONCE_ACCOUNT pubkey")
                 ),
         )
         .subcommand(


### PR DESCRIPTION
#### Problem

The `--seed` parameter for `create-nonce-account` is declared on the wrong CLI subcommand, preventing access to this feature

#### Summary of Changes

Move `--seed` parameter declaration to `create-nonce-account` delcaration
Add "NONCE" option to `create-address-with-seed` program names/IDs
Add an integration test demonstrating the workflow of one of our partners

~Will need rebased upon #8927~