### PR TITLE
Cleanup BPF helper symbols

### DIFF
--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -134,7 +134,9 @@ void sol_log_(const char *, uint64_t);
 /**
  * Prints a 64 bit values represented in hexadecimal to stdout
  */
-void sol_log_64(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+void sol_log_64_(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+#define sol_log_64 sol_log_64_
+
 
 /**
  * Size of Public key in bytes


### PR DESCRIPTION
#### Problem

There are multiple BPF helper symbol names for the same function which is confusing and unnecessary.

#### Summary of Changes

Unify the symbol names where possible.

**This is a breaking change and requires all BPF programs to be rebuilt, specifically anyone who calls `sol_log_64()`**

Fixes #9769
