### PR TITLE
Move Install Solana doc into the Command-line Guide

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,8 +1,8 @@
 # Table of contents
 
 * [Introduction](introduction.md)
-* [Install the Solana Tool Suite](install-solana.md)
 * [Command-line Guide](cli/README.md)
+  * [Install the Solana Tool Suite](install-solana.md)
   * [Choose a Wallet](cli/choose-a-wallet.md)
   * [Hardware Wallets](remote-wallet/README.md)
     * [Ledger Hardware Wallet](remote-wallet/ledger.md)


### PR DESCRIPTION
#### Problem

Per @danpaul000, we currently start using commad-line operations before the Command-line Guide section.

#### Summary of Changes

Move installation instructions into the command-line guide.
