### PR TITLE
Explicitly specificy old version for cargo update

### DIFF
--- a/ci/dependabot-updater.sh
+++ b/ci/dependabot-updater.sh
@@ -8,9 +8,9 @@ commit_range="$(git merge-base HEAD origin/master)..HEAD"
 parsed_update_args="$(
   git log "$commit_range" --author "dependabot-preview" --oneline -n1 |
     grep -o 'Bump.*$' |
-    sed -r 's/Bump ([^ ]+) from [^ ]+ to ([^ ]+)/-p \1 --precise \2/'
+    sed -r 's/Bump ([^ ]+) from ([^ ]+) to ([^ ]+)/-p \1:\2 --precise \3/'
 )"
-package=$(echo "$parsed_update_args" | awk '{print $2}')
+package=$(echo "$parsed_update_args" | awk '{print $2}' | grep -o "^[^:]*")
 if [[ -n $parsed_update_args ]]; then
   # shellcheck disable=SC2086
   _ scripts/cargo-for-all-lock-files.sh \


### PR DESCRIPTION
#### Problem

There is very minor problem for some corner case in #9180...
```
+ cd programs/librapay
+ cargo update -p bs58 --precise 0.3.1
error: There are multiple `bs58` packages in your project, and the specification `bs58` is ambiguous.
Please re-run this command with `-p <spec>` where `<spec>` is one of the following:
  bs58:0.2.5
  bs58:0.3.0
```

#### Summary of Changes

Fix it.