### PR TITLE
Introduce type alias Ancestors

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -3,7 +3,7 @@ use rayon::prelude::*;
 use solana_measure::measure::Measure;
 use solana_runtime::{
     accounts::{create_test_accounts, update_accounts, Accounts},
-    accounts_index::AncestorList,
+    accounts_index::Ancestors,
 };
 use solana_sdk::pubkey::Pubkey;
 use std::fs;
@@ -78,7 +78,7 @@ fn main() {
         num_slots,
         create_time
     );
-    let mut ancestors: AncestorList = vec![(0, 0)].into_iter().collect();
+    let mut ancestors: Ancestors = vec![(0, 0)].into_iter().collect();
     for i in 1..num_slots {
         ancestors.insert(i as u64, i - 1);
         accounts.add_root(i as u64);

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -1,9 +1,11 @@
 use clap::{value_t, App, Arg};
 use rayon::prelude::*;
 use solana_measure::measure::Measure;
-use solana_runtime::accounts::{create_test_accounts, update_accounts, Accounts};
+use solana_runtime::{
+    accounts::{create_test_accounts, update_accounts, Accounts},
+    accounts_index::AncestorList,
+};
 use solana_sdk::pubkey::Pubkey;
-use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
@@ -76,7 +78,7 @@ fn main() {
         num_slots,
         create_time
     );
-    let mut ancestors: HashMap<u64, usize> = vec![(0, 0)].into_iter().collect();
+    let mut ancestors: AncestorList = vec![(0, 0)].into_iter().collect();
     for i in 1..num_slots {
         ancestors.insert(i as u64, i - 1);
         accounts.add_root(i as u64);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2,7 +2,7 @@ use crate::{
     accounts_db::{
         AccountInfo, AccountStorage, AccountsDB, AppendVecId, BankHashInfo, ErrorCounters,
     },
-    accounts_index::{AccountsIndex, AncestorList},
+    accounts_index::{AccountsIndex, Ancestors},
     append_vec::StoredAccount,
     bank::{HashAgeKind, TransactionProcessResult},
     blockhash_queue::BlockhashQueue,
@@ -76,7 +76,7 @@ impl Accounts {
 
     pub fn new_with_frozen_accounts(
         paths: Vec<PathBuf>,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         frozen_account_pubkeys: &[Pubkey],
     ) -> Self {
         let mut accounts = Accounts {
@@ -89,7 +89,7 @@ impl Accounts {
         accounts
     }
 
-    pub fn freeze_accounts(&mut self, ancestors: &AncestorList, frozen_account_pubkeys: &[Pubkey]) {
+    pub fn freeze_accounts(&mut self, ancestors: &Ancestors, frozen_account_pubkeys: &[Pubkey]) {
         Arc::get_mut(&mut self.accounts_db)
             .unwrap()
             .freeze_accounts(ancestors, frozen_account_pubkeys);
@@ -97,7 +97,7 @@ impl Accounts {
 
     pub fn from_stream<R: Read, P: AsRef<Path>>(
         account_paths: &[PathBuf],
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         frozen_account_pubkeys: &[Pubkey],
         stream: &mut BufReader<R>,
         stream_append_vecs_path: P,
@@ -130,7 +130,7 @@ impl Accounts {
     fn load_tx_accounts(
         &self,
         storage: &AccountStorage,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         accounts_index: &AccountsIndex<AccountInfo>,
         tx: &Transaction,
         fee: u64,
@@ -197,7 +197,7 @@ impl Accounts {
 
     fn load_executable_accounts(
         storage: &AccountStorage,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         accounts_index: &AccountsIndex<AccountInfo>,
         program_id: &Pubkey,
         error_counters: &mut ErrorCounters,
@@ -242,7 +242,7 @@ impl Accounts {
     /// For each program_id in the transaction, load its loaders.
     fn load_loaders(
         storage: &AccountStorage,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         accounts_index: &AccountsIndex<AccountInfo>,
         tx: &Transaction,
         error_counters: &mut ErrorCounters,
@@ -270,7 +270,7 @@ impl Accounts {
 
     pub fn load_accounts(
         &self,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         txs: &[Transaction],
         txs_iteration_order: Option<&[usize]>,
         lock_results: Vec<TransactionProcessResult>,
@@ -334,7 +334,7 @@ impl Accounts {
     }
 
     /// Slow because lock is held for 1 operation instead of many
-    pub fn load_slow(&self, ancestors: &AncestorList, pubkey: &Pubkey) -> Option<(Account, Slot)> {
+    pub fn load_slow(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
         let (account, slot) = self
             .accounts_db
             .load_slow(ancestors, pubkey)
@@ -392,7 +392,7 @@ impl Accounts {
     }
 
     #[must_use]
-    pub fn verify_bank_hash(&self, slot: Slot, ancestors: &AncestorList) -> bool {
+    pub fn verify_bank_hash(&self, slot: Slot, ancestors: &Ancestors) -> bool {
         if let Err(err) = self.accounts_db.verify_bank_hash(slot, ancestors) {
             warn!("verify_bank_hash failed: {:?}", err);
             false
@@ -403,7 +403,7 @@ impl Accounts {
 
     pub fn load_by_program(
         &self,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         program_id: Option<&Pubkey>,
     ) -> Vec<(Pubkey, Account)> {
         self.accounts_db.scan_accounts(

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -2,7 +2,7 @@ use crate::{
     accounts_db::{
         AccountInfo, AccountStorage, AccountsDB, AppendVecId, BankHashInfo, ErrorCounters,
     },
-    accounts_index::AccountsIndex,
+    accounts_index::{AccountsIndex, AncestorList},
     append_vec::StoredAccount,
     bank::{HashAgeKind, TransactionProcessResult},
     blockhash_queue::BlockhashQueue,
@@ -76,7 +76,7 @@ impl Accounts {
 
     pub fn new_with_frozen_accounts(
         paths: Vec<PathBuf>,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         frozen_account_pubkeys: &[Pubkey],
     ) -> Self {
         let mut accounts = Accounts {
@@ -89,11 +89,7 @@ impl Accounts {
         accounts
     }
 
-    pub fn freeze_accounts(
-        &mut self,
-        ancestors: &HashMap<Slot, usize>,
-        frozen_account_pubkeys: &[Pubkey],
-    ) {
+    pub fn freeze_accounts(&mut self, ancestors: &AncestorList, frozen_account_pubkeys: &[Pubkey]) {
         Arc::get_mut(&mut self.accounts_db)
             .unwrap()
             .freeze_accounts(ancestors, frozen_account_pubkeys);
@@ -101,7 +97,7 @@ impl Accounts {
 
     pub fn from_stream<R: Read, P: AsRef<Path>>(
         account_paths: &[PathBuf],
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         frozen_account_pubkeys: &[Pubkey],
         stream: &mut BufReader<R>,
         stream_append_vecs_path: P,
@@ -134,7 +130,7 @@ impl Accounts {
     fn load_tx_accounts(
         &self,
         storage: &AccountStorage,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         accounts_index: &AccountsIndex<AccountInfo>,
         tx: &Transaction,
         fee: u64,
@@ -201,7 +197,7 @@ impl Accounts {
 
     fn load_executable_accounts(
         storage: &AccountStorage,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         accounts_index: &AccountsIndex<AccountInfo>,
         program_id: &Pubkey,
         error_counters: &mut ErrorCounters,
@@ -246,7 +242,7 @@ impl Accounts {
     /// For each program_id in the transaction, load its loaders.
     fn load_loaders(
         storage: &AccountStorage,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         accounts_index: &AccountsIndex<AccountInfo>,
         tx: &Transaction,
         error_counters: &mut ErrorCounters,
@@ -274,7 +270,7 @@ impl Accounts {
 
     pub fn load_accounts(
         &self,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         txs: &[Transaction],
         txs_iteration_order: Option<&[usize]>,
         lock_results: Vec<TransactionProcessResult>,
@@ -338,11 +334,7 @@ impl Accounts {
     }
 
     /// Slow because lock is held for 1 operation instead of many
-    pub fn load_slow(
-        &self,
-        ancestors: &HashMap<Slot, usize>,
-        pubkey: &Pubkey,
-    ) -> Option<(Account, Slot)> {
+    pub fn load_slow(&self, ancestors: &AncestorList, pubkey: &Pubkey) -> Option<(Account, Slot)> {
         let (account, slot) = self
             .accounts_db
             .load_slow(ancestors, pubkey)
@@ -400,7 +392,7 @@ impl Accounts {
     }
 
     #[must_use]
-    pub fn verify_bank_hash(&self, slot: Slot, ancestors: &HashMap<Slot, usize>) -> bool {
+    pub fn verify_bank_hash(&self, slot: Slot, ancestors: &AncestorList) -> bool {
         if let Err(err) = self.accounts_db.verify_bank_hash(slot, ancestors) {
             warn!("verify_bank_hash failed: {:?}", err);
             false
@@ -411,7 +403,7 @@ impl Accounts {
 
     pub fn load_by_program(
         &self,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         program_id: Option<&Pubkey>,
     ) -> Vec<(Pubkey, Account)> {
         self.accounts_db.scan_accounts(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -19,7 +19,7 @@
 //! commit for each slot entry would be indexed.
 
 use crate::{
-    accounts_index::{AccountsIndex, AncestorList, SlotList, SlotSlice},
+    accounts_index::{AccountsIndex, Ancestors, SlotList, SlotSlice},
     append_vec::{AppendVec, StoredAccount, StoredMeta},
     bank::deserialize_from_snapshot,
 };
@@ -1083,7 +1083,7 @@ impl AccountsDB {
         }
     }
 
-    pub fn scan_accounts<F, A>(&self, ancestors: &AncestorList, scan_func: F) -> A
+    pub fn scan_accounts<F, A>(&self, ancestors: &Ancestors, scan_func: F) -> A
     where
         F: Fn(&mut A, Option<(&Pubkey, Account, Slot)>) -> (),
         A: Default,
@@ -1165,7 +1165,7 @@ impl AccountsDB {
 
     pub fn load(
         storage: &AccountStorage,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         accounts_index: &AccountsIndex<AccountInfo>,
         pubkey: &Pubkey,
     ) -> Option<(Account, Slot)> {
@@ -1183,7 +1183,7 @@ impl AccountsDB {
         }
     }
 
-    pub fn load_slow(&self, ancestors: &AncestorList, pubkey: &Pubkey) -> Option<(Account, Slot)> {
+    pub fn load_slow(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
         let accounts_index = self.accounts_index.read().unwrap();
         let storage = self.storage.read().unwrap();
         Self::load(&storage, ancestors, &accounts_index, pubkey)
@@ -1536,7 +1536,7 @@ impl AccountsDB {
 
     fn calculate_accounts_hash(
         &self,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         check_hash: bool,
     ) -> Result<Hash, BankHashVerificationError> {
         use BankHashVerificationError::*;
@@ -1594,7 +1594,7 @@ impl AccountsDB {
         bank_hash_info.snapshot_hash
     }
 
-    pub fn update_accounts_hash(&self, slot: Slot, ancestors: &AncestorList) -> Hash {
+    pub fn update_accounts_hash(&self, slot: Slot, ancestors: &Ancestors) -> Hash {
         let hash = self.calculate_accounts_hash(ancestors, false).unwrap();
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
@@ -1605,7 +1605,7 @@ impl AccountsDB {
     pub fn verify_bank_hash(
         &self,
         slot: Slot,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
@@ -1802,7 +1802,7 @@ impl AccountsDB {
         hashes
     }
 
-    pub fn freeze_accounts(&mut self, ancestors: &AncestorList, account_pubkeys: &[Pubkey]) {
+    pub fn freeze_accounts(&mut self, ancestors: &Ancestors, account_pubkeys: &[Pubkey]) {
         for account_pubkey in account_pubkeys {
             if let Some((account, _slot)) = self.load_slow(ancestors, &account_pubkey) {
                 let frozen_account_info = FrozenAccountInfo {
@@ -2003,8 +2003,8 @@ pub mod tests {
     use std::{fs, str::FromStr};
     use tempfile::TempDir;
 
-    fn linear_ancestors(end_slot: u64) -> AncestorList {
-        let mut ancestors: AncestorList = vec![(0, 0)].into_iter().collect();
+    fn linear_ancestors(end_slot: u64) -> Ancestors {
+        let mut ancestors: Ancestors = vec![(0, 0)].into_iter().collect();
         for i in 1..end_slot {
             ancestors.insert(i, (i - 1) as usize);
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -19,7 +19,7 @@
 //! commit for each slot entry would be indexed.
 
 use crate::{
-    accounts_index::{AccountsIndex, SlotList, SlotSlice},
+    accounts_index::{AccountsIndex, AncestorList, SlotList, SlotSlice},
     append_vec::{AppendVec, StoredAccount, StoredMeta},
     bank::deserialize_from_snapshot,
 };
@@ -1083,7 +1083,7 @@ impl AccountsDB {
         }
     }
 
-    pub fn scan_accounts<F, A>(&self, ancestors: &HashMap<Slot, usize>, scan_func: F) -> A
+    pub fn scan_accounts<F, A>(&self, ancestors: &AncestorList, scan_func: F) -> A
     where
         F: Fn(&mut A, Option<(&Pubkey, Account, Slot)>) -> (),
         A: Default,
@@ -1165,7 +1165,7 @@ impl AccountsDB {
 
     pub fn load(
         storage: &AccountStorage,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         accounts_index: &AccountsIndex<AccountInfo>,
         pubkey: &Pubkey,
     ) -> Option<(Account, Slot)> {
@@ -1183,11 +1183,7 @@ impl AccountsDB {
         }
     }
 
-    pub fn load_slow(
-        &self,
-        ancestors: &HashMap<Slot, usize>,
-        pubkey: &Pubkey,
-    ) -> Option<(Account, Slot)> {
+    pub fn load_slow(&self, ancestors: &AncestorList, pubkey: &Pubkey) -> Option<(Account, Slot)> {
         let accounts_index = self.accounts_index.read().unwrap();
         let storage = self.storage.read().unwrap();
         Self::load(&storage, ancestors, &accounts_index, pubkey)
@@ -1540,7 +1536,7 @@ impl AccountsDB {
 
     fn calculate_accounts_hash(
         &self,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         check_hash: bool,
     ) -> Result<Hash, BankHashVerificationError> {
         use BankHashVerificationError::*;
@@ -1598,7 +1594,7 @@ impl AccountsDB {
         bank_hash_info.snapshot_hash
     }
 
-    pub fn update_accounts_hash(&self, slot: Slot, ancestors: &HashMap<Slot, usize>) -> Hash {
+    pub fn update_accounts_hash(&self, slot: Slot, ancestors: &AncestorList) -> Hash {
         let hash = self.calculate_accounts_hash(ancestors, false).unwrap();
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
@@ -1609,7 +1605,7 @@ impl AccountsDB {
     pub fn verify_bank_hash(
         &self,
         slot: Slot,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
@@ -1806,11 +1802,7 @@ impl AccountsDB {
         hashes
     }
 
-    pub fn freeze_accounts(
-        &mut self,
-        ancestors: &HashMap<Slot, usize>,
-        account_pubkeys: &[Pubkey],
-    ) {
+    pub fn freeze_accounts(&mut self, ancestors: &AncestorList, account_pubkeys: &[Pubkey]) {
         for account_pubkey in account_pubkeys {
             if let Some((account, _slot)) = self.load_slow(ancestors, &account_pubkey) {
                 let frozen_account_info = FrozenAccountInfo {
@@ -2011,8 +2003,8 @@ pub mod tests {
     use std::{fs, str::FromStr};
     use tempfile::TempDir;
 
-    fn linear_ancestors(end_slot: u64) -> HashMap<Slot, usize> {
-        let mut ancestors: HashMap<Slot, usize> = vec![(0, 0)].into_iter().collect();
+    fn linear_ancestors(end_slot: u64) -> AncestorList {
+        let mut ancestors: AncestorList = vec![(0, 0)].into_iter().collect();
         for i in 1..end_slot {
             ancestors.insert(i, (i - 1) as usize);
         }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -7,6 +7,8 @@ use std::{
 
 pub type SlotList<T> = Vec<(Slot, T)>;
 pub type SlotSlice<'s, T> = &'s [(Slot, T)];
+pub type AncestorList = HashMap<Slot, usize>;
+
 pub type RefCount = u64;
 type AccountMapEntry<T> = (AtomicU64, RwLock<SlotList<T>>);
 
@@ -20,7 +22,7 @@ pub struct AccountsIndex<T> {
 
 impl<T: Clone> AccountsIndex<T> {
     /// call func with every pubkey and index visible from a given set of ancestors
-    pub fn scan_accounts<F>(&self, ancestors: &HashMap<Slot, usize>, mut func: F)
+    pub fn scan_accounts<F>(&self, ancestors: &AncestorList, mut func: F)
     where
         F: FnMut(&Pubkey, (&T, Slot)) -> (),
     {
@@ -56,7 +58,7 @@ impl<T: Clone> AccountsIndex<T> {
 
     // find the latest slot and T in a slice for a given ancestor
     // returns index into 'slice' if found, None if not.
-    fn latest_slot(&self, ancestors: &HashMap<Slot, usize>, slice: SlotSlice<T>) -> Option<usize> {
+    fn latest_slot(&self, ancestors: &AncestorList, slice: SlotSlice<T>) -> Option<usize> {
         let mut max = 0;
         let mut rv = None;
         for (i, (slot, _t)) in slice.iter().rev().enumerate() {
@@ -73,7 +75,7 @@ impl<T: Clone> AccountsIndex<T> {
     pub fn get(
         &self,
         pubkey: &Pubkey,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
     ) -> Option<(RwLockReadGuard<SlotList<T>>, usize)> {
         self.account_maps.get(pubkey).and_then(|list| {
             let list_r = list.1.read().unwrap();

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -7,7 +7,7 @@ use std::{
 
 pub type SlotList<T> = Vec<(Slot, T)>;
 pub type SlotSlice<'s, T> = &'s [(Slot, T)];
-pub type AncestorList = HashMap<Slot, usize>;
+pub type Ancestors = HashMap<Slot, usize>;
 
 pub type RefCount = u64;
 type AccountMapEntry<T> = (AtomicU64, RwLock<SlotList<T>>);
@@ -22,7 +22,7 @@ pub struct AccountsIndex<T> {
 
 impl<T: Clone> AccountsIndex<T> {
     /// call func with every pubkey and index visible from a given set of ancestors
-    pub fn scan_accounts<F>(&self, ancestors: &AncestorList, mut func: F)
+    pub fn scan_accounts<F>(&self, ancestors: &Ancestors, mut func: F)
     where
         F: FnMut(&Pubkey, (&T, Slot)) -> (),
     {
@@ -58,7 +58,7 @@ impl<T: Clone> AccountsIndex<T> {
 
     // find the latest slot and T in a slice for a given ancestor
     // returns index into 'slice' if found, None if not.
-    fn latest_slot(&self, ancestors: &AncestorList, slice: SlotSlice<T>) -> Option<usize> {
+    fn latest_slot(&self, ancestors: &Ancestors, slice: SlotSlice<T>) -> Option<usize> {
         let mut max = 0;
         let mut rv = None;
         for (i, (slot, _t)) in slice.iter().rev().enumerate() {
@@ -75,7 +75,7 @@ impl<T: Clone> AccountsIndex<T> {
     pub fn get(
         &self,
         pubkey: &Pubkey,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
     ) -> Option<(RwLockReadGuard<SlotList<T>>, usize)> {
         self.account_maps.get(pubkey).and_then(|list| {
             let list_r = list.1.read().unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5,6 +5,7 @@
 use crate::{
     accounts::{Accounts, TransactionAccounts, TransactionLoadResult, TransactionLoaders},
     accounts_db::{AccountsDBSerialize, ErrorCounters, SnapshotStorage, SnapshotStorages},
+    accounts_index::AncestorList,
     blockhash_queue::BlockhashQueue,
     epoch_stakes::{EpochStakes, NodeVoteAccounts},
     message_processor::{MessageProcessor, ProcessInstruction},
@@ -90,7 +91,7 @@ impl BankRc {
     pub fn from_stream<R: Read, P: AsRef<Path>>(
         account_paths: &[PathBuf],
         slot: Slot,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
         frozen_account_pubkeys: &[Pubkey],
         mut stream: &mut BufReader<R>,
         stream_append_vecs_path: P,
@@ -227,7 +228,7 @@ pub struct Bank {
     blockhash_queue: RwLock<BlockhashQueue>,
 
     /// The set of parents including this bank
-    pub ancestors: HashMap<Slot, usize>,
+    pub ancestors: AncestorList,
 
     /// Hash of this Bank's state. Only meaningful after freezing.
     hash: RwLock<Hash>,
@@ -1818,7 +1819,7 @@ impl Bank {
     }
 
     pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<(Account, Slot)> {
-        let just_self: HashMap<u64, usize> = vec![(self.slot(), 0)].into_iter().collect();
+        let just_self: AncestorList = vec![(self.slot(), 0)].into_iter().collect();
         if let Some((account, slot)) = self.rc.accounts.load_slow(&just_self, pubkey) {
             if slot == self.slot() {
                 return Some((account, slot));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5,7 +5,7 @@
 use crate::{
     accounts::{Accounts, TransactionAccounts, TransactionLoadResult, TransactionLoaders},
     accounts_db::{AccountsDBSerialize, ErrorCounters, SnapshotStorage, SnapshotStorages},
-    accounts_index::AncestorList,
+    accounts_index::Ancestors,
     blockhash_queue::BlockhashQueue,
     epoch_stakes::{EpochStakes, NodeVoteAccounts},
     message_processor::{MessageProcessor, ProcessInstruction},
@@ -91,7 +91,7 @@ impl BankRc {
     pub fn from_stream<R: Read, P: AsRef<Path>>(
         account_paths: &[PathBuf],
         slot: Slot,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
         frozen_account_pubkeys: &[Pubkey],
         mut stream: &mut BufReader<R>,
         stream_append_vecs_path: P,
@@ -228,7 +228,7 @@ pub struct Bank {
     blockhash_queue: RwLock<BlockhashQueue>,
 
     /// The set of parents including this bank
-    pub ancestors: AncestorList,
+    pub ancestors: Ancestors,
 
     /// Hash of this Bank's state. Only meaningful after freezing.
     hash: RwLock<Hash>,
@@ -1819,7 +1819,7 @@ impl Bank {
     }
 
     pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<(Account, Slot)> {
-        let just_self: AncestorList = vec![(self.slot(), 0)].into_iter().collect();
+        let just_self: Ancestors = vec![(self.slot(), 0)].into_iter().collect();
         if let Some((account, slot)) = self.rc.accounts.load_slow(&just_self, pubkey) {
             if slot == self.slot() {
                 return Some((account, slot));

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -1,3 +1,5 @@
+use crate::accounts_index::AncestorList;
+
 use log::*;
 use rand::{thread_rng, Rng};
 use serde::Serialize;
@@ -85,7 +87,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         &self,
         sig: &Signature,
         transaction_blockhash: &Hash,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
     ) -> Option<(Slot, T)> {
         let map = self.cache.get(transaction_blockhash)?;
         let (_, index, sigmap) = map;
@@ -106,7 +108,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
     pub fn get_signature_slot(
         &self,
         signature: &Signature,
-        ancestors: &HashMap<Slot, usize>,
+        ancestors: &AncestorList,
     ) -> Option<(Slot, T)> {
         let mut keys = vec![];
         let mut val: Vec<_> = self.cache.iter().map(|(k, _)| *k).collect();

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -1,4 +1,4 @@
-use crate::accounts_index::AncestorList;
+use crate::accounts_index::Ancestors;
 
 use log::*;
 use rand::{thread_rng, Rng};
@@ -87,7 +87,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
         &self,
         sig: &Signature,
         transaction_blockhash: &Hash,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
     ) -> Option<(Slot, T)> {
         let map = self.cache.get(transaction_blockhash)?;
         let (_, index, sigmap) = map;
@@ -108,7 +108,7 @@ impl<T: Serialize + Clone> StatusCache<T> {
     pub fn get_signature_slot(
         &self,
         signature: &Signature,
-        ancestors: &AncestorList,
+        ancestors: &Ancestors,
     ) -> Option<(Slot, T)> {
         let mut keys = vec![];
         let mut val: Vec<_> = self.cache.iter().map(|(k, _)| *k).collect();


### PR DESCRIPTION
define a type alias for fewer line breaks and slightly-improved readability. :)

spin-off of #9527; too tired of looking eye-sore `fn` signatures for newly defined methods in that pr...

no functional change
