### PR TITLE
Remove rpc-test agent filter

### DIFF
--- a/ci/buildkite-tests.yml
+++ b/ci/buildkite-tests.yml
@@ -21,8 +21,6 @@ steps:
     name: "stable"
     timeout_in_minutes: 60
     artifact_paths: "log-*.txt"
-    agents:
-      - "queue=rpc-test-capable"
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-move.sh"
     name: "move"
     timeout_in_minutes: 20
@@ -33,5 +31,3 @@ steps:
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
     name: "coverage"
     timeout_in_minutes: 30
-    agents:
-      - "queue=rpc-test-capable"


### PR DESCRIPTION
#### Problem
We were limiting certain CI test steps to Azure nodes from when they were less reliable on non-Azure nodes.  Now that Azure CI is going offline and the issue should be resolved, remove this artifact.

#### Summary of Changes
Allow `queue=default` machines to run all tests other than those requiring `cuda`