### PR TITLE
cli: Add transaction-history

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -229,8 +229,8 @@ pub enum CliCommand {
     },
     TransactionHistory {
         address: Pubkey,
-        start_slot: Option<Slot>,
-        end_slot: Option<Slot>,
+        end_slot: Option<Slot>, // None == latest slot
+        slot_limit: u64,
     },
     // Nonce commands
     AuthorizeNonceAccount {
@@ -1739,9 +1739,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_show_validators(&rpc_client, config, *use_lamports_unit, *commitment_config),
         CliCommand::TransactionHistory {
             address,
-            start_slot,
             end_slot,
-        } => process_transaction_history(&rpc_client, address, *start_slot, *end_slot),
+            slot_limit,
+        } => process_transaction_history(&rpc_client, address, *end_slot, *slot_limit),
 
         // Nonce Commands
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -227,6 +227,11 @@ pub enum CliCommand {
         use_lamports_unit: bool,
         commitment_config: CommitmentConfig,
     },
+    TransactionHistory {
+        address: Pubkey,
+        start_slot: Option<Slot>,
+        end_slot: Option<Slot>,
+    },
     // Nonce commands
     AuthorizeNonceAccount {
         nonce_account: Pubkey,
@@ -618,6 +623,9 @@ pub fn parse_command(
         }),
         ("stakes", Some(matches)) => parse_show_stakes(matches, wallet_manager),
         ("validators", Some(matches)) => parse_show_validators(matches),
+        ("transaction-history", Some(matches)) => {
+            parse_transaction_history(matches, wallet_manager)
+        }
         // Nonce Commands
         ("authorize-nonce-account", Some(matches)) => {
             parse_authorize_nonce_account(matches, default_signer_path, wallet_manager)
@@ -1729,6 +1737,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             use_lamports_unit,
             commitment_config,
         } => process_show_validators(&rpc_client, config, *use_lamports_unit, *commitment_config),
+        CliCommand::TransactionHistory {
+            address,
+            start_slot,
+            end_slot,
+        } => process_transaction_history(&rpc_client, address, *start_slot, *end_slot),
 
         // Nonce Commands
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -14,6 +14,7 @@ use solana_clap_utils::{input_parsers::*, input_validators::*, keypair::signer_f
 use solana_client::{
     pubsub_client::{PubsubClient, SlotInfoMessage},
     rpc_client::RpcClient,
+    rpc_request::MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE,
 };
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
@@ -1230,11 +1231,17 @@ pub fn process_transaction_history(
             if let Some(end_slot) = end_slot {
                 (start_slot, end_slot)
             } else {
-                (start_slot, start_slot + 1000)
+                (
+                    start_slot,
+                    start_slot + MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE,
+                )
             }
         } else {
             let current_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::max())?;
-            (current_slot.saturating_sub(1000), current_slot)
+            (
+                current_slot.saturating_sub(MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE),
+                current_slot,
+            )
         }
     };
 

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -42,6 +42,9 @@ pub enum RpcRequest {
     MinimumLedgerSlot,
 }
 
+pub const MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS: usize = 256;
+pub const MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE: u64 = 10_000;
+
 impl RpcRequest {
     pub(crate) fn build_request_json(&self, id: u64, params: Value) -> Value {
         let jsonrpc = "2.0";

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -7,7 +7,12 @@ use crate::{
 use bincode::serialize;
 use jsonrpc_core::{Error, Metadata, Result};
 use jsonrpc_derive::rpc;
-use solana_client::rpc_response::*;
+use solana_client::{
+    rpc_request::{
+        MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE, MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
+    },
+    rpc_response::*,
+};
 use solana_faucet::faucet::request_airdrop_transaction;
 use solana_ledger::{
     bank_forks::BankForks, blockstore::Blockstore, rooted_slot_iterator::RootedSlotIterator,
@@ -37,9 +42,6 @@ use std::{
     thread::sleep,
     time::{Duration, Instant},
 };
-
-const MAX_QUERY_ITEMS: usize = 256;
-const MAX_SLOT_RANGE: u64 = 10_000;
 
 type RpcResponse<T> = Result<Response<T>>;
 
@@ -1058,10 +1060,10 @@ impl RpcSol for RpcSolImpl {
         signature_strs: Vec<String>,
         config: Option<RpcSignatureStatusConfig>,
     ) -> RpcResponse<Vec<Option<TransactionStatus>>> {
-        if signature_strs.len() > MAX_QUERY_ITEMS {
+        if signature_strs.len() > MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS {
             return Err(Error::invalid_params(format!(
                 "Too many inputs provided; max {}",
-                MAX_QUERY_ITEMS
+                MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS
             )));
         }
         let mut signatures: Vec<Signature> = vec![];
@@ -1360,10 +1362,10 @@ impl RpcSol for RpcSolImpl {
                 start_slot, end_slot
             )));
         }
-        if end_slot - start_slot > MAX_SLOT_RANGE {
+        if end_slot - start_slot > MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE {
             return Err(Error::invalid_params(format!(
                 "Slot range too large; max {}",
-                MAX_SLOT_RANGE
+                MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE
             )));
         }
         meta.request_processor

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -499,6 +499,17 @@ fn analyze_storage(database: &Database) -> Result<(), String> {
         "TransactionStatus",
         TransactionStatus::key_size(),
     )?;
+    analyze_column::<TransactionStatus>(
+        database,
+        "TransactionStatusIndex",
+        TransactionStatusIndex::key_size(),
+    )?;
+    analyze_column::<AddressSignatures>(
+        database,
+        "AddressSignatures",
+        AddressSignatures::key_size(),
+    )?;
+    analyze_column::<Rewards>(database, "Rewards", Rewards::key_size())?;
 
     Ok(())
 }


### PR DESCRIPTION
Show historical transactions affecting the given address, ordered based on the slot in which they were confirmed in from lowest to highest slot
```
$  solana transaction-history  <ADDRESS> [optional start slot] [optional end slot]
```

The output is just a list of transaction signatures.   One could then run `solana confirm -v <signature>` to decode the full historical transaction.  I opted to not plumb an option to decode the transactions directly into `solana transaction-history` for now, to avoid adding a ton of unintentional load to the RPC servers

Fixes #9453