### PR TITLE
Add RPC subscription api for rooted slots

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -334,6 +334,7 @@ impl ReplayStage {
                                 &latest_root_senders,
                                 &mut earliest_vote_on_fork,
                                 &mut all_pubkeys,
+                                &subscriptions,
                             )?;
 
                             ancestors
@@ -712,6 +713,7 @@ impl ReplayStage {
         latest_root_senders: &[Sender<Slot>],
         earliest_vote_on_fork: &mut Slot,
         all_pubkeys: &mut HashSet<Rc<Pubkey>>,
+        subscriptions: &Arc<RpcSubscriptions>,
     ) -> Result<()> {
         if bank.is_empty() {
             inc_new_counter_info!("replay_stage-voted_empty_bank", 1);
@@ -745,6 +747,7 @@ impl ReplayStage {
                 earliest_vote_on_fork,
                 all_pubkeys,
             );
+            subscriptions.notify_roots(rooted_slots);
             latest_root_senders.iter().for_each(|s| {
                 if let Err(e) = s.send(new_root) {
                     trace!("latest root send failed: {:?}", e);

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1236,7 +1236,7 @@ None
 
 ### slotUnsubscribe
 
-Unsubscribe from signature confirmation notification
+Unsubscribe from slot notifications
 
 #### Parameters:
 
@@ -1251,6 +1251,58 @@ Unsubscribe from signature confirmation notification
 ```bash
 // Request
 {"jsonrpc":"2.0", "id":1, "method":"slotUnsubscribe", "params":[0]}
+
+// Result
+{"jsonrpc": "2.0","result": true,"id": 1}
+```
+
+### rootSubscribe
+
+Subscribe to receive notification anytime a new root is set by the validator.
+
+#### Parameters:
+
+None
+
+#### Results:
+
+* `integer` - subscription id \(needed to unsubscribe\)
+
+#### Example:
+
+```bash
+// Request
+{"jsonrpc":"2.0", "id":1, "method":"rootSubscribe"}
+
+// Result
+{"jsonrpc": "2.0","result": 0,"id": 1}
+```
+
+#### Notification Format:
+
+The result is the latest root slot number.
+
+```bash
+{"jsonrpc": "2.0","method": "rootNotification", "params": {"result":42,"subscription":0}}
+```
+
+### rootUnsubscribe
+
+Unsubscribe from root notifications
+
+#### Parameters:
+
+* `<integer>` - subscription id to cancel
+
+#### Results:
+
+* `<bool>` - unsubscribe success message
+
+#### Example:
+
+```bash
+// Request
+{"jsonrpc":"2.0", "id":1, "method":"rootUnsubscribe", "params":[0]}
 
 // Result
 {"jsonrpc": "2.0","result": true,"id": 1}


### PR DESCRIPTION
#### Problem
The pre-existing slot subscription RPC API is not sufficient to track rooted slots. The explorer should be able to display the root progress of a cluster.

#### Summary of Changes
Add new subscription API for tracking new root slots

Fixes #
