### PR TITLE
ci/docker-run.sh: Set HOME correctly

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -49,7 +49,7 @@ else
   # ~/.cargo
   ARGS+=(--volume "$PWD:/home")
 fi
-ARGS+=(--env "CARGO_HOME=/home/.cargo")
+ARGS+=(--env "HOME=/home" --env "CARGO_HOME=/home/.cargo")
 
 # kcov tries to set the personality of the binary which docker
 # doesn't allow by default.


### PR DESCRIPTION
Should fix https://buildkite.com/solana-labs/solana-secondary/builds/5366#f722b28d-8c4c-4e83-aa9e-213fbae6ad9d/59-132 without having to make custom buildkite-agent config changes