### PR TITLE
7442 refactor append vec

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
+atomic_enum = "0.1.0"
 bincode = "1.2.1"
 bv = { version = "0.11.1", features = ["serde"] }
 byteorder = "1.3.4"

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -176,7 +176,7 @@ impl AppendVec {
     }
 
     #[allow(clippy::mutex_atomic)]
-    fn new_empty_map(current_len: usize) -> Self {
+    pub fn new_empty_map(current_len: usize) -> Self {
         let map = MmapMut::map_anon(1).expect("failed to map the data file");
 
         AppendVec {


### PR DESCRIPTION
[This a work in progress]

#### Problem
Issue https://github.com/solana-labs/solana/issues/7442 relating to AccountStorageEntry.count_and_status and serialisation

#### Summary of Changes
- AccountStorageEntry (ASE) explicit implementaitons of Serialize / Deserialize traits added (modified from \#derive output)
- ASE currently implements produces / consumes a dummy count_and_status field (backward compatible)
- RwLock<count_and_status> in ASE removed & replaced with separate atomic count and status fields
- ASE is now lock-free (underlying AppendVec still has a mutex on append)
