### PR TITLE
Allow to run testnet-automation.sh directly from PRs

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -181,7 +181,7 @@ build() {
 
     buildVariant=
     if $debugBuild; then
-      buildVariant=debug
+      buildVariant=--debug
     fi
 
     $MAYBE_DOCKER bash -c "
@@ -861,6 +861,10 @@ while getopts "h?T:t:o:f:rc:Fn:i:d" opt "${shortArgs[@]}"; do
     edge|beta|stable|v*)
       releaseChannel=$OPTARG
       deployMethod=tar
+      ;;
+    local)
+      # just pass-through to use default values for $deployMethod and $doBuild
+      true
       ;;
     *)
       usage "Invalid release channel: $OPTARG"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -283,8 +283,12 @@ EOF
       --entrypoint "$entrypointIp:8001"
       --gossip-port 8001
       --rpc-port 8899
-      --expected-shred-version "$(cat config/shred-version)"
     )
+    if [[ -f config/shred-version && -s config/shred-version ]]; then
+      args+=(
+        --expected-shred-version "$(cat config/shred-version)"
+      )
+    fi
     if [[ $nodeType = blockstreamer ]]; then
       args+=(
         --blockstream /tmp/solana-blockstream.sock
@@ -374,6 +378,7 @@ cat >> ~/solana/on-reboot <<EOF
     oom_score_adj "\$pid" 1000
     disown
 EOF
+    grep -H ^ ~/solana/on-reboot
     ~/solana/on-reboot
     waitForNodeToInit
 
@@ -423,6 +428,7 @@ cat >> ~/solana/on-reboot <<EOF
     oom_score_adj "\$pid" 1000
     disown
 EOF
+    grep -H ^ ~/solana/on-reboot
     ~/solana/on-reboot
     sleep 1
     ;;

--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -18,6 +18,14 @@ function execution_step {
 
 function collect_logs {
   execution_step "Collect logs from remote nodes"
+
+  ls -lR "${REPO_ROOT}"/net/log/
+  for logfile in "${REPO_ROOT}"/net/log/*validator*; do
+    (
+      upload-ci-artifact "$logfile"
+    )
+  done
+
   rm -rf "${REPO_ROOT}"/net/log
   "${REPO_ROOT}"/net/net.sh logs
   for logfile in "${REPO_ROOT}"/net/log/*; do


### PR DESCRIPTION
#### Problem

While doing #9161, I noticed that I can't test testnet automation scripts with my changes in that PR.

#### Summary of Changes

I'm surprised testnet-automation.sh is really solid to this extent; just a small more wiring was needed to fix the problem.

_As a bonus, this paves the way to run preset of testnet runs from PRs directly and automatically._

Well, adequately streamlined, yet invoking bunch of `colo.sh`/`gcp.sh` and `net.sh` is a bit tedious for me just to run normal perf. tests. You know, engineers are lazy.. :p
