### PR TITLE
Tame wallet manager better

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -116,7 +116,7 @@ pub fn pubkeys_sigs_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<(Pubk
 pub fn signer_of(
     matches: &ArgMatches<'_>,
     name: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<(Option<Box<dyn Signer>>, Option<Pubkey>), Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
         let signer = signer_from_path(matches, location, name, wallet_manager)?;
@@ -130,7 +130,7 @@ pub fn signer_of(
 pub fn pubkey_of_signer(
     matches: &ArgMatches<'_>,
     name: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<Option<Pubkey>, Box<dyn std::error::Error>> {
     if let Some(location) = matches.value_of(name) {
         Ok(Some(pubkey_from_path(
@@ -147,7 +147,7 @@ pub fn pubkey_of_signer(
 pub fn pubkeys_of_multiple_signers(
     matches: &ArgMatches<'_>,
     name: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<Option<Vec<Pubkey>>, Box<dyn std::error::Error>> {
     if let Some(pubkey_matches) = matches.values_of(name) {
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -163,7 +163,7 @@ pub fn pubkeys_of_multiple_signers(
 pub fn resolve_signer(
     matches: &ArgMatches<'_>,
     name: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
     Ok(resolve_signer_from_path(
         matches,

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -47,13 +47,6 @@ pub fn parse_keypair_path(path: &str) -> KeypairUrl {
     }
 }
 
-pub fn check_for_usb<S>(mut items: impl Iterator<Item = S>) -> bool
-where
-    S: Into<String>,
-{
-    items.any(|arg| matches!(parse_keypair_path(&arg.into()), KeypairUrl::Usb(_)))
-}
-
 pub fn presigner_from_pubkey_sigs(
     pubkey: &Pubkey,
     signers: &[(Pubkey, Signature)],
@@ -262,21 +255,5 @@ mod tests {
             "Mary had a little lamb".to_owned(),
             sanitize_seed_phrase(seed_phrase)
         );
-    }
-
-    #[test]
-    fn test_check_for_usb() {
-        let args: Vec<&str> = vec![];
-        assert_eq!(check_for_usb(args.into_iter()), false);
-        let args = vec!["usb://"];
-        assert_eq!(check_for_usb(args.into_iter()), true);
-        let args = vec!["other"];
-        assert_eq!(check_for_usb(args.into_iter()), false);
-        let args = vec!["other", "usb://", "another"];
-        assert_eq!(check_for_usb(args.into_iter()), true);
-        let args = vec!["other", "another"];
-        assert_eq!(check_for_usb(args.into_iter()), false);
-        let args = vec!["usb://", "usb://"];
-        assert_eq!(check_for_usb(args.into_iter()), true);
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2633,11 +2633,11 @@ mod tests {
         write_keypair_file(&default_keypair, &default_keypair_file).unwrap();
 
         let signer_info =
-            generate_unique_signers(vec![], &matches, &default_keypair_file, None).unwrap();
+            generate_unique_signers(vec![], &matches, &default_keypair_file, &mut None).unwrap();
         assert_eq!(signer_info.signers.len(), 0);
 
         let signer_info =
-            generate_unique_signers(vec![None, None], &matches, &default_keypair_file, None)
+            generate_unique_signers(vec![None, None], &matches, &default_keypair_file, &mut None)
                 .unwrap();
         assert_eq!(signer_info.signers.len(), 1);
         assert_eq!(signer_info.index_of(None), Some(0));
@@ -2649,7 +2649,7 @@ mod tests {
         let keypair0_clone_pubkey = keypair0.pubkey();
         let signers = vec![None, Some(keypair0.into()), Some(keypair0_clone.into())];
         let signer_info =
-            generate_unique_signers(signers, &matches, &default_keypair_file, None).unwrap();
+            generate_unique_signers(signers, &matches, &default_keypair_file, &mut None).unwrap();
         assert_eq!(signer_info.signers.len(), 2);
         assert_eq!(signer_info.index_of(None), Some(0));
         assert_eq!(signer_info.index_of(Some(keypair0_pubkey)), Some(1));
@@ -2660,7 +2660,7 @@ mod tests {
         let keypair0_clone = keypair_from_seed(&[1u8; 32]).unwrap();
         let signers = vec![Some(keypair0.into()), Some(keypair0_clone.into())];
         let signer_info =
-            generate_unique_signers(signers, &matches, &default_keypair_file, None).unwrap();
+            generate_unique_signers(signers, &matches, &default_keypair_file, &mut None).unwrap();
         assert_eq!(signer_info.signers.len(), 1);
         assert_eq!(signer_info.index_of(Some(keypair0_pubkey)), Some(0));
 
@@ -2681,7 +2681,7 @@ mod tests {
             Some(keypair1.into()),
         ];
         let signer_info =
-            generate_unique_signers(signers, &matches, &default_keypair_file, None).unwrap();
+            generate_unique_signers(signers, &matches, &default_keypair_file, &mut None).unwrap();
         assert_eq!(signer_info.signers.len(), 2);
         assert_eq!(signer_info.index_of(Some(keypair0_pubkey)), Some(0));
         assert_eq!(signer_info.index_of(Some(keypair1_pubkey)), Some(1));
@@ -2707,7 +2707,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "airdrop", "50", &pubkey_string]);
         assert_eq!(
-            parse_command(&test_airdrop, "", None).unwrap(),
+            parse_command(&test_airdrop, "", &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Airdrop {
                     faucet_host: None,
@@ -2730,7 +2730,7 @@ mod tests {
             &keypair.pubkey().to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_balance, "", None).unwrap(),
+            parse_command(&test_balance, "", &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey: Some(keypair.pubkey()),
@@ -2746,7 +2746,7 @@ mod tests {
             "--lamports",
         ]);
         assert_eq!(
-            parse_command(&test_balance, "", None).unwrap(),
+            parse_command(&test_balance, "", &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey: Some(keypair.pubkey()),
@@ -2760,7 +2760,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "balance", "--lamports"]);
         assert_eq!(
-            parse_command(&test_balance, &keypair_file, None).unwrap(),
+            parse_command(&test_balance, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey: None,
@@ -2776,7 +2776,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "cancel", &pubkey_string]);
         assert_eq!(
-            parse_command(&test_cancel, &keypair_file, None).unwrap(),
+            parse_command(&test_cancel, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Cancel(pubkey),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -2791,7 +2791,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "confirm", &signature_string]);
         assert_eq!(
-            parse_command(&test_confirm, "", None).unwrap(),
+            parse_command(&test_confirm, "", &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Confirm(signature),
                 signers: vec![],
@@ -2800,7 +2800,7 @@ mod tests {
         let test_bad_signature = test_commands
             .clone()
             .get_matches_from(vec!["test", "confirm", "deadbeef"]);
-        assert!(parse_command(&test_bad_signature, "", None).is_err());
+        assert!(parse_command(&test_bad_signature, "", &mut None).is_err());
 
         // Test CreateAddressWithSeed
         let from_pubkey = Some(Pubkey::new_rand());
@@ -2820,7 +2820,7 @@ mod tests {
                 &from_str,
             ]);
             assert_eq!(
-                parse_command(&test_create_address_with_seed, "", None).unwrap(),
+                parse_command(&test_create_address_with_seed, "", &mut None).unwrap(),
                 CliCommandInfo {
                     command: CliCommand::CreateAddressWithSeed {
                         from_pubkey,
@@ -2838,7 +2838,7 @@ mod tests {
             "STAKE",
         ]);
         assert_eq!(
-            parse_command(&test_create_address_with_seed, &keypair_file, None).unwrap(),
+            parse_command(&test_create_address_with_seed, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateAddressWithSeed {
                     from_pubkey: None,
@@ -2855,7 +2855,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "deploy", "/Users/test/program.o"]);
         assert_eq!(
-            parse_command(&test_deploy, &keypair_file, None).unwrap(),
+            parse_command(&test_deploy, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Deploy("/Users/test/program.o".to_string()),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -2868,7 +2868,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "resolve-signer", &keypair_file]);
         assert_eq!(
-            parse_command(&test_resolve_signer, "", None).unwrap(),
+            parse_command(&test_resolve_signer, "", &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::ResolveSigner(Some(keypair_file.clone())),
                 signers: vec![],
@@ -2880,7 +2880,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "resolve-signer", &pubkey_string]);
         assert_eq!(
-            parse_command(&test_resolve_signer, "", None).unwrap(),
+            parse_command(&test_resolve_signer, "", &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::ResolveSigner(Some(pubkey.to_string())),
                 signers: vec![],
@@ -2893,7 +2893,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "pay", &pubkey_string, "50"]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, None).unwrap(),
+            parse_command(&test_pay, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2916,7 +2916,7 @@ mod tests {
             &witness1_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay_multiple_witnesses, &keypair_file, None).unwrap(),
+            parse_command(&test_pay_multiple_witnesses, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2936,7 +2936,7 @@ mod tests {
             &witness0_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay_single_witness, &keypair_file, None).unwrap(),
+            parse_command(&test_pay_single_witness, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2960,7 +2960,7 @@ mod tests {
             &witness0_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay_timestamp, &keypair_file, None).unwrap(),
+            parse_command(&test_pay_timestamp, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -2986,7 +2986,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, None).unwrap(),
+            parse_command(&test_pay, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -3009,7 +3009,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, None).unwrap(),
+            parse_command(&test_pay, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -3038,7 +3038,7 @@ mod tests {
             &pubkey_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, None).unwrap(),
+            parse_command(&test_pay, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -3071,7 +3071,7 @@ mod tests {
             &keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, None).unwrap(),
+            parse_command(&test_pay, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -3109,7 +3109,7 @@ mod tests {
             &signer_arg,
         ]);
         assert_eq!(
-            parse_command(&test_pay, &keypair_file, None).unwrap(),
+            parse_command(&test_pay, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -3147,7 +3147,7 @@ mod tests {
             "--signer",
             &signer_arg,
         ]);
-        assert!(parse_command(&test_pay, &keypair_file, None).is_err());
+        assert!(parse_command(&test_pay, &keypair_file, &mut None).is_err());
 
         // Test Send-Signature Subcommand
         let test_send_signature = test_commands.clone().get_matches_from(vec![
@@ -3157,7 +3157,7 @@ mod tests {
             &pubkey_string,
         ]);
         assert_eq!(
-            parse_command(&test_send_signature, &keypair_file, None).unwrap(),
+            parse_command(&test_send_signature, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Witness(pubkey, pubkey),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -3178,7 +3178,7 @@ mod tests {
             &witness1_string,
         ]);
         assert_eq!(
-            parse_command(&test_pay_multiple_witnesses, &keypair_file, None).unwrap(),
+            parse_command(&test_pay_multiple_witnesses, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Pay(PayCommand {
                     lamports: 50_000_000_000,
@@ -3202,7 +3202,7 @@ mod tests {
             "2018-09-19T17:30:59",
         ]);
         assert_eq!(
-            parse_command(&test_send_timestamp, &keypair_file, None).unwrap(),
+            parse_command(&test_send_timestamp, &keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::TimeElapsed(pubkey, pubkey, dt),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -3216,7 +3216,7 @@ mod tests {
             "--date",
             "20180919T17:30:59",
         ]);
-        assert!(parse_command(&test_bad_timestamp, &keypair_file, None).is_err());
+        assert!(parse_command(&test_bad_timestamp, &keypair_file, &mut None).is_err());
     }
 
     #[test]
@@ -3591,7 +3591,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "transfer", &to_string, "42"]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
@@ -3617,7 +3617,7 @@ mod tests {
             "42",
         ]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
@@ -3647,7 +3647,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
@@ -3682,7 +3682,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,
@@ -3721,7 +3721,7 @@ mod tests {
             &nonce_authority_file,
         ]);
         assert_eq!(
-            parse_command(&test_transfer, &default_keypair_file, None).unwrap(),
+            parse_command(&test_transfer, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Transfer {
                     lamports: 42_000_000_000,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -86,7 +86,7 @@ pub(crate) fn generate_unique_signers(
     bulk_signers: Vec<Option<Box<dyn Signer>>>,
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliSignerInfo, Box<dyn error::Error>> {
     let mut unique_signers = vec![];
 
@@ -574,7 +574,7 @@ impl Default for CliConfig<'_> {
 pub fn parse_command(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, Box<dyn error::Error>> {
     let response = match matches.subcommand() {
         // Cluster Query Commands
@@ -1054,7 +1054,7 @@ pub fn return_signers(tx: &Transaction) -> ProcessResult {
 pub fn parse_create_address_with_seed(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let from_pubkey = pubkey_of_signer(matches, "from", wallet_manager)?;
     let signers = if from_pubkey.is_some() {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1193,7 +1193,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "cluster-version"]);
         assert_eq!(
-            parse_command(&test_cluster_version, &default_keypair_file, None).unwrap(),
+            parse_command(&test_cluster_version, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::ClusterVersion,
                 signers: vec![],
@@ -1202,7 +1202,7 @@ mod tests {
 
         let test_fees = test_commands.clone().get_matches_from(vec!["test", "fees"]);
         assert_eq!(
-            parse_command(&test_fees, &default_keypair_file, None).unwrap(),
+            parse_command(&test_fees, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Fees,
                 signers: vec![],
@@ -1215,7 +1215,7 @@ mod tests {
                 .clone()
                 .get_matches_from(vec!["test", "block-time", &slot.to_string()]);
         assert_eq!(
-            parse_command(&test_get_block_time, &default_keypair_file, None).unwrap(),
+            parse_command(&test_get_block_time, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetBlockTime { slot },
                 signers: vec![],
@@ -1226,7 +1226,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "epoch-info"]);
         assert_eq!(
-            parse_command(&test_get_epoch_info, &default_keypair_file, None).unwrap(),
+            parse_command(&test_get_epoch_info, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetEpochInfo {
                     commitment_config: CommitmentConfig::recent(),
@@ -1239,7 +1239,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "genesis-hash"]);
         assert_eq!(
-            parse_command(&test_get_genesis_hash, &default_keypair_file, None).unwrap(),
+            parse_command(&test_get_genesis_hash, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetGenesisHash,
                 signers: vec![],
@@ -1248,7 +1248,7 @@ mod tests {
 
         let test_get_slot = test_commands.clone().get_matches_from(vec!["test", "slot"]);
         assert_eq!(
-            parse_command(&test_get_slot, &default_keypair_file, None).unwrap(),
+            parse_command(&test_get_slot, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetSlot {
                     commitment_config: CommitmentConfig::recent(),
@@ -1261,7 +1261,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "epoch"]);
         assert_eq!(
-            parse_command(&test_get_epoch, &default_keypair_file, None).unwrap(),
+            parse_command(&test_get_epoch, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetEpoch {
                     commitment_config: CommitmentConfig::recent(),
@@ -1274,7 +1274,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "total-supply"]);
         assert_eq!(
-            parse_command(&test_total_supply, &default_keypair_file, None).unwrap(),
+            parse_command(&test_total_supply, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::TotalSupply {
                     commitment_config: CommitmentConfig::recent(),
@@ -1287,7 +1287,7 @@ mod tests {
             .clone()
             .get_matches_from(vec!["test", "transaction-count"]);
         assert_eq!(
-            parse_command(&test_transaction_count, &default_keypair_file, None).unwrap(),
+            parse_command(&test_transaction_count, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetTransactionCount {
                     commitment_config: CommitmentConfig::recent(),
@@ -1308,7 +1308,7 @@ mod tests {
             "--confirmed",
         ]);
         assert_eq!(
-            parse_command(&test_ping, &default_keypair_file, None).unwrap(),
+            parse_command(&test_ping, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::Ping {
                     lamports: 1,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -278,7 +278,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
 
 pub fn parse_catchup(
     matches: &ArgMatches<'_>,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let node_pubkey = pubkey_of_signer(matches, "node_pubkey", wallet_manager)?.unwrap();
     let node_json_rpc_url = value_t!(matches, "node_json_rpc_url", String).ok();
@@ -302,7 +302,7 @@ pub fn parse_catchup(
 pub fn parse_cluster_ping(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let lamports = value_t_or_exit!(matches, "lamports", u64);
     let interval = Duration::from_secs(value_t_or_exit!(matches, "interval", u64));
@@ -404,7 +404,7 @@ pub fn parse_get_transaction_count(matches: &ArgMatches<'_>) -> Result<CliComman
 
 pub fn parse_show_stakes(
     matches: &ArgMatches<'_>,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let use_lamports_unit = matches.is_present("lamports");
     let vote_account_pubkeys =

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,9 +2,7 @@ use clap::{crate_description, crate_name, AppSettings, Arg, ArgGroup, ArgMatches
 use console::style;
 
 use solana_clap_utils::{
-    input_validators::is_url,
-    keypair::{check_for_usb, SKIP_SEED_PHRASE_VALIDATION_ARG},
-    offline::SIGN_ONLY_ARG,
+    input_validators::is_url, keypair::SKIP_SEED_PHRASE_VALIDATION_ARG, offline::SIGN_ONLY_ARG,
     DisplayError,
 };
 use solana_cli::{
@@ -254,20 +252,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     )
     .get_matches();
 
-    do_main(&matches, check_for_usb(std::env::args()))
-        .map_err(|err| DisplayError::new_as_boxed(err).into())
+    do_main(&matches).map_err(|err| DisplayError::new_as_boxed(err).into())
 }
 
-fn do_main(
-    matches: &ArgMatches<'_>,
-    need_wallet_manager: bool,
-) -> Result<(), Box<dyn error::Error>> {
+fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
     if parse_settings(&matches)? {
-        let wallet_manager = if need_wallet_manager {
-            maybe_wallet_manager()?
-        } else {
-            None
-        };
+        let wallet_manager = maybe_wallet_manager()?;
 
         let (mut config, signers) = parse_args(&matches, wallet_manager)?;
         config.signers = signers.iter().map(|s| s.as_ref()).collect();

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -263,7 +263,7 @@ pub fn data_from_state(state: &State) -> Result<&Data, CliNonceError> {
 pub fn parse_authorize_nonce_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
     let new_authority = pubkey_of_signer(matches, "new_authority", wallet_manager)?.unwrap();
@@ -291,7 +291,7 @@ pub fn parse_authorize_nonce_account(
 pub fn parse_nonce_create_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let (nonce_account, nonce_account_pubkey) =
         signer_of(matches, "nonce_account_keypair", wallet_manager)?;
@@ -320,7 +320,7 @@ pub fn parse_nonce_create_account(
 
 pub fn parse_get_nonce(
     matches: &ArgMatches<'_>,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account_pubkey =
         pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
@@ -334,7 +334,7 @@ pub fn parse_get_nonce(
 pub fn parse_new_nonce(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
     let (nonce_authority, nonce_authority_pubkey) =
@@ -359,7 +359,7 @@ pub fn parse_new_nonce(
 
 pub fn parse_show_nonce_account(
     matches: &ArgMatches<'_>,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account_pubkey =
         pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
@@ -377,7 +377,7 @@ pub fn parse_show_nonce_account(
 pub fn parse_withdraw_from_nonce_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let nonce_account = pubkey_of_signer(matches, "nonce_account_pubkey", wallet_manager)?.unwrap();
     let destination_account_pubkey =

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -672,7 +672,12 @@ mod tests {
             &Pubkey::default().to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_authorize_nonce_account, &default_keypair_file, None).unwrap(),
+            parse_command(
+                &test_authorize_nonce_account,
+                &default_keypair_file,
+                &mut None
+            )
+            .unwrap(),
             CliCommandInfo {
                 command: CliCommand::AuthorizeNonceAccount {
                     nonce_account: nonce_account_pubkey,
@@ -693,7 +698,12 @@ mod tests {
             &authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_authorize_nonce_account, &default_keypair_file, None).unwrap(),
+            parse_command(
+                &test_authorize_nonce_account,
+                &default_keypair_file,
+                &mut None
+            )
+            .unwrap(),
             CliCommandInfo {
                 command: CliCommand::AuthorizeNonceAccount {
                     nonce_account: read_keypair_file(&keypair_file).unwrap().pubkey(),
@@ -715,7 +725,7 @@ mod tests {
             "50",
         ]);
         assert_eq!(
-            parse_command(&test_create_nonce_account, &default_keypair_file, None).unwrap(),
+            parse_command(&test_create_nonce_account, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
                     nonce_account: 1,
@@ -740,7 +750,7 @@ mod tests {
             &authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_create_nonce_account, &default_keypair_file, None).unwrap(),
+            parse_command(&test_create_nonce_account, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateNonceAccount {
                     nonce_account: 1,
@@ -762,7 +772,7 @@ mod tests {
             &nonce_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_get_nonce, &default_keypair_file, None).unwrap(),
+            parse_command(&test_get_nonce, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::GetNonce(nonce_account_keypair.pubkey()),
                 signers: vec![],
@@ -776,7 +786,7 @@ mod tests {
                 .get_matches_from(vec!["test", "new-nonce", &keypair_file]);
         let nonce_account = read_keypair_file(&keypair_file).unwrap();
         assert_eq!(
-            parse_command(&test_new_nonce, &default_keypair_file, None).unwrap(),
+            parse_command(&test_new_nonce, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::NewNonce {
                     nonce_account: nonce_account.pubkey(),
@@ -796,7 +806,7 @@ mod tests {
         ]);
         let nonce_account = read_keypair_file(&keypair_file).unwrap();
         assert_eq!(
-            parse_command(&test_new_nonce, &default_keypair_file, None).unwrap(),
+            parse_command(&test_new_nonce, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::NewNonce {
                     nonce_account: nonce_account.pubkey(),
@@ -816,7 +826,7 @@ mod tests {
             &nonce_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_show_nonce_account, &default_keypair_file, None).unwrap(),
+            parse_command(&test_show_nonce_account, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::ShowNonceAccount {
                     nonce_account_pubkey: nonce_account_keypair.pubkey(),
@@ -838,7 +848,7 @@ mod tests {
             parse_command(
                 &test_withdraw_from_nonce_account,
                 &default_keypair_file,
-                None
+                &mut None
             )
             .unwrap(),
             CliCommandInfo {
@@ -866,7 +876,7 @@ mod tests {
             parse_command(
                 &test_withdraw_from_nonce_account,
                 &default_keypair_file,
-                None
+                &mut None
             )
             .unwrap(),
             CliCommandInfo {

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -376,7 +376,7 @@ impl StakeSubCommands for App<'_, '_> {
 pub fn parse_stake_create_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let epoch = value_of(matches, "lockup_epoch").unwrap_or(0);
@@ -428,7 +428,7 @@ pub fn parse_stake_create_account(
 pub fn parse_stake_delegate_stake(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -470,7 +470,7 @@ pub fn parse_stake_delegate_stake(
 pub fn parse_stake_authorize(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -553,7 +553,7 @@ pub fn parse_stake_authorize(
 pub fn parse_split_stake(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -598,7 +598,7 @@ pub fn parse_split_stake(
 pub fn parse_stake_deactivate_stake(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -635,7 +635,7 @@ pub fn parse_stake_deactivate_stake(
 pub fn parse_stake_withdraw_stake(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -677,7 +677,7 @@ pub fn parse_stake_withdraw_stake(
 pub fn parse_stake_set_lockup(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();
@@ -722,7 +722,7 @@ pub fn parse_stake_set_lockup(
 
 pub fn parse_show_stake_account(
     matches: &ArgMatches<'_>,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let stake_account_pubkey =
         pubkey_of_signer(matches, "stake_account_pubkey", wallet_manager)?.unwrap();

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1487,7 +1487,7 @@ mod tests {
             &new_withdraw_string,
         ]);
         assert_eq!(
-            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_stake_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1521,7 +1521,7 @@ mod tests {
             &withdraw_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_stake_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1559,7 +1559,7 @@ mod tests {
             &withdraw_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_stake_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1589,7 +1589,7 @@ mod tests {
             &new_stake_string,
         ]);
         assert_eq!(
-            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_stake_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1613,7 +1613,7 @@ mod tests {
             &stake_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_stake_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1643,7 +1643,7 @@ mod tests {
             &withdraw_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_stake_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1670,7 +1670,7 @@ mod tests {
             &new_withdraw_string,
         ]);
         assert_eq!(
-            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_stake_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1698,7 +1698,7 @@ mod tests {
             &withdraw_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_stake_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_stake_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1736,7 +1736,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1769,7 +1769,7 @@ mod tests {
             &pubkey.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1815,7 +1815,7 @@ mod tests {
             &pubkey2.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1847,7 +1847,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1884,7 +1884,7 @@ mod tests {
             &nonce_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1920,7 +1920,7 @@ mod tests {
             &fee_payer_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1954,7 +1954,7 @@ mod tests {
             &signer,
         ]);
         assert_eq!(
-            parse_command(&test_authorize, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::StakeAuthorize {
                     stake_account_pubkey,
@@ -1995,7 +1995,7 @@ mod tests {
             "43",
         ]);
         assert_eq!(
-            parse_command(&test_create_stake_account, &default_keypair_file, None).unwrap(),
+            parse_command(&test_create_stake_account, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
                     stake_account: 1,
@@ -2036,7 +2036,12 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_create_stake_account2, &default_keypair_file, None).unwrap(),
+            parse_command(
+                &test_create_stake_account2,
+                &default_keypair_file,
+                &mut None
+            )
+            .unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
                     stake_account: 1,
@@ -2089,7 +2094,12 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_create_stake_account2, &default_keypair_file, None).unwrap(),
+            parse_command(
+                &test_create_stake_account2,
+                &default_keypair_file,
+                &mut None
+            )
+            .unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateStakeAccount {
                     stake_account: 1,
@@ -2125,7 +2135,7 @@ mod tests {
             &vote_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2154,7 +2164,7 @@ mod tests {
             &stake_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2185,7 +2195,7 @@ mod tests {
             &vote_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2214,7 +2224,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2244,7 +2254,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2278,7 +2288,7 @@ mod tests {
             &key1.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2324,7 +2334,7 @@ mod tests {
             &key2.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2361,7 +2371,7 @@ mod tests {
             &fee_payer_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_delegate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_delegate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DelegateStake {
                     stake_account_pubkey,
@@ -2391,7 +2401,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_withdraw_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_withdraw_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::WithdrawStake {
                     stake_account_pubkey,
@@ -2420,7 +2430,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_withdraw_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_withdraw_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::WithdrawStake {
                     stake_account_pubkey,
@@ -2464,7 +2474,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            parse_command(&test_withdraw_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_withdraw_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::WithdrawStake {
                     stake_account_pubkey,
@@ -2496,7 +2506,7 @@ mod tests {
             &stake_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2520,7 +2530,7 @@ mod tests {
             &stake_authority_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2551,7 +2561,7 @@ mod tests {
             &blockhash_string,
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2578,7 +2588,7 @@ mod tests {
             "--sign-only",
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2609,7 +2619,7 @@ mod tests {
             &key1.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2652,7 +2662,7 @@ mod tests {
             &key2.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2683,7 +2693,7 @@ mod tests {
             &fee_payer_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_deactivate_stake, &default_keypair_file, None).unwrap(),
+            parse_command(&test_deactivate_stake, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::DeactivateStake {
                     stake_account_pubkey,
@@ -2717,7 +2727,7 @@ mod tests {
             "50",
         ]);
         assert_eq!(
-            parse_command(&test_split_stake_account, &default_keypair_file, None).unwrap(),
+            parse_command(&test_split_stake_account, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::SplitStake {
                     stake_account_pubkey: stake_account_keypair.pubkey(),
@@ -2778,7 +2788,7 @@ mod tests {
             &stake_signer,
         ]);
         assert_eq!(
-            parse_command(&test_split_stake_account, &default_keypair_file, None).unwrap(),
+            parse_command(&test_split_stake_account, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::SplitStake {
                     stake_account_pubkey: stake_account_keypair.pubkey(),

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -102,7 +102,7 @@ impl StorageSubCommands for App<'_, '_> {
 pub fn parse_storage_create_archiver_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let account_owner =
         pubkey_of_signer(matches, "storage_account_owner", wallet_manager)?.unwrap();
@@ -130,7 +130,7 @@ pub fn parse_storage_create_archiver_account(
 pub fn parse_storage_create_validator_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let account_owner =
         pubkey_of_signer(matches, "storage_account_owner", wallet_manager)?.unwrap();
@@ -158,7 +158,7 @@ pub fn parse_storage_create_validator_account(
 pub fn parse_storage_claim_reward(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let node_account_pubkey =
         pubkey_of_signer(matches, "node_account_pubkey", wallet_manager)?.unwrap();
@@ -180,7 +180,7 @@ pub fn parse_storage_claim_reward(
 
 pub fn parse_storage_get_account_command(
     matches: &ArgMatches<'_>,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let storage_account_pubkey =
         pubkey_of_signer(matches, "storage_account_pubkey", wallet_manager)?.unwrap();

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -330,7 +330,7 @@ mod tests {
             parse_command(
                 &test_create_archiver_storage_account,
                 &default_keypair_file,
-                None
+                &mut None
             )
             .unwrap(),
             CliCommandInfo {
@@ -362,7 +362,7 @@ mod tests {
             parse_command(
                 &test_create_validator_storage_account,
                 &default_keypair_file,
-                None
+                &mut None
             )
             .unwrap(),
             CliCommandInfo {
@@ -385,7 +385,7 @@ mod tests {
             &storage_account_string,
         ]);
         assert_eq!(
-            parse_command(&test_claim_storage_reward, &default_keypair_file, None).unwrap(),
+            parse_command(&test_claim_storage_reward, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::ClaimStorageReward {
                     node_account_pubkey: pubkey,

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -228,7 +228,7 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
 pub fn parse_validator_info_command(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let info_pubkey = pubkey_of(matches, "info_pubkey");
     // Prepare validator info

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -223,7 +223,7 @@ impl VoteSubCommands for App<'_, '_> {
 pub fn parse_create_vote_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let (vote_account, _) = signer_of(matches, "vote_account", wallet_manager)?;
     let seed = matches.value_of("seed").map(|s| s.to_string());
@@ -256,7 +256,7 @@ pub fn parse_create_vote_account(
 pub fn parse_vote_authorize(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
     vote_authorize: VoteAuthorize,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
@@ -286,7 +286,7 @@ pub fn parse_vote_authorize(
 pub fn parse_vote_update_validator(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
@@ -313,7 +313,7 @@ pub fn parse_vote_update_validator(
 
 pub fn parse_vote_get_account_command(
     matches: &ArgMatches<'_>,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
@@ -336,7 +336,7 @@ pub fn parse_vote_get_account_command(
 pub fn parse_withdraw_from_vote_account(
     matches: &ArgMatches<'_>,
     default_signer_path: &str,
-    wallet_manager: Option<&Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -663,7 +663,7 @@ mod tests {
             &pubkey2_string,
         ]);
         assert_eq!(
-            parse_command(&test_authorize_voter, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize_voter, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::VoteAuthorize {
                     vote_account_pubkey: pubkey,
@@ -686,7 +686,7 @@ mod tests {
             &pubkey2_string,
         ]);
         assert_eq!(
-            parse_command(&test_authorize_voter, &default_keypair_file, None).unwrap(),
+            parse_command(&test_authorize_voter, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::VoteAuthorize {
                     vote_account_pubkey: pubkey,
@@ -716,7 +716,7 @@ mod tests {
             "10",
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account, &default_keypair_file, None).unwrap(),
+            parse_command(&test_create_vote_account, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
                     seed: None,
@@ -744,7 +744,7 @@ mod tests {
             &identity_keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account2, &default_keypair_file, None).unwrap(),
+            parse_command(&test_create_vote_account2, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
                     seed: None,
@@ -776,7 +776,7 @@ mod tests {
             &authed.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account3, &default_keypair_file, None).unwrap(),
+            parse_command(&test_create_vote_account3, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
                     seed: None,
@@ -806,7 +806,7 @@ mod tests {
             &authed.to_string(),
         ]);
         assert_eq!(
-            parse_command(&test_create_vote_account4, &default_keypair_file, None).unwrap(),
+            parse_command(&test_create_vote_account4, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
                     seed: None,
@@ -831,7 +831,7 @@ mod tests {
             &keypair_file,
         ]);
         assert_eq!(
-            parse_command(&test_update_validator, &default_keypair_file, None).unwrap(),
+            parse_command(&test_update_validator, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::VoteUpdateValidator {
                     vote_account_pubkey: pubkey,
@@ -857,7 +857,7 @@ mod tests {
             parse_command(
                 &test_withdraw_from_vote_account,
                 &default_keypair_file,
-                None
+                &mut None
             )
             .unwrap(),
             CliCommandInfo {
@@ -888,7 +888,7 @@ mod tests {
             parse_command(
                 &test_withdraw_from_vote_account,
                 &default_keypair_file,
-                None
+                &mut None
             )
             .unwrap(),
             CliCommandInfo {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -407,12 +407,11 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
         Config::default()
     };
 
-    let wallet_manager =
-        if check_for_usb(std::env::args()) || check_for_usb([config.keypair_path.clone()].iter()) {
-            maybe_wallet_manager()?
-        } else {
-            None
-        };
+    let wallet_manager = if check_for_usb(std::env::args()) {
+        maybe_wallet_manager()?
+    } else {
+        None
+    };
 
     match matches.subcommand() {
         ("pubkey", Some(matches)) => {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -14,7 +14,7 @@ use solana_clap_utils::{
     DisplayError,
 };
 use solana_cli_config::{Config, CONFIG_FILE};
-use solana_remote_wallet::remote_wallet::{maybe_wallet_manager, RemoteWalletManager};
+use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     message::Message,
@@ -53,7 +53,7 @@ fn check_for_overwrite(outfile: &str, matches: &ArgMatches) {
 fn get_keypair_from_matches(
     matches: &ArgMatches,
     config: Config,
-    wallet_manager: Option<Arc<RemoteWalletManager>>,
+    wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<Box<dyn Signer>, Box<dyn error::Error>> {
     let mut path = dirs::home_dir().expect("home directory");
     let path = if matches.is_present("keypair") {
@@ -64,7 +64,7 @@ fn get_keypair_from_matches(
         path.extend(&[".config", "solana", "id.json"]);
         path.to_str().unwrap()
     };
-    signer_from_path(matches, path, "pubkey recovery", wallet_manager.as_ref())
+    signer_from_path(matches, path, "pubkey recovery", wallet_manager)
 }
 
 fn output_keypair(
@@ -407,11 +407,12 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
         Config::default()
     };
 
-    let wallet_manager = maybe_wallet_manager()?;
+    let mut wallet_manager = None;
 
     match matches.subcommand() {
         ("pubkey", Some(matches)) => {
-            let pubkey = get_keypair_from_matches(matches, config, wallet_manager)?.try_pubkey()?;
+            let pubkey =
+                get_keypair_from_matches(matches, config, &mut wallet_manager)?.try_pubkey()?;
 
             if matches.is_present("outfile") {
                 let outfile = matches.value_of("outfile").unwrap();
@@ -601,7 +602,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
             }
         }
         ("verify", Some(matches)) => {
-            let keypair = get_keypair_from_matches(matches, config, wallet_manager)?;
+            let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
             let simple_message = Message::new(&[Instruction::new(
                 Pubkey::default(),
                 &0,

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -8,7 +8,7 @@ use num_cpus;
 use solana_clap_utils::{
     input_validators::is_derivation,
     keypair::{
-        check_for_usb, keypair_from_seed_phrase, prompt_passphrase, signer_from_path,
+        keypair_from_seed_phrase, prompt_passphrase, signer_from_path,
         SKIP_SEED_PHRASE_VALIDATION_ARG,
     },
     DisplayError,
@@ -407,11 +407,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
         Config::default()
     };
 
-    let wallet_manager = if check_for_usb(std::env::args()) {
-        maybe_wallet_manager()?
-    } else {
-        None
-    };
+    let wallet_manager = maybe_wallet_manager()?;
 
     match matches.subcommand() {
         ("pubkey", Some(matches)) => {


### PR DESCRIPTION
#### Problem
#9262 and #9555 weren't quite the right approach, due to the default keypair; wallet manager should only be initialized when a signer is actually needed from a remote wallet, not any time config is set to a remote wallet url.

#### Summary of Changes
- Pass wallet_manager as `&mut`, and only initialize/read_devices when needed and not already done.
