### PR TITLE
Docs: Fix error during CLI usage build

### DIFF
--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -25,6 +25,8 @@ section() {
 
 section "$usage" >> "$out"
 
+usage=$(sed -e '/^ \{5,\}/d' <<<"$usage")
+
 in_subcommands=0
 while read -r subcommand rest; do
   [[ $subcommand == "SUBCOMMANDS:" ]] && in_subcommands=1 && continue


### PR DESCRIPTION
#### Problem

The `resolve-signer` subcommand's description is long enough that `clap`
wraps it. The CLI usage build script incorrectly interprets the first
word of the wrap line a subcommand

#### Summary of Changes
Drop wrapped lines after emitting top-level usage, but before iterating
the subcommand usages