### PR TITLE
Revert "Move Install Solana doc into the Command-line Guide"

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,8 +1,8 @@
 # Table of contents
 
 * [Introduction](introduction.md)
+* [Install the Solana Tool Suite](install-solana.md)
 * [Command-line Guide](cli/README.md)
-  * [Install the Solana Tool Suite](install-solana.md)
   * [Choose a Wallet](cli/choose-a-wallet.md)
   * [Hardware Wallets](remote-wallet/README.md)
     * [Ledger Hardware Wallet](remote-wallet/ledger.md)


### PR DESCRIPTION
Gitbook can't handle simple relative links...

Reverts solana-labs/solana#8982

cc https://github.com/solana-labs/solana/issues/8746