### PR TITLE
Handle no hit correctly...

### DIFF
--- a/ci/dependabot-updater.sh
+++ b/ci/dependabot-updater.sh
@@ -13,9 +13,11 @@ parsed_update_args="$(
 package=$(echo "$parsed_update_args" | awk '{print $2}' | grep -o "^[^:]*")
 if [[ -n $parsed_update_args ]]; then
   # shellcheck disable=SC2086
-  _ scripts/cargo-for-all-lock-files.sh \
-    "$(git grep --files-with-matches "$package" :**/Cargo.lock)" -- \
-    update $parsed_update_args
+  for lock in $(git grep --files-with-matches --fixed-strings "$package" :**/Cargo.lock); do
+    _ scripts/cargo-for-all-lock-files.sh \
+      "$lock" -- \
+      update $parsed_update_args
+  done
 fi
 
 echo --- ok


### PR DESCRIPTION
#### Problem

Fix this error:

```
+ echo '--- scripts/cargo-for-all-lock-files.sh  -- update -p jsonrpc-http-server:14.0.6 --precise 14.1.0'
+ scripts/cargo-for-all-lock-files.sh '' -- update -p jsonrpc-http-server:14.0.6 --precise 14.1.0
scripts/cargo-for-all-lock-files.sh -- update -p jsonrpc-http-server:14.0.6 --precise 14.1.0
++ dirname programs/bpf/Cargo.lock
+ cd programs/bpf
+ cargo '' -- update -p jsonrpc-http-server:14.0.6 --precise 14.1.0
error: no such subcommand: ``
 
	Did you mean `doc`?
```