### PR TITLE
Print signature as part of progress spinner

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -998,14 +998,15 @@ impl RpcClient {
         let mut confirmations = 0;
 
         let progress_bar = new_spinner_progress_bar();
-        progress_bar.set_message(&format!(
-            "[{}/{}] Waiting for confirmations",
-            confirmations,
-            MAX_LOCKOUT_HISTORY + 1,
-        ));
 
         let mut send_retries = 20;
         let signature = loop {
+            progress_bar.set_message(&format!(
+                "[{}/{}] Finalizing transaction {}",
+                confirmations,
+                MAX_LOCKOUT_HISTORY + 1,
+                transaction.signatures[0],
+            ));
             let mut status_retries = 15;
             let (signature, status) = loop {
                 let signature = self.send_transaction(transaction)?;
@@ -1066,9 +1067,10 @@ impl RpcClient {
                 return Ok(signature);
             }
             progress_bar.set_message(&format!(
-                "[{}/{}] Waiting for confirmations",
+                "[{}/{}] Finalizing transaction {}",
                 confirmations + 1,
                 MAX_LOCKOUT_HISTORY + 1,
+                signature,
             ));
             sleep(Duration::from_millis(500));
             confirmations = self.get_num_blocks_since_signature_confirmation(&signature)?;


### PR DESCRIPTION
#### Problem
The progress bar in the CLI could be a little better. Currently it reads `[##/32] Waiting for confirmations`; user probably doesn't know what a confirmation is. Also, it is tedious to have to wait until the transaction is fully confirmed to get the signature.

#### Summary of Changes
- Reword to read `[##/32] Finalizing transaction with signature <SIGNATURE>`
Note: if the terminal isn't wide enough, the message doesn't wrap, so the signature may be cut off. Indicatif doesn't seem to offer a way around this; running onto a 2nd line (with `{msg}` template, for example) breaks the dynamic update of the message.

Toward #9192 
Fixes: irritating wait for signature from Cli
