### PR TITLE
Ignore test_helper_sol_log due to solana_logger concurency issue

### DIFF
--- a/programs/bpf_loader/src/helpers.rs
+++ b/programs/bpf_loader/src/helpers.rs
@@ -403,6 +403,9 @@ mod tests {
         .unwrap();
     }
 
+    // Ignore this test: solana_logger conflicts when running tests concurrently, 
+    // this results in the bad string length being ignored and not returning an error
+    #[ignore]
     #[test]
     fn test_helper_sol_log() {
         let string = "Gaggablaghblagh!";

--- a/programs/bpf_loader/src/helpers.rs
+++ b/programs/bpf_loader/src/helpers.rs
@@ -403,7 +403,7 @@ mod tests {
         .unwrap();
     }
 
-    // Ignore this test: solana_logger conflicts when running tests concurrently, 
+    // Ignore this test: solana_logger conflicts when running tests concurrently,
     // this results in the bad string length being ignored and not returning an error
     #[ignore]
     #[test]


### PR DESCRIPTION
#### Problem

When `cargo test` runs tests concurrently `solana-logger`conflicts.  `test_helper_sol_log` relies on the logger being enabled but gets disabled by other tests

#### Summary of Changes

Ignore this test for now

Fixes #
