### PR TITLE
Update getSignatureStatuses to return historical statuses

### DIFF
--- a/client/src/mock_rpc_client_request.rs
+++ b/client/src/mock_rpc_client_request.rs
@@ -94,7 +94,7 @@ impl GenericRpcClientRequest for MockRpcClientRequest {
                     Some(TransactionStatus {
                         status,
                         slot: 1,
-                        confirmations: Some(0),
+                        confirmations: None,
                         err,
                     })
                 };

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -77,13 +77,13 @@ impl RpcClient {
         signature: &Signature,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<bool> {
-        let Response { context, value } =
-            self.get_signature_statuses_with_commitment(&[*signature], commitment_config)?;
+        let Response { context, value } = self.get_signature_statuses(&[*signature])?;
 
         Ok(Response {
             context,
             value: value[0]
                 .as_ref()
+                .filter(|result| result.satisfies_commitment(commitment_config))
                 .map(|result| result.status.is_ok())
                 .unwrap_or_default(),
         })
@@ -112,17 +112,14 @@ impl RpcClient {
         self.get_signature_status_with_commitment(signature, CommitmentConfig::default())
     }
 
-    pub fn get_signature_statuses_with_commitment(
+    pub fn get_signature_statuses(
         &self,
         signatures: &[Signature],
-        commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<Option<TransactionStatus>>> {
         let signatures: Vec<_> = signatures.iter().map(|s| s.to_string()).collect();
-        let signature_status = self.client.send(
-            &RpcRequest::GetSignatureStatuses,
-            json!([&signatures, commitment_config]),
-            5,
-        )?;
+        let signature_status =
+            self.client
+                .send(&RpcRequest::GetSignatureStatuses, json!([signatures]), 5)?;
         Ok(serde_json::from_value(signature_status)
             .map_err(|err| ClientError::new_with_command(err.into(), "GetSignatureStatuses"))?)
     }
@@ -134,7 +131,7 @@ impl RpcClient {
     ) -> ClientResult<Option<transaction::Result<()>>> {
         let signature_status = self.client.send(
             &RpcRequest::GetSignatureStatuses,
-            json!([[signature.to_string()], commitment_config]),
+            json!([[signature.to_string()]]),
             5,
         )?;
         let result: Response<Vec<Option<TransactionStatus>>> =
@@ -142,6 +139,7 @@ impl RpcClient {
                 .map_err(|err| ClientError::new_with_command(err.into(), "GetSignatureStatuses"))?;
         Ok(result.value[0]
             .clone()
+            .filter(|result| result.satisfies_commitment(commitment_config))
             .map(|status_meta| status_meta.status))
     }
 
@@ -957,7 +955,7 @@ impl RpcClient {
             .client
             .send(
                 &RpcRequest::GetSignatureStatuses,
-                json!([[signature.to_string()], CommitmentConfig::recent().ok()]),
+                json!([[signature.to_string()]]),
                 1,
             )
             .map_err(|err| err.into_with_command("GetSignatureStatuses"))?;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -36,6 +36,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+const MAX_QUERY_ITEMS: usize = 256;
+
 type RpcResponse<T> = Result<Response<T>>;
 
 fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
@@ -1012,6 +1014,12 @@ impl RpcSol for RpcSolImpl {
         signature_strs: Vec<String>,
         config: Option<RpcSignatureStatusConfig>,
     ) -> RpcResponse<Vec<Option<TransactionStatus>>> {
+        if signature_strs.len() > MAX_QUERY_ITEMS {
+            return Err(Error::invalid_params(format!(
+                "Too many inputs provided; max {}",
+                MAX_QUERY_ITEMS
+            )));
+        }
         let mut signatures: Vec<Signature> = vec![];
         for signature_str in signature_strs {
             signatures.push(verify_signature(&signature_str)?);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -425,7 +425,7 @@ impl JsonRpcRequestProcessor {
             .map(|(_, status)| status)
     }
 
-    pub fn get_signature_statuses_with_commitment(
+    pub fn get_signature_statuses(
         &self,
         signatures: Vec<Signature>,
         commitment: Option<CommitmentConfig>,
@@ -611,7 +611,7 @@ pub trait RpcSol {
     fn get_fee_rate_governor(&self, meta: Self::Metadata) -> RpcResponse<RpcFeeRateGovernor>;
 
     #[rpc(meta, name = "getSignatureStatuses")]
-    fn get_signature_statuses_with_commitment(
+    fn get_signature_statuses(
         &self,
         meta: Self::Metadata,
         signature_strs: Vec<String>,
@@ -973,7 +973,7 @@ impl RpcSol for RpcSolImpl {
             .get_signature_status(signature, commitment))
     }
 
-    fn get_signature_statuses_with_commitment(
+    fn get_signature_statuses(
         &self,
         meta: Self::Metadata,
         signature_strs: Vec<String>,
@@ -986,7 +986,7 @@ impl RpcSol for RpcSolImpl {
         meta.request_processor
             .read()
             .unwrap()
-            .get_signature_statuses_with_commitment(signatures, commitment)
+            .get_signature_statuses(signatures, commitment)
     }
 
     fn get_slot(&self, meta: Self::Metadata, commitment: Option<CommitmentConfig>) -> Result<u64> {
@@ -1079,7 +1079,7 @@ impl RpcSol for RpcSolImpl {
                 .request_processor
                 .read()
                 .unwrap()
-                .get_signature_statuses_with_commitment(vec![signature], commitment.clone())?
+                .get_signature_statuses(vec![signature], commitment.clone())?
                 .value[0]
                 .clone()
                 .map(|x| x.status);

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -633,13 +633,16 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ### getSignatureStatuses
 
-Returns the statuses of a list of signatures. This method only searches the recent status cache of signatures, which retains statuses for all active slots plus `MAX_RECENT_BLOCKHASHES` rooted slots.
+Returns the statuses of a list of signatures. Unless the
+`searchTransactionHistory` configuration parameter is included, this method only
+searches the recent status cache of signatures, which retains statuses for all
+active slots plus `MAX_RECENT_BLOCKHASHES` rooted slots.
 
 #### Parameters:
 
 * `<array>` - An array of transaction signatures to confirm, as base-58 encoded strings
-* `<object>` - (optional) Extended Rpc configuration, containing the following optional fields:
-  * `commitment: <string>` - [Commitment](jsonrpc-api.md#configuring-state-commitment)
+* `<object>` - (optional) Configuration object containing the following field:
+  * `searchTransactionHistory: <bool>` - if true, a Solana node will search its ledger cache for any signatures not found in the recent status cache
 
 #### Results:
 
@@ -662,7 +665,10 @@ An array of:
 
 ```bash
 // Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatuses", "params":[["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW", "5j7s6NiJS3JAkvgkoc18WVAsiSaci2pxB2A6ueCJP4tprA2TFg9wSyTLeYouxPBJEMzJinENTkpA52YStRW5Dia7"]]]}' http://localhost:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatuses", "params":[["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW", "5j7s6NiJS3JAkvgkoc18WVAsiSaci2pxB2A6ueCJP4tprA2TFg9wSyTLeYouxPBJEMzJinENTkpA52YStRW5Dia7"]]}' http://localhost:8899
+
+// Request with configuration
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getSignatureStatuses", "params":[["5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW"], {"searchTransactionHistory": true}]}' http://localhost:8899
 
 // Result
 {"jsonrpc":"2.0","result":{"context":{"slot":82},"value":[{"slot": 72, "confirmations": 10, "err": null, "status": {"Ok": null}}, null]},"id":1}

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1644,6 +1644,41 @@ impl Blockstore {
         self.transaction_status_cf.put(index, status)
     }
 
+    // Returns a transaction status if it was processed in a root, as well as a loop counter for
+    // unit testing
+    fn get_transaction_status_with_counter(
+        &self,
+        signature: Signature,
+    ) -> Result<(Option<(Slot, TransactionStatusMeta)>, u64)> {
+        let mut counter = 0;
+        for i in 0..=1 {
+            let index_iterator = self.transaction_status_cf.iter(IteratorMode::From(
+                (i, signature, 0),
+                IteratorDirection::Forward,
+            ))?;
+            for ((_, sig, slot), data) in index_iterator {
+                counter += 1;
+                if sig != signature {
+                    break;
+                }
+                if self.is_root(slot) {
+                    let status: TransactionStatusMeta = deserialize(&data)?;
+                    return Ok((Some((slot, status)), counter));
+                }
+            }
+        }
+        Ok((None, counter))
+    }
+
+    /// Returns a transaction status if it was processed in a root
+    pub fn get_transaction_status(
+        &self,
+        signature: Signature,
+    ) -> Result<Option<(Slot, TransactionStatusMeta)>> {
+        self.get_transaction_status_with_counter(signature)
+            .map(|(status, _)| status)
+    }
+
     pub fn read_rewards(&self, index: Slot) -> Result<Option<Rewards>> {
         self.rewards_cf.get(index)
     }
@@ -5592,6 +5627,127 @@ pub mod tests {
                     frozen: true,
                 }
             );
+        }
+        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
+    }
+
+    #[test]
+    fn test_get_transaction_status() {
+        let blockstore_path = get_tmp_ledger_path!();
+        {
+            let blockstore = Blockstore::open(&blockstore_path).unwrap();
+            let transaction_status_cf = blockstore.db.column::<cf::TransactionStatus>();
+
+            let pre_balances_vec = vec![1, 2, 3];
+            let post_balances_vec = vec![3, 2, 1];
+            let status = TransactionStatusMeta {
+                status: solana_sdk::transaction::Result::<()>::Ok(()),
+                fee: 42u64,
+                pre_balances: pre_balances_vec.clone(),
+                post_balances: post_balances_vec.clone(),
+            };
+
+            let signature1 = Signature::new(&[1u8; 64]);
+            let signature2 = Signature::new(&[2u8; 64]);
+            let signature3 = Signature::new(&[3u8; 64]);
+            let signature4 = Signature::new(&[4u8; 64]);
+            let signature5 = Signature::new(&[5u8; 64]);
+            let signature6 = Signature::new(&[6u8; 64]);
+
+            // Initialize index 0, including:
+            //   signature2 in non-root and root,
+            //   signature4 in 2 non-roots,
+            //   extra entries
+            transaction_status_cf
+                .put((0, signature2.clone(), 1), &status)
+                .unwrap();
+
+            transaction_status_cf
+                .put((0, signature2.clone(), 2), &status)
+                .unwrap();
+
+            transaction_status_cf
+                .put((0, signature4.clone(), 0), &status)
+                .unwrap();
+
+            transaction_status_cf
+                .put((0, signature4.clone(), 1), &status)
+                .unwrap();
+
+            transaction_status_cf
+                .put((0, signature5.clone(), 0), &status)
+                .unwrap();
+
+            transaction_status_cf
+                .put((0, signature5.clone(), 1), &status)
+                .unwrap();
+
+            // Initialize index 1, including:
+            //   signature4 in non-root and root,
+            //   extra entries
+            transaction_status_cf
+                .put((1, signature4.clone(), 1), &status)
+                .unwrap();
+
+            transaction_status_cf
+                .put((1, signature4.clone(), 2), &status)
+                .unwrap();
+
+            transaction_status_cf
+                .put((1, signature5.clone(), 0), &status)
+                .unwrap();
+
+            transaction_status_cf
+                .put((1, signature5.clone(), 1), &status)
+                .unwrap();
+
+            blockstore.set_roots(&[2]).unwrap();
+
+            // Signature exists, root found in index 0
+            if let (Some((slot, _status)), counter) = blockstore
+                .get_transaction_status_with_counter(signature2)
+                .unwrap()
+            {
+                assert_eq!(slot, 2);
+                assert_eq!(counter, 2);
+            }
+
+            // Signature exists, root found in index 1
+            if let (Some((slot, _status)), counter) = blockstore
+                .get_transaction_status_with_counter(signature4)
+                .unwrap()
+            {
+                assert_eq!(slot, 2);
+                assert_eq!(counter, 5);
+            }
+
+            // Signature exists, no root found
+            let (status, counter) = blockstore
+                .get_transaction_status_with_counter(signature5)
+                .unwrap();
+            assert_eq!(status, None);
+            assert_eq!(counter, 5);
+
+            // Signature does not exist, smaller than existing entries
+            let (status, counter) = blockstore
+                .get_transaction_status_with_counter(signature1)
+                .unwrap();
+            assert_eq!(status, None);
+            assert_eq!(counter, 2);
+
+            // Signature does not exist, between existing entries
+            let (status, counter) = blockstore
+                .get_transaction_status_with_counter(signature3)
+                .unwrap();
+            assert_eq!(status, None);
+            assert_eq!(counter, 2);
+
+            // Signature does not exist, larger than existing entries
+            let (status, counter) = blockstore
+                .get_transaction_status_with_counter(signature6)
+                .unwrap();
+            assert_eq!(status, None);
+            assert_eq!(counter, 1);
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1651,9 +1651,9 @@ impl Blockstore {
         signature: Signature,
     ) -> Result<(Option<(Slot, TransactionStatusMeta)>, u64)> {
         let mut counter = 0;
-        for i in 0..=1 {
+        for transaction_status_cf_primary_index in 0..=1 {
             let index_iterator = self.transaction_status_cf.iter(IteratorMode::From(
-                (i, signature, 0),
+                (transaction_status_cf_primary_index, signature, 0),
                 IteratorDirection::Forward,
             ))?;
             for ((_, sig, slot), data) in index_iterator {


### PR DESCRIPTION
#### Problem
Once a transaction signature has passed out of the bank status_cache (ie. it is older than MAX_CACHE_ENTRIES, currently 300), there is no way for a client to get the status of that transaction from a validator.

#### Summary of Changes
- Update `getSignatureStatuses` to query blockstore if signature is not found in status-cache, using `searchTransactionHistory` config param to opt in
In contrast to #8823 , in this pr, `blockstore.get_transaction_status` only returns statuses in rooted slots. Ancestor slots > root should be handled by the existing status-cache-based `get_transaction_status`, and we currently have no need to return results from other forks.

```
curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getSignatureStatuses", "params":[["2NtWeBMt4fmrQas345cFxk1s9TBP5tKvvLmN4RSNfHdZ2tCji3Mbeb2pCtZqrVmkaTgc1t1ocfAKHECU8KAKmoqK", "63Jc535eCJ3d5q3VAwT9Y9oVsFVdjApBdAm9o7176ZYfXEob9pbmkCfwea8Yu4e7bqNXrquS5PcsKPkjY6GU91uh"], {"searchTransactionHistory":true}]}' 127.0.0.1:8899

{"jsonrpc":"2.0","result":{"context":{"slot":1153},"value":[null,{"confirmations":null,"err":null,"slot":844,"status":{"Ok":null}}]},"id":1}
```

Closes #8823 
