### PR TITLE
[wip][abi-incompat.] Introduce background stale slot coalescence

### DIFF
--- a/ledger/src/hardened_unpack.rs
+++ b/ledger/src/hardened_unpack.rs
@@ -130,7 +130,7 @@ pub fn unpack_snapshot<A: Read, P: AsRef<Path>>(
 }
 
 fn is_valid_snapshot_archive_entry(parts: &[&str], kind: tar::EntryType) -> bool {
-    let like_storage = Regex::new(r"^\d+\.\d+$").unwrap();
+    let like_storage = Regex::new(r"^[0-9a-f]{16}.dat$").unwrap();
     let like_slot = Regex::new(r"^\d+$").unwrap();
 
     trace!("validating: {:?} {:?}", parts, kind);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1,9 +1,7 @@
 use crate::{
-    accounts_db::{
-        AccountInfo, AccountStorage, AccountsDB, AppendVecId, BankHashInfo, ErrorCounters,
-    },
+    accounts_db::{AccountInfo, AccountStorage, AccountsDB, BankHashInfo, ErrorCounters},
     accounts_index::AccountsIndex,
-    append_vec::StoredAccount,
+    append_vec::{AppendVecId, StoredAccount},
     bank::{HashAgeKind, TransactionProcessResult},
     blockhash_queue::BlockhashQueue,
     nonce_utils,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4,7 +4,7 @@
 //! already been signed and verified.
 use crate::{
     accounts::{Accounts, TransactionAccounts, TransactionLoadResult, TransactionLoaders},
-    accounts_db::{AccountsDBSerialize, ErrorCounters, SnapshotStorage, SnapshotStorages},
+    accounts_db::{AccountsDBSerialize, ErrorCounters, SnapshotStorages},
     blockhash_queue::BlockhashQueue,
     epoch_stakes::{EpochStakes, NodeVoteAccounts},
     message_processor::{MessageProcessor, ProcessInstruction},
@@ -123,7 +123,7 @@ impl BankRc {
 
 pub struct BankRcSerialize<'a, 'b> {
     pub bank_rc: &'a BankRc,
-    pub snapshot_storages: &'b [SnapshotStorage],
+    pub snapshot_storages: &'b SnapshotStorages,
 }
 
 impl<'a, 'b> Serialize for BankRcSerialize<'a, 'b> {
@@ -2211,11 +2211,11 @@ impl Bank {
     }
 
     pub fn process_stale_slot(&self) {
-        self.rc.accounts.accounts_db.process_stale_slot();
+        self.rc.accounts.accounts_db.process_stale_storage();
     }
 
     pub fn shrink_all_stale_slots(&self) {
-        self.rc.accounts.accounts_db.shrink_all_stale_slots();
+        self.rc.accounts.accounts_db.shrink_all_stale_storages();
     }
 }
 


### PR DESCRIPTION
Quick follow-up to #9219 for the final fix for the break & devnet issue.

#### Problem

Too many DOS-able `mmap`s (#8931) as exemplified by devnet with the break app.

Even with #9219, an attacker can force a validator to use too much system recources (AppendVec/mmap).

#### Summary of Changes

After much thought, I've come up with this PR's strategy: Make it possible for a single AppendVec to hold multiple slots' accounts by exploiting the existing reference-count in AccountStorageEntry.

So, AccountsBackgroundService now starts to pack several neighbor small AppendVecs into one, not only shrinking them individually.

pros:

- easy to implement
  - no additional costly data structure to maintain via the hot code path.
- well integrates with slot shrinking mechanism.
- adaptive/self-balancing
  - can behave under gaps between sequence of slots (this is now storage-based traversing; previously that was slot-based traversing...)
  - can coalesce already-coalesced slot once that gets enough free space to shrink again in the future
  - can make the background thread load to increase/decrease proportional to cluster's storage demand linearly.)

con:

- abi breakage
- increase storage cost for AppendVecs by +8 byte (Slot is duplicated for all each Account). 

Alternatives:

- LRU-based eviction (unmap) and on-demand (mmap)
- Another kind of appendvec: CompressedVec or similar
- maintain slot coalescence candidate list ordered by alive account count
- or more higher-level solution (like rent-collection?)

Given ease of implementation, effect on performance, efficacy for the DoS attach, I think this idea might be good. :)

Fixes #8931

Part of #7167 
