### PR TITLE
Fail gracefully if older AddressSignatures rocksdb keys are present

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -499,6 +499,17 @@ fn analyze_storage(database: &Database) -> Result<(), String> {
         "TransactionStatus",
         TransactionStatus::key_size(),
     )?;
+    analyze_column::<TransactionStatus>(
+        database,
+        "TransactionStatusIndex",
+        TransactionStatusIndex::key_size(),
+    )?;
+    analyze_column::<AddressSignatures>(
+        database,
+        "AddressSignatures",
+        AddressSignatures::key_size(),
+    )?;
+    analyze_column::<Rewards>(database, "Rewards", Rewards::key_size())?;
 
     Ok(())
 }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -368,11 +368,15 @@ impl Column for columns::AddressSignatures {
     }
 
     fn index(key: &[u8]) -> (u64, Pubkey, Slot, Signature) {
-        let index = BigEndian::read_u64(&key[0..8]);
-        let pubkey = Pubkey::new(&key[8..40]);
-        let slot = BigEndian::read_u64(&key[40..48]);
-        let signature = Signature::new(&key[48..112]);
-        (index, pubkey, slot, signature)
+        if key.len() != 112 {
+            (0, Pubkey::default(), 0, Signature::default())
+        } else {
+            let index = BigEndian::read_u64(&key[0..8]);
+            let pubkey = Pubkey::new(&key[8..40]);
+            let slot = BigEndian::read_u64(&key[40..48]);
+            let signature = Signature::new(&key[48..112]);
+            (index, pubkey, slot, signature)
+        }
     }
 
     fn primary_index(index: Self::Index) -> u64 {


### PR DESCRIPTION
`getConfirmedSignaturesForAddress` into devnet.solana.com panics, seemingly because there exists older data in the AddressSignatures column without the additional Signature at the end of the key:
https://github.com/solana-labs/solana/pull/9407/files#diff-5f6b1e8d3bf211c4eb9bc67a7718a665R362

I haven't tested testnet or mainnet-beta but suspect we'll see the same there.  Gracefully handle the older keys (by essentially ignoring them)