### PR TITLE
ci: Add dependabot placeholder build step

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -2,6 +2,11 @@
 #
 # Release tags use buildkite-release.yml instead
 steps:
+  - command: "true"
+    name: "dependabot"
+    timeout_in_minutes: 5
+    if: build.env("GITHUB_USER") == "dependabot-preview[bot]"
+  - wait
   - command: "ci/shellcheck.sh"
     name: "shellcheck"
     timeout_in_minutes: 5


### PR DESCRIPTION
Use https://github.com/mvines/ci-gate/commit/e17af6a0feafb7f6461be5ea00323f6448b155ab to demonstrate how to filter build steps based on PR author.

cc: https://github.com/solana-labs/solana/pull/9180#issuecomment-606948101