### PR TITLE
Avoid panic in solana catchup caused by float->duration underflow

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -481,14 +481,13 @@ pub fn process_catchup(
         let slot_distance = rpc_slot as i64 - node_slot as i64;
         let slots_per_second =
             (previous_slot_distance - slot_distance) as f64 / f64::from(sleep_interval);
-        let time_remaining = if slots_per_second <= 0.0 {
+        let time_remaining = (slot_distance as f64 / slots_per_second).round();
+        let time_remaining = if !time_remaining.is_normal() || time_remaining <= 0.0 {
             "".to_string()
         } else {
             format!(
                 ". Time remaining: {}",
-                humantime::format_duration(Duration::from_secs_f64(
-                    (slot_distance as f64 / slots_per_second).round()
-                ))
+                humantime::format_duration(Duration::from_secs_f64(time_remaining))
             )
         };
 


### PR DESCRIPTION
PR for issue #9866 affecting `solana catchup` in v1.1.8.