### PR TITLE
Swap index order in blockstore TransactionStatus column 

### DIFF
--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -72,7 +72,7 @@ impl TransactionStatusService {
                 let fee = fee_calculator.calculate_fee(transaction.message());
                 blockstore
                     .write_transaction_status(
-                        (slot, transaction.signatures[0]),
+                        (transaction.signatures[0], slot),
                         &TransactionStatusMeta {
                             status,
                             fee,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -145,7 +145,7 @@ fn output_slot(
                             println!("        Data: {:?}", instruction.data);
                         }
                     }
-                    match blockstore.read_transaction_status((slot, transaction.signatures[0])) {
+                    match blockstore.read_transaction_status((transaction.signatures[0], slot)) {
                         Ok(transaction_status) => {
                             if let Some(transaction_status) = transaction_status {
                                 println!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -363,10 +363,6 @@ impl Blockstore {
                 .unwrap_or(false)
             & self
                 .db
-                .delete_range_cf::<cf::TransactionStatus>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or(false)
-            & self
-                .db
                 .delete_range_cf::<cf::Rewards>(&mut write_batch, from_slot, to_slot)
                 .unwrap_or(false);
         if let Err(e) = self.db.write(write_batch) {
@@ -415,10 +411,6 @@ impl Blockstore {
                 .unwrap_or(false)
             && self
                 .index_cf
-                .compact_range(from_slot, to_slot)
-                .unwrap_or(false)
-            && self
-                .transaction_status_cf
                 .compact_range(from_slot, to_slot)
                 .unwrap_or(false)
             && self

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1530,7 +1530,7 @@ impl Blockstore {
         to_slot: Slot,
     ) -> Result<bool> {
         let mut results: Vec<bool> = vec![];
-        for slot in from_slot..=to_slot {
+        for slot in from_slot..to_slot {
             let res = self
                 .get_slot_entries(slot, 0, None)?
                 .iter()
@@ -4589,6 +4589,93 @@ pub mod tests {
 
         drop(blockstore);
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
+    }
+
+    #[test]
+    fn test_prune_transaction_status() {
+        let slot = 5;
+        let entries_batch0 = make_slot_entries_with_transactions(5);
+        let entries_batch1 = make_slot_entries_with_transactions(5);
+        let shreds = entries_to_test_shreds(entries_batch0.clone(), slot, slot - 1, true, 0);
+        let more_shreds = entries_to_test_shreds(entries_batch1.clone(), slot + 1, slot, true, 0);
+        let ledger_path = get_tmp_ledger_path!();
+        let ledger = Blockstore::open(&ledger_path).unwrap();
+        ledger.insert_shreds(shreds, None, false).unwrap();
+        ledger.insert_shreds(more_shreds, None, false).unwrap();
+        ledger.set_roots(&[slot - 1, slot, slot + 1]).unwrap();
+
+        let signatures_batch0: Vec<Signature> = entries_batch0
+            .iter()
+            .cloned()
+            .filter(|entry| !entry.is_tick())
+            .flat_map(|entry| entry.transactions)
+            .map(|transaction| {
+                let mut pre_balances: Vec<u64> = vec![];
+                let mut post_balances: Vec<u64> = vec![];
+                for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
+                    pre_balances.push(i as u64 * 10);
+                    post_balances.push(i as u64 * 11);
+                }
+                let signature = transaction.signatures[0];
+                ledger
+                    .transaction_status_cf
+                    .put(
+                        (signature, slot),
+                        &TransactionStatusMeta {
+                            status: Ok(()),
+                            fee: 42,
+                            pre_balances: pre_balances.clone(),
+                            post_balances: post_balances.clone(),
+                        },
+                    )
+                    .unwrap();
+                signature
+            })
+            .collect();
+
+        let signatures_batch1: Vec<Signature> = entries_batch1
+            .iter()
+            .cloned()
+            .filter(|entry| !entry.is_tick())
+            .flat_map(|entry| entry.transactions)
+            .map(|transaction| {
+                let mut pre_balances: Vec<u64> = vec![];
+                let mut post_balances: Vec<u64> = vec![];
+                for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
+                    pre_balances.push(i as u64 * 10);
+                    post_balances.push(i as u64 * 11);
+                }
+                let signature = transaction.signatures[0];
+                ledger
+                    .transaction_status_cf
+                    .put(
+                        (signature, slot + 1),
+                        &TransactionStatusMeta {
+                            status: Ok(()),
+                            fee: 42,
+                            pre_balances: pre_balances.clone(),
+                            post_balances: post_balances.clone(),
+                        },
+                    )
+                    .unwrap();
+                signature
+            })
+            .collect();
+
+        ledger.purge_slots(0, Some(slot));
+
+        for signature in signatures_batch0.into_iter() {
+            assert!(ledger
+                .read_transaction_status((signature, slot))
+                .unwrap()
+                .is_none());
+        }
+        for signature in signatures_batch1.into_iter() {
+            assert!(ledger
+                .read_transaction_status((signature, slot + 1))
+                .unwrap()
+                .is_some());
+        }
     }
 
     #[test]

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -297,27 +297,27 @@ impl<T: SlotColumn> Column for T {
 }
 
 impl Column for columns::TransactionStatus {
-    type Index = (Slot, Signature);
+    type Index = (Signature, Slot);
 
-    fn key((slot, index): (Slot, Signature)) -> Vec<u8> {
+    fn key((signature, slot): (Signature, Slot)) -> Vec<u8> {
         let mut key = vec![0; 8 + 64];
-        BigEndian::write_u64(&mut key[..8], slot);
-        key[8..72].clone_from_slice(&index.as_ref()[0..64]);
+        key[..64].clone_from_slice(&signature.as_ref()[0..64]);
+        BigEndian::write_u64(&mut key[64..72], slot);
         key
     }
 
-    fn index(key: &[u8]) -> (Slot, Signature) {
-        let slot = BigEndian::read_u64(&key[..8]);
-        let index = Signature::new(&key[8..72]);
-        (slot, index)
+    fn index(key: &[u8]) -> (Signature, Slot) {
+        let signature = Signature::new(&key[0..64]);
+        let slot = BigEndian::read_u64(&key[64..72]);
+        (signature, slot)
     }
 
     fn slot(index: Self::Index) -> Slot {
-        index.0
+        index.1
     }
 
     fn as_index(slot: Slot) -> Self::Index {
-        (slot, Signature::default())
+        (Signature::default(), slot)
     }
 }
 


### PR DESCRIPTION
#### Problem
It is currently extremely expensive to find a transaction status in blockstore by signature, a thing that we would like to do to support our new rpc-based explorer. TransactionStatus is indexed by `(Slot, Signature)`. Without the slot number, the only approach is to search through all the slots and compare signatures.
It will be much more performant to swap the index to `(Signature, Slot)` so that status searches can jump to the right part of the column and then select an appropriate record. This requires a hand-rolled prune method, because the general `delete_range_cf` operates on column slot ranges.

#### Summary of Changes
- Swap index order on TransactionStatus column
- Add method to prune TransactionStatus by slot

This is a ledger ABI change, so will likely require an upgrade process (a conversion tool?) for existing ledgers

Required for #8823 