### PR TITLE
Extend snapshot interval to 400

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -83,7 +83,7 @@ args+=(
   --enable-rpc-set-log-filter
   --ledger "$ledger_dir"
   --rpc-port 8899
-  --snapshot-interval-slots 200
+  --snapshot-interval-slots 400
   --identity "$identity"
   --vote-account "$vote_account"
   --rpc-faucet-address 127.0.0.1:9900


### PR DESCRIPTION
#### Problem
Recently extended snapshot interval to 200, which works with GPU nodes.  Testing the same config on CPU GCE nodes, the validator in europe-west4 fails to catch up to the cluster and causes automation to hang.

#### Summary of Changes
Moar longer.

Fixes #
