### PR TITLE
Remove old logging enabler artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,7 +4795,6 @@ dependencies = [
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 1.2.0",
  "solana-metrics 1.2.0",
  "solana-sdk 1.2.0",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1899,7 +1899,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 1.2.0",
  "solana-sdk 1.2.0",
 ]
 
@@ -2059,7 +2058,6 @@ dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-config-program 1.2.0",
- "solana-logger 1.2.0",
  "solana-metrics 1.2.0",
  "solana-sdk 1.2.0",
  "solana-vote-program 1.2.0",
@@ -2091,7 +2089,6 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 1.2.0",
  "solana-metrics 1.2.0",
  "solana-sdk 1.2.0",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/programs/config/Cargo.toml
+++ b/programs/config/Cargo.toml
@@ -14,8 +14,10 @@ chrono = { version = "0.4.11", features = ["serde"] }
 log = "0.4.8"
 serde = "1.0.106"
 serde_derive = "1.0.103"
-solana-logger = { path = "../../logger", version = "1.2.0" }
 solana-sdk = { path = "../../sdk", version = "1.2.0" }
+
+[dev-dependencies]
+solana-logger = { path = "../../logger", version = "1.2.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/librapay/Cargo.lock
+++ b/programs/librapay/Cargo.lock
@@ -2352,7 +2352,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 1.2.0",
  "solana-sdk 1.2.0",
 ]
 
@@ -2550,7 +2549,6 @@ dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-config-program 1.2.0",
- "solana-logger 1.2.0",
  "solana-metrics 1.2.0",
  "solana-sdk 1.2.0",
  "solana-vote-program 1.2.0",
@@ -2582,7 +2580,6 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 1.2.0",
  "solana-metrics 1.2.0",
  "solana-sdk 1.2.0",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/programs/stake/Cargo.toml
+++ b/programs/stake/Cargo.toml
@@ -15,12 +15,14 @@ num-derive = "0.3"
 num-traits = "0.2"
 serde = "1.0.106"
 serde_derive = "1.0.103"
-solana-logger = { path = "../../logger", version = "1.2.0" }
 solana-metrics = { path = "../../metrics", version = "1.2.0" }
 solana-sdk = { path = "../../sdk", version = "1.2.0" }
 solana-vote-program = { path = "../vote", version = "1.2.0" }
 solana-config-program = { path = "../config", version = "1.2.0" }
 thiserror = "1.0"
+
+[dev-dependencies]
+solana-logger = { path = "../../logger", version = "1.2.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -368,8 +368,6 @@ pub fn process_instruction(
     keyed_accounts: &[KeyedAccount],
     data: &[u8],
 ) -> Result<(), InstructionError> {
-    solana_logger::setup();
-
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -15,7 +15,6 @@ num-derive = "0.3"
 num-traits = "0.2"
 serde = "1.0.106"
 serde_derive = "1.0.103"
-solana-logger = { path = "../../logger", version = "1.2.0" }
 solana-metrics = { path = "../../metrics", version = "1.2.0" }
 solana-sdk = { path = "../../sdk", version = "1.2.0" }
 thiserror = "1.0"

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -215,8 +215,6 @@ pub fn process_instruction(
     keyed_accounts: &[KeyedAccount],
     data: &[u8],
 ) -> Result<(), InstructionError> {
-    solana_logger::setup_with_default("solana=info");
-
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 


### PR DESCRIPTION
#### Problem

When the stake and vote programs were dynamic they had to turn on their own logging (which just applied to their shared object).  Now that they are static they should not be setting the log mask for the rest of Solana.

#### Summary of Changes

Rely on the main Solana logger mask

Fixes #
