### PR TITLE
Make TestValidator mint_lamports configurable

### DIFF
--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -265,6 +265,7 @@ fn test_create_account_with_seed() {
     } = TestValidator::run_with_options(TestValidatorOptions {
         fees: 1,
         bootstrap_validator_lamports: 42_000,
+        ..TestValidatorOptions::default()
     });
 
     let (sender, receiver) = channel();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -811,6 +811,7 @@ fn test_stake_authorize_with_fee_payer() {
     } = TestValidator::run_with_options(TestValidatorOptions {
         fees: SIG_FEE,
         bootstrap_validator_lamports: 42_000,
+        ..TestValidatorOptions::default()
     });
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
@@ -938,6 +939,7 @@ fn test_stake_split() {
     } = TestValidator::run_with_options(TestValidatorOptions {
         fees: 1,
         bootstrap_validator_lamports: 42_000,
+        ..TestValidatorOptions::default()
     });
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
@@ -1085,6 +1087,7 @@ fn test_stake_set_lockup() {
     } = TestValidator::run_with_options(TestValidatorOptions {
         fees: 1,
         bootstrap_validator_lamports: 42_000,
+        ..TestValidatorOptions::default()
     });
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -40,6 +40,7 @@ fn test_transfer() {
     } = TestValidator::run_with_options(TestValidatorOptions {
         fees: 1,
         bootstrap_validator_lamports: 42_000,
+        ..TestValidatorOptions::default()
     });
 
     let (sender, receiver) = channel();
@@ -229,6 +230,7 @@ fn test_transfer_multisession_signing() {
     } = TestValidator::run_with_options(TestValidatorOptions {
         fees: 1,
         bootstrap_validator_lamports: 42_000,
+        ..TestValidatorOptions::default()
     });
 
     let (sender, receiver) = channel();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -670,6 +670,7 @@ pub struct TestValidator {
 pub struct TestValidatorOptions {
     pub fees: u64,
     pub bootstrap_validator_lamports: u64,
+    pub mint_lamports: u64,
 }
 
 impl Default for TestValidatorOptions {
@@ -678,6 +679,7 @@ impl Default for TestValidatorOptions {
         TestValidatorOptions {
             fees: 0,
             bootstrap_validator_lamports: BOOTSTRAP_VALIDATOR_LAMPORTS,
+            mint_lamports: 1_000_000,
         }
     }
 }
@@ -696,6 +698,7 @@ impl TestValidator {
         let TestValidatorOptions {
             fees,
             bootstrap_validator_lamports,
+            mint_lamports,
         } = options;
         let node_keypair = Arc::new(Keypair::new());
         let node = Node::new_localhost_with_pubkey(&node_keypair.pubkey());
@@ -706,7 +709,7 @@ impl TestValidator {
             mint_keypair,
             voting_keypair,
         } = create_genesis_config_with_leader_ex(
-            1_000_000,
+            mint_lamports,
             &contact_info.id,
             42,
             bootstrap_validator_lamports,


### PR DESCRIPTION
#### Problem
The `TestValidator` initializes its mint with only 1_000_000 lamports, which is problematic for realistic tests.

#### Summary of Changes
- Allow user to configure mint balance as part of TestValidatorOptions

cc @garious 