### PR TITLE
vote: Rename UpdateNode to UpdateValidatorIdentity

### DIFF
--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -500,7 +500,7 @@ pub fn process_vote_update_validator(
         (&new_identity_pubkey, "new_identity_account".to_string()),
     )?;
     let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
-    let ixs = vec![vote_instruction::update_node(
+    let ixs = vec![vote_instruction::update_validator_identity(
         vote_account_pubkey,
         &authorized_withdrawer.pubkey(),
         &new_identity_pubkey,

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -87,14 +87,14 @@ pub enum VoteInstruction {
     ///    1 - Destination account for the withdrawal
     Withdraw(u64),
 
-    /// Update the vote account's validator identity (node id)
+    /// Update the vote account's validator identity (node_pubkey)
     ///    requires authorized withdrawer and new validator identity signature
     ///
     /// Expects 2 Accounts:
     ///    0 - Vote account to be updated with the Pubkey for authorization
-    ///    1 - New validator identity (node id)
+    ///    1 - New validator identity (node_pubkey)
     ///
-    UpdateNode,
+    UpdateValidatorIdentity,
 }
 
 fn initialize_account(vote_pubkey: &Pubkey, vote_init: &VoteInit) -> Instruction {
@@ -166,7 +166,7 @@ pub fn authorize(
     )
 }
 
-pub fn update_node(
+pub fn update_validator_identity(
     vote_pubkey: &Pubkey,
     authorized_withdrawer_pubkey: &Pubkey,
     node_pubkey: &Pubkey,
@@ -177,7 +177,11 @@ pub fn update_node(
     ]
     .with_signer(authorized_withdrawer_pubkey);
 
-    Instruction::new(id(), &VoteInstruction::UpdateNode, account_metas)
+    Instruction::new(
+        id(),
+        &VoteInstruction::UpdateValidatorIdentity,
+        account_metas,
+    )
 }
 
 pub fn vote(vote_pubkey: &Pubkey, authorized_voter_pubkey: &Pubkey, vote: Vote) -> Instruction {
@@ -238,7 +242,7 @@ pub fn process_instruction(
             &signers,
             &Clock::from_keyed_account(next_keyed_account(keyed_accounts)?)?,
         ),
-        VoteInstruction::UpdateNode => vote_state::update_node(
+        VoteInstruction::UpdateValidatorIdentity => vote_state::update_validator_identity(
             me,
             next_keyed_account(keyed_accounts)?.unsigned_key(),
             &signers,
@@ -336,7 +340,7 @@ mod tests {
             Err(InstructionError::InvalidAccountData),
         );
         assert_eq!(
-            process_instruction(&update_node(
+            process_instruction(&update_validator_identity(
                 &Pubkey::default(),
                 &Pubkey::default(),
                 &Pubkey::default(),

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -578,7 +578,7 @@ pub fn authorize<S: std::hash::BuildHasher>(
 }
 
 /// Update the node_pubkey, requires signature of the authorized voter
-pub fn update_node<S: std::hash::BuildHasher>(
+pub fn update_validator_identity<S: std::hash::BuildHasher>(
     vote_account: &KeyedAccount,
     node_pubkey: &Pubkey,
     signers: &HashSet<Pubkey, S>,
@@ -949,7 +949,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vote_update_node_id() {
+    fn test_vote_update_validator_identity() {
         let (vote_pubkey, _authorized_voter, authorized_withdrawer, vote_account) =
             create_test_account_with_authorized();
 
@@ -963,7 +963,7 @@ mod tests {
             KeyedAccount::new(&authorized_withdrawer, true, &authorized_withdrawer_account),
         ];
         let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
-        let res = update_node(&keyed_accounts[0], &node_pubkey, &signers);
+        let res = update_validator_identity(&keyed_accounts[0], &node_pubkey, &signers);
         assert_eq!(res, Err(InstructionError::MissingRequiredSignature));
 
         let keyed_accounts = &[
@@ -976,7 +976,7 @@ mod tests {
             ),
         ];
         let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
-        let res = update_node(&keyed_accounts[0], &node_pubkey, &signers);
+        let res = update_validator_identity(&keyed_accounts[0], &node_pubkey, &signers);
         assert_eq!(res, Err(InstructionError::MissingRequiredSignature));
         let vote_state: VoteState = StateMut::<VoteStateVersions>::state(&*vote_account.borrow())
             .unwrap()
@@ -989,7 +989,7 @@ mod tests {
             KeyedAccount::new(&authorized_withdrawer, true, &authorized_withdrawer_account),
         ];
         let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
-        let res = update_node(&keyed_accounts[0], &node_pubkey, &signers);
+        let res = update_validator_identity(&keyed_accounts[0], &node_pubkey, &signers);
         assert_eq!(res, Ok(()));
         let vote_state: VoteState = StateMut::<VoteStateVersions>::state(&*vote_account.borrow())
             .unwrap()


### PR DESCRIPTION
The name of the UpdateNode instruction has bugged me for a while, this improves the situation slightly.  I still want to rename `node_pubkey` in the vote state on day, but not today