### PR TITLE
Reduce shred size

### DIFF
--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -80,7 +80,14 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         let (stakes, shreds) = receiver.lock().unwrap().recv()?;
         let all_seeds: Vec<[u8; 32]> = shreds.iter().map(|s| s.seed()).collect();
         // Broadcast data
-        let all_shred_bufs: Vec<Vec<u8>> = shreds.to_vec().into_iter().map(|s| s.payload).collect();
+        let all_shred_bufs: Vec<Vec<u8>> = shreds
+            .to_vec()
+            .into_iter()
+            .map(|mut s| {
+                s.payload.resize(s.payload_size, 0);
+                s.payload
+            })
+            .collect();
         cluster_info
             .write()
             .unwrap()

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -261,7 +261,14 @@ impl StandardBroadcastRun {
 
         // Broadcast the shreds
         let broadcast_start = Instant::now();
-        let shred_bufs: Vec<Vec<u8>> = shreds.to_vec().into_iter().map(|s| s.payload).collect();
+        let shred_bufs: Vec<Vec<u8>> = shreds
+            .to_vec()
+            .into_iter()
+            .map(|mut s| {
+                s.payload.resize(s.payload_size, 0);
+                s.payload
+            })
+            .collect();
         trace!("Broadcasting {:?} shreds", shred_bufs.len());
 
         cluster_info

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -426,7 +426,7 @@ impl ServeRepair {
             let mut packet = Packet::default();
             packet.meta.size = data.len();
             packet.meta.set_addr(dest);
-            packet.data.copy_from_slice(&data);
+            packet.data[..data.len()].copy_from_slice(&data);
             packet
         }))
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -968,7 +968,10 @@ impl Blockstore {
 
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
-        write_batch.put_bytes::<cf::ShredCode>((slot, shred_index), &shred.payload)?;
+        write_batch.put_bytes::<cf::ShredCode>(
+            (slot, shred_index),
+            &shred.payload[..shred.payload_size],
+        )?;
         index_meta.coding_mut().set_present(shred_index, true);
 
         Ok(())
@@ -1072,7 +1075,8 @@ impl Blockstore {
 
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
-        write_batch.put_bytes::<cf::ShredData>((slot, index), &shred.payload)?;
+        write_batch
+            .put_bytes::<cf::ShredData>((slot, index), &shred.payload[..shred.payload_size])?;
         update_slot_meta(
             last_in_slot,
             last_in_data,


### PR DESCRIPTION
#### Problem

Shreds are always zero padded to 1300 bytes, which in an idle slot, can cause 3-4x the bandwidth and storage required.

#### Summary of Changes

Add a payload_size to shred meta to track the actual used size of the shred. Use that to store in blockstore and transfer over the network. Pad out the in-memory representation for erasure coding.

Fixes #8909 
