### PR TITLE
Decouple accounts hash calculation from snapshot hash

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -20,7 +20,7 @@ use solana_ledger::{
     blockstore_processor::{self, BlockstoreProcessorError, TransactionStatusSender},
     entry::VerifyRecyclers,
     leader_schedule_cache::LeaderScheduleCache,
-    snapshot_package::SnapshotPackageSender,
+    snapshot_package::AccountsPackageSender,
 };
 use solana_measure::thread_mem_usage;
 use solana_metrics::inc_new_counter_info;
@@ -97,7 +97,7 @@ pub struct ReplayStageConfig {
     pub subscriptions: Arc<RpcSubscriptions>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
     pub latest_root_senders: Vec<Sender<Slot>>,
-    pub accounts_hash_sender: Option<SnapshotPackageSender>,
+    pub accounts_hash_sender: Option<AccountsPackageSender>,
     pub block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     pub transaction_status_sender: Option<TransactionStatusSender>,
     pub rewards_recorder_sender: Option<RewardsRecorderSender>,
@@ -690,7 +690,7 @@ impl ReplayStage {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         root_bank_sender: &Sender<Vec<Arc<Bank>>>,
         lockouts_sender: &Sender<CommitmentAggregationData>,
-        accounts_hash_sender: &Option<SnapshotPackageSender>,
+        accounts_hash_sender: &Option<AccountsPackageSender>,
         latest_root_senders: &[Sender<Slot>],
         all_pubkeys: &mut HashSet<Rc<Pubkey>>,
         subscriptions: &Arc<RpcSubscriptions>,
@@ -1485,7 +1485,7 @@ impl ReplayStage {
         new_root: u64,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
-        accounts_hash_sender: &Option<SnapshotPackageSender>,
+        accounts_hash_sender: &Option<AccountsPackageSender>,
         all_pubkeys: &mut HashSet<Rc<Pubkey>>,
     ) {
         let old_epoch = bank_forks.read().unwrap().root_bank().epoch();

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -1,5 +1,5 @@
 use crate::cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES};
-use solana_ledger::{snapshot_package::SnapshotPackageReceiver, snapshot_utils};
+use solana_ledger::{snapshot_package::AccountsPackageReceiver, snapshot_utils};
 use solana_sdk::{clock::Slot, hash::Hash};
 use std::{
     sync::{
@@ -17,7 +17,7 @@ pub struct SnapshotPackagerService {
 
 impl SnapshotPackagerService {
     pub fn new(
-        snapshot_package_receiver: SnapshotPackageReceiver,
+        snapshot_package_receiver: AccountsPackageReceiver,
         starting_snapshot_hash: Option<(Slot, Hash)>,
         exit: &Arc<AtomicBool>,
         cluster_info: &Arc<RwLock<ClusterInfo>>,
@@ -86,7 +86,7 @@ mod tests {
     use bincode::serialize_into;
     use solana_ledger::bank_forks::CompressionType;
     use solana_ledger::{
-        snapshot_package::SnapshotPackage,
+        snapshot_package::AccountsPackage,
         snapshot_utils::{self, SNAPSHOT_STATUS_CACHE_FILE_NAME},
     };
     use solana_runtime::{
@@ -172,7 +172,8 @@ mod tests {
             &(42, Hash::default()),
             &CompressionType::Bzip2,
         );
-        let snapshot_package = SnapshotPackage::new(
+        let snapshot_package = AccountsPackage::new(
+            5,
             5,
             vec![],
             link_snapshots_dir,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -81,6 +81,7 @@ pub struct ValidatorConfig {
     pub accounts_hash_fault_injection_slots: u64, // 0 = no fault injection
     pub frozen_accounts: Vec<Pubkey>,
     pub no_rocksdb_compaction: bool,
+    pub accounts_hash_interval_slots: u64,
 }
 
 impl Default for ValidatorConfig {
@@ -107,6 +108,7 @@ impl Default for ValidatorConfig {
             accounts_hash_fault_injection_slots: 0,
             frozen_accounts: vec![],
             no_rocksdb_compaction: false,
+            accounts_hash_interval_slots: std::u64::MAX,
         }
     }
 }
@@ -622,6 +624,7 @@ fn new_banks_from_blockstore(
     leader_schedule_cache.set_fixed_leader_schedule(config.fixed_leader_schedule.clone());
 
     bank_forks.set_snapshot_config(config.snapshot_config.clone());
+    bank_forks.set_accounts_hash_interval_slots(config.accounts_hash_interval_slots);
 
     (
         genesis_config,

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -38,7 +38,7 @@ mod tests {
         genesis_config_info: GenesisConfigInfo,
     }
 
-    fn setup_snapshot_test(snapshot_interval_slots: usize) -> SnapshotTestConfig {
+    fn setup_snapshot_test(snapshot_interval_slots: u64) -> SnapshotTestConfig {
         let accounts_dir = TempDir::new().unwrap();
         let snapshot_dir = TempDir::new().unwrap();
         let snapshot_output_path = TempDir::new().unwrap();
@@ -50,6 +50,7 @@ mod tests {
         );
         bank0.freeze();
         let mut bank_forks = BankForks::new(0, bank0);
+        bank_forks.accounts_hash_interval_slots = snapshot_interval_slots;
 
         let snapshot_config = SnapshotConfig {
             snapshot_interval_slots,
@@ -265,7 +266,7 @@ mod tests {
             };
 
             bank_forks
-                .generate_snapshot(slot, &vec![], &package_sender)
+                .generate_accounts_package(slot, &vec![], &package_sender)
                 .unwrap();
 
             if slot == saved_slot as u64 {
@@ -371,7 +372,7 @@ mod tests {
             let (snapshot_sender, _snapshot_receiver) = channel();
             // Make sure this test never clears bank.slots_since_snapshot
             let mut snapshot_test_config =
-                setup_snapshot_test(add_root_interval * num_set_roots * 2);
+                setup_snapshot_test((add_root_interval * num_set_roots * 2) as u64);
             let mut current_bank = snapshot_test_config.bank_forks[0].clone();
             let snapshot_sender = Some(snapshot_sender);
             for _ in 0..num_set_roots {

--- a/ledger/src/snapshot_package.rs
+++ b/ledger/src/snapshot_package.rs
@@ -8,13 +8,14 @@ use std::{
 };
 use tempfile::TempDir;
 
-pub type SnapshotPackageSender = Sender<SnapshotPackage>;
-pub type SnapshotPackageReceiver = Receiver<SnapshotPackage>;
-pub type SnapshotPackageSendError = SendError<SnapshotPackage>;
+pub type AccountsPackageSender = Sender<AccountsPackage>;
+pub type AccountsPackageReceiver = Receiver<AccountsPackage>;
+pub type AccountsPackageSendError = SendError<AccountsPackage>;
 
 #[derive(Debug)]
-pub struct SnapshotPackage {
+pub struct AccountsPackage {
     pub root: Slot,
+    pub block_height: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
     pub storages: SnapshotStorages,
@@ -23,9 +24,10 @@ pub struct SnapshotPackage {
     pub compression: CompressionType,
 }
 
-impl SnapshotPackage {
+impl AccountsPackage {
     pub fn new(
         root: Slot,
+        block_height: u64,
         slot_deltas: Vec<BankSlotDelta>,
         snapshot_links: TempDir,
         storages: SnapshotStorages,
@@ -35,6 +37,7 @@ impl SnapshotPackage {
     ) -> Self {
         Self {
             root,
+            block_height,
             slot_deltas,
             snapshot_links,
             storages,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1260,7 +1260,7 @@ struct SnapshotValidatorConfig {
 }
 
 fn setup_snapshot_validator_config(
-    snapshot_interval_slots: usize,
+    snapshot_interval_slots: u64,
     num_account_paths: usize,
 ) -> SnapshotValidatorConfig {
     // Create the snapshot config
@@ -1281,6 +1281,7 @@ fn setup_snapshot_validator_config(
     validator_config.rpc_config.enable_validator_exit = true;
     validator_config.snapshot_config = Some(snapshot_config);
     validator_config.account_paths = account_storage_paths;
+    validator_config.accounts_hash_interval_slots = snapshot_interval_slots;
 
     SnapshotValidatorConfig {
         _snapshot_dir: snapshot_dir,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -398,6 +398,15 @@ fn download_then_check_genesis_hash(
     Ok(genesis_config.hash())
 }
 
+fn is_snapshot_config_invalid(
+    snapshot_interval_slots: u64,
+    accounts_hash_interval_slots: u64,
+) -> bool {
+    snapshot_interval_slots != 0
+        && (snapshot_interval_slots < accounts_hash_interval_slots
+            || snapshot_interval_slots % accounts_hash_interval_slots != 0)
+}
+
 #[allow(clippy::cognitive_complexity)]
 pub fn main() {
     let default_dynamic_port_range =
@@ -607,6 +616,14 @@ pub fn main() {
                 .takes_value(true)
                 .default_value("100")
                 .help("Number of slots between generating snapshots, 0 to disable snapshots"),
+        )
+        .arg(
+            clap::Arg::with_name("accounts_hash_interval_slots")
+                .long("accounts-hash-slots")
+                .value_name("ACCOUNTS_HASH_INTERVAL_SLOTS")
+                .takes_value(true)
+                .default_value("100")
+                .help("Number of slots between generating accounts hash."),
         )
         .arg(
             clap::Arg::with_name("limit_ledger_size")
@@ -849,7 +866,7 @@ pub fn main() {
         })
         .collect();
 
-    let snapshot_interval_slots = value_t_or_exit!(matches, "snapshot_interval_slots", usize);
+    let snapshot_interval_slots = value_t_or_exit!(matches, "snapshot_interval_slots", u64);
     let snapshot_path = ledger_path.clone().join("snapshot");
     fs::create_dir_all(&snapshot_path).unwrap_or_else(|err| {
         eprintln!(
@@ -873,12 +890,29 @@ pub fn main() {
         snapshot_interval_slots: if snapshot_interval_slots > 0 {
             snapshot_interval_slots
         } else {
-            std::usize::MAX
+            std::u64::MAX
         },
         snapshot_path,
         snapshot_package_output_path: ledger_path.clone(),
         compression: snapshot_compression,
     });
+
+    validator_config.accounts_hash_interval_slots =
+        value_t_or_exit!(matches, "accounts_hash_interval_slots", u64);
+    if validator_config.accounts_hash_interval_slots == 0 {
+        eprintln!("Accounts hash interval should not be 0.");
+        exit(1);
+    }
+    if is_snapshot_config_invalid(
+        snapshot_interval_slots,
+        validator_config.accounts_hash_interval_slots,
+    ) {
+        eprintln!("Invalid snapshot interval provided ({}), must be a multiple of accounts_hash_interval_slots ({})",
+            snapshot_interval_slots,
+            validator_config.accounts_hash_interval_slots,
+        );
+        exit(1);
+    }
 
     if matches.is_present("limit_ledger_size") {
         let limit_ledger_size = value_t_or_exit!(matches, "limit_ledger_size", u64);
@@ -1181,4 +1215,18 @@ pub fn main() {
     info!("Validator initialized");
     validator.join().expect("validator exit");
     info!("Validator exiting..");
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_interval_check() {
+        assert!(!is_snapshot_config_invalid(0, 100));
+        assert!(is_snapshot_config_invalid(1, 100));
+        assert!(is_snapshot_config_invalid(230, 100));
+        assert!(!is_snapshot_config_invalid(500, 100));
+        assert!(!is_snapshot_config_invalid(5, 5));
+    }
 }


### PR DESCRIPTION
#### Problem

Accounts hash and snapshot hash are tied to the same rate, but the node operator may want to create snapshots at a different rate. Also accounts cleaning functions are tied to creating snapshots and not being run otherwise.

#### Summary of Changes

Decouple the snapshot creation rate and accounts clean and accounts hashing rate.

Fixes #
