### PR TITLE
Add getLowestNonpurgedBlock rpc; use blockstore api in getConfirmedBlocks

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -17,9 +17,7 @@ use solana_client::{
     rpc_response::*,
 };
 use solana_faucet::faucet::request_airdrop_transaction;
-use solana_ledger::{
-    bank_forks::BankForks, blockstore::Blockstore, rooted_slot_iterator::RootedSlotIterator,
-};
+use solana_ledger::{bank_forks::BankForks, blockstore::Blockstore};
 use solana_perf::packet::PACKET_DATA_SIZE;
 use solana_runtime::bank::Bank;
 use solana_sdk::{
@@ -380,18 +378,12 @@ impl JsonRpcRequestProcessor {
         if end_slot < start_slot {
             return Ok(vec![]);
         }
-
-        let start_slot = (start_slot..end_slot).find(|&slot| self.blockstore.is_root(slot));
-        if let Some(start_slot) = start_slot {
-            let mut slots: Vec<Slot> = RootedSlotIterator::new(start_slot, &self.blockstore)
-                .unwrap()
-                .map(|(slot, _)| slot)
-                .collect();
-            slots.retain(|&x| x <= end_slot);
-            Ok(slots)
-        } else {
-            Ok(vec![])
-        }
+        Ok(self
+            .blockstore
+            .rooted_slot_iterator(start_slot)
+            .map_err(|_| Error::internal_error())?
+            .filter(|&slot| slot <= end_slot)
+            .collect())
     }
 
     pub fn get_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -531,10 +531,10 @@ impl JsonRpcRequestProcessor {
         }
     }
 
-    pub fn get_lowest_nonpurged_block(&self) -> Result<Slot> {
+    pub fn get_first_available_block(&self) -> Result<Slot> {
         Ok(self
             .blockstore
-            .get_lowest_nonpurged_block()
+            .get_first_available_block()
             .unwrap_or_default())
     }
 }
@@ -796,8 +796,8 @@ pub trait RpcSol {
         end_slot: Slot,
     ) -> Result<Vec<String>>;
 
-    #[rpc(meta, name = "getLowestNonpurgedBlock")]
-    fn get_lowest_nonpurged_block(&self, meta: Self::Metadata) -> Result<Slot>;
+    #[rpc(meta, name = "getFirstAvailableBlock")]
+    fn get_first_available_block(&self, meta: Self::Metadata) -> Result<Slot>;
 }
 
 pub struct RpcSolImpl;
@@ -1387,11 +1387,11 @@ impl RpcSol for RpcSolImpl {
             })
     }
 
-    fn get_lowest_nonpurged_block(&self, meta: Self::Metadata) -> Result<Slot> {
+    fn get_first_available_block(&self, meta: Self::Metadata) -> Result<Slot> {
         meta.request_processor
             .read()
             .unwrap()
-            .get_lowest_nonpurged_block()
+            .get_first_available_block()
     }
 }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -538,6 +538,13 @@ impl JsonRpcRequestProcessor {
             Ok(vec![])
         }
     }
+
+    pub fn get_lowest_nonpurged_block(&self) -> Result<Slot> {
+        Ok(self
+            .blockstore
+            .get_lowest_nonpurged_block()
+            .unwrap_or_default())
+    }
 }
 
 fn get_tpu_addr(cluster_info: &ClusterInfo) -> Result<SocketAddr> {
@@ -796,6 +803,9 @@ pub trait RpcSol {
         start_slot: Slot,
         end_slot: Slot,
     ) -> Result<Vec<String>>;
+
+    #[rpc(meta, name = "getLowestNonpurgedBlock")]
+    fn get_lowest_nonpurged_block(&self, meta: Self::Metadata) -> Result<Slot>;
 }
 
 pub struct RpcSolImpl;
@@ -1383,6 +1393,13 @@ impl RpcSol for RpcSolImpl {
                     .map(|signature| signature.to_string())
                     .collect()
             })
+    }
+
+    fn get_lowest_nonpurged_block(&self, meta: Self::Metadata) -> Result<Slot> {
+        meta.request_processor
+            .read()
+            .unwrap()
+            .get_lowest_nonpurged_block()
     }
 }
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -27,6 +27,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getEpochSchedule](jsonrpc-api.md#getepochschedule)
 * [getFeeCalculatorForBlockhash](jsonrpc-api.md#getfeecalculatorforblockhash)
 * [getFeeRateGovernor](jsonrpc-api.md#getfeerategovernor)
+* [getFirstAvailableBlock](jsonrpc-api.md#getfirstavailableblock)
 * [getGenesisHash](jsonrpc-api.md#getgenesishash)
 * [getIdentity](jsonrpc-api.md#getidentity)
 * [getInflation](jsonrpc-api.md#getinflation)
@@ -284,7 +285,7 @@ The result field will be an object with the following fields:
 * `<null>` - if specified block is not confirmed
 * `<object>` - if block is confirmed, an object with the following fields:
   * `blockhash: <string>` - the blockhash of this block, as base-58 encoded string
-  * `previousBlockhash: <string>` - the blockhash of this block's parent, as base-58 encoded string
+  * `previousBlockhash: <string>` - the blockhash of this block's parent, as base-58 encoded string; if the parent block is not available due to ledger cleanup, this field will return "11111111111111111111111111111111"
   * `parentSlot: <u64>` - the slot index of this block's parent
   * `transactions: <array>` - an array of JSON objects containing:
     * `transaction: <object|string>` - [Transaction](#transaction-structure) object, either in JSON format or base-58 encoded binary data, depending on encoding parameter
@@ -534,6 +535,28 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":{"context":{"slot":54},"value":{"feeRateGovernor":{"burnPercent":50,"maxLamportsPerSignature":100000,"minLamportsPerSignature":5000,"targetLamportsPerSignature":10000,"targetSignaturesPerSlot":20000}}},"id":1}
+```
+
+### getFirstAvailableBlock
+
+Returns the slot of the lowest confirmed block that has not been purged from the ledger
+
+#### Parameters:
+
+None
+
+#### Results:
+
+* `<u64>` - Slot
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getFirstAvailableBlock"}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":250000,"id":1}
 ```
 
 ### getGenesisHash

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1633,7 +1633,9 @@ impl Blockstore {
                     .iter()
                     .cloned()
                     .flat_map(|entry| entry.transactions);
-                let parent_slot_entries = self.get_slot_entries(slot_meta.parent_slot, 0)?;
+                let parent_slot_entries = self
+                    .get_slot_entries(slot_meta.parent_slot, 0)
+                    .unwrap_or_default();
                 let previous_blockhash = if !parent_slot_entries.is_empty() {
                     get_last_hash(parent_slot_entries.iter()).unwrap()
                 } else {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1601,7 +1601,7 @@ impl Blockstore {
         slots
     }
 
-    pub fn get_lowest_nonpurged_block(&self) -> Result<Slot> {
+    pub fn get_first_available_block(&self) -> Result<Slot> {
         let mut root_iterator = self.rooted_slot_iterator(0)?;
         Ok(root_iterator.next().unwrap_or_default())
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1601,6 +1601,11 @@ impl Blockstore {
         slots
     }
 
+    pub fn get_lowest_nonpurged_block(&self) -> Result<Slot> {
+        let mut root_iterator = self.rooted_slot_iterator(0)?;
+        Ok(root_iterator.next().unwrap_or_default())
+    }
+
     pub fn get_confirmed_block(
         &self,
         slot: Slot,


### PR DESCRIPTION
#### Problem
When browsing or searching for confirmed blocks via rpc, there is no way to determine the lower bound, ie. the lowest block that has not been purged.

#### Summary of Changes
- Add Blockstore `get_lowest_nonpurged_block` helper function, and plumb to `getLowestNonpurgedBlock`
Also:
- Enable `getConfirmedBlock` on lowest-available block, even though its parent blockhash can't be derived, because it's weird for a block to show up as the lowest-nonpurged but return null when queried by this method
- Rework `getConfirmedBlocks` to find start slot more efficiently
