### PR TITLE
One less alloc per transaction

### DIFF
--- a/archiver-lib/src/archiver.rs
+++ b/archiver-lib/src/archiver.rs
@@ -598,14 +598,14 @@ impl Archiver {
                 }
             };
 
-            let ix = storage_instruction::create_storage_account(
+            let ixs = storage_instruction::create_storage_account(
                 &keypair.pubkey(),
                 &keypair.pubkey(),
                 &storage_keypair.pubkey(),
                 1,
                 StorageAccountType::Archiver,
             );
-            let tx = Transaction::new_signed_instructions(&[keypair], ix, blockhash);
+            let tx = Transaction::new_signed_instructions(&[keypair], &ixs, blockhash);
             let signature = client.async_send_transaction(tx)?;
             client
                 .poll_for_signature_with_commitment(&signature, client_commitment)

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -459,7 +459,7 @@ fn swapper<T>(
                     let owner = &signer.pubkey();
                     Transaction::new_signed_instructions(
                         &[s],
-                        vec![exchange_instruction::swap_request(
+                        &[exchange_instruction::swap_request(
                             owner,
                             &swap.0.pubkey,
                             &swap.1.pubkey,
@@ -590,7 +590,7 @@ fn trader<T>(
                     let space = mem::size_of::<ExchangeState>() as u64;
                     Transaction::new_signed_instructions(
                         &[owner.as_ref(), trade],
-                        vec![
+                        &[
                             system_instruction::create_account(
                                 owner_pubkey,
                                 trade_pubkey,
@@ -749,7 +749,7 @@ pub fn fund_keys<T: Client>(client: &T, source: &Keypair, dests: &[Arc<Keypair>]
                 .map(|(k, m)| {
                     (
                         k.clone(),
-                        Transaction::new_unsigned_instructions(system_instruction::transfer_many(
+                        Transaction::new_unsigned_instructions(&system_instruction::transfer_many(
                             &k.pubkey(),
                             &m,
                         )),
@@ -849,7 +849,7 @@ pub fn create_token_accounts<T: Client>(
                         exchange_instruction::account_request(owner_pubkey, &new_keypair.pubkey());
                     (
                         (from_keypair, new_keypair),
-                        Transaction::new_unsigned_instructions(vec![create_ix, request_ix]),
+                        Transaction::new_unsigned_instructions(&[create_ix, request_ix]),
                     )
                 })
                 .collect();

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -936,7 +936,7 @@ fn fund_move_keys<T: Client>(
         .collect();
     let tx = Transaction::new_signed_instructions(
         &[funding_key],
-        system_instruction::transfer_many(&funding_key.pubkey(), &pubkey_amounts),
+        &system_instruction::transfer_many(&funding_key.pubkey(), &pubkey_amounts),
         blockhash,
     );
     client.send_message(&[funding_key], tx.message).unwrap();

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -563,10 +563,9 @@ impl<'a> FundingTransactions<'a> for Vec<(&'a Keypair, Transaction)> {
         let to_fund_txs: Vec<(&Keypair, Transaction)> = to_fund
             .par_iter()
             .map(|(k, t)| {
-                let tx = Transaction::new_unsigned_instructions(system_instruction::transfer_many(
-                    &k.pubkey(),
-                    &t,
-                ));
+                let tx = Transaction::new_unsigned_instructions(
+                    &system_instruction::transfer_many(&k.pubkey(), &t),
+                );
                 (*k, tx)
             })
             .collect();

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -29,7 +29,7 @@ use solana_sdk::timing::{duration_as_us, timestamp};
 use solana_sdk::transaction::Transaction;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use test::Bencher;
 

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -117,7 +117,7 @@ fn make_programs_txs(txes: usize, hash: Hash) -> Vec<Transaction> {
                 let to_key = Pubkey::new_rand();
                 instructions.push(system_instruction::transfer(&from_key.pubkey(), &to_key, 1));
             }
-            let mut new = Transaction::new_unsigned_instructions(instructions);
+            let mut new = Transaction::new_unsigned_instructions(&instructions);
             new.sign(&[&from_key], hash);
             new
         })

--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -9,7 +9,6 @@ use solana_core::contact_info::ContactInfo;
 use solana_ledger::shred::Shred;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::timing::timestamp;
-use std::sync::RwLock;
 use std::{
     collections::HashMap,
     net::UdpSocket,
@@ -22,7 +21,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     solana_logger::setup();
     let leader_pubkey = Pubkey::new_rand();
     let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
-    let mut cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info.clone());
+    let cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info.clone());
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
 
     const NUM_SHREDS: usize = 32;

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -29,7 +29,7 @@ use test::Bencher;
 #[bench]
 fn bench_retransmitter(bencher: &mut Bencher) {
     solana_logger::setup();
-    let mut cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
+    let cluster_info = ClusterInfo::new_with_invalid_keypair(Node::new_localhost().info);
     const NUM_PEERS: usize = 4;
     let mut peer_sockets = Vec::new();
     for _ in 0..NUM_PEERS {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -823,7 +823,7 @@ impl ReplayStage {
             vote,
         );
 
-        let mut vote_tx = Transaction::new_with_payer(vec![vote_ix], Some(&node_keypair.pubkey()));
+        let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
 
         let blockhash = bank.last_blockhash();
         vote_tx.partial_sign(&[node_keypair.as_ref()], blockhash);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1506,7 +1506,7 @@ pub mod tests {
         );
         let vote_tx = Transaction::new_signed_instructions(
             &[&leader_vote_keypair],
-            vec![vote_ix],
+            &[vote_ix],
             Hash::default(),
         );
         let shreds = entries_to_test_shreds(
@@ -2777,7 +2777,7 @@ pub mod tests {
 
         let transaction = Transaction::new_signed_instructions(
             &[&alice, &alice_vote_keypair],
-            instructions,
+            &instructions,
             bank.last_blockhash(),
         );
         bank.process_transaction(&transaction)
@@ -2807,7 +2807,7 @@ pub mod tests {
             bank.freeze();
 
             // Votes
-            let instructions = vec![
+            let instructions = [
                 vote_instruction::vote(
                     &leader_vote_keypair.pubkey(),
                     &leader_vote_keypair.pubkey(),
@@ -2835,7 +2835,7 @@ pub mod tests {
             ));
 
             let transaction = Transaction::new_signed_with_payer(
-                instructions,
+                &instructions,
                 Some(&alice.pubkey()),
                 &[&alice, &leader_vote_keypair, &alice_vote_keypair],
                 bank.last_blockhash(),

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -527,7 +527,7 @@ mod tests {
         );
         let tx = Transaction::new_signed_instructions(
             &[&contract_funds, &contract_state],
-            ixs,
+            &ixs,
             blockhash,
         );
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions).unwrap();
@@ -571,7 +571,7 @@ mod tests {
             &contract_state.pubkey(),
             &bob_pubkey,
         );
-        let tx = Transaction::new_signed_instructions(&[&witness], vec![ix], blockhash);
+        let tx = Transaction::new_signed_instructions(&[&witness], &[ix], blockhash);
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions).unwrap();
         sleep(Duration::from_millis(200));
 

--- a/core/tests/storage_stage.rs
+++ b/core/tests/storage_stage.rs
@@ -86,7 +86,7 @@ mod tests {
 
         // create accounts
         let bank = Arc::new(Bank::new_from_parent(&bank, &keypair.pubkey(), 1));
-        let account_ix = storage_instruction::create_storage_account(
+        let account_ixs = storage_instruction::create_storage_account(
             &mint_keypair.pubkey(),
             &Pubkey::new_rand(),
             &archiver_keypair.pubkey(),
@@ -95,7 +95,7 @@ mod tests {
         );
         let account_tx = Transaction::new_signed_instructions(
             &[&mint_keypair, &archiver_keypair],
-            account_ix,
+            &account_ixs,
             bank.last_blockhash(),
         );
         bank.process_transaction(&account_tx).expect("create");

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -212,13 +212,13 @@ fn new_update_manifest(
         let lamports = rpc_client
             .get_minimum_balance_for_rent_exemption(SignedUpdateManifest::max_space() as usize)?;
 
-        let new_account = config_instruction::create_account::<SignedUpdateManifest>(
+        let instructions = config_instruction::create_account::<SignedUpdateManifest>(
             &from_keypair.pubkey(),
             &update_manifest_keypair.pubkey(),
             lamports,
             vec![], // additional keys
         );
-        let mut transaction = Transaction::new_unsigned_instructions(new_account);
+        let mut transaction = Transaction::new_unsigned_instructions(&instructions);
         let signers = [from_keypair, update_manifest_keypair];
         transaction.sign(&signers, recent_blockhash);
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5431,7 +5431,7 @@ pub mod tests {
             let vote_ix = vote_instruction::vote(&keypair.pubkey(), &keypair.pubkey(), vote);
 
             let vote_tx =
-                Transaction::new_signed_instructions(&[keypair], vec![vote_ix], Hash::default());
+                Transaction::new_signed_instructions(&[keypair], &[vote_ix], Hash::default());
 
             vote_entries.push(next_entry_mut(&mut Hash::default(), 0, vec![vote_tx]));
             let mut tick = create_ticks(1, 0, hash(&serialize(&i).unwrap()));

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -490,19 +490,19 @@ mod tests {
         let budget_contract = Keypair::new();
         let budget_pubkey = budget_contract.pubkey();
         let ixs = budget_instruction::payment(&pubkey, &pubkey, &budget_pubkey, 1);
-        Transaction::new_signed_instructions(&[keypair, &budget_contract], ixs, hash)
+        Transaction::new_signed_instructions(&[keypair, &budget_contract], &ixs, hash)
     }
 
     fn create_sample_timestamp(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ix = budget_instruction::apply_timestamp(&pubkey, &pubkey, &pubkey, Utc::now());
-        Transaction::new_signed_instructions(&[keypair], vec![ix], hash)
+        Transaction::new_signed_instructions(&[keypair], &[ix], hash)
     }
 
     fn create_sample_apply_signature(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ix = budget_instruction::apply_signature(&pubkey, &pubkey, &pubkey);
-        Transaction::new_signed_instructions(&[keypair], vec![ix], hash)
+        Transaction::new_signed_instructions(&[keypair], &[ix], hash)
     }
 
     #[test]

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -134,7 +134,7 @@ pub(crate) mod tests {
         amount: u64,
     ) {
         let vote_pubkey = vote_account.pubkey();
-        fn process_instructions<T: Signers>(bank: &Bank, keypairs: &T, ixs: Vec<Instruction>) {
+        fn process_instructions<T: Signers>(bank: &Bank, keypairs: &T, ixs: &[Instruction]) {
             let tx = Transaction::new_signed_with_payer(
                 ixs,
                 Some(&keypairs.pubkeys()[0]),
@@ -147,7 +147,7 @@ pub(crate) mod tests {
         process_instructions(
             bank,
             &[from_account, vote_account, validator_identity_account],
-            vote_instruction::create_account(
+            &vote_instruction::create_account(
                 &from_account.pubkey(),
                 &vote_pubkey,
                 &VoteInit {
@@ -166,7 +166,7 @@ pub(crate) mod tests {
         process_instructions(
             bank,
             &[from_account, &stake_account_keypair],
-            stake_instruction::create_account_and_delegate_stake(
+            &stake_instruction::create_account_and_delegate_stake(
                 &from_account.pubkey(),
                 &stake_account_pubkey,
                 &vote_pubkey,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -502,7 +502,7 @@ impl LocalCluster {
 
             let mut transaction = Transaction::new_signed_instructions(
                 &[from_account.as_ref(), vote_account],
-                vote_instruction::create_account(
+                &vote_instruction::create_account(
                     &from_account.pubkey(),
                     &vote_account_pubkey,
                     &VoteInit {
@@ -531,7 +531,7 @@ impl LocalCluster {
 
             let mut transaction = Transaction::new_signed_instructions(
                 &[from_account.as_ref(), &stake_account_keypair],
-                stake_instruction::create_account_and_delegate_stake(
+                &stake_instruction::create_account_and_delegate_stake(
                     &from_account.pubkey(),
                     &stake_account_pubkey,
                     &vote_account_pubkey,

--- a/programs/librapay/src/librapay_transaction.rs
+++ b/programs/librapay/src/librapay_transaction.rs
@@ -17,12 +17,7 @@ use std::{boxed::Box, error, fmt};
 
 pub fn create_genesis(keypair: &Keypair, microlibras: u64, recent_blockhash: Hash) -> Transaction {
     let ix = librapay_instruction::genesis(&keypair.pubkey(), microlibras);
-    Transaction::new_signed_with_payer(
-        vec![ix],
-        Some(&keypair.pubkey()),
-        &[keypair],
-        recent_blockhash,
-    )
+    Transaction::new_signed_with_payer(&[ix], Some(&keypair.pubkey()), &[keypair], recent_blockhash)
 }
 
 pub fn mint_tokens(
@@ -40,7 +35,7 @@ pub fn mint_tokens(
         microlibras,
     );
     Transaction::new_signed_with_payer(
-        vec![ix],
+        &[ix],
         Some(&payer_keypair.pubkey()),
         &[payer_keypair, genesis_keypair],
         recent_blockhash,
@@ -64,7 +59,7 @@ pub fn transfer(
         microlibras,
     );
     Transaction::new_signed_with_payer(
-        vec![ix],
+        &[ix],
         Some(&payer_keypair.pubkey()),
         &[payer_keypair, from_keypair],
         recent_blockhash,
@@ -77,7 +72,7 @@ pub fn create_accounts(
     lamports: u64,
     recent_blockhash: Hash,
 ) -> Transaction {
-    let instructions = to_keypair
+    let instructions: Vec<_> = to_keypair
         .iter()
         .map(|keypair| {
             system_instruction::create_account(
@@ -92,7 +87,7 @@ pub fn create_accounts(
 
     let mut from_signers = vec![from_keypair];
     from_signers.extend_from_slice(to_keypair);
-    Transaction::new_signed_instructions(&from_signers, instructions, recent_blockhash)
+    Transaction::new_signed_instructions(&from_signers, &instructions, recent_blockhash)
 }
 
 pub fn create_account(

--- a/programs/vote/src/vote_transaction.rs
+++ b/programs/vote/src/vote_transaction.rs
@@ -22,7 +22,7 @@ pub fn new_vote_transaction(
         votes,
     );
 
-    let mut vote_tx = Transaction::new_with_payer(vec![vote_ix], Some(&node_keypair.pubkey()));
+    let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
 
     vote_tx.partial_sign(&[node_keypair], blockhash);
     vote_tx.partial_sign(&[authorized_voter_keypair], blockhash);

--- a/ramp-tps/src/voters.rs
+++ b/ramp-tps/src/voters.rs
@@ -140,7 +140,7 @@ fn delegate_stake(
 
         let mut transaction = Transaction::new_signed_instructions(
             &[faucet_keypair, &stake_account_keypair],
-            stake_instruction::create_account_and_delegate_stake(
+            &stake_instruction::create_account_and_delegate_stake(
                 &faucet_keypair.pubkey(),
                 &stake_account_keypair.pubkey(),
                 &vote_account_pubkey,

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -53,7 +53,7 @@ pub fn create_builtin_transactions(
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
             let (blockhash, _fee_calculator) = bank_client.get_recent_blockhash().unwrap();
-            Transaction::new_signed_instructions(&[&rando0], vec![instruction], blockhash)
+            Transaction::new_signed_instructions(&[&rando0], &[instruction], blockhash)
         })
         .collect()
 }
@@ -75,7 +75,7 @@ pub fn create_native_loader_transactions(
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
             let (blockhash, _fee_calculator) = bank_client.get_recent_blockhash().unwrap();
-            Transaction::new_signed_instructions(&[&rando0], vec![instruction], blockhash)
+            Transaction::new_signed_instructions(&[&rando0], &[instruction], blockhash)
         })
         .collect()
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2610,7 +2610,7 @@ mod tests {
         let deduct_instruction =
             Instruction::new(mock_program_id, &MockInstruction::Deduction, account_metas);
         Transaction::new_signed_with_payer(
-            vec![deduct_instruction],
+            &[deduct_instruction],
             Some(&payer.pubkey()),
             &[payer, keypair1, keypair2],
             recent_blockhash,
@@ -3391,7 +3391,7 @@ mod tests {
             system_instruction::transfer_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
         let tx = Transaction::new_signed_instructions(
             &[&mint_keypair],
-            instructions,
+            &instructions,
             genesis_config.hash(),
         );
         assert_eq!(
@@ -3416,7 +3416,7 @@ mod tests {
             system_instruction::transfer_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
         let tx = Transaction::new_signed_instructions(
             &[&mint_keypair],
-            instructions,
+            &instructions,
             genesis_config.hash(),
         );
         bank.process_transaction(&tx).unwrap();
@@ -3809,14 +3809,14 @@ mod tests {
         let vote = Vote::new(vec![1], Hash::default());
         let ix0 = vote_instruction::vote(&vote_pubkey0, &authorized_voter.pubkey(), vote.clone());
         let tx0 = Transaction::new_signed_with_payer(
-            vec![ix0],
+            &[ix0],
             Some(&payer0.pubkey()),
             &[&payer0, &authorized_voter],
             bank.last_blockhash(),
         );
         let ix1 = vote_instruction::vote(&vote_pubkey1, &authorized_voter.pubkey(), vote.clone());
         let tx1 = Transaction::new_signed_with_payer(
-            vec![ix1],
+            &[ix1],
             Some(&payer1.pubkey()),
             &[&payer1, &authorized_voter],
             bank.last_blockhash(),
@@ -3831,7 +3831,7 @@ mod tests {
 
         let ix0 = vote_instruction::vote(&vote_pubkey2, &authorized_voter.pubkey(), vote.clone());
         let tx0 = Transaction::new_signed_with_payer(
-            vec![ix0],
+            &[ix0],
             Some(&payer0.pubkey()),
             &[&payer0, &authorized_voter],
             bank.last_blockhash(),
@@ -4554,7 +4554,7 @@ mod tests {
 
         let tx = Transaction::new_signed_instructions(
             &Vec::<&Keypair>::new(),
-            vec![transfer_instruction],
+            &[transfer_instruction],
             bank.last_blockhash(),
         );
 
@@ -4735,7 +4735,7 @@ mod tests {
 
         let transaction = Transaction::new_signed_instructions(
             &[&mint_keypair, &vote_keypair],
-            instructions,
+            &instructions,
             bank.last_blockhash(),
         );
 
@@ -4792,7 +4792,7 @@ mod tests {
 
         let transaction = Transaction::new_signed_instructions(
             &[&mint_keypair, &vote_keypair, &stake_keypair],
-            instructions,
+            &instructions,
             bank.last_blockhash(),
         );
 
@@ -5051,7 +5051,7 @@ mod tests {
 
         let transaction = Transaction::new_signed_instructions(
             &[&mint_keypair, &mock_account, &mock_validator_identity],
-            instructions,
+            &instructions,
             bank.last_blockhash(),
         );
 
@@ -5096,7 +5096,7 @@ mod tests {
 
         let transaction = Transaction::new_signed_instructions(
             &[&mint_keypair, &mock_account, &mock_validator_identity],
-            instructions,
+            &instructions,
             bank.last_blockhash(),
         );
 
@@ -5281,7 +5281,7 @@ mod tests {
         ));
         let setup_tx = Transaction::new_signed_instructions(
             &[mint_keypair, &custodian_keypair, &nonce_keypair],
-            setup_ixs,
+            &setup_ixs,
             bank.last_blockhash(),
         );
         bank.process_transaction(&setup_tx)?;
@@ -5329,7 +5329,7 @@ mod tests {
 
         let nonce_hash = get_nonce_account(&bank, &nonce_pubkey).unwrap();
         let tx = Transaction::new_signed_with_payer(
-            vec![
+            &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
@@ -5353,7 +5353,7 @@ mod tests {
 
         let nonce_hash = get_nonce_account(&bank, &nonce_pubkey).unwrap();
         let tx = Transaction::new_signed_with_payer(
-            vec![
+            &[
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
             ],
@@ -5373,7 +5373,7 @@ mod tests {
 
         let nonce_hash = get_nonce_account(&bank, &nonce_pubkey).unwrap();
         let mut tx = Transaction::new_signed_with_payer(
-            vec![
+            &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
@@ -5396,7 +5396,7 @@ mod tests {
 
         let nonce_hash = get_nonce_account(&bank, &nonce_pubkey).unwrap();
         let tx = Transaction::new_signed_with_payer(
-            vec![
+            &[
                 system_instruction::advance_nonce_account(&missing_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
@@ -5415,7 +5415,7 @@ mod tests {
         let nonce_pubkey = nonce_keypair.pubkey();
 
         let tx = Transaction::new_signed_with_payer(
-            vec![
+            &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &nonce_pubkey, 100_000),
             ],
@@ -5444,7 +5444,7 @@ mod tests {
 
         let tx = Transaction::new_signed_instructions(
             &[&nonce],
-            vec![system_instruction::assign(
+            &[system_instruction::assign(
                 &nonce.pubkey(),
                 &Pubkey::new(&[9u8; 32]),
             )],
@@ -5502,7 +5502,7 @@ mod tests {
 
         /* Durable Nonce transfer */
         let durable_tx = Transaction::new_signed_with_payer(
-            vec![
+            &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000),
             ],
@@ -5523,7 +5523,7 @@ mod tests {
 
         /* Durable Nonce re-use fails */
         let durable_tx = Transaction::new_signed_with_payer(
-            vec![
+            &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000),
             ],
@@ -5548,7 +5548,7 @@ mod tests {
         }
 
         let durable_tx = Transaction::new_signed_with_payer(
-            vec![
+            &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&custodian_pubkey, &alice_pubkey, 100_000_000),
             ],
@@ -5705,7 +5705,7 @@ mod tests {
         ];
         let instruction = Instruction::new(mock_program_id, &10, account_metas);
         let tx = Transaction::new_signed_with_payer(
-            vec![instruction],
+            &[instruction],
             Some(&mint_keypair.pubkey()),
             &[&mint_keypair],
             bank.last_blockhash(),
@@ -5749,7 +5749,7 @@ mod tests {
         ];
         let instruction = Instruction::new(mock_program_id, &10, account_metas);
         let tx = Transaction::new_signed_with_payer(
-            vec![instruction],
+            &[instruction],
             Some(&mint_keypair.pubkey()),
             &[&mint_keypair],
             bank.last_blockhash(),

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -108,7 +108,7 @@ mod tests {
         let nonce_pubkey = nonce_keypair.pubkey();
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
-            vec![
+            &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
             ],
@@ -125,8 +125,7 @@ mod tests {
 
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
-        let tx =
-            Transaction::new_signed_instructions(&[&Keypair::new(); 0], vec![], Hash::default());
+        let tx = Transaction::new_signed_instructions(&[&Keypair::new(); 0], &[], Hash::default());
         assert!(transaction_uses_durable_nonce(&tx).is_none());
     }
 
@@ -145,7 +144,7 @@ mod tests {
         let nonce_pubkey = nonce_keypair.pubkey();
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
-            vec![
+            &[
                 system_instruction::transfer(&from_pubkey, &nonce_pubkey, 42),
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
             ],
@@ -162,7 +161,7 @@ mod tests {
         let nonce_pubkey = nonce_keypair.pubkey();
         let tx = Transaction::new_signed_instructions(
             &[&from_keypair, &nonce_keypair],
-            vec![
+            &[
                 system_instruction::withdraw_nonce_account(
                     &nonce_pubkey,
                     &nonce_pubkey,

--- a/sdk/src/system_transaction.rs
+++ b/sdk/src/system_transaction.rs
@@ -21,10 +21,9 @@ pub fn create_account(
     let to_pubkey = to_keypair.pubkey();
     let create_instruction =
         system_instruction::create_account(&from_pubkey, &to_pubkey, lamports, space, program_id);
-    let instructions = vec![create_instruction];
     Transaction::new_signed_instructions(
         &[from_keypair, to_keypair],
-        instructions,
+        &[create_instruction],
         recent_blockhash,
     )
 }
@@ -33,8 +32,7 @@ pub fn create_account(
 pub fn assign(from_keypair: &Keypair, recent_blockhash: Hash, program_id: &Pubkey) -> Transaction {
     let from_pubkey = from_keypair.pubkey();
     let assign_instruction = system_instruction::assign(&from_pubkey, program_id);
-    let instructions = vec![assign_instruction];
-    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
+    Transaction::new_signed_instructions(&[from_keypair], &[assign_instruction], recent_blockhash)
 }
 
 /// Create and sign new system_instruction::Transfer transaction
@@ -46,8 +44,7 @@ pub fn transfer(
 ) -> Transaction {
     let from_pubkey = from_keypair.pubkey();
     let transfer_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
-    let instructions = vec![transfer_instruction];
-    Transaction::new_signed_instructions(&[from_keypair], instructions, recent_blockhash)
+    Transaction::new_signed_instructions(&[from_keypair], &[transfer_instruction], recent_blockhash)
 }
 
 /// Create and sign new nonced system_instruction::Transfer transaction

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -373,7 +373,7 @@ mod test {
         let stake1_signature = rpc_client
             .send_transaction(&Transaction::new_signed_instructions(
                 &[&payer, &stake1_keypair],
-                stake_instruction::create_account(
+                &stake_instruction::create_account(
                     &payer.pubkey(),
                     &stake1_keypair.pubkey(),
                     &Authorized::auto(&payer.pubkey()),
@@ -403,7 +403,7 @@ mod test {
         let stake2_signature = rpc_client
             .send_transaction(&Transaction::new_signed_instructions(
                 &[&payer, &stake2_keypair],
-                stake_instruction::create_account(
+                &stake_instruction::create_account(
                     &payer.pubkey(),
                     &stake2_keypair.pubkey(),
                     &Authorized::auto(&payer.pubkey()),
@@ -422,7 +422,7 @@ mod test {
         let stake3_initialize_signature = rpc_client
             .send_transaction(&Transaction::new_signed_instructions(
                 &[&payer, &stake3_keypair],
-                stake_instruction::create_account(
+                &stake_instruction::create_account(
                     &payer.pubkey(),
                     &stake3_keypair.pubkey(),
                     &Authorized::auto(&payer.pubkey()),
@@ -470,7 +470,7 @@ mod test {
         let stake4_initialize_signature = rpc_client
             .send_transaction(&Transaction::new_signed_instructions(
                 &[&payer, &stake4_keypair],
-                stake_instruction::create_account(
+                &stake_instruction::create_account(
                     &payer.pubkey(),
                     &stake4_keypair.pubkey(),
                     &Authorized::auto(&payer.pubkey()),


### PR DESCRIPTION
#### Problem

Several Transaction constructors unnecessarily force the caller to do a memory allocation to pass it Instructions.

#### Summary of Changes

Pass in a slice instead of a Vec.
