### PR TITLE
Default to mainnet-beta

### DIFF
--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -26,7 +26,7 @@ impl Default for Config {
             keypair_path.extend(&[".config", "solana", "id.json"]);
             keypair_path.to_str().unwrap().to_string()
         };
-        let json_rpc_url = "http://127.0.0.1:8899".to_string();
+        let json_rpc_url = "https://api.mainnet-beta.solana.com".to_string();
 
         // Empty websocket_url string indicates the client should
         // `Config::compute_websocket_url(&json_rpc_url)`


### PR DESCRIPTION
#### Problem

The solana CLI defaults to a cluster on localhost, which doesn't exist for most users. The user can't call solana balance `<MY_ACCOUNT>` without explicitly configuring the CLI or adding the `--url` option.

#### Summary of Changes

Default to https://api.mainnet-beta.solana.com

Fixes #8960
