### PR TITLE
Build windows binaries on v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os:
   - osx
+  - windows
 
 language: rust
 rust:


### PR DESCRIPTION
Add windows to travis CI build flow on v1.0 branch to support broader public wallet creation.
