### PR TITLE
Search for ports sequentially instead of at random for more predictable port selection

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1998,20 +1998,16 @@ mod tests {
 
     #[test]
     fn new_with_external_ip_test_gossip() {
-        let ip = IpAddr::V4(Ipv4Addr::from(0));
-        let port = {
-            bind_in_range(ip, VALIDATOR_PORT_RANGE)
-                .expect("Failed to bind")
-                .0
-        };
-        let node = Node::new_with_external_ip(
-            &Pubkey::new_rand(),
-            &socketaddr!(0, port),
-            VALIDATOR_PORT_RANGE,
-            ip,
-        );
+        // Can't use VALIDATOR_PORT_RANGE because if this test runs in parallel with others, the
+        // port returned by `bind_in_range()` might be snatched up before `Node::new_with_external_ip()` runs
+        let port_range = (VALIDATOR_PORT_RANGE.1 + 10, VALIDATOR_PORT_RANGE.1 + 20);
 
-        check_node_sockets(&node, ip, VALIDATOR_PORT_RANGE);
+        let ip = IpAddr::V4(Ipv4Addr::from(0));
+        let port = bind_in_range(ip, port_range).expect("Failed to bind").0;
+        let node =
+            Node::new_with_external_ip(&Pubkey::new_rand(), &socketaddr!(0, port), port_range, ip);
+
+        check_node_sockets(&node, ip, port_range);
 
         assert_eq!(node.sockets.gossip.local_addr().unwrap().port(), port);
     }

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -267,10 +267,10 @@ pub fn bind_common_in_range(
         }
     }
 
-    return Err(io::Error::new(
+    Err(io::Error::new(
         io::ErrorKind::Other,
         format!("No available TCP/UDP ports in {:?}", range),
-    ));
+    ))
 }
 
 pub fn bind_in_range(ip_addr: IpAddr, range: PortRange) -> io::Result<(u16, UdpSocket)> {
@@ -285,10 +285,10 @@ pub fn bind_in_range(ip_addr: IpAddr, range: PortRange) -> io::Result<(u16, UdpS
         }
     }
 
-    return Err(io::Error::new(
+    Err(io::Error::new(
         io::ErrorKind::Other,
         format!("No available UDP ports in {:?}", range),
-    ));
+    ))
 }
 
 // binds many sockets to the same port in a range


### PR DESCRIPTION
`solana-validator` currently randomly selects UDP/TCP ports within its port range at startup, which makes traffic analysis harder than it should be.   Instead sequentially walk the port range for the first open port so allocations are deterministic (assuming no port conflicts).

Fixes #9399
cc: @leoluk 
