### PR TITLE
Make colo.sh support Bash 5

### DIFF
--- a/net/scripts/colo-provider.sh
+++ b/net/scripts/colo-provider.sh
@@ -48,7 +48,7 @@ __cloud_FindInstances() {
   fi
   INSTANCES_TEXT="$(
     for AVAIL in "${COLO_RES_AVAILABILITY[@]}"; do
-      IFS=$'\v' read -r HOST_NAME IP PRIV_IP STATUS ZONE LOCK_USER INSTNAME PREEMPTIBLE <<<"${AVAIL}"
+      IFS=$'\x1f' read -r HOST_NAME IP PRIV_IP STATUS ZONE LOCK_USER INSTNAME PREEMPTIBLE <<<"${AVAIL}"
       if [[ ${INSTNAME} =~ ${filter} ]]; then
         if [[ -n $onlyPreemptible && $PREEMPTIBLE == "false" ]]; then
           continue
@@ -57,7 +57,7 @@ __cloud_FindInstances() {
           echo -e "${INSTNAME}:${IP}:${PRIV_IP}:${ZONE}"
         fi
       fi
-    done | sort -t $'\v' -k1
+    done | sort -t $'\x1f' -k1
   )"
   if [[ -n "${INSTANCES_TEXT}" ]]; then
     while read -r LINE; do
@@ -180,17 +180,17 @@ cloud_CreateInstances() {
     declare AVAILABLE_TEXT
     AVAILABLE_TEXT="$(
       for RES in "${COLO_RES_AVAILABILITY[@]}"; do
-        IFS=$'\v' read -r HOST_NAME IP PRIV_IP STATUS ZONE LOCK_USER INSTNAME <<<"${RES}"
+        IFS=$'\x1f' read -r HOST_NAME IP PRIV_IP STATUS ZONE LOCK_USER INSTNAME <<<"${RES}"
         if [[ "FREE" = "${STATUS}" ]]; then
           INDEX=$(colo_res_index_from_ip "${IP}")
           RES_MACH="${COLO_RES_MACHINE[${INDEX}]}"
           if colo_machine_types_compatible "${RES_MACH}" "${machineType}"; then
             if ! colo_node_is_requisitioned "${INDEX}" "${COLO_RES_REQUISITIONED[*]}"; then
-              echo -e "${RES_MACH}\v${IP}"
+              echo -e "${RES_MACH}\x1f${IP}"
             fi
           fi
         fi
-      done | sort -nt $'\v' -k1,1
+      done | sort -nt $'\x1f' -k1,1
     )"
 
     if [[ -n "${AVAILABLE_TEXT}" ]]; then
@@ -207,7 +207,7 @@ cloud_CreateInstances() {
     declare node
     declare AI=0
     for node in "${nodes[@]}"; do
-      IFS=$'\v' read -r _ IP <<<"${AVAILABLE[${AI}]}"
+      IFS=$'\x1f' read -r _ IP <<<"${AVAILABLE[${AI}]}"
       colo_node_requisition "${IP}" "${node}" >/dev/null
       AI=$((AI+1))
     done
@@ -284,7 +284,7 @@ cloud_StatusAll() {
     colo_load_availability false
   fi
   for AVAIL in "${COLO_RES_AVAILABILITY[@]}"; do
-    IFS=$'\v' read -r HOST_NAME IP PRIV_IP STATUS ZONE LOCK_USER INSTNAME PREEMPTIBLE <<<"${AVAIL}"
+    IFS=$'\x1f' read -r HOST_NAME IP PRIV_IP STATUS ZONE LOCK_USER INSTNAME PREEMPTIBLE <<<"${AVAIL}"
     printf "%-30s | publicIp=%-16s privateIp=%s status=%s who=%s zone=%s inst=%s preemptible=%s\n" "${HOST_NAME}" "${IP}" "${PRIV_IP}" "${STATUS}" "${LOCK_USER}" "${ZONE}" "${INSTNAME}" "${PREEMPTIBLE}"
   done
 }


### PR DESCRIPTION
#### Problem

`colo.sh` doesn't work under Bash 5. I've known this for long time and I can't take it anymore...

Bash 5 changed the behavior of `$'\v'` for IFS and word-splitting behavior since Bash 4. Specifically, it started to treat the character as one of white-spaces. So, a sequence of the character is collapsed to one and doesn't create empty positional parameters.

Hard to grasp?

Seeing is believing!:

Bash 4 & 5

`","` isn't a white-space IFS and `" "`  is a white-space IFS.

```
$ echo -e 'a,b,,,e' | (while IFS=',' read A B C D E; do echo A=$A B=$B C=$C D=$D E=$E; done)
A=a B=b C= D= E=e
$ echo -e 'a b   e' | (while IFS=' ' read A B C D E; do echo A=$A B=$B C=$C D=$D E=$E; done)
A=a B=b C=e D= E=
```

Bash 4

`\v` (vertical tab) isn't a white-space IFS (same behavior as `,`)

```
$ echo -e 'a\vb\v\v\ve' | (while IFS=$'\v' read A B C D E; do echo A=$A B=$B C=$C D=$D E=$E; done)
A=a B=b C= D= E=e
```

Bash 5

`\v` (vertical tab) IS a white-space IFS (same behavior as *` `*)

```
$ echo -e 'a\vb\v\v\ve' | (while IFS=$'\v' read A B C D E; do echo A=$A B=$B C=$C D=$D E=$E; done)
A=a B=b C=e D= E=
```

#### Summary of Changes

Use ASCII's [`US`](https://en.wikipedia.org/wiki/Unit_Separator) instead.

Fixes: #6963