### PR TITLE
Relax dependabot-updater preciseness

### DIFF
--- a/ci/dependabot-updater.sh
+++ b/ci/dependabot-updater.sh
@@ -10,14 +10,25 @@ parsed_update_args="$(
     grep -o 'Bump.*$' |
     sed -r 's/Bump ([^ ]+) from ([^ ]+) to ([^ ]+)/-p \1:\2 --precise \3/'
 )"
+# relaxed_parsed_update_args is temporal measure...
+relaxed_parsed_update_args="$(
+  git log "$commit_range" --author "dependabot-preview" --oneline -n1 |
+    grep -o 'Bump.*$' |
+    sed -r 's/Bump ([^ ]+) from [^ ]+ to ([^ ]+)/-p \1 --precise \2/'
+)"
 package=$(echo "$parsed_update_args" | awk '{print $2}' | grep -o "^[^:]*")
 if [[ -n $parsed_update_args ]]; then
   # find other Cargo.lock files and update them, excluding the default Cargo.lock
   # shellcheck disable=SC2086
   for lock in $(git grep --files-with-matches '^name = "'$package'"$' :**/Cargo.lock); do
+    # it's possible our current versions are out of sync across lock files,
+    # in that case try to sync them up with $relaxed_parsed_update_args
     _ scripts/cargo-for-all-lock-files.sh \
       "$lock" -- \
-      update $parsed_update_args
+      update $parsed_update_args ||
+      _ scripts/cargo-for-all-lock-files.sh \
+        "$lock" -- \
+        update $relaxed_parsed_update_args
   done
 fi
 


### PR DESCRIPTION
#### Problem

#9621  was too strict for current state of our `Cargo.lock`s...

https://buildkite.com/solana-labs/solana/builds/23441#f04026e6-1937-49df-a72f-a4e62e71b57b/126

```
scripts/cargo-for-all-lock-files.sh programs/bpf/Cargo.lock -- update -p thiserror:1.0.15 --precise 1.0.16
++ dirname programs/bpf/Cargo.lock
+ cd programs/bpf
+ cargo update -p thiserror:1.0.15 --precise 1.0.16
error: package ID specification `thiserror:1.0.15` matched no packages
```

`thiserror` in `programs/bpf/Cargo.lock` is **`1.0.6`**:

```
$ git grep thiserror programs/bpf/Cargo.lock
programs/bpf/Cargo.lock: "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock: "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock: "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock: "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock: "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock: "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock: "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock:name = "thiserror"
programs/bpf/Cargo.lock: "thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
programs/bpf/Cargo.lock:name = "thiserror-impl"
programs/bpf/Cargo.lock:"checksum thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cc6b305ec0e323c7b6cfff6098a22516e0063d0bb7c3d88660a890217dca099a"
programs/bpf/Cargo.lock:"checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"

```

#### Summary of Changes

After giving up individual updates like #9685, relax a bit.

found at https://github.com/solana-labs/solana/pull/9746
