### PR TITLE
Cli: polish transaction progress bar

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1029,7 +1029,8 @@ impl RpcClient {
             }
             progress_bar.set_message(&format!(
                 "[{}/{}] Waiting for confirmations",
-                confirmations, MAX_LOCKOUT_HISTORY,
+                confirmations + 1,
+                MAX_LOCKOUT_HISTORY + 1,
             ));
             sleep(Duration::from_millis(500));
             confirmations = self.get_num_blocks_since_signature_confirmation(&signature)?;

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -954,6 +954,15 @@ impl RpcClient {
         transaction: &mut Transaction,
         signer_keys: &T,
     ) -> ClientResult<String> {
+        let mut confirmations = 0;
+
+        let progress_bar = new_spinner_progress_bar();
+        progress_bar.set_message(&format!(
+            "[{}/{}] Waiting for confirmations",
+            confirmations,
+            MAX_LOCKOUT_HISTORY + 1,
+        ));
+
         let mut send_retries = 20;
         let signature_str = loop {
             let mut status_retries = 15;
@@ -1009,10 +1018,6 @@ impl RpcClient {
                 }
             }
         };
-
-        let progress_bar = new_spinner_progress_bar();
-        progress_bar.set_message("Confirming...");
-        let mut confirmations = 0;
         let signature = Signature::from_str(&signature_str).map_err(|_| {
             ClientError::from(ClientErrorKind::Custom(format!(
                 "Returned string {} cannot be parsed as a signature",


### PR DESCRIPTION
#### Summary of Changes
- Bump block count to include the block containing the transaction
- Display progress bar before initial status check

