### PR TITLE
Reinstate commitment param on `getSignatureStatuses` to support old clients

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -57,7 +57,10 @@ pub struct JsonRpcConfig {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcSignatureStatusConfig {
-    pub search_transaction_history: bool,
+    pub search_transaction_history: Option<bool>,
+    // DEPRECATED
+    #[serde(flatten)]
+    pub commitment: Option<CommitmentConfig>,
 }
 
 #[derive(Clone)]
@@ -440,10 +443,16 @@ impl JsonRpcRequestProcessor {
     ) -> RpcResponse<Vec<Option<TransactionStatus>>> {
         let mut statuses: Vec<Option<TransactionStatus>> = vec![];
 
+        // DEPRECATED
+        let commitment = config
+            .clone()
+            .and_then(|x| x.commitment)
+            .or_else(|| Some(CommitmentConfig::recent()));
+
         let search_transaction_history = config
-            .map(|x| x.search_transaction_history)
+            .and_then(|x| x.search_transaction_history)
             .unwrap_or(false);
-        let bank = self.bank(Some(CommitmentConfig::recent()));
+        let bank = self.bank(commitment);
 
         for signature in signatures {
             let status = if let Some(status) = self.get_transaction_status(signature, &bank) {


### PR DESCRIPTION
#### Problem
Using an old client/cli with the new rpc results in commitment-related errors:
```
$ solana airdrop 10 --url http://devnet.solana.com

Requesting airdrop of 10 SOL from 35.233.193.70:9900
Error: rpc request error: RPC Error response: {"code":-32602,"message":"Invalid params: missing field searchTransactionHistory."}
```

#### Summary of Changes
- Reinstate commitment to support old clients, mark as deprecated to be removed on next client release
