### PR TITLE
Backpropagate Cargo.lock updates to all lock files

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -5,6 +5,13 @@
 # Release tags use buildkite-release.yml instead
 
 steps:
+  - command: "ci/dependabot-pr.sh"
+    name: "dependabot"
+    timeout_in_minutes: 5
+    if: build.env("GITHUB_USER") == "ryoqun"
+
+  - wait
+
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-checks.sh"
     name: "checks"
     timeout_in_minutes: 20

--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -8,7 +8,7 @@ steps:
   - command: "ci/dependabot-pr.sh"
     name: "dependabot"
     timeout_in_minutes: 5
-    if: build.env("GITHUB_USER") == "ryoqun"
+    if: build.env("GITHUB_USER") == "dependabot-preview[bot]"
 
   - wait
 

--- a/ci/dependabot-pr.sh
+++ b/ci/dependabot-pr.sh
@@ -13,24 +13,24 @@ source ci/rust-version.sh stable
 
 ci/docker-run.sh $rust_nightly_docker_image ci/dependabot-updater.sh
 
-if [[ $(git status --short :**/Cargo.lock | wc -l) -gt 0 ]]; then
-  (
-    echo --- "(FAILING) Backpropagating dependabot-triggered Cargo.lock updates"
-
-    git add :**/Cargo.lock
-    NAME="dependabot-buildkite"
-    GIT_AUTHOR_NAME="$NAME" \
-      GIT_COMMITTER_NAME="$NAME" \
-      EMAIL="dependabot-buildkite@noreply.solana.com" \
-      git commit -m "[auto-commit] Update all Cargo lock files"
-    api_base="https://api.github.com/repos/solana-labs/solana/pulls"
-    pr_num=$(echo "$BUILDKITE_BRANCH" | grep -Eo '[0-9]+')
-    branch=$(curl -s "$api_base/$pr_num" | python -c 'import json,sys;print json.load(sys.stdin)["head"]["ref"]')
-    git push origin "HEAD:$branch"
-
-    echo "Source branch is updated; failing this build for the next"
-    exit 1
-  )
+if [[ $(git status --short :**/Cargo.lock | wc -l) -eq 0 ]]; then
+  echo --- ok
+  exit 0
 fi
 
-echo --- ok
+echo --- "(FAILING) Backpropagating dependabot-triggered Cargo.lock updates"
+
+name="dependabot-buildkite"
+api_base="https://api.github.com/repos/solana-labs/solana/pulls"
+pr_num=$(echo "$BUILDKITE_BRANCH" | grep -Eo '[0-9]+')
+branch=$(curl -s "$api_base/$pr_num" | python -c 'import json,sys;print json.load(sys.stdin)["head"]["ref"]')
+
+git add :**/Cargo.lock
+EMAIL="dependabot-buildkite@noreply.solana.com" \
+  GIT_AUTHOR_NAME="$name" \
+  GIT_COMMITTER_NAME="$name" \
+  git commit -m "[auto-commit] Update all Cargo lock files"
+git push origin "HEAD:$branch"
+
+echo "Source branch is updated; failing this build for the next"
+exit 1

--- a/ci/dependabot-pr.sh
+++ b/ci/dependabot-pr.sh
@@ -9,7 +9,6 @@ if ! echo "$BUILDKITE_BRANCH" | grep -E '^pull/[0-9]+/head$'; then
   exit 1
 fi
 
-source ci/_
 source ci/rust-version.sh stable
 
 ci/docker-run.sh $rust_nightly_docker_image ci/dependabot-updater.sh
@@ -23,10 +22,10 @@ if [[ $(git status --short :**/Cargo.lock | wc -l) -gt 0 ]]; then
     GIT_AUTHOR_NAME="$NAME" \
       GIT_COMMITTER_NAME="$NAME" \
       EMAIL="dependabot-buildkite@noreply.solana.com" \
-      git commit -m "Update all Cargo lock files"
+      git commit -m "[auto-commit] Update all Cargo lock files"
     api_base="https://api.github.com/repos/solana-labs/solana/pulls"
     pr_num=$(echo "$BUILDKITE_BRANCH" | grep -Eo '[0-9]+')
-    branch=$(curl -s "$api_base/$pr_num" | ruby -r json -e 'puts JSON.parse(STDIN.read())["head"]["ref"]')
+    branch=$(curl -s "$api_base/$pr_num" | python -c 'import json,sys;print json.load(sys.stdin)["head"]["ref"]')
     git push origin "HEAD:$branch"
 
     echo "Source branch is updated; failing this build for the next"

--- a/ci/dependabot-pr.sh
+++ b/ci/dependabot-pr.sh
@@ -5,7 +5,7 @@ set -ex
 cd "$(dirname "$0")/.."
 
 if ! echo "$BUILDKITE_BRANCH" | grep -E '^pull/[0-9]+/head$'; then
-  echo "not pull request!?"
+  echo "not pull request!?" >&2
   exit 1
 fi
 

--- a/ci/dependabot-pr.sh
+++ b/ci/dependabot-pr.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -ex
+
+cd "$(dirname "$0")/.."
+
+if ! echo "$BUILDKITE_BRANCH" | grep -E '^pull/[0-9]+/head$'; then
+  echo "not pull request!?"
+  exit 1
+fi
+
+source ci/_
+source ci/rust-version.sh stable
+
+ci/docker-run.sh $rust_nightly_docker_image ci/dependabot-updater.sh
+
+if [[ $(git status --short :**/Cargo.lock | wc -l) -gt 0 ]]; then
+  (
+    echo --- "(FAILING) Backpropagating dependabot-triggered Cargo.lock updates"
+
+    git add :**/Cargo.lock
+    NAME="dependabot-buildkite"
+    GIT_AUTHOR_NAME="$NAME" \
+      GIT_COMMITTER_NAME="$NAME" \
+      EMAIL="dependabot-buildkite@noreply.solana.com" \
+      git commit -m "Update all Cargo lock files"
+    api_base="https://api.github.com/repos/solana-labs/solana/pulls"
+    pr_num=$(echo "$BUILDKITE_BRANCH" | grep -Eo '[0-9]+')
+    branch=$(curl -s "$api_base/$pr_num" | ruby -r json -e 'puts JSON.parse(STDIN.read())["head"]["ref"]')
+    git push origin "HEAD:$branch"
+
+    echo "Source branch is updated; failing this build for the next"
+    exit 1
+  )
+fi
+
+echo --- ok

--- a/ci/dependabot-updater.sh
+++ b/ci/dependabot-updater.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -ex
+
+commit_range="$(git merge-base HEAD origin/master)..HEAD"
+parsed_update_args="$(
+  git log "$commit_range" --author "dependabot-preview" --oneline -n1 |
+    grep -o 'Bump.*$' |
+    sed -r 's/Bump ([^ ]+) from [^ ]+ to ([^ ]+)/-p \1 --precise \2/'
+)"
+if [[ -n $parsed_update_args ]]; then
+  # shellcheck disable=SC2086
+  _ scripts/cargo-for-all-lock-files.sh update $parsed_update_args
+fi
+
+echo --- ok

--- a/ci/dependabot-updater.sh
+++ b/ci/dependabot-updater.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 set -ex
+cd "$(dirname "$0")/.."
+source ci/_
 
 commit_range="$(git merge-base HEAD origin/master)..HEAD"
 parsed_update_args="$(
@@ -8,9 +10,11 @@ parsed_update_args="$(
     grep -o 'Bump.*$' |
     sed -r 's/Bump ([^ ]+) from [^ ]+ to ([^ ]+)/-p \1 --precise \2/'
 )"
+package=$(echo "$parsed_update_args" | awk '{print $2}')
 if [[ -n $parsed_update_args ]]; then
   # shellcheck disable=SC2086
-  _ scripts/cargo-for-all-lock-files.sh update $parsed_update_args
+  _TARGET_LOCK_FILES=$(git grep --files-with-matches "$package" :**/Cargo.lock) \
+    _ scripts/cargo-for-all-lock-files.sh update $parsed_update_args
 fi
 
 echo --- ok

--- a/ci/dependabot-updater.sh
+++ b/ci/dependabot-updater.sh
@@ -13,8 +13,9 @@ parsed_update_args="$(
 package=$(echo "$parsed_update_args" | awk '{print $2}')
 if [[ -n $parsed_update_args ]]; then
   # shellcheck disable=SC2086
-  _TARGET_LOCK_FILES=$(git grep --files-with-matches "$package" :**/Cargo.lock) \
-    _ scripts/cargo-for-all-lock-files.sh update $parsed_update_args
+  _ scripts/cargo-for-all-lock-files.sh \
+    "$(git grep --files-with-matches "$package" :**/Cargo.lock)" -- \
+    update $parsed_update_args
 fi
 
 echo --- ok

--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -76,19 +76,6 @@ ARGS+=(
   --env CRATES_IO_TOKEN
 )
 
-if [[ $BUILDKITE_LABEL == "checks" ]] && echo "$BUILDKITE_BRANCH" | grep -E '^pull/[0-9]+/head$'; then
-  api_base="https://api.github.com/repos/solana-labs/solana/pulls"
-  pr_num=$(echo "$BUILDKITE_BRANCH" | grep -Eo '[0-9]+')
-  branch=$(curl -s "$api_base/$pr_num" | ruby -r json -e 'puts JSON.parse(STDIN.read())["head"]["ref"]')
-  source_repo=$(curl -s "$api_base/$pr_num" | ruby -r json -e 'puts JSON.parse(STDIN.read())["head"]["repo"]["full_name"]')
-
-  if [[ $source_repo == "solana-labs/solana" ]] && echo "$branch" | grep "^dependabot/cargo/"; then
-    export CI_WITH_DEPENDABOT=true
-    ARGS+=(--env CI_WITH_DEPENDABOT)
-  fi
-fi
-
-
 # Also propagate environment variables needed for codecov
 # https://docs.codecov.io/docs/testing-with-docker#section-codecov-inside-docker
 # We normalize CI to `1`; but codecov expects it to be `true` to detect Buildkite...
@@ -109,28 +96,4 @@ fi
 
 set -x
 # shellcheck disable=SC2086
-if docker run "${ARGS[@]}" $CODECOV_ENVS "$IMAGE" "$@"; then
-  docker_status=0
-else
-  docker_status=$?
-fi
-
-if [[ -n $CI_WITH_DEPENDABOT && $(git status --short :**/Cargo.lock | wc -l) -gt 0 ]]; then
-  (
-    echo --- "(FAILING) Backpropagating dependabot-triggered Cargo.lock updates"
-    set -x
-
-    git add :**/Cargo.lock
-    NAME="dependabot-buildkite"
-    GIT_AUTHOR_NAME="$NAME" \
-      GIT_COMMITTER_NAME="$NAME" \
-      EMAIL="dependabot-buildkite@noreply.solana.com" \
-      git commit -m "Update all Cargo lock files"
-    git push origin "HEAD:$branch"
-
-    echo "Source branch is updated; failing this build for the next"
-    exit 1
-  )
-fi
-
-exit $docker_status
+exec docker run "${ARGS[@]}" $CODECOV_ENVS "$IMAGE" "$@"

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -13,31 +13,16 @@ export RUSTFLAGS="-D warnings"
 # Look for failed mergify.io backports
 _ git show HEAD --check --oneline
 
-_ cargo +"$rust_stable" fmt --all -- --check
+if _ scripts/cargo-for-all-lock-files.sh check --locked; then
+  true
+else
+  check_status=$?
+  echo "Some Cargo.lock is outdated; please update them as well"
+  echo "protip: you can use ./scripts/cargo-for-all-lock-files.sh update ..."
+  exit "$check_status"
+fi
 
-(
-  set -x
-  if [[ -n $CI_WITH_DEPENDABOT ]]; then
-    commit_range="$(git merge-base HEAD origin/master)..HEAD"
-    parsed_update_args="$(
-      git log "$commit_range" --author "dependabot-preview" --oneline -n1 |
-        grep -o 'Bump.*$' |
-        sed -r 's/Bump ([^ ]+) from [^ ]+ to ([^ ]+)/-p \1 --precise \2/'
-    )"
-    if [[ -n $parsed_update_args ]]; then
-      # shellcheck disable=SC2086
-      _ scripts/cargo-for-all-lock-files.sh update $parsed_update_args
-    fi
-  fi
-  if _ scripts/cargo-for-all-lock-files.sh check --locked; then
-    true
-  else
-    check_status=$?
-    echo "Some Cargo.lock is outdated; please update them as well"
-    echo "protip: you can use ./scripts/cargo-for-all-lock-files.sh update ..."
-    exit "$check_status"
-  fi
-)
+_ cargo +"$rust_stable" fmt --all -- --check
 
 # Clippy gets stuck for unknown reasons if sdk-c is included in the build, so check it separately.
 # See https://github.com/solana-labs/solana/issues/5503

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
-for lock_file in $(git ls-files :**/Cargo.lock)
+if [[ -n $_TARGET_LOCK_FILES ]]; then
+  files="$_TARGET_LOCK_FILES"
+else
+  files="$(git ls-files :**/Cargo.lock)"
+fi
+
+for lock_file in $files
 do
   (
+    set -x
     cd "$(dirname "$lock_file")"
     cargo "$@"
   )

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -ex
+
+for lock_file in $(git ls-files :**/Cargo.lock)
+do
+  (
+    cd "$(dirname "$lock_file")"
+    cargo "$@"
+  )
+done

--- a/scripts/cargo-for-all-lock-files.sh
+++ b/scripts/cargo-for-all-lock-files.sh
@@ -2,17 +2,37 @@
 
 set -e
 
-if [[ -n $_TARGET_LOCK_FILES ]]; then
-  files="$_TARGET_LOCK_FILES"
+shifted_args=()
+while [[ -n $1 ]]; do
+  if [[ $1 = -- ]]; then
+    escape_marker=found
+    shift
+    break
+  else
+    shifted_args+=("$1")
+    shift
+  fi
+done
+
+# When "--" appear at the first and shifted_args is empty, consume it here
+# to unambiguously pass and use any other "--" for cargo
+if [[ -n $escape_marker && ${#shifted_args[@]} -gt 0 ]]; then
+  files="${shifted_args[*]}"
+  for file in $files; do
+    if [[ $file = "${file%Cargo.lock}" ]]; then
+      echo "$0: unrecognizable as Cargo.lock path (prepend \"--\"?): $file" >&2
+      exit 1
+    fi
+  done
+  shifted_args=()
 else
   files="$(git ls-files :**/Cargo.lock)"
 fi
 
-for lock_file in $files
-do
+for lock_file in $files; do
   (
     set -x
     cd "$(dirname "$lock_file")"
-    cargo "$@"
+    cargo "${shifted_args[@]}" "$@"
   )
 done


### PR DESCRIPTION
#### Problem

Non-default Cargo lock files tend to be forgot to update. this causes many problems:
  - CI build isn't deterministic because lock files are changed on the fly while ci is running; So, `git diff` on CI shows some difference.
  - auditing cumulative Cargo lock update is very tedious or hard: https://github.com/solana-labs/solana/commit/959c1ea857b7a52c590f7d02efaa09eb041e732c#diff-7d7ecaa361c7585f6ee9b01378cd1393R2872
  - back-porting sometimes incurs noise of unrelated previous cargo lock updates, which is again tedious to audit: https://github.com/solana-labs/solana/commit/d2107270eaae80ac44cdf3998564e58a49db2654#diff-d2ede298d9a75c849170d6ef285eda1eR6578
- dependabot sometimes fails because it can't update non-default Cargo lock files

This is a problem which I noticed at https://github.com/solana-labs/solana/pull/8882. Since then, I've been always bothered with our trust-chain in the build/CI system a bit... Let's fortify it step by step before we get pray of third-party crate publisher's credential hack :)

#### Summary of Changes
- never accept stale lock files
 - for that, give special handling to dependabot

live example: https://github.com/solana-labs/solana/pull/9159/commits


partly related to this: https://github.com/solana-labs/solana/issues/8587#issuecomment-597376904
