### PR TITLE
Add single region TPS report testcases

### DIFF
--- a/system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml
@@ -1,0 +1,19 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "GCE - GPU Enabled 10 Nodes"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "gce"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
+      TEST_DURATION_SECONDS: 600
+      NUMBER_OF_VALIDATOR_NODES: 10
+      ENABLE_GPU: "true"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      NUMBER_OF_CLIENT_NODES: 2
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      TESTNET_ZONES: "us-west1-a"
+      USE_PUBLIC_IP_ADDRESSES: "true"
+      ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
+    agents:
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml
@@ -1,0 +1,19 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "GCE - GPU Enabled 25 Nodes"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "gce"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
+      TEST_DURATION_SECONDS: 600
+      NUMBER_OF_VALIDATOR_NODES: 25
+      ENABLE_GPU: "true"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      NUMBER_OF_CLIENT_NODES: 2
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      TESTNET_ZONES: "us-west1-a"
+      USE_PUBLIC_IP_ADDRESSES: "true"
+      ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
+    agents:
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml
@@ -1,0 +1,19 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "GCE - GPU Enabled 5 Nodes"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "gce"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
+      TEST_DURATION_SECONDS: 600
+      NUMBER_OF_VALIDATOR_NODES: 5
+      ENABLE_GPU: "true"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      NUMBER_OF_CLIENT_NODES: 2
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
+      TESTNET_ZONES: "us-west1-a"
+      USE_PUBLIC_IP_ADDRESSES: "true"
+      ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
+    agents:
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml
@@ -1,0 +1,20 @@
+steps:
+  - command: "system-test/testnet-automation.sh"
+    label: "GCE - GPU Enabled 50 Nodes"
+    env:
+      UPLOAD_RESULTS_TO_SLACK: "true"
+      CLOUD_PROVIDER: "gce"
+      TESTNET_TAG: "gce-perf-gpu-enabled"
+      TEST_DURATION_SECONDS: 600
+      NUMBER_OF_VALIDATOR_NODES: 50
+      ENABLE_GPU: "true"
+      VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
+      NUMBER_OF_CLIENT_NODES: 2
+      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      TESTNET_ZONES: "us-west1-a"
+      ALLOW_BOOT_FAILURES: "true"
+      USE_PUBLIC_IP_ADDRESSES: "true"
+      ADDITIONAL_FLAGS: "--dedicated"
+      TEST_TYPE: "fixed_duration"
+    agents:
+      - "queue=gce-deploy"

--- a/system-test/performance-testcases/tps-report-single-region.yml
+++ b/system-test/performance-testcases/tps-report-single-region.yml
@@ -1,0 +1,15 @@
+steps:
+  - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml"
+    name: "5 Node Test - TPS Report - Single Region"
+  - wait: ~
+    continue_on_failure: true
+  - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml"
+    name: "10 Node Test - TPS Report - Single Region"
+  - wait: ~
+    continue_on_failure: true
+  - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml"
+    name: "25 Node Test - TPS Report - Single Region"
+  - wait: ~
+    continue_on_failure: true
+  - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml"
+    name: "50 Node Test - TPS Report - Single Region"

--- a/system-test/performance-testcases/tps-report-single-region.yml
+++ b/system-test/performance-testcases/tps-report-single-region.yml
@@ -1,15 +1,23 @@
 steps:
   - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml"
     name: "5 Node Test - TPS Report - Single Region"
+    agents:
+      - "queue=pipeline-uploader"
   - wait: ~
     continue_on_failure: true
   - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml"
     name: "10 Node Test - TPS Report - Single Region"
+    agents:
+      - "queue=pipeline-uploader"
   - wait: ~
     continue_on_failure: true
   - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml"
     name: "25 Node Test - TPS Report - Single Region"
+    agents:
+      - "queue=pipeline-uploader"
   - wait: ~
     continue_on_failure: true
   - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml"
     name: "50 Node Test - TPS Report - Single Region"
+    agents:
+      - "queue=pipeline-uploader"

--- a/system-test/performance-testcases/tps-report.yml
+++ b/system-test/performance-testcases/tps-report.yml
@@ -1,15 +1,23 @@
 steps:
   - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-5-node.yml"
     name: "5 Node Test - TPS Report"
+    agents:
+      - "queue=pipeline-uploader"
   - wait: ~
     continue_on_failure: true
   - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-10-node.yml"
     name: "10 Node Test - TPS Report"
+    agents:
+      - "queue=pipeline-uploader"
   - wait: ~
     continue_on_failure: true
   - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-25-node.yml"
     name: "25 Node Test - TPS Report"
+    agents:
+      - "queue=pipeline-uploader"
   - wait: ~
     continue_on_failure: true
   - command: "buildkite-agent pipeline upload system-test/performance-testcases/gce-gpu-perf-50-node.yml"
     name: "50 Node Test - TPS Report"
+    agents:
+      - "queue=pipeline-uploader"


### PR DESCRIPTION
Add a series of TPS report testcases in a single GCE region, to get comparative results from the multi-region testcases.