### PR TITLE
Fix BPF unit test linkage

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1827,16 +1827,16 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-rust-invoke"
-version = "1.0.0"
+version = "1.2.0"
 dependencies = [
- "solana-bpf-rust-invoked 1.0.0",
+ "solana-bpf-rust-invoked 1.2.0",
  "solana-sdk 1.2.0",
  "solana-sdk-bpf-test 1.2.0",
 ]
 
 [[package]]
 name = "solana-bpf-rust-invoked"
-version = "1.0.0"
+version = "1.2.0"
 dependencies = [
  "solana-sdk 1.2.0",
  "solana-sdk-bpf-test 1.2.0",

--- a/programs/bpf/rust/invoke/Cargo.toml
+++ b/programs/bpf/rust/invoke/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-bpf-rust-invoke"
-version = "1.0.0"
+version = "1.2.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,11 +12,9 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-sdk = { path = "../../../../sdk/", version = "1.0.0", default-features = false }
 solana-bpf-rust-invoked = { path = "../invoked"}
-
-[dev_dependencies]
-solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "1.0.0" }
+solana-sdk = { path = "../../../../sdk/", version = "1.2.0", default-features = false }
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "1.2.0" }
 
 [features]
 program = ["solana-sdk/program"]
@@ -25,3 +23,6 @@ default = ["program"]
 [lib]
 name = "solana_bpf_rust_invoke"
 crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -143,3 +143,5 @@ fn process_instruction(
 
     Ok(())
 }
+
+solana_sdk_bpf_test::stubs!();

--- a/programs/bpf/rust/invoked/Cargo.toml
+++ b/programs/bpf/rust/invoked/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "solana-bpf-rust-invoked"
-version = "1.0.0"
+version = "1.2.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -12,10 +12,8 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-sdk = { path = "../../../../sdk/", version = "1.0.0", default-features = false }
-
-[dev_dependencies]
-solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "1.0.0" }
+solana-sdk = { path = "../../../../sdk/", version = "1.2.0", default-features = false }
+solana-sdk-bpf-test = { path = "../../../../sdk/bpf/rust/test", version = "1.2.0" }
 
 [features]
 program = ["solana-sdk/program"]
@@ -24,3 +22,6 @@ default = ["program"]
 [lib]
 name = "solana_bpf_rust_invoked"
 crate-type = ["lib", "cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/invoked/src/lib.rs
+++ b/programs/bpf/rust/invoked/src/lib.rs
@@ -158,3 +158,5 @@ fn process_instruction(
 
     Ok(())
 }
+
+solana_sdk_bpf_test::stubs!();

--- a/sdk/bpf/rust/test/src/lib.rs
+++ b/sdk/bpf/rust/test/src/lib.rs
@@ -13,6 +13,11 @@ pub fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     std::println!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5);
 }
 
+#[no_mangle]
+pub fn sol_invoke_signed_rust() {
+    std::println!("sol_invoke_signed_rust()");
+}
+
 #[macro_export]
 macro_rules! stubs {
     () => {
@@ -21,6 +26,7 @@ macro_rules! stubs {
             use $crate::*;
             unsafe { sol_log_("sol_log_".as_ptr(), 8) };
             sol_log_64_(1, 2, 3, 4, 5);
+            sol_invoke_signed_rust();
         }
     };
 }


### PR DESCRIPTION
#### Problem

Cross-program invoke test programs didn't support `cargo test` due to linkage issues

#### Summary of Changes

Add the required stubs

Fixes #
