### PR TITLE
Add stake-account to docs

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1259,8 +1259,8 @@ pub fn process_stake_set_lockup(
 
 pub fn print_stake_state(stake_lamports: u64, stake_state: &StakeState, use_lamports_unit: bool) {
     fn show_authorized(authorized: &Authorized) {
-        println!("Authorized Staker: {}", authorized.staker);
-        println!("Authorized Withdrawer: {}", authorized.withdrawer);
+        println!("Stake Authority: {}", authorized.staker);
+        println!("Withdraw Authority: {}", authorized.withdrawer);
     }
     fn show_lockup(lockup: &Lockup) {
         println!(
@@ -1289,7 +1289,10 @@ pub fn print_stake_state(stake_lamports: u64, stake_state: &StakeState, use_lamp
                 build_balance_message(stake.delegation.stake, use_lamports_unit, true)
             );
             if stake.delegation.voter_pubkey != Pubkey::default() {
-                println!("Delegated Voter Pubkey: {}", stake.delegation.voter_pubkey);
+                println!(
+                    "Delegated Vote Account Address: {}",
+                    stake.delegation.voter_pubkey
+                );
             }
             println!(
                 "Stake activates starting from epoch: {}",

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,7 +10,7 @@
     * [Paper Wallet Usage](paper-wallet/usage.md)
   * [Generate Keys](cli/generate-keys.md)
   * [Send and Receive Tokens](cli/transfer-tokens.md)
-  * [Earn Staking Rewards](cli/delegate-stake.md)
+  * [Delegate Stake](cli/delegate-stake.md)
   * [Offline Signing](offline-signing/README.md)
     * [Durable Transaction Nonces](offline-signing/durable-nonce.md)
   * [Command-line Reference](cli/usage.md)

--- a/docs/src/cli/delegate-stake.md
+++ b/docs/src/cli/delegate-stake.md
@@ -1,4 +1,4 @@
-# Earn Staking Rewards
+# Delegate Stake
 
 After you have [received SOL](transfer-tokens.md), you might consider putting
 it to use by delegating *stake* to a validator. Stake is what we call tokens
@@ -42,6 +42,21 @@ stake account at the public key of stake-account.json.
 The stake-account.json file can now be discarded. To authorize additional
 actions, you will use the `--stake-authority` or `withdraw-authority` keypair,
 not stake-account.json.
+
+View the new stake account with the `solana stake-account` command:
+
+```bash
+solana stake-account <STAKE_ACCOUNT_ADDRESS>
+```
+
+The output will look similar to this:
+
+```text
+Total Stake: 5000 SOL
+Stake account is undelegated
+Stake Authority: EXU95vqs93yPeCeAU7mPPu6HbRUmTFPEiGug9oCdvQ5F
+Withdraw Authority: EXU95vqs93yPeCeAU7mPPu6HbRUmTFPEiGug9oCdvQ5F
+```
 
 ### Set Stake and Withdraw Authorities
 
@@ -113,6 +128,26 @@ solana delegate-stake --stake-authority=<KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <VOTE_
 `<KEYPAIR>` authorizes the operation on the account with address
 `<STAKE_ACCOUNT_ADDRESS>`. The stake is delegated to the vote account with
 address `<VOTE_ACCOUNT_ADDRESS>`.
+
+After delegating stake, use `solana stake-account` to observe the changes
+to the stake account:
+
+```bash
+solana stake-account <STAKE_ACCOUNT_ADDRESS>
+```
+
+You will see new fields "Delegated Stake" and "Delegated Vote Account Address"
+in the output. The output will look similar to this:
+
+```text
+Total Stake: 5000 SOL
+Credits Observed: 147462
+Delegated Stake: 4999.99771712 SOL
+Delegated Vote Account Address: CcaHc2L43ZWjwCHART3oZoJvHLAe9hzT2DJNUpBzoTN1
+Stake activates starting from epoch: 42
+Stake Authority: EXU95vqs93yPeCeAU7mPPu6HbRUmTFPEiGug9oCdvQ5F
+Withdraw Authority: EXU95vqs93yPeCeAU7mPPu6HbRUmTFPEiGug9oCdvQ5F
+```
 
 ## Deactivate Stake
 


### PR DESCRIPTION
#### Problem

Staking docs don't show how to observe the chain state after running commands.

#### Summary of Changes

* Add `solana stake-account` usage
* Change `solana stake-account` field naming to match CLI
* Rename title from "Earn Staking Rewards" to "Delegate Stake".  Save the CTAs for the website.
