### PR TITLE
Refactor RPC subscriptions account handling

### DIFF
--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -163,6 +163,24 @@ impl BlockCommitmentCache {
     }
 
     #[cfg(test)]
+    pub fn new_for_tests_with_blockstore_bank(
+        blockstore: Arc<Blockstore>,
+        bank: Arc<Bank>,
+        root: Slot,
+    ) -> Self {
+        let mut block_commitment: HashMap<Slot, BlockCommitment> = HashMap::new();
+        block_commitment.insert(0, BlockCommitment::default());
+        Self {
+            block_commitment,
+            blockstore,
+            total_stake: 42,
+            largest_confirmed_root: root,
+            bank,
+            root,
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn set_get_largest_confirmed_root(&mut self, root: Slot) {
         self.largest_confirmed_root = root;
     }

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -209,7 +209,7 @@ fn filter_account_result(
     last_notified_slot: Slot,
 ) -> (Box<dyn Iterator<Item = RpcAccount>>, Slot) {
     if let Some((account, fork)) = result {
-        if fork > last_notified_slot {
+        if fork != last_notified_slot {
             return (Box::new(iter::once(RpcAccount::encode(account))), fork);
         }
     }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -304,11 +304,12 @@ pub mod tests {
             BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
         ));
         let (retransmit_slots_sender, _retransmit_slots_receiver) = unbounded();
+        let bank_forks = Arc::new(RwLock::new(bank_forks));
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
             vec![Arc::new(vote_keypair)],
             &storage_keypair,
-            &Arc::new(RwLock::new(bank_forks)),
+            &bank_forks,
             &cref1,
             {
                 Sockets {
@@ -321,7 +322,11 @@ pub mod tests {
             blockstore,
             &StorageState::default(),
             l_receiver,
-            &Arc::new(RpcSubscriptions::new(&exit, block_commitment_cache.clone())),
+            &Arc::new(RpcSubscriptions::new(
+                &exit,
+                bank_forks.clone(),
+                block_commitment_cache.clone(),
+            )),
             &poh_recorder,
             &leader_schedule_cache,
             &exit,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -241,7 +241,11 @@ impl Validator {
             BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
         ));
 
-        let subscriptions = Arc::new(RpcSubscriptions::new(&exit, block_commitment_cache.clone()));
+        let subscriptions = Arc::new(RpcSubscriptions::new(
+            &exit,
+            bank_forks.clone(),
+            block_commitment_cache.clone(),
+        ));
 
         let rpc_service = config.rpc_ports.map(|(rpc_port, rpc_pubsub_port)| {
             if ContactInfo::is_valid_address(&node.info.rpc) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1816,10 +1816,12 @@ impl Bank {
     }
 
     pub fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
-        self.rc
-            .accounts
-            .load_slow(&self.ancestors, pubkey)
+        self.get_account_modified_slot(pubkey)
             .map(|(acc, _slot)| acc)
+    }
+
+    pub fn get_account_modified_slot(&self, pubkey: &Pubkey) -> Option<(Account, Slot)> {
+        self.rc.accounts.load_slow(&self.ancestors, pubkey)
     }
 
     // Exclude self to really fetch the parent Bank's account hash and data.


### PR DESCRIPTION
#### Problem
Account notifications are lossy and inconsistent because subscriptions specify a specific confirmation level and will only be notified when the RPC pubsub service observes a slot at that confirmation level where the account has been modified.

#### Summary of Changes
- Update RPC subscriptions to use `commitment` parameter instead of confirmations count
- Add `last_notified-slot` to subscription cache, and use in conjunction with different bank method to loosen account notification match requirements. 

Fixes #9833 
