### PR TITLE
Fuzzer test and fixes

### DIFF
--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -64,6 +64,11 @@ pub enum TransactionError {
 
     /// This program may not be used for executing instructions
     InvalidProgramForExecution,
+
+    /// Transaction failed to sanitize accounts offsets correctly
+    /// implies that account locks are not taken for this TX, and should
+    /// not be unlocked.
+    SanitizeFailure,
 }
 
 pub type Result<T> = result::Result<T, TransactionError>;


### PR DESCRIPTION
#### Problem

No test to fuzz transaction inputs, and lock_accounts path needs to sanitize the transaction before working with it and also de-duplicate the keys.

#### Summary of Changes

Move transaction sanitize and key de-duplication earlier into the lock_accounts pass.

Fixes #
