### PR TITLE
Reorder CI jobs to allow for more concurrent PRs

### DIFF
--- a/ci/buildkite-secondary.yml
+++ b/ci/buildkite-secondary.yml
@@ -18,3 +18,6 @@ steps:
   - command: "ci/publish-docs.sh"
     timeout_in_minutes: 15
     name: "publish docs"
+  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-move.sh"
+    name: "move"
+    timeout_in_minutes: 20

--- a/ci/buildkite-tests.yml
+++ b/ci/buildkite-tests.yml
@@ -5,9 +5,16 @@ steps:
   - command: "ci/shellcheck.sh"
     name: "shellcheck"
     timeout_in_minutes: 5
-
   - wait
-
+  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
+    name: "coverage"
+    timeout_in_minutes: 30
+  - wait
+  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
+    name: "stable"
+    timeout_in_minutes: 60
+    artifact_paths: "log-*.txt"
+  - wait
   - command: "ci/test-stable-perf.sh"
     name: "stable-perf"
     timeout_in_minutes: 40
@@ -17,17 +24,7 @@ steps:
   - command: "ci/test-bench.sh"
     name: "bench"
     timeout_in_minutes: 30
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-stable.sh"
-    name: "stable"
-    timeout_in_minutes: 60
-    artifact_paths: "log-*.txt"
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-move.sh"
-    name: "move"
-    timeout_in_minutes: 20
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_stable_docker_image ci/test-local-cluster.sh"
     name: "local-cluster"
     timeout_in_minutes: 45
     artifact_paths: "log-*.txt"
-  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-coverage.sh"
-    name: "coverage"
-    timeout_in_minutes: 30


### PR DESCRIPTION
* `move` goes to secondary, because we're not actively doing much with it right now
* `coverage` must pass first, then `stable`, and then the PR is eligible for perf/bench/local-cluster.  This will hopefully filter out red PRs and unlock machines faster