### PR TITLE
Avoid holding the entire rooted path while loading bank forks

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2466,7 +2466,7 @@ pub(crate) mod tests {
         let arc_bank0 = Arc::new(bank0);
         let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
             &[arc_bank0.clone()],
-            vec![0],
+            0,
         )));
 
         assert!(block_commitment_cache

--- a/core/src/storage_stage.rs
+++ b/core/src/storage_stage.rs
@@ -689,10 +689,7 @@ mod tests {
         let cluster_info = test_cluster_info(&keypair.pubkey());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(1000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
-            &[bank.clone()],
-            vec![0],
-        )));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[bank.clone()], 0)));
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let block_commitment_cache = Arc::new(RwLock::new(

--- a/core/tests/storage_stage.rs
+++ b/core/tests/storage_stage.rs
@@ -56,10 +56,7 @@ mod tests {
 
         let bank = Bank::new(&genesis_config);
         let bank = Arc::new(bank);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
-            &[bank.clone()],
-            vec![0],
-        )));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[bank.clone()], 0)));
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
         ));
@@ -179,10 +176,7 @@ mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let slot = 1;
         let bank = Arc::new(Bank::new(&genesis_config));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
-            &[bank.clone()],
-            vec![0],
-        )));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[bank.clone()], 0)));
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
         ));

--- a/ledger/src/bank_forks.rs
+++ b/ledger/src/bank_forks.rs
@@ -141,7 +141,7 @@ impl BankForks {
         self.banks.get(&self.root()).expect("Root bank must exist")
     }
 
-    pub fn new_from_banks(initial_forks: &[Arc<Bank>], rooted_path: Vec<Slot>) -> Self {
+    pub fn new_from_banks(initial_forks: &[Arc<Bank>], root: Slot) -> Self {
         let mut banks = HashMap::new();
         let working_bank = initial_forks[0].clone();
 
@@ -157,7 +157,7 @@ impl BankForks {
                 banks.insert(parent.slot(), parent.clone());
             }
         }
-        let root = *rooted_path.last().unwrap();
+
         Self {
             root,
             banks,


### PR DESCRIPTION
`BankForks::new_from_banks()` just needs a root slot and not the entire rooted path, so avoid holding a vector of slots that nobody cares about while blockstore processing