### PR TITLE
Add fee-payer option to docs

### DIFF
--- a/docs/src/cli/delegate-stake.md
+++ b/docs/src/cli/delegate-stake.md
@@ -33,11 +33,13 @@ want to perform an action on the stake account you create next.
 Now, create a stake account:
 
 ```bash
-solana create-stake-account --from <KEYPAIR> stake-account.json <AMOUNT> --stake-authority <KEYPAIR> --withdraw-authority <KEYPAIR>
+solana create-stake-account --from <KEYPAIR> stake-account.json <AMOUNT> \
+    --stake-authority <KEYPAIR> --withdraw-authority <KEYPAIR> \
+    --fee-payer <KEYPAIR>
 ```
 
-`<AMOUNT>` tokens are transferred from the account at `<KEYPAIR>` to a new
-stake account at the public key of stake-account.json.
+`<AMOUNT>` tokens are transferred from the account at the "from" `<KEYPAIR>` to
+a new stake account at the public key of stake-account.json.
 
 The stake-account.json file can now be discarded. To authorize additional
 actions, you will use the `--stake-authority` or `withdraw-authority` keypair,
@@ -72,7 +74,9 @@ Stake and withdraw authorities can be set when creating an account via the
 run:
 
 ```bash
-solana stake-authorize <STAKE_ACCOUNT_ADDRESS> --stake-authority <KEYPAIR> --new-stake-authority <PUBKEY>
+solana stake-authorize <STAKE_ACCOUNT_ADDRESS> \
+    --stake-authority <KEYPAIR> --new-stake-authority <PUBKEY> \
+    --fee-payer <KEYPAIR>
 ```
 
 This will use the existing stake authority `<KEYPAIR>` to authorize a new stake
@@ -87,7 +91,8 @@ addresses can be cumbersome. Fortunately, you can derive stake addresses using
 the `--seed` option:
 
 ```bash
-solana create-stake-account --from <KEYPAIR> <STAKE_ACCOUNT_KEYPAIR> --seed <STRING> <AMOUNT> --stake-authority <PUBKEY> --withdraw-authority <PUBKEY>
+solana create-stake-account --from <KEYPAIR> <STAKE_ACCOUNT_KEYPAIR> --seed <STRING> <AMOUNT> \
+    --stake-authority <PUBKEY> --withdraw-authority <PUBKEY> --fee-payer <KEYPAIR>
 ```
 
 `<STRING>` is an arbitrary string up to 32 bytes, but will typically be a
@@ -122,12 +127,13 @@ is the vote account address. Choose a validator and use its vote account
 address in `solana delegate-stake`:
 
 ```bash
-solana delegate-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <VOTE_ACCOUNT_ADDRESS>
+solana delegate-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <VOTE_ACCOUNT_ADDRESS> \
+    --fee-payer <KEYPAIR>
 ```
 
-`<KEYPAIR>` authorizes the operation on the account with address
-`<STAKE_ACCOUNT_ADDRESS>`. The stake is delegated to the vote account with
-address `<VOTE_ACCOUNT_ADDRESS>`.
+The stake authority `<KEYPAIR>` authorizes the operation on the account with
+address `<STAKE_ACCOUNT_ADDRESS>`. The stake is delegated to the vote account
+with address `<VOTE_ACCOUNT_ADDRESS>`.
 
 After delegating stake, use `solana stake-account` to observe the changes
 to the stake account:
@@ -155,11 +161,12 @@ Once delegated, you can undelegate stake with the `solana deactivate-stake`
 command:
 
 ```bash
-solana deactivate-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS>
+solana deactivate-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> \
+    --fee-payer <KEYPAIR>
 ```
 
-`<KEYPAIR>` authorizes the operation on the account with address
-`<STAKE_ACCOUNT_ADDRESS>`.
+The stake authority `<KEYPAIR>` authorizes the operation on the account
+with address `<STAKE_ACCOUNT_ADDRESS>`.
 
 Note that stake takes several epochs to "cool down". Attempts to delegate stake
 in the cool down period will fail.
@@ -169,12 +176,13 @@ in the cool down period will fail.
 Transfer tokens out of a stake account with the `solana withdraw-stake` command:
 
 ```bash
-solana withdraw-stake --withdraw-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <RECIPIENT_ADDRESS> <AMOUNT>
+solana withdraw-stake --withdraw-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <RECIPIENT_ADDRESS> <AMOUNT> \
+    --fee-payer <KEYPAIR>
 ```
 
-`<STAKE_ACCOUNT_ADDRESS>` is the existing stake account, `<KEYPAIR>` is the
-withdraw authority, and `<AMOUNT>` is the number of tokens to transfer to
-`<RECIPIENT_ADDRESS>`.
+`<STAKE_ACCOUNT_ADDRESS>` is the existing stake account, the stake authority
+`<KEYPAIR>` is the withdraw authority, and `<AMOUNT>` is the number of tokens
+to transfer to `<RECIPIENT_ADDRESS>`.
 
 ## Split Stake
 
@@ -184,12 +192,14 @@ currently staked, cooling down, or locked up. To transfer tokens from an
 existing stake account to a new one, use the `solana split-stake` command:
 
 ```bash
-solana split-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <NEW_STAKE_ACCOUNT_KEYPAIR> <AMOUNT>
+solana split-stake --stake-authority <KEYPAIR> <STAKE_ACCOUNT_ADDRESS> <NEW_STAKE_ACCOUNT_KEYPAIR> <AMOUNT> \
+    --fee-payer <KEYPAIR>
 ```
 
-`<STAKE_ACCOUNT_ADDRESS>` is the existing stake account, `<KEYPAIR>` is the
-stake authority, `<NEW_STAKE_ACCOUNT_KEYPAIR>` is the keypair for the new account,
-and `<AMOUNT>` is the number of tokens to transfer to the new account.
+`<STAKE_ACCOUNT_ADDRESS>` is the existing stake account, the stake authority
+`<KEYPAIR>` is the stake authority, `<NEW_STAKE_ACCOUNT_KEYPAIR>` is the
+keypair for the new account, and `<AMOUNT>` is the number of tokens to transfer
+to the new account.
 
 To split a stake account into a derived account address, use the `--seed`
 option.  See

--- a/docs/src/cli/manage-stake-accounts.md
+++ b/docs/src/cli/manage-stake-accounts.md
@@ -16,7 +16,8 @@ Create and fund a derived stake account at the stake authority public key:
 
 ```bash
 solana-stake-accounts new <FUNDING_KEYPAIR> <BASE_KEYPAIR> <AMOUNT> \
-    --stake-authority <PUBKEY> --withdraw-authority <PUBKEY>
+    --stake-authority <PUBKEY> --withdraw-authority <PUBKEY> \
+    --fee-payer <KEYPAIR>
 ```
 
 ### Count accounts
@@ -51,7 +52,7 @@ Set new authorities on each derived stake account:
 solana-stake-accounts authorize <BASE_PUBKEY> \
     --stake-authority <KEYPAIR> --withdraw-authority <KEYPAIR> \
     --new-stake-authority <PUBKEY> --new-withdraw-authority <PUBKEY> \
-    --num-accounts <NUMBER>
+    --num-accounts <NUMBER> --fee-payer <KEYPAIR>
 ```
 
 ### Relocate stake accounts
@@ -60,7 +61,8 @@ Relocate stake accounts:
 
 ```bash
 solana-stake-accounts rebase <BASE_PUBKEY> <NEW_BASE_KEYPAIR> \
-    --stake-authority <KEYPAIR> --num-accounts <NUMBER>
+    --stake-authority <KEYPAIR> --num-accounts <NUMBER> \
+    --fee-payer <KEYPAIR>
 ```
 
 To atomically rebase and authorize each stake account, use the 'move'
@@ -70,5 +72,5 @@ command:
 solana-stake-accounts move <BASE_PUBKEY> <NEW_BASE_KEYPAIR> \
     --stake-authority <KEYPAIR> --withdraw-authority <KEYPAIR> \
     --new-stake-authority <PUBKEY> --new-withdraw-authority <PUBKEY> \
-    --num-accounts <NUMBER>
+    --num-accounts <NUMBER> --fee-payer <KEYPAIR>
 ```

--- a/docs/src/cli/transfer-tokens.md
+++ b/docs/src/cli/transfer-tokens.md
@@ -84,10 +84,10 @@ pubkey: GKvqsuNcnwWqPzzuhLmGi4rzzh55FhJtGizkhHaEJqiV
 ```
 
 ```bash
-solana transfer --from <SENDER_KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> 5 --url http://devnet.solana.com
+solana transfer --from <KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> 5--url http://devnet.solana.com --fee-payer <KEYPAIR>
 ```
 
-where you replace `<SENDER_KEYPAIR>` with the path to a keypair in your wallet,
+where you replace `<KEYPAIR>` with the path to a keypair in your wallet,
 and replace `<RECIPIENT_ACCOUNT_ADDRESS>` with the output of `solana-keygen new` above.
 
 Confirm the updated balances with `solana balance`:
@@ -107,7 +107,7 @@ tokens to transfer. Once you have that collected, you can transfer tokens
 with the `solana transfer` command:
 
 ```bash
-solana transfer --from <SENDER_KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> <AMOUNT>
+solana transfer --from <KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> <AMOUNT> --fee-payer <KEYPAIR>
 ```
 
 Confirm the updated balances with `solana balance`:


### PR DESCRIPTION
#### Problem

Docs assume a default signer is set, but the default signer is a foot-gun that we shouldn't encourage  until we stop using it as defaults for authority options.

#### Summary of Changes

Add `--fee-payer` option to all CLI commands

Fixes #9167 

