### PR TITLE
Fix broadcast metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,7 +4505,6 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-bpf-loader-program 1.2.0",
  "solana-logger 1.2.0",
  "solana-measure 1.2.0",
  "solana-metrics 1.2.0",

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -117,7 +117,7 @@ trait BroadcastRun {
         sock: &UdpSocket,
     ) -> Result<()>;
     fn record(
-        &self,
+        &mut self,
         receiver: &Arc<Mutex<Receiver<Arc<Vec<Shred>>>>>,
         blockstore: &Arc<Blockstore>,
     ) -> Result<()>;
@@ -250,7 +250,7 @@ impl BroadcastStage {
         let blockstore_receiver = Arc::new(Mutex::new(blockstore_receiver));
         for _ in 0..NUM_INSERT_THREADS {
             let blockstore_receiver = blockstore_receiver.clone();
-            let bs_record = broadcast_stage_run.clone();
+            let mut bs_record = broadcast_stage_run.clone();
             let btree = blockstore.clone();
             let t = Builder::new()
                 .name("solana-broadcaster-record".to_string())

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -40,11 +40,11 @@ pub(crate) mod broadcast_utils;
 mod fail_entry_verification_broadcast_run;
 mod standard_broadcast_run;
 
-pub const NUM_INSERT_THREADS: usize = 2;
-pub type RetransmitSlotsSender = CrossbeamSender<HashMap<Slot, Arc<Bank>>>;
-pub type RetransmitSlotsReceiver = CrossbeamReceiver<HashMap<Slot, Arc<Bank>>>;
-pub type RecordReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
-pub type TransmitReceiver = Receiver<(TransmitShreds, Option<BroadcastShredBatchInfo>)>;
+pub(crate) const NUM_INSERT_THREADS: usize = 2;
+pub(crate) type RetransmitSlotsSender = CrossbeamSender<HashMap<Slot, Arc<Bank>>>;
+pub(crate) type RetransmitSlotsReceiver = CrossbeamReceiver<HashMap<Slot, Arc<Bank>>>;
+pub(crate) type RecordReceiver = Receiver<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>;
+pub(crate) type TransmitReceiver = Receiver<(TransmitShreds, Option<BroadcastShredBatchInfo>)>;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BroadcastStageReturnType {

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -119,7 +119,7 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         Ok(())
     }
     fn record(
-        &self,
+        &mut self,
         receiver: &Arc<Mutex<Receiver<Arc<Vec<Shred>>>>>,
         blockstore: &Arc<Blockstore>,
     ) -> Result<()> {

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -28,8 +28,8 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         &mut self,
         blockstore: &Arc<Blockstore>,
         receiver: &Receiver<WorkingBankEntry>,
-        socket_sender: &Sender<TransmitShreds>,
-        blockstore_sender: &Sender<Arc<Vec<Shred>>>,
+        socket_sender: &Sender<(TransmitShreds, bool)>,
+        blockstore_sender: &Sender<(Arc<Vec<Shred>>, bool)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let receive_results = broadcast_utils::recv_slot_entries(receiver)?;
@@ -83,25 +83,31 @@ impl BroadcastRun for BroadcastFakeShredsRun {
         }
 
         let data_shreds = Arc::new(data_shreds);
-        blockstore_sender.send(data_shreds.clone())?;
+        blockstore_sender.send((data_shreds.clone(), false))?;
 
         // 3) Start broadcast step
         //some indicates fake shreds
-        socket_sender.send((Some(Arc::new(HashMap::new())), Arc::new(fake_data_shreds)))?;
-        socket_sender.send((Some(Arc::new(HashMap::new())), Arc::new(fake_coding_shreds)))?;
+        socket_sender.send((
+            (Some(Arc::new(HashMap::new())), Arc::new(fake_data_shreds)),
+            false,
+        ))?;
+        socket_sender.send((
+            (Some(Arc::new(HashMap::new())), Arc::new(fake_coding_shreds)),
+            false,
+        ))?;
         //none indicates real shreds
-        socket_sender.send((None, data_shreds))?;
-        socket_sender.send((None, Arc::new(coding_shreds)))?;
+        socket_sender.send(((None, data_shreds), false))?;
+        socket_sender.send(((None, Arc::new(coding_shreds)), false))?;
 
         Ok(())
     }
     fn transmit(
         &mut self,
-        receiver: &Arc<Mutex<Receiver<TransmitShreds>>>,
+        receiver: &Arc<Mutex<Receiver<(TransmitShreds, bool)>>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sock: &UdpSocket,
     ) -> Result<()> {
-        for (stakes, data_shreds) in receiver.lock().unwrap().iter() {
+        for ((stakes, data_shreds), _) in receiver.lock().unwrap().iter() {
             let peers = cluster_info.read().unwrap().tvu_peers();
             peers.iter().enumerate().for_each(|(i, peer)| {
                 if i <= self.partition && stakes.is_some() {
@@ -120,10 +126,10 @@ impl BroadcastRun for BroadcastFakeShredsRun {
     }
     fn record(
         &mut self,
-        receiver: &Arc<Mutex<Receiver<Arc<Vec<Shred>>>>>,
+        receiver: &Arc<Mutex<RecordReceiver>>,
         blockstore: &Arc<Blockstore>,
     ) -> Result<()> {
-        for data_shreds in receiver.lock().unwrap().iter() {
+        for (data_shreds, _) in receiver.lock().unwrap().iter() {
             blockstore.insert_shreds(data_shreds.to_vec(), None, true)?;
         }
         Ok(())

--- a/core/src/broadcast_stage/broadcast_metrics.rs
+++ b/core/src/broadcast_stage/broadcast_metrics.rs
@@ -105,6 +105,7 @@ pub(crate) struct BatchCounter<T: BroadcastStats + Default> {
 }
 
 impl<T: BroadcastStats + Default> BatchCounter<T> {
+    #[cfg(test)]
     pub(crate) fn num_batches(&self) -> usize {
         self.num_batches
     }
@@ -114,6 +115,7 @@ impl<T: BroadcastStats + Default> BatchCounter<T> {
 pub(crate) struct SlotBroadcastStats<T: BroadcastStats + Default>(HashMap<Slot, BatchCounter<T>>);
 
 impl<T: BroadcastStats + Default> SlotBroadcastStats<T> {
+    #[cfg(test)]
     pub(crate) fn get(&self, slot: Slot) -> Option<&BatchCounter<T>> {
         self.0.get(&slot)
     }

--- a/core/src/broadcast_stage/broadcast_metrics.rs
+++ b/core/src/broadcast_stage/broadcast_metrics.rs
@@ -1,8 +1,100 @@
 use super::*;
 
+pub(crate) trait BroadcastShredStats {
+    fn update(&mut self, new_stats: &Self);
+    fn report_stats(&mut self, slot: Slot, slot_start: Instant);
+}
 #[derive(Clone)]
-pub struct BroadcastShredBatchInfo {
-    pub slot: Slot,
-    pub num_expected_batches: Option<usize>,
-    pub slot_start_ts: Instant,
+pub(crate) struct BroadcastShredBatchInfo {
+    pub(crate) slot: Slot,
+    pub(crate) num_expected_batches: Option<usize>,
+    pub(crate) slot_start_ts: Instant,
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct ProcessShredsStats {
+    // Per-slot elapsed time
+    pub(crate) shredding_elapsed: u64,
+    pub(crate) receive_elapsed: u64,
+}
+impl ProcessShredsStats {
+    pub(crate) fn update(&mut self, new_stats: &ProcessShredsStats) {
+        self.shredding_elapsed += new_stats.shredding_elapsed;
+        self.receive_elapsed += new_stats.receive_elapsed;
+    }
+    pub(crate) fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct TransmitShredsStats {
+    pub(crate) transmit_elapsed: u64,
+    pub(crate) send_mmsg_elapsed: u64,
+    pub(crate) get_peers_elapsed: u64,
+    pub(crate) num_shreds: usize,
+    pub(crate) num_transmitted_batches: usize,
+    // Filled in when the last batch of shreds is received,
+    // signals how many batches of shreds to expect
+    pub(crate) num_expected_batches: Option<usize>,
+}
+impl BroadcastShredStats for TransmitShredsStats {
+    fn update(&mut self, new_stats: &TransmitShredsStats) {
+        self.transmit_elapsed += new_stats.transmit_elapsed;
+        self.send_mmsg_elapsed += new_stats.send_mmsg_elapsed;
+        self.get_peers_elapsed += new_stats.get_peers_elapsed;
+        self.num_shreds += new_stats.num_shreds;
+    }
+    fn report_stats(&mut self, slot: Slot, slot_start: Instant) {
+        datapoint_info!(
+            "broadcast-transmit-shreds-stats",
+            ("slot", slot as i64, i64),
+            (
+                "end_to_end_elapsed",
+                // `slot_start` signals when the first batch of shreds was
+                // received, used to measure duration of broadcast
+                slot_start.elapsed().as_micros() as i64,
+                i64
+            ),
+            ("transmit_elapsed", self.transmit_elapsed as i64, i64),
+            ("send_mmsg_elapsed", self.send_mmsg_elapsed as i64, i64),
+            ("get_peers_elapsed", self.get_peers_elapsed as i64, i64),
+            ("num_shreds", self.num_shreds as i64, i64),
+        );
+    }
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct InsertShredsStats {
+    insert_shreds_elapsed: u64,
+    num_shreds: usize,
+    num_inserted_batches: usize,
+    // Filled in when the last batch of shreds is received,
+    // signals how many batches of shreds to expect
+    num_expected_batches: Option<usize>,
+}
+impl BroadcastShredStats for InsertShredsStats {
+    fn update(&mut self, new_stats: &InsertShredsStats) {
+        self.insert_shreds_elapsed += new_stats.insert_shreds_elapsed;
+        self.num_shreds += new_stats.num_shreds;
+    }
+    fn report_stats(&mut self, slot: Slot, slot_start: Instant) {
+        datapoint_info!(
+            "broadcast-insert-shreds-stats",
+            ("slot", slot as i64, i64),
+            (
+                "end_to_end_elapsed",
+                // `slot_start` signals when the first batch of shreds was
+                // received, used to measure duration of broadcast
+                slot_start.elapsed().as_micros() as i64,
+                i64
+            ),
+            (
+                "insert_shreds_elapsed",
+                self.insert_shreds_elapsed as i64,
+                i64
+            ),
+            ("num_shreds", self.num_shreds as i64, i64),
+        );
+    }
 }

--- a/core/src/broadcast_stage/broadcast_metrics.rs
+++ b/core/src/broadcast_stage/broadcast_metrics.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+#[derive(Clone)]
+pub struct BroadcastShredBatchInfo {
+    pub slot: Slot,
+    pub num_expected_batches: Option<usize>,
+    pub slot_start_ts: Instant,
+}

--- a/core/src/broadcast_stage/broadcast_metrics.rs
+++ b/core/src/broadcast_stage/broadcast_metrics.rs
@@ -1,9 +1,10 @@
 use super::*;
 
-pub(crate) trait BroadcastShredStats {
+pub(crate) trait BroadcastStats {
     fn update(&mut self, new_stats: &Self);
     fn report_stats(&mut self, slot: Slot, slot_start: Instant);
 }
+
 #[derive(Clone)]
 pub(crate) struct BroadcastShredBatchInfo {
     pub(crate) slot: Slot,
@@ -33,12 +34,9 @@ pub(crate) struct TransmitShredsStats {
     pub(crate) send_mmsg_elapsed: u64,
     pub(crate) get_peers_elapsed: u64,
     pub(crate) num_shreds: usize,
-    pub(crate) num_transmitted_batches: usize,
-    // Filled in when the last batch of shreds is received,
-    // signals how many batches of shreds to expect
-    pub(crate) num_expected_batches: Option<usize>,
 }
-impl BroadcastShredStats for TransmitShredsStats {
+
+impl BroadcastStats for TransmitShredsStats {
     fn update(&mut self, new_stats: &TransmitShredsStats) {
         self.transmit_elapsed += new_stats.transmit_elapsed;
         self.send_mmsg_elapsed += new_stats.send_mmsg_elapsed;
@@ -66,14 +64,10 @@ impl BroadcastShredStats for TransmitShredsStats {
 
 #[derive(Default, Clone)]
 pub(crate) struct InsertShredsStats {
-    insert_shreds_elapsed: u64,
-    num_shreds: usize,
-    num_inserted_batches: usize,
-    // Filled in when the last batch of shreds is received,
-    // signals how many batches of shreds to expect
-    num_expected_batches: Option<usize>,
+    pub(crate) insert_shreds_elapsed: u64,
+    pub(crate) num_shreds: usize,
 }
-impl BroadcastShredStats for InsertShredsStats {
+impl BroadcastStats for InsertShredsStats {
     fn update(&mut self, new_stats: &InsertShredsStats) {
         self.insert_shreds_elapsed += new_stats.insert_shreds_elapsed;
         self.num_shreds += new_stats.num_shreds;
@@ -96,5 +90,52 @@ impl BroadcastShredStats for InsertShredsStats {
             ),
             ("num_shreds", self.num_shreds as i64, i64),
         );
+    }
+}
+
+// Tracks metrics of type `T` acrosss multiple threads
+#[derive(Default)]
+pub(crate) struct BatchCounter<T: BroadcastStats + Default> {
+    // The number of batches processed across all threads so far
+    num_batches: usize,
+    // Filled in when the last batch of shreds is received,
+    // signals how many batches of shreds to expect
+    num_expected_batches: Option<usize>,
+    broadcast_shred_stats: T,
+}
+
+#[derive(Default)]
+pub(crate) struct SlotBroadcastStats<T: BroadcastStats + Default>(HashMap<Slot, BatchCounter<T>>);
+
+impl<T: BroadcastStats + Default> SlotBroadcastStats<T> {
+    pub(crate) fn update(&mut self, new_stats: &T, batch_info: &Option<BroadcastShredBatchInfo>) {
+        if let Some(batch_info) = batch_info {
+            let mut should_delete = false;
+            {
+                let slot_batch_counter = self.0.entry(batch_info.slot).or_default();
+                slot_batch_counter.broadcast_shred_stats.update(new_stats);
+                // Only count the ones where `broadcast_shred_batch_info`.is_some(), because
+                // there could potentially be other `retransmit` slots inserted into the
+                // transmit pipeline (signaled by ReplayStage) that are not created by the
+                // main shredding/broadcast pipeline
+                slot_batch_counter.num_batches += 1;
+                if let Some(num_expected_batches) = batch_info.num_expected_batches {
+                    slot_batch_counter.num_expected_batches = Some(num_expected_batches);
+                }
+                if let Some(num_expected_batches) = slot_batch_counter.num_expected_batches {
+                    if slot_batch_counter.num_batches == num_expected_batches {
+                        slot_batch_counter
+                            .broadcast_shred_stats
+                            .report_stats(batch_info.slot, batch_info.slot_start_ts);
+                    }
+                    should_delete = true;
+                }
+            }
+            if should_delete {
+                self.0
+                    .remove(&batch_info.slot)
+                    .expect("delete should be successful");
+            }
+        }
     }
 }

--- a/core/src/broadcast_stage/broadcast_metrics.rs
+++ b/core/src/broadcast_stage/broadcast_metrics.rs
@@ -104,10 +104,19 @@ pub(crate) struct BatchCounter<T: BroadcastStats + Default> {
     broadcast_shred_stats: T,
 }
 
+impl<T: BroadcastStats + Default> BatchCounter<T> {
+    pub(crate) fn num_batches(&self) -> usize {
+        self.num_batches
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct SlotBroadcastStats<T: BroadcastStats + Default>(HashMap<Slot, BatchCounter<T>>);
 
 impl<T: BroadcastStats + Default> SlotBroadcastStats<T> {
+    pub(crate) fn get(&self, slot: Slot) -> Option<&BatchCounter<T>> {
+        self.0.get(&slot)
+    }
     pub(crate) fn update(&mut self, new_stats: &T, batch_info: &Option<BroadcastShredBatchInfo>) {
         if let Some(batch_info) = batch_info {
             let mut should_delete = false;
@@ -127,8 +136,8 @@ impl<T: BroadcastStats + Default> SlotBroadcastStats<T> {
                         slot_batch_counter
                             .broadcast_shred_stats
                             .report_stats(batch_info.slot, batch_info.slot_start_ts);
+                        should_delete = true;
                     }
-                    should_delete = true;
                 }
             }
             if should_delete {
@@ -136,6 +145,142 @@ impl<T: BroadcastStats + Default> SlotBroadcastStats<T> {
                     .remove(&batch_info.slot)
                     .expect("delete should be successful");
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Default)]
+    struct TestStats {
+        sender: Option<Sender<(usize, Slot, Instant)>>,
+        count: usize,
+    }
+
+    impl BroadcastStats for TestStats {
+        fn update(&mut self, new_stats: &TestStats) {
+            self.count += new_stats.count;
+            self.sender = new_stats.sender.clone();
+        }
+        fn report_stats(&mut self, slot: Slot, slot_start: Instant) {
+            self.sender
+                .as_ref()
+                .unwrap()
+                .send((self.count, slot, slot_start))
+                .unwrap()
+        }
+    }
+
+    #[test]
+    fn test_update() {
+        let start = Instant::now();
+        let mut slot_broadcast_stats = SlotBroadcastStats::default();
+        slot_broadcast_stats.update(
+            &TransmitShredsStats {
+                transmit_elapsed: 1,
+                get_peers_elapsed: 1,
+                send_mmsg_elapsed: 1,
+                num_shreds: 1,
+            },
+            &Some(BroadcastShredBatchInfo {
+                slot: 0,
+                num_expected_batches: Some(2),
+                slot_start_ts: start.clone(),
+            }),
+        );
+
+        // Singular update
+        let slot_0_stats = slot_broadcast_stats.0.get(&0).unwrap();
+        assert_eq!(slot_0_stats.num_batches, 1);
+        assert_eq!(slot_0_stats.num_expected_batches.unwrap(), 2);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.transmit_elapsed, 1);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.get_peers_elapsed, 1);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.send_mmsg_elapsed, 1);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.num_shreds, 1);
+
+        slot_broadcast_stats.update(
+            &TransmitShredsStats {
+                transmit_elapsed: 1,
+                get_peers_elapsed: 1,
+                send_mmsg_elapsed: 1,
+                num_shreds: 1,
+            },
+            &None,
+        );
+
+        // If BroadcastShredBatchInfo == None, then update should be ignored
+        let slot_0_stats = slot_broadcast_stats.0.get(&0).unwrap();
+        assert_eq!(slot_0_stats.num_batches, 1);
+        assert_eq!(slot_0_stats.num_expected_batches.unwrap(), 2);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.transmit_elapsed, 1);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.get_peers_elapsed, 1);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.send_mmsg_elapsed, 1);
+        assert_eq!(slot_0_stats.broadcast_shred_stats.num_shreds, 1);
+
+        // If another batch is given, then total number of batches == num_expected_batches == 2,
+        // so the batch should be purged from the HashMap
+        slot_broadcast_stats.update(
+            &TransmitShredsStats {
+                transmit_elapsed: 1,
+                get_peers_elapsed: 1,
+                send_mmsg_elapsed: 1,
+                num_shreds: 1,
+            },
+            &Some(BroadcastShredBatchInfo {
+                slot: 0,
+                num_expected_batches: None,
+                slot_start_ts: start.clone(),
+            }),
+        );
+
+        assert!(slot_broadcast_stats.0.get(&0).is_none());
+    }
+
+    #[test]
+    fn test_update_multi_threaded() {
+        for round in 0..50 {
+            let start = Instant::now();
+            let slot_broadcast_stats = Arc::new(Mutex::new(SlotBroadcastStats::default()));
+            let num_threads = 5;
+            let slot = 0;
+            let (sender, receiver) = channel();
+            let thread_handles: Vec<_> = (0..num_threads)
+                .into_iter()
+                .map(|i| {
+                    let slot_broadcast_stats = slot_broadcast_stats.clone();
+                    let sender = Some(sender.clone());
+                    let test_stats = TestStats { sender, count: 1 };
+                    let mut broadcast_batch_info = BroadcastShredBatchInfo {
+                        slot,
+                        num_expected_batches: None,
+                        slot_start_ts: start.clone(),
+                    };
+                    if i == round % num_threads {
+                        broadcast_batch_info.num_expected_batches = Some(num_threads);
+                    }
+                    Builder::new()
+                        .name("test_update_multi_threaded".to_string())
+                        .spawn(move || {
+                            slot_broadcast_stats
+                                .lock()
+                                .unwrap()
+                                .update(&test_stats, &Some(broadcast_batch_info))
+                        })
+                        .unwrap()
+                })
+                .collect();
+
+            for t in thread_handles {
+                t.join().unwrap();
+            }
+
+            assert!(slot_broadcast_stats.lock().unwrap().0.get(&slot).is_none());
+            let (returned_count, returned_slot, returned_instant) = receiver.recv().unwrap();
+            assert_eq!(returned_count, num_threads);
+            assert_eq!(returned_slot, slot);
+            assert_eq!(returned_instant, returned_instant);
         }
     }
 }

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -23,8 +23,8 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         &mut self,
         blockstore: &Arc<Blockstore>,
         receiver: &Receiver<WorkingBankEntry>,
-        socket_sender: &Sender<TransmitShreds>,
-        blockstore_sender: &Sender<Arc<Vec<Shred>>>,
+        socket_sender: &Sender<(TransmitShreds, bool)>,
+        blockstore_sender: &Sender<(Arc<Vec<Shred>>, bool)>,
     ) -> Result<()> {
         // 1) Pull entries from banking stage
         let mut receive_results = broadcast_utils::recv_slot_entries(receiver)?;
@@ -61,23 +61,23 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         );
 
         let data_shreds = Arc::new(data_shreds);
-        blockstore_sender.send(data_shreds.clone())?;
+        blockstore_sender.send((data_shreds.clone(), false))?;
         // 3) Start broadcast step
         let bank_epoch = bank.get_leader_schedule_epoch(bank.slot());
         let stakes = staking_utils::staked_nodes_at_epoch(&bank, bank_epoch);
 
         let stakes = stakes.map(Arc::new);
-        socket_sender.send((stakes.clone(), data_shreds))?;
-        socket_sender.send((stakes, Arc::new(coding_shreds)))?;
+        socket_sender.send(((stakes.clone(), data_shreds), false))?;
+        socket_sender.send(((stakes, Arc::new(coding_shreds)), false))?;
         Ok(())
     }
     fn transmit(
         &mut self,
-        receiver: &Arc<Mutex<Receiver<TransmitShreds>>>,
+        receiver: &Arc<Mutex<Receiver<(TransmitShreds, bool)>>>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
         sock: &UdpSocket,
     ) -> Result<()> {
-        let (stakes, shreds) = receiver.lock().unwrap().recv()?;
+        let ((stakes, shreds), _) = receiver.lock().unwrap().recv()?;
         // Broadcast data
         let (peers, peers_and_stakes) = get_broadcast_peers(cluster_info, stakes);
 
@@ -95,10 +95,10 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
     }
     fn record(
         &mut self,
-        receiver: &Arc<Mutex<Receiver<Arc<Vec<Shred>>>>>,
+        receiver: &Arc<Mutex<RecordReceiver>>,
         blockstore: &Arc<Blockstore>,
     ) -> Result<()> {
-        let all_shreds = receiver.lock().unwrap().recv()?;
+        let (all_shreds, _) = receiver.lock().unwrap().recv()?;
         blockstore
             .insert_shreds(all_shreds.to_vec(), None, true)
             .expect("Failed to insert shreds in blockstore");

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -94,7 +94,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
         Ok(())
     }
     fn record(
-        &self,
+        &mut self,
         receiver: &Arc<Mutex<Receiver<Arc<Vec<Shred>>>>>,
         blockstore: &Arc<Blockstore>,
     ) -> Result<()> {

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -1,5 +1,4 @@
 use super::{
-    broadcast_metrics::BroadcastShredBatchInfo,
     broadcast_utils::{self, ReceiveResults},
     *,
 };
@@ -11,94 +10,6 @@ use solana_ledger::{
 use solana_sdk::{pubkey::Pubkey, signature::Keypair, timing::duration_as_us};
 use std::collections::HashMap;
 use std::time::Duration;
-
-#[derive(Default, Clone)]
-struct ProcessShredsStats {
-    // Per-slot elapsed time
-    shredding_elapsed: u64,
-    receive_elapsed: u64,
-}
-impl ProcessShredsStats {
-    fn update(&mut self, new_stats: &ProcessShredsStats) {
-        self.shredding_elapsed += new_stats.shredding_elapsed;
-        self.receive_elapsed += new_stats.receive_elapsed;
-    }
-    fn reset(&mut self) {
-        *self = Self::default();
-    }
-}
-
-#[derive(Default, Clone)]
-struct TransmitShredsStats {
-    transmit_elapsed: u64,
-    send_mmsg_elapsed: u64,
-    get_peers_elapsed: u64,
-    num_shreds: usize,
-    num_transmitted_batches: usize,
-    // Filled in when the last batch of shreds is received,
-    // signals how many batches of shreds to expect
-    num_expected_batches: Option<usize>,
-}
-impl TransmitShredsStats {
-    fn update(&mut self, new_stats: &TransmitShredsStats) {
-        self.transmit_elapsed += new_stats.transmit_elapsed;
-        self.send_mmsg_elapsed += new_stats.send_mmsg_elapsed;
-        self.get_peers_elapsed += new_stats.get_peers_elapsed;
-        self.num_shreds += new_stats.num_shreds;
-    }
-    fn report_stats(&mut self, slot: Slot, slot_start: Instant) {
-        datapoint_info!(
-            "broadcast-transmit-shreds-stats",
-            ("slot", slot as i64, i64),
-            (
-                "end_to_end_elapsed",
-                // `slot_start` signals when the first batch of shreds was
-                // received, used to measure duration of broadcast
-                slot_start.elapsed().as_micros() as i64,
-                i64
-            ),
-            ("transmit_elapsed", self.transmit_elapsed as i64, i64),
-            ("send_mmsg_elapsed", self.send_mmsg_elapsed as i64, i64),
-            ("get_peers_elapsed", self.get_peers_elapsed as i64, i64),
-            ("num_shreds", self.num_shreds as i64, i64),
-        );
-    }
-}
-
-#[derive(Default, Clone)]
-struct InsertShredsStats {
-    insert_shreds_elapsed: u64,
-    num_shreds: usize,
-    num_inserted_batches: usize,
-    // Filled in when the last batch of shreds is received,
-    // signals how many batches of shreds to expect
-    num_expected_batches: Option<usize>,
-}
-/*impl InsertShredsStats {
-    fn update(&mut self, new_stats: &InsertShredsStats) {
-        self.insert_shreds_elapsed += new_stats.insert_shreds_elapsed;
-        self.num_shreds += new_stats.num_shreds;
-    }
-    fn report_stats(&mut self, slot: Slot, slot_start: Instant) {
-        datapoint_info!(
-            "broadcast-insert-shreds-stats",
-            ("slot", slot as i64, i64),
-            (
-                "end_to_end_elapsed",
-                // `slot_start` signals when the first batch of shreds was
-                // received, used to measure duration of broadcast
-                slot_start.elapsed().as_micros() as i64,
-                i64
-            ),
-            (
-                "insert_shreds_elapsed",
-                self.insert_shreds_elapsed as i64,
-                i64
-            ),
-            ("num_shreds", self.num_shreds as i64, i64),
-        );
-    }
-}*/
 
 #[derive(Clone)]
 pub struct StandardBroadcastRun {

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -278,7 +278,7 @@ impl CrdsGossipPull {
         failed
     }
     // build a set of filters of the current crds table
-    // num_filters - used to increase the likely hood of a value in crds being added to some filter
+    // num_filters - used to increase the likelyhood of a value in crds being added to some filter
     pub fn build_crds_filters(&self, crds: &Crds, bloom_size: usize) -> Vec<CrdsFilter> {
         let num = cmp::max(
             CRDS_GOSSIP_DEFAULT_BLOOM_ITEMS,

--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -5150,7 +5150,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"receive_time\") AS \"receive_time\" FROM \"$testnet\".\"autogen\".\"broadcast-bank-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"receive_time\") AS \"receive_time\" FROM \"$testnet\".\"autogen\".\"broadcast-process-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -5189,7 +5189,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"shredding_time\") AS \"shredding_time\" FROM \"$testnet\".\"autogen\".\"broadcast-bank-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"shredding_time\") AS \"shredding_time\" FROM \"$testnet\".\"autogen\".\"broadcast-process-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
@@ -5228,7 +5228,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"broadcast_time\") AS \"broadcast_time\" FROM \"$testnet\".\"autogen\".\"broadcast-bank-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"slot_broadcast_time\") AS \"slot_broadcast_time\" FROM \"$testnet\".\"autogen\".\"broadcast-process-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -5267,85 +5267,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"num_shreds\") AS \"num_shreds\" FROM \"$testnet\".\"autogen\".\"broadcast-bank-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
-          "rawQuery": true,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "count"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "cluster_info-vote-count",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "SELECT mean(\"slot_broadcast_time\") AS \"slot_broadcast_time\" FROM \"$testnet\".\"autogen\".\"broadcast-bank-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
-          "rawQuery": true,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "count"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "cluster_info-vote-count",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "SELECT mean(\"insertion_time\") AS \"insertion_time\" FROM \"$testnet\".\"autogen\".\"broadcast-bank-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"num_data_shreds\") AS \"num_data_shreds\" FROM \"$testnet\".\"autogen\".\"broadcast-process-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "D",
           "resultFormat": "time_series",
@@ -5369,7 +5291,407 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Time spent in Broadcast ($hostid)",
+      "title": "Broadcast Receive/Shredding Stats ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 62
+      },
+      "id": 74,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "broadcast-bank-stats.num_shreds",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"transmit_elapsed\") AS \"transmit_elapsed\" FROM \"$testnet\".\"autogen\".\"broadcast-transmit-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"send_mmsg_elapsed\") AS \"send_mmsg_elapsed\" FROM \"$testnet\".\"autogen\".\"broadcast-transmit-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"get_peers_elapsed\") AS \"get_peers_elapsed\" FROM \"$testnet\".\"autogen\".\"broadcast-transmit-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"num_shreds\") AS \"num_data_and_coding_shreds\" FROM \"$testnet\".\"autogen\".\"broadcast-transmit-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Broadcast Transmit Stats ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 62
+      },
+      "id": 75,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "broadcast-bank-stats.num_shreds",
+          "yaxis": 2
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"insert_shreds_elapsed\") AS \"insert_shreds_elapsed\" FROM \"$testnet\".\"autogen\".\"broadcast-insert-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"num_shreds\") AS \"num_data_and_coding_shreds\" FROM \"$testnet\".\"autogen\".\"broadcast-insert-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Broadcast Insert Shreds Stats ($hostid)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -5423,8 +5745,8 @@
       "gridPos": {
         "h": 6,
         "w": 8,
-        "x": 8,
-        "y": 62
+        "x": 0,
+        "y": 68
       },
       "id": 44,
       "legend": {
@@ -5775,6 +6097,248 @@
     },
     {
       "aliasColors": {
+        "banking_stage-buffered_packets.sum": "#3f6833",
+        "banking_stage-consumed_buffered_packets.last": "#65c5db",
+        "banking_stage-consumed_buffered_packets.sum": "#614d93",
+        "banking_stage-forwarded_packets.last": "#f9ba8f",
+        "banking_stage-forwarded_packets.sum": "#b7dbab",
+        "banking_stage-rebuffered_packets.last": "#e5a8e2",
+        "cluster-info.repair": "#ba43a9",
+        "fetch_stage-discard_forwards.sum": "#00ffbb",
+        "fetch_stage-honor_forwards.sum": "#bf1b00",
+        "poh_recorder-record_lock_contention.sum": "#5195ce",
+        "poh_recorder-tick_lock_contention.sum": "#962d82",
+        "replay_stage-new_leader.last": "#00ffbb",
+        "tower-vote.last": "#00ffbb",
+        "window-service.receive": "#b7dbab",
+        "window-stage.consumed": "#5195ce"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 68
+      },
+      "id": 47,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"poh_recorder-tick_lock_contention\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "F",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"poh_recorder-record_lock_contention\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"poh_recorder-tick_overhead\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"poh_recorder-record_ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "PoH Lock Contention ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "µs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
         "cluster-info.repair": "#ba43a9",
         "replay_stage-new_leader.last": "#00ffbb",
         "tower-observed.squash_account": "#0a437c",
@@ -5791,7 +6355,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 62
+        "y": 68
       },
       "id": 71,
       "legend": {
@@ -6112,7 +6676,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 68
+        "y": 74
       },
       "id": 46,
       "legend": {
@@ -6516,35 +7080,19 @@
       }
     },
     {
-      "aliasColors": {
-        "banking_stage-buffered_packets.sum": "#3f6833",
-        "banking_stage-consumed_buffered_packets.last": "#65c5db",
-        "banking_stage-consumed_buffered_packets.sum": "#614d93",
-        "banking_stage-forwarded_packets.last": "#f9ba8f",
-        "banking_stage-forwarded_packets.sum": "#b7dbab",
-        "banking_stage-rebuffered_packets.last": "#e5a8e2",
-        "cluster-info.repair": "#ba43a9",
-        "fetch_stage-discard_forwards.sum": "#00ffbb",
-        "fetch_stage-honor_forwards.sum": "#bf1b00",
-        "poh_recorder-record_lock_contention.sum": "#5195ce",
-        "poh_recorder-tick_lock_contention.sum": "#962d82",
-        "replay_stage-new_leader.last": "#00ffbb",
-        "tower-vote.last": "#00ffbb",
-        "window-service.receive": "#b7dbab",
-        "window-stage.consumed": "#5195ce"
-      },
+      "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 8,
         "x": 8,
-        "y": 68
+        "y": 74
       },
-      "id": 47,
+      "id": 54,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -6556,11 +7104,11 @@
         "values": false
       },
       "lines": true,
-      "linewidth": 2,
+      "linewidth": 1,
       "links": [],
-      "nullPointMode": "null as zero",
+      "nullPointMode": "null",
       "percentage": false,
-      "pointradius": 2,
+      "pointradius": 5,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
@@ -6583,46 +7131,10 @@
               "type": "fill"
             }
           ],
+          "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"poh_recorder-tick_lock_contention\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
-          "rawQuery": true,
-          "refId": "F",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"poh_recorder-record_lock_contention\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "policy": "autogen",
+          "query": "SELECT sum(\"count\") AS \"window receive\" FROM \"$testnet\".\"autogen\".\"streamer-recv_window-recv\" WHERE $timeFilter GROUP BY time($__interval) FILL(0)\n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -6630,13 +7142,13 @@
             [
               {
                 "params": [
-                  "value"
+                  "count"
                 ],
                 "type": "field"
               },
               {
                 "params": [],
-                "type": "mean"
+                "type": "sum"
               }
             ]
           ],
@@ -6659,46 +7171,9 @@
           ],
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"poh_recorder-tick_overhead\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT sum(\"count\") AS \"window receive\" FROM \"$testnet\".\"autogen\".\"streamer-recv_window-consume\" WHERE $timeFilter GROUP BY time($__interval) FILL(0)",
           "rawQuery": true,
           "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"poh_recorder-record_ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
-          "rawQuery": true,
-          "refId": "C",
           "resultFormat": "time_series",
           "select": [
             [
@@ -6720,7 +7195,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "PoH Lock Contention ($hostid)",
+      "title": "Window",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -6736,7 +7211,7 @@
       },
       "yaxes": [
         {
-          "format": "µs",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -6749,7 +7224,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": false
+          "show": true
         }
       ],
       "yaxis": {
@@ -6775,7 +7250,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 68
+        "y": 74
       },
       "id": 45,
       "legend": {
@@ -7077,6 +7552,123 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "(Must pick a host id for this to make sense)",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 79
+      },
+      "id": 73,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT count(\"slot\") AS \"num_my_leader_slots\" FROM \"$testnet\".\"autogen\".\"replay_stage-my_leader_slot\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time(1s) fill(null)\n",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "My Leader Slots ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "aliasColors": {
         "banking_stage-buffered_packets.sum": "#3f6833",
         "banking_stage-consumed_buffered_packets.last": "#65c5db",
@@ -7101,7 +7693,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 74
+        "y": 80
       },
       "id": 53,
       "legend": {
@@ -7402,161 +7994,8 @@
       "gridPos": {
         "h": 5,
         "w": 8,
-        "x": 8,
-        "y": 74
-      },
-      "id": 54,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "cluster_info-vote-count",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "SELECT sum(\"count\") AS \"window receive\" FROM \"$testnet\".\"autogen\".\"streamer-recv_window-recv\" WHERE $timeFilter GROUP BY time($__interval) FILL(0)\n",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "count"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "orderByTime": "ASC",
-          "policy": "default",
-          "query": "SELECT sum(\"count\") AS \"window receive\" FROM \"$testnet\".\"autogen\".\"streamer-recv_window-consume\" WHERE $timeFilter GROUP BY time($__interval) FILL(0)",
-          "rawQuery": true,
-          "refId": "B",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Window",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "gridPos": {
-        "h": 5,
-        "w": 8,
         "x": 16,
-        "y": 74
+        "y": 80
       },
       "id": 48,
       "legend": {
@@ -7673,7 +8112,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 79
+        "y": 85
       },
       "id": 61,
       "legend": {
@@ -7826,129 +8265,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
-      "description": "(Must pick a host id for this to make sense)",
-      "fill": 1,
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 8,
-        "y": 79
-      },
-      "id": 73,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "cluster_info-vote-count",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "SELECT count(\"slot\") AS \"num_my_leader_slots\" FROM \"$testnet\".\"autogen\".\"replay_stage-my_leader_slot\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time(1s) fill(null)\n",
-          "rawQuery": true,
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "count"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "My Leader Slots ($hostid)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 79
+        "y": 85
       },
       "id": 52,
       "legend": {
@@ -8059,7 +8381,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 91
       },
       "id": 55,
       "panels": [],
@@ -8082,7 +8404,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 86
+        "y": 92
       },
       "id": 56,
       "legend": {
@@ -8242,7 +8564,7 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 86
+        "y": 92
       },
       "id": 57,
       "legend": {
@@ -8402,7 +8724,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 86
+        "y": 92
       },
       "id": 58,
       "legend": {
@@ -8587,7 +8909,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 91
+        "y": 97
       },
       "id": 59,
       "panels": [],
@@ -8606,7 +8928,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 92
+        "y": 98
       },
       "id": 60,
       "legend": {
@@ -8839,7 +9161,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 92
+        "y": 98
       },
       "id": 72,
       "legend": {
@@ -8992,7 +9314,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 97
+        "y": 103
       },
       "id": 62,
       "panels": [],
@@ -9010,7 +9332,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 98
+        "y": 104
       },
       "id": 63,
       "legend": {
@@ -9212,7 +9534,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 98
+        "y": 104
       },
       "id": 64,
       "legend": {
@@ -9361,7 +9683,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 103
+        "y": 109
       },
       "id": 65,
       "panels": [],
@@ -9379,7 +9701,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 104
+        "y": 110
       },
       "id": 66,
       "legend": {
@@ -9571,7 +9893,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 104
+        "y": 110
       },
       "id": 67,
       "legend": {
@@ -9839,7 +10161,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 104
+        "y": 110
       },
       "id": 68,
       "legend": {
@@ -10028,7 +10350,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 110
+        "y": 116
       },
       "id": 69,
       "panels": [],
@@ -10046,7 +10368,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 111
+        "y": 117
       },
       "id": 70,
       "legend": {

--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -5364,6 +5364,10 @@
         {
           "alias": "broadcast-bank-stats.num_shreds",
           "yaxis": 2
+        },
+        {
+          "alias": "broadcast-transmit-shreds-stats.num_data_and_coding_shreds",
+          "yaxis": 2
         }
       ],
       "spaceLength": 10,
@@ -5641,6 +5645,10 @@
       "seriesOverrides": [
         {
           "alias": "broadcast-bank-stats.num_shreds",
+          "yaxis": 2
+        },
+        {
+          "alias": "broadcast-insert-shreds-stats.num_data_and_coding_shreds",
           "yaxis": 2
         }
       ],

--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -5525,6 +5525,45 @@
             ]
           ],
           "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"end_to_end_elapsed\") AS \"end_to_end_elapsed\" FROM \"$testnet\".\"autogen\".\"broadcast-transmit-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
         }
       ],
       "thresholds": [],
@@ -5670,6 +5709,45 @@
           "query": "SELECT mean(\"num_shreds\") AS \"num_data_and_coding_shreds\" FROM \"$testnet\".\"autogen\".\"broadcast-insert-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"end_to_end_elapsed\") AS \"end_to_end_elapsed\" FROM \"$testnet\".\"autogen\".\"broadcast-insert-shreds-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
           "resultFormat": "time_series",
           "select": [
             [


### PR DESCRIPTION
#### Problem
During refactoring of broadcast into asynchronous transmit/insert of shreds, the broadcast metrics were not updated to track transmit/insert times asynchronously, leading to improper reporting.

#### Summary of Changes
Refactor broadcast metrics so insert and broadcast threads track/report their metrics separately from the main processing/shredding thread.

Fixes #
