### PR TITLE
Rpc: Use cluster largest_confirmed_root as commitment max

### DIFF
--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -161,6 +161,11 @@ impl BlockCommitmentCache {
             root: Slot::default(),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn set_get_largest_confirmed_root(&mut self, root: Slot) {
+        self.largest_confirmed_root = root;
+    }
 }
 
 pub struct CommitmentAggregationData {


### PR DESCRIPTION
#### Problem
All the pieces are in place to redefine `{"commitment":"max"}` for RPC to mean the latest slot/Bank both rooted in this node and rooted by a supermajority of the cluster. 

#### Summary of Changes
Use cluster `largest_confirmed_root` as "max" bank. As part of this, make `JsonRpcRequestProcessor::bank()` return a Result, so that RPC returns an error if the node does not have the `largest_confirmed_root` in BankForks when a max-commitment query is processed (typically during node boot).

Fyi, this change makes `solana catchup --confirmed` a little weird (ie. return an error) until the node is moving forward making roots and processes a cluster root. Once this happens, though, that command/arg combo works fine. This seems okay to me, but could be rewritten to use `BankForks::root()` in just this case, if it's an issue.
