### PR TITLE
Fix lowest_cleanup_slot check in Blockstore

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1173,7 +1173,7 @@ impl Blockstore {
         // lowest_cleanup_slot is the last slot that was not cleaned up by
         // LedgerCleanupService
         let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
-        if *lowest_cleanup_slot > slot {
+        if *lowest_cleanup_slot > 0 && *lowest_cleanup_slot >= slot {
             return Err(BlockstoreError::SlotCleanedUp);
         }
         let meta_cf = self.db.column::<cf::SlotMeta>();
@@ -1420,7 +1420,7 @@ impl Blockstore {
         let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
         // lowest_cleanup_slot is the last slot that was not cleaned up by
         // LedgerCleanupService
-        if *lowest_cleanup_slot > slot {
+        if *lowest_cleanup_slot > 0 && *lowest_cleanup_slot >= slot {
             return Err(BlockstoreError::SlotCleanedUp);
         }
 
@@ -1489,7 +1489,7 @@ impl Blockstore {
         let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
         // lowest_cleanup_slot is the last slot that was not cleaned up by
         // LedgerCleanupService
-        if *lowest_cleanup_slot > slot {
+        if *lowest_cleanup_slot > 0 && *lowest_cleanup_slot >= slot {
             return Err(BlockstoreError::SlotCleanedUp);
         }
         let encoding = encoding.unwrap_or(TransactionEncoding::Json);
@@ -1784,7 +1784,7 @@ impl Blockstore {
         // lowest_cleanup_slot is the last slot that was not cleaned up by
         // LedgerCleanupService
         let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
-        if *lowest_cleanup_slot > slot {
+        if *lowest_cleanup_slot > 0 && *lowest_cleanup_slot >= slot {
             return Err(BlockstoreError::SlotCleanedUp);
         }
 


### PR DESCRIPTION
#### Problem
`Blockstore::lowest_cleanup_slot` is set to the top of the `run_purge` range, which is inclusive. Therefore it should be included in the set of slots that prompt `BlockstoreError::SlotCleanedUp`

#### Summary of Changes
`lowest_cleanup_slot > slot` => `lowest_cleanup_slot >= slot`, plus handling for zero case
