### PR TITLE
Check ClusterSlots for confirmation of block propagation

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -482,6 +482,7 @@ pub mod test {
     use super::*;
     use crate::{
         cluster_info_vote_listener::VoteTracker,
+        cluster_slots::ClusterSlots,
         progress_map::ForkProgress,
         replay_stage::{HeaviestForkFailures, ReplayStage},
     };
@@ -612,6 +613,7 @@ pub mod test {
                 tower,
                 progress,
                 &VoteTracker::default(),
+                &ClusterSlots::default(),
                 bank_forks,
                 &mut HashSet::new(),
             );

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -1,6 +1,6 @@
 use crate::{
-    cluster_info_vote_listener::SlotVoteTracker, consensus::StakeLockout,
-    replay_stage::SUPERMINORITY_THRESHOLD,
+    cluster_info_vote_listener::SlotVoteTracker, cluster_slots::SlotPubkeys,
+    consensus::StakeLockout, replay_stage::SUPERMINORITY_THRESHOLD,
 };
 use solana_ledger::{
     bank_forks::BankForks,
@@ -179,11 +179,13 @@ pub(crate) struct ForkStats {
 #[derive(Clone, Default)]
 pub(crate) struct PropagatedStats {
     pub(crate) propagated_validators: HashSet<Rc<Pubkey>>,
+    pub(crate) propagated_node_ids: HashSet<Rc<Pubkey>>,
     pub(crate) propagated_validators_stake: u64,
     pub(crate) is_propagated: bool,
     pub(crate) is_leader_slot: bool,
     pub(crate) prev_leader_slot: Option<Slot>,
     pub(crate) slot_vote_tracker: Option<Arc<RwLock<SlotVoteTracker>>>,
+    pub(crate) cluster_slot_pubkeys: Option<Arc<RwLock<SlotPubkeys>>>,
     pub(crate) total_epoch_stake: u64,
 }
 

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -225,7 +225,7 @@ impl PropagatedStats {
                     node_pubkey,
                     all_pubkeys,
                     node_vote_accounts,
-                    bank.epoch_vote_accounts(bank.slot())
+                    bank.epoch_vote_accounts(bank.epoch())
                         .expect("Epoch stakes for bank's own epoch must exist"),
                 );
             }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -291,10 +291,11 @@ impl ReplayStage {
                                         progress.get_propagated_stats(latest_leader_slot)
                                     {
                                         info!(
-                                            "total staked: {}, observed staked: {}, pubkeys: {:?}, latest_leader_slot: {}, epoch: {:?}",
+                                            "total staked: {}, observed staked: {}, vote pubkeys: {:?}, node_pubkeys: {:?}, latest_leader_slot: {}, epoch: {:?}",
                                             stats.total_epoch_stake,
                                             stats.propagated_validators_stake,
                                             stats.propagated_validators,
+                                            stats.propagated_node_ids,
                                             latest_leader_slot,
                                             bank_forks.read().unwrap().get(latest_leader_slot).map(|x| x.epoch()),
                                         );

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -198,6 +198,7 @@ impl Tvu {
             ledger_signal_receiver,
             poh_recorder.clone(),
             vote_tracker,
+            cluster_slots,
             retransmit_slots_sender,
         );
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -160,7 +160,7 @@ impl Tvu {
             *bank_forks.read().unwrap().working_bank().epoch_schedule(),
             cfg,
             tvu_config.shred_version,
-            cluster_slots,
+            cluster_slots.clone(),
         );
 
         let (ledger_cleanup_slot_sender, ledger_cleanup_slot_receiver) = channel();


### PR DESCRIPTION
#### Problem
ReplayStage doesn't check `ClusterSlots` for confirmation of block propagation, which is a fallback for when/if vote propagation fails

#### Summary of Changes
Add check in ReplayStage for propagated confirmation from `ClusterSlots`

Fixes #
