### PR TITLE
Extend snapshot interval in multinode demo

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -83,7 +83,7 @@ args+=(
   --enable-rpc-set-log-filter
   --ledger "$ledger_dir"
   --rpc-port 8899
-  --snapshot-interval-slots 100
+  --snapshot-interval-slots 200
   --identity "$identity"
   --vote-account "$vote_account"
   --rpc-faucet-address 127.0.0.1:9900

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -96,7 +96,7 @@ waitForNodeToInit() {
   echo "--- waiting for $hostname to boot up"
   SECONDS=
   while [[ ! -r $initCompleteFile ]]; do
-    if [[ $SECONDS -ge 240 ]]; then
+    if [[ $SECONDS -ge 600 ]]; then
       echo "^^^ +++"
       echo "Error: $initCompleteFile not found in $SECONDS seconds"
       exit 1


### PR DESCRIPTION
#### Problem
Large snapshots with bench-tps client accounts take longer to load than the first epoch, causing non-bootstrap validators to fail to catch up.

#### Summary of Changes
Extend snapshot creation interval on bootstrapper and extend allowable validator boot time.

Short term fix to https://github.com/solana-labs/solana/issues/9146


