### PR TITLE
Added no superminority and isolated node test cases

### DIFF
--- a/system-test/netem-configs/complete-loss-four-partitions
+++ b/system-test/netem-configs/complete-loss-four-partitions
@@ -1,0 +1,70 @@
+{
+    "partitions":[
+         25,
+         25,
+         25,
+         25
+    ],
+    "interconnects":[
+        {
+            "a":0,
+            "b":1,
+            "config":"loss 100%"
+        },
+        {
+            "a":1,
+            "b":0,
+            "config":"loss 100%"
+        },
+        {
+            "a":0,
+            "b":2,
+            "config":"loss 100%"
+        },
+        {
+            "a":2,
+            "b":0,
+            "config":"loss 100%"
+        },
+        {
+            "a":0,
+            "b":3,
+            "config":"loss 100%"
+        },
+        {
+            "a":3,
+            "b":0,
+            "config":"loss 100%"
+        },
+        {
+            "a":1,
+            "b":2,
+            "config":"loss 100%"
+        },
+        {
+            "a":2,
+            "b":1,
+            "config":"loss 100%"
+        },
+        {
+            "a":1,
+            "b":3,
+            "config":"loss 100%"
+        },
+        {
+            "a":3,
+            "b":1,
+            "config":"loss 100%"
+        },
+        {
+            "a":2,
+            "b":3,
+            "config":"loss 100%"
+        },
+        {
+            "a":3,
+            "b":2,
+            "config":"loss 100%"
+        }
+    ]
+}

--- a/system-test/partition-testcases/colo-3-partition.yml
+++ b/system-test/partition-testcases/colo-3-partition.yml
@@ -8,7 +8,7 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 4
       ENABLE_GPU: "false"
       NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 5000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"

--- a/system-test/partition-testcases/colo-partition-2-1-test.yml
+++ b/system-test/partition-testcases/colo-partition-2-1-test.yml
@@ -1,20 +1,20 @@
 steps:
   - command: "system-test/testnet-automation.sh"
-    label: "Colo - CPU Only - 1 minute partition then 5 minute stabilization"
+    label: "Colo - CPU Only - Complete Loss 2 - 1 Partition"
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "colo"
       TESTNET_TAG: "colo-perf-cpu-only"
-      NUMBER_OF_VALIDATOR_NODES: 3
+      NUMBER_OF_VALIDATOR_NODES: 2
       ENABLE_GPU: "false"
       NUMBER_OF_CLIENT_NODES: 1
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 5000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       APPLY_PARTITIONS: "true"
-      NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"
+      NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-two-partitions"
       PARTITION_ACTIVE_DURATION: 60
-      PARTITION_INACTIVE_DURATION: 300
-      PARTITION_ITERATION_COUNT: 1
+      PARTITION_INACTIVE_DURATION: 60
+      PARTITION_ITERATION_COUNT: 10
       TEST_TYPE: "partition"
     agents:
       - "queue=colo-deploy"

--- a/system-test/partition-testcases/colo-partition-long-sanity-test.yml
+++ b/system-test/partition-testcases/colo-partition-long-sanity-test.yml
@@ -8,7 +8,7 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 4
       ENABLE_GPU: "false"
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 5000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"

--- a/system-test/partition-testcases/colo-partition-no-superminority-test.yml
+++ b/system-test/partition-testcases/colo-partition-no-superminority-test.yml
@@ -1,6 +1,6 @@
 steps:
   - command: "system-test/testnet-automation.sh"
-    label: "Colo - CPU Only - 1 minute partition then 5 minute stabilization"
+    label: "Colo - CPU Only - Complete Loss 4 Partitions"
     env:
       UPLOAD_RESULTS_TO_SLACK: "true"
       CLOUD_PROVIDER: "colo"
@@ -11,10 +11,11 @@ steps:
       CLIENT_OPTIONS: "bench-tps=1=--tx_count 5000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       APPLY_PARTITIONS: "true"
-      NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"
+      NETEM_CONFIG_FILE: "system-test/netem-configs/complete-loss-four-partitions"
       PARTITION_ACTIVE_DURATION: 60
-      PARTITION_INACTIVE_DURATION: 300
-      PARTITION_ITERATION_COUNT: 1
+      PARTITION_INACTIVE_DURATION: 60
+      PARTITION_ITERATION_COUNT: 10
+      BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 33
       TEST_TYPE: "partition"
     agents:
       - "queue=colo-deploy"

--- a/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
+++ b/system-test/partition-testcases/gce-5-node-single-region-2-partitions.yml
@@ -9,7 +9,7 @@ steps:
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 20000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 5000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"


### PR DESCRIPTION
#### Problem
Need more coverage of various partitioning test cases.

#### Summary of Changes
The below are some of the ones I've been running:

4 partitions - No superminority
2 / 1 partition - requested by @aeyakovenko 

Some issues to deal with:
1) Stake takes a while to warm up, so it takes a long time for the bootstrap leader to reach `< superminority (1/3)` stake when there are `> 3` total nodes on the network. Will probably need to plumb accounts into genesis for auto warmup

2) These partition tests are hard to run for longer than a few minutes because the warmup intervals are pretty short in the beginning, will probably need to turn off warmup epochs for these tests

Fixes #
