### PR TITLE
Deprecate `confirmTransaction`, `getSignatureStatus`, and `getSignatureConfirmation`

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -77,17 +77,16 @@ impl RpcClient {
         signature: &Signature,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<bool> {
-        let response = self
-            .client
-            .send(
-                &RpcRequest::ConfirmTransaction,
-                json!([signature.to_string(), commitment_config]),
-                0,
-            )
-            .map_err(|err| err.into_with_command("ConfirmTransaction"))?;
+        let Response { context, value } =
+            self.get_signature_statuses(&[*signature], commitment_config)?;
 
-        serde_json::from_value::<Response<bool>>(response)
-            .map_err(|err| ClientError::new_with_command(err.into(), "ConfirmTransaction"))
+        Ok(Response {
+            context,
+            value: value[0]
+                .as_ref()
+                .map(|result| result.status.is_ok())
+                .unwrap_or_default(),
+        })
     }
 
     pub fn send_transaction(&self, transaction: &Transaction) -> ClientResult<Signature> {
@@ -111,6 +110,21 @@ impl RpcClient {
         signature: &Signature,
     ) -> ClientResult<Option<transaction::Result<()>>> {
         self.get_signature_status_with_commitment(signature, CommitmentConfig::default())
+    }
+
+    pub fn get_signature_statuses(
+        &self,
+        signatures: &[Signature],
+        commitment_config: CommitmentConfig,
+    ) -> RpcResult<Vec<Option<TransactionStatus>>> {
+        let signatures: Vec<_> = signatures.iter().map(|s| s.to_string()).collect();
+        let signature_status = self.client.send(
+            &RpcRequest::GetSignatureStatuses,
+            json!([&signatures, commitment_config]),
+            5,
+        )?;
+        Ok(serde_json::from_value(signature_status)
+            .map_err(|err| ClientError::new_with_command(err.into(), "GetSignatureStatuses"))?)
     }
 
     pub fn get_signature_status_with_commitment(
@@ -856,14 +870,13 @@ impl RpcClient {
         trace!("check_signature: {:?}", signature);
 
         for _ in 0..30 {
-            let response = self.client.send(
-                &RpcRequest::ConfirmTransaction,
-                json!([signature.to_string(), CommitmentConfig::recent()]),
-                0,
-            );
-
+            let response =
+                self.confirm_transaction_with_commitment(signature, CommitmentConfig::recent());
             match response {
-                Ok(Value::Bool(signature_status)) => {
+                Ok(Response {
+                    value: signature_status,
+                    ..
+                }) => {
                     if signature_status {
                         trace!("Response found signature");
                     } else {
@@ -871,12 +884,6 @@ impl RpcClient {
                     }
 
                     return signature_status;
-                }
-                Ok(other) => {
-                    debug!(
-                        "check_signature request failed, expected bool, got: {:?}",
-                        other
-                    );
                 }
                 Err(err) => {
                     debug!("check_signature request failed: {:?}", err);

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -78,7 +78,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<bool> {
         let Response { context, value } =
-            self.get_signature_statuses(&[*signature], commitment_config)?;
+            self.get_signature_statuses_with_commitment(&[*signature], commitment_config)?;
 
         Ok(Response {
             context,
@@ -112,7 +112,7 @@ impl RpcClient {
         self.get_signature_status_with_commitment(signature, CommitmentConfig::default())
     }
 
-    pub fn get_signature_statuses(
+    pub fn get_signature_statuses_with_commitment(
         &self,
         signatures: &[Signature],
         commitment_config: CommitmentConfig,

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -3,7 +3,6 @@ use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum RpcRequest {
-    ConfirmTransaction,
     DeregisterNode,
     ValidatorExit,
     GetAccountInfo,
@@ -22,7 +21,6 @@ pub enum RpcRequest {
     GetRecentBlockhash,
     GetFeeCalculatorForBlockhash,
     GetFeeRateGovernor,
-    GetSignatureStatus,
     GetSignatureStatuses,
     GetSlot,
     GetSlotLeader,
@@ -46,7 +44,6 @@ impl RpcRequest {
     pub(crate) fn build_request_json(&self, id: u64, params: Value) -> Value {
         let jsonrpc = "2.0";
         let method = match self {
-            RpcRequest::ConfirmTransaction => "confirmTransaction",
             RpcRequest::DeregisterNode => "deregisterNode",
             RpcRequest::ValidatorExit => "validatorExit",
             RpcRequest::GetAccountInfo => "getAccountInfo",
@@ -65,7 +62,6 @@ impl RpcRequest {
             RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
             RpcRequest::GetFeeCalculatorForBlockhash => "getFeeCalculatorForBlockhash",
             RpcRequest::GetFeeRateGovernor => "getFeeRateGovernor",
-            RpcRequest::GetSignatureStatus => "getSignatureStatus",
             RpcRequest::GetSignatureStatuses => "getSignatureStatuses",
             RpcRequest::GetSlot => "getSlot",
             RpcRequest::GetSlotLeader => "getSlotLeader",

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -425,7 +425,7 @@ impl JsonRpcRequestProcessor {
             .map(|(_, status)| status)
     }
 
-    pub fn get_signature_statuses(
+    pub fn get_signature_statuses_with_commitment(
         &self,
         signatures: Vec<Signature>,
         commitment: Option<CommitmentConfig>,
@@ -609,7 +609,7 @@ pub trait RpcSol {
     fn get_fee_rate_governor(&self, meta: Self::Metadata) -> RpcResponse<RpcFeeRateGovernor>;
 
     #[rpc(meta, name = "getSignatureStatuses")]
-    fn get_signature_statuses(
+    fn get_signature_statuses_with_commitment(
         &self,
         meta: Self::Metadata,
         signature_strs: Vec<String>,
@@ -971,7 +971,7 @@ impl RpcSol for RpcSolImpl {
             .get_signature_status(signature, commitment))
     }
 
-    fn get_signature_statuses(
+    fn get_signature_statuses_with_commitment(
         &self,
         meta: Self::Metadata,
         signature_strs: Vec<String>,
@@ -984,7 +984,7 @@ impl RpcSol for RpcSolImpl {
         meta.request_processor
             .read()
             .unwrap()
-            .get_signature_statuses(signatures, commitment)
+            .get_signature_statuses_with_commitment(signatures, commitment)
     }
 
     fn get_slot(&self, meta: Self::Metadata, commitment: Option<CommitmentConfig>) -> Result<u64> {
@@ -1077,7 +1077,7 @@ impl RpcSol for RpcSolImpl {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_signature_statuses(vec![signature], commitment.clone())?
+                .get_signature_statuses_with_commitment(vec![signature], commitment.clone())?
                 .value[0]
                 .clone()
                 .map(|x| x.status);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -494,6 +494,7 @@ impl Metadata for Meta {}
 pub trait RpcSol {
     type Metadata;
 
+    // DEPRECATED
     #[rpc(meta, name = "confirmTransaction")]
     fn confirm_transaction(
         &self,
@@ -501,6 +502,24 @@ pub trait RpcSol {
         signature_str: String,
         commitment: Option<CommitmentConfig>,
     ) -> RpcResponse<bool>;
+
+    // DEPRECATED
+    #[rpc(meta, name = "getSignatureStatus")]
+    fn get_signature_status(
+        &self,
+        meta: Self::Metadata,
+        signature_str: String,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Option<transaction::Result<()>>>;
+
+    // DEPRECATED (used by Trust Wallet)
+    #[rpc(meta, name = "getSignatureConfirmation")]
+    fn get_signature_confirmation(
+        &self,
+        meta: Self::Metadata,
+        signature_str: String,
+        commitment: Option<CommitmentConfig>,
+    ) -> Result<Option<RpcSignatureConfirmation>>;
 
     #[rpc(meta, name = "getAccountInfo")]
     fn get_account_info(
@@ -588,22 +607,6 @@ pub trait RpcSol {
 
     #[rpc(meta, name = "getFeeRateGovernor")]
     fn get_fee_rate_governor(&self, meta: Self::Metadata) -> RpcResponse<RpcFeeRateGovernor>;
-
-    #[rpc(meta, name = "getSignatureConfirmation")]
-    fn get_signature_confirmation(
-        &self,
-        meta: Self::Metadata,
-        signature_str: String,
-        commitment: Option<CommitmentConfig>,
-    ) -> Result<Option<RpcSignatureConfirmation>>;
-
-    #[rpc(meta, name = "getSignatureStatus")]
-    fn get_signature_status(
-        &self,
-        meta: Self::Metadata,
-        signature_str: String,
-        commitment: Option<CommitmentConfig>,
-    ) -> Result<Option<transaction::Result<()>>>;
 
     #[rpc(meta, name = "getSignatureStatuses")]
     fn get_signature_statuses(

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -14,7 +14,6 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 
 ## Methods
 
-* [confirmTransaction](jsonrpc-api.md#confirmtransaction)
 * [getAccountInfo](jsonrpc-api.md#getaccountinfo)
 * [getBalance](jsonrpc-api.md#getbalance)
 * [getBlockCommitment](jsonrpc-api.md#getblockcommitment)
@@ -33,7 +32,6 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getMinimumBalanceForRentExemption](jsonrpc-api.md#getminimumbalanceforrentexemption)
 * [getProgramAccounts](jsonrpc-api.md#getprogramaccounts)
 * [getRecentBlockhash](jsonrpc-api.md#getrecentblockhash)
-* [getSignatureStatus](jsonrpc-api.md#getsignaturestatus)
 * [getSignatureStatuses](jsonrpc-api.md#getsignaturestatuses)
 * [getSlot](jsonrpc-api.md#getslot)
 * [getSlotLeader](jsonrpc-api.md#getslotleader)
@@ -116,29 +114,6 @@ Many methods that take a commitment parameter return an RpcResponse JSON object 
 
 
 ## JSON RPC API Reference
-
-### confirmTransaction
-
-Returns a transaction receipt. This method only searches the recent status cache of signatures, which retains all active slots plus `MAX_RECENT_BLOCKHASHES` rooted slots.
-
-#### Parameters:
-
-* `<string>` - Signature of Transaction to confirm, as base-58 encoded string
-* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
-
-#### Results:
-
-* `RpcResponse<bool>` - RpcResponse JSON object with `value` field set to Transaction status, boolean true if Transaction is confirmed
-
-#### Example:
-
-```bash
-// Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"confirmTransaction", "params":["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"]}' http://localhost:8899
-
-// Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":true},"id":1}
-```
 
 ### getAccountInfo
 
@@ -655,35 +630,9 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 {"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"blockhash":"CSymwgTNX1j3E4qhKfJAUE41nBWEwXufoYryPbkde5RR","feeCalculator":{"burnPercent":50,"lamportsPerSignature":5000,"maxLamportsPerSignature":100000,"minLamportsPerSignature":5000,"targetLamportsPerSignature":10000,"targetSignaturesPerSlot":20000}}},"id":1}
 ```
 
-### getSignatureStatus
-
-Returns the status of a given signature. This method is similar to [confirmTransaction](jsonrpc-api.md#confirmtransaction) but provides more resolution for error events. This method only searches the recent status cache of signatures, which retains all active slots plus `MAX_RECENT_BLOCKHASHES` rooted slots.
-
-#### Parameters:
-
-* `<string>` - Signature of Transaction to confirm, as base-58 encoded string
-* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
-
-#### Results:
-
-* `<null>` - Unknown transaction
-* `<object>` - Transaction status:
-  * `"Ok": <null>` - Transaction was successful
-  * `"Err": <ERR>` - Transaction failed with TransactionError  [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
-
-#### Example:
-
-```bash
-// Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatus", "params":["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"]}' http://localhost:8899
-
-// Result
-{"jsonrpc":"2.0","result":{"Ok": null},"id":1}
-```
-
 ### getSignatureStatuses
 
-Returns the statuses of a list of signatures. This method is similar to [confirmTransaction](jsonrpc-api.md#confirmtransaction) but provides more resolution for error events. This method only searches the recent status cache of signatures, which retains all active slots plus `MAX_RECENT_BLOCKHASHES` rooted slots.
+Returns the statuses of a list of signatures. This method only searches the recent status cache of signatures, which retains statuses for all active slots plus `MAX_RECENT_BLOCKHASHES` rooted slots.
 
 #### Parameters:
 
@@ -711,7 +660,7 @@ An array of:
 
 ```bash
 // Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatus", "params":[["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW", "5j7s6NiJS3JAkvgkoc18WVAsiSaci2pxB2A6ueCJP4tprA2TFg9wSyTLeYouxPBJEMzJinENTkpA52YStRW5Dia7"]]]}' http://localhost:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatuses", "params":[["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW", "5j7s6NiJS3JAkvgkoc18WVAsiSaci2pxB2A6ueCJP4tprA2TFg9wSyTLeYouxPBJEMzJinENTkpA52YStRW5Dia7"]]]}' http://localhost:8899
 
 // Result
 {"jsonrpc":"2.0","result":{"context":{"slot":82},"value":[{"slot": 72, "confirmations": 10, "status": {"Ok": null}}, null]},"id":1}


### PR DESCRIPTION
#### Problem
Various client JSON RPC libraries appear to have problems processing the `status: { "Ok": null } `transaction status returned by methods such as `getSignatureStatuses`. The `null` value causes the removal of `Ok` entirely and the client ends up with a status object of `{}`.

We don't know who is using these two endpoints so we'll have to support them for now, but we should actively discourage anyone from using them from this point forward.

#### Summary of Changes
* Remove all uses of these endpoints from our clients
* Remove docs
* Mark the endpoints as deprecated in the code

Related to: https://github.com/solana-labs/solana/issues/9297
