### PR TITLE
Tame overeager wallet manager

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -51,10 +51,7 @@ pub fn check_for_usb<S>(mut items: impl Iterator<Item = S>) -> bool
 where
     S: Into<String>,
 {
-    items.any(|arg| match parse_keypair_path(&arg.into()) {
-        KeypairUrl::Usb(_) => true,
-        _ => false,
-    })
+    items.any(|arg| matches!(parse_keypair_path(&arg.into()), KeypairUrl::Usb(_)))
 }
 
 pub fn presigner_from_pubkey_sigs(
@@ -265,5 +262,21 @@ mod tests {
             "Mary had a little lamb".to_owned(),
             sanitize_seed_phrase(seed_phrase)
         );
+    }
+
+    #[test]
+    fn test_check_for_usb() {
+        let args: Vec<&str> = vec![];
+        assert_eq!(check_for_usb(args.into_iter()), false);
+        let args = vec!["usb://"];
+        assert_eq!(check_for_usb(args.into_iter()), true);
+        let args = vec!["other"];
+        assert_eq!(check_for_usb(args.into_iter()), false);
+        let args = vec!["other", "usb://", "another"];
+        assert_eq!(check_for_usb(args.into_iter()), true);
+        let args = vec!["other", "another"];
+        assert_eq!(check_for_usb(args.into_iter()), false);
+        let args = vec!["usb://", "usb://"];
+        assert_eq!(check_for_usb(args.into_iter()), true);
     }
 }

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -47,6 +47,16 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
     }
 }
 
+pub fn check_for_usb<S>(mut items: impl Iterator<Item = S>) -> bool
+where
+    S: Into<String>,
+{
+    items.any(|arg| match parse_keypair_path(&arg.into()) {
+        KeypairUrl::Usb(_) => true,
+        _ => false,
+    })
+}
+
 pub fn presigner_from_pubkey_sigs(
     pubkey: &Pubkey,
     signers: &[(Pubkey, Signature)],

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -8,7 +8,7 @@ use num_cpus;
 use solana_clap_utils::{
     input_validators::is_derivation,
     keypair::{
-        keypair_from_seed_phrase, prompt_passphrase, signer_from_path,
+        check_for_usb, keypair_from_seed_phrase, prompt_passphrase, signer_from_path,
         SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
     DisplayError,
@@ -407,7 +407,11 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
         Config::default()
     };
 
-    let wallet_manager = maybe_wallet_manager()?;
+    let wallet_manager = if check_for_usb(std::env::args()) {
+        maybe_wallet_manager()?
+    } else {
+        None
+    };
 
     match matches.subcommand() {
         ("pubkey", Some(matches)) => {


### PR DESCRIPTION
#### Problem
The cli's wallet manager is indexing usb devices anytime it detects one, even if a command doesn't require a remote wallet. This is particularly problematic if a hardware wallet is connected but has timed out, because the cli may return a remote-wallet error instead of processing the command normally.

#### Summary of Changes
Add helper function to check for KeypairUrl::Usb args, and only initialize the wallet manager if one or more is present.

Fixes #8768
