### PR TITLE
Rpc: remove unwraps

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -894,22 +894,15 @@ impl RpcSol for RpcSolImpl {
         commitment: Option<CommitmentConfig>,
     ) -> Result<Inflation> {
         debug!("get_inflation rpc request received");
-        Ok(meta
-            .request_processor
+        meta.request_processor
             .read()
             .unwrap()
             .get_inflation(commitment)
-            .unwrap())
     }
 
     fn get_epoch_schedule(&self, meta: Self::Metadata) -> Result<EpochSchedule> {
         debug!("get_epoch_schedule rpc request received");
-        Ok(meta
-            .request_processor
-            .read()
-            .unwrap()
-            .get_epoch_schedule()
-            .unwrap())
+        meta.request_processor.read().unwrap().get_epoch_schedule()
     }
 
     fn get_balance(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -169,7 +169,9 @@ impl JsonRpcRequestProcessor {
     pub fn get_epoch_schedule(&self) -> Result<EpochSchedule> {
         // Since epoch schedule data comes from the genesis config, any commitment level should be
         // fine
-        Ok(*self.bank(None)?.epoch_schedule())
+        Ok(*self
+            .bank(Some(CommitmentConfig::recent()))?
+            .epoch_schedule())
     }
 
     pub fn get_balance(


### PR DESCRIPTION
#### Problem
We recently made some changes to rpc to query the cluster's largest-confirmed-root by default, which is a fallible operation. But there are two methods that incorrectly assume it is infallible, and `unwrap` :(

#### Summary of Changes
Remove the `unwrap`s in `getEpochSchedule` and `getInflation` and allow them to error gracefully
Also, since commitment is not customizable for `getEpochSchedule`, update it to use `recent` and succeed even when validator is very far behind (consider updating this to `root` when that option is plumbed in)

Fixes #9791 
