### PR TITLE
Rework TransactionStatus index in blockstore

### DIFF
--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -72,7 +72,7 @@ impl TransactionStatusService {
                 let fee = fee_calculator.calculate_fee(transaction.message());
                 blockstore
                     .write_transaction_status(
-                        (slot, transaction.signatures[0]),
+                        (transaction.signatures[0], slot),
                         &TransactionStatusMeta {
                             status,
                             fee,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -146,7 +146,7 @@ fn output_slot(
                             println!("        Data: {:?}", instruction.data);
                         }
                     }
-                    match blockstore.read_transaction_status((slot, transaction.signatures[0])) {
+                    match blockstore.read_transaction_status((transaction.signatures[0], slot)) {
                         Ok(transaction_status) => {
                             if let Some(transaction_status) = transaction_status {
                                 println!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1604,6 +1604,7 @@ impl Blockstore {
         let i = *w_active_transaction_status_index;
         let mut index_meta = self.transaction_status_index_cf.get(i)?.unwrap();
         if slot > index_meta.max_slot {
+            assert!(!index_meta.frozen);
             index_meta.max_slot = slot;
             self.transaction_status_index_cf.put(i, &index_meta)?;
         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -87,6 +87,7 @@ pub struct Blockstore {
     data_shred_cf: LedgerColumn<cf::ShredData>,
     code_shred_cf: LedgerColumn<cf::ShredCode>,
     transaction_status_cf: LedgerColumn<cf::TransactionStatus>,
+    transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
     rewards_cf: LedgerColumn<cf::Rewards>,
     last_root: Arc<RwLock<Slot>>,
     insert_shreds_lock: Arc<Mutex<()>>,
@@ -200,6 +201,7 @@ impl Blockstore {
         let data_shred_cf = db.column();
         let code_shred_cf = db.column();
         let transaction_status_cf = db.column();
+        let transaction_status_index_cf = db.column();
         let rewards_cf = db.column();
 
         let db = Arc::new(db);
@@ -225,6 +227,7 @@ impl Blockstore {
             data_shred_cf,
             code_shred_cf,
             transaction_status_cf,
+            transaction_status_index_cf,
             rewards_cf,
             new_shreds_signals: vec![],
             completed_slots_senders: vec![],
@@ -321,7 +324,7 @@ impl Blockstore {
             .expect("Database Error: Failed to get write batch");
         // delete range cf is not inclusive
         let to_slot = to_slot.checked_add(1).unwrap_or_else(|| std::u64::MAX);
-        let columns_empty = self
+        let mut columns_empty = self
             .db
             .delete_range_cf::<cf::SlotMeta>(&mut write_batch, from_slot, to_slot)
             .unwrap_or(false)
@@ -359,12 +362,14 @@ impl Blockstore {
                 .unwrap_or(false)
             & self
                 .db
-                .delete_range_cf::<cf::TransactionStatus>(&mut write_batch, from_slot, to_slot)
-                .unwrap_or(false)
-            & self
-                .db
                 .delete_range_cf::<cf::Rewards>(&mut write_batch, from_slot, to_slot)
                 .unwrap_or(false);
+        if let Some(index) = self.toggle_transaction_status_index(&mut write_batch, to_slot)? {
+            columns_empty &= &self
+                .db
+                .delete_range_cf::<cf::TransactionStatus>(&mut write_batch, index, index + 1)
+                .unwrap_or(false);
+        }
         if let Err(e) = self.db.write(write_batch) {
             error!(
                 "Error: {:?} while submitting write batch for slot {:?} retrying...",
@@ -415,7 +420,7 @@ impl Blockstore {
                 .unwrap_or(false)
             && self
                 .transaction_status_cf
-                .compact_range(from_slot, to_slot)
+                .compact_range(0, 2)
                 .unwrap_or(false)
             && self
                 .rewards_cf
@@ -1498,8 +1503,7 @@ impl Blockstore {
                 TransactionWithStatusMeta {
                     transaction: encoded_transaction,
                     meta: self
-                        .transaction_status_cf
-                        .get((slot, signature))
+                        .read_transaction_status((signature, slot))
                         .expect("Expect database get to succeed")
                         .map(RpcTransactionStatusMeta::from),
                 }
@@ -1507,18 +1511,105 @@ impl Blockstore {
             .collect()
     }
 
+    fn initialize_transaction_status_index(&self) -> Result<()> {
+        self.transaction_status_index_cf
+            .put(0, &TransactionStatusIndexMeta::default())?;
+        self.transaction_status_index_cf
+            .put(1, &TransactionStatusIndexMeta::default())?;
+        // This dummy status improves compaction performance
+        self.transaction_status_cf.put(
+            (2, Signature::default(), 0),
+            &TransactionStatusMeta::default(),
+        )
+    }
+
+    fn toggle_transaction_status_index(
+        &self,
+        batch: &mut WriteBatch,
+        to_slot: Slot,
+    ) -> Result<Option<u64>> {
+        let index0 = self.transaction_status_index_cf.get(0)?;
+        if index0.is_none() {
+            return Ok(None);
+        }
+        let mut index0 = self.transaction_status_index_cf.get(0)?.unwrap();
+        let mut index1 = self.transaction_status_index_cf.get(1)?.unwrap();
+
+        if !index0.frozen && !index1.frozen {
+            index0.frozen = true;
+            batch.put::<cf::TransactionStatusIndex>(0, &index0)?;
+            Ok(None)
+        } else {
+            let result = if index0.frozen && to_slot >= index0.max_slot {
+                debug!("Pruning transaction index 0 at slot {}", index0.max_slot);
+                Some(0)
+            } else if index1.frozen && to_slot >= index1.max_slot {
+                debug!("Pruning transaction index 1 at slot {}", index1.max_slot);
+                Some(1)
+            } else {
+                None
+            };
+
+            if result.is_some() {
+                if index0.frozen {
+                    index0.max_slot = 0
+                };
+                index0.frozen = !index0.frozen;
+                batch.put::<cf::TransactionStatusIndex>(0, &index0)?;
+                if index1.frozen {
+                    index1.max_slot = 0
+                };
+                index1.frozen = !index1.frozen;
+                batch.put::<cf::TransactionStatusIndex>(1, &index1)?;
+            }
+
+            Ok(result)
+        }
+    }
+
+    fn make_transaction_status_index(
+        &self,
+        index: (Signature, Slot),
+    ) -> Result<(u64, Signature, Slot)> {
+        let (signature, slot) = index;
+        if self.transaction_status_index_cf.get(0)?.is_none() {
+            self.initialize_transaction_status_index()?;
+        }
+        let (i, mut index_meta) = self
+            .db
+            .iter::<cf::TransactionStatusIndex>(IteratorMode::Start)?
+            .map(|(i, bytes)| {
+                let value: TransactionStatusIndexMeta = deserialize(&bytes).unwrap();
+                (i, value)
+            })
+            .find(|(_, meta)| !meta.frozen)
+            .expect("One of the transaction_status indexes should always be unfrozen");
+        if slot > index_meta.max_slot {
+            index_meta.max_slot = slot;
+            self.transaction_status_index_cf.put(i, &index_meta)?;
+        }
+        Ok((i, signature, slot))
+    }
+
     pub fn read_transaction_status(
         &self,
-        index: (Slot, Signature),
+        index: (Signature, Slot),
     ) -> Result<Option<TransactionStatusMeta>> {
-        self.transaction_status_cf.get(index)
+        let (signature, slot) = index;
+        let result = self.transaction_status_cf.get((0, signature, slot))?;
+        if result.is_none() {
+            Ok(self.transaction_status_cf.get((1, signature, slot))?)
+        } else {
+            Ok(result)
+        }
     }
 
     pub fn write_transaction_status(
         &self,
-        index: (Slot, Signature),
+        index: (Signature, Slot),
         status: &TransactionStatusMeta,
     ) -> Result<()> {
+        let index = self.make_transaction_status_index(index)?;
         self.transaction_status_cf.put(index, status)
     }
 
@@ -2648,7 +2739,7 @@ pub mod tests {
                 .iter::<cf::TransactionStatus>(IteratorMode::Start)
                 .unwrap()
                 .next()
-                .map(|((slot, _), _)| slot >= min_slot)
+                .map(|((_, _, slot), _)| slot >= min_slot)
                 .unwrap_or(true)
             & blockstore
                 .db
@@ -4865,7 +4956,7 @@ pub mod tests {
                 ledger
                     .transaction_status_cf
                     .put(
-                        (slot, signature),
+                        (0, signature, slot),
                         &TransactionStatusMeta {
                             status: Ok(()),
                             fee: 42,
@@ -4877,7 +4968,7 @@ pub mod tests {
                 ledger
                     .transaction_status_cf
                     .put(
-                        (slot + 1, signature),
+                        (0, signature, slot + 1),
                         &TransactionStatusMeta {
                             status: Ok(()),
                             fee: 42,
@@ -5146,14 +5237,14 @@ pub mod tests {
 
             // result not found
             assert!(transaction_status_cf
-                .get((0, Signature::default()))
+                .get((0, Signature::default(), 0))
                 .unwrap()
                 .is_none());
 
             // insert value
             assert!(transaction_status_cf
                 .put(
-                    (0, Signature::default()),
+                    (0, Signature::default(), 0),
                     &TransactionStatusMeta {
                         status: solana_sdk::transaction::Result::<()>::Err(
                             TransactionError::AccountNotFound
@@ -5172,7 +5263,7 @@ pub mod tests {
                 pre_balances,
                 post_balances,
             } = transaction_status_cf
-                .get((0, Signature::default()))
+                .get((0, Signature::default(), 0))
                 .unwrap()
                 .unwrap();
             assert_eq!(status, Err(TransactionError::AccountNotFound));
@@ -5183,7 +5274,7 @@ pub mod tests {
             // insert value
             assert!(transaction_status_cf
                 .put(
-                    (9, Signature::default()),
+                    (0, Signature::new(&[2u8; 64]), 9),
                     &TransactionStatusMeta {
                         status: solana_sdk::transaction::Result::<()>::Ok(()),
                         fee: 9u64,
@@ -5200,7 +5291,7 @@ pub mod tests {
                 pre_balances,
                 post_balances,
             } = transaction_status_cf
-                .get((9, Signature::default()))
+                .get((0, Signature::new(&[2u8; 64]), 9))
                 .unwrap()
                 .unwrap();
 
@@ -5209,6 +5300,155 @@ pub mod tests {
             assert_eq!(fee, 9u64);
             assert_eq!(pre_balances, pre_balances_vec);
             assert_eq!(post_balances, post_balances_vec);
+        }
+        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
+    }
+
+    #[test]
+    fn test_transaction_status_index() {
+        let blockstore_path = get_tmp_ledger_path!();
+        {
+            let blockstore = Blockstore::open(&blockstore_path).unwrap();
+            let transaction_status_index_cf = blockstore.db.column::<cf::TransactionStatusIndex>();
+            let slot0 = 10;
+
+            assert!(transaction_status_index_cf.get(0).unwrap().is_none());
+            assert!(transaction_status_index_cf.get(1).unwrap().is_none());
+
+            for _ in 0..5 {
+                let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
+                blockstore
+                    .write_transaction_status(
+                        (Signature::new(&random_bytes), slot0),
+                        &TransactionStatusMeta::default(),
+                    )
+                    .unwrap();
+            }
+
+            // New statuses bump index 0 max_slot
+            assert_eq!(
+                transaction_status_index_cf.get(0).unwrap().unwrap(),
+                TransactionStatusIndexMeta {
+                    max_slot: slot0,
+                    frozen: false,
+                }
+            );
+            assert_eq!(
+                transaction_status_index_cf.get(1).unwrap().unwrap(),
+                TransactionStatusIndexMeta::default()
+            );
+
+            let first_status_entry = blockstore
+                .db
+                .iter::<cf::TransactionStatus>(IteratorMode::From(
+                    (0, Signature::default(), 0),
+                    IteratorDirection::Forward,
+                ))
+                .unwrap()
+                .next()
+                .unwrap()
+                .0;
+            assert_eq!(first_status_entry.0, 0);
+            assert_eq!(first_status_entry.2, slot0);
+
+            blockstore.run_purge(0, 8).unwrap();
+            // First successful prune freezes index 0
+            assert_eq!(
+                transaction_status_index_cf.get(0).unwrap().unwrap(),
+                TransactionStatusIndexMeta {
+                    max_slot: slot0,
+                    frozen: true,
+                }
+            );
+            assert_eq!(
+                transaction_status_index_cf.get(1).unwrap().unwrap(),
+                TransactionStatusIndexMeta::default()
+            );
+
+            let slot1 = 20;
+            for _ in 0..5 {
+                let random_bytes: Vec<u8> = (0..64).map(|_| rand::random::<u8>()).collect();
+                blockstore
+                    .write_transaction_status(
+                        (Signature::new(&random_bytes), slot1),
+                        &TransactionStatusMeta::default(),
+                    )
+                    .unwrap();
+            }
+
+            assert_eq!(
+                transaction_status_index_cf.get(0).unwrap().unwrap(),
+                TransactionStatusIndexMeta {
+                    max_slot: slot0,
+                    frozen: true,
+                }
+            );
+            // Index 0 is frozen, so new statuses bump index 1 max_slot
+            assert_eq!(
+                transaction_status_index_cf.get(1).unwrap().unwrap(),
+                TransactionStatusIndexMeta {
+                    max_slot: slot1,
+                    frozen: false,
+                }
+            );
+
+            // Index 0 statuses still exist
+            let first_status_entry = blockstore
+                .db
+                .iter::<cf::TransactionStatus>(IteratorMode::From(
+                    (0, Signature::default(), 0),
+                    IteratorDirection::Forward,
+                ))
+                .unwrap()
+                .next()
+                .unwrap()
+                .0;
+            assert_eq!(first_status_entry.0, 0);
+            assert_eq!(first_status_entry.2, 10);
+            // New statuses are stored in index 1
+            let index1_first_status_entry = blockstore
+                .db
+                .iter::<cf::TransactionStatus>(IteratorMode::From(
+                    (1, Signature::default(), 0),
+                    IteratorDirection::Forward,
+                ))
+                .unwrap()
+                .next()
+                .unwrap()
+                .0;
+            assert_eq!(index1_first_status_entry.0, 1);
+            assert_eq!(index1_first_status_entry.2, slot1);
+
+            blockstore.run_purge(0, 18).unwrap();
+            // Successful prune toggles TransactionStatusIndex
+            assert_eq!(
+                transaction_status_index_cf.get(0).unwrap().unwrap(),
+                TransactionStatusIndexMeta {
+                    max_slot: 0,
+                    frozen: false,
+                }
+            );
+            assert_eq!(
+                transaction_status_index_cf.get(1).unwrap().unwrap(),
+                TransactionStatusIndexMeta {
+                    max_slot: slot1,
+                    frozen: true,
+                }
+            );
+
+            // Index 0 has been pruned, so first status entry is now index 1
+            let first_status_entry = blockstore
+                .db
+                .iter::<cf::TransactionStatus>(IteratorMode::From(
+                    (0, Signature::default(), 0),
+                    IteratorDirection::Forward,
+                ))
+                .unwrap()
+                .next()
+                .unwrap()
+                .0;
+            assert_eq!(first_status_entry.0, 1);
+            assert_eq!(first_status_entry.2, slot1);
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }
@@ -5248,7 +5488,7 @@ pub mod tests {
                 );
                 transaction_status_cf
                     .put(
-                        (slot, transaction.signatures[0]),
+                        (0, transaction.signatures[0], slot),
                         &TransactionStatusMeta {
                             status: solana_sdk::transaction::Result::<()>::Err(
                                 TransactionError::AccountNotFound,

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -256,7 +256,7 @@ pub trait Column {
 
     fn key(index: Self::Index) -> Vec<u8>;
     fn index(key: &[u8]) -> Self::Index;
-    fn slot(index: Self::Index) -> Slot;
+    fn primary_index(index: Self::Index) -> Slot;
     fn as_index(slot: Slot) -> Self::Index;
 }
 
@@ -287,7 +287,7 @@ impl<T: SlotColumn> Column for T {
         BigEndian::read_u64(&key[..8])
     }
 
-    fn slot(index: u64) -> Slot {
+    fn primary_index(index: u64) -> Slot {
         index
     }
 
@@ -312,7 +312,7 @@ impl Column for columns::TransactionStatus {
         (slot, index)
     }
 
-    fn slot(index: Self::Index) -> Slot {
+    fn primary_index(index: Self::Index) -> Slot {
         index.0
     }
 
@@ -344,7 +344,7 @@ impl Column for columns::ShredCode {
         columns::ShredData::index(key)
     }
 
-    fn slot(index: Self::Index) -> Slot {
+    fn primary_index(index: Self::Index) -> Slot {
         index.0
     }
 
@@ -373,7 +373,7 @@ impl Column for columns::ShredData {
         (slot, index)
     }
 
-    fn slot(index: Self::Index) -> Slot {
+    fn primary_index(index: Self::Index) -> Slot {
         index.0
     }
 
@@ -451,7 +451,7 @@ impl Column for columns::ErasureMeta {
         key
     }
 
-    fn slot(index: Self::Index) -> Slot {
+    fn primary_index(index: Self::Index) -> Slot {
         index.0
     }
 
@@ -583,7 +583,7 @@ impl Database {
         let max_slot = self
             .iter::<C>(IteratorMode::End)?
             .next()
-            .map(|(i, _)| C::slot(i))
+            .map(|(i, _)| C::primary_index(i))
             .unwrap_or(0);
         let end = max_slot <= to;
         result.map(|_| end)
@@ -624,7 +624,7 @@ where
         let iter = self.iter(iter_config)?;
         for (index, _) in iter {
             if let Some(to) = to {
-                if C::slot(index) > to {
+                if C::primary_index(index) > to {
                     end = false;
                     break;
                 }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -222,6 +222,12 @@ impl DuplicateSlotProof {
     }
 }
 
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct TransactionStatusIndexMeta {
+    pub max_slot: Slot,
+    pub frozen: bool,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -222,7 +222,7 @@ impl DuplicateSlotProof {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct TransactionStatusIndexMeta {
     pub max_slot: Slot,
     pub frozen: bool,

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -26,6 +26,17 @@ pub struct TransactionStatusMeta {
     pub post_balances: Vec<u64>,
 }
 
+impl Default for TransactionStatusMeta {
+    fn default() -> Self {
+        Self {
+            status: Ok(()),
+            fee: 0,
+            pre_balances: vec![],
+            post_balances: vec![],
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionStatusMeta {


### PR DESCRIPTION
#### Problem
It is currently extremely expensive to find a transaction status in blockstore by signature, a thing that we would like to do to support our new rpc-based explorer. TransactionStatus is indexed by `(Slot, Signature)`. Without the slot number, the only approach is to search through all the slots and compare signatures.
It would be much more performant to swap the index to `(Signature, Slot)` so that status searches can jump to the right part of the column and then select an appropriate record. However, this causes a problem for ledger pruning, as it becomes very expensive to find and delete transaction statuses by slot.

#### Summary of Changes
- Reworks TransactionStatus column to be indexed by `(u64, Signature, Slot)` (primary index, signature, slot). Statuses are inserted at a primary index of either `0u64` or `1u64`. When purging happens, all the statuses in a primary index are deleted in one batch.
- Adds a new TransactionStatusIndex column which contains primary index metadata, namely the max Slot existing in the primary-index range and whether the primary index is frozen. This metadata is used on ledger purge to decide whether to purge one of the primary indexes.
- When the ledger cleanup service calls `purge_slots()`, the api checks the TransactionStatusIndex. If neither primary index is currently frozen, index 0 is marked as frozen and subsequent statuses are added to index 1. If one of the indexes is frozen and the purge range includes the max Slot, that index is deleted, and the other index is marked as frozen. This way, the TransactionStatus column always contains at least as many slots as limit-ledger-size currently allows

Closes #9038 
