### PR TITLE
Swap index order in blockstore TransactionStatus column

### DIFF
--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -72,7 +72,7 @@ impl TransactionStatusService {
                 let fee = fee_calculator.calculate_fee(transaction.message());
                 blockstore
                     .write_transaction_status(
-                        (slot, transaction.signatures[0]),
+                        (transaction.signatures[0], slot),
                         &RpcTransactionStatusMeta {
                             status,
                             fee,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -109,7 +109,7 @@ fn output_slot(
                             println!("        Data: {:?}", instruction.data);
                         }
                     }
-                    match blockstore.read_transaction_status((slot, transaction.signatures[0])) {
+                    match blockstore.read_transaction_status((transaction.signatures[0], slot)) {
                         Ok(transaction_status) => {
                             if let Some(transaction_status) = transaction_status {
                                 println!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -320,9 +320,12 @@ impl Blockstore {
         // delete range cf is not inclusive
         let to_slot = to_slot.checked_add(1).unwrap_or_else(|| std::u64::MAX);
         let columns_empty = self
-            .db
-            .delete_range_cf::<cf::SlotMeta>(&mut write_batch, from_slot, to_slot)
+            .prune_transaction_status_cf_by_slot(&mut write_batch, from_slot, to_slot)
             .unwrap_or(false)
+            & self
+                .db
+                .delete_range_cf::<cf::SlotMeta>(&mut write_batch, from_slot, to_slot)
+                .unwrap_or(false)
             & self
                 .db
                 .delete_range_cf::<cf::Root>(&mut write_batch, from_slot, to_slot)
@@ -1511,6 +1514,30 @@ impl Blockstore {
         status: &RpcTransactionStatusMeta,
     ) -> Result<()> {
         self.transaction_status_cf.put(index, status)
+    }
+
+    fn prune_transaction_status_cf_by_slot(
+        &self,
+        batch: &mut WriteBatch,
+        from_slot: Slot,
+        to_slot: Slot,
+    ) -> Result<bool> {
+        let mut results: Vec<bool> = vec![];
+        for slot in from_slot..=to_slot {
+            let res = self
+                .get_slot_entries(slot, 0, None)?
+                .iter()
+                .cloned()
+                .flat_map(|entry| entry.transactions)
+                .map(|transaction| {
+                    batch
+                        .delete::<cf::TransactionStatus>((transaction.signatures[0], slot))
+                        .is_ok()
+                })
+                .all(|res| res);
+            results.push(res);
+        }
+        Ok(results.iter().all(|res| *res))
     }
 
     pub fn read_rewards(&self, index: Slot) -> Result<Option<RpcRewards>> {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -297,27 +297,27 @@ impl<T: SlotColumn> Column for T {
 }
 
 impl Column for columns::TransactionStatus {
-    type Index = (Slot, Signature);
+    type Index = (Signature, Slot);
 
-    fn key((slot, index): (Slot, Signature)) -> Vec<u8> {
+    fn key((signature, slot): (Signature, Slot)) -> Vec<u8> {
         let mut key = vec![0; 8 + 64];
-        BigEndian::write_u64(&mut key[..8], slot);
-        key[8..72].clone_from_slice(&index.as_ref()[0..64]);
+        key[..64].clone_from_slice(&signature.as_ref()[0..64]);
+        BigEndian::write_u64(&mut key[64..72], slot);
         key
     }
 
-    fn index(key: &[u8]) -> (Slot, Signature) {
-        let slot = BigEndian::read_u64(&key[..8]);
-        let index = Signature::new(&key[8..72]);
-        (slot, index)
+    fn index(key: &[u8]) -> (Signature, Slot) {
+        let signature = Signature::new(&key[0..64]);
+        let slot = BigEndian::read_u64(&key[64..72]);
+        (signature, slot)
     }
 
     fn slot(index: Self::Index) -> Slot {
-        index.0
+        index.1
     }
 
     fn as_index(slot: Slot) -> Self::Index {
-        (slot, Signature::default())
+        (Signature::default(), slot)
     }
 }
 


### PR DESCRIPTION
#### Problem
It is currently extremely expensive to find a transaction status in blockstore by signature, a thing that we would like to do to support our new rpc-based explorer. TransactionStatus is indexed by `(Slot, Signature)`. Without the slot number, the only approach is to search through all the slots and compare signatures.
It will be much more performant to swap the index to `(Signature, Slot)` so that status searches can jump to the right part of the column and then select an appropriate record. This requires a hand-rolled prune method, because the general `delete_range_cf` operates on column slot ranges.

#### Summary of Changes
- Swap index order on TransactionStatus column
- Add method to prune TransactionStatus by slot

This is a ledger ABI change, so will likely require an upgrade process (a conversion tool?) for existing ledgers

Required for #8823 