### PR TITLE
Relax setting withdraw authority during lockup

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -62,7 +62,8 @@ pub enum StakeInstruction {
     /// Expects 2 Accounts:
     ///    0 - StakeAccount to be updated with the Pubkey for
     ///          authorization
-    ///    1 - Clock sysvar Account that carries clock bank epoch
+    ///    1 - (reserved for future use) Clock sysvar Account that carries
+    ///        clock bank epoch
     Authorize(Pubkey, StakeAuthorize),
 
     /// `Delegate` a stake to a particular vote account
@@ -383,12 +384,9 @@ pub fn process_instruction(
             &lockup,
             &Rent::from_keyed_account(next_keyed_account(keyed_accounts)?)?,
         ),
-        StakeInstruction::Authorize(authorized_pubkey, stake_authorize) => me.authorize(
-            &authorized_pubkey,
-            stake_authorize,
-            &signers,
-            &Clock::from_keyed_account(next_keyed_account(keyed_accounts)?)?,
-        ),
+        StakeInstruction::Authorize(authorized_pubkey, stake_authorize) => {
+            me.authorize(&authorized_pubkey, stake_authorize, &signers)
+        }
         StakeInstruction::DelegateStake => {
             let vote = next_keyed_account(keyed_accounts)?;
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -922,6 +922,22 @@ mod tests {
     }
 
     #[test]
+    fn test_authorized_authorize() {
+        let staker = Pubkey::new_rand();
+        let mut authorized = Authorized::auto(&staker);
+        let mut signers = HashSet::new();
+        assert_eq!(
+            authorized.authorize(&signers, &staker, StakeAuthorize::Staker),
+            Err(InstructionError::MissingRequiredSignature)
+        );
+        signers.insert(staker);
+        assert_eq!(
+            authorized.authorize(&signers, &staker, StakeAuthorize::Staker),
+            Ok(())
+        );
+    }
+
+    #[test]
     fn test_meta_authorize_withdraw() {
         let staker = Pubkey::new_rand();
         let custodian = Pubkey::new_rand();
@@ -936,19 +952,9 @@ mod tests {
         };
         // verify sig check
         let mut signers = HashSet::new();
+        signers.insert(staker);
         let mut clock = Clock::default();
 
-        assert_eq!(
-            meta.authorized
-                .authorize(&signers, &staker, StakeAuthorize::Staker),
-            Err(InstructionError::MissingRequiredSignature)
-        );
-        signers.insert(staker);
-        assert_eq!(
-            meta.authorized
-                .authorize(&signers, &staker, StakeAuthorize::Staker),
-            Ok(())
-        );
         // verify lockup check
         meta.lockup.epoch = 1;
         assert_eq!(

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -588,15 +588,17 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         authority: &Pubkey,
         stake_authorize: StakeAuthorize,
         signers: &HashSet<Pubkey>,
-        clock: &Clock,
+        _clock: &Clock,
     ) -> Result<(), InstructionError> {
         match self.state()? {
             StakeState::Stake(mut meta, stake) => {
-                meta.authorize_withdraw(authority, stake_authorize, signers, clock)?;
+                meta.authorized
+                    .authorize(signers, authority, stake_authorize)?;
                 self.set_state(&StakeState::Stake(meta, stake))
             }
             StakeState::Initialized(mut meta) => {
-                meta.authorize_withdraw(authority, stake_authorize, signers, clock)?;
+                meta.authorized
+                    .authorize(signers, authority, stake_authorize)?;
                 self.set_state(&StakeState::Initialized(meta))
             }
             _ => Err(InstructionError::InvalidAccountData),


### PR DESCRIPTION
#### Problem

The stake account's withdraw authority can't be set when withdraws are locked up.

#### Summary of Changes

Allow any authority to be set while locked up, not just the stake authority.

cc: @mvines 