### PR TITLE
Remove validator-info publish from net scripts

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -253,12 +253,6 @@ cat >> ~/solana/on-reboot <<EOF
 EOF
     ~/solana/on-reboot
     waitForNodeToInit
-
-    if [[ $skipSetup != true ]]; then
-      solana --url http://"$entrypointIp":8899 \
-        --keypair ~/solana/config/bootstrap-validator/identity.json \
-        validator-info publish "$(hostname)" -n team/solana --force || true
-    fi
     ;;
   validator|blockstreamer)
     if [[ $deployMethod != skip ]]; then
@@ -393,12 +387,6 @@ EOF
       fi
 
       multinode-demo/delegate-stake.sh "${args[@]}" "$internalNodesStakeLamports"
-    fi
-
-    if [[ $skipSetup != true ]]; then
-      solana --url http://"$entrypointIp":8899 \
-        --keypair config/validator-identity.json \
-        validator-info publish "$(hostname)" -n team/solana --force || true
     fi
     ;;
   archiver)


### PR DESCRIPTION
#### Problem
We no longer need to publish validator info from `net` scripts as these scripts are not used to maintain our official clusters.

Publish command can get stuck in background, occasionally causing developer testnet launches to hang.

#### Summary of Changes
Baleeted!

