### PR TITLE
Add some information about what an address can be for CLI commands

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2255,24 +2255,20 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .help("The airdrop amount to request, in SOL"),
                 )
                 .arg(
-                    Arg::with_name("to")
+                    pubkey!(Arg::with_name("to")
                         .index(2)
-                        .value_name("RECIPIENT_ADDRESS")
-                        .takes_value(true)
-                        .validator(is_valid_pubkey)
-                        .help("The account address of airdrop recipient"),
+                        .value_name("RECIPIENT_ADDRESS"),
+                        "The account address of airdrop recipient. "),
                 ),
         )
         .subcommand(
             SubCommand::with_name("balance")
                 .about("Get your balance")
                 .arg(
-                    Arg::with_name("pubkey")
+                    pubkey!(Arg::with_name("pubkey")
                         .index(1)
-                        .value_name("ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .validator(is_valid_pubkey)
-                        .help("The account address of the balance to check"),
+                        .value_name("ACCOUNT_ADDRESS"),
+                        "The account address of the balance to check. ")
                 )
                 .arg(
                     Arg::with_name("lamports")
@@ -2329,13 +2325,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         ),
                 )
                 .arg(
-                    Arg::with_name("from")
+                    pubkey!(Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_PUBKEY")
-                        .takes_value(true)
-                        .required(false)
-                        .validator(is_valid_pubkey)
-                        .help("From (base) key, [default: cli config keypair]"),
+                        .required(false),
+                        "From (base) key, [default: cli config keypair]. "),
                 ),
         )
         .subcommand(
@@ -2354,13 +2348,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
             SubCommand::with_name("pay")
                 .about("Send a payment")
                 .arg(
-                    Arg::with_name("to")
+                    pubkey!(Arg::with_name("to")
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("The account address of recipient"),
+                        .required(true),
+                        "The account address of recipient. "),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -2423,13 +2415,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
             SubCommand::with_name("send-signature")
                 .about("Send a signature to authorize a transfer")
                 .arg(
-                    Arg::with_name("to")
+                    pubkey!(Arg::with_name("to")
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey)
-                        .help("The account address of recipient"),
+                        .required(true),
+                        "The account address of recipient. "),
                 )
                 .arg(
                     Arg::with_name("process_id")
@@ -2444,13 +2434,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
             SubCommand::with_name("send-timestamp")
                 .about("Send a timestamp to unlock a transfer")
                 .arg(
-                    Arg::with_name("to")
+                    pubkey!(Arg::with_name("to")
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_pubkey)
-                        .help("The account address of recipient"),
+                        .required(true),
+                        "The account address of recipient. "),
                 )
                 .arg(
                     Arg::with_name("process_id")
@@ -2472,13 +2460,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
             SubCommand::with_name("transfer")
                 .about("Transfer funds between system accounts")
                 .arg(
-                    Arg::with_name("to")
+                    pubkey!(Arg::with_name("to")
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("The account address of recipient"),
+                        .required(true),
+                        "The account address of recipient. "),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -2490,12 +2476,10 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .help("The amount to send, in SOL"),
                 )
                 .arg(
-                    Arg::with_name("from")
+                    pubkey!(Arg::with_name("from")
                         .long("from")
-                        .takes_value(true)
-                        .value_name("KEYPAIR")
-                        .validator(is_valid_signer)
-                        .help("Source account of funds (if different from client local account)"),
+                        .value_name("FROM_ADDRESS"),
+                        "Source account of funds (if different from client local account). "),
                 )
                 .offline_args()
                 .arg(nonce_arg())
@@ -2507,13 +2491,11 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .about("Show the contents of an account")
                 .alias("account")
                 .arg(
-                    Arg::with_name("account_pubkey")
+                    pubkey!(Arg::with_name("account_pubkey")
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Account pubkey"),
+                        .required(true),
+                        "Account key URI. ")
                 )
                 .arg(
                     Arg::with_name("output_file")

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -54,13 +54,11 @@ impl ClusterQuerySubCommands for App<'_, '_> {
             SubCommand::with_name("catchup")
                 .about("Wait for a validator to catch up to the cluster")
                 .arg(
-                    Arg::with_name("node_pubkey")
+                    pubkey!(Arg::with_name("node_pubkey")
                         .index(1)
-                        .takes_value(true)
                         .value_name("VALIDATOR_PUBKEY")
-                        .validator(is_valid_pubkey)
-                        .required(true)
-                        .help("Identity pubkey of the validator"),
+                        .required(true),
+                        "Identity pubkey of the validator"),
                 )
                 .arg(
                     Arg::with_name("node_json_rpc_url")
@@ -219,13 +217,11 @@ impl ClusterQuerySubCommands for App<'_, '_> {
             SubCommand::with_name("stakes")
                 .about("Show stake account information")
                 .arg(
-                    Arg::with_name("vote_account_pubkeys")
+                    pubkey!(Arg::with_name("vote_account_pubkeys")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_PUBKEYS")
-                        .takes_value(true)
-                        .multiple(true)
-                        .validator(is_valid_pubkey)
-                        .help("Only show stake accounts delegated to the provided vote accounts"),
+                        .multiple(true),
+                        "Only show stake accounts delegated to the provided vote accounts. "),
                 )
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,23 @@
+macro_rules! ACCOUNT_STRING {
+    () => {
+        r#"Can be:
+  * a bs58 pubkey string
+  * path to keypair file
+  * '-' to take json-encoded keypair string from stdin
+  * 'ASK' to ask for a passphrase
+  * path to hardware wallet (usb://..)"#
+    };
+}
+
+#[macro_use]
+macro_rules! pubkey {
+    ($arg:expr, $help:expr) => {
+        $arg.takes_value(true)
+            .validator(is_valid_pubkey)
+            .help(concat!($help, ACCOUNT_STRING!()))
+    };
+}
+
 pub mod cli;
 pub mod cluster_query;
 pub mod display;

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -92,22 +92,18 @@ impl NonceSubCommands for App<'_, '_> {
             SubCommand::with_name("authorize-nonce-account")
                 .about("Assign account authority to a new entity")
                 .arg(
-                    Arg::with_name("nonce_account_pubkey")
+                    pubkey!(Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Address of the nonce account"),
+                        .required(true),
+                        "Address of the nonce account. "),
                 )
                 .arg(
-                    Arg::with_name("new_authority")
+                    pubkey!(Arg::with_name("new_authority")
                         .index(2)
                         .value_name("AUTHORITY_PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Account to be granted authority of the nonce account"),
+                        .required(true),
+                        "Account to be granted authority of the nonce account. "),
                 )
                 .arg(nonce_authority_arg()),
         )
@@ -133,12 +129,10 @@ impl NonceSubCommands for App<'_, '_> {
                         .help("The amount to load the nonce account with, in SOL"),
                 )
                 .arg(
-                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
+                    pubkey!(Arg::with_name(NONCE_AUTHORITY_ARG.name)
                         .long(NONCE_AUTHORITY_ARG.long)
-                        .takes_value(true)
-                        .value_name("PUBKEY")
-                        .validator(is_valid_pubkey)
-                        .help("Assign noncing authority to another entity"),
+                        .value_name("PUBKEY"),
+                        "Assign noncing authority to another entity. "),
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -153,26 +147,22 @@ impl NonceSubCommands for App<'_, '_> {
                 .about("Get the current nonce value")
                 .alias("get-nonce")
                 .arg(
-                    Arg::with_name("nonce_account_pubkey")
+                    pubkey!(Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Address of the nonce account to display"),
+                        .required(true),
+                        "Address of the nonce account to display. "),
                 ),
         )
         .subcommand(
             SubCommand::with_name("new-nonce")
                 .about("Generate a new nonce, rendering the existing nonce useless")
                 .arg(
-                    Arg::with_name("nonce_account_pubkey")
+                    pubkey!(Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Address of the nonce account"),
+                        .required(true),
+                        "Address of the nonce account. "),
                 )
                 .arg(nonce_authority_arg()),
         )
@@ -181,13 +171,11 @@ impl NonceSubCommands for App<'_, '_> {
                 .about("Show the contents of a nonce account")
                 .alias("show-nonce-account")
                 .arg(
-                    Arg::with_name("nonce_account_pubkey")
+                    pubkey!(Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Address of the nonce account to display"),
+                        .required(true),
+                        "Address of the nonce account to display. "),
                 )
                 .arg(
                     Arg::with_name("lamports")
@@ -200,22 +188,18 @@ impl NonceSubCommands for App<'_, '_> {
             SubCommand::with_name("withdraw-from-nonce-account")
                 .about("Withdraw SOL from the nonce account")
                 .arg(
-                    Arg::with_name("nonce_account_pubkey")
+                    pubkey!(Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Nonce account to withdraw from"),
+                        .required(true),
+                        "Nonce account to withdraw from. "),
                 )
                 .arg(
-                    Arg::with_name("destination_account_pubkey")
+                    pubkey!(Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("The account to which the SOL should be transferred"),
+                        .required(true),
+                        "The account to which the SOL should be transferred. "),
                 )
                 .arg(
                     Arg::with_name("amount")

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -89,12 +89,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("The amount to send to the stake account, in SOL")
                 )
                 .arg(
-                    Arg::with_name("custodian")
+                    pubkey!(Arg::with_name("custodian")
                         .long("custodian")
-                        .value_name("PUBKEY")
-                        .takes_value(true)
-                        .validator(is_valid_pubkey)
-                        .help("Authority to modify lockups")
+                        .value_name("PUBKEY"),
+                        "Authority to modify lockups. ")
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -158,22 +156,18 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("Override vote account sanity checks (use carefully!)")
                 )
                 .arg(
-                    Arg::with_name("stake_account_pubkey")
+                    pubkey!(Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Stake account to delegate")
+                        .required(true),
+                        "Stake account to delegate")
                 )
                 .arg(
-                    Arg::with_name("vote_account_pubkey")
+                    pubkey!(Arg::with_name("vote_account_pubkey")
                         .index(2)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("The vote account to which the stake will be delegated")
+                        .required(true),
+                        "The vote account to which the stake will be delegated")
                 )
                 .arg(stake_authority_arg())
                 .offline_args()
@@ -185,31 +179,25 @@ impl StakeSubCommands for App<'_, '_> {
             SubCommand::with_name("stake-authorize")
                 .about("Authorize a new signing keypair for the given stake account")
                 .arg(
-                    Arg::with_name("stake_account_pubkey")
+                    pubkey!(Arg::with_name("stake_account_pubkey")
                         .required(true)
                         .index(1)
-                        .takes_value(true)
-                        .value_name("STAKE_ACCOUNT_ADDRESS")
-                        .validator(is_valid_pubkey)
-                        .help("Stake account in which to set a new authority")
+                        .value_name("STAKE_ACCOUNT_ADDRESS"),
+                        "Stake account in which to set a new authority. ")
                 )
                 .arg(
-                    Arg::with_name("new_stake_authority")
+                    pubkey!(Arg::with_name("new_stake_authority")
                         .long("new-stake-authority")
                         .required_unless("new_withdraw_authority")
-                        .takes_value(true)
-                        .value_name("PUBKEY")
-                        .validator(is_valid_pubkey)
-                        .help("New authorized staker")
+                        .value_name("PUBKEY"),
+                        "New authorized staker")
                 )
                 .arg(
-                    Arg::with_name("new_withdraw_authority")
+                    pubkey!(Arg::with_name("new_withdraw_authority")
                         .long("new-withdraw-authority")
                         .required_unless("new_stake_authority")
-                        .takes_value(true)
-                        .value_name("PUBKEY")
-                        .validator(is_valid_pubkey)
-                        .help("New authorized withdrawer")
+                        .value_name("PUBKEY"),
+                        "New authorized withdrawer. ")
                 )
                 .arg(stake_authority_arg())
                 .arg(withdraw_authority_arg())
@@ -222,13 +210,11 @@ impl StakeSubCommands for App<'_, '_> {
             SubCommand::with_name("deactivate-stake")
                 .about("Deactivate the delegated stake from the stake account")
                 .arg(
-                    Arg::with_name("stake_account_pubkey")
+                    pubkey!(Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Stake account to be deactivated.")
+                        .required(true),
+                        "Stake account to be deactivated. ")
                 )
                 .arg(stake_authority_arg())
                 .offline_args()
@@ -240,13 +226,11 @@ impl StakeSubCommands for App<'_, '_> {
             SubCommand::with_name("split-stake")
                 .about("Duplicate a stake account, splitting the tokens between the two")
                 .arg(
-                    Arg::with_name("stake_account_pubkey")
+                    pubkey!(Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Stake account to split (or base of derived address if --seed is used)")
+                        .required(true),
+                        "Stake account to split (or base of derived address if --seed is used). ")
                 )
                 .arg(
                     Arg::with_name("split_stake_account")
@@ -283,22 +267,18 @@ impl StakeSubCommands for App<'_, '_> {
             SubCommand::with_name("withdraw-stake")
                 .about("Withdraw the unstaked SOL from the stake account")
                 .arg(
-                    Arg::with_name("stake_account_pubkey")
+                    pubkey!(Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Stake account from which to withdraw")
+                        .required(true),
+                        "Stake account from which to withdraw")
                 )
                 .arg(
-                    Arg::with_name("destination_account_pubkey")
+                    pubkey!(Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Recipient of withdrawn SOL")
+                        .required(true),
+                        "Recipient of withdrawn SOL")
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -319,13 +299,11 @@ impl StakeSubCommands for App<'_, '_> {
             SubCommand::with_name("stake-set-lockup")
                 .about("Set Lockup for the stake account")
                 .arg(
-                    Arg::with_name("stake_account_pubkey")
+                    pubkey!(Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Stake account for which to set lockup parameters")
+                        .required(true),
+                        "Stake account for which to set lockup parameters. ")
                 )
                 .arg(
                     Arg::with_name("lockup_epoch")
@@ -343,12 +321,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("The date and time at which this account will be available for withdrawal")
                 )
                 .arg(
-                    Arg::with_name("new_custodian")
+                    pubkey!(Arg::with_name("new_custodian")
                         .long("new-custodian")
-                        .value_name("PUBKEY")
-                        .takes_value(true)
-                        .validator(is_valid_pubkey)
-                        .help("Identity of a new lockup custodian")
+                        .value_name("PUBKEY"),
+                        "Identity of a new lockup custodian. ")
                 )
                 .group(ArgGroup::with_name("lockup_details")
                     .args(&["lockup_epoch", "lockup_date", "new_custodian"])
@@ -371,13 +347,11 @@ impl StakeSubCommands for App<'_, '_> {
                 .about("Show the contents of a stake account")
                 .alias("show-stake-account")
                 .arg(
-                    Arg::with_name("stake_account_pubkey")
+                    pubkey!(Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("The stake account to display")
+                        .required(true),
+                        "The stake account to display. ")
                 )
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -53,20 +53,16 @@ impl VoteSubCommands for App<'_, '_> {
                         .help("The commission taken on reward redemption (0-100)"),
                 )
                 .arg(
-                    Arg::with_name("authorized_voter")
+                    pubkey!(Arg::with_name("authorized_voter")
                         .long("authorized-voter")
-                        .value_name("VOTER_PUBKEY")
-                        .takes_value(true)
-                        .validator(is_valid_pubkey)
-                        .help("Public key of the authorized voter [default: validator identity pubkey]"),
+                        .value_name("VOTER_PUBKEY"),
+                        "Public key of the authorized voter [default: validator identity pubkey]. "),
                 )
                 .arg(
-                    Arg::with_name("authorized_withdrawer")
+                    pubkey!(Arg::with_name("authorized_withdrawer")
                         .long("authorized-withdrawer")
-                        .value_name("WITHDRAWER_PUBKEY")
-                        .takes_value(true)
-                        .validator(is_valid_pubkey)
-                        .help("Public key of the authorized withdrawer [default: validator identity pubkey]"),
+                        .value_name("WITHDRAWER_PUBKEY"),
+                        "Public key of the authorized withdrawer [default: validator identity pubkey]. "),
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -80,57 +76,47 @@ impl VoteSubCommands for App<'_, '_> {
             SubCommand::with_name("vote-authorize-voter")
                 .about("Authorize a new vote signing keypair for the given vote account")
                 .arg(
-                    Arg::with_name("vote_account_pubkey")
+                    pubkey!(Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Vote account in which to set the authorized voter"),
+                        .required(true),
+                        "Vote account in which to set the authorized voter. "),
                 )
                 .arg(
-                    Arg::with_name("new_authorized_pubkey")
+                    pubkey!(Arg::with_name("new_authorized_pubkey")
                         .index(2)
                         .value_name("AUTHORIZED_PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("New authorized vote signer"),
+                        .required(true),
+                        "New authorized vote signer. "),
                 ),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-withdrawer")
                 .about("Authorize a new withdraw signing keypair for the given vote account")
                 .arg(
-                    Arg::with_name("vote_account_pubkey")
+                    pubkey!(Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Vote account in which to set the authorized withdrawer"),
+                        .required(true),
+                        "Vote account in which to set the authorized withdrawer. "),
                 )
                 .arg(
-                    Arg::with_name("new_authorized_pubkey")
+                    pubkey!(Arg::with_name("new_authorized_pubkey")
                         .index(2)
                         .value_name("AUTHORIZED_PUBKEY")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("New authorized withdrawer"),
+                        .required(true),
+                        "New authorized withdrawer. "),
                 ),
         )
         .subcommand(
             SubCommand::with_name("vote-update-validator")
                 .about("Update the vote account's validator identity")
                 .arg(
-                    Arg::with_name("vote_account_pubkey")
+                    pubkey!(Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Vote account to update"),
+                        .required(true),
+                        "Vote account to update. "),
                 )
                 .arg(
                     Arg::with_name("new_identity_account")
@@ -164,13 +150,11 @@ impl VoteSubCommands for App<'_, '_> {
                         ),
                 )
                 .arg(
-                    Arg::with_name("vote_account_pubkey")
+                    pubkey!(Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Vote account pubkey"),
+                        .required(true),
+                        "Vote account pubkey. "),
                 )
                 .arg(
                     Arg::with_name("lamports")
@@ -183,22 +167,18 @@ impl VoteSubCommands for App<'_, '_> {
             SubCommand::with_name("withdraw-from-vote-account")
                 .about("Withdraw lamports from a vote account into a specified account")
                 .arg(
-                    Arg::with_name("vote_account_pubkey")
+                    pubkey!(Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("Vote account from which to withdraw"),
+                        .required(true),
+                        "Vote account from which to withdraw. "),
                 )
                 .arg(
-                    Arg::with_name("destination_account_pubkey")
+                    pubkey!(Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
-                        .takes_value(true)
-                        .required(true)
-                        .validator(is_valid_pubkey)
-                        .help("The recipient of withdrawn SOL"),
+                        .required(true),
+                        "The recipient of withdrawn SOL. "),
                 )
                 .arg(
                     Arg::with_name("amount")


### PR DESCRIPTION
#### Problem

CLI documentation makes no mention of the many ways that a pubkey could be input from the commad line for various commands.

#### Summary of Changes

Add some help documentation which makes poor error messages make a little more sense.

Fixes #
