### PR TITLE
Fix accounts indexing

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5843,4 +5843,44 @@ mod tests {
         info!("account: {:?}", account);
         assert!(account.executable);
     }
+
+    #[test]
+    fn test_ref_account_key_after_program_id() {
+        let (genesis_config, mint_keypair) = create_genesis_config(500);
+        let mut bank = Bank::new(&genesis_config);
+
+        let from_pubkey = Pubkey::new_rand();
+        let to_pubkey = Pubkey::new_rand();
+
+        let account_metas = vec![
+            AccountMeta::new(from_pubkey, false),
+            AccountMeta::new(to_pubkey, false),
+        ];
+
+        fn mock_vote_processor(
+            _pubkey: &Pubkey,
+            _ka: &[KeyedAccount],
+            _data: &[u8],
+        ) -> std::result::Result<(), InstructionError> {
+            Ok(())
+        }
+
+        bank.add_static_program("mock_vote", solana_vote_program::id(), mock_vote_processor);
+
+        let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+        let mut tx = Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&mint_keypair.pubkey()),
+            &[&mint_keypair],
+            bank.last_blockhash(),
+        );
+
+        tx.message.account_keys.push(Pubkey::new_rand());
+        assert_eq!(tx.message.account_keys.len(), 5);
+        tx.message.instructions[0].accounts.remove(0);
+        tx.message.instructions[0].accounts.push(4);
+
+        let result = bank.process_transaction(&tx);
+        assert_eq!(result, Ok(()));
+    }
 }


### PR DESCRIPTION
#### Problem

Transaction indexes are offsets into the account_keys array, but accounts gets passed around which is not 1-1 with accounts since program accounts are filtered.

#### Summary of Changes

Insert empty accounts for program accounts, so that indexing is consistent.

Fixes #9817