### PR TITLE
Remove thread-priority crate which is not cross-platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,6 +4495,7 @@ dependencies = [
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4511,7 +4512,6 @@ dependencies = [
  "solana-vote-program 1.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread-priority 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5359,14 +5359,6 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread-priority"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6676,7 +6668,6 @@ dependencies = [
 "checksum thiserror-impl 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a3ecbaa927a1d5a73d14a20af52463fa433c0727d07ef5e208f0546841d2efd"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-"checksum thread-priority 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52c084e908948709a7f7f6d44b5368e0134aa322e0e569431a92c989bf855188"
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4.8"
 memmap = "0.7.0"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
+num_cpus = "1.0.0"
 rand = "0.6.5"
 rayon = "1.3.0"
 serde = { version = "1.0.105", features = ["rc"] }
@@ -37,7 +38,6 @@ solana-storage-program = { path = "../programs/storage", version = "1.1.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.1.0" }
 tempfile = "3.1.0"
 thiserror = "1.0"
-thread-priority = "0.1.1"
 
 
 [lib]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -479,21 +479,9 @@ pub struct AccountsDB {
 }
 
 fn make_min_priority_thread_pool() -> ThreadPool {
-    use thread_priority::{
-        set_thread_priority, thread_native_id, NormalThreadSchedulePolicy, ThreadPriority,
-        ThreadSchedulePolicy,
-    };
-    let num_threads = get_thread_count();
+    // Use lower thread count to reduce priority.
+    let num_threads = std::cmp::max(2, num_cpus::get() / 4);
     rayon::ThreadPoolBuilder::new()
-        .start_handler(|_id| {
-            let thread_id = thread_native_id();
-            set_thread_priority(
-                thread_id,
-                ThreadPriority::Min,
-                ThreadSchedulePolicy::Normal(NormalThreadSchedulePolicy::Normal),
-            )
-            .unwrap();
-        })
         .thread_name(|i| format!("solana-accounts-cleanup-{}", i))
         .num_threads(num_threads)
         .build()


### PR DESCRIPTION
#### Problem

thread-priority crate not supported on mac/windows.

#### Summary of Changes

Remove usage, and use limited rayon thread count to reduce priority.

Fixes #
