### PR TITLE
Rpc Client: Prevent error out on get_num_blocks_since_signature_confirmation

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1131,6 +1131,7 @@ impl RpcClient {
                 }
             }
         };
+        let now = Instant::now();
         loop {
             // Return when default (max) commitment is reached
             // Failed transactions have already been eliminated, `is_some` check is sufficient
@@ -1146,7 +1147,14 @@ impl RpcClient {
                 signature,
             ));
             sleep(Duration::from_millis(500));
-            confirmations = self.get_num_blocks_since_signature_confirmation(&signature)?;
+            confirmations = self
+                .get_num_blocks_since_signature_confirmation(&signature)
+                .unwrap_or(confirmations);
+            if now.elapsed().as_secs() >= 120 {
+                return Err(
+                    RpcError::ForUser("transaction not finalized. This can happen when a transaction lands in a minor fork. Please retry.".to_string()).into(),
+                );
+            }
         }
     }
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -12,7 +12,10 @@ use log::*;
 use serde_json::{json, Value};
 use solana_sdk::{
     account::Account,
-    clock::{Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT},
+    clock::{
+        Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT,
+        MAX_HASH_AGE_IN_SECONDS,
+    },
     commitment_config::CommitmentConfig,
     epoch_schedule::EpochSchedule,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -1150,9 +1153,9 @@ impl RpcClient {
             confirmations = self
                 .get_num_blocks_since_signature_confirmation(&signature)
                 .unwrap_or(confirmations);
-            if now.elapsed().as_secs() >= 120 {
+            if now.elapsed().as_secs() >= MAX_HASH_AGE_IN_SECONDS as u64 {
                 return Err(
-                    RpcError::ForUser("transaction not finalized. This can happen when a transaction lands in a minor fork. Please retry.".to_string()).into(),
+                    RpcError::ForUser("transaction not finalized. This can happen when a transaction lands in an abandoned fork. Please retry.".to_string()).into(),
                 );
             }
         }


### PR DESCRIPTION
#### Problem
Sometimes the CLI returns `Custom: signature not found` from a transaction that subsequently succeeds. This error is generated by `RpcClient::get_num_blocks_since_signature_confirmation()`, and it can only be reached in `send_and_confirm_transaction_with_spinner()` if a transaction has been confirmed in a recent block and the method has moved on to counting confirmed blocks.

Hypothesis is that on an early `get_num_blocks_since_signature_confirmation` call the rpc client is targeting a minor fork that doesn't include the transaction and so returns the `signature not found` error.

#### Summary of Changes
Prevent an early `signature not found` from erroring out `send_and_confirm_transaction_with_spinner()` entirely. Instead, keep trying until transaction is finalized, or timeout is reached.

Toward #9305 
