### PR TITLE
Some Cli polish

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2189,17 +2189,9 @@ where
             )) = err.kind()
             {
                 if let Some(specific_error) = E::decode_custom_error_to_enum(*code) {
-                    error!("{}::{:?}", E::type_of(), specific_error);
-                    eprintln!(
-                        "Program Error ({}::{:?}): {}",
-                        E::type_of(),
-                        specific_error,
-                        specific_error
-                    );
                     return Err(specific_error.into());
                 }
             }
-            error!("{:?}", err);
             Err(err.into())
         }
         Ok(sig) => Ok(sig),

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -236,7 +236,8 @@ impl LedgerWallet {
         self.write(command, p1, p2, data)?;
         if p1 == P1_CONFIRM && is_last_part(p2) {
             println!(
-                "Waiting for approval from remote wallet {}",
+                "Waiting for your approval on {} {}",
+                self.name(),
                 self.pretty_path
             );
             let result = self.read()?;
@@ -261,6 +262,10 @@ impl LedgerWallet {
 }
 
 impl RemoteWallet for LedgerWallet {
+    fn name(&self) -> &str {
+        "Ledger hardware wallet"
+    }
+
     fn read_device(
         &self,
         dev_info: &hidapi::DeviceInfo,

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -173,6 +173,10 @@ impl RemoteWalletManager {
 
 /// `RemoteWallet` trait
 pub trait RemoteWallet {
+    fn name(&self) -> &str {
+        "remote wallet"
+    }
+
     /// Parse device info and get device base pubkey
     fn read_device(
         &self,


### PR DESCRIPTION
#### Problem
- Ledger device "waiting" message not a clear call to action
- In addition to the final response message, the Cli prints a 2nd message (ERROR log) on transactions errors, and a 3rd message to stderr on custom program errors!

#### Summary of Changes
- Improve device "waiting" message:
before
```
Waiting for approval from remote wallet usb://ledger/FDmtjsHEM3bxekTmT7MF2JJpv8qkiW9vczuTPZ58hS5X
```
after
```
Waiting for your approval on Ledger hardware wallet usb://ledger/FDmtjsHEM3bxekTmT7MF2JJpv8qkiW9vczuTPZ58hS5X
```
- Remove duplicative errors

