### PR TITLE
Update getSignatureStatus RPC with mapped error objects

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,6 +39,7 @@ mod result;
 pub mod retransmit_stage;
 pub mod rewards_recorder_service;
 pub mod rpc;
+pub mod rpc_error;
 pub mod rpc_pubsub;
 pub mod rpc_pubsub_service;
 pub mod rpc_service;

--- a/core/src/rpc_error.rs
+++ b/core/src/rpc_error.rs
@@ -3,10 +3,12 @@ use solana_sdk::clock::Slot;
 
 const JSON_RPC_SERVER_ERROR_0: i64 = -32000;
 const JSON_RPC_SERVER_ERROR_1: i64 = -32001;
+const JSON_RPC_SERVER_ERROR_2: i64 = -32002;
 
 pub enum RpcCustomError {
     NonexistentClusterRoot { cluster_root: Slot, node_root: Slot },
     TransactionError(Value),
+    TransactionNotFound,
 }
 
 impl From<RpcCustomError> for Error {
@@ -27,6 +29,11 @@ impl From<RpcCustomError> for Error {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_1),
                 message: "on-chain transaction error".to_string(),
                 data: Some(data),
+            },
+            RpcCustomError::TransactionNotFound => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_2),
+                message: "transaction not found".to_string(),
+                data: None,
             },
         }
     }

--- a/core/src/rpc_error.rs
+++ b/core/src/rpc_error.rs
@@ -1,0 +1,33 @@
+use jsonrpc_core::{Error, ErrorCode, Value};
+use solana_sdk::clock::Slot;
+
+const JSON_RPC_SERVER_ERROR_0: i64 = -32000;
+const JSON_RPC_SERVER_ERROR_1: i64 = -32001;
+
+pub enum RpcCustomError {
+    NonexistentClusterRoot { cluster_root: Slot, node_root: Slot },
+    TransactionError(Value),
+}
+
+impl From<RpcCustomError> for Error {
+    fn from(e: RpcCustomError) -> Self {
+        match e {
+            RpcCustomError::NonexistentClusterRoot {
+                cluster_root,
+                node_root,
+            } => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_0),
+                message: format!(
+                    "Cluster largest_confirmed_root {} does not exist on node. Node root: {}",
+                    cluster_root, node_root,
+                ),
+                data: None,
+            },
+            RpcCustomError::TransactionError(data) => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_1),
+                message: "on-chain transaction error".to_string(),
+                data: Some(data),
+            },
+        }
+    }
+}


### PR DESCRIPTION
#### Problem
It would be easier for some downstream users to consume on-chain transaction errors as jsonrpc error objects, since there is already a standard error format.

#### Summary of Changes
- Add RpcCustomError module, and refactor `getSignatureStatus` to use it

New behavior:
```json
// Transaction succeeded
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getSignatureStatus","params":["e6mgpDaNxA1UDFs7ELiBQysUCEdw4F8YhhKoMuiFsoMX5uTwFd94gTaMdAguujeXnH6m5Mp8zfadHfaZNDBXanU"]}' 127.0.0.1:8899

{"jsonrpc":"2.0","result":true,"id":1}

// Transaction not found
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getSignatureStatus","params":["e6mgpDaNxA1UDFs7ELiBQysUCEdw4F8YhhKoMuiFsoMX5uTwFd94gTaMdAguujeXnH6m5Mp8zfadHfaZNDBXanU"]}' 127.0.0.1:8899

{"jsonrpc":"2.0","error":{"code":-32002,"message":"transaction not found"},"id":1}

// On-chain Transaction Error
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getSignatureStatus","params":["2kfd3PNcP5QvzmhDPo8RtvE6GwsJk7PWoqFVPtZoDmJFKsfPfkQS9o9ZqUZonmFWXZQPjNevD5mH13fVFWbcEYgT"]}' 127.0.0.1:8899

{"jsonrpc":"2.0","error":{"code":-32001,"message":"on-chain transaction error","data":{"InstructionError":[0,{"Custom":1}]}},"id":1}
```

Fixes #9665 
