### PR TITLE
Fix solana-install-init.sh for Windows

### DIFF
--- a/install/solana-install-init.sh
+++ b/install/solana-install-init.sh
@@ -70,7 +70,11 @@ main() {
       TARGET=x86_64-apple-darwin
       ;;
     *)
-      err "machine architecture is currently unsupported"
+      if [[ -n "$(systeminfo)" ]]; then # LOL, windows
+        TARGET=x86_64-pc-windows-gnu.exe
+      else
+        err "machine architecture is currently unsupported"
+      fi
       ;;
     esac
 


### PR DESCRIPTION
#### Problem
Can't do one-line install to a Windows machine like we can for Mac/Linux

#### Summary of Changes
Make it so.
