### PR TITLE
Add a proposal for multiple gossip identities.

### DIFF
--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -72,6 +72,7 @@ fn main() {
     let ledger_path = PathBuf::from(matches.value_of("ledger").unwrap());
 
     let identity_keypair = keypair_of(&matches, "identity_keypair").unwrap_or_else(Keypair::new);
+    let node_keypair = keypair_of(&matches, "node_keypair").unwrap_or_else(Keypair::new);
 
     let storage_keypair = keypair_of(&matches, "storage_keypair").unwrap_or_else(|| {
         clap::Error::with_description(
@@ -97,6 +98,7 @@ fn main() {
     };
     let node = Node::new_archiver_with_external_ip(
         &identity_keypair.pubkey(),
+        &node_keypair.pubkey(),
         &gossip_addr,
         VALIDATOR_PORT_RANGE,
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
@@ -122,6 +124,7 @@ fn main() {
         node,
         entrypoint_info,
         Arc::new(identity_keypair),
+        Arc::new(node_keypair),
         Arc::new(storage_keypair),
         CommitmentConfig::recent(),
     )

--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -13,8 +13,9 @@ use test::Bencher;
 #[bench]
 fn broadcast_shreds_bench(bencher: &mut Bencher) {
     solana_logger::setup();
+    let leader_id_pubkey = Pubkey::new_rand();
     let leader_pubkey = Pubkey::new_rand();
-    let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
+    let leader_info = Node::new_localhost_with_pubkey(&leader_id_pubkey, &leader_pubkey);
     let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info.clone());
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
 

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -33,9 +33,10 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     const NUM_PEERS: usize = 4;
     let mut peer_sockets = Vec::new();
     for _ in 0..NUM_PEERS {
+        let validator_id = Pubkey::new_rand();
         let id = Pubkey::new_rand();
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let mut contact_info = ContactInfo::new_localhost(&id, timestamp());
+        let mut contact_info = ContactInfo::new_localhost(&validator_id, &id, timestamp());
         contact_info.tvu = socket.local_addr().unwrap();
         contact_info.tvu.set_ip("127.0.0.1".parse().unwrap());
         contact_info.tvu_forwards = contact_info.tvu;

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -178,9 +178,11 @@ mod tests {
 
     #[test]
     fn test_should_halt() {
+        let validator_keypair = Keypair::new();
         let keypair = Keypair::new();
 
-        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        let contact_info =
+            ContactInfo::new_localhost(&validator_keypair.pubkey(), &keypair.pubkey(), 0);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(contact_info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
 
@@ -214,9 +216,11 @@ mod tests {
         solana_logger::setup();
         use std::path::PathBuf;
         use tempfile::TempDir;
-        let keypair = Keypair::new();
+        let validator_keypair = Keypair::new();
+        let node_keypair = Keypair::new();
 
-        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        let contact_info =
+            ContactInfo::new_localhost(&validator_keypair.pubkey(), &node_keypair.pubkey(), 0);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(contact_info);
         let cluster_info = Arc::new(RwLock::new(cluster_info));
 
@@ -248,7 +252,7 @@ mod tests {
         }
         let cluster_info_r = cluster_info.read().unwrap();
         let cluster_hashes = cluster_info_r
-            .get_accounts_hash_for_node(&keypair.pubkey())
+            .get_accounts_hash_for_node(&node_keypair.pubkey())
             .unwrap();
         info!("{:?}", cluster_hashes);
         assert_eq!(hashes.len(), MAX_SNAPSHOT_HASHES);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -333,8 +333,15 @@ impl BankingStage {
                             cluster_info
                                 .read()
                                 .unwrap()
-                                .lookup(&leader_pubkey)
-                                .map(|leader| leader.tpu_forwards)
+                                .lookup_nodes(&leader_pubkey)
+                                .get(0)
+                                .and_then(|leader_node| {
+                                    cluster_info
+                                        .read()
+                                        .unwrap()
+                                        .lookup(&leader_node.id)
+                                        .map(|leader| leader.tpu_forwards)
+                                })
                         };
 
                         leader_addr.map_or((), |leader_addr| {

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -468,6 +468,7 @@ pub mod test {
     }
 
     fn setup_dummy_broadcast_service(
+        leader_id_pubkey: &Pubkey,
         leader_pubkey: &Pubkey,
         ledger_path: &Path,
         entry_receiver: Receiver<WorkingBankEntry>,
@@ -477,11 +478,13 @@ pub mod test {
         let blockstore = Arc::new(Blockstore::open(ledger_path).unwrap());
 
         // Make the leader node and scheduler
-        let leader_info = Node::new_localhost_with_pubkey(leader_pubkey);
+        let leader_info = Node::new_localhost_with_pubkey(leader_id_pubkey, leader_pubkey);
 
         // Make a node to broadcast to
+        let buddy_id_keypair = Keypair::new();
         let buddy_keypair = Keypair::new();
-        let broadcast_buddy = Node::new_localhost_with_pubkey(&buddy_keypair.pubkey());
+        let broadcast_buddy =
+            Node::new_localhost_with_pubkey(&buddy_id_keypair.pubkey(), &buddy_keypair.pubkey());
 
         // Fill the cluster_info with the buddy's info
         let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info.clone());
@@ -519,11 +522,13 @@ pub mod test {
 
         {
             // Create the leader scheduler
+            let leader_validator_keypair = Keypair::new();
             let leader_keypair = Keypair::new();
 
             let (entry_sender, entry_receiver) = channel();
             let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
             let broadcast_service = setup_dummy_broadcast_service(
+                &leader_validator_keypair.pubkey(),
                 &leader_keypair.pubkey(),
                 &ledger_path,
                 entry_receiver,

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -141,6 +141,7 @@ mod tests {
     fn test_tvu_peers_ordering() {
         let mut cluster = ClusterInfo::new_with_invalid_keypair(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         ));
         cluster.insert_info(ContactInfo::new_with_socketaddr(&SocketAddr::new(

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -387,9 +387,11 @@ mod test {
         let blockstore = Arc::new(
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
+        let leader_id_keypair = Arc::new(Keypair::new());
+        let leader_id_pubkey = leader_id_keypair.pubkey();
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
-        let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
+        let leader_info = Node::new_localhost_with_pubkey(&leader_id_pubkey, &leader_pubkey);
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
             leader_info.info.clone(),
         )));

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -203,10 +203,12 @@ mod test {
         let mut crds = Crds::default();
         let original = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::default(),
+            &Pubkey::default(),
             0,
         )));
         assert_matches!(crds.insert(original.clone(), 0), Ok(_));
         let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::default(),
             &Pubkey::default(),
             1,
         )));
@@ -220,6 +222,7 @@ mod test {
     fn test_update_timestamp() {
         let mut crds = Crds::default();
         let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::default(),
             &Pubkey::default(),
             0,
         )));
@@ -328,11 +331,13 @@ mod test {
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
                 &Pubkey::default(),
+                &Pubkey::default(),
                 0,
             ))),
         );
         let v2 = VersionedCrdsValue::new(1, {
-            let mut contact_info = ContactInfo::new_localhost(&Pubkey::default(), 0);
+            let mut contact_info =
+                ContactInfo::new_localhost(&Pubkey::default(), &Pubkey::default(), 0);
             contact_info.rpc = socketaddr!("0.0.0.0:0");
             CrdsValue::new_unsigned(CrdsData::ContactInfo(contact_info))
         });
@@ -358,12 +363,14 @@ mod test {
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
                 &Pubkey::default(),
+                &Pubkey::default(),
                 1,
             ))),
         );
         let v2 = VersionedCrdsValue::new(
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+                &Pubkey::default(),
                 &Pubkey::default(),
                 0,
             ))),
@@ -380,12 +387,14 @@ mod test {
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
                 &Pubkey::new_rand(),
+                &Pubkey::new_rand(),
                 0,
             ))),
         );
         let v2 = VersionedCrdsValue::new(
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+                &Pubkey::new_rand(),
                 &Pubkey::new_rand(),
                 0,
             ))),

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -233,7 +233,7 @@ mod test {
         let mut crds_gossip = CrdsGossip::default();
         crds_gossip.id = Pubkey::new(&[0; 32]);
         let id = crds_gossip.id;
-        let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), 0);
+        let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), &Pubkey::new(&[1; 32]), 0);
         let prune_pubkey = Pubkey::new(&[2; 32]);
         crds_gossip
             .crds

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -383,11 +383,13 @@ mod test {
         let node = CrdsGossipPull::default();
         let me = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         crds.insert(me.clone(), 0).unwrap();
         for i in 1..=30 {
             let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+                &Pubkey::new_rand(),
                 &Pubkey::new_rand(),
                 0,
             )));
@@ -411,6 +413,7 @@ mod test {
         let mut crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let id = entry.label().pubkey();
@@ -428,6 +431,7 @@ mod test {
 
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         crds.insert(new.clone(), 0).unwrap();
@@ -442,6 +446,7 @@ mod test {
         let mut crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
@@ -449,10 +454,12 @@ mod test {
         crds.insert(entry.clone(), 0).unwrap();
         let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         crds.insert(old.clone(), 0).unwrap();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -481,12 +488,14 @@ mod test {
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
         let node = CrdsGossipPull::default();
         node_crds.insert(entry.clone(), 0).unwrap();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -526,6 +535,7 @@ mod test {
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
@@ -534,21 +544,27 @@ mod test {
 
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         node_crds.insert(new.clone(), 0).unwrap();
 
         let mut dest = CrdsGossipPull::default();
         let mut dest_crds = Crds::default();
+        let new_validator_id = Pubkey::new_rand();
         let new_id = Pubkey::new_rand();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &new_id, 1,
+            &new_validator_id,
+            &new_id,
+            1,
         )));
         dest_crds.insert(new.clone(), 0).unwrap();
 
         // node contains a key from the dest node, but at an older local timestamp
         let same_key = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &new_id, 0,
+            &new_validator_id,
+            &new_id,
+            0,
         )));
         assert_eq!(same_key.label(), new.label());
         assert!(same_key.wallclock() < new.wallclock());
@@ -616,6 +632,7 @@ mod test {
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let node_label = entry.label();
@@ -623,6 +640,7 @@ mod test {
         let mut node = CrdsGossipPull::default();
         node_crds.insert(entry.clone(), 0).unwrap();
         let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -735,9 +753,10 @@ mod test {
         let mut node_crds = Crds::default();
         let mut node = CrdsGossipPull::default();
 
+        let peer_validator_pubkey = Pubkey::new_rand();
         let peer_pubkey = Pubkey::new_rand();
         let peer_entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(
-            ContactInfo::new_localhost(&peer_pubkey, 0),
+            ContactInfo::new_localhost(&peer_validator_pubkey, &peer_pubkey, 0),
         ));
         let mut timeouts = HashMap::new();
         timeouts.insert(Pubkey::default(), node.crds_timeout);
@@ -756,7 +775,7 @@ mod test {
 
         let mut node_crds = Crds::default();
         let unstaked_peer_entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(
-            ContactInfo::new_localhost(&peer_pubkey, 0),
+            ContactInfo::new_localhost(&peer_validator_pubkey, &peer_pubkey, 0),
         ));
         // check that old contact infos fail if they are too old, regardless of "timeouts"
         assert_eq!(

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -360,9 +360,11 @@ mod test {
 
     #[test]
     fn test_signature() {
+        let validator_keypair = Keypair::new();
         let keypair = Keypair::new();
         let wrong_keypair = Keypair::new();
         let mut v = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &validator_keypair.pubkey(),
             &keypair.pubkey(),
             timestamp(),
         )));

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -588,7 +588,7 @@ mod test {
 
     #[test]
     pub fn test_update_lowest_slot() {
-        let node_info = Node::new_localhost_with_pubkey(&Pubkey::default());
+        let node_info = Node::new_localhost_with_pubkey(&Pubkey::default(), &Pubkey::default());
         let cluster_info = RwLock::new(ClusterInfo::new_with_invalid_keypair(
             node_info.info.clone(),
         ));

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -303,7 +303,7 @@ mod tests {
         let leader_schedule_cache = Arc::new(cached_leader_schedule);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
-        let mut me = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut me = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
         let ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let port = find_available_port_in_range(ip_addr, (8000, 10000)).unwrap();
         let me_retransmit = UdpSocket::bind(format!("127.0.0.1:{}", port)).unwrap();
@@ -315,7 +315,7 @@ mod tests {
             .local_addr()
             .unwrap();
 
-        let other = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let other = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
         let mut cluster_info = ClusterInfo::new_with_invalid_keypair(other);
         cluster_info.insert_info(me);
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1461,6 +1461,7 @@ pub mod tests {
             .unwrap()
             .insert_info(ContactInfo::new_with_pubkey_socketaddr(
                 &leader_pubkey,
+                &leader_pubkey,
                 &socketaddr!("127.0.0.1:1234"),
             ));
 

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -588,6 +588,7 @@ mod tests {
         {
             let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
             let me = ContactInfo {
+                validator_id: Pubkey::new_rand(),
                 id: Pubkey::new_rand(),
                 gossip: socketaddr!("127.0.0.1:1234"),
                 tvu: socketaddr!("127.0.0.1:1235"),
@@ -653,7 +654,7 @@ mod tests {
     #[test]
     fn window_index_request() {
         let cluster_slots = ClusterSlots::default();
-        let me = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let me = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), timestamp());
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(me)));
         let serve_repair = ServeRepair::new(cluster_info.clone());
         let rv = serve_repair.repair_request(
@@ -666,6 +667,7 @@ mod tests {
 
         let serve_repair_addr = socketaddr!([127, 0, 0, 1], 1243);
         let nxt = ContactInfo {
+            validator_id: Pubkey::new_rand(),
             id: Pubkey::new_rand(),
             gossip: socketaddr!([127, 0, 0, 1], 1234),
             tvu: socketaddr!([127, 0, 0, 1], 1235),
@@ -694,6 +696,7 @@ mod tests {
 
         let serve_repair_addr2 = socketaddr!([127, 0, 0, 2], 1243);
         let nxt = ContactInfo {
+            validator_id: Pubkey::new_rand(),
             id: Pubkey::new_rand(),
             gossip: socketaddr!([127, 0, 0, 1], 1234),
             tvu: socketaddr!([127, 0, 0, 1], 1235),

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -652,8 +652,8 @@ impl StorageStage {
     }
 }
 
-pub fn test_cluster_info(id: &Pubkey) -> Arc<RwLock<ClusterInfo>> {
-    let contact_info = ContactInfo::new_localhost(id, 0);
+pub fn test_cluster_info(validator_id: &Pubkey, id: &Pubkey) -> Arc<RwLock<ClusterInfo>> {
+    let contact_info = ContactInfo::new_localhost(validator_id, id, 0);
     let cluster_info = ClusterInfo::new_with_invalid_keypair(contact_info);
     Arc::new(RwLock::new(cluster_info))
 }
@@ -679,11 +679,12 @@ mod tests {
 
     #[test]
     fn test_storage_stage_none_ledger() {
+        let validator_keypair = Arc::new(Keypair::new());
         let keypair = Arc::new(Keypair::new());
         let storage_keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
 
-        let cluster_info = test_cluster_info(&keypair.pubkey());
+        let cluster_info = test_cluster_info(&validator_keypair.pubkey(), &keypair.pubkey());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(1000);
         let bank = Arc::new(Bank::new(&genesis_config));
         let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -266,8 +266,12 @@ pub mod tests {
     fn test_tvu_exit() {
         solana_logger::setup();
         let leader = Node::new_localhost();
+        let target1_id_keypair = Keypair::new();
         let target1_keypair = Keypair::new();
-        let target1 = Node::new_localhost_with_pubkey(&target1_keypair.pubkey());
+        let target1 = Node::new_localhost_with_pubkey(
+            &target1_id_keypair.pubkey(),
+            &target1_keypair.pubkey(),
+        );
 
         let starting_balance = 10_000;
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(starting_balance);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -148,7 +148,8 @@ impl Validator {
     #[allow(clippy::cognitive_complexity)]
     pub fn new(
         mut node: Node,
-        keypair: &Arc<Keypair>,
+        validator_keypair: &Arc<Keypair>,
+        node_keypair: &Arc<Keypair>,
         ledger_path: &Path,
         vote_account: &Pubkey,
         mut authorized_voter_keypairs: Vec<Arc<Keypair>>,
@@ -157,10 +158,13 @@ impl Validator {
         poh_verify: bool,
         config: &ValidatorConfig,
     ) -> Self {
-        let id = keypair.pubkey();
-        assert_eq!(id, node.info.id);
+        let validator_id = validator_keypair.pubkey();
+        let node_id = node_keypair.pubkey();
+        assert_eq!(validator_id, node.info.validator_id);
+        assert_eq!(node_id, node.info.id);
 
-        warn!("identity: {}", id);
+        warn!("identity: {}", validator_id);
+        warn!("node: {}", node_id);
         warn!("vote account: {}", vote_account);
 
         if config.voting_disabled {
@@ -231,7 +235,8 @@ impl Validator {
 
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(
             node.info.clone(),
-            keypair.clone(),
+            validator_keypair.clone(),
+            node_keypair.clone(),
         )));
 
         let storage_state = StorageState::new(
@@ -325,14 +330,14 @@ impl Validator {
             bank.last_blockhash(),
             bank.slot(),
             leader_schedule_cache.next_leader_slot(
-                &id,
+                &validator_id,
                 bank.slot(),
                 &bank,
                 Some(&blockstore),
                 GRACE_TICKS_FACTOR * MAX_GRACE_SLOTS,
             ),
             bank.ticks_per_slot(),
-            &id,
+            &validator_id,
             &blockstore,
             blockstore.new_shreds_signals.first().cloned(),
             &leader_schedule_cache,
@@ -471,9 +476,9 @@ impl Validator {
             bank_forks,
         );
 
-        datapoint_info!("validator-new", ("id", id.to_string(), String));
+        datapoint_info!("validator-new", ("id", validator_id.to_string(), String));
         Self {
-            id,
+            id: validator_id,
             gossip_service,
             serve_repair_service,
             rpc_service,
@@ -697,8 +702,10 @@ impl TestValidator {
             fees,
             bootstrap_validator_lamports,
         } = options;
+        let validator_keypair = Arc::new(Keypair::new());
         let node_keypair = Arc::new(Keypair::new());
-        let node = Node::new_localhost_with_pubkey(&node_keypair.pubkey());
+        let node =
+            Node::new_localhost_with_pubkey(&validator_keypair.pubkey(), &node_keypair.pubkey());
         let contact_info = node.info.clone();
 
         let GenesisConfigInfo {
@@ -707,7 +714,7 @@ impl TestValidator {
             voting_keypair,
         } = create_genesis_config_with_leader_ex(
             1_000_000,
-            &contact_info.id,
+            &contact_info.validator_id,
             42,
             bootstrap_validator_lamports,
         );
@@ -732,6 +739,7 @@ impl TestValidator {
         };
         let node = Validator::new(
             node,
+            &validator_keypair,
             &node_keypair,
             &ledger_path,
             &leader_voting_keypair.pubkey(),
@@ -820,10 +828,18 @@ mod tests {
     fn validator_exit() {
         solana_logger::setup();
         let leader_keypair = Keypair::new();
-        let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
+        let leader_node_keypair = Keypair::new();
+        let leader_node = Node::new_localhost_with_pubkey(
+            &leader_keypair.pubkey(),
+            &leader_node_keypair.pubkey(),
+        );
 
         let validator_keypair = Keypair::new();
-        let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
+        let validator_node_keypair = Keypair::new();
+        let validator_node = Node::new_localhost_with_pubkey(
+            &validator_keypair.pubkey(),
+            &validator_node_keypair.pubkey(),
+        );
         let genesis_config =
             create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1000)
                 .genesis_config;
@@ -841,6 +857,7 @@ mod tests {
         let validator = Validator::new(
             validator_node,
             &Arc::new(validator_keypair),
+            &Arc::new(validator_node_keypair),
             &validator_ledger_path,
             &voting_keypair.pubkey(),
             vec![voting_keypair.clone()],
@@ -855,14 +872,20 @@ mod tests {
 
     #[test]
     fn validator_parallel_exit() {
+        let leader_id_keypair = Keypair::new();
         let leader_keypair = Keypair::new();
-        let leader_node = Node::new_localhost_with_pubkey(&leader_keypair.pubkey());
+        let leader_node =
+            Node::new_localhost_with_pubkey(&leader_id_keypair.pubkey(), &leader_keypair.pubkey());
 
         let mut ledger_paths = vec![];
         let mut validators: Vec<Validator> = (0..2)
             .map(|_| {
                 let validator_keypair = Keypair::new();
-                let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
+                let validator_node_keypair = Keypair::new();
+                let validator_node = Node::new_localhost_with_pubkey(
+                    &validator_keypair.pubkey(),
+                    &validator_node_keypair.pubkey(),
+                );
                 let genesis_config =
                     create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1000)
                         .genesis_config;
@@ -880,6 +903,7 @@ mod tests {
                 Validator::new(
                     validator_node,
                     &Arc::new(validator_keypair),
+                    &Arc::new(validator_node_keypair),
                     &validator_ledger_path,
                     &vote_account_keypair.pubkey(),
                     vec![vote_account_keypair.clone()],

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -634,7 +634,7 @@ mod test {
         let blockstore = Arc::new(blockstore);
         let (retransmit_sender, _retransmit_receiver) = channel();
         let cluster_info = Arc::new(RwLock::new(ClusterInfo::new_with_invalid_keypair(
-            ContactInfo::new_localhost(&Pubkey::default(), 0),
+            ContactInfo::new_localhost(&Pubkey::default(), &Pubkey::default(), 0),
         )));
         let cluster_slots = Arc::new(ClusterSlots::default());
         let repair_sock = Arc::new(UdpSocket::bind(socketaddr_any!()).unwrap());

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -71,7 +71,7 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
     let timeout = 60 * 5;
 
     // describe the leader
-    let leader_info = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+    let leader_info = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
     let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.clone());
 
     // setup staked nodes
@@ -90,19 +90,40 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
         .insert(leader_info.id, (false, HashSet::new(), r));
     let range: Vec<_> = (1..=stakes.len()).collect();
     let chunk_size = (stakes.len() + num_threads - 1) / num_threads;
+
+    // Set 5% of nodes running multiple nodes per vote identity.
+    let multi_node_count = (stakes.len() as f64 * 0.05) as usize;
+
+    let mut ids = HashMap::new();
+    let mut nodes = HashMap::new();
     range.chunks(chunk_size).for_each(|chunk| {
         chunk.into_iter().for_each(|i| {
             //distribute neighbors across threads to maximize parallel compute
             let batch_ix = *i as usize % batches.len();
-            let node = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
-            staked_nodes.insert(node.id, stakes[*i - 1]);
-            cluster_info.insert_info(node.clone());
-            let (s, r) = channel();
-            batches
-                .get_mut(batch_ix)
-                .unwrap()
-                .insert(node.id, (false, HashSet::new(), r));
-            senders.lock().unwrap().insert(node.id, s);
+
+            // Every nth node has an additional id, distributed evenly.
+            let mut nodes_per_identity = if *i % (stakes.len() / multi_node_count) == 0 {
+                2
+            } else {
+                1
+            };
+
+            // Create nodes, sharing id, but with random node identifiers.
+            let identity = Pubkey::new_rand();
+            while nodes_per_identity > 0 {
+                nodes_per_identity -= 1;
+                let node = ContactInfo::new_localhost(&identity, &Pubkey::new_rand(), 0);
+                ids.insert(node.validator_id, 1);
+                nodes.insert(node.id, 1);
+                staked_nodes.insert(node.id, stakes[*i - 1]);
+                cluster_info.insert_info(node.clone());
+                let (s, r) = channel();
+                batches
+                    .get_mut(batch_ix)
+                    .unwrap()
+                    .insert(node.id, (false, HashSet::new(), r));
+                senders.lock().unwrap().insert(node.id, s);
+            }
         })
     });
     let c_info = cluster_info.clone();

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -75,22 +75,23 @@ fn stakes(network: &Network) -> HashMap<Pubkey, u64> {
 fn star_network_create(num: usize) -> Network {
     let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
         &Pubkey::new_rand(),
+        &Pubkey::new_rand(),
         0,
     )));
-    let mut network: HashMap<_, _> = (1..num)
-        .map(|_| {
-            let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
-                0,
-            )));
-            let id = new.label().pubkey();
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), 0).unwrap();
-            node.crds.insert(entry.clone(), 0).unwrap();
-            node.set_self(&id);
-            (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
-        })
-        .collect();
+    let mut network: HashMap<_, _> =
+        (1..num)
+            .map(|_| {
+                let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(
+                    ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
+                ));
+                let id = new.label().pubkey();
+                let mut node = CrdsGossip::default();
+                node.crds.insert(new.clone(), 0).unwrap();
+                node.crds.insert(entry.clone(), 0).unwrap();
+                node.set_self(&id);
+                (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
+            })
+            .collect();
     let mut node = CrdsGossip::default();
     let id = entry.label().pubkey();
     node.crds.insert(entry.clone(), 0).unwrap();
@@ -102,44 +103,45 @@ fn star_network_create(num: usize) -> Network {
 fn rstar_network_create(num: usize) -> Network {
     let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
         &Pubkey::new_rand(),
+        &Pubkey::new_rand(),
         0,
     )));
     let mut origin = CrdsGossip::default();
     let id = entry.label().pubkey();
     origin.crds.insert(entry.clone(), 0).unwrap();
     origin.set_self(&id);
-    let mut network: HashMap<_, _> = (1..num)
-        .map(|_| {
-            let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
-                0,
-            )));
-            let id = new.label().pubkey();
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), 0).unwrap();
-            origin.crds.insert(new.clone(), 0).unwrap();
-            node.set_self(&id);
-            (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
-        })
-        .collect();
+    let mut network: HashMap<_, _> =
+        (1..num)
+            .map(|_| {
+                let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(
+                    ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
+                ));
+                let id = new.label().pubkey();
+                let mut node = CrdsGossip::default();
+                node.crds.insert(new.clone(), 0).unwrap();
+                origin.crds.insert(new.clone(), 0).unwrap();
+                node.set_self(&id);
+                (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
+            })
+            .collect();
     network.insert(id, Node::new(Arc::new(Mutex::new(origin))));
     Network::new(network)
 }
 
 fn ring_network_create(num: usize) -> Network {
-    let mut network: HashMap<_, _> = (0..num)
-        .map(|_| {
-            let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
-                0,
-            )));
-            let id = new.label().pubkey();
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), 0).unwrap();
-            node.set_self(&id);
-            (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
-        })
-        .collect();
+    let mut network: HashMap<_, _> =
+        (0..num)
+            .map(|_| {
+                let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(
+                    ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
+                ));
+                let id = new.label().pubkey();
+                let mut node = CrdsGossip::default();
+                node.crds.insert(new.clone(), 0).unwrap();
+                node.set_self(&id);
+                (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
+            })
+            .collect();
     let keys: Vec<Pubkey> = network.keys().cloned().collect();
     for k in 0..keys.len() {
         let start_info = {
@@ -161,22 +163,22 @@ fn ring_network_create(num: usize) -> Network {
 
 fn connected_staked_network_create(stakes: &[u64]) -> Network {
     let num = stakes.len();
-    let mut network: HashMap<_, _> = (0..num)
-        .map(|n| {
-            let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
-                0,
-            )));
-            let id = new.label().pubkey();
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), 0).unwrap();
-            node.set_self(&id);
-            (
-                new.label().pubkey(),
-                Node::staked(Arc::new(Mutex::new(node)), stakes[n]),
-            )
-        })
-        .collect();
+    let mut network: HashMap<_, _> =
+        (0..num)
+            .map(|n| {
+                let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(
+                    ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
+                ));
+                let id = new.label().pubkey();
+                let mut node = CrdsGossip::default();
+                node.crds.insert(new.clone(), 0).unwrap();
+                node.set_self(&id);
+                (
+                    new.label().pubkey(),
+                    Node::staked(Arc::new(Mutex::new(node)), stakes[n]),
+                )
+            })
+            .collect();
 
     let keys: Vec<Pubkey> = network.keys().cloned().collect();
     let start_entries: Vec<_> = keys
@@ -573,7 +575,7 @@ fn test_prune_errors() {
     let mut crds_gossip = CrdsGossip::default();
     crds_gossip.id = Pubkey::new(&[0; 32]);
     let id = crds_gossip.id;
-    let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), 0);
+    let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), &Pubkey::new(&[1; 32]), 0);
     let prune_pubkey = Pubkey::new(&[2; 32]);
     crds_gossip
         .crds

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -15,10 +15,13 @@ use std::thread::sleep;
 use std::time::Duration;
 
 fn test_node(exit: &Arc<AtomicBool>) -> (Arc<RwLock<ClusterInfo>>, GossipService, UdpSocket) {
+    let validator_keypair = Arc::new(Keypair::new());
     let keypair = Arc::new(Keypair::new());
-    let mut test_node = Node::new_localhost_with_pubkey(&keypair.pubkey());
+    let mut test_node =
+        Node::new_localhost_with_pubkey(&validator_keypair.pubkey(), &keypair.pubkey());
     let cluster_info = Arc::new(RwLock::new(ClusterInfo::new(
         test_node.info.clone(),
+        validator_keypair,
         keypair,
     )));
     let gossip_service = GossipService::new(&cluster_info, None, test_node.sockets.gossip, exit);

--- a/core/tests/storage_stage.rs
+++ b/core/tests/storage_stage.rs
@@ -37,6 +37,7 @@ mod tests {
     #[test]
     fn test_storage_stage_process_account_proofs() {
         solana_logger::setup();
+        let validator_keypair = Arc::new(Keypair::new());
         let keypair = Arc::new(Keypair::new());
         let storage_keypair = Arc::new(Keypair::new());
         let archiver_keypair = Arc::new(Keypair::new());
@@ -61,7 +62,7 @@ mod tests {
             vec![0],
         )));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
-        let cluster_info = test_cluster_info(&keypair.pubkey());
+        let cluster_info = test_cluster_info(&validator_keypair.pubkey(), &keypair.pubkey());
 
         let (bank_sender, bank_receiver) = channel();
         let storage_state = StorageState::new(
@@ -167,6 +168,7 @@ mod tests {
     #[test]
     fn test_storage_stage_process_banks() {
         solana_logger::setup();
+        let validator_keypair = Arc::new(Keypair::new());
         let keypair = Arc::new(Keypair::new());
         let storage_keypair = Arc::new(Keypair::new());
         let exit = Arc::new(AtomicBool::new(false));
@@ -183,7 +185,7 @@ mod tests {
         )));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
 
-        let cluster_info = test_cluster_info(&keypair.pubkey());
+        let cluster_info = test_cluster_info(&validator_keypair.pubkey(), &keypair.pubkey());
         let (bank_sender, bank_receiver) = channel();
         let storage_state = StorageState::new(
             &bank.last_blockhash(),

--- a/docs/src/proposals/multiple-gossip-identities.md
+++ b/docs/src/proposals/multiple-gossip-identities.md
@@ -1,0 +1,61 @@
+# Multiple Gossip Identities
+
+The current design of gossip requires that a single validator ID is run by a
+single node. If more than one machine runs at the same time they will overwrite
+each others CRDS values. Ideally, a validator might want to be able to run
+multiple nodes in gossip that represent the same ID.
+
+Some use cases:
+
+- Enables H/A with multiple nodes to be run in parallel.
+- Autoscaling by running low/high power nodes at the same time.
+- Prioritize Turbine traffic to nodes shared by a single validator.
+
+
+
+# Proposal
+
+Extend gossip with another public key, known as a "node" key. This key only
+identifies an individual machine in gossip, and is not associated with any on
+chain state. `CrdsValue` entries are then associated with the node key instead
+of the current ID key. The ID key can still sign and be verified against chain
+state, so no security is lost.
+
+Internally, lookups for the the validator ID can now treat gossip as "groups"
+of nodes. Looking up some validator ID in gossip can return a list of
+`ContactInfo` which for example Turbine can then use.
+
+
+
+# Impact
+
+1. Initially, this will mean turbine will begin sending data to multiple nodes
+   owned by a single validator, which opens up a potential attack vector. To
+   resolve this, Turbine should take into account validator groups and only
+   send data to a single node. That node can then within its own turbine
+   prioritize forwarding traffic to nodes in its own group. With this change
+   this actually increases turbines throughput.
+
+2. Internally, services should continue to use the ID key for packet and shred
+   data, but many services rely on `cluster_info` and gossip to find this key.
+   This change requires a careful check to make sure the correct keys are being
+   used within the various staged.
+
+
+
+# Alternatives
+
+One alternative, is to allow VoteState to contain multiple ID keys. It already
+allows multiple voting keys, though currently only one is possibly active as
+the codebase currently handles it.
+
+With this change, two `ID` keys in Gossip can be owned by the same VoteState. There
+are a few problems with this model though:
+
+1. VoteState key changes don't take effect until Epoch boundaries. Validators
+   who are changing their internal machine setups likely don't have any effect
+   on chain state, and having to wait for Epoch boundaries to introduce a new
+   machine removes the possibility of things like fast autoscaling
+2. The changes to implement this are more complex, as a lot of the codebase
+   will have to deal with the possibility of receiving data signed by multiple
+   different keys. A node key keeps the current one job one key status.

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -167,7 +167,11 @@ pub mod test {
 
     #[test]
     fn test_dos() {
-        let nodes = [ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp())];
+        let nodes = [ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
+            timestamp(),
+        )];
         let entrypoint_addr = nodes[0].gossip.clone();
         run_dos(
             &nodes,

--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 pub struct ValidatorInfo {
+    pub validator_keypair: Arc<Keypair>,
     pub keypair: Arc<Keypair>,
     pub voting_keypair: Arc<Keypair>,
     pub storage_keypair: Arc<Keypair>,


### PR DESCRIPTION
#### Problem

It's currently not possible to run multiple validators using the same identity keypair. This opens up the ability for multiple nodes to exist in gossip at the same time. Opening this ticket up to track the change. With a better understanding of Solana's key setup and consensus, I'd like to get this or something like it merged in to allow software like StrongGate/SignOS to work well with multiple nodes.

Initially, it would be good to just be able to have a second node enter the cluster to allow for a clean handover.

#### Summary of Changes

* Includes a [proposal](https://github.com/solana-labs/solana/blob/d30758371cac8365cd7240f75b31101256edcd73/docs/src/proposals/multiple-gossip-identities.md).
* `ContactInfo` gains a new keypair associated with the node.
* This keypair is currently randomly generated on each run.
* `ClusterInfo` also gains a new keypair that tracks the `contact_info` change.
* `ClusterInfo` methods now sign with the node keypair.
* Issue: `banking_stage` forwards packets to one node currently.