### PR TITLE
Cli: enable multiple stake lockup fields to be set at once

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -335,6 +335,7 @@ impl StakeSubCommands for App<'_, '_> {
                 )
                 .group(ArgGroup::with_name("lockup_details")
                     .args(&["lockup_epoch", "lockup_date", "new_custodian"])
+                    .multiple(true)
                     .required(true))
                 .arg(
                     Arg::with_name("custodian")


### PR DESCRIPTION
#### Problem
`solana stake-set-lockup` unnecessarily makes `--lockup-epoch`, `--lockup-date`, and `--new-custodian` mutually exclusive.

#### Summary of Changes
Clap defaults to `multiple(false)` for arg groups; make this one `multiple(true)`!

Fixes #9828 
