### PR TITLE
Introduce eager rent collection

### DIFF
--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -20,6 +20,7 @@ mod tests {
     };
     use solana_sdk::{
         clock::Slot,
+        genesis_config::GenesisConfig,
         hash::hashv,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
@@ -95,6 +96,7 @@ mod tests {
                 &CompressionType::Bzip2,
             ),
             CompressionType::Bzip2,
+            &GenesisConfig::default(),
         )
         .unwrap();
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -60,6 +60,7 @@ pub fn load(
                     &snapshot_config.snapshot_path,
                     &archive_filename,
                     compression,
+                    genesis_config,
                 )
                 .expect("Load from snapshot failed");
 

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -15,7 +15,7 @@ use solana_runtime::{
         MAX_SNAPSHOT_DATA_FILE_SIZE,
     },
 };
-use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
+use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash, pubkey::Pubkey};
 use std::{
     cmp::Ordering,
     fs::{self, File},
@@ -451,6 +451,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     snapshot_path: &PathBuf,
     snapshot_tar: P,
     compression: CompressionType,
+    genesis_config: &GenesisConfig,
 ) -> Result<Bank> {
     // Untar the snapshot into a temp directory under `snapshot_config.snapshot_path()`
     let unpack_dir = tempfile::tempdir_in(snapshot_path)?;
@@ -470,6 +471,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
         frozen_account_pubkeys,
         &unpacked_snapshots_dir,
         unpacked_accounts_dir,
+        genesis_config,
     )?;
 
     if !bank.verify_snapshot_bank() {
@@ -615,6 +617,7 @@ fn rebuild_bank_from_snapshots<P>(
     frozen_account_pubkeys: &[Pubkey],
     unpacked_snapshots_dir: &PathBuf,
     append_vecs_path: P,
+    genesis_config: &GenesisConfig,
 ) -> Result<Bank>
 where
     P: AsRef<Path>,
@@ -643,6 +646,7 @@ where
                     )));
                 }
             };
+            bank.operating_mode = Some(genesis_config.operating_mode);
             info!("Rebuilding accounts...");
             let rc = bank::BankRc::from_stream(
                 account_paths,

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -647,7 +647,6 @@ where
                 }
             };
             bank.operating_mode = Some(genesis_config.operating_mode);
-            bank.genesis_hash = Some(genesis_config.hash());
             info!("Rebuilding accounts...");
             let rc = bank::BankRc::from_stream(
                 account_paths,

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -647,6 +647,7 @@ where
                 }
             };
             bank.operating_mode = Some(genesis_config.operating_mode);
+            bank.genesis_hash = Some(genesis_config.hash());
             info!("Rebuilding accounts...");
             let rc = bank::BankRc::from_stream(
                 account_paths,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -476,6 +476,25 @@ impl Accounts {
         )
     }
 
+    pub fn load_to_collect_rent_eargerly<R: std::ops::RangeBounds<solana_sdk::pubkey::Pubkey>>(
+        &self,
+        ancestors: &HashMap<Slot, usize>,
+        range: R,
+    ) -> Vec<(Pubkey, Account)> {
+        self.accounts_db.scan_accounts_under_range(
+            ancestors,
+            range,
+            |collector: &mut Vec<(Pubkey, Account)>, option| {
+                if let Some(data) = option
+                    .filter(|(_, account, _)| account.lamports != 0)
+                    .map(|(pubkey, account, _slot)| (*pubkey, account))
+                {
+                    collector.push(data)
+                }
+            },
+        )
+    }
+
     /// Slow because lock is held for 1 operation instead of many
     pub fn store_slow(&self, slot: Slot, pubkey: &Pubkey, account: &Account) {
         self.accounts_db.store(slot, &[(pubkey, account)]);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -27,6 +27,7 @@ use solana_sdk::{
 use std::{
     collections::{HashMap, HashSet},
     io::{BufReader, Error as IOError, Read},
+    ops::RangeBounds,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, RwLock},
 };
@@ -455,6 +456,19 @@ impl Accounts {
         }
     }
 
+    fn load_while_filtering<F: Fn(&Account) -> bool>(
+        collector: &mut Vec<(Pubkey, Account)>,
+        option: Option<(&Pubkey, Account, Slot)>,
+        filter: F,
+    ) {
+        if let Some(data) = option
+            .filter(|(_, account, _)| filter(account))
+            .map(|(pubkey, account, _slot)| (*pubkey, account))
+        {
+            collector.push(data)
+        }
+    }
+
     pub fn load_by_program(
         &self,
         ancestors: &Ancestors,
@@ -463,34 +477,24 @@ impl Accounts {
         self.accounts_db.scan_accounts(
             ancestors,
             |collector: &mut Vec<(Pubkey, Account)>, option| {
-                if let Some(data) = option
-                    .filter(|(_, account, _)| {
-                        (program_id.is_none() || Some(&account.owner) == program_id)
-                            && account.lamports != 0
-                    })
-                    .map(|(pubkey, account, _slot)| (*pubkey, account))
-                {
-                    collector.push(data)
-                }
+                Self::load_while_filtering(collector, option, |account| {
+                    (program_id.is_none() || Some(&account.owner) == program_id)
+                        && account.lamports != 0
+                })
             },
         )
     }
 
-    pub fn load_to_collect_rent_eargerly<R: std::ops::RangeBounds<solana_sdk::pubkey::Pubkey>>(
+    pub fn load_to_collect_rent_eargerly<R: RangeBounds<Pubkey>>(
         &self,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &Ancestors,
         range: R,
     ) -> Vec<(Pubkey, Account)> {
-        self.accounts_db.scan_accounts_under_range(
+        self.accounts_db.range_scan_accounts(
             ancestors,
             range,
             |collector: &mut Vec<(Pubkey, Account)>, option| {
-                if let Some(data) = option
-                    .filter(|(_, account, _)| account.lamports != 0)
-                    .map(|(pubkey, account, _slot)| (*pubkey, account))
-                {
-                    collector.push(data)
-                }
+                Self::load_while_filtering(collector, option, |account| account.lamports != 0)
             },
         )
     }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -494,6 +494,7 @@ impl Accounts {
             ancestors,
             range,
             |collector: &mut Vec<(Pubkey, Account)>, option| {
+                // THINK ABOUT ZERO LAMPORTS FILTERING RAMIFICATION
                 Self::load_while_filtering(collector, option, |account| account.lamports != 0)
             },
         )

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -486,7 +486,7 @@ impl Accounts {
         )
     }
 
-    pub fn load_to_collect_rent_eargerly<R: RangeBounds<Pubkey>>(
+    pub fn load_to_collect_rent_eagerly<R: RangeBounds<Pubkey>>(
         &self,
         ancestors: &Ancestors,
         range: R,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1122,12 +1122,7 @@ impl AccountsDB {
         collector
     }
 
-    pub fn range_scan_accounts<F, A, R>(
-        &self,
-        ancestors: &Ancestors,
-        range: R,
-        scan_func: F,
-    ) -> A
+    pub fn range_scan_accounts<F, A, R>(&self, ancestors: &Ancestors, range: R, scan_func: F) -> A
     where
         F: Fn(&mut A, Option<(&Pubkey, Account, Slot)>) -> (),
         A: Default,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -47,6 +47,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt,
     io::{BufReader, Cursor, Error as IOError, ErrorKind, Read, Result as IOResult},
+    ops::RangeBounds,
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     sync::{Arc, Mutex, RwLock},
@@ -1130,7 +1131,7 @@ impl AccountsDB {
     where
         F: Fn(&mut A, Option<(&Pubkey, Account, Slot)>) -> (),
         A: Default,
-        R: std::ops::RangeBounds<solana_sdk::pubkey::Pubkey>,
+        R: RangeBounds<Pubkey>,
     {
         let mut collector = A::default();
         let accounts_index = self.accounts_index.read().unwrap();

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1,7 +1,7 @@
 use solana_sdk::{clock::Slot, pubkey::Pubkey};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::{RwLock, RwLockReadGuard},
 };
 
@@ -14,7 +14,7 @@ type AccountMapEntry<T> = (AtomicU64, RwLock<SlotList<T>>);
 
 #[derive(Debug, Default)]
 pub struct AccountsIndex<T> {
-    pub account_maps: HashMap<Pubkey, AccountMapEntry<T>>,
+    pub account_maps: BTreeMap<Pubkey, AccountMapEntry<T>>,
 
     pub roots: HashSet<Slot>,
     pub uncleaned_roots: HashSet<Slot>,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -22,8 +22,7 @@ pub struct AccountsIndex<T> {
 }
 
 impl<'a, T: 'a + Clone> AccountsIndex<T> {
-    /// call func with every pubkey and index visible from a given set of ancestors
-    pub fn do_scan_accounts<F, I>(&self, ancestors: &Ancestors, mut func: F, iter: I)
+    fn do_scan_accounts<F, I>(&self, ancestors: &Ancestors, mut func: F, iter: I)
     where
         F: FnMut(&Pubkey, (&T, Slot)) -> (),
         I: Iterator<Item = (&'a Pubkey, &'a AccountMapEntry<T>)>,
@@ -36,6 +35,7 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
         }
     }
 
+    /// call func with every pubkey and index visible from a given set of ancestors
     pub fn scan_accounts<F>(&self, ancestors: &Ancestors, func: F)
     where
         F: FnMut(&Pubkey, (&T, Slot)) -> (),
@@ -43,6 +43,7 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
         self.do_scan_accounts(ancestors, func, self.account_maps.iter());
     }
 
+    /// call func with every pubkey and index visible from a given set of ancestors with range
     pub fn range_scan_accounts<F, R>(&self, ancestors: &Ancestors, range: R, func: F)
     where
         F: FnMut(&Pubkey, (&T, Slot)) -> (),

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -34,6 +34,23 @@ impl<T: Clone> AccountsIndex<T> {
         }
     }
 
+    pub fn scan_accounts_under_range<F, R>(
+        &self,
+        ancestors: &HashMap<Slot, usize>,
+        range: R,
+        mut func: F,
+    ) where
+        F: FnMut(&Pubkey, (&T, Slot)) -> (),
+        R: std::ops::RangeBounds<solana_sdk::pubkey::Pubkey>,
+    {
+        for (pubkey, list) in self.account_maps.range(range) {
+            let list_r = &list.1.read().unwrap();
+            if let Some(index) = self.latest_slot(ancestors, &list_r) {
+                func(pubkey, (&list_r[index].1, list_r[index].0));
+            }
+        }
+    }
+
     fn get_rooted_entries(&self, slice: SlotSlice<T>) -> SlotList<T> {
         slice
             .iter()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -64,6 +64,7 @@ use std::{
     collections::{HashMap, HashSet},
     io::{BufReader, Cursor, Error as IOError, Read},
     mem,
+    ops::RangeInclusive,
     path::{Path, PathBuf},
     rc::Rc,
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
@@ -1718,7 +1719,7 @@ impl Bank {
 
     fn pubkey_range_by_partition(
         (start_index, end_index, partition_count): Partition,
-    ) -> std::ops::RangeInclusive<Pubkey> {
+    ) -> RangeInclusive<Pubkey> {
         type Prefix = u64;
         const PREFIX_SIZE: usize = mem::size_of::<Prefix>();
         let partition_width = Prefix::max_value() / partition_count;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1694,8 +1694,8 @@ impl Bank {
         }
     }
 
-    fn collect_rent_in_partition(&self, (range_start, range_end, partition_count): Partition) {
-        let subrange = Self::pubkey_range_by_partition(range_start, range_end, partition_count);
+    fn collect_rent_in_partition(&self, partition: Partition) {
+        let subrange = Self::pubkey_range_by_partition(partition);
 
         let accounts = self
             .rc
@@ -1717,9 +1717,7 @@ impl Bank {
     }
 
     fn pubkey_range_by_partition(
-        start_index: PartitionIndex,
-        end_index: PartitionIndex,
-        partition_count: PartitionsPerCycle,
+        (start_index, end_index, partition_count): Partition,
     ) -> std::ops::RangeInclusive<Pubkey> {
         type Prefix = u64;
         const PREFIX_SIZE: usize = mem::size_of::<Prefix>();
@@ -3844,7 +3842,7 @@ mod tests {
 
     #[test]
     fn test_rent_eager_pubkey_range_minimal() {
-        let range = Bank::pubkey_range_by_partition(0, 0, 1);
+        let range = Bank::pubkey_range_by_partition((0, 0, 1));
         assert_eq!(
             range,
             Pubkey::new_from_array([0x00; 32])..=Pubkey::new_from_array([0xff; 32])
@@ -3853,7 +3851,7 @@ mod tests {
 
     #[test]
     fn test_rent_eager_pubkey_range_dividable() {
-        let range = Bank::pubkey_range_by_partition(0, 0, 2);
+        let range = Bank::pubkey_range_by_partition((0, 0, 2));
         assert_eq!(
             range,
             Pubkey::new_from_array([
@@ -3868,7 +3866,7 @@ mod tests {
                 ])
         );
 
-        let range = Bank::pubkey_range_by_partition(0, 1, 2);
+        let range = Bank::pubkey_range_by_partition((0, 1, 2));
         assert_eq!(
             range,
             Pubkey::new_from_array([
@@ -3888,7 +3886,7 @@ mod tests {
     fn test_rent_eager_pubkey_range_not_dividable() {
         solana_logger::setup();
 
-        let range = Bank::pubkey_range_by_partition(0, 0, 3);
+        let range = Bank::pubkey_range_by_partition((0, 0, 3));
         assert_eq!(
             range,
             Pubkey::new_from_array([
@@ -3903,7 +3901,7 @@ mod tests {
                 ])
         );
 
-        let range = Bank::pubkey_range_by_partition(0, 1, 3);
+        let range = Bank::pubkey_range_by_partition((0, 1, 3));
         assert_eq!(
             range,
             Pubkey::new_from_array([
@@ -3918,7 +3916,7 @@ mod tests {
                 ])
         );
 
-        let range = Bank::pubkey_range_by_partition(1, 2, 3);
+        let range = Bank::pubkey_range_by_partition((1, 2, 3));
         assert_eq!(
             range,
             Pubkey::new_from_array([
@@ -3937,7 +3935,7 @@ mod tests {
     #[test]
     fn test_rent_eager_pubkey_range_gap() {
         solana_logger::setup();
-        let range = Bank::pubkey_range_by_partition(120, 1023, 12345);
+        let range = Bank::pubkey_range_by_partition((120, 1023, 12345));
         assert_eq!(
             range,
             Pubkey::new_from_array([

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2641,7 +2641,7 @@ mod tests {
     use super::*;
     use crate::{
         accounts_db::{get_temp_accounts_paths, tests::copy_append_vecs},
-        accounts_index::AncestorList,
+        accounts_index::Ancestors,
         genesis_utils::{
             create_genesis_config_with_leader, GenesisConfigInfo, BOOTSTRAP_VALIDATOR_LAMPORTS,
         },
@@ -3953,7 +3953,7 @@ mod tests {
     }
 
     impl Bank {
-        fn slots_by_pubkey(&self, pubkey: &Pubkey, ancestors: &AncestorList) -> Vec<Slot> {
+        fn slots_by_pubkey(&self, pubkey: &Pubkey, ancestors: &Ancestors) -> Vec<Slot> {
             let accounts_index = self.rc.accounts.accounts_db.accounts_index.read().unwrap();
             let (accounts, _) = accounts_index.get(&pubkey, &ancestors).unwrap();
             accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1753,7 +1753,7 @@ impl Bank {
         let accounts = self
             .rc
             .accounts
-            .load_to_collect_rent_eargerly(&self.ancestors, subrange);
+            .load_to_collect_rent_eagerly(&self.ancestors, subrange);
         let account_count = accounts.len();
 
         // parallelize?

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -85,6 +85,12 @@ pub type Segment = u64;
 ///  some number of Slots.
 pub type Epoch = u64;
 
+/// SlotIndex is an index to the slots of a epoch
+pub type SlotIndex = u64;
+
+/// SlotCount is the number of slots in a epoch
+pub type SlotCount = u64;
+
 /// UnixTimestamp is an approximate measure of real-world time,
 /// expressed as Unix time (ie. seconds since the Unix epoch)
 pub type UnixTimestamp = i64;

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -78,6 +78,14 @@ impl Hash {
     pub fn new(hash_slice: &[u8]) -> Self {
         Hash(<[u8; HASH_BYTES]>::try_from(hash_slice).unwrap())
     }
+
+    pub const fn new_from_array(hash_array: [u8; HASH_BYTES]) -> Self {
+        Self(hash_array)
+    }
+
+    pub fn to_bytes(self) -> [u8; HASH_BYTES] {
+        self.0
+    }
 }
 
 /// Return a Sha256 hash for the given data.


### PR DESCRIPTION
#### Problem

rent-due (!= rent-exempt) accounts are never garbage-collected unless updated (i.e. lazy collection), which accumulates over time and can be a DoS attack vector.

Also, the current rent collection mechanism has some gaming factor due to being lazy. (noted below)

Even more, there is [some UX issue for the lazy rent collection](https://github.com/solana-labs/solana/issues/7413#issuecomment-615136356).

#### Summary of Changes

- scan the whole pubkey domain space over an epoch (or 2 day (if epoch is less than 2 day and not warmed-up); ~not implemented yet~ _implemented_) for each slot progress, while updating all accounts.
  - (cons) **`AccountIndex` was switched from `HashMap` to `BTreeMap` for range queries to realize that**
- (pro) thus, maximum number of `AppendVec` is now bound to the number of slots of given epoch, combined with the recently-introduced per-slot shrinking #9219.
  - Also, this fixes unbound increase of `AccountsIndex.roots`.
- as a side effect, the rent collection schedule is now universally consistent: all existing accounts and newly-created accounts both alike are collected for the next epoch for each epoch exactly once.
  - (pro) technically, we can remove `account.rent_epoch` as a bonus. (`ACCOUNT_STORAGE_OVERHEAD`: 128 -> 120, -6.25% for IO bandwidth)
- the iteration algorithm intentionally designed to be deterministic as a requirement because rent collection generally affects account delta bank hash, distribution, and capitalization. Also it's stete-less as desired to avoid ABI breakage.
- (pro) the system load is well spread across an epoch because we can assume vast of pubkey space is uniformly distributed.
- (pro) this doesn't introduce ABI break; only an epoch-triggered enactment `if` guard is needed.

##### minor problem of current rent colletion

_Also I found that the lazy rent collection is problematic because delayed rent collection doesn't account for past rent fees were different or not._
That means the current calculation is based on the latest rent fee multiple of epochs. it's not the integral of past actual (dynamic) rent fees over epochs.
This means it introduces some gaming much like recently removed `redeem-vote-credits` (#7916):
A validator or an account owner might send 0 lamports to rent-due accounts to collect/save rent when the at-the-time dynamic rent is more profitable.
Although, the dynamic rent isn't still implemented...

##### (cons) new dos vector

An attacker can send lamports to arbitrary address if prepared to burn them so we're vulnerable to a new attack vector of targeted DoS (send so many pubkeys under some subrange corresponding to victim leader's slot), given publicly available deterministic next epoch's leader schedule.
But, I think that's tolerable given that there is already easier attack with similar threat profile: just flood the victim leader by burst TXes for some specific slot.
Still, If forced to mitigate, I think cloning the whole `Pubkey` set is required and then `.iter().chunk(.len() / SLOT_COUNT)`-ing on it.

#### Alternatives:

- scan whole `account_index` and collect rent when new epoch begins
  - (pro) most straightforward to reason and to implement.
  - (cons) too much sudden system load at the start of new epoch
- upfront `clone()` of `account_index.keys()` at each epoch boundary and process `.chunk()` of it for each slot like this PR.
  - (pro) no need to resort to `BTreeMap`.
  - (cons) moderate cluster hiccup and ABI break on Bank/Snapshot; also must include that into trust chain in some way.
- lookup by slot/slot range:
  - (cons) account updates aren't uniformly distributed across the slots in general
- slot coalescence (WIP: #9319):
  -  (cons) as pointed, single `AppendVec` for several slots showed performance degradation in the past. Also, this solution still doesn't solve stale rent-due accounts and gaming problem.
- stale slot/AppendVec eviction/unmap by LRU and on-demand mmap after eviction:
  - (cons) still too many unbound-number-of small AppendVec in the snapshot
- cold-store stale accounts:
  - (cons) too much effort to implement; could implemented later if there is so much account storage need. hampers the accounts index under huge number of active pubkeys.
  - (cons) also, we need to revise economic design/fee for executing TXes on accounts in the cold-storage; otherwise, economically-efficient DoS attack is possible
- maintain a `HashSet<Pubkey>` for rent-due accounts, separately:
   - (cons) can be another DoS vector when those account set gets large and we need a deterministic iteration algorithm.

(Also, I've lightly researched the rent mechanism of other blockchain projects and found there is no better solution. ;)

#### todo (once the direction is confirmed)

- ~[ ] update docs for rents~ (let's do with another future pr, this pr is already big).
- [x] hard fork logic
- [x] write/fix tests
- [x] refactor the copy and paste
- [x] check perf. degradation of using `BTreeMap` over `HashMap` (doing right now)
- [x] warmup epochs & rent? what to do? (DONE: introduced constant cycle collection).

Fixes #9383
