### PR TITLE
Decouple accounts hash calculation from snapshot hash

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -20,7 +20,7 @@ use solana_ledger::{
     blockstore_processor::{self, BlockstoreProcessorError, TransactionStatusSender},
     entry::VerifyRecyclers,
     leader_schedule_cache::LeaderScheduleCache,
-    snapshot_package::SnapshotPackageSender,
+    snapshot_package::AccountsPackageSender,
 };
 use solana_measure::thread_mem_usage;
 use solana_metrics::inc_new_counter_info;
@@ -97,7 +97,7 @@ pub struct ReplayStageConfig {
     pub subscriptions: Arc<RpcSubscriptions>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
     pub latest_root_senders: Vec<Sender<Slot>>,
-    pub accounts_hash_sender: Option<SnapshotPackageSender>,
+    pub accounts_hash_sender: Option<AccountsPackageSender>,
     pub block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     pub transaction_status_sender: Option<TransactionStatusSender>,
     pub rewards_recorder_sender: Option<RewardsRecorderSender>,
@@ -690,7 +690,7 @@ impl ReplayStage {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         root_bank_sender: &Sender<Vec<Arc<Bank>>>,
         lockouts_sender: &Sender<CommitmentAggregationData>,
-        accounts_hash_sender: &Option<SnapshotPackageSender>,
+        accounts_hash_sender: &Option<AccountsPackageSender>,
         latest_root_senders: &[Sender<Slot>],
         all_pubkeys: &mut HashSet<Rc<Pubkey>>,
         subscriptions: &Arc<RpcSubscriptions>,
@@ -1485,7 +1485,7 @@ impl ReplayStage {
         new_root: u64,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
-        accounts_hash_sender: &Option<SnapshotPackageSender>,
+        accounts_hash_sender: &Option<AccountsPackageSender>,
         all_pubkeys: &mut HashSet<Rc<Pubkey>>,
     ) {
         let old_epoch = bank_forks.read().unwrap().root_bank().epoch();

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,5 +1,5 @@
 use crate::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
-use solana_ledger::{snapshot_package::SnapshotPackageReceiver, snapshot_utils};
+use solana_ledger::{snapshot_package::AccountsPackageReceiver, snapshot_utils};
 use solana_sdk::{clock::Slot, hash::Hash};
 use std::{
     sync::{
@@ -17,7 +17,7 @@ pub struct SnapshotPackagerService {
 
 impl SnapshotPackagerService {
     pub fn new(
-        snapshot_package_receiver: SnapshotPackageReceiver,
+        snapshot_package_receiver: AccountsPackageReceiver,
         starting_snapshot_hash: Option<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
@@ -86,7 +86,7 @@ mod tests {
     use bincode::serialize_into;
     use solana_ledger::bank_forks::CompressionType;
     use solana_ledger::{
-        snapshot_package::SnapshotPackage,
+        snapshot_package::AccountsPackage,
         snapshot_utils::{self, SNAPSHOT_STATUS_CACHE_FILE_NAME},
     };
     use solana_runtime::{
@@ -172,7 +172,8 @@ mod tests {
             &(42, Hash::default()),
             &CompressionType::Bzip2,
         );
-        let snapshot_package = SnapshotPackage::new(
+        let snapshot_package = AccountsPackage::new(
+            5,
             5,
             vec![],
             link_snapshots_dir,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -81,6 +81,7 @@ pub struct ValidatorConfig {
     pub accounts_hash_fault_injection_slots: u64, // 0 = no fault injection
     pub frozen_accounts: Vec<Pubkey>,
     pub no_rocksdb_compaction: bool,
+    pub accounts_hash_interval_slots: u64,
 }
 
 impl Default for ValidatorConfig {
@@ -107,6 +108,7 @@ impl Default for ValidatorConfig {
             accounts_hash_fault_injection_slots: 0,
             frozen_accounts: vec![],
             no_rocksdb_compaction: false,
+            accounts_hash_interval_slots: std::u64::MAX,
         }
     }
 }
@@ -621,6 +623,7 @@ fn new_banks_from_blockstore(
     leader_schedule_cache.set_fixed_leader_schedule(config.fixed_leader_schedule.clone());
 
     bank_forks.set_snapshot_config(config.snapshot_config.clone());
+    bank_forks.set_accounts_hash_interval_slots(config.accounts_hash_interval_slots);
 
     (
         genesis_config,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1,6 +1,7 @@
 //! The `validator` module hosts all the validator microservices.
 
 use crate::{
+    accounts_hash_verifier::HashVerifierConfig,
     broadcast_stage::BroadcastStageType,
     cluster_info::{ClusterInfo, Node},
     cluster_info_vote_listener::VoteTracker,
@@ -47,7 +48,6 @@ use solana_sdk::{
     timing::timestamp,
 };
 use std::{
-    collections::HashSet,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::{Path, PathBuf},
     process,
@@ -76,12 +76,10 @@ pub struct ValidatorConfig {
     pub fixed_leader_schedule: Option<FixedSchedule>,
     pub wait_for_supermajority: Option<Slot>,
     pub new_hard_forks: Option<Vec<Slot>>,
-    pub trusted_validators: Option<HashSet<Pubkey>>, // None = trust all
-    pub halt_on_trusted_validators_accounts_hash_mismatch: bool,
-    pub accounts_hash_fault_injection_slots: u64, // 0 = no fault injection
     pub frozen_accounts: Vec<Pubkey>,
     pub no_rocksdb_compaction: bool,
     pub accounts_hash_interval_slots: u64,
+    pub hash_verifier_config: HashVerifierConfig,
 }
 
 impl Default for ValidatorConfig {
@@ -103,12 +101,10 @@ impl Default for ValidatorConfig {
             fixed_leader_schedule: None,
             wait_for_supermajority: None,
             new_hard_forks: None,
-            trusted_validators: None,
-            halt_on_trusted_validators_accounts_hash_mismatch: false,
-            accounts_hash_fault_injection_slots: 0,
             frozen_accounts: vec![],
             no_rocksdb_compaction: false,
             accounts_hash_interval_slots: std::u64::MAX,
+            hash_verifier_config: HashVerifierConfig::default(),
         }
     }
 }
@@ -443,11 +439,8 @@ impl Validator {
             TvuConfig {
                 max_ledger_shreds: config.max_ledger_shreds,
                 sigverify_disabled: config.dev_sigverify_disabled,
-                halt_on_trusted_validators_accounts_hash_mismatch: config
-                    .halt_on_trusted_validators_accounts_hash_mismatch,
                 shred_version: node.info.shred_version,
-                trusted_validators: config.trusted_validators.clone(),
-                accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
+                hash_verifier_config: config.hash_verifier_config.clone(),
             },
         );
 

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -38,7 +38,7 @@ mod tests {
         genesis_config_info: GenesisConfigInfo,
     }
 
-    fn setup_snapshot_test(snapshot_interval_slots: usize) -> SnapshotTestConfig {
+    fn setup_snapshot_test(snapshot_interval_slots: u64) -> SnapshotTestConfig {
         let accounts_dir = TempDir::new().unwrap();
         let snapshot_dir = TempDir::new().unwrap();
         let snapshot_output_path = TempDir::new().unwrap();
@@ -50,6 +50,7 @@ mod tests {
         );
         bank0.freeze();
         let mut bank_forks = BankForks::new(0, bank0);
+        bank_forks.accounts_hash_interval_slots = snapshot_interval_slots;
 
         let snapshot_config = SnapshotConfig {
             snapshot_interval_slots,
@@ -265,7 +266,7 @@ mod tests {
             };
 
             bank_forks
-                .generate_snapshot(slot, &vec![], &package_sender)
+                .generate_accounts_package(slot, &vec![], &package_sender)
                 .unwrap();
 
             if slot == saved_slot as u64 {
@@ -371,7 +372,7 @@ mod tests {
             let (snapshot_sender, _snapshot_receiver) = channel();
             // Make sure this test never clears bank.slots_since_snapshot
             let mut snapshot_test_config =
-                setup_snapshot_test(add_root_interval * num_set_roots * 2);
+                setup_snapshot_test((add_root_interval * num_set_roots * 2) as u64);
             let mut current_bank = snapshot_test_config.bank_forks[0].clone();
             let snapshot_sender = Some(snapshot_sender);
             for _ in 0..num_set_roots {

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -1,6 +1,6 @@
 //! The `bank_forks` module implments BankForks a DAG of checkpointed Banks
 
-use crate::snapshot_package::{SnapshotPackageSendError, SnapshotPackageSender};
+use crate::snapshot_package::{AccountsPackageSendError, AccountsPackageSender};
 use crate::snapshot_utils::{self, SnapshotError};
 use log::*;
 use solana_measure::measure::Measure;
@@ -27,7 +27,7 @@ pub enum CompressionType {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SnapshotConfig {
     // Generate a new snapshot every this many slots
-    pub snapshot_interval_slots: usize,
+    pub snapshot_interval_slots: u64,
 
     // Where to store the latest packaged snapshot
     pub snapshot_package_output_path: PathBuf,
@@ -43,8 +43,8 @@ pub enum BankForksError {
     #[error("snapshot error")]
     SnapshotError(#[from] SnapshotError),
 
-    #[error("snapshot package send error")]
-    SnapshotPackageSendError(#[from] SnapshotPackageSendError),
+    #[error("accounts package send error")]
+    AccountsPackageSendError(#[from] AccountsPackageSendError),
 }
 type Result<T> = std::result::Result<T, BankForksError>;
 
@@ -54,6 +54,9 @@ pub struct BankForks {
     root: Slot,
     pub snapshot_config: Option<SnapshotConfig>,
     last_snapshot_slot: Slot,
+
+    pub accounts_hash_interval_slots: Slot,
+    last_accounts_hash_slot: Slot,
 }
 
 impl Index<u64> for BankForks {
@@ -68,12 +71,15 @@ impl BankForks {
         let mut banks = HashMap::new();
         let working_bank = Arc::new(bank);
         banks.insert(bank_slot, working_bank.clone());
+        warn!("BankForks::new");
         Self {
             banks,
             working_bank,
             root: 0,
             snapshot_config: None,
             last_snapshot_slot: bank_slot,
+            accounts_hash_interval_slots: std::u64::MAX,
+            last_accounts_hash_slot: bank_slot,
         }
     }
 
@@ -153,12 +159,15 @@ impl BankForks {
             }
         }
         let root = *rooted_path.last().unwrap();
+        warn!("BankForks::new_from_banks");
         Self {
             root,
             banks,
             working_bank,
             snapshot_config: None,
             last_snapshot_slot: root,
+            accounts_hash_interval_slots: std::u64::MAX,
+            last_accounts_hash_slot: root,
         }
     }
 
@@ -178,7 +187,7 @@ impl BankForks {
     pub fn set_root(
         &mut self,
         root: Slot,
-        snapshot_package_sender: &Option<SnapshotPackageSender>,
+        accounts_package_sender: &Option<AccountsPackageSender>,
     ) {
         let old_epoch = self.root_bank().epoch();
         self.root = root;
@@ -209,43 +218,46 @@ impl BankForks {
             .last()
             .map(|bank| bank.transaction_count())
             .unwrap_or(0);
-        // Generate each snapshot at a fixed interval
+        // Calculate the accounts hash at a fixed interval
         let mut is_root_bank_squashed = false;
-        if self.snapshot_config.is_some() && snapshot_package_sender.is_some() {
-            let config = self.snapshot_config.as_ref().unwrap();
-            let mut banks = vec![root_bank];
-            let parents = root_bank.parents();
-            banks.extend(parents.iter());
-            for bank in banks.iter() {
-                let bank_slot = bank.slot();
-                if bank.block_height() % (config.snapshot_interval_slots as u64) == 0 {
-                    // Generate a snapshot if snapshots are configured and it's been an appropriate number
-                    // of banks since the last snapshot
-                    if bank_slot > self.last_snapshot_slot {
-                        bank.squash();
-                        is_root_bank_squashed = bank_slot == root;
-                        let mut snapshot_time = Measure::start("total-snapshot-ms");
-                        let r = self.generate_snapshot(
-                            bank_slot,
-                            &bank.src.roots(),
-                            snapshot_package_sender.as_ref().unwrap(),
-                        );
-                        if r.is_err() {
-                            warn!(
-                                "Error generating snapshot for bank: {}, err: {:?}",
-                                bank_slot, r
-                            );
-                        } else {
-                            self.last_snapshot_slot = bank_slot;
-                        }
+        let mut banks = vec![root_bank];
+        let parents = root_bank.parents();
+        banks.extend(parents.iter());
+        for bank in banks.iter() {
+            let bank_slot = bank.slot();
+            if bank.block_height() % self.accounts_hash_interval_slots == 0
+                && bank_slot > self.last_accounts_hash_slot
+            {
+                self.last_accounts_hash_slot = bank_slot;
+                bank.squash();
+                is_root_bank_squashed = bank_slot == root;
 
-                        // Cleanup outdated snapshots
-                        self.purge_old_snapshots();
-                        snapshot_time.stop();
-                        inc_new_counter_info!("total-snapshot-ms", snapshot_time.as_ms() as usize);
+                bank.clean_accounts();
+                bank.update_accounts_hash();
+
+                if self.snapshot_config.is_some() && accounts_package_sender.is_some() {
+                    // Generate an accounts package
+                    let mut snapshot_time = Measure::start("total-snapshot-ms");
+                    let r = self.generate_accounts_package(
+                        bank_slot,
+                        &bank.src.roots(),
+                        accounts_package_sender.as_ref().unwrap(),
+                    );
+                    if r.is_err() {
+                        warn!(
+                            "Error generating snapshot for bank: {}, err: {:?}",
+                            bank_slot, r
+                        );
+                    } else {
+                        self.last_snapshot_slot = bank_slot;
                     }
-                    break;
+
+                    // Cleanup outdated snapshots
+                    self.purge_old_snapshots();
+                    snapshot_time.stop();
+                    inc_new_counter_info!("total-snapshot-ms", snapshot_time.as_ms() as usize);
                 }
+                break;
             }
         }
         if !is_root_bank_squashed {
@@ -282,11 +294,11 @@ impl BankForks {
         }
     }
 
-    pub fn generate_snapshot(
+    pub fn generate_accounts_package(
         &self,
         root: Slot,
         slots_to_snapshot: &[Slot],
-        snapshot_package_sender: &SnapshotPackageSender,
+        accounts_package_sender: &AccountsPackageSender,
     ) -> Result<()> {
         let config = self.snapshot_config.as_ref().unwrap();
 
@@ -319,8 +331,7 @@ impl BankForks {
             config.compression.clone(),
         )?;
 
-        // Send the package to the packaging thread
-        snapshot_package_sender.send(package)?;
+        accounts_package_sender.send(package)?;
 
         Ok(())
     }
@@ -337,6 +348,10 @@ impl BankForks {
 
     pub fn snapshot_config(&self) -> &Option<SnapshotConfig> {
         &self.snapshot_config
+    }
+
+    pub fn set_accounts_hash_interval_slots(&mut self, accounts_interval_slots: u64) {
+        self.accounts_hash_interval_slots = accounts_interval_slots;
     }
 }
 

--- a/ledger/src/snapshot_package.rs
+++ b/ledger/src/snapshot_package.rs
@@ -8,13 +8,14 @@ use std::{
 };
 use tempfile::TempDir;
 
-pub type SnapshotPackageSender = Sender<SnapshotPackage>;
-pub type SnapshotPackageReceiver = Receiver<SnapshotPackage>;
-pub type SnapshotPackageSendError = SendError<SnapshotPackage>;
+pub type AccountsPackageSender = Sender<AccountsPackage>;
+pub type AccountsPackageReceiver = Receiver<AccountsPackage>;
+pub type AccountsPackageSendError = SendError<AccountsPackage>;
 
 #[derive(Debug)]
-pub struct SnapshotPackage {
+pub struct AccountsPackage {
     pub root: Slot,
+    pub block_height: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
     pub storages: SnapshotStorages,
@@ -23,9 +24,10 @@ pub struct SnapshotPackage {
     pub compression: CompressionType,
 }
 
-impl SnapshotPackage {
+impl AccountsPackage {
     pub fn new(
         root: Slot,
+        block_height: u64,
         slot_deltas: Vec<BankSlotDelta>,
         snapshot_links: TempDir,
         storages: SnapshotStorages,
@@ -35,6 +37,7 @@ impl SnapshotPackage {
     ) -> Self {
         Self {
             root,
+            block_height,
             slot_deltas,
             snapshot_links,
             storages,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1260,7 +1260,7 @@ struct SnapshotValidatorConfig {
 }
 
 fn setup_snapshot_validator_config(
-    snapshot_interval_slots: usize,
+    snapshot_interval_slots: u64,
     num_account_paths: usize,
 ) -> SnapshotValidatorConfig {
     // Create the snapshot config
@@ -1281,6 +1281,7 @@ fn setup_snapshot_validator_config(
     validator_config.rpc_config.enable_validator_exit = true;
     validator_config.snapshot_config = Some(snapshot_config);
     validator_config.account_paths = account_storage_paths;
+    validator_config.accounts_hash_interval_slots = snapshot_interval_slots;
 
     SnapshotValidatorConfig {
         _snapshot_dir: snapshot_dir,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -725,6 +725,7 @@ fn test_consistency_halt() {
         setup_snapshot_validator_config(snapshot_interval_slots, num_account_paths);
     leader_snapshot_test_config
         .validator_config
+        .hash_verifier_config
         .accounts_hash_fault_injection_slots = 40;
 
     let validator_stake = 10_000;
@@ -751,9 +752,11 @@ fn test_consistency_halt() {
 
     validator_snapshot_test_config
         .validator_config
+        .hash_verifier_config
         .trusted_validators = Some(trusted_validators);
     validator_snapshot_test_config
         .validator_config
+        .hash_verifier_config
         .halt_on_trusted_validators_accounts_hash_mismatch = true;
 
     warn!("adding a validator");
@@ -986,6 +989,7 @@ fn test_snapshots_blockstore_floor() {
     trusted_validators.insert(cluster_nodes[0].id);
     validator_snapshot_test_config
         .validator_config
+        .hash_verifier_config
         .trusted_validators = Some(trusted_validators);
 
     cluster.add_validator(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -390,6 +390,15 @@ fn download_then_check_genesis_hash(
     Ok(genesis_config.hash())
 }
 
+fn is_snapshot_config_invalid(
+    snapshot_interval_slots: u64,
+    accounts_hash_interval_slots: u64,
+) -> bool {
+    snapshot_interval_slots != 0
+        && (snapshot_interval_slots < accounts_hash_interval_slots
+            || snapshot_interval_slots % accounts_hash_interval_slots != 0)
+}
+
 #[allow(clippy::cognitive_complexity)]
 pub fn main() {
     let default_dynamic_port_range =
@@ -599,6 +608,14 @@ pub fn main() {
                 .takes_value(true)
                 .default_value("100")
                 .help("Number of slots between generating snapshots, 0 to disable snapshots"),
+        )
+        .arg(
+            clap::Arg::with_name("accounts_hash_interval_slots")
+                .long("accounts-hash-slots")
+                .value_name("ACCOUNTS_HASH_INTERVAL_SLOTS")
+                .takes_value(true)
+                .default_value("100")
+                .help("Number of slots between generating accounts hash."),
         )
         .arg(
             clap::Arg::with_name("limit_ledger_size")
@@ -841,7 +858,7 @@ pub fn main() {
         })
         .collect();
 
-    let snapshot_interval_slots = value_t_or_exit!(matches, "snapshot_interval_slots", usize);
+    let snapshot_interval_slots = value_t_or_exit!(matches, "snapshot_interval_slots", u64);
     let snapshot_path = ledger_path.clone().join("snapshot");
     fs::create_dir_all(&snapshot_path).unwrap_or_else(|err| {
         eprintln!(
@@ -865,12 +882,29 @@ pub fn main() {
         snapshot_interval_slots: if snapshot_interval_slots > 0 {
             snapshot_interval_slots
         } else {
-            std::usize::MAX
+            std::u64::MAX
         },
         snapshot_path,
         snapshot_package_output_path: ledger_path.clone(),
         compression: snapshot_compression,
     });
+
+    validator_config.accounts_hash_interval_slots =
+        value_t_or_exit!(matches, "accounts_hash_interval_slots", u64);
+    if validator_config.accounts_hash_interval_slots == 0 {
+        eprintln!("Accounts hash interval should not be 0.");
+        exit(1);
+    }
+    if is_snapshot_config_invalid(
+        snapshot_interval_slots,
+        validator_config.accounts_hash_interval_slots,
+    ) {
+        eprintln!("Invalid snapshot interval provided ({}), must be a multiple of accounts_hash_interval_slots ({})",
+            snapshot_interval_slots,
+            validator_config.accounts_hash_interval_slots,
+        );
+        exit(1);
+    }
 
     if matches.is_present("limit_ledger_size") {
         let limit_ledger_size = value_t_or_exit!(matches, "limit_ledger_size", u64);
@@ -1173,4 +1207,18 @@ pub fn main() {
     info!("Validator initialized");
     validator.join().expect("validator exit");
     info!("Validator exiting..");
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_interval_check() {
+        assert!(!is_snapshot_config_invalid(0, 100));
+        assert!(is_snapshot_config_invalid(1, 100));
+        assert!(is_snapshot_config_invalid(230, 100));
+        assert!(!is_snapshot_config_invalid(500, 100));
+        assert!(!is_snapshot_config_invalid(5, 5));
+    }
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -14,6 +14,7 @@ use solana_core::ledger_cleanup_service::{
     DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS,
 };
 use solana_core::{
+    accounts_hash_verifier::HashVerifierConfig,
     cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE},
     contact_info::ContactInfo,
     gossip_service::GossipService,
@@ -178,7 +179,10 @@ fn get_rpc_node(
         let rpc_peers_trusted = rpc_peers
             .iter()
             .filter(|rpc_peer| {
-                is_trusted_validator(&rpc_peer.id, &validator_config.trusted_validators)
+                is_trusted_validator(
+                    &rpc_peer.id,
+                    &validator_config.hash_verifier_config.trusted_validators,
+                )
             })
             .count();
 
@@ -202,14 +206,19 @@ fn get_rpc_node(
         let eligible_rpc_peers = if snapshot_not_required {
             rpc_peers
         } else {
-            let trusted_snapshot_hashes =
-                get_trusted_snapshot_hashes(&cluster_info, &validator_config.trusted_validators);
+            let trusted_snapshot_hashes = get_trusted_snapshot_hashes(
+                &cluster_info,
+                &validator_config.hash_verifier_config.trusted_validators,
+            );
 
             let mut eligible_rpc_peers = vec![];
 
             for rpc_peer in rpc_peers.iter() {
                 if no_untrusted_rpc
-                    && !is_trusted_validator(&rpc_peer.id, &validator_config.trusted_validators)
+                    && !is_trusted_validator(
+                        &rpc_peer.id,
+                        &validator_config.hash_verifier_config.trusted_validators,
+                    )
                 {
                     continue;
                 }
@@ -725,6 +734,12 @@ pub fn main() {
                 .help("Abort the validator if a bank hash mismatch is detected within trusted validator set"),
         )
         .arg(
+            clap::Arg::with_name("halt_supermajority_accounts_hash_mismatch")
+                .long("halt-on-supermajority-accounts-hash-mismatch")
+                .takes_value(false)
+                .help("Abort the validator if a bank hash mismatch is detected with with a supermajority (2/3+) of the network by stake."),
+        )
+        .arg(
             clap::Arg::with_name("frozen_accounts")
                 .long("frozen-account")
                 .validator(is_pubkey)
@@ -810,9 +825,12 @@ pub fn main() {
             .map(|rpc_port| (rpc_port, rpc_port + 1)),
         voting_disabled: matches.is_present("no_voting"),
         wait_for_supermajority: value_t!(matches, "wait_for_supermajority", Slot).ok(),
-        trusted_validators,
         frozen_accounts: values_t!(matches, "frozen_accounts", Pubkey).unwrap_or_default(),
         no_rocksdb_compaction,
+        hash_verifier_config: HashVerifierConfig {
+            trusted_validators,
+            ..HashVerifierConfig::default()
+        },
         ..ValidatorConfig::default()
     };
 
@@ -919,7 +937,15 @@ pub fn main() {
     }
 
     if matches.is_present("halt_on_trusted_validators_accounts_hash_mismatch") {
-        validator_config.halt_on_trusted_validators_accounts_hash_mismatch = true;
+        validator_config
+            .hash_verifier_config
+            .halt_on_trusted_validators_accounts_hash_mismatch = true;
+    }
+
+    if matches.is_present("halt_on_supermajority_accounts_hash_mismatch") {
+        validator_config
+            .hash_verifier_config
+            .halt_on_supermajority_hash_mismatch = true;
     }
 
     if matches.value_of("signer_addr").is_some() {
@@ -1161,7 +1187,9 @@ pub fn main() {
                 }
                 warn!("{}", result.unwrap_err());
 
-                if let Some(ref trusted_validators) = validator_config.trusted_validators {
+                if let Some(ref trusted_validators) =
+                    validator_config.hash_verifier_config.trusted_validators
+                {
                     if trusted_validators.contains(&rpc_contact_info.id) {
                         continue; // Never blacklist a trusted node
                     }


### PR DESCRIPTION
#### Problem

Accounts hash calculation rate tied to snapshot creation, but it may be desirable to check the accounts hash more often than creating a snapshot. Also accounts 0-lamport purge is only enabled when snapshots are enabled, but this is an operation that should always be going so that accounts_db does not grow excessively large.

#### Summary of Changes

Decouple accounts hash rate and clean from snapshot creation rate.

Fixes #
