### PR TITLE
Add bpf_rust feature to bench CI tests

### DIFF
--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -64,7 +64,7 @@ _ cargo +$rust_nightly bench --manifest-path core/Cargo.toml ${V:+--verbose} \
   -- -Z unstable-options --format=json | tee -a "$BENCH_FILE"
 
 # Run bpf benches
-_ cargo +$rust_nightly bench --manifest-path programs/bpf/Cargo.toml ${V:+--verbose} --features=bpf_c \
+_ cargo +$rust_nightly bench --manifest-path programs/bpf/Cargo.toml ${V:+--verbose} --features=bpf_c,bpf_rust \
   -- -Z unstable-options --format=json --nocapture | tee -a "$BENCH_FILE"
 
 # Run banking/accounts bench. Doesn't require nightly, but use since it is already built.


### PR DESCRIPTION
#### Problem

CI bench tests only define bpf_c feature

#### Summary of Changes

Add bpf_rust to make consistent with other CI tests and avoid footgun of possibly not running tests if a test is added that relies on this feature.

Fixes #
