### PR TITLE
Don't attempt to rebase or move empty accounts

### DIFF
--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -103,6 +103,10 @@ fn process_rebase_stake_accounts(
         &args.stake_authority.pubkey(),
         &balances,
     );
+    if messages.is_empty() {
+        eprintln!("No accounts found");
+        return Ok(());
+    }
     let signers = vec![
         &*args.fee_payer,
         &*args.new_base_keypair,
@@ -134,6 +138,10 @@ fn process_move_stake_accounts(
         &authorize_args.new_withdraw_authority,
         &balances,
     );
+    if messages.is_empty() {
+        eprintln!("No accounts found");
+        return Ok(());
+    }
     let signers = vec![
         &*args.fee_payer,
         &*args.new_base_keypair,


### PR DESCRIPTION
#### Problem

A derived stake account may be empty because:
* the user withdrew all tokens from one of the many
* a previous run failed halfway through (this command is not atomic)
* --num-accounts was too big
* wrong base key

#### Summary of Changes

Filter out empty accounts