### PR TITLE
Rpc: Add getConfirmedSignaturesForAddress

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -39,6 +39,7 @@ use std::{
 };
 
 const MAX_QUERY_ITEMS: usize = 256;
+const MAX_SLOT_RANGE: u64 = 10_000;
 
 type RpcResponse<T> = Result<Response<T>>;
 
@@ -515,16 +516,16 @@ impl JsonRpcRequestProcessor {
         }
     }
 
-    pub fn get_address_confirmed_signatures(
+    pub fn get_confirmed_signatures_for_address(
         &self,
         pubkey: Pubkey,
-        start_slot: Option<Slot>,
-        end_slot: Option<Slot>,
+        start_slot: Slot,
+        end_slot: Slot,
     ) -> Result<Vec<Signature>> {
         if self.config.enable_rpc_transaction_history {
             Ok(self
                 .blockstore
-                .get_address_confirmed_signatures(pubkey, start_slot, end_slot)
+                .get_confirmed_signatures_for_address(pubkey, start_slot, end_slot)
                 .unwrap_or_else(|_| vec![]))
         } else {
             Ok(vec![])
@@ -780,13 +781,13 @@ pub trait RpcSol {
         encoding: Option<TransactionEncoding>,
     ) -> Result<Option<ConfirmedTransaction>>;
 
-    #[rpc(meta, name = "getAddressConfirmedSignatures")]
-    fn get_address_confirmed_signatures(
+    #[rpc(meta, name = "getConfirmedSignaturesForAddress")]
+    fn get_confirmed_signatures_for_address(
         &self,
         meta: Self::Metadata,
         pubkey_str: String,
-        start_slot: Option<Slot>,
-        end_slot: Option<Slot>,
+        start_slot: Slot,
+        end_slot: Slot,
     ) -> Result<Vec<String>>;
 }
 
@@ -1345,18 +1346,30 @@ impl RpcSol for RpcSolImpl {
             .get_confirmed_transaction(signature, encoding)
     }
 
-    fn get_address_confirmed_signatures(
+    fn get_confirmed_signatures_for_address(
         &self,
         meta: Self::Metadata,
         pubkey_str: String,
-        start_slot: Option<Slot>,
-        end_slot: Option<Slot>,
+        start_slot: Slot,
+        end_slot: Slot,
     ) -> Result<Vec<String>> {
         let pubkey = verify_pubkey(pubkey_str)?;
+        if end_slot <= start_slot {
+            return Err(Error::invalid_params(format!(
+                "start_slot {} must be smaller than end_slot {}",
+                start_slot, end_slot
+            )));
+        }
+        if end_slot - start_slot > MAX_SLOT_RANGE {
+            return Err(Error::invalid_params(format!(
+                "Slot range too large; max {}",
+                MAX_SLOT_RANGE
+            )));
+        }
         meta.request_processor
             .read()
             .unwrap()
-            .get_address_confirmed_signatures(pubkey, start_slot, end_slot)
+            .get_confirmed_signatures_for_address(pubkey, start_slot, end_slot)
             .map(|signatures| {
                 signatures
                     .iter()

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -362,6 +362,8 @@ Returns a list of all the confirmed signatures for transactions involving an add
 The result field will be an array of:
 * `<string>` - transaction signature as base-58 encoded string
 
+The signatures will be ordered based on the Slot in which they were confirmed in, from lowest to highest Slot
+
 #### Example:
 
 ```bash

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -21,6 +21,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getClusterNodes](jsonrpc-api.md#getclusternodes)
 * [getConfirmedBlock](jsonrpc-api.md#getconfirmedblock)
 * [getConfirmedBlocks](jsonrpc-api.md#getconfirmedblocks)
+* [getConfirmedSignaturesForAddress](jsonrpc-api.md#getconfirmedsignaturesforaddress)
 * [getConfirmedTransaction](jsonrpc-api.md#getconfirmedtransaction)
 * [getEpochInfo](jsonrpc-api.md#getepochinfo)
 * [getEpochSchedule](jsonrpc-api.md#getepochschedule)
@@ -344,6 +345,31 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"m
 
 // Result
 {"jsonrpc":"2.0","result":[5,6,7,8,9,10],"id":1}
+```
+
+### getConfirmedSignaturesForAddress
+
+Returns a list of all the confirmed signatures for transactions involving an address, within a specified Slot range. Max range allowed is 10_000 Slots.
+
+#### Parameters:
+
+* `<string>` - account address as base-58 encoded string
+* `<u64>` - start slot, inclusive
+* `<u64>` - end slot, inclusive
+
+#### Results:
+
+The result field will be an array of:
+* `<string>` - transaction signature as base-58 encoded string
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedSignaturesForAddress","params":["6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC", 0, 100]}' localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":{["35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby","4bJdGN8Tt2kLWZ3Fa1dpwPSEkXWWTSszPSf1rRVsCwNjxbbUdwTeiWtmi8soA26YmwnKD4aAxNp8ci1Gjpdv4gsr","4LQ14a7BYY27578Uj8LPCaVhSdJGLn9DJqnUJHpy95FMqdKf9acAhUhecPQNjNUy6VoNFUbvwYkPociFSf87cWbG"]},"id":1}
 ```
 
 ### getConfirmedTransaction

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1667,20 +1667,14 @@ impl Blockstore {
             .put((primary_index, signature, slot), status)?;
         for address in writable_keys {
             self.address_signatures_cf.put(
-                (primary_index, *address, slot),
-                &AddressSignatureMeta {
-                    signature,
-                    writeable: true,
-                },
+                (primary_index, *address, slot, signature),
+                &AddressSignatureMeta { writeable: true },
             )?;
         }
         for address in readonly_keys {
             self.address_signatures_cf.put(
-                (primary_index, *address, slot),
-                &AddressSignatureMeta {
-                    signature,
-                    writeable: false,
-                },
+                (primary_index, *address, slot, signature),
+                &AddressSignatureMeta { writeable: false },
             )?;
         }
         Ok(())
@@ -2892,7 +2886,7 @@ pub mod tests {
                 .iter::<cf::AddressSignatures>(IteratorMode::Start)
                 .unwrap()
                 .next()
-                .map(|((primary_index, _, slot), _)| {
+                .map(|((primary_index, _, slot, _), _)| {
                     slot >= min_slot || (primary_index == 2 && slot == 0)
                 })
                 .unwrap_or(true)
@@ -5520,7 +5514,7 @@ pub mod tests {
             let first_status_entry = blockstore
                 .db
                 .iter::<cf::TransactionStatus>(IteratorMode::From(
-                    (0, Signature::default(), 0),
+                    cf::TransactionStatus::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap()
@@ -5532,7 +5526,7 @@ pub mod tests {
             let first_address_entry = blockstore
                 .db
                 .iter::<cf::AddressSignatures>(IteratorMode::From(
-                    (0, Pubkey::default(), 0),
+                    cf::AddressSignatures::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap()
@@ -5590,7 +5584,7 @@ pub mod tests {
             let first_status_entry = blockstore
                 .db
                 .iter::<cf::TransactionStatus>(IteratorMode::From(
-                    (0, Signature::default(), 0),
+                    cf::TransactionStatus::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap()
@@ -5602,7 +5596,7 @@ pub mod tests {
             let first_address_entry = blockstore
                 .db
                 .iter::<cf::AddressSignatures>(IteratorMode::From(
-                    (0, Pubkey::default(), 0),
+                    cf::AddressSignatures::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap()
@@ -5615,7 +5609,7 @@ pub mod tests {
             let index1_first_status_entry = blockstore
                 .db
                 .iter::<cf::TransactionStatus>(IteratorMode::From(
-                    (1, Signature::default(), 0),
+                    cf::TransactionStatus::as_index(1),
                     IteratorDirection::Forward,
                 ))
                 .unwrap()
@@ -5627,7 +5621,7 @@ pub mod tests {
             let index1_first_address_entry = blockstore
                 .db
                 .iter::<cf::AddressSignatures>(IteratorMode::From(
-                    (1, Pubkey::default(), 0),
+                    cf::AddressSignatures::as_index(1),
                     IteratorDirection::Forward,
                 ))
                 .unwrap()
@@ -5658,7 +5652,7 @@ pub mod tests {
             let first_status_entry = blockstore
                 .db
                 .iter::<cf::TransactionStatus>(IteratorMode::From(
-                    (0, Signature::default(), 0),
+                    cf::TransactionStatus::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap()
@@ -5670,7 +5664,7 @@ pub mod tests {
             let first_address_entry = blockstore
                 .db
                 .iter::<cf::AddressSignatures>(IteratorMode::From(
-                    (0, Pubkey::default(), 0),
+                    cf::AddressSignatures::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap()
@@ -5707,7 +5701,7 @@ pub mod tests {
             let mut status_entry_iterator = blockstore
                 .db
                 .iter::<cf::TransactionStatus>(IteratorMode::From(
-                    (0, Signature::default(), 0),
+                    cf::TransactionStatus::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap();
@@ -5719,7 +5713,7 @@ pub mod tests {
             let mut address_transactions_iterator = blockstore
                 .db
                 .iter::<cf::AddressSignatures>(IteratorMode::From(
-                    (0, Pubkey::default(), 0),
+                    (0, Pubkey::default(), 0, Signature::default()),
                     IteratorDirection::Forward,
                 ))
                 .unwrap();
@@ -5741,7 +5735,7 @@ pub mod tests {
             let mut status_entry_iterator = blockstore
                 .db
                 .iter::<cf::TransactionStatus>(IteratorMode::From(
-                    (0, Signature::default(), 0),
+                    cf::TransactionStatus::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap();
@@ -5753,7 +5747,7 @@ pub mod tests {
             let mut address_transactions_iterator = blockstore
                 .db
                 .iter::<cf::AddressSignatures>(IteratorMode::From(
-                    (0, Pubkey::default(), 0),
+                    cf::AddressSignatures::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap();
@@ -5775,7 +5769,7 @@ pub mod tests {
             let mut status_entry_iterator = blockstore
                 .db
                 .iter::<cf::TransactionStatus>(IteratorMode::From(
-                    (0, Signature::default(), 0),
+                    cf::TransactionStatus::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap();
@@ -5787,7 +5781,7 @@ pub mod tests {
             let mut address_transactions_iterator = blockstore
                 .db
                 .iter::<cf::AddressSignatures>(IteratorMode::From(
-                    (0, Pubkey::default(), 0),
+                    cf::AddressSignatures::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap();
@@ -5808,7 +5802,7 @@ pub mod tests {
             let mut status_entry_iterator = blockstore
                 .db
                 .iter::<cf::TransactionStatus>(IteratorMode::From(
-                    (0, Signature::default(), 0),
+                    cf::TransactionStatus::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap();
@@ -5819,7 +5813,7 @@ pub mod tests {
             let mut address_transactions_iterator = blockstore
                 .db
                 .iter::<cf::AddressSignatures>(IteratorMode::From(
-                    (0, Pubkey::default(), 0),
+                    cf::AddressSignatures::as_index(0),
                     IteratorDirection::Forward,
                 ))
                 .unwrap();

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,6 +1,6 @@
 use crate::erasure::ErasureConfig;
 use serde::{Deserialize, Serialize};
-use solana_sdk::{clock::Slot, signature::Signature};
+use solana_sdk::clock::Slot;
 use std::{collections::BTreeSet, ops::RangeBounds};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
@@ -230,7 +230,6 @@ pub struct TransactionStatusIndexMeta {
 
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct AddressSignatureMeta {
-    pub signature: Signature,
     pub writeable: bool,
 }
 


### PR DESCRIPTION
#### Problem
For the history that an API node maintains, it's not possible to fetch the list of transactions that affect a given address. Now that we index signatures by address, the next step would be to return those signatures 

#### Summary of Changes
- Fix AddressSignatures blockstore column to handle multiple transactions per address-slot (also clean up some iterator indexes in tests so changes are on in one place in the future)
- Add blockstore apis to return signatures by address (forward-looking to returning full transactions by address)
- Add `getConfirmedSignaturesforAddress` rpc endpoint to expose signatures-by-address data

Fixes #9317 
