### PR TITLE
Fix sed command for mac and linux

### DIFF
--- a/docs/set-solana-release-tag.sh
+++ b/docs/set-solana-release-tag.sh
@@ -14,7 +14,7 @@ else
 fi
 
 set -x
-find html/ -name \*.html -exec sed -i '' "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
+find html/ -name \*.html -exec sed -i="" "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
 if [[ -n $CI ]]; then
-  find src/ -name \*.md -exec sed -i '' "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
+  find src/ -name \*.md -exec sed -i="" "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
 fi


### PR DESCRIPTION
#### Problem
We aren't correctly replacing the LATEST_SOLANA_RELEASE_VERSION string in the docs due to the way BSD sed and GNU sed arg parse a bit differently.  The outgoing form worked only on mac/BSD and not in CI.

#### Summary of Changes
Find a happy middle ground where both OSes/default CLI tool can play.
