### PR TITLE
Cli: add cluster-date subcommand, and make block-time slot optional

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -179,6 +179,7 @@ pub enum CliCommand {
         commitment_config: CommitmentConfig,
         follow: bool,
     },
+    ClusterDate,
     ClusterVersion,
     CreateAddressWithSeed {
         from_pubkey: Option<Pubkey>,
@@ -587,6 +588,10 @@ pub fn parse_command(
     let response = match matches.subcommand() {
         // Cluster Query Commands
         ("catchup", Some(matches)) => parse_catchup(matches, wallet_manager),
+        ("cluster-date", Some(_matches)) => Ok(CliCommandInfo {
+            command: CliCommand::ClusterDate,
+            signers: vec![],
+        }),
         ("cluster-version", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::ClusterVersion,
             signers: vec![],
@@ -1685,6 +1690,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             *commitment_config,
             *follow,
         ),
+        CliCommand::ClusterDate => process_cluster_date(&rpc_client, config),
         CliCommand::ClusterVersion => process_cluster_version(&rpc_client),
         CliCommand::CreateAddressWithSeed {
             from_pubkey,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -188,7 +188,7 @@ pub enum CliCommand {
     },
     Fees,
     GetBlockTime {
-        slot: Slot,
+        slot: Option<Slot>,
     },
     GetEpochInfo {
         commitment_config: CommitmentConfig,
@@ -1698,7 +1698,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             program_id,
         } => process_create_address_with_seed(config, from_pubkey.as_ref(), &seed, &program_id),
         CliCommand::Fees => process_fees(&rpc_client),
-        CliCommand::GetBlockTime { slot } => process_get_block_time(&rpc_client, *slot),
+        CliCommand::GetBlockTime { slot } => process_get_block_time(&rpc_client, config, *slot),
         CliCommand::GetGenesisHash => process_get_genesis_hash(&rpc_client),
         CliCommand::GetEpochInfo { commitment_config } => {
             process_get_epoch_info(&rpc_client, config, *commitment_config)

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -839,3 +839,23 @@ impl From<&Lockout> for CliLockout {
         }
     }
 }
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliBlockTime {
+    pub slot: Slot,
+    pub timestamp: UnixTimestamp,
+}
+
+impl fmt::Display for CliBlockTime {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Block: {}", self.slot)?;
+        write!(
+            f,
+            "{} (UnixTimestamp: {})",
+            DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(self.timestamp, 0), Utc)
+                .to_rfc3339_opts(SecondsFormat::Secs, true),
+            self.timestamp
+        )
+    }
+}

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -849,13 +849,16 @@ pub struct CliBlockTime {
 
 impl fmt::Display for CliBlockTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "Block: {}", self.slot)?;
-        write!(
+        writeln_name_value(f, "Block:", &self.slot.to_string())?;
+        writeln_name_value(
             f,
-            "{} (UnixTimestamp: {})",
-            DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(self.timestamp, 0), Utc)
-                .to_rfc3339_opts(SecondsFormat::Secs, true),
-            self.timestamp
+            "Date:",
+            &format!(
+                "{} (UnixTimestamp: {})",
+                DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(self.timestamp, 0), Utc)
+                    .to_rfc3339_opts(SecondsFormat::Secs, true),
+                self.timestamp
+            ),
         )
     }
 }


### PR DESCRIPTION
#### Problem
The cluster calculates the date as a function of slots from genesis, and it uses that date to determine if a stake account is locked. If we want to set an unlock for something like "one day from now", there's no RPC endpoint to ask the cluster what it thinks "now" is.

#### Summary of Changes
- Add `solana cluster-date` command to return `sysvar::Clock.unix_timestamp` from the most recent cluster-confirmed root
- Make `solana block-time` slot param optional, and return `getBlockTime` from the most recent cluster-confirmed root if None
- `--output json` available for both commands

```
$ solana cluster-date --url http://api.mainnet-beta.solana.com

Block: 9198022
Date: 2020-04-28T04:29:09Z (UnixTimestamp: 1588048149)
```

```
$ solana block-time --url http://api.mainnet-beta.solana.com

Block: 9198023
Date: 2020-05-05T00:22:27Z (UnixTimestamp: 1588638147)
```
Oof, almost a week difference (cc #9874 )

Fixes #9847 
