### PR TITLE
Rpc: add getLargestAccounts endpoint

### DIFF
--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -196,6 +196,6 @@ pub struct RpcStorageTurn {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcAccountBalance {
-    pub pubkey: String,
+    pub address: String,
     pub lamports: u64,
 }

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -192,3 +192,10 @@ pub struct RpcStorageTurn {
     pub blockhash: String,
     pub slot: Slot,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcAccountBalance {
+    pub pubkey: String,
+    pub lamports: u64,
+}

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -193,7 +193,7 @@ pub struct RpcStorageTurn {
     pub slot: Slot,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcAccountBalance {
     pub pubkey: String,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -294,8 +294,8 @@ impl JsonRpcRequestProcessor {
                 AccountAddressFilter::Exclude,
             )
             .into_iter()
-            .map(|(pubkey, lamports)| RpcAccountBalance {
-                pubkey: pubkey.to_string(),
+            .map(|(address, lamports)| RpcAccountBalance {
+                address: address.to_string(),
                 lamports,
             })
             .collect(),
@@ -1836,7 +1836,7 @@ pub mod tests {
         let alice_balance: u64 = serde_json::from_value(json["result"]["value"].clone())
             .expect("actual response deserialization");
         assert!(largest_accounts.contains(&RpcAccountBalance {
-            pubkey: alice.pubkey().to_string(),
+            address: alice.pubkey().to_string(),
             lamports: alice_balance,
         }));
 
@@ -1850,7 +1850,7 @@ pub mod tests {
         let bob_balance: u64 = serde_json::from_value(json["result"]["value"].clone())
             .expect("actual response deserialization");
         assert!(largest_accounts.contains(&RpcAccountBalance {
-            pubkey: bob_pubkey.to_string(),
+            address: bob_pubkey.to_string(),
             lamports: bob_balance,
         }));
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -19,7 +19,7 @@ use solana_client::{
 use solana_faucet::faucet::request_airdrop_transaction;
 use solana_ledger::{bank_forks::BankForks, blockstore::Blockstore};
 use solana_perf::packet::PACKET_DATA_SIZE;
-use solana_runtime::bank::Bank;
+use solana_runtime::{accounts::AccountAddressFilter, bank::Bank};
 use solana_sdk::{
     clock::{Slot, UnixTimestamp},
     commitment_config::{CommitmentConfig, CommitmentLevel},
@@ -37,7 +37,7 @@ use solana_transaction_status::{
 use solana_vote_program::vote_state::{VoteState, MAX_LOCKOUT_HISTORY};
 use std::{
     cmp::max,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     net::{SocketAddr, UdpSocket},
     str::FromStr,
     sync::{Arc, RwLock},
@@ -287,7 +287,11 @@ impl JsonRpcRequestProcessor {
     ) -> Result<Vec<RpcAccountBalance>> {
         Ok(self
             .bank(commitment)?
-            .get_largest_accounts(NUM_LARGEST_ACCOUNTS, &[], true)
+            .get_largest_accounts(
+                NUM_LARGEST_ACCOUNTS,
+                &HashSet::new(),
+                AccountAddressFilter::Exclude,
+            )
             .into_iter()
             .map(|(pubkey, lamports)| RpcAccountBalance {
                 pubkey: pubkey.to_string(),

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -31,6 +31,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getGenesisHash](jsonrpc-api.md#getgenesishash)
 * [getIdentity](jsonrpc-api.md#getidentity)
 * [getInflation](jsonrpc-api.md#getinflation)
+* [getLargestAccounts](jsonrpc-api.md#getlargestaccounts)
 * [getLeaderSchedule](jsonrpc-api.md#getleaderschedule)
 * [getMinimumBalanceForRentExemption](jsonrpc-api.md#getminimumbalanceforrentexemption)
 * [getProgramAccounts](jsonrpc-api.md#getprogramaccounts)
@@ -632,6 +633,32 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":{"foundation":0.05,"foundationTerm":7.0,"initial":0.15,"storage":0.1,"taper":0.15,"terminal":0.015},"id":1}
+```
+
+### getLargestAccounts
+
+Returns the 20 largest accounts, by lamport balance
+
+#### Parameters:
+
+* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+
+#### Results:
+
+The result will be an RpcResponse JSON object with `value` equal to an array of:
+
+* `<object>` - otherwise, a JSON object containing:
+  * `pubkey: <string>`, base-58 encoded Pubkey address of the account
+  * `lamports: <u64>`, number of lamports in the account, as a u64
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getInflation"}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":{"context":{"slot":54},"value":[{"lamports":999974,"pubkey":"99P8ZgtJYe1buSK8JXkvpLh8xPsCFuLYhz9hQFNw93WJ"},{"lamports":42,"pubkey":"uPwWLo16MVehpyWqsLkK3Ka8nLowWvAHbBChqv2FZeL"},{"lamports":42,"pubkey":"aYJCgU7REfu3XF8b3QhkqgqQvLizx8zxuLBHA25PzDS"},{"lamports":42,"pubkey":"CTvHVtQ4gd4gUcw3bdVgZJJqApXE9nCbbbP4VTS5wE1D"},{"lamports":20,"pubkey":"4fq3xJ6kfrh9RkJQsmVd5gNMvJbuSHfErywvEjNQDPxu"},{"lamports":4,"pubkey":"AXJADheGVp9cruP8WYu46oNkRbeASngN5fPCMVGQqNHa"},{"lamports":2,"pubkey":"8NT8yS6LiwNprgW4yM1jPPow7CwRUotddBVkrkWgYp24"},{"lamports":1,"pubkey":"SysvarEpochSchedu1e111111111111111111111111"},{"lamports":1,"pubkey":"11111111111111111111111111111111"},{"lamports":1,"pubkey":"Stake11111111111111111111111111111111111111"},{"lamports":1,"pubkey":"SysvarC1ock11111111111111111111111111111111"},{"lamports":1,"pubkey":"StakeConfig11111111111111111111111111111111"},{"lamports":1,"pubkey":"SysvarRent111111111111111111111111111111111"},{"lamports":1,"pubkey":"Config1111111111111111111111111111111111111"},{"lamports":1,"pubkey":"SysvarStakeHistory1111111111111111111111111"},{"lamports":1,"pubkey":"SysvarRecentB1ockHashes11111111111111111111"},{"lamports":1,"pubkey":"SysvarFees111111111111111111111111111111111"},{"lamports":1,"pubkey":"Vote111111111111111111111111111111111111111"}]},"id":1}
 ```
 
 ### getLeaderSchedule

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -648,7 +648,7 @@ Returns the 20 largest accounts, by lamport balance
 The result will be an RpcResponse JSON object with `value` equal to an array of:
 
 * `<object>` - otherwise, a JSON object containing:
-  * `pubkey: <string>`, base-58 encoded Pubkey address of the account
+  * `address: <string>`, base-58 encoded address of the account
   * `lamports: <u64>`, number of lamports in the account, as a u64
 
 #### Example:
@@ -658,7 +658,7 @@ The result will be an RpcResponse JSON object with `value` equal to an array of:
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getInflation"}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":54},"value":[{"lamports":999974,"pubkey":"99P8ZgtJYe1buSK8JXkvpLh8xPsCFuLYhz9hQFNw93WJ"},{"lamports":42,"pubkey":"uPwWLo16MVehpyWqsLkK3Ka8nLowWvAHbBChqv2FZeL"},{"lamports":42,"pubkey":"aYJCgU7REfu3XF8b3QhkqgqQvLizx8zxuLBHA25PzDS"},{"lamports":42,"pubkey":"CTvHVtQ4gd4gUcw3bdVgZJJqApXE9nCbbbP4VTS5wE1D"},{"lamports":20,"pubkey":"4fq3xJ6kfrh9RkJQsmVd5gNMvJbuSHfErywvEjNQDPxu"},{"lamports":4,"pubkey":"AXJADheGVp9cruP8WYu46oNkRbeASngN5fPCMVGQqNHa"},{"lamports":2,"pubkey":"8NT8yS6LiwNprgW4yM1jPPow7CwRUotddBVkrkWgYp24"},{"lamports":1,"pubkey":"SysvarEpochSchedu1e111111111111111111111111"},{"lamports":1,"pubkey":"11111111111111111111111111111111"},{"lamports":1,"pubkey":"Stake11111111111111111111111111111111111111"},{"lamports":1,"pubkey":"SysvarC1ock11111111111111111111111111111111"},{"lamports":1,"pubkey":"StakeConfig11111111111111111111111111111111"},{"lamports":1,"pubkey":"SysvarRent111111111111111111111111111111111"},{"lamports":1,"pubkey":"Config1111111111111111111111111111111111111"},{"lamports":1,"pubkey":"SysvarStakeHistory1111111111111111111111111"},{"lamports":1,"pubkey":"SysvarRecentB1ockHashes11111111111111111111"},{"lamports":1,"pubkey":"SysvarFees111111111111111111111111111111111"},{"lamports":1,"pubkey":"Vote111111111111111111111111111111111111111"}]},"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":54},"value":[{"lamports":999974,"address":"99P8ZgtJYe1buSK8JXkvpLh8xPsCFuLYhz9hQFNw93WJ"},{"lamports":42,"address":"uPwWLo16MVehpyWqsLkK3Ka8nLowWvAHbBChqv2FZeL"},{"lamports":42,"address":"aYJCgU7REfu3XF8b3QhkqgqQvLizx8zxuLBHA25PzDS"},{"lamports":42,"address":"CTvHVtQ4gd4gUcw3bdVgZJJqApXE9nCbbbP4VTS5wE1D"},{"lamports":20,"address":"4fq3xJ6kfrh9RkJQsmVd5gNMvJbuSHfErywvEjNQDPxu"},{"lamports":4,"address":"AXJADheGVp9cruP8WYu46oNkRbeASngN5fPCMVGQqNHa"},{"lamports":2,"address":"8NT8yS6LiwNprgW4yM1jPPow7CwRUotddBVkrkWgYp24"},{"lamports":1,"address":"SysvarEpochSchedu1e111111111111111111111111"},{"lamports":1,"address":"11111111111111111111111111111111"},{"lamports":1,"address":"Stake11111111111111111111111111111111111111"},{"lamports":1,"address":"SysvarC1ock11111111111111111111111111111111"},{"lamports":1,"address":"StakeConfig11111111111111111111111111111111"},{"lamports":1,"address":"SysvarRent111111111111111111111111111111111"},{"lamports":1,"address":"Config1111111111111111111111111111111111111"},{"lamports":1,"address":"SysvarStakeHistory1111111111111111111111111"},{"lamports":1,"address":"SysvarRecentB1ockHashes11111111111111111111"},{"lamports":1,"address":"SysvarFees111111111111111111111111111111111"},{"lamports":1,"address":"Vote111111111111111111111111111111111111111"}]},"id":1}
 ```
 
 ### getLeaderSchedule

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -422,6 +422,8 @@ impl Accounts {
                         (!exclude && pubkeys.contains(&pubkey)
                             || exclude && !pubkeys.contains(&pubkey))
                             && account.lamports != 0
+                            && !(account.lamports == std::u64::MAX
+                                && account.owner == solana_storage_program::id())
                     })
                     .map(|(pubkey, account, _slot)| (*pubkey, account.lamports))
                 {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1844,6 +1844,17 @@ impl Bank {
         None
     }
 
+    pub fn get_largest_accounts(
+        &self,
+        num: usize,
+        pubkeys: &[Pubkey],
+        exclude: bool,
+    ) -> Vec<(Pubkey, u64)> {
+        self.rc
+            .accounts
+            .load_largest_accounts(&self.ancestors, num, pubkeys, exclude)
+    }
+
     pub fn transaction_count(&self) -> u64 {
         self.transaction_count.load(Ordering::Relaxed)
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3,7 +3,10 @@
 //! on behalf of the caller, and a low-level API for when they have
 //! already been signed and verified.
 use crate::{
-    accounts::{Accounts, TransactionAccounts, TransactionLoadResult, TransactionLoaders},
+    accounts::{
+        AccountAddressFilter, Accounts, TransactionAccounts, TransactionLoadResult,
+        TransactionLoaders,
+    },
     accounts_db::{AccountsDBSerialize, ErrorCounters, SnapshotStorage, SnapshotStorages},
     accounts_index::Ancestors,
     blockhash_queue::BlockhashQueue,
@@ -58,7 +61,7 @@ use solana_stake_program::stake_state::{self, Delegation};
 use solana_vote_program::vote_state::VoteState;
 use std::{
     cell::RefCell,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     io::{BufReader, Cursor, Error as IOError, Read},
     path::{Path, PathBuf},
     rc::Rc,
@@ -1847,12 +1850,12 @@ impl Bank {
     pub fn get_largest_accounts(
         &self,
         num: usize,
-        pubkeys: &[Pubkey],
-        exclude: bool,
+        filter_by_address: &HashSet<Pubkey>,
+        filter: AccountAddressFilter,
     ) -> Vec<(Pubkey, u64)> {
         self.rc
             .accounts
-            .load_largest_accounts(&self.ancestors, num, pubkeys, exclude)
+            .load_largest_accounts(&self.ancestors, num, filter_by_address, filter)
     }
 
     pub fn transaction_count(&self) -> u64 {


### PR DESCRIPTION
#### Problem
People want an easy way to find the 🐳 accounts by JSON RPC.

#### Summary of Changes
- Add `getLargestAccounts` rpc endpoint that returns the addresses and balances of the 20 accounts with the most lamports in them
- Include plumbing to limit accounts to a provided list of pubkeys or to exclude a list of pubkeys, in order to support limiting to circulating or non-circulating accounts once #9541
- Filter out Storage program `RewardsPool`s that get initialized with u64::MAX lamports

Fixes #9811 
