### PR TITLE
remove squashing bench

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -40,34 +40,6 @@ fn test_accounts_create(bencher: &mut Bencher) {
 }
 
 #[bench]
-fn test_accounts_squash(bencher: &mut Bencher) {
-    let (genesis_config, _) = create_genesis_config(100_000);
-    let mut banks: Vec<Arc<Bank>> = Vec::with_capacity(10);
-    banks.push(Arc::new(Bank::new_with_paths(
-        &genesis_config,
-        vec![PathBuf::from("bench_a1")],
-        &[],
-    )));
-    let mut pubkeys: Vec<Pubkey> = vec![];
-    deposit_many(&banks[0], &mut pubkeys, 250000);
-    banks[0].freeze();
-    // Measures the performance of the squash operation merging the accounts
-    // with the majority of the accounts present in the parent bank that is
-    // moved over to this bank.
-    bencher.iter(|| {
-        banks.push(Arc::new(Bank::new_from_parent(
-            &banks[0],
-            &Pubkey::default(),
-            1u64,
-        )));
-        for accounts in 0..10000 {
-            banks[1].deposit(&pubkeys[accounts], (accounts + 1) as u64);
-        }
-        banks[1].squash();
-    });
-}
-
-#[bench]
 fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let accounts = Accounts::new(vec![PathBuf::from("bench_accounts_hash_internal")]);
     let mut pubkeys: Vec<Pubkey> = vec![];


### PR DESCRIPTION
#### Problem

Creating a bank from parent and depositing to accounts are already benched in previous bench. Benching squash doesn't really make sense, as it is a 300ns operation updating 2 slot hashsets. Fixes log error due to repeatedly creating a bank at slot 1 referencing the same account_db.

#### Summary of Changes
remove uneccessary bench

Fixes #
