### PR TITLE
cli: Remove "Credits Observed:" field from `solana stake-account` output

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1257,7 +1257,6 @@ pub fn print_stake_state(stake_lamports: u64, stake_state: &StakeState, use_lamp
                 "Total Stake: {}",
                 build_balance_message(stake_lamports, use_lamports_unit, true)
             );
-            println!("Credits Observed: {}", stake.credits_observed);
             println!(
                 "Delegated Stake: {}",
                 build_balance_message(stake.delegation.stake, use_lamports_unit, true)


### PR DESCRIPTION
As discussed on Discord, for stake accounts the credits observed field is just an internal accounting field and not really something overly useful for users to view