### PR TITLE
Merge stake_instruction::withdraw variants

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1002,6 +1002,7 @@ pub fn process_withdraw_stake(
         &withdraw_authority.pubkey(),
         destination_account_pubkey,
         lamports,
+        None,
     )];
 
     let fee_payer = config.signers[fee_payer];

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -224,6 +224,7 @@ fn test_stake_account_lifetime() {
             &stake_pubkey,
             &Pubkey::new_rand(),
             1,
+            None,
         )],
         Some(&mint_pubkey),
     );
@@ -318,6 +319,7 @@ fn test_stake_account_lifetime() {
             &stake_pubkey,
             &Pubkey::new_rand(),
             lamports / 2 - split_staked + 1,
+            None,
         )],
         Some(&mint_pubkey),
     );
@@ -339,6 +341,7 @@ fn test_stake_account_lifetime() {
             &stake_pubkey,
             &Pubkey::new_rand(),
             lamports / 2,
+            None,
         )],
         Some(&mint_pubkey),
     );
@@ -354,6 +357,7 @@ fn test_stake_account_lifetime() {
             &stake_pubkey,
             &Pubkey::new_rand(),
             lamports / 2 - split_staked,
+            None,
         )],
         Some(&mint_pubkey),
     );
@@ -378,6 +382,7 @@ fn test_stake_account_lifetime() {
             &stake_pubkey,
             &Pubkey::new_rand(),
             split_staked,
+            None,
         )],
         Some(&mint_pubkey),
     );

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -450,6 +450,7 @@ mod test {
                         &stake3_keypair.pubkey(),
                         &payer.pubkey(),
                         one_sol,
+                        None,
                     )],
                     Some(&payer.pubkey()),
                 ),


### PR DESCRIPTION
#### Problem

The stake program allows users to withdraw stake early, if the transaction is signed by the custodian, but that functionality isn't implemented by the CLI.  Part of the problem is that functionality is exposed with a separate, unused function instead of an optional custodian parameter.

#### Summary of Changes

Refactor such that we can see the CLI isn't exposing the custodian parameter to the end user.
