### PR TITLE
Fix xargo to version 0.3.19 to avoid unstable feature

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -25,6 +25,7 @@ download() {
 # Install or upgrade xargo
 (
   cargo install cargo-update
+  cargo install-update-config --version =0.3.19 xargo
   set -e
   cargo install-update -i xargo
   xargo --version > xargo.md 2>&1


### PR DESCRIPTION
#### Problem
xargo 0.3.20 install is failing on CI

#### Summary of Changes
Fix xargo version to 0.3.19 until CI issue is resolved

Fixes #
