### PR TITLE
Add append-vec subcommand & another env knob

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4340,7 +4340,8 @@ name = "solana-ledger-tool"
 version = "1.2.0"
 dependencies = [
  "assert_cmd",
- "bs58 0.3.1",
+ "base64",
+ "bs58",
  "clap",
  "histogram",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,6 +3934,7 @@ name = "solana-cli"
 version = "1.2.0"
 dependencies = [
  "Inflector",
+ "base64 0.12.0",
  "bincode",
  "bs58 0.3.1",
  "chrono",
@@ -3951,6 +3952,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_yaml",
  "solana-budget-program",
  "solana-clap-utils",
  "solana-cli-config",
@@ -3990,6 +3992,7 @@ name = "solana-client"
 version = "1.2.0"
 dependencies = [
  "assert_matches",
+ "base64 0.12.0",
  "bincode",
  "bs58 0.3.1",
  "indicatif",
@@ -4340,8 +4343,7 @@ name = "solana-ledger-tool"
 version = "1.2.0"
 dependencies = [
  "assert_cmd",
- "base64",
- "bs58",
+ "bs58 0.3.1",
  "clap",
  "histogram",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://solana.com/"
 
 [dependencies]
 bincode = "1.2.1"
+base64 = "0.12.0"
 bs58 = "0.3.1"
 chrono = { version = "0.4.11", features = ["serde"] }
 clap = "2.33.0"
@@ -27,6 +28,7 @@ reqwest = { version = "0.10.4", default-features = false, features = ["blocking"
 serde = "1.0.110"
 serde_derive = "1.0.103"
 serde_json = "1.0.53"
+serde_yaml = "0.8.11"
 solana-budget-program = { path = "../programs/budget", version = "1.2.0" }
 solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-cli-config = { path = "../cli-config", version = "1.2.0" }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1300,14 +1300,14 @@ fn process_show_account(
                     writeln!(
                         &mut account_string,
                         "Data (base58): {}",
-                        &bs58::encode(data.clone()).into_string()
+                        &bs58::encode(data).into_string()
                     )?;
                 }
                 AccountDataOutputFormat::Base64 => {
                     writeln!(
                         &mut account_string,
                         "Data (base64): {}",
-                        &base64::encode(data.clone()).to_string()
+                        &base64::encode(data)
                     )?;
                 }
                 AccountDataOutputFormat::Hex => {

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -235,6 +235,7 @@ pub fn output_accounts(
     account_data_output: AccountDataOutputFormat,
 ) -> String {
     let mut cli_accounts = std::collections::BTreeMap::new();
+
     for (pubkey, account) in accounts {
         let rpc_account = match account_data_output {
             AccountDataOutputFormat::Base58 => RpcAccount::encode_with_base58(account.clone()),
@@ -243,6 +244,7 @@ pub fn output_accounts(
         };
         cli_accounts.insert(pubkey.to_string(), rpc_account);
     }
+
     output_format.formatted_string(&CliAccounts {
         accounts: cli_accounts,
         use_lamports_unit,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -132,6 +132,7 @@ pub fn parse_args<'a>(
         .map(|value| match value {
             "json" => OutputFormat::Json,
             "json-compact" => OutputFormat::JsonCompact,
+            "yaml" => OutputFormat::Yaml,
             _ => unreachable!(),
         })
         .unwrap_or(OutputFormat::Display);
@@ -213,7 +214,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .value_name("FORMAT")
             .global(true)
             .takes_value(true)
-            .possible_values(&["json", "json-compact"])
+            .possible_values(&["json", "json-compact", "yaml"])
             .help("Return information in specified output format"),
     )
     .arg(

--- a/cli/src/offline/blockhash_query.rs
+++ b/cli/src/offline/blockhash_query.rs
@@ -344,7 +344,7 @@ mod tests {
         )
         .unwrap();
         let nonce_pubkey = Pubkey::new(&[4u8; 32]);
-        let rpc_nonce_account = RpcAccount::encode(nonce_account);
+        let rpc_nonce_account = RpcAccount::encode_with_base58(nonce_account);
         let get_account_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
             value: json!(Some(rpc_nonce_account.clone())),

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.2.1"
+base64 = "0.12.0"
 bs58 = "0.3.1"
 indicatif = "0.14.0"
 jsonrpc-core = "14.1.0"

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -538,7 +538,8 @@ impl RpcClient {
                     value: rpc_account,
                 } = serde_json::from_value::<Response<Option<RpcAccount>>>(result_json)?;
                 trace!("Response account {:?} {:?}", pubkey, rpc_account);
-                let account = rpc_account.and_then(|rpc_account| rpc_account.decode().ok());
+                let account =
+                    rpc_account.and_then(|rpc_account| rpc_account.decode_with_base58().ok());
                 Ok(Response {
                     context,
                     value: account,
@@ -606,7 +607,7 @@ impl RpcClient {
                     RpcRequest::GetProgramAccounts,
                 )
             })?;
-            pubkey_accounts.push((pubkey, account.decode().unwrap()));
+            pubkey_accounts.push((pubkey, account.decode_with_base58().unwrap()));
         }
         Ok(pubkey_accounts)
     }

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -72,17 +72,25 @@ pub struct RpcAccount {
 }
 
 impl RpcAccount {
-    pub fn encode(account: Account) -> Self {
+    fn do_encode(account: &Account, data: String) -> Self {
         RpcAccount {
             lamports: account.lamports,
-            data: bs58::encode(account.data.clone()).into_string(),
+            data,
             owner: account.owner.to_string(),
             executable: account.executable,
             rent_epoch: account.rent_epoch,
         }
     }
 
-    pub fn decode(&self) -> std::result::Result<Account, RpcError> {
+    pub fn encode_with_base58(account: Account) -> Self {
+        Self::do_encode(&account, bs58::encode(account.data.clone()).into_string())
+    }
+
+    pub fn encode_with_base64(account: Account) -> Self {
+        Self::do_encode(&account, base64::encode(account.data.clone()))
+    }
+
+    pub fn decode_with_base58(&self) -> std::result::Result<Account, RpcError> {
         Ok(Account {
             lamports: self.lamports,
             data: bs58::decode(self.data.clone()).into_vec().map_err(|_| {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -139,7 +139,12 @@ impl JsonRpcRequestProcessor {
         commitment: Option<CommitmentConfig>,
     ) -> RpcResponse<Option<RpcAccount>> {
         let bank = &*self.bank(commitment)?;
-        pubkey.and_then(|key| new_response(bank, bank.get_account(&key).map(RpcAccount::encode)))
+        pubkey.and_then(|key| {
+            new_response(
+                bank,
+                bank.get_account(&key).map(RpcAccount::encode_with_base58),
+            )
+        })
     }
 
     pub fn get_minimum_balance_for_rent_exemption(
@@ -163,7 +168,7 @@ impl JsonRpcRequestProcessor {
             .into_iter()
             .map(|(pubkey, account)| RpcKeyedAccount {
                 pubkey: pubkey.to_string(),
-                account: RpcAccount::encode(account),
+                account: RpcAccount::encode_with_base58(account),
             })
             .collect())
     }

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -207,7 +207,10 @@ fn filter_account_result(
 ) -> (Box<dyn Iterator<Item = RpcAccount>>, Slot) {
     if let Some((account, fork)) = result {
         if fork != last_notified_slot {
-            return (Box::new(iter::once(RpcAccount::encode(account))), fork);
+            return (
+                Box::new(iter::once(RpcAccount::encode_with_base58(account))),
+                fork,
+            );
         }
     }
     (Box::new(iter::empty()), last_notified_slot)
@@ -237,7 +240,7 @@ fn filter_program_results(
                 .into_iter()
                 .map(|(pubkey, account)| RpcKeyedAccount {
                     pubkey: pubkey.to_string(),
-                    account: RpcAccount::encode(account),
+                    account: RpcAccount::encode_with_base58(account),
                 }),
         ),
         last_notified_slot,

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
+base64 = "0.12.0"
 bs58 = "0.3.1"
 clap = "2.33.0"
 histogram = "*"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
-base64 = "0.12.0"
 bs58 = "0.3.1"
 clap = "2.33.0"
 histogram = "*"

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -591,7 +591,8 @@ fn print_account(pubkey: &Pubkey, account: &Account) {
     println!("  - balance: {} SOL", lamports_to_sol(account.lamports));
     println!("  - owner: '{}'", account.owner);
     println!("  - executable: {}", account.executable);
-    println!("  - data: '{}'", bs58::encode(&account.data).into_string());
+    println!("  - rent_epoch: {}", account.rent_epoch);
+    println!("  - data: '{}'", base64::encode(&account.data));
     println!("  - data_len: {}", data_len);
 }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -601,7 +601,7 @@ fn print_append_vec_accounts(paths: &[String]) {
         .iter()
         .map(|path| {
             let file_size = std::fs::metadata(&path).unwrap().len() as usize;
-            let mut append_vec = AppendVec::new_empty_map(file_size);
+            let mut append_vec = AppendVec::new_empty_map_ro(file_size);
             // ignore sanitization because we can't do so properly without AccountsDB
             let _ignored = append_vec.set_file(Path::new(path));
             append_vec
@@ -628,9 +628,7 @@ fn print_bank_accounts(bank: &Bank, include_sysvars: bool) {
     let accounts: BTreeMap<_, _> = bank
         .get_program_accounts(None)
         .into_iter()
-        .filter(|(pubkey, _account)| {
-            include_sysvars || !solana_sdk::sysvar::is_sysvar_id(pubkey)
-        })
+        .filter(|(pubkey, _account)| include_sysvars || !solana_sdk::sysvar::is_sysvar_id(pubkey))
         .collect();
 
     println!("---");

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -17,8 +17,8 @@ use solana_ledger::{
 };
 use solana_runtime::{append_vec::AppendVec, bank::Bank};
 use solana_sdk::{
-    account::Account, clock::Slot, genesis_config::GenesisConfig, native_token::lamports_to_sol, pubkey::Pubkey,
-    shred_version::compute_shred_version,
+    account::Account, clock::Slot, genesis_config::GenesisConfig, native_token::lamports_to_sol,
+    pubkey::Pubkey, shred_version::compute_shred_version,
 };
 use solana_vote_program::vote_state::VoteState;
 use std::{

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -8,7 +8,7 @@ use solana_sdk::{
     pubkey::Pubkey,
 };
 use std::{
-    fmt,
+    env, fmt,
     fs::{remove_file, OpenOptions},
     io,
     io::{Cursor, Seek, SeekFrom, Write},
@@ -117,6 +117,10 @@ pub struct AppendVec {
 
 impl Drop for AppendVec {
     fn drop(&mut self) {
+        if env::var("SOLANA_DISABLE_DEAD_APPEND_VEC_REMOVAL").is_ok() {
+            return;
+        }
+
         let _ignored = remove_file(&self.path);
     }
 }
@@ -176,7 +180,7 @@ impl AppendVec {
     }
 
     #[allow(clippy::mutex_atomic)]
-    fn new_empty_map(current_len: usize) -> Self {
+    pub fn new_empty_map(current_len: usize) -> Self {
         let map = MmapMut::map_anon(1).expect("failed to map the data file");
 
         AppendVec {

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -598,6 +598,13 @@ pub mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Unable to open data path")]
+    fn test_append_vec_new_not_existing() {
+        let path = get_append_vec_path("test_append_vec_new_not_existing");
+        let _av = AppendVec::new(&path.path, false, 1);
+    }
+
+    #[test]
     fn test_append_vec_set_file_bad_size() {
         let file = get_append_vec_path("test_append_vec_set_file_bad_size");
         let path = &file.path;
@@ -616,7 +623,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_append_vec_new_empty_tmp_rw() {
+    fn test_append_vec_new_empty_map_rw() {
         let file = get_append_vec_path("test_append_vec_new_empty_map_rw");
         let path = &file.path;
 
@@ -630,7 +637,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_append_vec_new_empty_tmp_ro() {
+    fn test_append_vec_new_empty_map_ro() {
         let file = get_append_vec_path("test_append_vec_new_empty_map_ro");
         let path = &file.path;
 


### PR DESCRIPTION
#### Problem

There is no handy way to display the content of `AppendVec` and there is no easy way to view historical old state of written accounts by `solana-validator`. Both are handy when debugging.

#### Summary of Changes

- Add such a subcommand to `ledger-tool` and such a environment variable, respectively.

Needed this while investigation toward to #9423 / #9357 
