### PR TITLE
Add log before opening database

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -180,6 +180,7 @@ impl Blockstore {
 
         // Open the database
         let mut measure = Measure::start("open");
+        info!("Opening database at {:?}", blockstore_path);
         let db = Database::open(&blockstore_path)?;
 
         // Create the metadata column family


### PR DESCRIPTION
`Database::open()` can take tens of minutes, add a log beforehand to help users identify this is happening to them