### PR TITLE
Rpc: Add getConfirmedTransaction

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -25,7 +25,9 @@ use solana_sdk::{
     timing::slot_duration_from_slots_per_year,
     transaction::{self, Transaction},
 };
-use solana_transaction_status::{ConfirmedBlock, TransactionEncoding, TransactionStatus};
+use solana_transaction_status::{
+    ConfirmedBlock, ConfirmedTransaction, TransactionEncoding, TransactionStatus,
+};
 use solana_vote_program::vote_state::{VoteState, MAX_LOCKOUT_HISTORY};
 use std::{
     collections::HashMap,
@@ -497,6 +499,21 @@ impl JsonRpcRequestProcessor {
                 }
             })
     }
+
+    pub fn get_confirmed_transaction(
+        &self,
+        signature: Signature,
+        encoding: Option<TransactionEncoding>,
+    ) -> Result<Option<ConfirmedTransaction>> {
+        if self.config.enable_rpc_transaction_history {
+            Ok(self
+                .blockstore
+                .get_confirmed_transaction(signature, encoding)
+                .unwrap_or(None))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 fn get_tpu_addr(cluster_info: &Arc<RwLock<ClusterInfo>>) -> Result<SocketAddr> {
@@ -738,6 +755,14 @@ pub trait RpcSol {
         start_slot: Slot,
         end_slot: Option<Slot>,
     ) -> Result<Vec<Slot>>;
+
+    #[rpc(meta, name = "getConfirmedTransaction")]
+    fn get_confirmed_transaction(
+        &self,
+        meta: Self::Metadata,
+        signature_str: String,
+        encoding: Option<TransactionEncoding>,
+    ) -> Result<Option<ConfirmedTransaction>>;
 }
 
 pub struct RpcSolImpl;
@@ -1280,6 +1305,19 @@ impl RpcSol for RpcSolImpl {
 
     fn get_block_time(&self, meta: Self::Metadata, slot: Slot) -> Result<Option<UnixTimestamp>> {
         meta.request_processor.read().unwrap().get_block_time(slot)
+    }
+
+    fn get_confirmed_transaction(
+        &self,
+        meta: Self::Metadata,
+        signature_str: String,
+        encoding: Option<TransactionEncoding>,
+    ) -> Result<Option<ConfirmedTransaction>> {
+        let signature = verify_signature(&signature_str)?;
+        meta.request_processor
+            .read()
+            .unwrap()
+            .get_confirmed_transaction(signature, encoding)
     }
 }
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -21,6 +21,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getClusterNodes](jsonrpc-api.md#getclusternodes)
 * [getConfirmedBlock](jsonrpc-api.md#getconfirmedblock)
 * [getConfirmedBlocks](jsonrpc-api.md#getconfirmedblocks)
+* [getConfirmedTransaction](jsonrpc-api.md#getconfirmedtransaction)
 * [getEpochInfo](jsonrpc-api.md#getepochinfo)
 * [getEpochSchedule](jsonrpc-api.md#getepochschedule)
 * [getFeeCalculatorForBlockhash](jsonrpc-api.md#getfeecalculatorforblockhash)
@@ -343,6 +344,45 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"m
 
 // Result
 {"jsonrpc":"2.0","result":[5,6,7,8,9,10],"id":1}
+```
+
+### getConfirmedTransaction
+
+Returns transaction details for a confirmed transaction
+
+#### Parameters:
+
+* `<string>` - transaction signature as base-58 encoded string
+* `<string>` - (optional) encoding for the returned Transaction, either "json" or "binary". If not provided, the default encoding is JSON.
+
+#### Results:
+
+The result field will be an object with the following fields:
+* `slot: <u64>` - the slot this transaction was processed in
+* `transaction: <object|string>` - [Transaction](#transaction-structure) object, either in JSON format or base-58 encoded binary data, depending on encoding parameter
+* `meta: <object>` - transaction status metadata object, containing `null` or:
+  * `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
+  * `fee: <u64>` - fee this transaction was charged, as u64 integer
+  * `preBalances: <array>` - array of u64 account balances from before the transaction was processed
+  * `postBalances: <array>` - array of u64 account balances after the transaction was processed
+  * DEPRECATED: `status: <object>` - Transaction status
+    * `"Ok": <null>` - Transaction was successful
+    * `"Err": <ERR>` - Transaction failed with TransactionError
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedTransaction","params":["35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby", "json"]}' localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":{"slot":430,"transaction":{"message":{"accountKeys":["6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC","39UAy8hsoYPywGPGdmun747omSr79zLSjqvPJN3zetoH","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":2},"instructions":[{"accounts":[1,2,3],"data":"29z5mr1JoRmJYQ6ynmk3pf31cGFRziAF1M3mT3L6sFXf5cKLdkEaMXMT8AqLpD4CpcupHmuMEmtZHpomrwfdZetSomNy3d","programIdIndex":4}],"recentBlockhash":"EFejToxii1L5aUF2NrK9dsbAEmZSNyN5nsipmZHQR1eA"},"signatures":["35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby","4vANMjSKiwEchGSXwVrQkwHnmsbKQmy9vdrsYxWdCup1bLsFzX8gKrFTSVDCZCae2dbxJB9mPNhqB2sD1vvr4sAD"]},"meta":{"err":null,"fee":18000,"postBalances":[499999972500,15298080,1,1,1],"preBalances":[499999990500,15298080,1,1,1],"status":{"Ok":null}}},"id":1}
+
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedTransaction","params":["35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby", "binary"]}' localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":{"slot":430,"transaction":"81UZJt4dh4Do66jDhrgkQudS8J2N6iG3jaVav7gJrqJSFY4Ug53iA9JFJZh2gxKWcaFdLJwhHx9mRdg9JwDAWB4ywiu5154CRwXV4FMdnPLg7bhxRLwhhYaLsVgMF5AyNRcTzjCVoBvqFgDU7P8VEKDEiMvD3qxzm1pLZVxDG1LTQpT3Dz4Uviv4KQbFQNuC22KupBoyHFB7Zh6KFdMqux4M9PvhoqcoJsJKwXjWpKu7xmEKnnrSbfLadkgjBmmjhW3fdTrFvnhQdTkhtdJxUL1xS9GMuJQer8YgSKNtUXB1eXZQwXU8bU2BjYkZE6Q5Xww8hu9Z4E4Mo4QsooVtHoP6BM3NKw8zjVbWfoCQqxTrwuSzrNCWCWt58C24LHecH67CTt2uXbYSviixvrYkK7A3t68BxTJcF1dXJitEPTFe2ceTkauLJqrJgnER4iUrsjr26T8YgWvpY9wkkWFSviQW6wV5RASTCUasVEcrDiaKj8EQMkgyDoe9HyKitSVg67vMWJFpUXpQobseWJUs5FTWWzmfHmFp8FZ","meta":{"err":null,"fee":18000,"postBalances":[499999972500,15298080,1,1,1],"preBalances":[499999990500,15298080,1,1,1],"status":{"Ok":null}}},"id":1}
 ```
 
 ### getEpochInfo

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -37,8 +37,8 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_transaction_status::{
-    ConfirmedBlock, EncodedTransaction, Rewards, RpcTransactionStatusMeta, TransactionEncoding,
-    TransactionStatusMeta, TransactionWithStatusMeta,
+    ConfirmedBlock, ConfirmedTransaction, EncodedTransaction, Rewards, RpcTransactionStatusMeta,
+    TransactionEncoding, TransactionStatusMeta, TransactionWithStatusMeta,
 };
 use solana_vote_program::{vote_instruction::VoteInstruction, vote_state::TIMESTAMP_SLOT_INTERVAL};
 use std::{
@@ -1719,6 +1719,42 @@ impl Blockstore {
     ) -> Result<Option<(Slot, TransactionStatusMeta)>> {
         self.get_transaction_status_with_counter(signature)
             .map(|(status, _)| status)
+    }
+
+    /// Returns a complete transaction if it was processed in a root
+    pub fn get_confirmed_transaction(
+        &self,
+        signature: Signature,
+        encoding: Option<TransactionEncoding>,
+    ) -> Result<Option<ConfirmedTransaction>> {
+        if let Some((slot, status)) = self.get_transaction_status(signature.clone())? {
+            let transaction = self.find_transaction_in_slot(slot, signature)?
+                .expect("Transaction to exist in slot entries if it exists in statuses and hasn't been cleaned up");
+            let encoding = encoding.unwrap_or(TransactionEncoding::Json);
+            let encoded_transaction = EncodedTransaction::encode(transaction, encoding);
+            Ok(Some(ConfirmedTransaction {
+                slot,
+                transaction: TransactionWithStatusMeta {
+                    transaction: encoded_transaction,
+                    meta: Some(status.into()),
+                },
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn find_transaction_in_slot(
+        &self,
+        slot: Slot,
+        signature: Signature,
+    ) -> Result<Option<Transaction>> {
+        let slot_entries = self.get_slot_entries(slot, 0, None)?;
+        Ok(slot_entries
+            .iter()
+            .cloned()
+            .flat_map(|entry| entry.transactions)
+            .find(|transaction| transaction.signatures[0] == signature))
     }
 
     pub fn read_rewards(&self, index: Slot) -> Result<Option<Rewards>> {
@@ -5909,6 +5945,88 @@ pub mod tests {
             assert_eq!(counter, 2);
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
+    }
+
+    #[test]
+    fn test_get_confirmed_transaction() {
+        let slot = 2;
+        let entries = make_slot_entries_with_transactions(5);
+        let shreds = entries_to_test_shreds(entries.clone(), slot, slot - 1, true, 0);
+        let ledger_path = get_tmp_ledger_path!();
+        let blockstore = Blockstore::open(&ledger_path).unwrap();
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.set_roots(&[slot - 1, slot]).unwrap();
+
+        let expected_transactions: Vec<(Transaction, Option<RpcTransactionStatusMeta>)> = entries
+            .iter()
+            .cloned()
+            .filter(|entry| !entry.is_tick())
+            .flat_map(|entry| entry.transactions)
+            .map(|transaction| {
+                let mut pre_balances: Vec<u64> = vec![];
+                let mut post_balances: Vec<u64> = vec![];
+                for (i, _account_key) in transaction.message.account_keys.iter().enumerate() {
+                    pre_balances.push(i as u64 * 10);
+                    post_balances.push(i as u64 * 11);
+                }
+                let signature = transaction.signatures[0];
+                blockstore
+                    .transaction_status_cf
+                    .put(
+                        (0, signature, slot),
+                        &TransactionStatusMeta {
+                            status: Ok(()),
+                            fee: 42,
+                            pre_balances: pre_balances.clone(),
+                            post_balances: post_balances.clone(),
+                        },
+                    )
+                    .unwrap();
+                (
+                    transaction,
+                    Some(
+                        TransactionStatusMeta {
+                            status: Ok(()),
+                            fee: 42,
+                            pre_balances,
+                            post_balances,
+                        }
+                        .into(),
+                    ),
+                )
+            })
+            .collect();
+
+        for (transaction, status) in expected_transactions.clone() {
+            let signature = transaction.signatures[0];
+            let encoded_transaction =
+                EncodedTransaction::encode(transaction, TransactionEncoding::Json);
+            let expected_transaction = ConfirmedTransaction {
+                slot,
+                transaction: TransactionWithStatusMeta {
+                    transaction: encoded_transaction,
+                    meta: status,
+                },
+            };
+            assert_eq!(
+                blockstore
+                    .get_confirmed_transaction(signature, None)
+                    .unwrap(),
+                Some(expected_transaction)
+            );
+        }
+
+        blockstore.run_purge(0, 2).unwrap();
+        *blockstore.lowest_cleanup_slot.write().unwrap() = slot;
+        for (transaction, _) in expected_transactions {
+            let signature = transaction.signatures[0];
+            assert_eq!(
+                blockstore
+                    .get_confirmed_transaction(signature, None)
+                    .unwrap(),
+                None,
+            );
+        }
     }
 
     #[test]

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -94,6 +94,14 @@ pub struct ConfirmedBlock {
     pub rewards: Rewards,
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmedTransaction {
+    pub slot: Slot,
+    #[serde(flatten)]
+    pub transaction: TransactionWithStatusMeta,
+}
+
 /// A duplicate representation of a Transaction for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
#### Problem
It's not possible to fetch the details of a specific transaction from an API node unless you happen to know the Slot it was processed in (for`getConfirmedBlock`). Now that we have a performant way to query statuses by Signature, we can offer a more targeted approach.

#### Summary of Changes
- Add apis to return from blockstore details of a single transaction given its signature, building on `Blockstore::get_transaction_status`
- Add `getConfirmedTransaction` RPC endpoint and hook up to blockstore. As implied by the endpoint name, `getConfirmedTransaction` will only return details for transactions in rooted blocks.

Toward #9317 
