### PR TITLE
Consolidate signature-status rpcs

### DIFF
--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -101,7 +101,11 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                 let status = if self.url == "sig_not_found" {
                     None
                 } else {
-                    Some(TransactionStatus { status, slot: 1 })
+                    Some(TransactionStatus {
+                        status,
+                        slot: 1,
+                        confirmations: Some(0),
+                    })
                 };
                 serde_json::to_value(vec![status])?
             }

--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -107,7 +107,10 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                         confirmations: Some(0),
                     })
                 };
-                serde_json::to_value(vec![status])?
+                serde_json::to_value(Response {
+                    context: RpcResponseContext { slot: 1 },
+                    value: vec![status],
+                })?
             }
             RpcRequest::GetTransactionCount => Value::Number(Number::from(1234)),
             RpcRequest::GetSlot => Value::Number(Number::from(0)),

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -120,9 +120,11 @@ impl RpcClient {
             json!([[signature.to_string()], commitment_config]),
             5,
         )?;
-        let result: Vec<Option<TransactionStatus>> =
+        let result: Response<Vec<Option<TransactionStatus>>> =
             serde_json::from_value(signature_status).unwrap();
-        Ok(result[0].clone().map(|status_meta| status_meta.status))
+        Ok(result.value[0]
+            .clone()
+            .map(|status_meta| status_meta.status))
     }
 
     pub fn get_slot(&self) -> ClientResult<Slot> {
@@ -949,9 +951,10 @@ impl RpcClient {
                 1,
             )
             .map_err(|err| err.into_with_command("GetSignatureStatus"))?;
-        let result: Vec<Option<TransactionStatus>> = serde_json::from_value(response).unwrap();
+        let result: Response<Vec<Option<TransactionStatus>>> =
+            serde_json::from_value(response).unwrap();
 
-        let confirmations = result[0]
+        let confirmations = result.value[0]
             .clone()
             .ok_or_else(|| {
                 ClientError::new_with_command(

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -963,7 +963,7 @@ impl RpcClient {
                 )
             })?
             .confirmations
-            .unwrap_or(32);
+            .unwrap_or(MAX_LOCKOUT_HISTORY + 1);
         Ok(confirmations)
     }
 

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -18,7 +18,6 @@ pub enum RpcRequest {
     GetIdentity,
     GetInflation,
     GetLeaderSchedule,
-    GetNumBlocksSinceSignatureConfirmation,
     GetProgramAccounts,
     GetRecentBlockhash,
     GetFeeCalculatorForBlockhash,
@@ -61,9 +60,6 @@ impl RpcRequest {
             RpcRequest::GetIdentity => "getIdentity",
             RpcRequest::GetInflation => "getInflation",
             RpcRequest::GetLeaderSchedule => "getLeaderSchedule",
-            RpcRequest::GetNumBlocksSinceSignatureConfirmation => {
-                "getNumBlocksSinceSignatureConfirmation"
-            }
             RpcRequest::GetProgramAccounts => "getProgramAccounts",
             RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
             RpcRequest::GetFeeCalculatorForBlockhash => "getFeeCalculatorForBlockhash",

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -642,14 +642,6 @@ pub trait RpcSol {
     #[rpc(meta, name = "validatorExit")]
     fn validator_exit(&self, meta: Self::Metadata) -> Result<bool>;
 
-    #[rpc(meta, name = "getNumBlocksSinceSignatureConfirmation")]
-    fn get_num_blocks_since_signature_confirmation(
-        &self,
-        meta: Self::Metadata,
-        signature_str: String,
-        commitment: Option<CommitmentConfig>,
-    ) -> Result<Option<usize>>;
-
     #[rpc(meta, name = "getSignatureConfirmation")]
     fn get_signature_confirmation(
         &self,
@@ -934,16 +926,6 @@ impl RpcSol for RpcSolImpl {
 
     fn get_slot(&self, meta: Self::Metadata, commitment: Option<CommitmentConfig>) -> Result<u64> {
         meta.request_processor.read().unwrap().get_slot(commitment)
-    }
-
-    fn get_num_blocks_since_signature_confirmation(
-        &self,
-        meta: Self::Metadata,
-        signature_str: String,
-        commitment: Option<CommitmentConfig>,
-    ) -> Result<Option<usize>> {
-        self.get_signature_confirmation(meta, signature_str, commitment)
-            .map(|res| res.map(|x| x.confirmations))
     }
 
     fn get_signature_confirmation(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -417,7 +417,7 @@ impl JsonRpcRequestProcessor {
                  }| TransactionStatus {
                     slot,
                     status,
-                    confirmations: if confirmations < MAX_LOCKOUT_HISTORY {
+                    confirmations: if confirmations <= MAX_LOCKOUT_HISTORY {
                         Some(confirmations)
                     } else {
                         None

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -429,9 +429,18 @@ impl JsonRpcRequestProcessor {
 
         for signature in signatures {
             let status = bank.get_signature_confirmation_status(&signature).map(
-                |SignatureConfirmationStatus { slot, status, .. }| TransactionStatus {
+                |SignatureConfirmationStatus {
+                     slot,
+                     status,
+                     confirmations,
+                 }| TransactionStatus {
                     slot,
                     status,
+                    confirmations: if confirmations <= 32 {
+                        Some(confirmations)
+                    } else {
+                        None
+                    },
                 },
             );
             statuses.push(status);

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -33,7 +33,6 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getMinimumBalanceForRentExemption](jsonrpc-api.md#getminimumbalanceforrentexemption)
 * [getProgramAccounts](jsonrpc-api.md#getprogramaccounts)
 * [getRecentBlockhash](jsonrpc-api.md#getrecentblockhash)
-* [getSignatureConfirmation](jsonrpc-api.md#getsignatureconfirmation)
 * [getSignatureStatus](jsonrpc-api.md#getsignaturestatus)
 * [getSlot](jsonrpc-api.md#getslot)
 * [getSlotLeader](jsonrpc-api.md#getslotleader)
@@ -634,33 +633,6 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"blockhash":"CSymwgTNX1j3E4qhKfJAUE41nBWEwXufoYryPbkde5RR","feeCalculator":{"burnPercent":50,"lamportsPerSignature":5000,"maxLamportsPerSignature":100000,"minLamportsPerSignature":5000,"targetLamportsPerSignature":10000,"targetSignaturesPerSlot":20000}}},"id":1}
-```
-
-### getSignatureConfirmation
-
-Returns the status and number of confirmations of a given signature.
-#### Parameters:
-
-* `<string>` - Signature of Transaction to confirm, as base-58 encoded string
-* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
-
-#### Results:
-
-* `<null>` - Unknown transaction
-* `<object>` - Transaction confirmations and status:
-  * `confirmations: <u64>` - count of confirmations since transaction was processed
-  * `status: <object>` -
-    * `"Ok": <null>` - Transaction was successful
-    * `"Err": <ERR>` - Transaction failed with TransactionError  [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
-
-#### Example:
-
-```bash
-// Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureConfirmation", "params":["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"]}' http://localhost:8899
-
-// Result
-{"jsonrpc":"2.0","result":{"confirmations":12,"status":{"Ok": null}},"id":1}
 ```
 
 ### getSignatureStatus

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -648,11 +648,16 @@ Returns the status of a given signature. This method is similar to [confirmTrans
 
 #### Results:
 
+An RpcResponse containing a JSON object consisting of an array of TransactionStatus objects.
+
+* `RpcResponse<object>` - RpcResponse JSON object with `value` field:
+
 An array of:
 
 * `<null>` - Unknown transaction
 * `<object>`
   * `slot: <u64>` - The slot the transaction was processed
+  * `confirmations: <usize>` - Number of blocks since signature confirmation
   * `status: <object>` - Transaction status
     * `"Ok": <null>` - Transaction was successful
     * `"Err": <ERR>` - Transaction failed with TransactionError  [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
@@ -664,7 +669,7 @@ An array of:
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatus", "params":[["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW", "5j7s6NiJS3JAkvgkoc18WVAsiSaci2pxB2A6ueCJP4tprA2TFg9wSyTLeYouxPBJEMzJinENTkpA52YStRW5Dia7"]]]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":[{"slot": 72, "status": {"Ok": null}}, null],"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":82},"value":[{"slot": 72, "confirmations": 10, "status": {"Ok": null}}, null]},"id":1}
 ```
 
 ### getSlot

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -31,7 +31,6 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getInflation](jsonrpc-api.md#getinflation)
 * [getLeaderSchedule](jsonrpc-api.md#getleaderschedule)
 * [getMinimumBalanceForRentExemption](jsonrpc-api.md#getminimumbalanceforrentexemption)
-* [getNumBlocksSinceSignatureConfirmation](jsonrpc-api.md#getnumblockssincesignatureconfirmation)
 * [getProgramAccounts](jsonrpc-api.md#getprogramaccounts)
 * [getRecentBlockhash](jsonrpc-api.md#getrecentblockhash)
 * [getSignatureConfirmation](jsonrpc-api.md#getsignatureconfirmation)
@@ -578,29 +577,6 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 
 // Result
 {"jsonrpc":"2.0","result":500,"id":1}
-```
-
-### getNumBlocksSinceSignatureConfirmation
-
-Returns the current number of blocks since signature has been confirmed.
-
-#### Parameters:
-
-* `<string>` - Signature of Transaction to confirm, as base-58 encoded string
-* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
-
-#### Results:
-
-* `<u64>` - count, or null if signature not found
-
-#### Example:
-
-```bash
-// Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getNumBlocksSinceSignatureConfirmation", "params":["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"]}' http://localhost:8899
-
-// Result
-{"jsonrpc":"2.0","result":8,"id":1}
 ```
 
 ### getProgramAccounts

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -657,7 +657,7 @@ An array of:
 * `<null>` - Unknown transaction
 * `<object>`
   * `slot: <u64>` - The slot the transaction was processed
-  * `confirmations: <usize>` - Number of blocks since signature confirmation
+  * `confirmations: <usize | null>` - Number of blocks since signature confirmation, null if rooted
   * `status: <object>` - Transaction status
     * `"Ok": <null>` - Transaction was successful
     * `"Err": <ERR>` - Transaction failed with TransactionError  [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
@@ -670,6 +670,9 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 
 // Result
 {"jsonrpc":"2.0","result":{"context":{"slot":82},"value":[{"slot": 72, "confirmations": 10, "status": {"Ok": null}}, null]},"id":1}
+
+// Result, first transaction rooted
+{"jsonrpc":"2.0","result":{"context":{"slot":82},"value":[{"slot": 48, "confirmations": null, "status": {"Ok": null}}, null]},"id":1}
 ```
 
 ### getSlot

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -30,6 +30,7 @@ pub struct TransactionStatusMeta {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionStatus {
     pub slot: Slot,
+    pub confirmations: Option<usize>,
     pub status: Result<()>,
 }
 


### PR DESCRIPTION
#### Problem
Multiple signature-status rpc methods exist, which is not very friendly for developers. One method will do.

#### Summary of Changes
- Update `getSignatureStatus` to return number of blocks since signature confirmation (already calling this information; request processor was stripping it out before returning the json reponse)
- Remove `getSignatureConfirmation` and `getNumBlocksSinceSignatureConfirmation` rpcs. Update rpc-client to call `getSignatureStatus` for number of blocks since signature confirmation
