### PR TITLE
Log proper slot on propagation failure

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -283,7 +283,11 @@ impl ReplayStage {
 
                         for r in failure_reasons {
                             if let HeaviestForkFailures::NoPropagatedConfirmation(slot) = r {
-                                progress.log_propagated_stats(slot, &bank_forks);
+                                if let Some(latest_leader_slot) =
+                                    progress.get_latest_leader_slot(slot)
+                                {
+                                    progress.log_propagated_stats(latest_leader_slot, &bank_forks);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
#### Problem
Propagation failure logs info about the current slot, not the leader slot. Result of a bad merge, was dropped here: https://github.com/solana-labs/solana/pull/9342/files#diff-5984b6b0429f857c13a2a362669ab37cL284

#### Summary of Changes
Log the leader slot's propagation stats

Fixes #
