### PR TITLE
Make validator ready for HSM or other secure authorized voter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4656,6 +4656,7 @@ dependencies = [
  "solana-metrics 1.1.0",
  "solana-net-utils 1.1.0",
  "solana-perf 1.1.0",
+ "solana-remote-wallet 1.1.0",
  "solana-runtime 1.1.0",
  "solana-sdk 1.1.0",
  "solana-vote-program 1.1.0",

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -80,7 +80,7 @@ impl Tvu {
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
     pub fn new(
         vote_account: &Pubkey,
-        voting_keypair: Option<Arc<Keypair>>,
+        voting_keypair: Option<Arc<Mutex<Box<dyn Signer>>>>,
         storage_keypair: &Arc<Keypair>,
         bank_forks: &Arc<RwLock<BankForks>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -6,7 +6,11 @@ use dialoguer::{theme::ColorfulTheme, Select};
 use log::*;
 use semver::Version as FirmwareVersion;
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
-use std::{cmp::min, fmt, sync::Arc};
+use std::{
+    cmp::min,
+    fmt,
+    sync::{Arc, Mutex},
+};
 
 static CHECK_MARK: Emoji = Emoji("✅ ", "");
 
@@ -424,7 +428,7 @@ pub fn get_ledger_from_info(
     info: RemoteWalletInfo,
     keypair_name: &str,
     wallet_manager: &RemoteWalletManager,
-) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
+) -> Result<Arc<Mutex<LedgerWallet>>, RemoteWalletError> {
     let devices = wallet_manager.list_devices();
     let mut matches = devices
         .iter()

--- a/remote-wallet/src/remote_keypair.rs
+++ b/remote-wallet/src/remote_keypair.rs
@@ -25,7 +25,10 @@ impl RemoteKeypair {
         path: String,
     ) -> Result<Self, RemoteWalletError> {
         let pubkey = match &wallet_type {
-            RemoteWalletType::Ledger(wallet) => wallet.get_pubkey(&derivation_path, confirm_key)?,
+            RemoteWalletType::Ledger(wallet) => wallet
+                .lock()
+                .unwrap()
+                .get_pubkey(&derivation_path, confirm_key)?,
         };
 
         Ok(Self {
@@ -45,6 +48,8 @@ impl Signer for RemoteKeypair {
     fn try_sign_message(&self, message: &[u8]) -> Result<Signature, SignerError> {
         match &self.wallet_type {
             RemoteWalletType::Ledger(wallet) => wallet
+                .lock()
+                .unwrap()
                 .sign_message(&self.derivation_path, message)
                 .map_err(|e| e.into()),
         }
@@ -60,7 +65,11 @@ pub fn generate_remote_keypair(
     let (remote_wallet_info, derivation_path) = RemoteWalletInfo::parse_path(path)?;
     if remote_wallet_info.manufacturer == "ledger" {
         let ledger = get_ledger_from_info(remote_wallet_info, keypair_name, wallet_manager)?;
-        let path = format!("{}{}", ledger.pretty_path, derivation_path.get_query());
+        let path = format!(
+            "{}{}",
+            ledger.lock().unwrap().pretty_path,
+            derivation_path.get_query()
+        );
         Ok(RemoteKeypair::new(
             RemoteWalletType::Ledger(ledger),
             derivation_path,

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -113,7 +113,9 @@ impl RemoteWalletManager {
                                 v.push(Device {
                                     path,
                                     info,
-                                    wallet_type: RemoteWalletType::Ledger(Arc::new(ledger)),
+                                    wallet_type: RemoteWalletType::Ledger(Arc::new(
+                                        std::sync::Mutex::new(ledger),
+                                    )),
                                 })
                             }
                         }
@@ -136,7 +138,10 @@ impl RemoteWalletManager {
 
     /// Get a particular wallet
     #[allow(unreachable_patterns)]
-    pub fn get_ledger(&self, pubkey: &Pubkey) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
+    pub fn get_ledger(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Result<Arc<std::sync::Mutex<LedgerWallet>>, RemoteWalletError> {
         self.devices
             .read()
             .iter()
@@ -209,7 +214,7 @@ pub struct Device {
 /// Remote wallet convenience enum to hold various wallet types
 #[derive(Debug)]
 pub enum RemoteWalletType {
-    Ledger(Arc<LedgerWallet>),
+    Ledger(Arc<std::sync::Mutex<LedgerWallet>>),
 }
 
 /// Remote wallet information.

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -130,7 +130,7 @@ impl FromStr for Signature {
     }
 }
 
-pub trait Signer {
+pub trait Signer: Send {
     fn pubkey(&self) -> Pubkey {
         self.try_pubkey().unwrap_or_default()
     }

--- a/sdk/src/signers.rs
+++ b/sdk/src/signers.rs
@@ -2,6 +2,7 @@ use crate::{
     pubkey::Pubkey,
     signature::{Signature, Signer, SignerError},
 };
+use std::sync::MutexGuard;
 
 pub trait Signers {
     fn pubkeys(&self) -> Vec<Pubkey>;
@@ -45,6 +46,10 @@ impl<T: Signer> Signers for [&T] {
 }
 
 impl Signers for [Box<dyn Signer>] {
+    default_keypairs_impl!();
+}
+
+impl Signers for [MutexGuard<'_, Box<dyn Signer>>; 1] {
     default_keypairs_impl!();
 }
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -25,6 +25,7 @@ solana-logger = { path = "../logger", version = "1.1.0" }
 solana-perf = { path = "../perf", version = "1.1.0" }
 solana-metrics = { path = "../metrics", version = "1.1.0" }
 solana-net-utils = { path = "../net-utils", version = "1.1.0" }
+solana-remote-wallet = { path = "../remote-wallet", version = "1.1.0" }
 solana-runtime = { path = "../runtime", version = "1.1.0" }
 solana-sdk = { path = "../sdk", version = "1.1.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.1.0" }


### PR DESCRIPTION
#### Problem
Currently, a validator must depend on a keypair file on disk in order to sign every vote. This isn't very secure. We envision validators using HSM devices (we are considering our own Ledger device HSM app) or other secure signers. In order to enable these signers, the validator app needs to accept other Signers for the `authorized-voter` argument.

#### Summary of Changes
- Make RemoteKeypair + Send, so that it can be passed into the ReplayStage thread
- Enable flexible Signer for validator `authorized-voter`
- Also sneak in allowing a pubkey from a Ledger or other flexible signer for a validator vote-account

Still todo:

- [ ] Fix authorized-voter in local-cluster
- [ ] More robust testing
