### PR TITLE
CLI: Support setting both stake authorities at once

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -650,19 +650,19 @@ pub fn parse_command(
             matches,
             default_signer_path,
             wallet_manager,
-            &vec![StakeAuthorize::Staker, StakeAuthorize::Withdrawer],
+            &[StakeAuthorize::Staker, StakeAuthorize::Withdrawer],
         ),
         ("stake-authorize-staker", Some(matches)) => parse_stake_authorize(
             matches,
             default_signer_path,
             wallet_manager,
-            &vec![StakeAuthorize::Staker],
+            &[StakeAuthorize::Staker],
         ),
         ("stake-authorize-withdrawer", Some(matches)) => parse_stake_authorize(
             matches,
             default_signer_path,
             wallet_manager,
-            &vec![StakeAuthorize::Withdrawer],
+            &[StakeAuthorize::Withdrawer],
         ),
         ("stake-set-lockup", Some(matches)) => {
             parse_stake_set_lockup(matches, default_signer_path, wallet_manager)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -304,9 +304,7 @@ pub enum CliCommand {
     },
     StakeAuthorize {
         stake_account_pubkey: Pubkey,
-        new_authorized_pubkey: Pubkey,
-        stake_authorize: StakeAuthorize,
-        authority: SignerIndex,
+        new_authorizations: Vec<(StakeAuthorize, Pubkey, SignerIndex)>,
         sign_only: bool,
         blockhash_query: BlockhashQuery,
         nonce_account: Option<Pubkey>,
@@ -652,13 +650,13 @@ pub fn parse_command(
             matches,
             default_signer_path,
             wallet_manager,
-            StakeAuthorize::Staker,
+            &vec![StakeAuthorize::Staker],
         ),
         ("stake-authorize-withdrawer", Some(matches)) => parse_stake_authorize(
             matches,
             default_signer_path,
             wallet_manager,
-            StakeAuthorize::Withdrawer,
+            &vec![StakeAuthorize::Withdrawer],
         ),
         ("stake-set-lockup", Some(matches)) => {
             parse_stake_set_lockup(matches, default_signer_path, wallet_manager)
@@ -1832,9 +1830,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         }
         CliCommand::StakeAuthorize {
             stake_account_pubkey,
-            new_authorized_pubkey,
-            stake_authorize,
-            authority,
+            ref new_authorizations,
             sign_only,
             blockhash_query,
             nonce_account,
@@ -1844,9 +1840,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             &rpc_client,
             config,
             &stake_account_pubkey,
-            &new_authorized_pubkey,
-            *stake_authorize,
-            *authority,
+            new_authorizations,
             *sign_only,
             blockhash_query,
             *nonce_account,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -646,6 +646,12 @@ pub fn parse_command(
         ("split-stake", Some(matches)) => {
             parse_split_stake(matches, default_signer_path, wallet_manager)
         }
+        ("stake-authorize", Some(matches)) => parse_stake_authorize(
+            matches,
+            default_signer_path,
+            wallet_manager,
+            &vec![StakeAuthorize::Staker, StakeAuthorize::Withdrawer],
+        ),
         ("stake-authorize-staker", Some(matches)) => parse_stake_authorize(
             matches,
             default_signer_path,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -646,24 +646,9 @@ pub fn parse_command(
         ("split-stake", Some(matches)) => {
             parse_split_stake(matches, default_signer_path, wallet_manager)
         }
-        ("stake-authorize", Some(matches)) => parse_stake_authorize(
-            matches,
-            default_signer_path,
-            wallet_manager,
-            &[StakeAuthorize::Staker, StakeAuthorize::Withdrawer],
-        ),
-        ("stake-authorize-staker", Some(matches)) => parse_stake_authorize(
-            matches,
-            default_signer_path,
-            wallet_manager,
-            &[StakeAuthorize::Staker],
-        ),
-        ("stake-authorize-withdrawer", Some(matches)) => parse_stake_authorize(
-            matches,
-            default_signer_path,
-            wallet_manager,
-            &[StakeAuthorize::Withdrawer],
-        ),
+        ("stake-authorize", Some(matches)) => {
+            parse_stake_authorize(matches, default_signer_path, wallet_manager)
+        }
         ("stake-set-lockup", Some(matches)) => {
             parse_stake_set_lockup(matches, default_signer_path, wallet_manager)
         }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -183,7 +183,7 @@ impl StakeSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("stake-authorize")
-                .about("Authorize a new stake signing keypair for the given stake account")
+                .about("Authorize a new signing keypair for the given stake account")
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .required(true)

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -189,7 +189,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .required(true)
                         .index(1)
                         .takes_value(true)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .validator(is_valid_pubkey)
                         .help("Stake account in which to set a new authority")
                 )

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1952,8 +1952,12 @@ mod tests {
                 },
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file).unwrap().into(),
+                    read_keypair_file(&stake_authority_keypair_file)
+                        .unwrap()
+                        .into(),
+                    read_keypair_file(&withdraw_authority_keypair_file)
+                        .unwrap()
+                        .into(),
                 ],
             },
         );
@@ -2002,7 +2006,9 @@ mod tests {
                 },
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file).unwrap().into(),
+                    read_keypair_file(&stake_authority_keypair_file)
+                        .unwrap()
+                        .into(),
                 ],
             },
         );
@@ -2059,7 +2065,9 @@ mod tests {
                 },
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file).unwrap().into(),
+                    read_keypair_file(&withdraw_authority_keypair_file)
+                        .unwrap()
+                        .into(),
                 ],
             },
         );

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -212,6 +212,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("New authorized withdrawer")
                 )
                 .arg(stake_authority_arg())
+                .arg(withdraw_authority_arg())
                 .offline_args()
                 .arg(nonce_arg())
                 .arg(nonce_authority_arg())
@@ -1918,6 +1919,44 @@ mod tests {
                 signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
             },
         );
+        let (withdraw_authority_keypair_file, mut tmp_file) = make_tmp_file();
+        let withdraw_authority_keypair = Keypair::new();
+        write_keypair(&withdraw_authority_keypair, tmp_file.as_file_mut()).unwrap();
+        let test_stake_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            "stake-authorize",
+            &stake_account_string,
+            "--new-stake-authority",
+            &new_stake_string,
+            "--new-withdraw-authority",
+            &new_withdraw_string,
+            "--stake-authority",
+            &stake_authority_keypair_file,
+            "--withdraw-authority",
+            &withdraw_authority_keypair_file,
+        ]);
+        assert_eq!(
+            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorizations: vec![
+                        (StakeAuthorize::Staker, new_stake_authority, 1,),
+                        (StakeAuthorize::Withdrawer, new_withdraw_authority, 2,),
+                    ],
+                    sign_only: false,
+                    blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
+                    nonce_account: None,
+                    nonce_authority: 0,
+                    fee_payer: 0,
+                },
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    read_keypair_file(&stake_authority_keypair_file).unwrap().into(),
+                    read_keypair_file(&withdraw_authority_keypair_file).unwrap().into(),
+                ],
+            },
+        );
         let test_stake_authorize = test_commands.clone().get_matches_from(vec![
             "test",
             "stake-authorize",
@@ -1944,6 +1983,33 @@ mod tests {
             "test",
             "stake-authorize",
             &stake_account_string,
+            "--new-stake-authority",
+            &new_stake_string,
+            "--stake-authority",
+            &stake_authority_keypair_file,
+        ]);
+        assert_eq!(
+            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorizations: vec![(StakeAuthorize::Staker, new_stake_authority, 1,),],
+                    sign_only: false,
+                    blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
+                    nonce_account: None,
+                    nonce_authority: 0,
+                    fee_payer: 0,
+                },
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    read_keypair_file(&stake_authority_keypair_file).unwrap().into(),
+                ],
+            },
+        );
+        let test_stake_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            "stake-authorize",
+            &stake_account_string,
             "--new-withdraw-authority",
             &new_withdraw_string,
         ]);
@@ -1964,6 +2030,37 @@ mod tests {
                     fee_payer: 0,
                 },
                 signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
+            },
+        );
+        let test_stake_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            "stake-authorize",
+            &stake_account_string,
+            "--new-withdraw-authority",
+            &new_withdraw_string,
+            "--withdraw-authority",
+            &withdraw_authority_keypair_file,
+        ]);
+        assert_eq!(
+            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorizations: vec![(
+                        StakeAuthorize::Withdrawer,
+                        new_withdraw_authority,
+                        1,
+                    ),],
+                    sign_only: false,
+                    blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
+                    nonce_account: None,
+                    nonce_authority: 0,
+                    fee_payer: 0,
+                },
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    read_keypair_file(&withdraw_authority_keypair_file).unwrap().into(),
+                ],
             },
         );
 

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -191,7 +191,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("ACCOUNT_PUBKEY")
                         .validator(is_valid_pubkey)
-                        .help("Stake account in which to set the authorized staker")
+                        .help("Stake account in which to set a new authority")
                 )
                 .arg(
                     Arg::with_name("new_stake_authority")

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -562,7 +562,9 @@ pub fn parse_stake_authorize(
             StakeAuthorize::Staker => (STAKE_AUTHORITY_ARG.name, "new_stake_authority"),
             StakeAuthorize::Withdrawer => (WITHDRAW_AUTHORITY_ARG.name, "new_withdraw_authority"),
         };
-        if let Some(new_authority_pubkey) = pubkey_of_signer(matches, new_authority_flag, wallet_manager)? {
+        if let Some(new_authority_pubkey) =
+            pubkey_of_signer(matches, new_authority_flag, wallet_manager)?
+        {
             let (authority, authority_pubkey) = signer_of(matches, authority_flag, wallet_manager)?;
             new_authorizations.push((*stake_authorize, new_authority_pubkey, authority_pubkey));
             bulk_signers.push(authority);
@@ -586,13 +588,15 @@ pub fn parse_stake_authorize(
 
     let new_authorizations = new_authorizations
         .into_iter()
-        .map(|(stake_authorize, new_authority_pubkey, authority_pubkey)| {
-            (
-                stake_authorize,
-                new_authority_pubkey,
-                signer_info.index_of(authority_pubkey).unwrap(),
-            )
-        })
+        .map(
+            |(stake_authorize, new_authority_pubkey, authority_pubkey)| {
+                (
+                    stake_authorize,
+                    new_authority_pubkey,
+                    signer_info.index_of(authority_pubkey).unwrap(),
+                )
+            },
+        )
         .collect();
 
     Ok(CliCommandInfo {
@@ -932,7 +936,7 @@ pub fn process_stake_authorize(
     fee_payer: SignerIndex,
 ) -> ProcessResult {
     let mut ixs = Vec::new();
-    for (stake_authorize, authorized_pubkey, authority) in new_authorizations.into_iter() {
+    for (stake_authorize, authorized_pubkey, authority) in new_authorizations.iter() {
         check_unique_pubkeys(
             (stake_account_pubkey, "stake_account_pubkey".to_string()),
             (authorized_pubkey, "new_authorized_pubkey".to_string()),
@@ -1902,16 +1906,8 @@ mod tests {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
                     new_authorizations: vec![
-                        (
-                            StakeAuthorize::Staker,
-                            new_stake_authority,
-                            0,
-                        ),
-                        (
-                            StakeAuthorize::Withdrawer,
-                            new_withdraw_authority,
-                            0,
-                        ),
+                        (StakeAuthorize::Staker, new_stake_authority, 0,),
+                        (StakeAuthorize::Withdrawer, new_withdraw_authority, 0,),
                     ],
                     sign_only: false,
                     blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
@@ -1919,9 +1915,7 @@ mod tests {
                     nonce_authority: 0,
                     fee_payer: 0,
                 },
-                signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                ],
+                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
             },
         );
         let test_stake_authorize = test_commands.clone().get_matches_from(vec![
@@ -1936,22 +1930,14 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
-                    new_authorizations: vec![
-                        (
-                            StakeAuthorize::Staker,
-                            new_stake_authority,
-                            0,
-                        ),
-                    ],
+                    new_authorizations: vec![(StakeAuthorize::Staker, new_stake_authority, 0,),],
                     sign_only: false,
                     blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
                     nonce_account: None,
                     nonce_authority: 0,
                     fee_payer: 0,
                 },
-                signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                ],
+                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
             },
         );
         let test_stake_authorize = test_commands.clone().get_matches_from(vec![
@@ -1966,22 +1952,18 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
-                    new_authorizations: vec![
-                        (
-                            StakeAuthorize::Withdrawer,
-                            new_withdraw_authority,
-                            0,
-                        ),
-                    ],
+                    new_authorizations: vec![(
+                        StakeAuthorize::Withdrawer,
+                        new_withdraw_authority,
+                        0,
+                    ),],
                     sign_only: false,
                     blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
                     nonce_account: None,
                     nonce_authority: 0,
                     fee_payer: 0,
                 },
-                signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                ],
+                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
             },
         );
 

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1598,6 +1598,41 @@ mod tests {
                 ],
             },
         );
+        // Withdraw authority may set both new authorities
+        let test_stake_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            "stake-authorize",
+            &stake_account_string,
+            "--new-stake-authority",
+            &new_stake_string,
+            "--new-withdraw-authority",
+            &new_withdraw_string,
+            "--withdraw-authority",
+            &withdraw_authority_keypair_file,
+        ]);
+        assert_eq!(
+            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorizations: vec![
+                        (StakeAuthorize::Staker, new_stake_authority, 1,),
+                        (StakeAuthorize::Withdrawer, new_withdraw_authority, 1,),
+                    ],
+                    sign_only: false,
+                    blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
+                    nonce_account: None,
+                    nonce_authority: 0,
+                    fee_payer: 0,
+                },
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    read_keypair_file(&withdraw_authority_keypair_file)
+                        .unwrap()
+                        .into(),
+                ],
+            },
+        );
         let test_stake_authorize = test_commands.clone().get_matches_from(vec![
             "test",
             "stake-authorize",
@@ -1644,6 +1679,36 @@ mod tests {
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),
                     read_keypair_file(&stake_authority_keypair_file)
+                        .unwrap()
+                        .into(),
+                ],
+            },
+        );
+        // Withdraw authority may set new stake authority
+        let test_stake_authorize = test_commands.clone().get_matches_from(vec![
+            "test",
+            "stake-authorize",
+            &stake_account_string,
+            "--new-stake-authority",
+            &new_stake_string,
+            "--withdraw-authority",
+            &withdraw_authority_keypair_file,
+        ]);
+        assert_eq!(
+            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::StakeAuthorize {
+                    stake_account_pubkey,
+                    new_authorizations: vec![(StakeAuthorize::Staker, new_stake_authority, 1,),],
+                    sign_only: false,
+                    blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
+                    nonce_account: None,
+                    nonce_authority: 0,
+                    fee_payer: 0,
+                },
+                signers: vec![
+                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    read_keypair_file(&withdraw_authority_keypair_file)
                         .unwrap()
                         .into(),
                 ],

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -650,16 +650,8 @@ fn test_stake_authorize() {
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorizations: vec![
-            (
-                StakeAuthorize::Staker,
-                online_authority2_pubkey,
-                1,
-            ),
-            (
-                StakeAuthorize::Withdrawer,
-                withdraw_authority_pubkey,
-                0,
-            ),
+            (StakeAuthorize::Staker, online_authority2_pubkey, 1),
+            (StakeAuthorize::Withdrawer, withdraw_authority_pubkey, 0),
         ],
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -625,9 +625,7 @@ fn test_stake_authorize() {
     config.signers.pop();
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: online_authority_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 0,
+        new_authorizations: vec![(StakeAuthorize::Staker, online_authority_pubkey, 0)],
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
@@ -647,9 +645,7 @@ fn test_stake_authorize() {
     config.signers.push(&online_authority);
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: offline_authority_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 1,
+        new_authorizations: vec![(StakeAuthorize::Staker, offline_authority_pubkey, 1)],
         sign_only: false,
         blockhash_query: BlockhashQuery::default(),
         nonce_account: None,
@@ -671,9 +667,7 @@ fn test_stake_authorize() {
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: nonced_authority_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 0,
+        new_authorizations: vec![(StakeAuthorize::Staker, nonced_authority_pubkey, 0)],
         sign_only: true,
         blockhash_query: BlockhashQuery::None(blockhash),
         nonce_account: None,
@@ -687,9 +681,7 @@ fn test_stake_authorize() {
     config.signers = vec![&offline_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: nonced_authority_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 0,
+        new_authorizations: vec![(StakeAuthorize::Staker, nonced_authority_pubkey, 0)],
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash_query::Source::Cluster, blockhash),
         nonce_account: None,
@@ -731,9 +723,7 @@ fn test_stake_authorize() {
     config_offline.signers.push(&nonced_authority);
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: online_authority_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 1,
+        new_authorizations: vec![(StakeAuthorize::Staker, online_authority_pubkey, 1)],
         sign_only: true,
         blockhash_query: BlockhashQuery::None(nonce_hash),
         nonce_account: Some(nonce_account.pubkey()),
@@ -749,9 +739,7 @@ fn test_stake_authorize() {
     config.signers = vec![&offline_presigner, &nonced_authority_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: online_authority_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 1,
+        new_authorizations: vec![(StakeAuthorize::Staker, online_authority_pubkey, 1)],
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(
             blockhash_query::Source::NonceAccount(nonce_account.pubkey()),
@@ -858,9 +846,7 @@ fn test_stake_authorize_with_fee_payer() {
     config.signers = vec![&default_signer, &payer_keypair];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: offline_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 0,
+        new_authorizations: vec![(StakeAuthorize::Staker, offline_pubkey, 0)],
         sign_only: false,
         blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
         nonce_account: None,
@@ -878,9 +864,7 @@ fn test_stake_authorize_with_fee_payer() {
     let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: payer_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 0,
+        new_authorizations: vec![(StakeAuthorize::Staker, payer_pubkey, 0)],
         sign_only: true,
         blockhash_query: BlockhashQuery::None(blockhash),
         nonce_account: None,
@@ -894,9 +878,7 @@ fn test_stake_authorize_with_fee_payer() {
     config.signers = vec![&offline_presigner];
     config.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
-        new_authorized_pubkey: payer_pubkey,
-        stake_authorize: StakeAuthorize::Staker,
-        authority: 0,
+        new_authorizations: vec![(StakeAuthorize::Staker, payer_pubkey, 0)],
         sign_only: false,
         blockhash_query: BlockhashQuery::FeeCalculator(blockhash_query::Source::Cluster, blockhash),
         nonce_account: None,

--- a/docs/src/offline-signing/README.md
+++ b/docs/src/offline-signing/README.md
@@ -18,6 +18,7 @@ At present, the following commands support offline signing:
 * [`deactivate-stake`](../cli/usage.md#solana-deactivate-stake)
 * [`delegate-stake`](../cli/usage.md#solana-delegate-stake)
 * [`split-stake`](../cli/usage.md#solana-split-stake)
+* [`stake-authorize`](../cli/usage.md#solana-stake-authorize)
 * [`stake-authorize-staker`](../cli/usage.md#solana-stake-authorize-staker)
 * [`stake-authorize-withdrawer`](../cli/usage.md#solana-stake-authorize-withdrawer)
 * [`stake-set-lockup`](../cli/usage.md#solana-stake-set-lockup)

--- a/docs/src/offline-signing/README.md
+++ b/docs/src/offline-signing/README.md
@@ -19,8 +19,6 @@ At present, the following commands support offline signing:
 * [`delegate-stake`](../cli/usage.md#solana-delegate-stake)
 * [`split-stake`](../cli/usage.md#solana-split-stake)
 * [`stake-authorize`](../cli/usage.md#solana-stake-authorize)
-* [`stake-authorize-staker`](../cli/usage.md#solana-stake-authorize-staker)
-* [`stake-authorize-withdrawer`](../cli/usage.md#solana-stake-authorize-withdrawer)
 * [`stake-set-lockup`](../cli/usage.md#solana-stake-set-lockup)
 * [`transfer`](../cli/usage.md#solana-transfer)
 * [`withdraw-stake`](../cli/usage.md#solana-withdraw-stake)


### PR DESCRIPTION
#### Problem

CLI currently requires two transactions to set both authorities on a stake account

#### Summary of Changes

Rework current `CliCommand::StakeAuthority` handling to work on a vec of requests
Add a new `stake-authorize` subcommand that allows the authorities to be specified via options (one required)

```
$ solana stake-authorize --help
solana-stake-authorize 
Authorize a new signing keypair for the given stake account

USAGE:
    solana stake-authorize [FLAGS] [OPTIONS] <ACCOUNT_PUBKEY> --new-stake-authority <PUBKEY> --new-withdraw-authority <PUBKEY>
```

Fixes #8910
