### PR TITLE
Fix local-cluster test - archiver should wait for itself + 1 validator

### DIFF
--- a/archiver-lib/src/archiver.rs
+++ b/archiver-lib/src/archiver.rs
@@ -200,7 +200,7 @@ impl Archiver {
 
         info!("Connecting to the cluster via {:?}", cluster_entrypoint);
         let (nodes, _) =
-            match solana_core::gossip_service::discover_cluster(&cluster_entrypoint.gossip, 1) {
+            match solana_core::gossip_service::discover_cluster(&cluster_entrypoint.gossip, 2) {
                 Ok(nodes_and_archivers) => nodes_and_archivers,
                 Err(e) => {
                     //shutdown services before exiting


### PR DESCRIPTION
#### Problem

Archiver can find itself and not just the validator on startup and then not have an RPC peer to talk to.

`test_local_cluster_start_and_exit_with_config` failing because of this.

#### Summary of Changes

Check for 2 nodes on discover.

Fixes #
