### PR TITLE
Untar is called for shred archives that do not exist.

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1263,10 +1263,11 @@ impl Blockstore {
         let f = fs::File::open(path);
         if f.is_err() {
             if let Some(archive) = tgz {
-                Self::extract_data(archive, shred_path)
-            } else {
-                Ok(None)
+                if Path::new(archive).is_file() {
+                    return Self::extract_data(archive, shred_path);
+                }
             }
+            Ok(None)
         } else {
             let mut buf = vec![];
             f?.read_to_end(&mut buf)?;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -344,7 +344,7 @@ impl Blockstore {
     }
 
     fn tar_dir(dir: String, archive: String) -> Result<()> {
-        let args = ["cfz", &archive, &dir];
+        let args = ["cfzP", &archive, &dir];
         let output = std::process::Command::new("tar").args(&args).output()?;
         if !output.status.success() {
             warn!(


### PR DESCRIPTION
#### Problem

Untar is called for shred archives that do not exist.

#### Summary of Changes

1. If the archive doesn't exist, there is no point to call the tar command.
2. tar gets confused about paths, so don't strip them out

Fixes #

tag: @sakridge @carllin 