### PR TITLE
Improve CLI usage messages

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2254,7 +2254,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("faucet_port")
                         .long("faucet-port")
-                        .value_name("NUMBER")
+                        .value_name("PORT_NUMBER")
                         .takes_value(true)
                         .default_value(solana_faucet::faucet::FAUCET_PORT_STR)
                         .help("Faucet port to use"),
@@ -2271,7 +2271,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("RECIPIENT_PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
                         .help("The pubkey of airdrop recipient"),
@@ -2301,7 +2301,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("PROCESS_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -2334,7 +2334,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("program_id")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("PROGRAM_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help(
@@ -2345,7 +2345,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("from")
                         .long("from")
-                        .value_name("PUBKEY")
+                        .value_name("FROM_PUBKEY")
                         .takes_value(true)
                         .required(false)
                         .validator(is_valid_pubkey)
@@ -2370,7 +2370,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("RECIPIENT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -2439,7 +2439,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("RECIPIENT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -2448,7 +2448,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("PROCESS_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help("The process id of the transfer to authorize"),
@@ -2460,7 +2460,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("RECIPIENT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
@@ -2469,7 +2469,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("PROCESS_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .help("The process id of the transfer to unlock"),
@@ -2488,7 +2488,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("RECIPIENT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2262,7 +2262,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("amount")
                         .index(1)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -2379,7 +2379,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -2497,7 +2497,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2283,7 +2283,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
                         .help("The public key of the balance to check"),
@@ -2314,7 +2314,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("signature")
                         .index(1)
-                        .value_name("SIGNATURE")
+                        .value_name("TRANSACTION_SIGNATURE")
                         .takes_value(true)
                         .required(true)
                         .help("The transaction signature to confirm"),
@@ -2326,7 +2326,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("seed")
                         .index(1)
-                        .value_name("STRING")
+                        .value_name("SEED_STRING")
                         .takes_value(true)
                         .required(true)
                         .help("The seed.  Must not take more than 32 bytes to encode as utf-8"),
@@ -2358,7 +2358,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("program_location")
                         .index(1)
-                        .value_name("FILEPATH")
+                        .value_name("PROGRAM_FILEPATH")
                         .takes_value(true)
                         .required(true)
                         .help("/path/to/program.o"),
@@ -2426,7 +2426,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("signer")
                         .index(1)
-                        .value_name("KEYPAIR")
+                        .value_name("SIGNER_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -2523,7 +2523,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -57,7 +57,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                     Arg::with_name("node_pubkey")
                         .index(1)
                         .takes_value(true)
-                        .value_name("PUBKEY")
+                        .value_name("VALIDATOR_PUBKEY")
                         .validator(is_valid_pubkey)
                         .required(true)
                         .help("Identity pubkey of the validator"),
@@ -221,7 +221,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkeys")
                         .index(1)
-                        .value_name("VOTE ACCOUNT PUBKEYS")
+                        .value_name("VOTE_ACCOUNT_PUBKEYS")
                         .takes_value(true)
                         .multiple(true)
                         .validator(is_valid_pubkey)

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -95,7 +95,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -104,7 +104,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("new_authority")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("AUTHORITY_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -118,7 +118,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_keypair")
                         .index(1)
-                        .value_name("KEYPAIR")
+                        .value_name("ACCOUNT_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -156,7 +156,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -169,7 +169,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -184,7 +184,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -203,7 +203,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -212,7 +212,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("RECIPIENT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -127,7 +127,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount)
@@ -221,7 +221,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount)

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -73,11 +73,11 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account")
                         .index(1)
-                        .value_name("KEYPAIR")
+                        .value_name("ACCOUNT_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Signing authority of the stake address to fund")
+                        .help("Stake account to create (or base of derived address if --seed is used)")
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -94,7 +94,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help("Identity of the custodian (can withdraw before lockup expires)")
+                        .help("Authority to modify lockups")
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -140,7 +140,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
-                        .help("Source account of funds (if different from client local account)"),
+                        .help("Source account of funds [default: cli config keypair]"),
                 )
                 .offline_args()
                 .arg(nonce_arg())
@@ -160,7 +160,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -169,7 +169,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("VOTE_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -187,7 +187,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -196,7 +196,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("AUTHORIZED_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -214,7 +214,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -223,7 +223,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("AUTHORIZED_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -241,7 +241,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -255,24 +255,24 @@ impl StakeSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("split-stake")
-                .about("Split a stake account")
+                .about("Create a new stake account using tokens from an existing one")
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("Stake account to be split")
+                        .help("Stake account to split (or base of derived address if --seed is used)")
                 )
                 .arg(
                     Arg::with_name("split_stake_account")
                         .index(2)
-                        .value_name("KEYPAIR")
+                        .value_name("ACCOUNT_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Keypair of the new stake account to split funds into")
+                        .help("Keypair of the new stake account")
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -302,7 +302,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -311,11 +311,11 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("RECIPIENT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("The account to which the SOL should be transferred")
+                        .help("Recipient of withdrawn SOL")
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -338,11 +338,11 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("Stake account for which to set Lockup")
+                        .help("Stake account for which to set lockup parameters")
                 )
                 .arg(
                     Arg::with_name("lockup_epoch")
@@ -365,7 +365,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help("Identity of the new lockup custodian (can withdraw before lockup expires)")
+                        .help("Identity of a new lockup custodian")
                 )
                 .group(ArgGroup::with_name("lockup_details")
                     .args(&["lockup_epoch", "lockup_date", "new_custodian"])
@@ -376,7 +376,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
-                        .help("Public key of signing custodian [default: cli config pubkey]")
+                        .help("Keypair of the existing custodian [default: cli config pubkey]")
                 )
                 .offline_args()
                 .arg(nonce_arg())
@@ -390,11 +390,11 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("Address of the stake account to display")
+                        .help("The stake account to display")
                 )
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -82,7 +82,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -255,7 +255,7 @@ impl StakeSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("split-stake")
-                .about("Create a new stake account using tokens from an existing one")
+                .about("Duplicate a stake account, splitting the tokens between the two")
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
@@ -277,7 +277,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
@@ -320,7 +320,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -26,7 +26,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_owner")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("AUTHORITY_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey),
@@ -34,7 +34,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account")
                         .index(2)
-                        .value_name("KEYPAIR")
+                        .value_name("ACCOUNT_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer),
@@ -46,7 +46,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_owner")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("AUTHORITY_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey),
@@ -54,7 +54,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account")
                         .index(2)
-                        .value_name("KEYPAIR")
+                        .value_name("ACCOUNT_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer),
@@ -66,7 +66,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("node_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("NODE_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -75,7 +75,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -89,7 +89,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -51,7 +51,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("commission")
                         .long("commission")
-                        .value_name("NUMBER")
+                        .value_name("PERCENTAGE")
                         .takes_value(true)
                         .default_value("100")
                         .help("The commission taken on reward redemption (0-100)"),
@@ -207,7 +207,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
-                        .value_name("NUMBER")
+                        .value_name("AMOUNT")
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount)

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -33,16 +33,16 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account")
                         .index(1)
-                        .value_name("KEYPAIR")
+                        .value_name("ACCOUNT_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Vote account keypair to fund"),
+                        .help("Vote account keypair to create"),
                 )
                 .arg(
                     Arg::with_name("identity_account")
                         .index(2)
-                        .value_name("KEYPAIR")
+                        .value_name("IDENTITY_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -59,7 +59,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_voter")
                         .long("authorized-voter")
-                        .value_name("PUBKEY")
+                        .value_name("VOTER_PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
                         .help("Public key of the authorized voter [default: validator identity pubkey]"),
@@ -67,7 +67,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_withdrawer")
                         .long("authorized-withdrawer")
-                        .value_name("PUBKEY")
+                        .value_name("WITHDRAWER_PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
                         .help("Public key of the authorized withdrawer [default: validator identity pubkey]"),
@@ -86,7 +86,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -95,11 +95,11 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("new_authorized_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("AUTHORIZED_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("New vote signer to authorize"),
+                        .help("New authorized vote signer"),
                 ),
         )
         .subcommand(
@@ -108,7 +108,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -117,11 +117,11 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("new_authorized_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("AUTHORIZED_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("New withdrawer to authorize"),
+                        .help("New authorized withdrawer"),
                 ),
         )
         .subcommand(
@@ -130,7 +130,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -139,7 +139,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("new_identity_account")
                         .index(2)
-                        .value_name("KEYPAIR")
+                        .value_name("IDENTITY_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -148,7 +148,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_withdrawer")
                         .index(3)
-                        .value_name("KEYPAIR")
+                        .value_name("AUTHORIZED_KEYPAIR")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
@@ -170,7 +170,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -189,7 +189,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("PUBKEY")
+                        .value_name("ACCOUNT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -198,11 +198,11 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("PUBKEY")
+                        .value_name("RECIPIENT_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("The account to which the SOL should be transferred"),
+                        .help("The recipient of withdrawn SOL"),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -216,7 +216,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("authorized_withdrawer")
                         .long("authorized-withdrawer")
-                        .value_name("KEYPAIR")
+                        .value_name("AUTHORIZED_KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
                         .help("Authorized withdrawer [default: cli config keypair]"),


### PR DESCRIPTION
#### Problem

I caused a usability regression in the CLI usage messages when I changed the value_names to types.

#### Summary of Changes

* Qualify the value name in positional arguments
* Tighten some help messages along the way

Fixes #8962 
