### PR TITLE
process_blockstore_from_root(): Log how much data the ledger holds before processing it

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -433,7 +433,7 @@ impl Blockstore {
     pub fn slot_meta_iterator<'a>(
         &'a self,
         slot: Slot,
-    ) -> Result<impl Iterator<Item = (u64, SlotMeta)> + 'a> {
+    ) -> Result<impl Iterator<Item = (Slot, SlotMeta)> + 'a> {
         let meta_iter = self
             .db
             .iter::<cf::SlotMeta>(IteratorMode::From(slot, IteratorDirection::Forward))?;

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -310,7 +310,7 @@ pub fn process_blockstore_from_root(
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
 ) -> BlockstoreProcessorResult {
-    info!("processing ledger from root slot {}...", bank.slot());
+    info!("processing ledger from slot {}...", bank.slot());
     let allocated = thread_mem_usage::Allocatedp::default();
     let initial_allocation = allocated.get();
 
@@ -344,6 +344,12 @@ pub fn process_blockstore_from_root(
     blockstore
         .set_roots(&[start_slot])
         .expect("Couldn't set root slot on startup");
+
+    if let Ok(metas) = blockstore.slot_meta_iterator(start_slot) {
+        if let Some((slot, _meta)) = metas.last() {
+            info!("ledger holds data through slot {}", slot);
+        }
+    }
 
     let meta = blockstore.meta(start_slot).unwrap();
 


### PR DESCRIPTION
Just a little nicety to figure what kind of wait you might be looking at