### PR TITLE
Use Blockstore lowest_slot to initialize root iterator

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1502,7 +1502,7 @@ impl Blockstore {
     }
 
     pub fn get_first_available_block(&self) -> Result<Slot> {
-        let mut root_iterator = self.rooted_slot_iterator(0)?;
+        let mut root_iterator = self.rooted_slot_iterator(self.lowest_slot())?;
         Ok(root_iterator.next().unwrap_or_default())
     }
 


### PR DESCRIPTION
#### Problem
On a node booted from a snapshot, `getConfirmedBlocks` and `getFirstAvailableBlock` always include slot 0. It is technically a root retained from genesis, but isn't useful for clients trying to determine the node's lowest available root _with data_.

#### Summary of Changes
Initialize `Blockstore::rooted_slot_iterator()` for both these rpcs with `Blockstore::lowest_slot()` (or the max of lowest_slot and the query start_slot, in the case of `getConfirmedBlocks`) to bypass slot 0.

One upshot is that even a bootstrap validator booting for scratch will not return slot 0 for either of these methods. Since `getConfirmedBlock` on slot 0 never returns any populated data except blockhash, this seems okay to me.
