### PR TITLE
LowestSlots (old EpochSlots) has extra values that should be dropped

### DIFF
--- a/sdk/src/sanitize.rs
+++ b/sdk/src/sanitize.rs
@@ -3,6 +3,7 @@ pub enum SanitizeError {
     Failed,
     IndexOutOfBounds,
     ValueOutOfRange,
+    InvalidValue,
 }
 
 pub trait Sanitize {


### PR DESCRIPTION
#### Problem

LowestSlots (old EpochSlots) has extra values that should be dropped.

#### Summary of Changes

Sanitize the LowestSlot values.

Fixes #

tag: @mvines 