### PR TITLE
Fix race in RPC subscriptions test

### DIFF
--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -159,8 +159,11 @@ where
             let root = if root.len() == 1 { root[0] } else { 0 };
             if desired_slot.len() == 1 {
                 let slot = desired_slot[0];
-                let desired_bank = bank_forks.read().unwrap().get(slot).unwrap().clone();
-                let results = bank_method(&desired_bank, hashmap_key);
+                let results = {
+                    let bank_forks = bank_forks.read().unwrap();
+                    let desired_bank = bank_forks.get(slot).unwrap();
+                    bank_method(&desired_bank, hashmap_key)
+                };
                 for result in filter_results(results, root) {
                     notifier.notify(
                         Response {


### PR DESCRIPTION
#### Problem
The RPC subscriptions test has a race due to transaction processing starting before subscriptions are finished being setup.

#### Summary of Changes
* Fix the "ready signal" that is supposed to detect when subscriptions are setup
* Improve reliability of how we detect that all transactions have finished processing

---

The issue was that the RPC client signature subscription future immediately resolves. It doesn't wait it receives a response  from the pubsub server. Instead, subscribe to slots after subscribing to signatures and listen for the first slot notification before starting to send transactions.

Fixes #
