### PR TITLE
Reduce ticks_per_second and ticks_per_slot in test config

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -711,6 +711,8 @@ impl TestValidator {
             42,
             bootstrap_validator_lamports,
         );
+        genesis_config.ticks_per_slot = 4;
+        genesis_config.poh_config.target_tick_duration = Duration::from_millis(10);
         genesis_config
             .native_instruction_processors
             .push(solana_budget_program!());


### PR DESCRIPTION
#### Problem

Tests take too long

#### Summary of Changes

Use a config with a higher slot/s rate.

Fixes #
