### PR TITLE
Prevent add/subtract from executable account

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2974,11 +2974,14 @@ mod tests {
             genesis_config.hash(),
         );
 
-        assert_eq!(bank.process_transaction(&tx), Ok(()));
         assert_eq!(
-            bank.get_balance(&account_pubkey),
-            account_balance + transfer_lamports
+            bank.process_transaction(&tx),
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::ExecutableLamportChange
+            ))
         );
+        assert_eq!(bank.get_balance(&account_pubkey), account_balance);
     }
 
     #[test]

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -65,8 +65,8 @@ pub enum InstructionError {
     #[error("instruction modified data of an account it does not own")]
     ExternalAccountDataModified,
 
-    /// Read-only account modified lamports
-    #[error("instruction changed balance of a read-only account")]
+    /// Read-only account's lamports modified
+    #[error("instruction changed the balance of a read-only account")]
     ReadonlyLamportChange,
 
     /// Read-only account's data was modified
@@ -126,6 +126,10 @@ pub enum InstructionError {
     /// Executable account's data was modified
     #[error("instruction changed executable accounts data")]
     ExecutableDataModified,
+
+    /// Executable account's lamports modified
+    #[error("instruction changed the balance of a executable account")]
+    ExecutableLamportChange,
 }
 
 impl InstructionError {


### PR DESCRIPTION
#### Problem

An executable account could be drained of lamports and deleted, leaving owned accounts adrift or worse yet owned by a newly loaded program with the same program_id.

#### Summary of Changes

* Once an account is marked executable prevent any addition or subtraction of its lamports.
* Test code was getting ugly as the number of executable variables that needed to be tested grew, clean it up.

Fixes #9052
