### PR TITLE
Return appropriate error for invalid program account

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -230,9 +230,9 @@ impl Accounts {
                     return Err(TransactionError::ProgramAccountNotFound);
                 }
             };
-            if !program.executable || program.owner == Pubkey::default() {
-                error_counters.account_not_found += 1;
-                return Err(TransactionError::AccountNotFound);
+            if !program.executable {
+                error_counters.invalid_program_for_execution += 1;
+                return Err(TransactionError::InvalidProgramForExecution);
             }
 
             // add loader to chain
@@ -1154,12 +1154,12 @@ mod tests {
 
         let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
 
-        assert_eq!(error_counters.account_not_found, 1);
+        assert_eq!(error_counters.invalid_program_for_execution, 1);
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0],
             (
-                Err(TransactionError::AccountNotFound),
+                Err(TransactionError::InvalidProgramForExecution),
                 Some(HashAgeKind::Extant)
             )
         );
@@ -1197,7 +1197,7 @@ mod tests {
         assert_eq!(
             loaded_accounts[0],
             (
-                Err(TransactionError::AccountNotFound),
+                Err(TransactionError::ProgramAccountNotFound),
                 Some(HashAgeKind::Extant)
             )
         );
@@ -1229,12 +1229,12 @@ mod tests {
 
         let loaded_accounts = load_accounts(tx, &accounts, &mut error_counters);
 
-        assert_eq!(error_counters.account_not_found, 1);
+        assert_eq!(error_counters.invalid_program_for_execution, 1);
         assert_eq!(loaded_accounts.len(), 1);
         assert_eq!(
             loaded_accounts[0],
             (
-                Err(TransactionError::AccountNotFound),
+                Err(TransactionError::InvalidProgramForExecution),
                 Some(HashAgeKind::Extant)
             )
         );

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -77,6 +77,7 @@ pub struct ErrorCounters {
     pub insufficient_funds: usize,
     pub invalid_account_for_fee: usize,
     pub invalid_account_index: usize,
+    pub invalid_program_for_execution: usize,
 }
 
 #[derive(Default, Debug, PartialEq, Clone)]

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -30,6 +30,9 @@ pub enum TransactionError {
     /// Attempt to load a program that does not exist
     ProgramAccountNotFound,
 
+    /// This program may not be used for executing instructions
+    InvalidProgramForExecution,
+
     /// The from `Pubkey` does not have sufficient balance to pay the fee to schedule the transaction
     InsufficientFundsForFee,
 

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -30,9 +30,6 @@ pub enum TransactionError {
     /// Attempt to load a program that does not exist
     ProgramAccountNotFound,
 
-    /// This program may not be used for executing instructions
-    InvalidProgramForExecution,
-
     /// The from `Pubkey` does not have sufficient balance to pay the fee to schedule the transaction
     InsufficientFundsForFee,
 
@@ -63,6 +60,9 @@ pub enum TransactionError {
 
     /// Transaction did not pass signature verification
     SignatureFailure,
+
+    /// This program may not be used for executing instructions
+    InvalidProgramForExecution,
 }
 
 pub type Result<T> = result::Result<T, TransactionError>;


### PR DESCRIPTION
#### Problem
Invalid loaded program accounts will result in a `AccountNotFound` error which is not relevant.

#### Summary of Changes
* Update to `ProgramAccountNotFound`

Fixes #
