### PR TITLE
Use same max_age regardless of leader/not-leader (for v1.0)

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -26,6 +26,7 @@ use solana_ledger::{
     snapshot_package::SnapshotPackageSender,
 };
 use solana_sdk::{
+    genesis_config::GenesisConfig,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
 };
@@ -67,6 +68,7 @@ pub struct TvuConfig {
     pub halt_on_trusted_validators_accounts_hash_mismatch: bool,
     pub trusted_validators: Option<HashSet<Pubkey>>,
     pub accounts_hash_fault_injection_slots: u64,
+    pub genesis_config: GenesisConfig,
 }
 
 impl Tvu {
@@ -185,6 +187,7 @@ impl Tvu {
             block_commitment_cache: block_commitment_cache.clone(),
             transaction_status_sender,
             rewards_recorder_sender,
+            genesis_config: tvu_config.genesis_config,
         };
 
         let (replay_stage, root_bank_receiver) = ReplayStage::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -316,7 +316,7 @@ impl Validator {
             std::thread::park();
         }
 
-        let poh_config = Arc::new(genesis_config.poh_config);
+        let poh_config = Arc::new(genesis_config.poh_config.clone());
         let (mut poh_recorder, entry_receiver) = PohRecorder::new_with_clear_signal(
             bank.tick_height(),
             bank.last_blockhash(),
@@ -443,6 +443,7 @@ impl Validator {
                 shred_version: node.info.shred_version,
                 trusted_validators: config.trusted_validators.clone(),
                 accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
+                genesis_config,
             },
         );
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -20,7 +20,7 @@ use solana_runtime::{
     transaction_batch::TransactionBatch,
 };
 use solana_sdk::{
-    clock::{Slot, MAX_RECENT_BLOCKHASHES},
+    clock::{Slot, MAX_PROCESSING_AGE},
     genesis_config::GenesisConfig,
     hash::Hash,
     pubkey::Pubkey,
@@ -70,7 +70,7 @@ fn execute_batch(
         balances,
     ) = batch.bank().load_execute_and_commit_transactions(
         batch,
-        MAX_RECENT_BLOCKHASHES,
+        MAX_PROCESSING_AGE,
         transaction_status_sender.is_some(),
     );
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -20,7 +20,7 @@ use solana_runtime::{
     transaction_batch::TransactionBatch,
 };
 use solana_sdk::{
-    clock::{Slot, MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES},
+    clock::{Epoch, Slot, MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES},
     genesis_config::{GenesisConfig, OperatingMode},
     hash::Hash,
     pubkey::Pubkey,
@@ -57,7 +57,7 @@ fn first_err(results: &[Result<()>]) -> Result<()> {
     Ok(())
 }
 
-const MAX_AGE_CORRECTION_EPOCH: u64 = 14;
+const MAX_AGE_CORRECTION_EPOCH: Epoch = 14;
 
 fn execute_batch(
     batch: &TransactionBatch,


### PR DESCRIPTION
Manual backport of #9423!

According to [this transition plan](https://github.com/solana-labs/solana/pull/9423#issuecomment-612160763):

> on v1.0, `execute_batch()` checks for `OperatingMode::Stable` and uses the old or new value depending on the epoch, so we give mainnet-beta validators an epoch to upgrade.

