### PR TITLE
Use same max_age regardless of leader/not-leader

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -20,7 +20,7 @@ use solana_runtime::{
     transaction_batch::TransactionBatch,
 };
 use solana_sdk::{
-    clock::{Slot, MAX_RECENT_BLOCKHASHES},
+    clock::{Slot, MAX_PROCESSING_AGE},
     genesis_config::GenesisConfig,
     hash::Hash,
     pubkey::Pubkey,
@@ -70,7 +70,7 @@ fn execute_batch(
         balances,
     ) = batch.bank().load_execute_and_commit_transactions(
         batch,
-        MAX_RECENT_BLOCKHASHES,
+        MAX_PROCESSING_AGE,
         transaction_status_sender.is_some(),
     );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -32,7 +32,10 @@ use solana_metrics::{
 };
 use solana_sdk::{
     account::Account,
-    clock::{get_segment_from_slot, Epoch, Slot, UnixTimestamp, MAX_RECENT_BLOCKHASHES},
+    clock::{
+        get_segment_from_slot, Epoch, Slot, UnixTimestamp, MAX_PROCESSING_AGE,
+        MAX_RECENT_BLOCKHASHES,
+    },
     epoch_schedule::EpochSchedule,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     genesis_config::GenesisConfig,
@@ -1671,7 +1674,7 @@ impl Bank {
     #[must_use]
     pub fn process_transactions(&self, txs: &[Transaction]) -> Vec<Result<()>> {
         let batch = self.prepare_batch(txs, None);
-        self.load_execute_and_commit_transactions(&batch, MAX_RECENT_BLOCKHASHES, false)
+        self.load_execute_and_commit_transactions(&batch, MAX_PROCESSING_AGE, false)
             .0
             .fee_collection_results
     }
@@ -3859,7 +3862,7 @@ mod tests {
 
         let lock_result = bank.prepare_batch(&pay_alice, None);
         let results_alice = bank
-            .load_execute_and_commit_transactions(&lock_result, MAX_RECENT_BLOCKHASHES, false)
+            .load_execute_and_commit_transactions(&lock_result, MAX_PROCESSING_AGE, false)
             .0
             .fee_collection_results;
         assert_eq!(results_alice[0], Ok(()));
@@ -5640,7 +5643,7 @@ mod tests {
 
         let lock_result = bank0.prepare_batch(&txs, None);
         let (transaction_results, transaction_balances_set) =
-            bank0.load_execute_and_commit_transactions(&lock_result, MAX_RECENT_BLOCKHASHES, true);
+            bank0.load_execute_and_commit_transactions(&lock_result, MAX_PROCESSING_AGE, true);
 
         assert_eq!(transaction_balances_set.pre_balances.len(), 3);
         assert_eq!(transaction_balances_set.post_balances.len(), 3);


### PR DESCRIPTION
(I'm really tired at this time...)

## Problem

For deterministic execution of nonse TX error codepath, we must use consistent max_age for past TX expiration.

### Previously....:

#### Leader:

`Bank::load_and_execute_transactions()` is called with **`MAX_PROCESSING_AGE`** from `BankingStage::process_and_record_transactions_lock()`

#### Not-leader/ledger-tool (=blockstore_processor):

`Bank::load_and_execute_transactions()` is called with **`MAX_RECENT_BLOCKHASHES`** from `blockstore_processor::execute_batch()`

And in some corner case, this causes this:

```
if the given identical nonce tx causes insufficient fund error....
    Leader:     It updates nonce account and stores the pay destination account (correct)
             (but rejected by supermajority of other validators)
    Non-leader: It don't update nonce account and don't store the pay destination account. (wrong)

(In both cases, fees are collected as a side-effect, universally.)
```

because of this observed difference of hash age result:

#### leader (nonce is updated):

```
[2020-04-10T09:37:23.453277367Z ERROR solana_runtime::accounts] collect_accounts: Err(InstructionError(1, CustomError(1))) Some(DurableNonce(xdpCWLrjxTb8rNFTAco4E9jt2awraosXKtU2kCVxb92, Account { lamports: 1123456789 data.len: 80 owner: 11111111111111111111111111111111 executable: false rent_epoch: 5 data: 00000000010000005c48a3b41fe5a71522ca2d65ac355b1fc253107096c89e240bc3dcca71b9efb8b46e4f4a3e5dfba8473a7b581bb83b703f2c63c4a3b4c385 hash: FRihkb3Jv6V1DtyWcnqxqtoufiBCxwjXD8x8rVVjrTHQ }))

```

#### not leader (nonce is NOT updated):
```
[2020-04-10T09:37:23.514004924Z ERROR solana_runtime::accounts] collect_accounts: Err(InstructionError(1, CustomError(1))) Some(Extant)
```

```patch
     fn collect_accounts_to_store<'a>(
         &self,
         txs: &'a [Transaction],
         txs_iteration_order: Option<&'a [usize]>,
         res: &'a [TransactionProcessResult],
         loaded: &'a mut [(Result<TransactionLoadResult>, Option<HashAgeKind>)],
         rent_collector: &RentCollector,
         last_blockhash: &Hash,
     ) -> Vec<(&'a Pubkey, &'a Account)> {
+        error!("collect_accounts: {} txs", txs.len());
+
         let mut accounts = Vec::with_capacity(loaded.len());
         for (i, ((raccs, _hash_age_kind), tx)) in loaded
             .iter_mut()
             .zip(OrderedIterator::new(txs, txs_iteration_order))
             .enumerate()
         {
             if raccs.is_err() {
                 continue;
             }
             let (res, hash_age_kind) = &res[i];
+            error!("collect_accounts: {:?} {:?}", res, hash_age_kind);
             let maybe_nonce = match (res, hash_age_kind) {
                 (Ok(_), Some(HashAgeKind::DurableNonce(pubkey, acc))) => Some((pubkey, acc)),
                 (
                     Err(TransactionError::InstructionError(_, _)),
                     Some(HashAgeKind::DurableNonce(pubkey, acc)),
                 ) => Some((pubkey, acc)), // <= SHOULD REACH HERE!!!
                 (Ok(_), _hash_age_kind) => None,
                 (Err(_), _hash_age_kind) => continue,    // <= WRONG REACHED HERE!!!
```

And causing these missing nonce account updates for the validators but the leader:

```patch
 SysvarS1otHistory11111111111111111111111111:
   - lamports: 1
   - owner: 'Sysvar1111111111111111111111111111111111111'
   - executable: false
   - data: '4rmdYzwEyfJhmVo3p18YKQUsnrfh6NpJdTnebJgpg3KoxEsTLryKVtZ2kjhb8MbdmSdoqL4YcXuT36fKB443dnxtJb3wHqNWeqoXNDLHddTcbF8982TABTHwn6UvYmkhbJmqo4vJ189ZTwtsSf9Kt5478BCYuiqzB5cQkMw4iA4x1BvFJVnYDRMhu944KbEpAAFUamz2K5dFkbx6oSSXHZauaenHQB5SiZZHad86r7mQLmbPpSPq3QGSLm8FXDSkvM7jtAjrNnu5HRwN4zaBKUNRZRwkFrX1dFJJHXdBSWh>
quGeST64yhxsL58xPrvzm2uUwJUDf6D7edwkZijBTgoTG7DNSvCGH1VdUSx4p5A4sEhts7KoVL3Lu32uTwtS5FRBc8B9D13WnM6oFuRtuXpnvV8pTWRq7YCQtwTE5qgbNVQNq3jbAT64Z4jtP55dW9oF4sCVB7aHi1N2ZmaprQyEQUhca5SxmGWQzb6Fa8i5spipgkPhHe5mQ8tyexvQSqkNNbBDuTJnoRdjPzDnAuV6h1rCEnzouMDvyLkpzGzuxfoWkvacxQJBzhodTCe5B8E5N7MDLucVz3ZtbeNFJ9HDRZUdjPXGMqi>
   - data_len: 131097
-xdpCWLrjxTb8rNFTAco4E9jt2awraosXKtU2kCVxb92:
-  - lamports: 15123456789
-  - owner: '11111111111111111111111111111111'
-  - executable: false
-  - data: '11116bv5oki4iftAgi9rancYuWZ3qnKyaLjaP75dLXwUvFRk4CMh7q4aWeLgq1yWW1H2cn96Z2fRUvf1qbCLTHVd6ozarwHoniy5j1FnTJP'
-  - data_len: 80
 58xXjpcSGtEtBo3SfousER3SDUfAcUyG6PBYyxVB587h:
   - lamports: 499963177500
   - owner: '11111111111111111111111111111111'
   - executable: false
   - data: ''
   - data_len: 0
```

Resulting these bank hash input difference:

#### leader

```
Apr  7 08:31:22 validator-us-east1-b validator.sh[8909]: [2020-04-07T08:31:22.809585778Z INFO  solana_runtime::bank] bank frozen: 4187144 hash: FmRsY4WgARgNXf1dW9dXzGXWPvKNp4LoKZYovUSPWMKU accounts_delta: Uu2n1bkKHdv812mYR7KEgfqptoiVJM9CKagE1QqnwnF signature_count: 190 last_blockhash: jeKFjTNiWbkpU2u9KmaxGBM8rTnqGTCddnDTtxd4o9A
Apr  7 08:31:22 validator-us-east1-b validator.sh[8909]: [2020-04-07T08:31:22.809604179Z INFO  solana_runtime::bank] accounts hash slot: 4187144 stats: BankHashStats { num_removed_accounts: 356, num_added_accounts: 0, num_lamports_stored: 91925590448565, total_data_len: 747219, num_executable_accounts: 0 }

```

#### not leader/ledger-tool

```
Apr  7 08:31:23 validator-us-west1-b validator.sh[8135]: [2020-04-07T08:31:23.082385197Z INFO  solana_runtime::bank] bank frozen: 4187144 hash: 5M6n9bmiqdrRjr8myHMa2LWJqLhHLEs3WyMGfFniCGpH accounts_delta: CqxeRSyM5dPBKjySz2DEnGM93Rdw6uoTDPYPpJYMWC5S signature_count: 190 last_blockhash: jeKFjTNiWbkpU2u9KmaxGBM8rTnqGTCddnDTtxd4o9A
Apr  7 08:31:23 validator-us-west1-b validator.sh[8135]: [2020-04-07T08:31:23.082403977Z INFO  solana_runtime::bank] accounts hash slot: 4187144 stats: BankHashStats { num_removed_accounts: 354, num_added_accounts: 0, num_lamports_stored: 91835975463565, total_data_len: 747139, num_executable_accounts: 0 }
```

_**And inevitable bank_hash mismatch, forcing the leader at the time of processing out of circle by vote hash mismatch, ultimately**_

## Summary of Changes

I confirmed after back-porting this to v1.0, the vote mismatches don't happen.

Also, strictly speaking, this changes the execution semantics; so a variant of hard-fork.

- ~[ ] todo: write a test?~ (I'd skip)
- [x] todo: audit other callsites?

Fixes #9357

## Random

This was the 2nd hardest bug to fix in solana, with #7736 being the most. ;)