### PR TITLE
Rpc: Add getConfirmedTransactionsForAddress

### DIFF
--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -349,7 +349,8 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"m
 
 ### getConfirmedSignaturesForAddress
 
-Returns a list of all the confirmed signatures for transactions involving an address, within a specified Slot range. Max range allowed is 10_000 Slots.
+Returns a list of all the confirmed signatures for transactions involving an
+address, within a specified Slot range. Max range allowed is 10_000 Slots.
 
 #### Parameters:
 
@@ -362,7 +363,8 @@ Returns a list of all the confirmed signatures for transactions involving an add
 The result field will be an array of:
 * `<string>` - transaction signature as base-58 encoded string
 
-The signatures will be ordered based on the Slot in which they were confirmed in, from lowest to highest Slot
+The signatures will be ordered based on the Slot in which they were confirmed
+in, from lowest to highest Slot
 
 #### Example:
 
@@ -372,6 +374,51 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"m
 
 // Result
 {"jsonrpc":"2.0","result":{["35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby","4bJdGN8Tt2kLWZ3Fa1dpwPSEkXWWTSszPSf1rRVsCwNjxbbUdwTeiWtmi8soA26YmwnKD4aAxNp8ci1Gjpdv4gsr","4LQ14a7BYY27578Uj8LPCaVhSdJGLn9DJqnUJHpy95FMqdKf9acAhUhecPQNjNUy6VoNFUbvwYkPociFSf87cWbG"]},"id":1}
+```
+
+### getConfirmedTransactionsForAddress
+
+Returns a list of all the confirmed transactions involving an address, within a
+specified Slot range. Max range allowed is 10_000 Slots.
+
+#### Parameters:
+
+* `<string>` - account address as base-58 encoded string
+* `<u64>` - start slot, inclusive
+* `<u64>` - end slot, inclusive
+* `<string>` - (optional) encoding for the returned Transactions, either "json" or "binary". If not provided, the default encoding is JSON.
+
+#### Results:
+
+The result field will be an array of objects with the following fields:
+* `slot: <u64>` - the slot this transaction was processed in
+* `transaction: <object|string>` - [Transaction](#transaction-structure) object, either in JSON format or base-58 encoded binary data, depending on encoding parameter
+* `meta: <object>` - transaction status metadata object, containing `null` or:
+  * `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
+  * `fee: <u64>` - fee this transaction was charged, as u64 integer
+  * `preBalances: <array>` - array of u64 account balances from before the transaction was processed
+  * `postBalances: <array>` - array of u64 account balances after the transaction was processed
+  * DEPRECATED: `status: <object>` - Transaction status
+    * `"Ok": <null>` - Transaction was successful
+    * `"Err": <ERR>` - Transaction failed with TransactionError
+
+The signatures will be ordered based on the Slot in which they were confirmed
+in, from lowest to highest Slot
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedSignaturesForAddress","params":["6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC", 0, 100, "json"]}' localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":[{"slot":430,"transaction":{"message":{"accountKeys":["6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC","39UAy8hsoYPywGPGdmun747omSr79zLSjqvPJN3zetoH","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":2},"instructions":[{"accounts":[1,2,3],"data":"29z5mr1JoRmJYQ6ynmk3pf31cGFRziAF1M3mT3L6sFXf5cKLdkEaMXMT8AqLpD4CpcupHmuMEmtZHpomrwfdZetSomNy3d","programIdIndex":4}],"recentBlockhash":"EFejToxii1L5aUF2NrK9dsbAEmZSNyN5nsipmZHQR1eA"},"signatures":["35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby","4vANMjSKiwEchGSXwVrQkwHnmsbKQmy9vdrsYxWdCup1bLsFzX8gKrFTSVDCZCae2dbxJB9mPNhqB2sD1vvr4sAD"]},"meta":{"err":null,"fee":18000,"postBalances":[499999972500,15298080,1,1,1],"preBalances":[499999990500,15298080,1,1,1],"status":{"Ok":null}}}],"id":1}
+
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedSignaturesForAddress","params":["6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC", 0, 100, "binary"]}' localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":[{"slot":430,"transaction":"81UZJt4dh4Do66jDhrgkQudS8J2N6iG3jaVav7gJrqJSFY4Ug53iA9JFJZh2gxKWcaFdLJwhHx9mRdg9JwDAWB4ywiu5154CRwXV4FMdnPLg7bhxRLwhhYaLsVgMF5AyNRcTzjCVoBvqFgDU7P8VEKDEiMvD3qxzm1pLZVxDG1LTQpT3Dz4Uviv4KQbFQNuC22KupBoyHFB7Zh6KFdMqux4M9PvhoqcoJsJKwXjWpKu7xmEKnnrSbfLadkgjBmmjhW3fdTrFvnhQdTkhtdJxUL1xS9GMuJQer8YgSKNtUXB1eXZQwXU8bU2BjYkZE6Q5Xww8hu9Z4E4Mo4QsooVtHoP6BM3NKw8zjVbWfoCQqxTrwuSzrNCWCWt58C24LHecH67CTt2uXbYSviixvrYkK7A3t68BxTJcF1dXJitEPTFe2ceTkauLJqrJgnER4iUrsjr26T8YgWvpY9wkkWFSviQW6wV5RASTCUasVEcrDiaKj8EQMkgyDoe9HyKitSVg67vMWJFpUXpQobseWJUs5FTWWzmfHmFp8FZ","meta":{"err":null,"fee":18000,"postBalances":[499999972500,15298080,1,1,1],"preBalances":[499999990500,15298080,1,1,1],"status":{"Ok":null}}}],"id":1}
 ```
 
 ### getConfirmedTransaction

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1744,11 +1744,7 @@ impl Blockstore {
         signature: Signature,
     ) -> Result<Option<Transaction>> {
         let slot_entries = self.get_slot_entries(slot, 0)?;
-        Ok(slot_entries
-            .iter()
-            .cloned()
-            .flat_map(|entry| entry.transactions)
-            .find(|transaction| transaction.signatures[0] == signature))
+        Ok(find_transaction_in_entries(&slot_entries, signature))
     }
 
     // Returns all cached signatures for an address, ordered by slot that the transaction was
@@ -2570,6 +2566,17 @@ fn calculate_stake_weighted_timestamp(
     } else {
         None
     }
+}
+
+fn find_transaction_in_entries(
+    slot_entries: &[Entry],
+    signature: Signature,
+) -> Option<Transaction> {
+    slot_entries
+        .iter()
+        .cloned()
+        .flat_map(|entry| entry.transactions)
+        .find(|transaction| transaction.signatures[0] == signature)
 }
 
 // Creates a new ledger with slot 0 full of ticks (and only ticks).


### PR DESCRIPTION
#### Problem
For the history that an API node maintains, it's not possible to fetch the list of transactions that affect a given address. All the pieces are in place to make it so.

#### Summary of Changes
- Small blockstore fixups to streamline apis
- Add blockstore api to return full transactions by address
- Add getConfirmedTransactionsforAddress rpc endpoint to expose transactions-by-address data

Still todo:

- [x] Add blockstore test of `get_confirmed_transactions_for_address()`
- [x] Rebase on #9407 
