### PR TITLE
Load all accounts in the message

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5883,4 +5883,62 @@ mod tests {
         // capitalization
         assert_eq!(bank.capitalization(), pre_capitalization - burn_amount);
     }
+
+    #[test]
+    fn test_ref_account_key_after_program_id() {
+        let (genesis_config, mint_keypair) = create_genesis_config(500);
+        let mut bank = Bank::new(&genesis_config);
+
+        let from_pubkey = Pubkey::new_rand();
+        let to_pubkey = Pubkey::new_rand();
+
+        fn mock_vote_processor(
+            _pubkey: &Pubkey,
+            _ka: &[KeyedAccount],
+            _data: &[u8],
+        ) -> std::result::Result<(), InstructionError> {
+            Ok(())
+        }
+        bank.add_static_program("mock_vote", solana_vote_program::id(), mock_vote_processor);
+
+        {
+            let account_metas = vec![
+                AccountMeta::new(from_pubkey, false),
+                AccountMeta::new(to_pubkey, false),
+            ];
+            let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+            let mut tx = Transaction::new_signed_with_payer(
+                &[instruction],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                bank.last_blockhash(),
+            );
+            tx.message.account_keys.push(Pubkey::new_rand());
+            assert_eq!(tx.message.account_keys.len(), 5);
+            tx.message.instructions[0].accounts.remove(0);
+            tx.message.instructions[0].accounts.push(4);
+            let result = bank.process_transaction(&tx);
+            assert_eq!(result, Ok(()));
+        }
+
+        // Issue #9817
+        {
+            let account_metas = vec![
+                AccountMeta::new(to_pubkey, false),
+                AccountMeta::new(from_pubkey, false),
+            ];
+            let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+            let mut tx = Transaction::new_signed_with_payer(
+                &[instruction],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair],
+                bank.last_blockhash(),
+            );
+            tx.message.account_keys.push(Pubkey::new_rand());
+            assert_eq!(tx.message.account_keys.len(), 5);
+            tx.message.instructions[0].accounts.insert(0, 4);
+            let result = bank.process_transaction(&tx);
+            assert_eq!(result, Ok(()));
+        }
+    }
 }


### PR DESCRIPTION
#### Problem

A subset of accounts is loaded and used to form KeyedAccounts but that information is not carried forward.  When the message processor builds its list of KeyedAccounts relies on the indices in the instruction but they don't match the subset list being used.

#### Summary of Changes

Load all the accounts so the Instruction indices match the list of accounts.  This solution hits a nail with a sledgehammer but its probably the safest fix in the short term until a deeper rework of account handling can be done.

Fixes #9817 

