### PR TITLE
docs/build-cli-usage.sh: Use $rust_stable

### DIFF
--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -3,7 +3,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-usage=$(cargo -q run -p solana-cli -- -C ~/.foo --help | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')
+usage=$(cargo +"$rust_stable" -q run -p solana-cli -- -C ~/.foo --help | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')
 
 out=${1:-src/cli/usage.md}
 
@@ -31,6 +31,6 @@ in_subcommands=0
 while read -r subcommand rest; do
   [[ $subcommand == "SUBCOMMANDS:" ]] && in_subcommands=1 && continue
   if ((in_subcommands)); then
-      section "$(cargo -q run -p solana-cli -- help "$subcommand" | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')" "####" >> "$out"
+      section "$(cargo +"$rust_stable" -q run -p solana-cli -- help "$subcommand" | sed -e 's|'"$HOME"'|~|g' -e 's/[[:space:]]\+$//')" "####" >> "$out"
   fi
 done <<<"$usage">>"$out"


### PR DESCRIPTION
Hopefully fixes test-check.sh failure on pacman.

eg: https://buildkite.com/solana-labs/solana/builds/22690#a781124f-61a9-4ab8-b423-1f225c8f8c87/1907