### PR TITLE
Fix automation stake parser

### DIFF
--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -71,7 +71,7 @@ function wait_for_bootstrap_validator_stake_drop {
 
   while true; do
   # shellcheck disable=SC2154
-    bootstrap_validator_validator_info="$(ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana validators | grep "$($HOME/.cargo/bin/solana-keygen pubkey ~/solana/config/bootstrap-validator/identity.json)"')"
+    bootstrap_validator_validator_info="$(ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana --url http://127.0.0.1:8899 validators | grep "$($HOME/.cargo/bin/solana-keygen pubkey ~/solana/config/bootstrap-validator/identity.json)"')"
     bootstrap_validator_stake_percentage="$(echo "$bootstrap_validator_validator_info" | awk '{gsub(/[\(,\),\%]/,""); print $9}')"
 
     if [[ $(echo "$bootstrap_validator_stake_percentage < $max_stake" | bc) -ne 0 ]]; then


### PR DESCRIPTION
#### Problem
Nightly automation is broken trying to parse validator stake values, as we were using an implicit RPC URL.

#### Summary of Changes
Set boot node to explicitly check local loopback for stake on its own test cluster.
