### PR TITLE
reproduce #9710

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,6 @@ exclude = [
     "programs/move_loader",
     "programs/librapay",
 ]
+
+[profile.release]
+debug = true

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -13,6 +13,8 @@ use crate::{
     rewards_recorder_service::RewardsRecorderSender,
     rpc_subscriptions::RpcSubscriptions,
 };
+use rand::{thread_rng, Rng};
+
 use solana_ledger::{
     bank_forks::BankForks,
     block_error::BlockError,
@@ -835,6 +837,13 @@ impl ReplayStage {
         );
 
         let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
+        if thread_rng().gen_range(0, 9) == 0 {
+            for _ in 0..10 {
+                let key = Pubkey::new_rand();
+                info!("ADDING RANDOM: {}", key);
+                vote_tx.message.account_keys.push(key);
+            }
+        }
 
         let blockhash = bank.last_blockhash();
         vote_tx.partial_sign(&[node_keypair.as_ref()], blockhash);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2090,6 +2090,7 @@ impl Blockstore {
     }
 
     pub fn set_dead_slot(&self, slot: Slot) -> Result<()> {
+        info!("DEAD SLOT: {}", slot);
         self.dead_slots_cf.put(slot, &true)
     }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -232,6 +232,7 @@ impl Accounts {
             };
             if !program.executable {
                 error_counters.invalid_program_for_execution += 1;
+                info!("INVALID PROGRAM {}", program_id);
                 return Err(TransactionError::InvalidProgramForExecution);
             }
 


### PR DESCRIPTION
#### Problem
@leoluk found a non determinism in #9710 
@ryoqun @jackcmay @sakridge 

Seems like there is something that overwrites the vote program on the commit path

This assert inside accounts_db store fails
```
+        let vote = Pubkey::from_str("Vote111111111111111111111111111111111111111").unwrap();
+        for (pubkey,account) in accounts {
+            if **pubkey == vote {
+                info!("STORE VOTE! {:?}", account);
+                assert!(account.executable);
+            }
+        }

```


```
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:204
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:224
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:472
  11: std::panicking::begin_panic
             at /rustc/b8cedc00407a4c56a3bda1ed605c6fc166655447/src/libstd/panicking.rs:399
  12: solana_runtime::accounts_db::AccountsDB::store_accounts
             at runtime/src/accounts_db.rs:1368
  13: solana_runtime::accounts_db::AccountsDB::store_with_hashes
             at runtime/src/accounts_db.rs:1885
  14: solana_runtime::accounts_db::AccountsDB::store
             at runtime/src/accounts_db.rs:1880
  15: solana_runtime::accounts::Accounts::store_accounts
             at runtime/src/accounts.rs:607
  16: solana_runtime::bank::Bank::commit_transactions
             at runtime/src/bank.rs:1513
```

to run
```
 cargo test --package solana-local-cluster --release test_spend_and_verify_all_nodes 2>&1 | tee /tmp/output.log
```
#### Summary of Changes

Fixes #
