### PR TITLE
Clarify Ledger security implications

### DIFF
--- a/docs/src/hardware-wallets/ledger.md
+++ b/docs/src/hardware-wallets/ledger.md
@@ -45,13 +45,21 @@ anywhere you see an option or argument that accepts a `<KEYPAIR>`.
 
 ### Install the Solana Beta App
 
-For those of you that enjoy life on the edge, you can use the command-line to
-install the latest Solana Ledger app release before it has been validated by
+You're invited to help us test the latest pre-release version of our Ledger app
+on one of the public testnets.
+
+You can use the command-line to install the latest Solana Ledger app release before it has been validated by
 the Ledger team and made available via Ledger Live.  Note that because the app
 is not installed via Ledger Live, you will need to approve installation from an
 "unsafe" manager, as well as see the message, "This app is not genuine" each
 time you open the app. Once the app is available on Ledger Live, you can
 reinstall the app from there, and the message will no longer be displayed.
+
+**WARNING:** Installing an unsigned Ledger app reduces the security of your Ledger device.
+If your client is compromised, an attacker will be able to trick you into signing arbitrary 
+transactions with arbitrary derivation paths. Only use this installation method if you understand 
+the security implications. We strongly recommend that you use a separate
+Ledger device, with no other wallets/apps sharing the same seed phrase.
 
 1. Connect your Ledger device via USB and enter your pin to unlock it
 2. Download and run the Solana Ledger app installer:

--- a/docs/src/hardware-wallets/ledger.md
+++ b/docs/src/hardware-wallets/ledger.md
@@ -56,8 +56,8 @@ time you open the app. Once the app is available on Ledger Live, you can
 reinstall the app from there, and the message will no longer be displayed.
 
 **WARNING:** Installing an unsigned Ledger app reduces the security of your Ledger device.
-If your client is compromised, an attacker will be able to trick you into signing arbitrary 
-transactions with arbitrary derivation paths. Only use this installation method if you understand 
+If your client is compromised, an attacker will be able to trick you into signing arbitrary
+transactions with arbitrary derivation paths. Only use this installation method if you understand
 the security implications. We strongly recommend that you use a separate
 Ledger device, with no other wallets/apps sharing the same seed phrase.
 


### PR DESCRIPTION
#### Problem

Installing an unsigned Ledger app has subtle security implications that the average user won't understand. Teaching users to ignore security warnings makes them an easier target for scams/phishing.

#### Summary of Changes

Point out security implications