### PR TITLE
Bump libloading to v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "6.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4519,7 +4527,7 @@ dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
- "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6528,6 +6536,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)" = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+"checksum libloading 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c4f51b790f5bdb65acb4cc94bb81d7b2ee60348a5431ac1467d390b017600b0"
 "checksum librocksdb-sys 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0785e816e1e11e7599388a492c61ef80ddc2afc91e313e61662cce537809be"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -17,7 +17,7 @@ fs_extra = "1.1.0"
 itertools = "0.9.0"
 lazy_static = "1.4.0"
 libc = "0.2.69"
-libloading = "0.5.2"
+libloading = "0.6.1"
 log = "0.4.8"
 memmap = "0.7.0"
 num-derive = { version = "0.3" }


### PR DESCRIPTION
#### Problem

Old version of libloading uses std:io:error amongst other things

#### Summary of Changes

Bump from v0.5.2 to v0.6.2

@ryoqun 
Renders https://github.com/solana-labs/solana/pull/9508#pullrequestreview-395567704 obsolete

Fixes #
