### PR TITLE
Reduce cluster-info metrics.

### DIFF
--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -10,7 +10,11 @@ use solana_ledger::shred::Shred;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::timestamp;
 use std::sync::RwLock;
-use std::{collections::HashMap, net::UdpSocket, sync::Arc, time::Instant};
+use std::{
+    collections::HashMap,
+    net::UdpSocket,
+    sync::{atomic::AtomicU64, Arc},
+};
 use test::Bencher;
 
 #[bench]
@@ -35,6 +39,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     let cluster_info = Arc::new(RwLock::new(cluster_info));
     let (peers, peers_and_stakes) = get_broadcast_peers(&cluster_info, Some(stakes.clone()));
     let shreds = Arc::new(shreds);
+    let last_datapoint = Arc::new(AtomicU64::new(0));
     bencher.iter(move || {
         let shreds = shreds.clone();
         broadcast_shreds(
@@ -42,7 +47,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
             &shreds,
             &peers_and_stakes,
             &peers,
-            &mut Instant::now(),
+            &last_datapoint,
             &mut 0,
         )
         .unwrap();

--- a/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
+++ b/core/src/broadcast_stage/fail_entry_verification_broadcast_run.rs
@@ -87,7 +87,7 @@ impl BroadcastRun for FailEntryVerificationBroadcastRun {
             &shreds,
             &peers_and_stakes,
             &peers,
-            &mut Instant::now(),
+            &Arc::new(AtomicU64::new(0)),
             &mut send_mmsg_total,
         )?;
 

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -34,7 +34,7 @@ pub struct StandardBroadcastRun {
     slot_broadcast_start: Option<Instant>,
     keypair: Arc<Keypair>,
     shred_version: u16,
-    last_datapoint_submit: Instant,
+    last_datapoint_submit: Arc<AtomicU64>,
 }
 
 impl StandardBroadcastRun {
@@ -46,7 +46,7 @@ impl StandardBroadcastRun {
             slot_broadcast_start: None,
             keypair,
             shred_version,
-            last_datapoint_submit: Instant::now(),
+            last_datapoint_submit: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -269,7 +269,7 @@ impl StandardBroadcastRun {
             &shreds,
             &peers_and_stakes,
             &peers,
-            &mut self.last_datapoint_submit,
+            &self.last_datapoint_submit,
             &mut send_mmsg_total,
         )?;
 


### PR DESCRIPTION
#### Problem

Multiple broadcast threads are reporting the same identical metrics.

#### Summary of Changes

Use an atomic to only have 1 thread submit each second.

Fixes #
