### PR TITLE
cli: Add epoch subcommand

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -188,6 +188,9 @@ pub enum CliCommand {
         commitment_config: CommitmentConfig,
     },
     GetGenesisHash,
+    GetEpoch {
+        commitment_config: CommitmentConfig,
+    },
     GetSlot {
         commitment_config: CommitmentConfig,
     },
@@ -586,6 +589,7 @@ pub fn parse_command(
             command: CliCommand::GetGenesisHash,
             signers: vec![],
         }),
+        ("epoch", Some(matches)) => parse_get_epoch(matches),
         ("slot", Some(matches)) => parse_get_slot(matches),
         ("total-supply", Some(matches)) => parse_total_supply(matches),
         ("transaction-count", Some(matches)) => parse_get_transaction_count(matches),
@@ -1601,6 +1605,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::GetGenesisHash => process_get_genesis_hash(&rpc_client),
         CliCommand::GetEpochInfo { commitment_config } => {
             process_get_epoch_info(&rpc_client, *commitment_config)
+        }
+        CliCommand::GetEpoch { commitment_config } => {
+            process_get_epoch(&rpc_client, *commitment_config)
         }
         CliCommand::GetSlot { commitment_config } => {
             process_get_slot(&rpc_client, *commitment_config)

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -120,6 +120,17 @@ impl ClusterQuerySubCommands for App<'_, '_> {
             ),
         )
         .subcommand(
+            SubCommand::with_name("epoch").about("Get current epoch")
+            .arg(
+                Arg::with_name("confirmed")
+                    .long("confirmed")
+                    .takes_value(false)
+                    .help(
+                        "Return epoch at maximum-lockout commitment level",
+                    ),
+            ),
+        )
+        .subcommand(
             SubCommand::with_name("total-supply").about("Get total number of SOL")
             .arg(
                 Arg::with_name("confirmed")
@@ -334,6 +345,18 @@ pub fn parse_get_slot(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliErr
     };
     Ok(CliCommandInfo {
         command: CliCommand::GetSlot { commitment_config },
+        signers: vec![],
+    })
+}
+
+pub fn parse_get_epoch(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+    let commitment_config = if matches.is_present("confirmed") {
+        CommitmentConfig::default()
+    } else {
+        CommitmentConfig::recent()
+    };
+    Ok(CliCommandInfo {
+        command: CliCommand::GetEpoch { commitment_config },
         signers: vec![],
     })
 }
@@ -615,6 +638,14 @@ pub fn process_get_slot(
 ) -> ProcessResult {
     let slot = rpc_client.get_slot_with_commitment(commitment_config.clone())?;
     Ok(slot.to_string())
+}
+
+pub fn process_get_epoch(
+    rpc_client: &RpcClient,
+    commitment_config: CommitmentConfig,
+) -> ProcessResult {
+    let epoch_info = rpc_client.get_epoch_info_with_commitment(commitment_config.clone())?;
+    Ok(epoch_info.epoch.to_string())
 }
 
 pub fn parse_show_block_production(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
@@ -1324,6 +1355,19 @@ mod tests {
             parse_command(&test_get_slot, &default_keypair_file, None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetSlot {
+                    commitment_config: CommitmentConfig::recent(),
+                },
+                signers: vec![],
+            }
+        );
+
+        let test_get_epoch = test_commands
+            .clone()
+            .get_matches_from(vec!["test", "epoch"]);
+        assert_eq!(
+            parse_command(&test_get_epoch, &default_keypair_file, None).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::GetEpoch {
                     commitment_config: CommitmentConfig::recent(),
                 },
                 signers: vec![],


### PR DESCRIPTION
`solana epoch-info` provides a bunch of useful info, but sometimes from the shell I just need the current epoch, just like how the current slot is available.  

Add `solana epoch`, paralleling the existing `solana slot`

(needed in the ledger warehouse script to be smarter about when the ledger is archived)