### PR TITLE
Increase the number of JSON RPC service threads

### DIFF
--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -289,7 +289,7 @@ impl JsonRpcService {
                         genesis_hash,
                     },
                 )
-                .threads(4)
+                .threads(num_cpus::get())
                 .cors(DomainsValidation::AllowOnly(vec![
                     AccessControlAllowOrigin::Any,
                 ]))


### PR DESCRIPTION
`testnet.solana.com` got crushed earlier today trying to serve up RPC and snapshots and genesis to all the TdS nodes that were restarting.  4 RPC threads was just not enough, instead create `num_cpus::get()` threads.   If it turns out that we have a use case where `num_cpus::get()` is not ok, then it's probably time to plumb a `solana-validator` command-line argument