### PR TITLE
Bump rBPF to v0.1.24, update rBPF/BPF Loader error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,7 +3740,7 @@ dependencies = [
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 1.1.0",
  "solana-sdk 1.1.0",
- "solana_rbpf 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5075,6 +5075,7 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6635,7 +6636,7 @@ dependencies = [
 "checksum solana_libra_vm_cache_map 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "37fa2e1f00a87514cd2169149a5f81a89279703b2523979688d6ef84081a4690"
 "checksum solana_libra_vm_runtime 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "ff9f8a7b8212dc4ece5d93f2839896e633c34d7463856e4a555cbcb5c67e9c26"
 "checksum solana_libra_vm_runtime_types 0.0.1-sol4 (registry+https://github.com/rust-lang/crates.io-index)" = "254c23c8f30e7c82ae4dc6694e743400d674c66d371b700eec03378ba994f00b"
-"checksum solana_rbpf 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "832c41d1f4184a9554c41aa29dbeb0d5f8873d72cf2be32411668bc5f047a150"
+"checksum solana_rbpf 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "3e73fe3cf1da0881709bf32e9a22d4894ce5fa317c9a6284c2b5d8c25be000b8"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-logger 1.1.0",
  "solana-sdk 1.1.0",
- "solana_rbpf 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1751,7 +1751,7 @@ dependencies = [
  "solana-logger 1.1.0",
  "solana-runtime 1.1.0",
  "solana-sdk 1.1.0",
- "solana_rbpf 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2101,6 +2101,7 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2962,7 +2963,7 @@ dependencies = [
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
-"checksum solana_rbpf 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "832c41d1f4184a9554c41aa29dbeb0d5f8873d72cf2be32411668bc5f047a150"
+"checksum solana_rbpf 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "3e73fe3cf1da0881709bf32e9a22d4894ce5fa317c9a6284c2b5d8c25be000b8"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -26,7 +26,7 @@ solana-bpf-loader-program = { path = "../bpf_loader", version = "1.1.0" }
 solana-logger = { path = "../../logger", version = "1.1.0" }
 solana-runtime = { path = "../../runtime", version = "1.1.0" }
 solana-sdk = { path = "../../sdk", version = "1.1.0" }
-solana_rbpf = "=0.1.23"
+solana_rbpf = "=0.1.24"
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -3,8 +3,8 @@
 extern crate test;
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
-use solana_rbpf::EbpfVm;
-use std::{env, fs::File, io::Error, io::Read, mem, path::PathBuf};
+use solana_rbpf::{EbpfVm};
+use std::{env, fs::File, io::Read, mem, path::PathBuf};
 use test::Bencher;
 
 /// BPF program file extension
@@ -21,7 +21,7 @@ fn create_bpf_path(name: &str) -> PathBuf {
     pathbuf
 }
 
-fn empty_check(_prog: &[u8]) -> Result<(), Error> {
+fn empty_check(_prog: &[u8]) -> Result<(), solana_bpf_loader_program::BPFError> {
     Ok(())
 }
 
@@ -39,7 +39,7 @@ const ARMSTRONG_EXPECTED: u64 = 5;
 #[bench]
 fn bench_program_load_elf(bencher: &mut Bencher) {
     let elf = load_elf().unwrap();
-    let mut vm = EbpfVm::new(None).unwrap();
+    let mut vm = EbpfVm::<solana_bpf_loader_program::BPFError>::new(None).unwrap();
     vm.set_verifier(empty_check).unwrap();
 
     bencher.iter(|| {
@@ -50,7 +50,7 @@ fn bench_program_load_elf(bencher: &mut Bencher) {
 #[bench]
 fn bench_program_verify(bencher: &mut Bencher) {
     let elf = load_elf().unwrap();
-    let mut vm = EbpfVm::new(None).unwrap();
+    let mut vm = EbpfVm::<solana_bpf_loader_program::BPFError>::new(None).unwrap();
     vm.set_verifier(empty_check).unwrap();
     vm.set_elf(&elf).unwrap();
 

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -17,7 +17,7 @@ num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
 solana-logger = { path = "../../logger", version = "1.1.0" }
 solana-sdk = { path = "../../sdk", version = "1.1.0" }
-solana_rbpf = "=0.1.23"
+solana_rbpf = "=0.1.24"
 thiserror = "1.0"
 
 [lib]


### PR DESCRIPTION
#### Problem

rBPF VM Helpers (trap calls) are provided to the VM by the caller (in this case the BPF Loader) and are forced to return `std::io::Error` which means they return strings.  Strings are not very good at returning more complex errors.  As the trap calls get more sophisticated (cross-program invocation for example) the return values of the Helpers should be dictated by the use case and not artificially constrained by VM.

#### Summary of Changes

The VM has been changed using generics to allow for callers to register helper and verifier functions that take a caller defined error type.  Doing so cleans up things considerably, is more efficient, and more explicit.  The primary motivation is to allow the cross-program invocations to return instruction errors directly rather than having to translate strings.

The changes in this PR switch the BPF Loader over to using its own error types for Helper and Verifier functions.

Fixes #
