### PR TITLE
Enforce an executable's rent exemption in the runtime

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1375,6 +1375,7 @@ impl Bank {
                         tx.message(),
                         &loader_refcells,
                         &account_refcells,
+                        &self.rent_collector,
                     );
 
                     Self::from_refcells(accounts, loaders, account_refcells, loader_refcells);

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -130,6 +130,10 @@ pub enum InstructionError {
     /// Executable account's lamports modified
     #[error("instruction changed the balance of a executable account")]
     ExecutableLamportChange,
+
+    /// Executable accounts must be rent exempt
+    #[error("executable accounts must be rent exempt")]
+    ExecutableAccountNotRentExempt,
 }
 
 impl InstructionError {


### PR DESCRIPTION
#### Problem

The Runtime does not enforce executable accounts to be rent exempt and instead relies on each loader to enforce it.

#### Summary of Changes

Move the enforcement out of the loaders and into the runtime.

Fixes #9110
