### PR TITLE
Wait for supermajority of cluster to have rooted a transaction to consider it finalized

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -487,7 +487,9 @@ impl JsonRpcRequestProcessor {
             .map(|(slot, status)| {
                 let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
-                let confirmations = if r_block_commitment_cache.root() >= slot {
+                let confirmations = if r_block_commitment_cache.root() >= slot
+                    && r_block_commitment_cache.is_confirmed_rooted(slot)
+                {
                     None
                 } else {
                     r_block_commitment_cache
@@ -2071,7 +2073,7 @@ pub mod tests {
                 .expect("actual response deserialization");
         let result = result.as_ref().unwrap();
         assert_eq!(expected_res, result.status);
-        assert_eq!(None, result.confirmations);
+        assert_eq!(Some(2), result.confirmations);
 
         // Test getSignatureStatus request on unprocessed tx
         let tx = system_transaction::transfer(&alice, &bob_pubkey, 10, blockhash);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1,8 +1,11 @@
 //! The `rpc` module implements the Solana RPC interface.
 
 use crate::{
-    cluster_info::ClusterInfo, commitment::BlockCommitmentCache, contact_info::ContactInfo,
-    storage_stage::StorageState, validator::ValidatorExit,
+    cluster_info::ClusterInfo,
+    commitment::{BlockCommitmentArray, BlockCommitmentCache},
+    contact_info::ContactInfo,
+    storage_stage::StorageState,
+    validator::ValidatorExit,
 };
 use bincode::serialize;
 use jsonrpc_core::{Error, Metadata, Result};
@@ -216,7 +219,7 @@ impl JsonRpcRequestProcessor {
         }
     }
 
-    fn get_block_commitment(&self, block: Slot) -> RpcBlockCommitment<[u64; MAX_LOCKOUT_HISTORY]> {
+    fn get_block_commitment(&self, block: Slot) -> RpcBlockCommitment<BlockCommitmentArray> {
         let r_block_commitment = self.block_commitment_cache.read().unwrap();
         RpcBlockCommitment {
             commitment: r_block_commitment
@@ -642,7 +645,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         block: Slot,
-    ) -> Result<RpcBlockCommitment<[u64; MAX_LOCKOUT_HISTORY]>>;
+    ) -> Result<RpcBlockCommitment<BlockCommitmentArray>>;
 
     #[rpc(meta, name = "getGenesisHash")]
     fn get_genesis_hash(&self, meta: Self::Metadata) -> Result<String>;
@@ -946,7 +949,7 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         block: Slot,
-    ) -> Result<RpcBlockCommitment<[u64; MAX_LOCKOUT_HISTORY]>> {
+    ) -> Result<RpcBlockCommitment<BlockCommitmentArray>> {
         Ok(meta
             .request_processor
             .read()
@@ -2419,8 +2422,8 @@ pub mod tests {
         let validator_exit = create_validator_exit(&exit);
         let bank_forks = new_bank_forks().0;
 
-        let commitment_slot0 = BlockCommitment::new([8; MAX_LOCKOUT_HISTORY]);
-        let commitment_slot1 = BlockCommitment::new([9; MAX_LOCKOUT_HISTORY]);
+        let commitment_slot0 = BlockCommitment::new([8; MAX_LOCKOUT_HISTORY + 1]);
+        let commitment_slot1 = BlockCommitment::new([9; MAX_LOCKOUT_HISTORY + 1]);
         let mut block_commitment: HashMap<u64, BlockCommitment> = HashMap::new();
         block_commitment
             .entry(0)
@@ -2512,7 +2515,7 @@ pub mod tests {
         let res = io.handle_request_sync(&req, meta);
         let result: Response = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
-        let commitment_response: RpcBlockCommitment<[u64; MAX_LOCKOUT_HISTORY]> =
+        let commitment_response: RpcBlockCommitment<BlockCommitmentArray> =
             if let Response::Single(res) = result {
                 if let Output::Success(res) = res {
                     serde_json::from_value(res.result).unwrap()

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -733,7 +733,7 @@ An array of:
 * `<null>` - Unknown transaction
 * `<object>`
   * `slot: <u64>` - The slot the transaction was processed
-  * `confirmations: <usize | null>` - Number of blocks since signature confirmation, null if rooted
+  * `confirmations: <usize | null>` - Number of blocks since signature confirmation, null if rooted, as well as finalized by a supermajority of the cluster
   * `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
   * DEPRECATED: `status: <object>` - Transaction status
     * `"Ok": <null>` - Transaction was successful


### PR DESCRIPTION
#### Problem
`send_and_confirm_transaction*` methods consider a transaction finalized when the node in question has rooted the transaction's block. This is a little too early; all the other confirmation levels depend on a supermajority of the cluster having reached that level.

#### Summary of Changes
- Distinguish rooted stake from `MAX_LOCKOUT_HISTORY` stake in BlockCommitment
- Use rooted stake to include check that 2/3 of cluster has rooted a transaction's block in `getSignatureStatuses` rpc (which means that rpc_client `send_and_confirm_transaction*` methods will wait until cluster-root check is met)

It has also been proposed to check the node's trusted validator set when considering a transaction/block finalized; will explore that in a separate pr.
