### PR TITLE
Improve error message on `solana-keygen new` filesystem permission errors

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -457,7 +457,8 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
             let keypair = keypair_from_seed(seed.as_bytes())?;
 
             if let Some(outfile) = outfile {
-                output_keypair(&keypair, &outfile, "new")?;
+                output_keypair(&keypair, &outfile, "new")
+                    .map_err(|err| format!("Unable to write {}: {}", outfile, err))?;
             }
 
             let silent = matches.is_present("silent");


### PR DESCRIPTION
Toward debugging why https://buildkite.com/solana-labs/solana/builds/22740#56e4cb64-1409-49dd-a512-3fe4294db203 failed