### PR TITLE
Unflake rpc subscriptions test by reducing sub count

### DIFF
--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -212,7 +212,7 @@ fn test_rpc_subscriptions() {
 
     // Create transaction signatures to subscribe to
     let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    let transactions: Vec<Transaction> = (0..500)
+    let transactions: Vec<Transaction> = (0..100)
         .map(|_| system_transaction::transfer(&alice, &Pubkey::new_rand(), 1, genesis_hash))
         .collect();
     let mut signature_set: HashSet<String> = transactions


### PR DESCRIPTION
#### Problem
test_rpc_subscriptions is flaky in CI

#### Summary of Changes
Reduce subscriptions count to ensure the test doesn't time out in CI

Fixes #
