### PR TITLE
Cache banks in BankForks until optional largest_confirmed_root

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -253,7 +253,7 @@ fn main() {
                 poh_recorder.lock().unwrap().set_bank(&bank);
                 assert!(poh_recorder.lock().unwrap().bank().is_some());
                 if bank.slot() > 32 {
-                    bank_forks.set_root(root, &None);
+                    bank_forks.set_root(root, &None, None);
                     root += 1;
                 }
                 debug!(

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -637,6 +637,7 @@ pub mod test {
                     &mut self.progress,
                     &None,
                     &mut HashSet::new(),
+                    None,
                 );
             }
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2127,15 +2127,22 @@ pub(crate) mod tests {
         let bank0 = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank0)));
         let confirmed_root = 1;
+        let fork = 2;
         let bank1 = Bank::new_from_parent(
             bank_forks.read().unwrap().get(0).unwrap(),
             &Pubkey::default(),
             confirmed_root,
         );
         bank_forks.write().unwrap().insert(bank1);
+        let bank2 = Bank::new_from_parent(
+            bank_forks.read().unwrap().get(confirmed_root).unwrap(),
+            &Pubkey::default(),
+            fork,
+        );
+        bank_forks.write().unwrap().insert(bank2);
         let root = 3;
         let root_bank = Bank::new_from_parent(
-            bank_forks.read().unwrap().get(1).unwrap(),
+            bank_forks.read().unwrap().get(confirmed_root).unwrap(),
             &Pubkey::default(),
             root,
         );
@@ -2154,9 +2161,11 @@ pub(crate) mod tests {
         );
         assert_eq!(bank_forks.read().unwrap().root(), root);
         assert!(bank_forks.read().unwrap().get(confirmed_root).is_some());
+        assert!(bank_forks.read().unwrap().get(fork).is_none());
         assert_eq!(progress.len(), 2);
         assert!(progress.get(&root).is_some());
         assert!(progress.get(&confirmed_root).is_some());
+        assert!(progress.get(&fork).is_none());
     }
 
     #[test]

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1528,7 +1528,7 @@ pub mod tests {
                     Bank::new_from_parent(&parent_bank, parent_bank.collector_id(), *root);
                 parent_bank = bank_forks.write().unwrap().insert(new_bank);
                 parent_bank.squash();
-                bank_forks.write().unwrap().set_root(*root, &None);
+                bank_forks.write().unwrap().set_root(*root, &None, None);
                 let parent = if i > 0 { roots[i - 1] } else { 1 };
                 fill_blockstore_slot_with_ticks(&blockstore, 5, *root, parent, Hash::default());
             }

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -139,7 +139,7 @@ mod tests {
             // and to allow snapshotting of bank and the purging logic on status_cache to
             // kick in
             if slot % set_root_interval == 0 || slot == last_slot - 1 {
-                bank_forks.set_root(bank.slot(), &sender);
+                bank_forks.set_root(bank.slot(), &sender, None);
             }
         }
         // Generate a snapshot package for last bank
@@ -380,9 +380,11 @@ mod tests {
                     snapshot_test_config.bank_forks.insert(new_bank);
                     current_bank = snapshot_test_config.bank_forks[new_slot].clone();
                 }
-                snapshot_test_config
-                    .bank_forks
-                    .set_root(current_bank.slot(), &snapshot_sender);
+                snapshot_test_config.bank_forks.set_root(
+                    current_bank.slot(),
+                    &snapshot_sender,
+                    None,
+                );
             }
 
             let num_old_slots = num_set_roots * *add_root_interval - MAX_CACHE_ENTRIES + 1;

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -338,9 +338,9 @@ impl BankForks {
     fn prune_non_root(&mut self, root: Slot, largest_confirmed_root: Option<Slot>) {
         let descendants = self.descendants();
         self.banks.retain(|slot, _| {
-            slot == &root
+            *slot == root
                 || descendants[&root].contains(slot)
-                || slot < &root && slot >= &largest_confirmed_root.unwrap_or(root)
+                || *slot < root && *slot >= largest_confirmed_root.unwrap_or(root)
         });
         datapoint_debug!(
             "bank_forks_purge_non_root",

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -342,6 +342,10 @@ impl BankForks {
                 || descendants[&root].contains(slot)
                 || slot < &root && slot >= &largest_confirmed_root.unwrap_or(root)
         });
+        datapoint_debug!(
+            "bank_forks_purge_non_root",
+            ("num_banks_retained", self.banks.len(), i64),
+        );
     }
 
     pub fn set_snapshot_config(&mut self, snapshot_config: Option<SnapshotConfig>) {

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -340,7 +340,9 @@ impl BankForks {
         self.banks.retain(|slot, _| {
             *slot == root
                 || descendants[&root].contains(slot)
-                || *slot < root && *slot >= largest_confirmed_root.unwrap_or(root)
+                || (*slot < root
+                    && *slot >= largest_confirmed_root.unwrap_or(root)
+                    && descendants[slot].contains(&root))
         });
         datapoint_debug!(
             "bank_forks_purge_non_root",

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -186,6 +186,7 @@ impl BankForks {
         &mut self,
         root: Slot,
         accounts_package_sender: &Option<AccountsPackageSender>,
+        largest_confirmed_root: Option<Slot>,
     ) {
         let old_epoch = self.root_bank().epoch();
         self.root = root;
@@ -263,7 +264,7 @@ impl BankForks {
         }
         let new_tx_count = root_bank.transaction_count();
 
-        self.prune_non_root(root);
+        self.prune_non_root(root, largest_confirmed_root);
 
         inc_new_counter_info!(
             "bank-forks_set_root_ms",
@@ -334,10 +335,13 @@ impl BankForks {
         Ok(())
     }
 
-    fn prune_non_root(&mut self, root: Slot) {
+    fn prune_non_root(&mut self, root: Slot, largest_confirmed_root: Option<Slot>) {
         let descendants = self.descendants();
-        self.banks
-            .retain(|slot, _| slot == &root || descendants[&root].contains(slot));
+        self.banks.retain(|slot, _| {
+            slot == &root
+                || descendants[&root].contains(slot)
+                || slot < &root && slot >= &largest_confirmed_root.unwrap_or(root)
+        });
     }
 
     pub fn set_snapshot_config(&mut self, snapshot_config: Option<SnapshotConfig>) {


### PR DESCRIPTION
#### Problem
We want to redefine `{"commitment":"max"}` for RPC to mean the latest slot/Bank both rooted in this node and rooted by a supermajority of the cluster. However, on `set_root()`, BankForks prunes any bank older than the current root; thus if a node is ahead, the cluster-confirmed root Bank isn't available for RPC queries.

#### Summary of Changes
- If a largest_confirmed_root value is provided to `BankForks::set_root()`, retain all the banks between `BankForks.root` and `largest_confirmed_root`
- Read `largest_confirmed_root` from BlockCommitmentCache to pass this value from ReplayStage

On a node keeping up with the cluster perfectly, the code is likely to result in 1-2 extra Banks in BankForks at a given time, due to timing updating BlockCommitmentCache in `AggregateCommitmentService`.

Empirically: on a GCE api node launched against mainnet-beta, num Banks retained in BankForks was pretty comparable between this code and master, usually hovering around 34 Banks in BankForks. Partitions and pre-root forking seem to be a much bigger factor in BankForks growth.
