### PR TITLE
Remove ForkStats.slot

### DIFF
--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -182,7 +182,6 @@ pub(crate) struct ForkStats {
     pub(crate) weight: u128,
     pub(crate) fork_weight: u128,
     pub(crate) total_staked: u64,
-    pub(crate) slot: Slot,
     pub(crate) block_height: u64,
     pub(crate) has_voted: bool,
     pub(crate) is_recent: bool,


### PR DESCRIPTION
#### Problem
ForkStats unnecessarily tracks `slot` field

#### Summary of Changes
Remove field, add test that select_forks() prioritizes lower slot when weights are equal
Fixes #
