### PR TITLE
Add slot info to Bank::get_signature_confirmation_status

### DIFF
--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -11,7 +11,9 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use solana_chacha_cuda::chacha_cuda::chacha_cbc_encrypt_file_many_keys;
 use solana_ledger::{bank_forks::BankForks, blockstore::Blockstore};
-use solana_runtime::{bank::Bank, storage_utils::archiver_accounts};
+use solana_runtime::{
+    bank::Bank, status_cache::SignatureConfirmationStatus, storage_utils::archiver_accounts,
+};
 use solana_sdk::{
     account::Account,
     account_utils::StateMut,
@@ -343,8 +345,13 @@ impl StorageStage {
                 .unwrap()
                 .working_bank()
                 .get_signature_confirmation_status(signature);
-            if let Some((confirmations, res)) = response {
-                if res.is_ok() {
+            if let Some(SignatureConfirmationStatus {
+                confirmations,
+                status,
+                ..
+            }) = response
+            {
+                if status.is_ok() {
                     if confirmed_blocks != confirmations {
                         now = Instant::now();
                         confirmed_blocks = confirmations;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -13,7 +13,7 @@ use crate::{
         deserialize_atomicbool, deserialize_atomicu64, serialize_atomicbool, serialize_atomicu64,
     },
     stakes::Stakes,
-    status_cache::{SlotDelta, StatusCache},
+    status_cache::{SignatureConfirmationStatus, SlotDelta, StatusCache},
     storage_utils,
     storage_utils::StorageAccounts,
     system_instruction_processor::{get_system_account_kind, SystemAccountKind},
@@ -1826,14 +1826,14 @@ impl Bank {
     pub fn get_signature_confirmation_status(
         &self,
         signature: &Signature,
-    ) -> Option<(usize, Result<()>)> {
+    ) -> Option<SignatureConfirmationStatus<Result<()>>> {
         let rcache = self.src.status_cache.read().unwrap();
         rcache.get_signature_status_slow(signature, &self.ancestors)
     }
 
     pub fn get_signature_status(&self, signature: &Signature) -> Option<Result<()>> {
         self.get_signature_confirmation_status(signature)
-            .map(|v| v.1)
+            .map(|v| v.status)
     }
 
     pub fn has_signature(&self, signature: &Signature) -> bool {

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -1,4 +1,4 @@
-use crate::bank::Bank;
+use crate::{bank::Bank, status_cache::SignatureConfirmationStatus};
 use solana_sdk::{
     account::Account,
     client::{AsyncClient, Client, SyncClient},
@@ -188,8 +188,13 @@ impl SyncClient for BankClient {
         let mut confirmed_blocks = 0;
         loop {
             let response = self.bank.get_signature_confirmation_status(signature);
-            if let Some((confirmations, res)) = response {
-                if res.is_ok() {
+            if let Some(SignatureConfirmationStatus {
+                confirmations,
+                status,
+                ..
+            }) = response
+            {
+                if status.is_ok() {
                     if confirmed_blocks != confirmations {
                         now = Instant::now();
                         confirmed_blocks = confirmations;

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -32,6 +32,13 @@ type SlotDeltaMap<T> = HashMap<Slot, SignatureStatus<T>>;
 // construct a new one. Usually derived from a status cache's `SlotDeltaMap`
 pub type SlotDelta<T> = (Slot, bool, SignatureStatus<T>);
 
+#[derive(Debug, PartialEq)]
+pub struct SignatureConfirmationStatus<T> {
+    pub slot: Slot,
+    pub confirmations: usize,
+    pub status: T,
+}
+
 #[derive(Clone, Debug)]
 pub struct StatusCache<T: Serialize + Clone> {
     cache: StatusMap<T>,
@@ -100,7 +107,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         &self,
         sig: &Signature,
         ancestors: &HashMap<Slot, usize>,
-    ) -> Option<(usize, T)> {
+    ) -> Option<SignatureConfirmationStatus<T>> {
         trace!("get_signature_status_slow");
         let mut keys = vec![];
         let mut val: Vec<_> = self.cache.iter().map(|(k, _)| *k).collect();
@@ -112,8 +119,18 @@ impl<T: Serialize + Clone> StatusCache<T> {
                 trace!("get_signature_status_slow: got {}", forkid);
                 return ancestors
                     .get(&forkid)
-                    .map(|id| (*id, res.clone()))
-                    .or_else(|| Some((ancestors.len(), res)));
+                    .map(|id| SignatureConfirmationStatus {
+                        slot: forkid,
+                        confirmations: *id,
+                        status: res.clone(),
+                    })
+                    .or_else(|| {
+                        Some(SignatureConfirmationStatus {
+                            slot: forkid,
+                            confirmations: ancestors.len(),
+                            status: res,
+                        })
+                    });
             }
         }
         None
@@ -272,7 +289,11 @@ mod tests {
         );
         assert_eq!(
             status_cache.get_signature_status_slow(&sig, &ancestors),
-            Some((1, ()))
+            Some(SignatureConfirmationStatus {
+                slot: 0,
+                confirmations: 1,
+                status: ()
+            })
         );
     }
 
@@ -317,7 +338,11 @@ mod tests {
         status_cache.add_root(0);
         assert_eq!(
             status_cache.get_signature_status_slow(&sig, &ancestors),
-            Some((ancestors.len(), ()))
+            Some(SignatureConfirmationStatus {
+                slot: 0,
+                confirmations: ancestors.len(),
+                status: ()
+            })
         );
     }
 


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/9002 depends on checking the slot for a particular signature confirmation status.

#### Summary of Changes
* Refactor `Bank::get_signature_confirmation_status` to return the slot which processed the signature's corresponding transaction.

Pulled out these changes from @CriesofCarrots PR: https://github.com/solana-labs/solana/pull/8823
