### PR TITLE
Add single testcase to run entire TPS report

### DIFF
--- a/system-test/performance-testcases/tps-report.yml
+++ b/system-test/performance-testcases/tps-report.yml
@@ -1,0 +1,15 @@
+steps:
+  - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-5-node.yml"
+    name: "5 Node Test - TPS Report"
+  - wait: ~
+    continue_on_failure: true
+  - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-10-node.yml"
+    name: "10 Node Test - TPS Report"
+  - wait: ~
+    continue_on_failure: true
+  - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-25-node.yml"
+    name: "25 Node Test - TPS Report"
+  - wait: ~
+    continue_on_failure: true
+  - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-50-node.yml"
+    name: "50 Node Test - TPS Report"


### PR DESCRIPTION
#### Problem
Triggering an entire TPS report run takes too many clicks

#### Summary of Changes
`clicks--;`
