### PR TITLE
Fix windows binary build on v1.0

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -45,7 +45,7 @@ linux)
   TARGET=x86_64-unknown-linux-gnu
   ;;
 windows)
-  TARGET=x86_64-pc-windows-msvc
+  TARGET=x86_64-pc-windows-gnu
   ;;
 *)
   echo CI_OS_NAME unset
@@ -72,15 +72,6 @@ echo --- Creating release tarball
 
   source ci/rust-version.sh stable
   scripts/cargo-install-all.sh +"$rust_stable" --use-move solana-release
-
-  # Reduce the Windows archive size until
-  # https://github.com/appveyor/ci/issues/2997 is fixed
-  if [[ -n $APPVEYOR ]]; then
-    rm -f \
-      solana-release/bin/solana-validator.exe \
-      solana-release/bin/solana-bench-exchange.exe \
-
-  fi
 
   tar cvf solana-release-$TARGET.tar solana-release
   bzip2 solana-release-$TARGET.tar

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -72,26 +72,36 @@ SECONDS=0
   fi
 )
 
-BINS=(
-  solana
-  solana-bench-exchange
-  solana-bench-tps
-  solana-faucet
-  solana-gossip
-  solana-install
-  solana-install-init
-  solana-keygen
-  solana-ledger-tool
-  solana-log-analyzer
-  solana-net-shaper
-  solana-sys-tuner
-  solana-validator
-  solana-watchtower
-)
 
-#XXX: Ensure `solana-genesis` is built LAST!
-# See https://github.com/solana-labs/solana/issues/5826
-BINS+=(solana-genesis)
+if [[ $CI_OS_NAME = windows ]]; then
+  # Limit windows to end-user command-line tools.  Full validator support is not
+  # yet available on windows
+  BINS=(
+    solana
+    solana-install
+    solana-install-init
+    solana-keygen
+  )
+else
+  BINS=(
+    solana
+    solana-bench-exchange
+    solana-bench-tps
+    solana-faucet
+    solana-gossip
+    solana-keygen
+    solana-ledger-tool
+    solana-log-analyzer
+    solana-net-shaper
+    solana-sys-tuner
+    solana-validator
+    solana-watchtower
+  )
+
+  #XXX: Ensure `solana-genesis` is built LAST!
+  # See https://github.com/solana-labs/solana/issues/5826
+  BINS+=(solana-genesis)
+fi
 
 binArgs=()
 for bin in "${BINS[@]}"; do

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -55,23 +55,8 @@ cargo=cargo
 echo "Install location: $installDir ($buildVariant)"
 
 cd "$(dirname "$0")"/..
-./fetch-perf-libs.sh
 
 SECONDS=0
-
-(
-  set -x
-  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  $cargo $maybeRustVersion build $maybeReleaseFlag
-
-  if $useMove; then
-    moveLoaderDir=programs/move_loader
-    # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    $cargo $maybeRustVersion build $maybeReleaseFlag --manifest-path "$moveLoaderDir/Cargo.toml"
-    cp -fv $moveLoaderDir/target/$buildVariant/libsolana_move_loader_program.* "$installDir/bin/deps"
-  fi
-)
-
 
 if [[ $CI_OS_NAME = windows ]]; then
   # Limit windows to end-user command-line tools.  Full validator support is not
@@ -83,12 +68,29 @@ if [[ $CI_OS_NAME = windows ]]; then
     solana-keygen
   )
 else
+  ./fetch-perf-libs.sh
+  (
+    set -x
+    # shellcheck disable=SC2086 # Don't want to double quote $rust_version
+    $cargo $maybeRustVersion build $maybeReleaseFlag
+
+    if $useMove; then
+      moveLoaderDir=programs/move_loader
+      # shellcheck disable=SC2086 # Don't want to double quote $rust_version
+      $cargo $maybeRustVersion build $maybeReleaseFlag --manifest-path "$moveLoaderDir/Cargo.toml"
+      cp -fv $moveLoaderDir/target/$buildVariant/libsolana_move_loader_program.* "$installDir/bin/deps"
+    fi
+  )
+
+
   BINS=(
     solana
     solana-bench-exchange
     solana-bench-tps
     solana-faucet
     solana-gossip
+    solana-install
+    solana-install-init
     solana-keygen
     solana-ledger-tool
     solana-log-analyzer


### PR DESCRIPTION
Cherry-picked @mvines fixes to only build `solana` `solana-install` `solan-install-init` and `solana-keygen` binaries for windows.