### PR TITLE
Fix versioning script on MacOS

### DIFF
--- a/docs/set-solana-release-tag.sh
+++ b/docs/set-solana-release-tag.sh
@@ -14,7 +14,7 @@ else
 fi
 
 set -x
-find html/ -name \*.html -exec sed -i "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
+find html/ -name \*.html -exec sed -i '' "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
 if [[ -n $CI ]]; then
-  find src/ -name \*.md -exec sed -i "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
+  find src/ -name \*.md -exec sed -i '' "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
 fi


### PR DESCRIPTION
#### Problem

Noisy build script on MacOS

```
sed: 1: "html//proposals/block-c ...": extra characters at the end of h command
sed: 1: "html//proposals/simple- ...": extra characters at the end of h command
sed: 1: "html//proposals/slashin ...": extra characters at the end of h command
...
```

#### Summary of Changes

More portable sed invocation

cc @mvines 