### PR TITLE
Fix accounts indexing

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4603,7 +4603,10 @@ mod tests {
             bank.last_blockhash(),
         );
 
-        assert_eq!(bank.process_transaction(&tx), Ok(()));
+        assert_eq!(
+            bank.process_transaction(&tx),
+            Err(TransactionError::InvalidAccountIndex)
+        );
         assert_eq!(bank.get_balance(&key.pubkey()), 0);
     }
 
@@ -5840,15 +5843,11 @@ mod tests {
 
         tx.message.account_keys.push(Pubkey::new_rand());
 
-        fn mock_vote_processor(
-            _pubkey: &Pubkey,
-            _ka: &[KeyedAccount],
-            _data: &[u8],
-        ) -> std::result::Result<(), InstructionError> {
-            Ok(())
-        }
-
-        bank.add_static_program("mock_vote", solana_vote_program::id(), mock_vote_processor);
+        bank.add_static_program(
+            "mock_vote",
+            solana_vote_program::id(),
+            mock_ok_vote_processor,
+        );
         let result = bank.process_transaction(&tx);
         assert_eq!(result, Ok(()));
         let account = bank.get_account(&solana_vote_program::id()).unwrap();
@@ -5882,5 +5881,97 @@ mod tests {
         // Ensure that no rent was collected, and the entire burn amount was removed from bank
         // capitalization
         assert_eq!(bank.capitalization(), pre_capitalization - burn_amount);
+    }
+
+    #[test]
+    fn test_program_id_as_payer() {
+        solana_logger::setup();
+        let (genesis_config, mint_keypair) = create_genesis_config(500);
+        let mut bank = Bank::new(&genesis_config);
+
+        let from_pubkey = Pubkey::new_rand();
+        let to_pubkey = Pubkey::new_rand();
+
+        let account_metas = vec![
+            AccountMeta::new(from_pubkey, false),
+            AccountMeta::new(to_pubkey, false),
+        ];
+
+        bank.add_static_program(
+            "mock_vote",
+            solana_vote_program::id(),
+            mock_ok_vote_processor,
+        );
+
+        let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+        let mut tx = Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&mint_keypair.pubkey()),
+            &[&mint_keypair],
+            bank.last_blockhash(),
+        );
+
+        info!(
+            "mint: {} account keys: {:?}",
+            mint_keypair.pubkey(),
+            tx.message.account_keys
+        );
+        assert_eq!(tx.message.account_keys.len(), 4);
+        tx.message.account_keys.clear();
+        tx.message.account_keys.push(solana_vote_program::id());
+        tx.message.account_keys.push(mint_keypair.pubkey());
+        tx.message.account_keys.push(from_pubkey);
+        tx.message.account_keys.push(to_pubkey);
+        tx.message.instructions[0].program_id_index = 0;
+        tx.message.instructions[0].accounts.clear();
+        tx.message.instructions[0].accounts.push(2);
+        tx.message.instructions[0].accounts.push(3);
+
+        let result = bank.process_transaction(&tx);
+        assert_eq!(result, Err(TransactionError::InvalidAccountIndex));
+    }
+
+    fn mock_ok_vote_processor(
+        _pubkey: &Pubkey,
+        _ka: &[KeyedAccount],
+        _data: &[u8],
+    ) -> std::result::Result<(), InstructionError> {
+        Ok(())
+    }
+
+    #[test]
+    fn test_ref_account_key_after_program_id() {
+        let (genesis_config, mint_keypair) = create_genesis_config(500);
+        let mut bank = Bank::new(&genesis_config);
+
+        let from_pubkey = Pubkey::new_rand();
+        let to_pubkey = Pubkey::new_rand();
+
+        let account_metas = vec![
+            AccountMeta::new(from_pubkey, false),
+            AccountMeta::new(to_pubkey, false),
+        ];
+
+        bank.add_static_program(
+            "mock_vote",
+            solana_vote_program::id(),
+            mock_ok_vote_processor,
+        );
+
+        let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+        let mut tx = Transaction::new_signed_with_payer(
+            &[instruction],
+            Some(&mint_keypair.pubkey()),
+            &[&mint_keypair],
+            bank.last_blockhash(),
+        );
+
+        tx.message.account_keys.push(Pubkey::new_rand());
+        assert_eq!(tx.message.account_keys.len(), 5);
+        tx.message.instructions[0].accounts.remove(0);
+        tx.message.instructions[0].accounts.push(4);
+
+        let result = bank.process_transaction(&tx);
+        assert_eq!(result, Ok(()));
     }
 }

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -137,14 +137,17 @@ fn test_stake_create_and_split_single_signature() {
         Pubkey::create_with_seed(&staker_pubkey, "split_stake", &solana_stake_program::id())
             .unwrap();
     // Test split
-    let message = Message::new(&stake_instruction::split_with_seed(
-        &stake_address, // original
-        &staker_pubkey, // authorized
-        lamports / 2,
-        &split_stake_address, // new address
-        &staker_pubkey,       // base
-        "split_stake",        // seed
-    ));
+    let message = Message::new_with_payer(
+        &stake_instruction::split_with_seed(
+            &stake_address, // original
+            &staker_pubkey, // authorized
+            lamports / 2,
+            &split_stake_address, // new address
+            &staker_pubkey,       // base
+            "split_stake",        // seed
+        ),
+        Some(&staker_keypair.pubkey()),
+    );
 
     assert!(bank_client
         .send_message(&[&staker_keypair], message)

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -510,6 +510,21 @@ mod tests {
         tx = o.clone();
         tx.message.instructions[0].accounts[0] = 3;
         assert_eq!(tx.sanitize(), Err(SanitizeError::IndexOutOfBounds));
+
+        tx = o.clone();
+        tx.message.instructions[0].program_id_index = 0;
+        assert_eq!(tx.sanitize(), Err(SanitizeError::IndexOutOfBounds));
+
+        tx = o.clone();
+        tx.message.header.num_readonly_signed_accounts = 2;
+        tx.message.header.num_readonly_unsigned_accounts = 3;
+        tx.message.account_keys.resize(4, Pubkey::default());
+        assert_eq!(tx.sanitize(), Err(SanitizeError::IndexOutOfBounds));
+
+        tx = o.clone();
+        tx.message.header.num_readonly_signed_accounts = 2;
+        tx.message.header.num_required_signatures = 1;
+        assert_eq!(tx.sanitize(), Err(SanitizeError::IndexOutOfBounds));
     }
 
     fn create_sample_transaction() -> Transaction {


### PR DESCRIPTION
#### Problem

Indexing into `accounts` vec assumes that the accounts are 1-1 with the indexes in `account_keys`.

#### Summary of Changes

Fill in empty accounts for program slots so indexing is 1:1, detect first non-program account as the payer.

Fixes #9817
