### PR TITLE
Strictly match against package names

### DIFF
--- a/ci/dependabot-updater.sh
+++ b/ci/dependabot-updater.sh
@@ -12,8 +12,9 @@ parsed_update_args="$(
 )"
 package=$(echo "$parsed_update_args" | awk '{print $2}' | grep -o "^[^:]*")
 if [[ -n $parsed_update_args ]]; then
+  # find other Cargo.lock files and update them, excluding the default Cargo.lock
   # shellcheck disable=SC2086
-  for lock in $(git grep --files-with-matches --fixed-strings "$package" :**/Cargo.lock); do
+  for lock in $(git grep --files-with-matches '^name = "'$package'"$' :**/Cargo.lock); do
     _ scripts/cargo-for-all-lock-files.sh \
       "$lock" -- \
       update $parsed_update_args


### PR DESCRIPTION
#### Problem

sloppy `grep` is biting us at #9726. 

https://buildkite.com/solana-labs/solana/builds/23394#e9c61031-bc88-4bef-93b3-f74e7525c27d/98-112

```
++ git grep --files-with-matches --fixed-strings console ':**/Cargo.lock'
+ for lock in $(git grep --files-with-matches --fixed-strings "$package" :**/Cargo.lock)
```

this (`grep "console"`) caused false-positive of `"winconsole"` to be hit:

```
$ git grep --files-with-matches --fixed-strings console ':**/Cargo.lock'
programs/bpf/Cargo.lock
$ git grep --fixed-strings console ':**/Cargo.lock'
programs/bpf/Cargo.lock: "winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock:name = "winconsole"
programs/bpf/Cargo.lock:"checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"

```

#### Summary of Changes

Use more strict pattern...