### PR TITLE
RPC: Add health check URI

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -265,6 +265,7 @@ impl Validator {
                     ledger_path,
                     storage_state.clone(),
                     validator_exit.clone(),
+                    config.trusted_validators.clone(),
                 ),
                 PubSubService::new(
                     &subscriptions,

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -115,6 +115,16 @@ Many methods that take a commitment parameter return an RpcResponse JSON object 
 * `value` : The value returned by the operation itself.
 
 
+## Health Check
+Although not a JSON RPC API, a `GET /heath` at the RPC HTTP Endpoint provides a
+health-check mechanism for use by load balancers or other network
+infrastructure.  This request will always return a HTTP 200 OK response with a body of
+"ok" or "behind" based on the following conditions:
+1. If one or more `--trusted-validator` arguments are provided to `solana-validator`, "ok" is returned
+   when the node has within `HEALTH_CHECK_SLOT_DISTANCE` slots of the highest trusted validator,
+   otherwise "behind" is returned.
+2. "ok" is always returned if no trusted validators are provided.
+
 ## JSON RPC API Reference
 
 ### getAccountInfo


### PR DESCRIPTION
RPC load balancers need a mechanism to exclude unhealthy nodes from their backend.  Simply testing for a functioning RPC port is insufficient because the node may be thousands of slots behind, trying to catchup after a restart.

`GET /health` will return "ok" if the node has no trusted validators.  If there are trusted validators, "ok" is returned when the node is within 100 slots of the highest trusted validator, otherwise "behind" is returned.
