### PR TITLE
Add using OutputFormat enum to --sign-only transactions

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2275,7 +2275,10 @@ pub fn request_and_confirm_airdrop(
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 
-pub fn log_instruction_custom_error<E>(result: ClientResult<Signature>, config: &CliConfig) -> ProcessResult
+pub fn log_instruction_custom_error<E>(
+    result: ClientResult<Signature>,
+    config: &CliConfig,
+) -> ProcessResult
 where
     E: 'static + std::error::Error + DecodeError<E> + FromPrimitive,
 {
@@ -2293,9 +2296,11 @@ where
             Err(err.into())
         }
         Ok(sig) => {
-                    let signature = CliSignature {signature: sig.to_string()};
-                    config.output_format.formatted_print(&signature);
-                    Ok("".to_string())
+            let signature = CliSignature {
+                signature: sig.to_string(),
+            };
+            config.output_format.formatted_print(&signature);
+            Ok("".to_string())
         }
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1076,9 +1076,7 @@ pub fn return_signers(tx: &Transaction, config: &CliConfig) -> ProcessResult {
         bad_sig,
     };
 
-    config.output_format.formatted_print(&cli_command);
-
-    Ok(json!(cli_command).to_string())
+    Ok(config.output_format.formatted_string(&cli_command))
 }
 
 pub fn parse_create_address_with_seed(
@@ -1347,8 +1345,9 @@ fn process_deploy(
     trace!("Creating program account");
     let result =
         rpc_client.send_and_confirm_transaction_with_spinner(&mut create_account_tx, &signers);
-    log_instruction_custom_error::<SystemError>(result, &config)
-        .map_err(|_| CliError::DynamicProgramError("Program account allocation failed".to_string()))?;
+    log_instruction_custom_error::<SystemError>(result, &config).map_err(|_| {
+        CliError::DynamicProgramError("Program account allocation failed".to_string())
+    })?;
 
     trace!("Writing program data");
     rpc_client
@@ -2309,8 +2308,7 @@ where
             let signature = CliSignature {
                 signature: sig.clone().to_string(),
             };
-            config.output_format.formatted_print(&signature);
-            Ok(sig.to_string())
+            Ok(config.output_format.formatted_string(&signature))
         }
     }
 }
@@ -3835,7 +3833,8 @@ mod tests {
             }
         }
 
-        let config = CliConfig::default();
+        let mut config = CliConfig::default();
+        config.output_format = OutputFormat::JsonCompact;
         let present: Box<dyn Signer> = Box::new(keypair_from_seed(&[2u8; 32]).unwrap());
         let absent: Box<dyn Signer> = Box::new(NullSigner::new(&Pubkey::new(&[3u8; 32])));
         let bad: Box<dyn Signer> = Box::new(BadSigner::new(Pubkey::new(&[4u8; 32])));

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1071,9 +1071,9 @@ pub fn return_signers(tx: &Transaction, config: &CliConfig) -> ProcessResult {
 
     let cli_command = CliSignOnlyData {
         blockhash: tx.message.recent_blockhash,
-        signers: signers,
-        absent: absent,
-        bad_sig: bad_sig,
+        signers,
+        absent,
+        bad_sig,
     };
 
     config.output_format.formatted_print(&cli_command);

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1070,21 +1070,15 @@ pub fn return_signers(tx: &Transaction, config: &CliConfig) -> ProcessResult {
         });
 
     let cli_command = CliSignOnlyData {
-        blockhash: tx.message.recent_blockhash.clone(),
-        signers: signers.clone(),
-        absent: absent.clone(),
-        bad_sig: bad_sig.clone(),
+        blockhash: tx.message.recent_blockhash.to_string(),
+        signers,
+        absent,
+        bad_sig,
     };
 
     config.output_format.formatted_print(&cli_command);
 
-    Ok(json!({
-        "blockhash": tx.message.recent_blockhash.to_string(),
-        "signers": &signers,
-        "absent": &absent,
-        "badSig": &bad_sig,
-    })
-    .to_string())
+    Ok(json!(cli_command).to_string())
 }
 
 pub fn parse_create_address_with_seed(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,7 +1,7 @@
 use crate::{
-    cli_output::{CliAccount, OutputFormat},
+    cli_output::{CliAccount, CliSignOnlyCommand, CliSignature, OutputFormat},
     cluster_query::*,
-    display::{println_name_value, println_signers},
+    display::println_name_value,
     nonce::{self, *},
     offline::{blockhash_query::BlockhashQuery, *},
     stake::*,
@@ -1050,7 +1050,7 @@ pub fn get_blockhash_and_fee_calculator(
     })
 }
 
-pub fn return_signers(tx: &Transaction) -> ProcessResult {
+pub fn return_signers(tx: &Transaction, config: &CliConfig) -> ProcessResult {
     let verify_results = tx.verify_with_results();
     let mut signers = Vec::new();
     let mut absent = Vec::new();
@@ -1069,15 +1069,16 @@ pub fn return_signers(tx: &Transaction) -> ProcessResult {
             }
         });
 
-    println_signers(&tx.message.recent_blockhash, &signers, &absent, &bad_sig);
+    let cli_command = CliSignOnlyCommand {
+        blockhash: tx.message.recent_blockhash,
+        signers: signers,
+        absent: absent,
+        bad_sig: bad_sig,
+    };
 
-    Ok(json!({
-        "blockhash": tx.message.recent_blockhash.to_string(),
-        "signers": &signers,
-        "absent": &absent,
-        "badSig": &bad_sig,
-    })
-    .to_string())
+    config.output_format.formatted_print(&cli_command);
+
+    Ok("".to_string())
 }
 
 pub fn parse_create_address_with_seed(
@@ -1165,7 +1166,7 @@ fn process_airdrop(
         }
     };
 
-    request_and_confirm_airdrop(&rpc_client, faucet_addr, &pubkey, lamports)?;
+    request_and_confirm_airdrop(&rpc_client, faucet_addr, &pubkey, lamports, &config)?;
 
     let current_balance = rpc_client
         .retry_get_balance(&pubkey, 5)?
@@ -1346,9 +1347,8 @@ fn process_deploy(
     trace!("Creating program account");
     let result =
         rpc_client.send_and_confirm_transaction_with_spinner(&mut create_account_tx, &signers);
-    log_instruction_custom_error::<SystemError>(result).map_err(|_| {
-        CliError::DynamicProgramError("Program account allocation failed".to_string())
-    })?;
+    log_instruction_custom_error::<SystemError>(result, &config)
+        .map_err(|_| CliError::DynamicProgramError("Program account allocation failed".to_string()))?;
 
     trace!("Writing program data");
     rpc_client
@@ -1411,7 +1411,7 @@ fn process_pay(
 
         if sign_only {
             tx.try_partial_sign(&config.signers, blockhash)?;
-            return_signers(&tx)
+            return_signers(&tx, &config)
         } else {
             tx.try_sign(&config.signers, blockhash)?;
             if let Some(nonce_account) = &nonce_account {
@@ -1426,7 +1426,7 @@ fn process_pay(
             )?;
             let result =
                 rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-            log_instruction_custom_error::<SystemError>(result)
+            log_instruction_custom_error::<SystemError>(result, &config)
         }
     } else if *witnesses == None {
         let dt = timestamp.unwrap();
@@ -1451,7 +1451,7 @@ fn process_pay(
         let mut tx = Transaction::new_unsigned(message);
         if sign_only {
             tx.try_partial_sign(&[config.signers[0], &contract_state], blockhash)?;
-            return_signers(&tx)
+            return_signers(&tx, &config)
         } else {
             tx.try_sign(&[config.signers[0], &contract_state], blockhash)?;
             check_account_for_fee(
@@ -1464,13 +1464,7 @@ fn process_pay(
                 &mut tx,
                 &[config.signers[0], &contract_state],
             );
-            let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
-
-            Ok(json!({
-                "signature": signature_str,
-                "processId": format!("{}", contract_state.pubkey()),
-            })
-            .to_string())
+            log_instruction_custom_error::<BudgetError>(result, &config)
         }
     } else if timestamp == None {
         let witness = if let Some(ref witness_vec) = *witnesses {
@@ -1497,7 +1491,7 @@ fn process_pay(
         let mut tx = Transaction::new_unsigned(message);
         if sign_only {
             tx.try_partial_sign(&[config.signers[0], &contract_state], blockhash)?;
-            return_signers(&tx)
+            return_signers(&tx, &config)
         } else {
             tx.try_sign(&[config.signers[0], &contract_state], blockhash)?;
             let result = rpc_client.send_and_confirm_transaction_with_spinner(
@@ -1510,13 +1504,7 @@ fn process_pay(
                 &fee_calculator,
                 &tx.message,
             )?;
-            let signature_str = log_instruction_custom_error::<BudgetError>(result)?;
-
-            Ok(json!({
-                "signature": signature_str,
-                "processId": format!("{}", contract_state.pubkey()),
-            })
-            .to_string())
+            log_instruction_custom_error::<BudgetError>(result, &config)
         }
     } else {
         Ok("Combo transactions not yet handled".to_string())
@@ -1541,7 +1529,7 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
     )?;
     let result =
         rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0]]);
-    log_instruction_custom_error::<BudgetError>(result)
+    log_instruction_custom_error::<BudgetError>(result, &config)
 }
 
 fn process_time_elapsed(
@@ -1565,7 +1553,7 @@ fn process_time_elapsed(
     )?;
     let result =
         rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0]]);
-    log_instruction_custom_error::<BudgetError>(result)
+    log_instruction_custom_error::<BudgetError>(result, &config)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1610,7 +1598,7 @@ fn process_transfer(
 
     if sign_only {
         tx.try_partial_sign(&config.signers, recent_blockhash)?;
-        return_signers(&tx)
+        return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
@@ -1628,7 +1616,7 @@ fn process_transfer(
         } else {
             rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers)
         };
-        log_instruction_custom_error::<SystemError>(result)
+        log_instruction_custom_error::<SystemError>(result, &config)
     }
 }
 
@@ -1652,7 +1640,7 @@ fn process_witness(
     )?;
     let result =
         rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0]]);
-    log_instruction_custom_error::<BudgetError>(result)
+    log_instruction_custom_error::<BudgetError>(result, &config)
 }
 
 pub fn process_command(config: &CliConfig) -> ProcessResult {
@@ -2268,6 +2256,7 @@ pub fn request_and_confirm_airdrop(
     faucet_addr: &SocketAddr,
     to_pubkey: &Pubkey,
     lamports: u64,
+    config: &CliConfig,
 ) -> ProcessResult {
     let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let keypair = {
@@ -2283,10 +2272,10 @@ pub fn request_and_confirm_airdrop(
     }?;
     let mut tx = keypair.airdrop_transaction();
     let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[&keypair]);
-    log_instruction_custom_error::<SystemError>(result)
+    log_instruction_custom_error::<SystemError>(result, &config)
 }
 
-pub fn log_instruction_custom_error<E>(result: ClientResult<Signature>) -> ProcessResult
+pub fn log_instruction_custom_error<E>(result: ClientResult<Signature>, config: &CliConfig) -> ProcessResult
 where
     E: 'static + std::error::Error + DecodeError<E> + FromPrimitive,
 {
@@ -2303,7 +2292,11 @@ where
             }
             Err(err.into())
         }
-        Ok(sig) => Ok(sig.to_string()),
+        Ok(sig) => {
+                    let signature = CliSignature {signature: sig.to_string()};
+                    config.output_format.formatted_print(&signature);
+                    Ok("".to_string())
+        }
     }
 }
 
@@ -3827,6 +3820,7 @@ mod tests {
             }
         }
 
+        let config = CliConfig::default();
         let present: Box<dyn Signer> = Box::new(keypair_from_seed(&[2u8; 32]).unwrap());
         let absent: Box<dyn Signer> = Box::new(NullSigner::new(&Pubkey::new(&[3u8; 32])));
         let bad: Box<dyn Signer> = Box::new(BadSigner::new(Pubkey::new(&[4u8; 32])));
@@ -3845,7 +3839,7 @@ mod tests {
         let signers = vec![present.as_ref(), absent.as_ref(), bad.as_ref()];
         let blockhash = Hash::new(&[7u8; 32]);
         tx.try_partial_sign(&signers, blockhash).unwrap();
-        let res = return_signers(&tx).unwrap();
+        let res = return_signers(&tx, &config).unwrap();
         let sign_only = parse_sign_only_reply_string(&res);
         assert_eq!(sign_only.blockhash, blockhash);
         assert_eq!(sign_only.present_signers[0].0, present.pubkey());

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli_output::{CliAccount, CliSignOnlyCommand, CliSignature, OutputFormat},
+    cli_output::{CliAccount, CliSignOnlyData, CliSignature, OutputFormat},
     cluster_query::*,
     display::println_name_value,
     nonce::{self, *},
@@ -1069,7 +1069,7 @@ pub fn return_signers(tx: &Transaction, config: &CliConfig) -> ProcessResult {
             }
         });
 
-    let cli_command = CliSignOnlyCommand {
+    let cli_command = CliSignOnlyData {
         blockhash: tx.message.recent_blockhash,
         signers: signers,
         absent: absent,

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -7,7 +7,6 @@ use serde_json::{Map, Value};
 use solana_client::rpc_response::{RpcEpochInfo, RpcKeyedAccount, RpcVoteAccountInfo};
 use solana_sdk::{
     clock::{self, Epoch, Slot, UnixTimestamp},
-    hash::Hash,
     stake_history::StakeHistoryEntry,
 };
 use solana_stake_program::stake_state::{Authorized, Lockup};
@@ -859,8 +858,9 @@ impl fmt::Display for CliBlockTime {
 }
 
 #[derive(Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct CliSignOnlyData {
-    pub blockhash: Hash,
+    pub blockhash: String,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub signers: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -872,7 +872,7 @@ pub struct CliSignOnlyData {
 impl fmt::Display for CliSignOnlyData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f)?;
-        writeln_name_value(f, "Blockhash:", &bs58::encode(self.blockhash).into_string())?;
+        writeln_name_value(f, "Blockhash:", &self.blockhash)?;
         if !self.signers.is_empty() {
             writeln!(f, "{}", style("Signers (Pubkey=Signature):").bold())?;
             for signer in self.signers.iter() {

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -7,8 +7,8 @@ use serde_json::{Map, Value};
 use solana_client::rpc_response::{RpcEpochInfo, RpcKeyedAccount, RpcVoteAccountInfo};
 use solana_sdk::{
     clock::{self, Epoch, Slot, UnixTimestamp},
-    stake_history::StakeHistoryEntry,
     hash::Hash,
+    stake_history::StakeHistoryEntry,
 };
 use solana_stake_program::stake_state::{Authorized, Lockup};
 use solana_vote_program::{

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -8,6 +8,7 @@ use solana_client::rpc_response::{RpcEpochInfo, RpcKeyedAccount, RpcVoteAccountI
 use solana_sdk::{
     clock::{self, Epoch, Slot, UnixTimestamp},
     stake_history::StakeHistoryEntry,
+    hash::Hash,
 };
 use solana_stake_program::stake_state::{Authorized, Lockup};
 use solana_vote_program::{
@@ -854,5 +855,55 @@ impl fmt::Display for CliBlockTime {
                 self.timestamp
             ),
         )
+    }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct CliSignOnlyCommand {
+    pub blockhash: Hash,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub signers: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub absent: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub bad_sig: Vec<String>,
+}
+
+impl fmt::Display for CliSignOnlyCommand {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f)?;
+        writeln_name_value(f, "Blockhash:", &bs58::encode(self.blockhash).into_string())?;
+        if !self.signers.is_empty() {
+            writeln!(f, "{}", style("Signers (Pubkey=Signature):").bold())?;
+            for signer in self.signers.iter() {
+                writeln!(f, " {}", signer)?;
+            }
+        }
+        if !self.absent.is_empty() {
+            writeln!(f, "{}", style("Absent Signers (Pubkey):").bold())?;
+            for pubkey in self.absent.iter() {
+                writeln!(f, " {}", pubkey)?;
+            }
+        }
+        if !self.bad_sig.is_empty() {
+            writeln!(f, "{}", style("Bad Signatures (Pubkey):").bold())?;
+            for pubkey in self.bad_sig.iter() {
+                writeln!(f, " {}", pubkey)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CliSignature {
+    pub signature: String,
+}
+
+impl fmt::Display for CliSignature {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f)?;
+        writeln_name_value(f, "Signature:", &self.signature)?;
+        Ok(())
     }
 }

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -859,7 +859,7 @@ impl fmt::Display for CliBlockTime {
 }
 
 #[derive(Serialize, Deserialize, Default)]
-pub struct CliSignOnlyCommand {
+pub struct CliSignOnlyData {
     pub blockhash: Hash,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub signers: Vec<String>,
@@ -869,7 +869,7 @@ pub struct CliSignOnlyCommand {
     pub bad_sig: Vec<String>,
 }
 
-impl fmt::Display for CliSignOnlyCommand {
+impl fmt::Display for CliSignOnlyData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f)?;
         writeln_name_value(f, "Blockhash:", &bs58::encode(self.blockhash).into_string())?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,8 +2,7 @@ use clap::{crate_description, crate_name, AppSettings, Arg, ArgGroup, ArgMatches
 use console::style;
 
 use solana_clap_utils::{
-    input_validators::is_url, keypair::SKIP_SEED_PHRASE_VALIDATION_ARG, offline::SIGN_ONLY_ARG,
-    DisplayError,
+    input_validators::is_url, keypair::SKIP_SEED_PHRASE_VALIDATION_ARG, DisplayError,
 };
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliSigners},
@@ -262,13 +261,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
         let (mut config, signers) = parse_args(&matches, &mut wallet_manager)?;
         config.signers = signers.iter().map(|s| s.as_ref()).collect();
         let result = process_command(&config)?;
-        let (_, submatches) = matches.subcommand();
-        let sign_only = submatches
-            .map(|m| m.is_present(SIGN_ONLY_ARG.name))
-            .unwrap_or(false);
-        if !sign_only {
-            println!("{}", result);
-        }
+        println!("{}", result);
     };
     Ok(())
 }

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -447,7 +447,7 @@ pub fn process_authorize_nonce_account(
         &tx.message,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-    log_instruction_custom_error::<NonceError>(result)
+    log_instruction_custom_error::<NonceError>(result, &config)
 }
 
 pub fn process_create_nonce_account(
@@ -524,7 +524,7 @@ pub fn process_create_nonce_account(
         &tx.message,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-    log_instruction_custom_error::<SystemError>(result)
+    log_instruction_custom_error::<SystemError>(result, &config)
 }
 
 pub fn process_get_nonce(rpc_client: &RpcClient, nonce_account_pubkey: &Pubkey) -> ProcessResult {
@@ -566,7 +566,7 @@ pub fn process_new_nonce(
     )?;
     let result = rpc_client
         .send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0], nonce_authority]);
-    log_instruction_custom_error::<SystemError>(result)
+    log_instruction_custom_error::<SystemError>(result, &config)
 }
 
 pub fn process_show_nonce_account(
@@ -625,7 +625,7 @@ pub fn process_withdraw_from_nonce_account(
         &tx.message,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-    log_instruction_custom_error::<NonceError>(result)
+    log_instruction_custom_error::<NonceError>(result, &config)
 }
 
 #[cfg(test)]

--- a/cli/src/offline/mod.rs
+++ b/cli/src/offline/mod.rs
@@ -81,53 +81,44 @@ pub fn parse_sign_only_reply_string(reply: &str) -> SignOnly {
     let blockhash = blockhash_str.parse::<Hash>().unwrap();
     let mut present_signers: Vec<(Pubkey, Signature)> = Vec::new();
     let signer_strings = object.get("signers");
-    match signer_strings {
-        Some(sig_strings) => {
-            present_signers = sig_strings
-                .as_array()
-                .unwrap()
-                .iter()
-                .map(|signer_string| {
-                    let mut signer = signer_string.as_str().unwrap().split('=');
-                    let key = Pubkey::from_str(signer.next().unwrap()).unwrap();
-                    let sig = Signature::from_str(signer.next().unwrap()).unwrap();
-                    (key, sig)
-                })
-                .collect();
-        }
-        _ => {}
+    if let Some(sig_strings) = signer_strings {
+        present_signers = sig_strings
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|signer_string| {
+                let mut signer = signer_string.as_str().unwrap().split('=');
+                let key = Pubkey::from_str(signer.next().unwrap()).unwrap();
+                let sig = Signature::from_str(signer.next().unwrap()).unwrap();
+                (key, sig)
+            })
+            .collect();
     }
     let mut absent_signers: Vec<Pubkey> = Vec::new();
     let signer_strings = object.get("absent");
-    match signer_strings {
-        Some(sig_strings) => {
-            absent_signers = sig_strings
-                .as_array()
-                .unwrap()
-                .iter()
-                .map(|val| {
-                    let s = val.as_str().unwrap();
-                    Pubkey::from_str(s).unwrap()
-                })
-                .collect();
-        }
-        _ => {}
+    if let Some(sig_strings) = signer_strings {
+        absent_signers = sig_strings
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|val| {
+                let s = val.as_str().unwrap();
+                Pubkey::from_str(s).unwrap()
+            })
+            .collect();
     }
     let mut bad_signers: Vec<Pubkey> = Vec::new();
     let signer_strings = object.get("badSig");
-    match signer_strings {
-        Some(sig_strings) => {
-            bad_signers = sig_strings
-                .as_array()
-                .unwrap()
-                .iter()
-                .map(|val| {
-                    let s = val.as_str().unwrap();
-                    Pubkey::from_str(s).unwrap()
-                })
-                .collect();
-        }
-        _ => {}
+    if let Some(sig_strings) = signer_strings {
+        bad_signers = sig_strings
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|val| {
+                let s = val.as_str().unwrap();
+                Pubkey::from_str(s).unwrap()
+            })
+            .collect();
     }
     SignOnly {
         blockhash,

--- a/cli/src/offline/mod.rs
+++ b/cli/src/offline/mod.rs
@@ -79,32 +79,56 @@ pub fn parse_sign_only_reply_string(reply: &str) -> SignOnly {
     let object: Value = serde_json::from_str(&reply).unwrap();
     let blockhash_str = object.get("blockhash").unwrap().as_str().unwrap();
     let blockhash = blockhash_str.parse::<Hash>().unwrap();
-    let signer_strings = object.get("signers").unwrap().as_array().unwrap();
-    let present_signers = signer_strings
-        .iter()
-        .map(|signer_string| {
-            let mut signer = signer_string.as_str().unwrap().split('=');
-            let key = Pubkey::from_str(signer.next().unwrap()).unwrap();
-            let sig = Signature::from_str(signer.next().unwrap()).unwrap();
-            (key, sig)
-        })
-        .collect();
-    let signer_strings = object.get("absent").unwrap().as_array().unwrap();
-    let absent_signers = signer_strings
-        .iter()
-        .map(|val| {
-            let s = val.as_str().unwrap();
-            Pubkey::from_str(s).unwrap()
-        })
-        .collect();
-    let signer_strings = object.get("badSig").unwrap().as_array().unwrap();
-    let bad_signers = signer_strings
-        .iter()
-        .map(|val| {
-            let s = val.as_str().unwrap();
-            Pubkey::from_str(s).unwrap()
-        })
-        .collect();
+    let mut present_signers: Vec<(Pubkey, Signature)> = Vec::new();
+    let signer_strings = object.get("signers");
+    match signer_strings {
+        Some(sig_strings) => {
+            present_signers = sig_strings
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|signer_string| {
+                    let mut signer = signer_string.as_str().unwrap().split('=');
+                    let key = Pubkey::from_str(signer.next().unwrap()).unwrap();
+                    let sig = Signature::from_str(signer.next().unwrap()).unwrap();
+                    (key, sig)
+                })
+                .collect();
+        }
+        _ => {}
+    }
+    let mut absent_signers: Vec<Pubkey> = Vec::new();
+    let signer_strings = object.get("absent");
+    match signer_strings {
+        Some(sig_strings) => {
+            absent_signers = sig_strings
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|val| {
+                    let s = val.as_str().unwrap();
+                    Pubkey::from_str(s).unwrap()
+                })
+                .collect();
+        }
+        _ => {}
+    }
+    let mut bad_signers: Vec<Pubkey> = Vec::new();
+    let signer_strings = object.get("badSig");
+    match signer_strings {
+        Some(sig_strings) => {
+            bad_signers = sig_strings
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|val| {
+                    let s = val.as_str().unwrap();
+                    Pubkey::from_str(s).unwrap()
+                })
+                .collect();
+        }
+        _ => {}
+    }
     SignOnly {
         blockhash,
         present_signers,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -856,7 +856,7 @@ pub fn process_create_stake_account(
 
     if sign_only {
         tx.try_partial_sign(&config.signers, recent_blockhash)?;
-        return_signers(&tx)
+        return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
@@ -870,7 +870,7 @@ pub fn process_create_stake_account(
             &tx.message,
         )?;
         let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-        log_instruction_custom_error::<SystemError>(result)
+        log_instruction_custom_error::<SystemError>(result, &config)
     }
 }
 
@@ -921,7 +921,7 @@ pub fn process_stake_authorize(
 
     if sign_only {
         tx.try_partial_sign(&config.signers, recent_blockhash)?;
-        return_signers(&tx)
+        return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
@@ -935,7 +935,7 @@ pub fn process_stake_authorize(
             &tx.message,
         )?;
         let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-        log_instruction_custom_error::<StakeError>(result)
+        log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
 
@@ -975,7 +975,7 @@ pub fn process_deactivate_stake_account(
 
     if sign_only {
         tx.try_partial_sign(&config.signers, recent_blockhash)?;
-        return_signers(&tx)
+        return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
@@ -989,7 +989,7 @@ pub fn process_deactivate_stake_account(
             &tx.message,
         )?;
         let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-        log_instruction_custom_error::<StakeError>(result)
+        log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
 
@@ -1038,7 +1038,7 @@ pub fn process_withdraw_stake(
 
     if sign_only {
         tx.try_partial_sign(&config.signers, recent_blockhash)?;
-        return_signers(&tx)
+        return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
@@ -1052,7 +1052,7 @@ pub fn process_withdraw_stake(
             &tx.message,
         )?;
         let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-        log_instruction_custom_error::<SystemError>(result)
+        log_instruction_custom_error::<SystemError>(result, &config)
     }
 }
 
@@ -1172,7 +1172,7 @@ pub fn process_split_stake(
 
     if sign_only {
         tx.try_partial_sign(&config.signers, recent_blockhash)?;
-        return_signers(&tx)
+        return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
@@ -1186,7 +1186,7 @@ pub fn process_split_stake(
             &tx.message,
         )?;
         let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-        log_instruction_custom_error::<StakeError>(result)
+        log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
 
@@ -1229,7 +1229,7 @@ pub fn process_stake_set_lockup(
 
     if sign_only {
         tx.try_partial_sign(&config.signers, recent_blockhash)?;
-        return_signers(&tx)
+        return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
@@ -1243,7 +1243,7 @@ pub fn process_stake_set_lockup(
             &tx.message,
         )?;
         let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-        log_instruction_custom_error::<StakeError>(result)
+        log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
 
@@ -1437,7 +1437,7 @@ pub fn process_delegate_stake(
 
     if sign_only {
         tx.try_partial_sign(&config.signers, recent_blockhash)?;
-        return_signers(&tx)
+        return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
@@ -1451,7 +1451,7 @@ pub fn process_delegate_stake(
             &tx.message,
         )?;
         let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-        log_instruction_custom_error::<StakeError>(result)
+        log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
 

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -243,7 +243,7 @@ pub fn process_create_storage_account(
         &tx.message,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-    log_instruction_custom_error::<SystemError>(result)
+    log_instruction_custom_error::<SystemError>(result, &config)
 }
 
 pub fn process_claim_storage_reward(

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -438,7 +438,7 @@ pub fn process_create_vote_account(
         &tx.message,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-    log_instruction_custom_error::<SystemError>(result)
+    log_instruction_custom_error::<SystemError>(result, &config)
 }
 
 pub fn process_vote_authorize(
@@ -479,7 +479,7 @@ pub fn process_vote_authorize(
     )?;
     let result =
         rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0]]);
-    log_instruction_custom_error::<VoteError>(result)
+    log_instruction_custom_error::<VoteError>(result, &config)
 }
 
 pub fn process_vote_update_validator(
@@ -512,7 +512,7 @@ pub fn process_vote_update_validator(
         &tx.message,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
-    log_instruction_custom_error::<VoteError>(result)
+    log_instruction_custom_error::<VoteError>(result, &config)
 }
 
 fn get_vote_account(
@@ -618,7 +618,7 @@ pub fn process_withdraw_from_vote_account(
     )?;
     let result =
         rpc_client.send_and_confirm_transaction_with_spinner(&mut transaction, &config.signers);
-    log_instruction_custom_error::<VoteError>(result)
+    log_instruction_custom_error::<VoteError>(result, &config)
 }
 
 #[cfg(test)]

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -1,6 +1,7 @@
 use solana_cli::test_utils::check_balance;
 use solana_cli::{
     cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig},
+    cli_output::OutputFormat,
     nonce,
     offline::{
         blockhash_query::{self, BlockhashQuery},
@@ -320,6 +321,7 @@ fn test_create_account_with_seed() {
         nonce_authority: 0,
         fee_payer: 0,
     };
+    authority_config.output_format = OutputFormat::JsonCompact;
     let sign_only_reply = process_command(&authority_config).unwrap();
     let sign_only = parse_sign_only_reply_string(&sign_only_reply);
     let authority_presigner = sign_only.presigner_of(&authority_pubkey).unwrap();

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -91,6 +91,7 @@ fn full_battery_tests(
         &faucet_addr,
         &config_payer.signers[0].pubkey(),
         2000,
+        &config_payer,
     )
     .unwrap();
     check_balance(2000, &rpc_client, &config_payer.signers[0].pubkey());
@@ -247,6 +248,7 @@ fn test_create_account_with_seed() {
     let offline_nonce_authority_signer = keypair_from_seed(&[1u8; 32]).unwrap();
     let online_nonce_creator_signer = keypair_from_seed(&[2u8; 32]).unwrap();
     let to_address = Pubkey::new(&[3u8; 32]);
+    let config = CliConfig::default();
 
     // Setup accounts
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
@@ -255,6 +257,7 @@ fn test_create_account_with_seed() {
         &faucet_addr,
         &offline_nonce_authority_signer.pubkey(),
         42,
+        &config,
     )
     .unwrap();
     request_and_confirm_airdrop(
@@ -262,6 +265,7 @@ fn test_create_account_with_seed() {
         &faucet_addr,
         &online_nonce_creator_signer.pubkey(),
         4242,
+        &config,
     )
     .unwrap();
     check_balance(42, &rpc_client, &offline_nonce_authority_signer.pubkey());

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use solana_cli::test_utils::check_balance;
 use solana_cli::{
     cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig, PayCommand},
+    cli_output::OutputFormat,
     nonce,
     offline::{
         blockhash_query::{self, BlockhashQuery},
@@ -323,6 +324,7 @@ fn test_offline_pay_tx() {
         sign_only: true,
         ..PayCommand::default()
     });
+    config_offline.output_format = OutputFormat::JsonCompact;
     let sig_response = process_command(&config_offline).unwrap();
 
     check_balance(50, &rpc_client, &config_offline.signers[0].pubkey());

--- a/cli/tests/pay.rs
+++ b/cli/tests/pay.rs
@@ -57,6 +57,7 @@ fn test_cli_timestamp_tx() {
         &faucet_addr,
         &config_payer.signers[0].pubkey(),
         50,
+        &config_witness,
     )
     .unwrap();
     check_balance(50, &rpc_client, &config_payer.signers[0].pubkey());
@@ -66,6 +67,7 @@ fn test_cli_timestamp_tx() {
         &faucet_addr,
         &config_witness.signers[0].pubkey(),
         1,
+        &config_witness,
     )
     .unwrap();
 
@@ -142,6 +144,7 @@ fn test_cli_witness_tx() {
         &faucet_addr,
         &config_payer.signers[0].pubkey(),
         50,
+        &config_witness,
     )
     .unwrap();
     request_and_confirm_airdrop(
@@ -149,6 +152,7 @@ fn test_cli_witness_tx() {
         &faucet_addr,
         &config_witness.signers[0].pubkey(),
         1,
+        &config_witness,
     )
     .unwrap();
 
@@ -222,6 +226,7 @@ fn test_cli_cancel_tx() {
         &faucet_addr,
         &config_payer.signers[0].pubkey(),
         50,
+        &config_witness,
     )
     .unwrap();
 
@@ -295,6 +300,7 @@ fn test_offline_pay_tx() {
         &faucet_addr,
         &config_offline.signers[0].pubkey(),
         50,
+        &config_offline,
     )
     .unwrap();
 
@@ -303,6 +309,7 @@ fn test_offline_pay_tx() {
         &faucet_addr,
         &config_online.signers[0].pubkey(),
         50,
+        &config_offline,
     )
     .unwrap();
     check_balance(50, &rpc_client, &config_offline.signers[0].pubkey());
@@ -376,6 +383,7 @@ fn test_nonced_pay_tx() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         50 + minimum_nonce_balance,
+        &config,
     )
     .unwrap();
     check_balance(

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -837,13 +837,16 @@ fn test_stake_authorize_with_fee_payer() {
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &default_pubkey, 100_000, &config).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &default_pubkey, 100_000, &config)
+        .unwrap();
     check_balance(100_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &payer_pubkey, 100_000, &config).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &payer_pubkey, 100_000, &config)
+        .unwrap();
     check_balance(100_000, &rpc_client, &payer_pubkey);
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config)
+        .unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
@@ -967,7 +970,8 @@ fn test_stake_split() {
     .unwrap();
     check_balance(500_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config)
+        .unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
@@ -1116,7 +1120,8 @@ fn test_stake_set_lockup() {
     .unwrap();
     check_balance(500_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config)
+        .unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
@@ -1367,7 +1372,8 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     .unwrap();
     check_balance(200_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config)
+        .unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create nonce account

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -47,6 +47,7 @@ fn test_stake_delegation_force() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         100_000,
+        &config,
     )
     .unwrap();
 
@@ -143,6 +144,7 @@ fn test_seed_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config_validator.signers[0].pubkey(),
         100_000,
+        &config_validator,
     )
     .unwrap();
     check_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
@@ -233,6 +235,7 @@ fn test_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config_validator.signers[0].pubkey(),
         100_000,
+        &config_validator,
     )
     .unwrap();
     check_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
@@ -329,6 +332,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config_validator.signers[0].pubkey(),
         100_000,
+        &config_offline,
     )
     .unwrap();
     check_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
@@ -338,6 +342,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config_offline.signers[0].pubkey(),
         100_000,
+        &config_validator,
     )
     .unwrap();
     check_balance(100_000, &rpc_client, &config_offline.signers[0].pubkey());
@@ -458,6 +463,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         100_000,
+        &config,
     )
     .unwrap();
 
@@ -567,6 +573,7 @@ fn test_stake_authorize() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         100_000,
+        &config,
     )
     .unwrap();
 
@@ -584,6 +591,7 @@ fn test_stake_authorize() {
         &faucet_addr,
         &config_offline.signers[0].pubkey(),
         100_000,
+        &config,
     )
     .unwrap();
 
@@ -829,13 +837,13 @@ fn test_stake_authorize_with_fee_payer() {
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &default_pubkey, 100_000).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &default_pubkey, 100_000, &config).unwrap();
     check_balance(100_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &payer_pubkey, 100_000).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &payer_pubkey, 100_000, &config).unwrap();
     check_balance(100_000, &rpc_client, &payer_pubkey);
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config).unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
@@ -954,11 +962,12 @@ fn test_stake_split() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         500_000,
+        &config,
     )
     .unwrap();
     check_balance(500_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config).unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
@@ -1102,11 +1111,12 @@ fn test_stake_set_lockup() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         500_000,
+        &config,
     )
     .unwrap();
     check_balance(500_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config).unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
@@ -1352,11 +1362,12 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         200_000,
+        &config,
     )
     .unwrap();
     check_balance(200_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config).unwrap();
     check_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create nonce account

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1,6 +1,7 @@
 use solana_cli::test_utils::check_balance;
 use solana_cli::{
     cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig},
+    cli_output::OutputFormat,
     nonce,
     offline::{
         blockhash_query::{self, BlockhashQuery},
@@ -378,6 +379,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         nonce_authority: 0,
         fee_payer: 0,
     };
+    config_offline.output_format = OutputFormat::JsonCompact;
     let sig_response = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sig_response);
     assert!(sign_only.has_all_signers());
@@ -699,6 +701,7 @@ fn test_stake_authorize() {
         nonce_authority: 0,
         fee_payer: 0,
     };
+    config_offline.output_format = OutputFormat::JsonCompact;
     let sign_reply = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sign_reply);
     assert!(sign_only.has_all_signers());
@@ -900,6 +903,7 @@ fn test_stake_authorize_with_fee_payer() {
         nonce_authority: 0,
         fee_payer: 0,
     };
+    config_offline.output_format = OutputFormat::JsonCompact;
     let sign_reply = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sign_reply);
     assert!(sign_only.has_all_signers());
@@ -1039,6 +1043,7 @@ fn test_stake_split() {
         lamports: 2 * minimum_stake_balance,
         fee_payer: 0,
     };
+    config_offline.output_format = OutputFormat::JsonCompact;
     let sig_response = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sig_response);
     assert!(sign_only.has_all_signers());
@@ -1295,6 +1300,7 @@ fn test_stake_set_lockup() {
         nonce_authority: 0,
         fee_payer: 0,
     };
+    config_offline.output_format = OutputFormat::JsonCompact;
     let sig_response = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sig_response);
     assert!(sign_only.has_all_signers());
@@ -1415,6 +1421,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         fee_payer: 0,
         from: 0,
     };
+    config_offline.output_format = OutputFormat::JsonCompact;
     let sig_response = process_command(&config_offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sig_response);
     assert!(sign_only.has_all_signers());

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -47,7 +47,7 @@ fn test_transfer() {
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::new(&[1u8; 32]);
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000, &config).unwrap();
     check_balance(50_000, &rpc_client, &sender_pubkey);
     check_balance(0, &rpc_client, &recipient_pubkey);
 
@@ -75,7 +75,7 @@ fn test_transfer() {
     process_command(&offline).unwrap_err();
 
     let offline_pubkey = offline.signers[0].pubkey();
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 50).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 50, &config).unwrap();
     check_balance(50, &rpc_client, &offline_pubkey);
 
     // Offline transfer
@@ -235,16 +235,18 @@ fn test_transfer_multisession_signing() {
     let offline_from_signer = keypair_from_seed(&[2u8; 32]).unwrap();
     let offline_fee_payer_signer = keypair_from_seed(&[3u8; 32]).unwrap();
     let from_null_signer = NullSigner::new(&offline_from_signer.pubkey());
+    let config = CliConfig::default();
 
     // Setup accounts
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_from_signer.pubkey(), 43)
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_from_signer.pubkey(), 43, &config)
         .unwrap();
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
         &offline_fee_payer_signer.pubkey(),
         3,
+        &config,
     )
     .unwrap();
     check_balance(43, &rpc_client, &offline_from_signer.pubkey());

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -47,7 +47,8 @@ fn test_transfer() {
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::new(&[1u8; 32]);
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000, &config).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000, &config)
+        .unwrap();
     check_balance(50_000, &rpc_client, &sender_pubkey);
     check_balance(0, &rpc_client, &recipient_pubkey);
 
@@ -239,8 +240,14 @@ fn test_transfer_multisession_signing() {
 
     // Setup accounts
     let rpc_client = RpcClient::new_socket(leader_data.rpc);
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_from_signer.pubkey(), 43, &config)
-        .unwrap();
+    request_and_confirm_airdrop(
+        &rpc_client,
+        &faucet_addr,
+        &offline_from_signer.pubkey(),
+        43,
+        &config,
+    )
+    .unwrap();
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -1,6 +1,7 @@
 use solana_cli::test_utils::check_balance;
 use solana_cli::{
     cli::{process_command, request_and_confirm_airdrop, CliCommand, CliConfig},
+    cli_output::OutputFormat,
     nonce,
     offline::{
         blockhash_query::{self, BlockhashQuery},
@@ -92,6 +93,7 @@ fn test_transfer() {
         nonce_authority: 0,
         fee_payer: 0,
     };
+    offline.output_format = OutputFormat::JsonCompact;
     let sign_only_reply = process_command(&offline).unwrap();
     let sign_only = parse_sign_only_reply_string(&sign_only_reply);
     assert!(sign_only.has_all_signers());
@@ -280,6 +282,7 @@ fn test_transfer_multisession_signing() {
         nonce_authority: 0,
         fee_payer: 0,
     };
+    fee_payer_config.output_format = OutputFormat::JsonCompact;
     let sign_only_reply = process_command(&fee_payer_config).unwrap();
     let sign_only = parse_sign_only_reply_string(&sign_only_reply);
     assert!(!sign_only.has_all_signers());
@@ -305,6 +308,7 @@ fn test_transfer_multisession_signing() {
         nonce_authority: 0,
         fee_payer: 0,
     };
+    from_config.output_format = OutputFormat::JsonCompact;
     let sign_only_reply = process_command(&from_config).unwrap();
     let sign_only = parse_sign_only_reply_string(&sign_only_reply);
     assert!(sign_only.has_all_signers());

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -36,6 +36,7 @@ fn test_vote_authorize_and_withdraw() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         100_000,
+        &config,
     )
     .unwrap();
 


### PR DESCRIPTION
Add using recently added global `--output` argument to` --sign-only` transactions.

Fixes #8281
