### PR TITLE
Distinguish account addresses from public keys

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2271,10 +2271,10 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(2)
-                        .value_name("RECIPIENT_PUBKEY")
+                        .value_name("RECIPIENT_ADDRESS")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help("The pubkey of airdrop recipient"),
+                        .help("The account address of airdrop recipient"),
                 ),
         )
         .subcommand(
@@ -2283,10 +2283,10 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help("The public key of the balance to check"),
+                        .help("The account address of the balance to check"),
                 )
                 .arg(
                     Arg::with_name("lamports")
@@ -2301,11 +2301,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("process_id")
                         .index(1)
-                        .value_name("PROCESS_PUBKEY")
+                        .value_name("ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
-                        .help("The process id of the transfer to cancel"),
+                        .help("The account address of the transfer to cancel"),
                 ),
         )
         .subcommand(
@@ -2334,7 +2334,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("program_id")
                         .index(2)
-                        .value_name("PROGRAM_PUBKEY")
+                        .value_name("PROGRAM_ID")
                         .takes_value(true)
                         .required(true)
                         .help(
@@ -2370,11 +2370,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("RECIPIENT_PUBKEY")
+                        .value_name("RECIPIENT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("The pubkey of recipient"),
+                        .help("The account address of recipient"),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -2439,19 +2439,19 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("RECIPIENT_PUBKEY")
+                        .value_name("RECIPIENT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
-                        .help("The pubkey of recipient"),
+                        .help("The account address of recipient"),
                 )
                 .arg(
                     Arg::with_name("process_id")
                         .index(2)
-                        .value_name("PROCESS_PUBKEY")
+                        .value_name("ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
-                        .help("The process id of the transfer to authorize"),
+                        .help("The account address of the transfer to authorize"),
                 ),
         )
         .subcommand(
@@ -2460,19 +2460,19 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("RECIPIENT_PUBKEY")
+                        .value_name("RECIPIENT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_pubkey)
-                        .help("The pubkey of recipient"),
+                        .help("The account address of recipient"),
                 )
                 .arg(
                     Arg::with_name("process_id")
                         .index(2)
-                        .value_name("PROCESS_PUBKEY")
+                        .value_name("ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
-                        .help("The process id of the transfer to unlock"),
+                        .help("The account address of the transfer to unlock"),
                 )
                 .arg(
                     Arg::with_name("datetime")
@@ -2488,11 +2488,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("to")
                         .index(1)
-                        .value_name("RECIPIENT_PUBKEY")
+                        .value_name("RECIPIENT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("The pubkey of recipient"),
+                        .help("The account address of recipient"),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -2523,7 +2523,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -94,7 +94,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("NONCE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -155,7 +155,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("NONCE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -168,7 +168,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("NONCE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -183,7 +183,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("NONCE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -202,7 +202,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("nonce_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("NONCE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -211,7 +211,7 @@ impl NonceSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("RECIPIENT_PUBKEY")
+                        .value_name("RECIPIENT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -160,7 +160,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -169,7 +169,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(2)
-                        .value_name("VOTE_PUBKEY")
+                        .value_name("VOTE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -187,7 +187,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -214,7 +214,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -241,7 +241,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -259,7 +259,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -302,7 +302,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -311,7 +311,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("RECIPIENT_PUBKEY")
+                        .value_name("RECIPIENT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -338,7 +338,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -390,7 +390,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("stake_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STAKE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -66,7 +66,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("node_account_pubkey")
                         .index(1)
-                        .value_name("NODE_PUBKEY")
+                        .value_name("NODE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -75,7 +75,7 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(2)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STORAGE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -89,11 +89,11 @@ impl StorageSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("storage_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("STORAGE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
-                        .help("Storage account pubkey"),
+                        .help("Storage account address"),
                 ),
         )
     }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -82,7 +82,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("VOTE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -104,7 +104,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("VOTE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -126,7 +126,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("VOTE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -166,7 +166,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("VOTE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -185,7 +185,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("vote_account_pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_PUBKEY")
+                        .value_name("VOTE_ACCOUNT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)
@@ -194,7 +194,7 @@ impl VoteSubCommands for App<'_, '_> {
                 .arg(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
-                        .value_name("RECIPIENT_PUBKEY")
+                        .value_name("RECIPIENT_ADDRESS")
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_pubkey)

--- a/docs/src/cli/transfer-tokens.md
+++ b/docs/src/cli/transfer-tokens.md
@@ -32,10 +32,10 @@ where you replace the text `<COMMAND>` with the name of the command you want
 to learn more about.
 
 The command's usage message will typically contain words such as `<AMOUNT>`,
-`<PUBKEY>` or `<KEYPAIR>`. Each word is a placeholder for the *type* of text
-you can execute the command with. For example, you can replace `<AMOUNT>`
-with a number such as `42` or `100.42`. You can replace `<PUBKEY>` with the
-base58 encoding of your public key. For `<KEYPAIR>`, it depends on what type
+`<ACCOUNT_ADDRESS>` or `<KEYPAIR>`. Each word is a placeholder for the *type* of
+text you can execute the command with. For example, you can replace `<AMOUNT>`
+with a number such as `42` or `100.42`. You can replace `<ACCOUNT_ADDRESS>` with
+the base58 encoding of your public key. For `<KEYPAIR>`, it depends on what type
 of wallet you chose. If you chose an fs wallet, that path might be
 `~/my-solana-wallet/my-keypair.json`.  If you chose a paper wallet, use the
 keyword `ASK`, and the Solana CLI will prompt you for your seed phrase. If
@@ -50,16 +50,17 @@ Try and *airdrop* yourself some play tokens on the developer testnet, called
 Devnet:
 
 ```bash
-solana airdrop 10 <RECIPIENT_PUBKEY> --url http://devnet.solana.com
+solana airdrop 10 <RECIPIENT_ACCOUNT_ADDRESS> --url http://devnet.solana.com
 ```
 
-where you replace the text `<RECIPIENT_PUBKEY>` with your base58 public key.
+where you replace the text `<RECIPIENT_ACCOUNT_ADDRESS>` with your base58-encoded
+public key.
 
 Confirm the airdrop was successful by checking the account's balance.
 It should output `10 SOL`:
 
 ```bash
-solana balance <ACCOUNT_PUBKEY> --url http://devnet.solana.com
+solana balance <ACCOUNT_ADDRESS> --url http://devnet.solana.com
 ```
 
 Next, prove that you own those tokens by transferring them. The Solana cluster
@@ -83,19 +84,19 @@ pubkey: GKvqsuNcnwWqPzzuhLmGi4rzzh55FhJtGizkhHaEJqiV
 ```
 
 ```bash
-solana transfer --keypair=<SENDER_KEYPAIR> <RECIPIENT_PUBKEY> 5 --url http://devnet.solana.com
+solana transfer --keypair=<SENDER_KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> 5 --url http://devnet.solana.com
 ```
 
 where you replace `<SENDER_KEYPAIR>` with the path to a keypair in your wallet,
-and replace `<RECIPIENT_PUBKEY>` with the output of `solana-keygen new` above.
+and replace `<RECIPIENT_ACCOUNT_ADDRESS>` with the output of `solana-keygen new` above.
 
 Confirm the updated balances with `solana balance`:
 
 ```bash
-solana balance <ACCOUNT_PUBKEY> --url http://devnet.solana.com
+solana balance <ACCOUNT_ADDRESS> --url http://devnet.solana.com
 ```
 
-where `<PUBKEY>` is either the public key from your keypair or the
+where `<ACCOUNT_ADDRESS>` is either the public key from your keypair or the
 recipient's public key.
 
 ## Send Tokens
@@ -106,11 +107,11 @@ tokens to transfer. Once you have that collected, you can transfer tokens
 with the `solana transfer` command:
 
 ```bash
-solana transfer --keypair=<SENDER_KEYPAIR> <RECIPIENT_PUBKEY> <AMOUNT>
+solana transfer --keypair=<SENDER_KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> <AMOUNT>
 ```
 
 Confirm the updated balances with `solana balance`:
 
 ```bash
-solana balance <ACCOUNT_PUBKEY>
+solana balance <ACCOUNT_ADDRESS>
 ```


### PR DESCRIPTION
#### Problem

Account addresses are sometimes public keys, sometimes derived addresses, sometimes a random string of bits (program IDs). Currently, the CLI calls them all public keys.

#### Summary of Changes

Add precision.