### PR TITLE
Rpc: Speed up getBlockTime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,7 +4505,6 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-bpf-loader-program 1.2.0",
  "solana-logger 1.2.0",
  "solana-measure 1.2.0",
  "solana-metrics 1.2.0",

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -66,7 +66,7 @@ thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
 pub const MAX_TURBINE_PROPAGATION_IN_MS: u64 = 100;
 pub const MAX_TURBINE_DELAY_IN_TICKS: u64 = MAX_TURBINE_PROPAGATION_IN_MS / MS_PER_TICK;
-const TIMESTAMP_SLOT_RANGE: usize = 50;
+const TIMESTAMP_SLOT_RANGE: usize = 16;
 
 // An upper bound on maximum number of data shreds we can handle in a slot
 // 32K shreds would allow ~320K peak TPS


### PR DESCRIPTION
#### Problem
`getBlockTime` rpc endpoint takes a long time to respond; sometimes stalls indefinitely.
The `Blockstore::get_timestamp_slots()` method depends on a RootedSlotIterator starting at the lowest_nonzero_slot and filtering every root thereafter. This takes a long time, and takes longer the more ledger history is retained.

#### Summary of Changes
- Refactor `get_timestamp_slots()`, using blockstore's column iterator to jump to an intelligent starting point, and only filter `TIMESTAMP_SLOT_RANGE` roots. On my local machine with a small ledger, this drops the duration of this method from 10ms to 100us. More importantly, the duration of this method stays steady over time, instead of growing with the number of roots in the ledger.
- Also reduce timestamp_slot_range, based on empirical data from mainnet-beta and testnet. No need to deserialize slots that are very unlikely to contain timestamped Votes.
- Also also add metrics to time `getBlockTime` operations, and to monitor quantity of rpc calls that hit blockstore apis

Fixes #9034
