### PR TITLE
Bump Rust-BPF version to be interoperable with latest Cargo

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -103,7 +103,7 @@ if [[ ! -f llvm-native-$machine-$version.md ]]; then
 fi
 
 # Install Rust-BPF
-version=v0.2.2
+version=v0.2.3
 if [[ ! -f rust-bpf-$machine-$version.md ]]; then
   (
     filename=solana-rust-bpf-$machine.tar.bz2


### PR DESCRIPTION
#### Problem

Newer versions of Cargo might use unstable options

#### Summary of Changes

Allow BPF Rust to accept unstable options.  This unblocks: https://github.com/solana-labs/solana/pull/9754

Fixes #
