### PR TITLE
Rename CustomError to Custom

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2173,7 +2173,7 @@ where
         Err(err) => {
             if let ClientErrorKind::TransactionError(TransactionError::InstructionError(
                 _,
-                InstructionError::CustomError(code),
+                InstructionError::Custom(code),
             )) = err.kind()
             {
                 if let Some(specific_error) = E::decode_custom_error_to_enum(*code) {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1988,7 +1988,7 @@ mod tests {
                             meta.unwrap().status,
                             Err(TransactionError::InstructionError(
                                 0,
-                                InstructionError::CustomError(1)
+                                InstructionError::Custom(1)
                             ))
                         );
                     } else {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2602,7 +2602,7 @@ pub(crate) mod tests {
                             meta.unwrap().status,
                             Err(TransactionError::InstructionError(
                                 0,
-                                InstructionError::CustomError(1)
+                                InstructionError::Custom(1)
                             ))
                         );
                     } else {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1802,7 +1802,7 @@ pub mod tests {
         let res = io.handle_request_sync(&req, meta.clone());
         let expected_res: transaction::Result<()> = Err(TransactionError::InstructionError(
             0,
-            InstructionError::CustomError(1),
+            InstructionError::Custom(1),
         ));
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
         let result: Option<TransactionStatus> =
@@ -2270,7 +2270,7 @@ pub mod tests {
                         meta.unwrap().status,
                         Err(TransactionError::InstructionError(
                             0,
-                            InstructionError::CustomError(1)
+                            InstructionError::Custom(1)
                         ))
                     );
                 } else {
@@ -2304,7 +2304,7 @@ pub mod tests {
                         meta.unwrap().status,
                         Err(TransactionError::InstructionError(
                             0,
-                            InstructionError::CustomError(1)
+                            InstructionError::Custom(1)
                         ))
                     );
                 } else {

--- a/programs/bpf/rust/error_handling/src/lib.rs
+++ b/programs/bpf/rust/error_handling/src/lib.rs
@@ -24,7 +24,7 @@ pub enum MyError {
 }
 impl From<MyError> for ProgramError {
     fn from(e: MyError) -> Self {
-        ProgramError::CustomError(e as u32)
+        ProgramError::Custom(e as u32)
     }
 }
 impl<T> DecodeError<T> for MyError {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -239,14 +239,14 @@ mod bpf {
             let result = bank_client.send_instruction(&mint_keypair, instruction);
             assert_eq!(
                 result.unwrap_err().unwrap(),
-                TransactionError::InstructionError(0, InstructionError::CustomError(0))
+                TransactionError::InstructionError(0, InstructionError::Custom(0))
             );
 
             let instruction = Instruction::new(program_id, &4u8, account_metas.clone());
             let result = bank_client.send_instruction(&mint_keypair, instruction);
             assert_eq!(
                 result.unwrap_err().unwrap(),
-                TransactionError::InstructionError(0, InstructionError::CustomError(42))
+                TransactionError::InstructionError(0, InstructionError::Custom(42))
             );
 
             let instruction = Instruction::new(program_id, &5u8, account_metas.clone());

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -426,7 +426,7 @@ mod tests {
                 .unwrap(),
             TransactionError::InstructionError(
                 0,
-                InstructionError::CustomError(BudgetError::DestinationMissing as u32)
+                InstructionError::Custom(BudgetError::DestinationMissing as u32)
             )
         );
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 1);

--- a/programs/failure/src/lib.rs
+++ b/programs/failure/src/lib.rs
@@ -13,5 +13,5 @@ fn process_instruction(
     _keyed_accounts: &[KeyedAccount],
     _data: &[u8],
 ) -> Result<(), InstructionError> {
-    Err(InstructionError::CustomError(0))
+    Err(InstructionError::Custom(0))
 }

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -23,6 +23,6 @@ fn test_program_native_failure() {
             .send_instruction(&alice_keypair, instruction)
             .unwrap_err()
             .unwrap(),
-        TransactionError::InstructionError(0, InstructionError::CustomError(0))
+        TransactionError::InstructionError(0, InstructionError::Custom(0))
     );
 }

--- a/programs/move_loader/src/error_mappers.rs
+++ b/programs/move_loader/src/error_mappers.rs
@@ -38,10 +38,10 @@ pub fn map_failure_error(err: failure::Error) -> InstructionError {
 }
 
 pub fn map_err_vm_status(status: VMStatus) -> InstructionError {
-    // Attempt to map the StatusCode (repr(u64)) to a u32 for CustomError.
+    // Attempt to map the StatusCode (repr(u64)) to a u32 for Custom.
     // The only defined StatusCode that fails is StatusCode::UNKNOWN_ERROR
     match <StatusCode as Into<u64>>::into(status.major_status).try_into() {
-        Ok(u) => InstructionError::CustomError(u),
+        Ok(u) => InstructionError::Custom(u),
         Err(_) => InstructionError::InvalidError,
     }
 }

--- a/programs/move_loader/src/processor.rs
+++ b/programs/move_loader/src/processor.rs
@@ -511,9 +511,7 @@ mod tests {
         let code = "main() { return; }";
         let sender_address = AccountAddress::default();
         let script = LibraAccount::create_script(&sender_address, code, vec![]);
-        let keyed_accounts = vec![
-            KeyedAccount::new(&script.key, true, &script.account),
-        ];
+        let keyed_accounts = vec![KeyedAccount::new(&script.key, true, &script.account)];
         MoveProcessor::do_finalize(&keyed_accounts).unwrap();
         let _ = MoveProcessor::deserialize_verified_script(&script.account.borrow().data).unwrap();
     }
@@ -551,9 +549,7 @@ mod tests {
         let script = LibraAccount::create_script(&sender_address, code, vec![]);
         let genesis = LibraAccount::create_genesis(1_000_000_000);
 
-        let keyed_accounts = vec![
-            KeyedAccount::new(&script.key, true, &script.account),
-        ];
+        let keyed_accounts = vec![KeyedAccount::new(&script.key, true, &script.account)];
 
         MoveProcessor::do_finalize(&keyed_accounts).unwrap();
 
@@ -578,9 +574,7 @@ mod tests {
             }
         ";
         let module = LibraAccount::create_module(code, vec![]);
-        let keyed_accounts = vec![
-            KeyedAccount::new(&module.key, true, &module.account),
-        ];
+        let keyed_accounts = vec![KeyedAccount::new(&module.key, true, &module.account)];
         keyed_accounts[0]
             .account
             .borrow_mut()
@@ -604,9 +598,7 @@ mod tests {
         let script = LibraAccount::create_script(&sender_address, code, vec![]);
         let genesis = LibraAccount::create_genesis(1_000_000_000);
 
-        let keyed_accounts = vec![
-            KeyedAccount::new(&script.key, true, &script.account),
-        ];
+        let keyed_accounts = vec![KeyedAccount::new(&script.key, true, &script.account)];
 
         MoveProcessor::do_finalize(&keyed_accounts).unwrap();
 
@@ -622,7 +614,7 @@ mod tests {
                 "main".to_string(),
                 vec![],
             ),
-            Err(InstructionError::CustomError(4002))
+            Err(InstructionError::Custom(4002))
         );
     }
 
@@ -676,9 +668,7 @@ mod tests {
         let script = LibraAccount::create_script(&genesis.address, code, vec![]);
         let payee = LibraAccount::create_unallocated(BIG_ENOUGH);
 
-        let keyed_accounts = vec![
-            KeyedAccount::new(&script.key, true, &script.account),
-        ];
+        let keyed_accounts = vec![KeyedAccount::new(&script.key, true, &script.account)];
 
         MoveProcessor::do_finalize(&keyed_accounts).unwrap();
 
@@ -731,9 +721,7 @@ mod tests {
         );
         let module = LibraAccount::create_module(&code, vec![]);
 
-        let keyed_accounts = vec![
-            KeyedAccount::new(&module.key, true, &module.account),
-        ];
+        let keyed_accounts = vec![KeyedAccount::new(&module.key, true, &module.account)];
         keyed_accounts[0]
             .account
             .borrow_mut()
@@ -774,9 +762,7 @@ mod tests {
         );
         let payee = LibraAccount::create_unallocated(BIG_ENOUGH);
 
-        let keyed_accounts = vec![
-            KeyedAccount::new(&script.key, true, &script.account),
-        ];
+        let keyed_accounts = vec![KeyedAccount::new(&script.key, true, &script.account)];
 
         MoveProcessor::do_finalize(&keyed_accounts).unwrap();
 
@@ -821,9 +807,7 @@ mod tests {
         let script = LibraAccount::create_script(&genesis.address.clone(), code, vec![]);
         let payee = LibraAccount::create_unallocated(BIG_ENOUGH);
 
-        let keyed_accounts = vec![
-            KeyedAccount::new(&script.key, true, &script.account),
-        ];
+        let keyed_accounts = vec![KeyedAccount::new(&script.key, true, &script.account)];
 
         MoveProcessor::do_finalize(&keyed_accounts).unwrap();
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -762,7 +762,7 @@ mod tests {
         where
             T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
         {
-            if let InstructionError::CustomError(code) = err {
+            if let InstructionError::Custom(code) = err {
                 let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
                 format!(
                     "{:?}: {}::{:?} - {}",
@@ -776,7 +776,7 @@ mod tests {
             }
         }
         assert_eq!(
-            "CustomError(0): StakeError::NoCreditsToRedeem - not enough credits to redeem",
+            "Custom(0): StakeError::NoCreditsToRedeem - not enough credits to redeem",
             pretty_err::<StakeError>(StakeError::NoCreditsToRedeem.into())
         )
     }

--- a/programs/storage/src/storage_contract.rs
+++ b/programs/storage/src/storage_contract.rs
@@ -194,7 +194,7 @@ impl<'a> StorageAccount<'a> {
 
             if segment_index >= current_segment {
                 // attempt to submit proof for unconfirmed segment
-                return Err(InstructionError::CustomError(
+                return Err(InstructionError::Custom(
                     StorageError::InvalidSegment as u32,
                 ));
             }
@@ -207,7 +207,7 @@ impl<'a> StorageAccount<'a> {
             // TODO check that this blockhash is valid and recent
             //            if !is_valid(&blockhash) {
             //                // proof isn't using a recent blockhash
-            //                return Err(InstructionError::CustomError(InvalidBlockhash as u32));
+            //                return Err(InstructionError::Custom(InvalidBlockhash as u32));
             //            }
 
             let proof = Proof {
@@ -220,13 +220,13 @@ impl<'a> StorageAccount<'a> {
             let segment_proofs = proofs.entry(current_segment).or_default();
             if segment_proofs.contains(&proof) {
                 // do not accept duplicate proofs
-                return Err(InstructionError::CustomError(
+                return Err(InstructionError::Custom(
                     StorageError::DuplicateProof as u32,
                 ));
             }
             if segment_proofs.len() >= MAX_PROOFS_PER_SEGMENT {
                 // do not accept more than MAX_PROOFS_PER_SEGMENT
-                return Err(InstructionError::CustomError(
+                return Err(InstructionError::Custom(
                     StorageError::ProofLimitReached as u32,
                 ));
             }
@@ -255,7 +255,7 @@ impl<'a> StorageAccount<'a> {
         {
             debug!("advertise new segment: {} orig: {}", segment, clock.segment);
             if segment < *state_segment || segment > clock.segment {
-                return Err(InstructionError::CustomError(
+                return Err(InstructionError::Custom(
                     StorageError::InvalidSegment as u32,
                 ));
             }
@@ -290,7 +290,7 @@ impl<'a> StorageAccount<'a> {
         } = &mut storage_contract
         {
             if segment_index > *state_segment {
-                return Err(InstructionError::CustomError(
+                return Err(InstructionError::Custom(
                     StorageError::InvalidSegment as u32,
                 ));
             }
@@ -329,7 +329,7 @@ impl<'a> StorageAccount<'a> {
 
             if accounts.len() != proofs_per_account.len() {
                 // don't have all the accounts to validate the proofs_per_account against
-                return Err(InstructionError::CustomError(
+                return Err(InstructionError::Custom(
                     StorageError::InvalidProofMask as u32,
                 ));
             }
@@ -380,9 +380,7 @@ impl<'a> StorageAccount<'a> {
         } = &mut storage_contract
         {
             if owner.id != *account_owner {
-                return Err(InstructionError::CustomError(
-                    StorageError::InvalidOwner as u32,
-                ));
+                return Err(InstructionError::Custom(StorageError::InvalidOwner as u32));
             }
 
             credits.update_epoch(clock.epoch);
@@ -397,9 +395,7 @@ impl<'a> StorageAccount<'a> {
         } = &mut storage_contract
         {
             if owner.id != *account_owner {
-                return Err(InstructionError::CustomError(
-                    StorageError::InvalidOwner as u32,
-                ));
+                return Err(InstructionError::Custom(StorageError::InvalidOwner as u32));
             }
             credits.update_epoch(clock.epoch);
             let (num_validations, _total_proofs) = count_valid_proofs(&validations);
@@ -422,7 +418,7 @@ fn check_redeemable(
 ) -> Result<(), InstructionError> {
     let rewards = (credits.redeemable as f64 * storage_point_value) as u64;
     if rewards_pool.lamports()? < rewards {
-        Err(InstructionError::CustomError(
+        Err(InstructionError::Custom(
             StorageError::RewardPoolDepleted as u32,
         ))
     } else {
@@ -629,7 +625,7 @@ mod tests {
         keyed_pool_account.account.borrow_mut().lamports = 0;
         assert_eq!(
             check_redeemable(&mut credits, 1.0, &keyed_pool_account, &mut owner),
-            Err(InstructionError::CustomError(
+            Err(InstructionError::Custom(
                 StorageError::RewardPoolDepleted as u32,
             ))
         );

--- a/programs/vest/src/vest_instruction.rs
+++ b/programs/vest/src/vest_instruction.rs
@@ -22,7 +22,7 @@ pub enum VestError {
 
 impl From<VestError> for InstructionError {
     fn from(e: VestError) -> Self {
-        InstructionError::CustomError(e as u32)
+        InstructionError::Custom(e as u32)
     }
 }
 

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -370,7 +370,7 @@ mod tests {
         where
             T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
         {
-            if let InstructionError::CustomError(code) = err {
+            if let InstructionError::Custom(code) = err {
                 let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
                 format!(
                     "{:?}: {}::{:?} - {}",
@@ -384,7 +384,7 @@ mod tests {
             }
         }
         assert_eq!(
-            "CustomError(0): VoteError::VoteTooOld - vote already recorded or not in slot hashes history",
+            "Custom(0): VoteError::VoteTooOld - vote already recorded or not in slot hashes history",
             pretty_err::<VoteError>(VoteError::VoteTooOld.into())
         )
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5018,7 +5018,7 @@ mod tests {
             if !solana_vote_program::check_id(program_id) {
                 return Err(InstructionError::IncorrectProgramId);
             }
-            Err(InstructionError::CustomError(42))
+            Err(InstructionError::Custom(42))
         }
 
         assert!(bank.get_account(&solana_vote_program::id()).is_none());
@@ -5047,7 +5047,7 @@ mod tests {
             bank.process_transaction(&transaction),
             Err(TransactionError::InstructionError(
                 1,
-                InstructionError::CustomError(42)
+                InstructionError::Custom(42)
             ))
         );
     }
@@ -5067,7 +5067,7 @@ mod tests {
             _ka: &[KeyedAccount],
             _data: &[u8],
         ) -> std::result::Result<(), InstructionError> {
-            Err(InstructionError::CustomError(42))
+            Err(InstructionError::Custom(42))
         }
 
         let mock_account = Keypair::new();
@@ -5097,7 +5097,7 @@ mod tests {
             bank.process_transaction(&transaction),
             Err(TransactionError::InstructionError(
                 1,
-                InstructionError::CustomError(42)
+                InstructionError::Custom(42)
             ))
         );
     }
@@ -5113,7 +5113,7 @@ mod tests {
             _ka: &[KeyedAccount],
             _data: &[u8],
         ) -> std::result::Result<(), InstructionError> {
-            Err(InstructionError::CustomError(42))
+            Err(InstructionError::Custom(42))
         }
 
         // Non-native loader accounts can not be used for instruction processing

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -115,7 +115,7 @@ pub enum InstructionError {
     /// Allows on-chain programs to implement program-specific error types and see them returned
     /// by the Solana runtime. A program-specific error may be any type that is represented as
     /// or serialized to a u32 integer.
-    #[error("program error: {0:#x}")]
+    #[error("custom program error: {0:#x}")]
     Custom(u32),
 
     /// The return value from the program was invalid.  Valid errors are either a defined builtin

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -116,7 +116,7 @@ pub enum InstructionError {
     /// by the Solana runtime. A program-specific error may be any type that is represented as
     /// or serialized to a u32 integer.
     #[error("program error: {0:#x}")]
-    CustomError(u32),
+    Custom(u32),
 
     /// The return value from the program was invalid.  Valid errors are either a defined builtin
     /// error value or a user-defined error in the lower 32 bits.

--- a/sdk/src/program_error.rs
+++ b/sdk/src/program_error.rs
@@ -15,7 +15,7 @@ pub enum ProgramError {
     /// by the Solana runtime. A program-specific error may be any type that is represented as
     /// or serialized to a u32 integer.
     #[error("Custom program error: {0}")]
-    CustomError(u32),
+    Custom(u32),
     #[error("The arguments provided to a program instruction where invalid")]
     InvalidArgument,
     #[error("An instruction's data contents was invalid")]
@@ -52,7 +52,7 @@ impl PrintProgramError for ProgramError {
         E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive,
     {
         match self {
-            ProgramError::CustomError(error) => {
+            ProgramError::Custom(error) => {
                 if let Some(custom_error) = E::decode_custom_error_to_enum(*error) {
                     custom_error.print::<E>();
                 } else {
@@ -109,7 +109,7 @@ impl From<ProgramError> for u64 {
             ProgramError::UninitializedAccount => UNINITIALIZED_ACCOUNT,
             ProgramError::NotEnoughAccountKeys => NOT_ENOUGH_ACCOUNT_KEYS,
             ProgramError::AccountBorrowFailed => ACCOUNT_BORROW_FAILED,
-            ProgramError::CustomError(error) => {
+            ProgramError::Custom(error) => {
                 if error == 0 {
                     CUSTOM_ZERO
                 } else {

--- a/sdk/src/program_error.rs
+++ b/sdk/src/program_error.rs
@@ -134,8 +134,8 @@ impl From<u64> for ProgramError {
             UNINITIALIZED_ACCOUNT => ProgramError::UninitializedAccount,
             NOT_ENOUGH_ACCOUNT_KEYS => ProgramError::NotEnoughAccountKeys,
             ACCOUNT_BORROW_FAILED => ProgramError::AccountBorrowFailed,
-            CUSTOM_ZERO => ProgramError::CustomError(0),
-            _ => ProgramError::CustomError(error as u32),
+            CUSTOM_ZERO => ProgramError::Custom(0),
+            _ => ProgramError::Custom(error as u32),
         }
     }
 }
@@ -145,7 +145,7 @@ impl TryFrom<InstructionError> for ProgramError {
 
     fn try_from(error: InstructionError) -> Result<Self, Self::Error> {
         match error {
-            Self::Error::CustomError(err) => Ok(Self::CustomError(err)),
+            Self::Error::Custom(err) => Ok(Self::Custom(err)),
             Self::Error::InvalidArgument => Ok(Self::InvalidArgument),
             Self::Error::InvalidInstructionData => Ok(Self::InvalidInstructionData),
             Self::Error::InvalidAccountData => Ok(Self::InvalidAccountData),
@@ -169,7 +169,7 @@ where
     fn from(error: T) -> Self {
         let error = error.to_u64().unwrap_or(0xbad_c0de);
         match error {
-            CUSTOM_ZERO => InstructionError::CustomError(0),
+            CUSTOM_ZERO => InstructionError::Custom(0),
             INVALID_ARGUMENT => InstructionError::InvalidArgument,
             INVALID_INSTRUCTION_DATA => InstructionError::InvalidInstructionData,
             INVALID_ACCOUNT_DATA => InstructionError::InvalidAccountData,
@@ -184,7 +184,7 @@ where
             _ => {
                 // A valid custom error has no bits set in the upper 32
                 if error >> BUILTIN_BIT_SHIFT == 0 {
-                    InstructionError::CustomError(error as u32)
+                    InstructionError::Custom(error as u32)
                 } else {
                     InstructionError::InvalidError
                 }

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -434,7 +434,7 @@ mod tests {
         where
             T: 'static + std::error::Error + DecodeError<T> + FromPrimitive,
         {
-            if let InstructionError::CustomError(code) = err {
+            if let InstructionError::Custom(code) = err {
                 let specific_error: T = T::decode_custom_error_to_enum(code).unwrap();
                 format!(
                     "{:?}: {}::{:?} - {}",
@@ -448,19 +448,19 @@ mod tests {
             }
         }
         assert_eq!(
-            "CustomError(0): NonceError::NoRecentBlockhashes - recent blockhash list is empty",
+            "Custom(0): NonceError::NoRecentBlockhashes - recent blockhash list is empty",
             pretty_err::<NonceError>(NonceError::NoRecentBlockhashes.into())
         );
         assert_eq!(
-            "CustomError(1): NonceError::NotExpired - stored nonce is still in recent_blockhashes",
+            "Custom(1): NonceError::NotExpired - stored nonce is still in recent_blockhashes",
             pretty_err::<NonceError>(NonceError::NotExpired.into())
         );
         assert_eq!(
-            "CustomError(2): NonceError::UnexpectedValue - specified nonce does not match stored nonce",
+            "Custom(2): NonceError::UnexpectedValue - specified nonce does not match stored nonce",
             pretty_err::<NonceError>(NonceError::UnexpectedValue.into())
         );
         assert_eq!(
-            "CustomError(3): NonceError::BadAccountState - cannot handle request in current account state",
+            "Custom(3): NonceError::BadAccountState - cannot handle request in current account state",
             pretty_err::<NonceError>(NonceError::BadAccountState.into())
         );
     }


### PR DESCRIPTION
#### Problem

Redudent "Error" in `InstructionError::CustomError` and `ProgramError::CustomError`

#### Summary of Changes

Rename it to `Custom`

Fixes #
