### PR TITLE
Fix hanging local cluster test: test_validator_exit_2

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -161,7 +161,6 @@ fn test_validator_exit_2() {
     let num_nodes = 2;
     let mut validator_config = ValidatorConfig::default();
     validator_config.rpc_config.enable_validator_exit = true;
-    validator_config.wait_for_supermajority = Some(0);
 
     let config = ClusterConfig {
         cluster_lamports: 10_000,


### PR DESCRIPTION
#### Problem
Local cluster tests hang in CI, on test `test_validator_exit_2` since #9560 . Test never sees active stake in gossip -- `get_stake_percent_in_gossip` no longer includes the current node, and local cluster never reaches this line https://github.com/solana-labs/solana/blob/master/local-cluster/src/local_cluster.rs#L272 -- so loops indefinitely.

#### Summary of Changes
Remove `wait_for_majority` config setting

@mvines , another solution would be to restore the `else if` case to `get_stake_percent_in_gossip()` here https://github.com/solana-labs/solana/blob/f142451a33fd22ec436709917a791b9bde3ac979/core/src/validator.rs#L838 like:
```
} else if vote_state.node_pubkey == cluster_info.read().unwrap().id() {
            online_stake += activated_stake;
}
```
But I assume that was a deliberate choice for the the 80% to not include the current node.