### PR TITLE
Speed up setting lockups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4040,6 +4040,7 @@ name = "solana-stake-accounts"
 version = "1.2.0"
 dependencies = [
  "clap",
+ "itertools 0.9.0",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://solana.com/"
 
 [dependencies]
 clap = "2.33.0"
+itertools = "0.9.0"
 solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-cli-config = { path = "../cli-config", version = "1.2.0" }
 solana-client = { path = "../client", version = "1.2.0" }

--- a/stake-accounts/src/arg_parser.rs
+++ b/stake-accounts/src/arg_parser.rs
@@ -249,6 +249,13 @@ where
                     Arg::with_name("no_wait")
                         .long("no-wait")
                         .help("Send transactions without waiting for confirmation"),
+                )
+                .arg(
+                    Arg::with_name("unlock_years")
+                        .long("unlock-years")
+                        .takes_value(true)
+                        .value_name("NUMBER")
+                        .help("Years to unlock after the cliff"),
                 ),
         )
         .subcommand(
@@ -322,6 +329,7 @@ fn parse_set_lockup_args(matches: &ArgMatches<'_>) -> SetLockupArgs<String, Stri
         new_custodian: value_t!(matches, "new_custodian", String).ok(),
         num_accounts: value_t_or_exit!(matches, "num_accounts", usize),
         no_wait: matches.is_present("no_wait"),
+        unlock_years: value_t!(matches, "unlock_years", f64).ok(),
     }
 }
 

--- a/stake-accounts/src/arg_parser.rs
+++ b/stake-accounts/src/arg_parser.rs
@@ -244,7 +244,12 @@ where
                 .arg(lockup_epoch_arg())
                 .arg(lockup_date_arg())
                 .arg(new_custodian_arg())
-                .arg(num_accounts_arg()),
+                .arg(num_accounts_arg())
+                .arg(
+                    Arg::with_name("no_wait")
+                        .long("no-wait")
+                        .help("Send transactions without waiting for confirmation"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("rebase")
@@ -316,6 +321,7 @@ fn parse_set_lockup_args(matches: &ArgMatches<'_>) -> SetLockupArgs<String, Stri
         lockup_date: unix_timestamp_from_rfc3339_datetime(matches, "lockup_date"),
         new_custodian: value_t!(matches, "new_custodian", String).ok(),
         num_accounts: value_t_or_exit!(matches, "num_accounts", usize),
+        no_wait: matches.is_present("no_wait"),
     }
 }
 

--- a/stake-accounts/src/args.rs
+++ b/stake-accounts/src/args.rs
@@ -46,6 +46,7 @@ pub(crate) struct SetLockupArgs<P, K> {
     pub lockup_date: Option<UnixTimestamp>,
     pub new_custodian: Option<P>,
     pub num_accounts: usize,
+    pub no_wait: bool,
 }
 
 pub(crate) struct RebaseArgs<P, K> {
@@ -191,6 +192,7 @@ fn resolve_set_lockup_args(
         lockup_date: args.lockup_date,
         new_custodian: resolve_new_custodian(wallet_manager, &args.new_custodian)?,
         num_accounts: args.num_accounts,
+        no_wait: args.no_wait,
     };
     Ok(resolved_args)
 }

--- a/stake-accounts/src/args.rs
+++ b/stake-accounts/src/args.rs
@@ -47,6 +47,7 @@ pub(crate) struct SetLockupArgs<P, K> {
     pub new_custodian: Option<P>,
     pub num_accounts: usize,
     pub no_wait: bool,
+    pub unlock_years: Option<f64>,
 }
 
 pub(crate) struct RebaseArgs<P, K> {
@@ -193,6 +194,7 @@ fn resolve_set_lockup_args(
         new_custodian: resolve_new_custodian(wallet_manager, &args.new_custodian)?,
         num_accounts: args.num_accounts,
         no_wait: args.no_wait,
+        unlock_years: args.unlock_years,
     };
     Ok(resolved_args)
 }

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -132,6 +132,7 @@ fn process_lockup_stake_accounts(
         &args.custodian.pubkey(),
         &lockup,
         &existing_lockups,
+        args.unlock_years,
     );
     if messages.is_empty() {
         eprintln!("No work to do");

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -86,10 +86,7 @@ fn process_authorize_stake_accounts(
         &*args.stake_authority,
         &*args.withdraw_authority,
     ];
-    for message in messages {
-        let signature = send_message(client, message, &signers)?;
-        println!("{}", signature);
-    }
+    send_messages(client, messages, &signers)?;
     Ok(())
 }
 
@@ -110,10 +107,7 @@ fn process_lockup_stake_accounts(
         args.num_accounts,
     );
     let signers = vec![&*args.fee_payer, &*args.custodian];
-    for message in messages {
-        let signature = send_message(client, message, &signers)?;
-        println!("{}", signature);
-    }
+    send_messages(client, messages, &signers)?;
     Ok(())
 }
 
@@ -140,10 +134,7 @@ fn process_rebase_stake_accounts(
         &*args.new_base_keypair,
         &*args.stake_authority,
     ];
-    for message in messages {
-        let signature = send_message(client, message, &signers)?;
-        println!("{}", signature);
-    }
+    send_messages(client, messages, &signers)?;
     Ok(())
 }
 
@@ -176,10 +167,7 @@ fn process_move_stake_accounts(
         &*args.stake_authority,
         &*authorize_args.withdraw_authority,
     ];
-    for message in messages {
-        let signature = send_message(client, message, &signers)?;
-        println!("{}", signature);
-    }
+    send_messages(client, messages, &signers)?;
     Ok(())
 }
 
@@ -191,6 +179,20 @@ fn send_message<S: Signers>(
     let mut transaction = Transaction::new_unsigned(message);
     client.resign_transaction(&mut transaction, signers)?;
     client.send_and_confirm_transaction_with_spinner(&mut transaction, signers)
+}
+
+fn send_messages<S: Signers>(
+    client: &RpcClient,
+    messages: Vec<Message>,
+    signers: &S,
+) -> Result<Vec<Signature>, ClientError> {
+    let mut signatures = vec![];
+    for message in messages {
+        let signature = send_message(client, message, signers)?;
+        signatures.push(signature);
+        println!("{}", signature);
+    }
+    Ok(signatures)
 }
 
 fn main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
#### Problem

Setting lockups is painfully slow.  There's currently 385 accounts under lockup and a CLI tool that finalizes each before moving to the next.

#### Summary of Changes

* Add `--no-wait` option
* Add `--unlock-years` option, with same meaning as in the genesis accounts
* Don't set lockups that are already set
