### PR TITLE
ledger-tool: Add --allow-dead-slots argument to `slot`/`print`/`json` commands

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -642,8 +642,8 @@ pub mod test {
             );
 
             let blockstore = broadcast_service.blockstore;
-            let (entries, _, _) = blockstore
-                .get_slot_entries_with_shred_info(slot, 0)
+            let entries = blockstore
+                .get_slot_entries(slot, 0)
                 .expect("Expect entries to be present");
             assert_eq!(entries.len(), max_tick_height as usize);
 

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -31,7 +31,7 @@ fn bad_arguments() {
 fn nominal() {
     let genesis_config = create_genesis_config(100).genesis_config;
     let ticks_per_slot = genesis_config.ticks_per_slot;
-    let meta_lines = 1;
+    let meta_lines = 2;
 
     let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
     let ticks = ticks_per_slot as usize;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1797,7 +1797,7 @@ impl Blockstore {
 
     /// Returns the entry vector for the slot starting with `shred_start_index`
     pub fn get_slot_entries(&self, slot: Slot, shred_start_index: u64) -> Result<Vec<Entry>> {
-        self.get_slot_entries_with_shred_info(slot, shred_start_index)
+        self.get_slot_entries_with_shred_info(slot, shred_start_index, false)
             .map(|x| x.0)
     }
 
@@ -1807,8 +1807,9 @@ impl Blockstore {
         &self,
         slot: Slot,
         start_index: u64,
+        allow_dead_slots: bool,
     ) -> Result<(Vec<Entry>, u64, bool)> {
-        if self.is_dead(slot) {
+        if self.is_dead(slot) && !allow_dead_slots {
             return Err(BlockstoreError::DeadSlot);
         }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -538,7 +538,7 @@ pub fn confirm_slot(
     let (entries, num_shreds, slot_full) = {
         let mut load_elapsed = Measure::start("load_elapsed");
         let load_result = blockstore
-            .get_slot_entries_with_shred_info(slot, progress.num_shreds)
+            .get_slot_entries_with_shred_info(slot, progress.num_shreds, false)
             .map_err(BlockstoreProcessorError::FailedToLoadEntries);
         load_elapsed.stop();
         if load_result.is_err() {


### PR DESCRIPTION
While debugging https://github.com/solana-labs/solana/issues/9369, I had to hack ledger-tool to make it print dead slots.

With this PR I can now run:
```
$ solana-ledger-tool slot 4401270 --allow-dead-slots
```