### PR TITLE
Place CrdsData::AccountsHashes in same enum ordinal position as the v1.0 version

### DIFF
--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -69,8 +69,8 @@ pub enum CrdsData {
     Vote(VoteIndex, Vote),
     LowestSlot(u8, LowestSlot),
     SnapshotHashes(SnapshotHash),
-    EpochSlots(EpochSlotsIndex, EpochSlots),
     AccountsHashes(SnapshotHash),
+    EpochSlots(EpochSlotsIndex, EpochSlots),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -189,8 +189,8 @@ impl CrdsValue {
             CrdsData::Vote(_, vote) => vote.wallclock,
             CrdsData::LowestSlot(_, obj) => obj.wallclock,
             CrdsData::SnapshotHashes(hash) => hash.wallclock,
-            CrdsData::EpochSlots(_, p) => p.wallclock,
             CrdsData::AccountsHashes(hash) => hash.wallclock,
+            CrdsData::EpochSlots(_, p) => p.wallclock,
         }
     }
     pub fn pubkey(&self) -> Pubkey {
@@ -199,8 +199,8 @@ impl CrdsValue {
             CrdsData::Vote(_, vote) => vote.from,
             CrdsData::LowestSlot(_, slots) => slots.from,
             CrdsData::SnapshotHashes(hash) => hash.from,
-            CrdsData::EpochSlots(_, p) => p.from,
             CrdsData::AccountsHashes(hash) => hash.from,
+            CrdsData::EpochSlots(_, p) => p.from,
         }
     }
     pub fn label(&self) -> CrdsValueLabel {
@@ -209,8 +209,8 @@ impl CrdsValue {
             CrdsData::Vote(ix, _) => CrdsValueLabel::Vote(*ix, self.pubkey()),
             CrdsData::LowestSlot(_, _) => CrdsValueLabel::LowestSlot(self.pubkey()),
             CrdsData::SnapshotHashes(_) => CrdsValueLabel::SnapshotHashes(self.pubkey()),
-            CrdsData::EpochSlots(ix, _) => CrdsValueLabel::EpochSlots(*ix, self.pubkey()),
             CrdsData::AccountsHashes(_) => CrdsValueLabel::AccountsHashes(self.pubkey()),
+            CrdsData::EpochSlots(ix, _) => CrdsValueLabel::EpochSlots(*ix, self.pubkey()),
         }
     }
     pub fn contact_info(&self) -> Option<&ContactInfo> {


### PR DESCRIPTION
`AccountsHashes` immediately follows `SnapshotHashes` in v1.0:
https://github.com/solana-labs/solana/blob/d4bb7cec69864c5056fd3a372d4c9875676e3e2b/core/src/crds_value.rs#L62-L68

In v1.1, the new `EpochSlots` item snuck in between them