### PR TITLE
Remove write lock on cluster_info

### DIFF
--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -265,7 +265,7 @@ impl StandardBroadcastRun {
         trace!("Broadcasting {:?} shreds", shred_bufs.len());
 
         cluster_info
-            .write()
+            .read()
             .unwrap()
             .broadcast_shreds(sock, shred_bufs, &seeds, stakes)?;
 


### PR DESCRIPTION
#### Problem

cluster_info write lock not needed for broadcast shreds.

#### Summary of Changes

Take a read lock and use an atomic for the datapoint print.

Fixes #
