### PR TITLE
Safer cargo command

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -36,7 +36,12 @@ download() {
 # Install xargo
 (
   set -ex
-  cargo +"${rust_stable:-}" install xargo
+  # shellcheck disable=SC2154
+  if [[ -n $rust_stable ]]; then
+    cargo +"$rust_stable" install xargo
+  else
+    cargo install xargo
+  fi
   xargo --version > xargo.md 2>&1
 )
 # shellcheck disable=SC2181


### PR DESCRIPTION
#### Problem

Some versions of Cargo don't like the extra '+' if `rust_stable` is not defined

#### Summary of Changes

Remove it

Fixes #
