### PR TITLE
cli: Sort the output of by active stake

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1272,7 +1272,9 @@ pub fn process_show_validators(
         );
     }
 
-    for vote_account in vote_accounts.current.into_iter() {
+    let mut current = vote_accounts.current;
+    current.sort_by(|a, b| b.activated_stake.cmp(&a.activated_stake));
+    for vote_account in current.into_iter() {
         print_vote_account(
             vote_account,
             epoch_info.epoch,
@@ -1281,7 +1283,9 @@ pub fn process_show_validators(
             false,
         );
     }
-    for vote_account in vote_accounts.delinquent.into_iter() {
+    let mut delinquent = vote_accounts.delinquent;
+    delinquent.sort_by(|a, b| b.activated_stake.cmp(&a.activated_stake));
+    for vote_account in delinquent.into_iter() {
         print_vote_account(
             vote_account,
             epoch_info.epoch,


### PR DESCRIPTION
The output of `solana validators` is currently randomly ordered, now it's by active stake.   More sort options in the future would be nice