### PR TITLE
Make CI build fail if docs have broken links

### DIFF
--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -32,6 +32,7 @@ RUN set -x \
  && cargo install cargo-audit \
  && cargo install svgbob_cli \
  && cargo install mdbook \
+ && cargo install mdbook-linkcheck \
  && rustc --version \
  && cargo --version \
  && curl -OL https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,3 +8,5 @@ create-missing = false
 
 [output.html]
 theme = "theme"
+
+[output.linkcheck]


### PR DESCRIPTION
#### Problem

Docs can have broken links

#### Summary of Changes

Add mdbook-linkcheck.  Getting this build to pass may break links in gitbook. Until gitbook is gone, we'll need to look for the subset that works in both.  Usually that means:

* No exotic relative paths. Gitbook needs the unrendered paths to match the rendered ones, so if SUMMARY.md nests a page that's not nested in the file system, that link will break.
* No anchors on README.md. Gitbook needs the link to match a semi-rendered name (i.e. index.md#anchor, not README.md#anchor or index.html#anchor)

Fixes #8742 
