### PR TITLE
add step in docs to update solana config with keypair

### DIFF
--- a/docs/src/cli/generate-keys.md
+++ b/docs/src/cli/generate-keys.md
@@ -50,6 +50,12 @@ where `<PUBKEY>` is the public key output from the previous command.
 The command will output "Success" if the given public key matches the
 the one in your keypair file, and "Failed" otherwise.
 
+Configure solana to use the keypair file.
+
+```bash
+solana config set --keypair ~/my-solana-wallet/my-keypair.json 
+```
+
 ## Generate a Paper Wallet Seed Phrase
 
 See [Creating a Paper Wallet](../paper-wallet/paper-wallet-usage.md#creating-a-paper-wallet).


### PR DESCRIPTION
this step appears necessary to transfer tokens in the "Send and Receive Tokens" section

#### Problem
A config step is missing in the gitbook when walking through the command line guide. Sending/Receiving tokens doesn't appear to work until the solana keypair config is set. 

#### Summary of Changes

added a step with command to update the solana config

Fixes #
