### PR TITLE
Install xargo using CI dictated cargo version if available

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -38,6 +38,7 @@ export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
     declare toolchain=$1
     if ! cargo +"$toolchain" -V; then
       rustup install "$toolchain"
+      rustup default "$toolchain"
       cargo +"$toolchain" -V
     fi
   }

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -22,16 +22,10 @@ download() {
   wget "${args[@]}"
 }
 
-# Install or upgrade xargo
+# Install xargo
 (
-  # cargo install cargo-update
-  # cargo install-update-config -a xargo
-  set -x
-  # cargo install-update -i xargo
-  env
-  cargo --version
-  rustup toolchain list
-  cargo install -f xargo
+  set -ex
+  cargo +"$rust_stable" install xargo
   xargo --version > xargo.md 2>&1
 )
 # shellcheck disable=SC2181

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -28,7 +28,9 @@ download() {
   # cargo install-update-config -a xargo
   set -x
   # cargo install-update -i xargo
+  env
   cargo --version
+  rustup toolchain list
   cargo install -f xargo
   xargo --version > xargo.md 2>&1
 )

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -26,7 +26,7 @@ download() {
 (
   # cargo install cargo-update
   # cargo install-update-config -a xargo
-  # set -e
+  set -e
   # cargo install-update -i xargo
   cargo install -f xargo
   xargo --version > xargo.md 2>&1

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -26,7 +26,7 @@ download() {
 (
   # cargo install cargo-update
   # cargo install-update-config -a xargo
-  set -e
+  set -ex
   # cargo install-update -i xargo
   cargo install -f xargo
   xargo --version > xargo.md 2>&1

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -25,7 +25,11 @@ download() {
 # Install xargo
 (
   set -ex
-  cargo +"${rust_stable:-}" install xargo
+  if [[ -n $rust_stable ]]; then
+    cargo +"$rust_stable" install xargo
+  else
+    cargo install xargo
+  fi
   xargo --version > xargo.md 2>&1
 )
 # shellcheck disable=SC2181

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -24,10 +24,11 @@ download() {
 
 # Install or upgrade xargo
 (
-  cargo install cargo-update
-  cargo install-update-config -a xargo
-  set -e
-  cargo install-update -i xargo
+  # cargo install cargo-update
+  # cargo install-update-config -a xargo
+  # set -e
+  # cargo install-update -i xargo
+  cargo install -f xargo
   xargo --version > xargo.md 2>&1
 )
 # shellcheck disable=SC2181

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -26,8 +26,9 @@ download() {
 (
   # cargo install cargo-update
   # cargo install-update-config -a xargo
-  set -ex
+  set -x
   # cargo install-update -i xargo
+  cargo --version
   cargo install -f xargo
   xargo --version > xargo.md 2>&1
 )

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -25,7 +25,7 @@ download() {
 # Install or upgrade xargo
 (
   cargo install cargo-update
-  cargo install-update-config --version =0.3.19 xargo
+  # cargo install-update-config --version =0.3.19 xargo
   set -e
   cargo install-update -i xargo
   xargo --version > xargo.md 2>&1

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -25,7 +25,7 @@ download() {
 # Install xargo
 (
   set -ex
-  cargo +"$rust_stable" install xargo
+  cargo +"${rust_stable:-}" install xargo
   xargo --version > xargo.md 2>&1
 )
 # shellcheck disable=SC2181

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -25,7 +25,7 @@ download() {
 # Install or upgrade xargo
 (
   cargo install cargo-update
-  # cargo install-update-config --version =0.3.19 xargo
+  cargo install-update-config -a xargo
   set -e
   cargo install-update -i xargo
   xargo --version > xargo.md 2>&1

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -25,11 +25,7 @@ download() {
 # Install xargo
 (
   set -ex
-  if [[ -n $rust_stable ]]; then
-    cargo +"$rust_stable" install xargo
-  else
-    cargo install xargo
-  fi
+  cargo +"${rust_stable:-}" install xargo
   xargo --version > xargo.md 2>&1
 )
 # shellcheck disable=SC2181


### PR DESCRIPTION
#### Problem

The SDK install script attempts to install xargo which is required to build Rust BPF programs.  The script uses whatever version of cargo is installed on the host machine to do so.  in CI the version of cargo is always explicit and the machine's default toolchain is not updated, consequently the CI machines default version is very old.  This old version does not support installing the latest version of xargo.

#### Summary of Changes

* Use the CI version of cargo if the CI defined cargo version environment variable is defined (`rust_stable`.
* `cargo install` now installs the latest version of a package so remove the use of `cargo install-update`

Fixes #
