### PR TITLE
Make default programs static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4133,7 +4133,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-bpf-loader-program 1.2.0",
  "solana-budget-program 1.2.0",
- "solana-config-program 1.2.0",
  "solana-exchange-program 1.2.0",
  "solana-runtime 1.2.0",
  "solana-sdk 1.2.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4137,10 +4137,8 @@ dependencies = [
  "solana-exchange-program 1.2.0",
  "solana-runtime 1.2.0",
  "solana-sdk 1.2.0",
- "solana-stake-program 1.2.0",
  "solana-storage-program 1.2.0",
  "solana-vest-program 1.2.0",
- "solana-vote-program 1.2.0",
 ]
 
 [[package]]
@@ -4542,6 +4540,7 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-config-program 1.2.0",
  "solana-logger 1.2.0",
  "solana-measure 1.2.0",
  "solana-metrics 1.2.0",

--- a/bench-exchange/tests/bench_exchange.rs
+++ b/bench-exchange/tests/bench_exchange.rs
@@ -86,7 +86,7 @@ fn test_exchange_bank_client() {
     solana_logger::setup();
     let (genesis_config, identity) = create_genesis_config(100_000_000_000_000);
     let mut bank = Bank::new(&genesis_config);
-    bank.add_instruction_processor(id(), process_instruction);
+    bank.add_static_program("exchange_program", id(), process_instruction);
     let clients = vec![BankClient::new(bank)];
 
     let mut config = Config::default();

--- a/genesis-programs/Cargo.toml
+++ b/genesis-programs/Cargo.toml
@@ -16,10 +16,8 @@ solana-config-program = { path = "../programs/config", version = "1.2.0" }
 solana-exchange-program = { path = "../programs/exchange", version = "1.2.0" }
 solana-runtime = { path = "../runtime", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
-solana-stake-program = { path = "../programs/stake", version = "1.2.0" }
 solana-storage-program = { path = "../programs/storage", version = "1.2.0" }
 solana-vest-program = { path = "../programs/vest", version = "1.2.0" }
-solana-vote-program = { path = "../programs/vote", version = "1.2.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/genesis-programs/Cargo.toml
+++ b/genesis-programs/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 log = { version = "0.4.8" }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "1.2.0" }
 solana-budget-program = { path = "../programs/budget", version = "1.2.0" }
-solana-config-program = { path = "../programs/config", version = "1.2.0" }
 solana-exchange-program = { path = "../programs/exchange", version = "1.2.0" }
 solana-runtime = { path = "../runtime", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -438,7 +438,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
 
     let native_instruction_processors =
-        solana_genesis_programs::get_programs(operating_mode, 0).unwrap();
+        solana_genesis_programs::get_programs(operating_mode, 0).unwrap_or_else(|| vec![]);
     let inflation = solana_genesis_programs::get_inflation(operating_mode, 0).unwrap();
 
     let mut genesis_config = GenesisConfig {

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -653,8 +653,8 @@ where
                 stream.by_ref(),
                 &append_vecs_path,
             )?;
-
             bank.set_bank_rc(rc, bank::StatusCacheRc::default());
+            bank.finish_init();
             Ok(bank)
         },
     )?;

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -169,9 +169,7 @@ impl LocalCluster {
             OperatingMode::Stable | OperatingMode::Preview => {
                 genesis_config.native_instruction_processors =
                     solana_genesis_programs::get_programs(genesis_config.operating_mode, 0)
-                        .unwrap()
-                        .into_iter()
-                        .collect()
+                        .unwrap_or_else(|| vec![])
             }
             OperatingMode::Development => {
                 genesis_config

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1988,6 +1988,7 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-config-program 1.2.0",
  "solana-logger 1.2.0",
  "solana-measure 1.2.0",
  "solana-metrics 1.2.0",

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -238,7 +238,7 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_instruction_processor(id(), process_instruction);
+        bank.add_static_program("budget_program", id(), process_instruction);
         (bank, mint_keypair)
     }
 

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -18,7 +18,7 @@ solana-logger = { path = "../../logger", version = "1.2.0" }
 solana-sdk = { path = "../../sdk", version = "1.2.0" }
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 name = "solana_config_program"
 
 [package.metadata.docs.rs]

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -2,16 +2,11 @@ pub mod config_instruction;
 pub mod config_processor;
 pub mod date_instruction;
 
-use crate::config_processor::process_instruction;
 use bincode::{deserialize, serialize, serialized_size};
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::{account::Account, pubkey::Pubkey, short_vec};
 
-solana_sdk::declare_program!(
-    "Config1111111111111111111111111111111111111",
-    solana_config_program,
-    process_instruction
-);
+solana_sdk::declare_id!("Config1111111111111111111111111111111111111");
 
 pub trait ConfigState: serde::Serialize + Default {
     /// Maximum space that the serialized representation will require

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -577,7 +577,7 @@ mod test {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_instruction_processor(id(), process_instruction);
+        bank.add_static_program("excahnge_program", id(), process_instruction);
         (bank, mint_keypair)
     }
 

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -13,7 +13,7 @@ fn test_program_native_failure() {
     let (genesis_config, alice_keypair) = create_genesis_config(50);
     let program_id = Pubkey::new_rand();
     let bank = Bank::new(&genesis_config);
-    bank.register_native_instruction_processor("solana_failure_program", &program_id);
+    bank.add_native_program("solana_failure_program", &program_id);
 
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);

--- a/programs/librapay/Cargo.lock
+++ b/programs/librapay/Cargo.lock
@@ -2483,6 +2483,7 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-config-program 1.2.0",
  "solana-logger 1.2.0",
  "solana-measure 1.2.0",
  "solana-metrics 1.2.0",

--- a/programs/librapay/src/librapay_transaction.rs
+++ b/programs/librapay/src/librapay_transaction.rs
@@ -156,10 +156,7 @@ mod tests {
         let (mut genesis_config, mint) = create_genesis_config(lamports);
         genesis_config.rent.lamports_per_byte_year = 0;
         let bank = Bank::new(&genesis_config);
-        bank.register_native_instruction_processor(
-            "solana_move_loader_program",
-            &solana_sdk::move_loader::id(),
-        );
+        bank.add_native_program("solana_move_loader_program", &solana_sdk::move_loader::id());
         let shared_bank = Arc::new(bank);
         let bank_client = BankClient::new_shared(&shared_bank);
         let genesis_pubkey = create_genesis(&mint, &bank_client, 1_000_000);

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -71,7 +71,7 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_instruction_processor(crate::id(), process_instruction);
+        bank.add_static_program("ownable_program", crate::id(), process_instruction);
         (bank, mint_keypair)
     }
 

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -23,7 +23,7 @@ solana-config-program = { path = "../config", version = "1.2.0" }
 thiserror = "1.0"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 name = "solana_stake_program"
 
 [package.metadata.docs.rs]

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -4,11 +4,7 @@ pub mod config;
 pub mod stake_instruction;
 pub mod stake_state;
 
-solana_sdk::declare_program!(
-    "Stake11111111111111111111111111111111111111",
-    solana_stake_program,
-    stake_instruction::process_instruction
-);
+solana_sdk::declare_id!("Stake11111111111111111111111111111111111111");
 
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig) -> u64 {
     config::add_genesis_account(genesis_config)

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -161,11 +161,12 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_instruction_processor(
+        bank.add_static_program(
+            "config_program",
             solana_config_program::id(),
             solana_config_program::config_processor::process_instruction,
         );
-        bank.add_instruction_processor(id(), process_instruction);
+        bank.add_static_program("vest_program", id(), process_instruction);
         (bank, mint_keypair)
     }
 

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -161,11 +161,6 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_static_program(
-            "config_program",
-            solana_config_program::id(),
-            solana_config_program::config_processor::process_instruction,
-        );
         bank.add_static_program("vest_program", id(), process_instruction);
         (bank, mint_keypair)
     }
@@ -473,7 +468,7 @@ mod tests {
         )
         .unwrap_err();
 
-        // Ensure bob can update which account he wants vested funds transfered to.
+        // Ensure bob can update which account he wants vested funds transferred to.
         bank_client
             .transfer(1, &alice_keypair, &bob_pubkey)
             .unwrap();

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -21,7 +21,7 @@ solana-sdk = { path = "../../sdk", version = "1.2.0" }
 thiserror = "1.0"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 name = "solana_vote_program"
 
 [package.metadata.docs.rs]

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -6,10 +6,4 @@ pub mod vote_transaction;
 #[macro_use]
 extern crate solana_metrics;
 
-use crate::vote_instruction::process_instruction;
-
-solana_sdk::declare_program!(
-    "Vote111111111111111111111111111111111111111",
-    solana_vote_program,
-    process_instruction
-);
+solana_sdk::declare_id!("Vote111111111111111111111111111111111111111");

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.6.5"
 rayon = "1.3.0"
 serde = { version = "1.0.106", features = ["rc"] }
 serde_derive = "1.0.103"
+solana-config-program = { path = "../programs/config", version = "1.2.0" }
 solana-logger = { path = "../logger", version = "1.2.0" }
 solana-measure = { path = "../measure", version = "1.2.0" }
 solana-metrics = { path = "../metrics", version = "1.2.0" }
@@ -37,7 +38,6 @@ solana-storage-program = { path = "../programs/storage", version = "1.2.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.2.0" }
 tempfile = "3.1.0"
 thiserror = "1.0"
-
 
 [lib]
 crate-type = ["lib"]

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -123,7 +123,7 @@ fn do_bench_transactions(
     genesis_config.ticks_per_slot = 100;
     let mut bank = Bank::new(&genesis_config);
     bank.add_static_program(
-        "builting_program",
+        "builtin_program",
         Pubkey::new(&BUILTIN_PROGRAM_ID),
         process_instruction,
     );

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -122,11 +122,12 @@ fn do_bench_transactions(
     let (mut genesis_config, mint_keypair) = create_genesis_config(100_000_000);
     genesis_config.ticks_per_slot = 100;
     let mut bank = Bank::new(&genesis_config);
-    bank.add_instruction_processor(Pubkey::new(&BUILTIN_PROGRAM_ID), process_instruction);
-    bank.register_native_instruction_processor(
-        "solana_noop_program",
-        &Pubkey::new(&NOOP_PROGRAM_ID),
+    bank.add_static_program(
+        "builting_program",
+        Pubkey::new(&BUILTIN_PROGRAM_ID),
+        process_instruction,
     );
+    bank.add_native_program("solana_noop_program", &Pubkey::new(&NOOP_PROGRAM_ID));
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
     let transactions = create_transactions(&bank_client, &mint_keypair);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2174,7 +2174,13 @@ impl Bank {
         program_id: Pubkey,
         process_instruction: ProcessInstruction,
     ) {
-        assert!(self.get_account(&program_id).is_none());
+        assert!(
+            self.get_account(&program_id).is_none(),
+            format!(
+                "Static program {} with program id {:?} already added to the bank",
+                name, program_id
+            )
+        );
 
         // Register a bogus executable account, which will be loaded and ignored.
         let account = native_loader::create_loadable_account(name);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5094,7 +5094,7 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_add_duplicate_program() {
+    fn test_add_duplicate_static_program() {
         let GenesisConfigInfo { genesis_config, .. } =
             create_genesis_config_with_leader(500, &Pubkey::new_rand(), 0);
         let mut bank = Bank::new(&genesis_config);

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -5,7 +5,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     rent::Rent,
     signature::{Keypair, Signer},
-    system_program::{self, solana_system_program},
+    system_program,
 };
 use solana_stake_program::stake_state;
 use solana_vote_program::vote_state;
@@ -133,17 +133,9 @@ pub fn create_genesis_config_with_leader_ex(
     .cloned()
     .collect();
 
-    // Bare minimum program set
-    let native_instruction_processors = vec![
-        solana_system_program(),
-        solana_vote_program!(),
-        solana_stake_program!(),
-    ];
-
     let fee_rate_governor = FeeRateGovernor::new(0, 0); // most tests can't handle transaction fees
     let mut genesis_config = GenesisConfig {
         accounts,
-        native_instruction_processors,
         fee_rate_governor,
         rent,
         ..GenesisConfig::default()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,15 +21,12 @@ mod system_instruction_processor;
 pub mod transaction_batch;
 pub mod transaction_utils;
 
-#[macro_use]
-extern crate solana_metrics;
-
-#[macro_use]
+extern crate solana_config_program;
+extern crate solana_stake_program;
 extern crate solana_vote_program;
 
 #[macro_use]
-extern crate solana_stake_program;
-
+extern crate solana_metrics;
 #[macro_use]
 extern crate serde_derive;
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -181,8 +181,16 @@ impl MessageProcessor {
         program_id: Pubkey,
         process_instruction: ProcessInstruction,
     ) {
-        self.instruction_processors
-            .push((program_id, process_instruction));
+        match self
+            .instruction_processors
+            .iter_mut()
+            .find(|(key, _)| program_id == *key)
+        {
+            Some((_, processor)) => *processor = process_instruction,
+            None => self
+                .instruction_processors
+                .push((program_id, process_instruction)),
+        }
     }
 
     /// Process an instruction

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1,6 +1,4 @@
-use crate::{
-    native_loader::NativeLoader, rent_collector::RentCollector, system_instruction_processor,
-};
+use crate::{native_loader::NativeLoader, rent_collector::RentCollector};
 use serde::{Deserialize, Serialize};
 use solana_sdk::{
     account::{create_keyed_readonly_accounts, Account, KeyedAccount},
@@ -161,20 +159,17 @@ impl PreAccount {
 
 pub type ProcessInstruction = fn(&Pubkey, &[KeyedAccount], &[u8]) -> Result<(), InstructionError>;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct MessageProcessor {
     #[serde(skip)]
     instruction_processors: Vec<(Pubkey, ProcessInstruction)>,
     #[serde(skip)]
     native_loader: NativeLoader,
 }
-impl Default for MessageProcessor {
-    fn default() -> Self {
-        Self {
-            instruction_processors: vec![(
-                system_program::id(),
-                system_instruction_processor::process_instruction,
-            )],
+impl Clone for MessageProcessor {
+    fn clone(&self) -> Self {
+        MessageProcessor {
+            instruction_processors: self.instruction_processors.clone(),
             native_loader: NativeLoader::default(),
         }
     }

--- a/runtime/src/storage_utils.rs
+++ b/runtime/src/storage_utils.rs
@@ -103,7 +103,8 @@ pub(crate) mod tests {
         let validator_keypair = Keypair::new();
         let validator_pubkey = validator_keypair.pubkey();
         let mut bank = Bank::new(&genesis_config);
-        bank.add_instruction_processor(
+        bank.add_static_program(
+            "storage_program",
             solana_storage_program::id(),
             storage_processor::process_instruction,
         );

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -12,7 +12,7 @@ fn test_program_native_noop() {
     let (genesis_config, alice_keypair) = create_genesis_config(50);
     let program_id = Pubkey::new_rand();
     let bank = Bank::new(&genesis_config);
-    bank.register_native_instruction_processor("solana_noop_program", &program_id);
+    bank.add_native_program("solana_noop_program", &program_id);
 
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -100,13 +100,10 @@ fn test_stake_create_and_split_single_signature() {
     solana_logger::setup();
 
     let GenesisConfigInfo {
-        mut genesis_config,
+        genesis_config,
         mint_keypair: staker_keypair,
         ..
     } = create_genesis_config_with_leader(100_000_000_000, &Pubkey::new_rand(), 1_000_000);
-    genesis_config
-        .native_instruction_processors
-        .push(solana_stake_program::solana_stake_program!());
 
     let staker_pubkey = staker_keypair.pubkey();
 
@@ -166,13 +163,10 @@ fn test_stake_account_lifetime() {
     let identity_pubkey = identity_keypair.pubkey();
 
     let GenesisConfigInfo {
-        mut genesis_config,
+        genesis_config,
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(100_000_000_000, &Pubkey::new_rand(), 1_000_000);
-    genesis_config
-        .native_instruction_processors
-        .push(solana_stake_program::solana_stake_program!());
     let bank = Bank::new(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let mut bank = Arc::new(bank);
@@ -403,13 +397,10 @@ fn test_create_stake_account_from_seed() {
     let identity_pubkey = identity_keypair.pubkey();
 
     let GenesisConfigInfo {
-        mut genesis_config,
+        genesis_config,
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(100_000_000_000, &Pubkey::new_rand(), 1_000_000);
-    genesis_config
-        .native_instruction_processors
-        .push(solana_stake_program::solana_stake_program!());
     let bank = Bank::new(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let bank = Arc::new(bank);

--- a/runtime/tests/storage.rs
+++ b/runtime/tests/storage.rs
@@ -45,7 +45,7 @@ fn test_account_owner() {
     } = create_genesis_config(1000);
     let mut bank = Bank::new(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
-    bank.add_instruction_processor(id(), process_instruction);
+    bank.add_static_program("storage_program", id(), process_instruction);
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
 

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -13,7 +13,7 @@ use crate::{
     rent::Rent,
     shred_version::compute_shred_version,
     signature::{Keypair, Signer},
-    system_program::{self, solana_system_program},
+    system_program,
 };
 use bincode::{deserialize, serialize};
 use chrono::{TimeZone, Utc};
@@ -72,7 +72,7 @@ pub fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
                 faucet_keypair.pubkey(),
                 Account::new(lamports, 0, &system_program::id()),
             )],
-            &[solana_system_program()],
+            &[],
         ),
         faucet_keypair,
     )

--- a/sdk/src/system_program.rs
+++ b/sdk/src/system_program.rs
@@ -1,5 +1,1 @@
 crate::declare_id!("11111111111111111111111111111111");
-
-pub fn solana_system_program() -> (String, crate::pubkey::Pubkey) {
-    ("solana_system_program".to_string(), id())
-}

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -217,7 +217,8 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair, u64) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_instruction_processor(
+        bank.add_static_program(
+            "stake_program",
             solana_stake_program::id(),
             solana_stake_program::stake_instruction::process_instruction,
         );

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -216,12 +216,7 @@ mod tests {
 
     fn create_bank(lamports: u64) -> (Bank, Keypair, u64) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
-        let mut bank = Bank::new(&genesis_config);
-        bank.add_static_program(
-            "stake_program",
-            solana_stake_program::id(),
-            solana_stake_program::stake_instruction::process_instruction,
-        );
+        let bank = Bank::new(&genesis_config);
         let rent = bank.get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeState>());
         (bank, mint_keypair, rent)
     }


### PR DESCRIPTION
#### Problem

Default programs are currently dynamic and dynamic programs run into this issue when Solana validators are used outside the Solana repo: https://github.com/solana-labs/solana/issues/5966

#### Summary of Changes

- Pull the default programs in statically
- Cleanup bank's program registration functions

Fixes #
