### PR TITLE
Support ad-hoc genesis args in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -63,6 +63,7 @@ fi
 if [[ -e "$ledgerDir"/genesis.bin || -e "$ledgerDir"/genesis.tar.bz2 ]]; then
   echo "Use existing genesis"
 else
+  # shellcheck disable=SC2086
   solana-genesis \
     --hashes-per-tick sleep \
     --faucet-pubkey "$dataDir"/faucet.json \
@@ -72,7 +73,8 @@ else
       "$dataDir"/validator-vote-account.json \
       "$dataDir"/validator-stake-account.json \
     --ledger "$ledgerDir" \
-    --operating-mode development
+    --operating-mode development \
+    $SOLANA_RUN_SH_GENESIS_ARGS
 fi
 
 abort() {
@@ -97,7 +99,8 @@ args=(
   --enable-rpc-transaction-history
   --init-complete-file "$dataDir"/init-completed
 )
-solana-validator "${args[@]}" &
+# shellcheck disable=SC2086
+solana-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS &
 validator=$!
 
 wait "$validator"

--- a/run.sh
+++ b/run.sh
@@ -99,8 +99,7 @@ args=(
   --enable-rpc-transaction-history
   --init-complete-file "$dataDir"/init-completed
 )
-# shellcheck disable=SC2086
-solana-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS &
+solana-validator "${args[@]}" &
 validator=$!
 
 wait "$validator"


### PR DESCRIPTION
Some times I want to add some ad-hoc options to `solana-genesis` and `solana-validator` like `--enable-warmup-epochs`.

Split off from #9527.