### PR TITLE
Cli: Update OutputFormat method to return a String to restore consistency

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -55,6 +55,7 @@ use solana_transaction_status::{EncodedTransaction, TransactionEncoding};
 use solana_vote_program::vote_state::VoteAuthorize;
 use std::{
     error,
+    fmt::Write as FmtWrite,
     fs::File,
     io::{Read, Write},
     net::{IpAddr, SocketAddr},
@@ -1265,21 +1266,21 @@ fn process_show_account(
         use_lamports_unit,
     };
 
-    println!("{}", config.output_format.formatted_string(&cli_account));
+    let mut account_string = config.output_format.formatted_string(&cli_account);
 
     if config.output_format == OutputFormat::Display {
         if let Some(output_file) = output_file {
             let mut f = File::create(output_file)?;
             f.write_all(&data)?;
-            println!();
-            println!("Wrote account data to {}", output_file);
+            writeln!(&mut account_string)?;
+            writeln!(&mut account_string, "Wrote account data to {}", output_file)?;
         } else if !data.is_empty() {
             use pretty_hex::*;
-            println!("{:?}", data.hex_dump());
+            writeln!(&mut account_string, "{:?}", data.hex_dump())?;
         }
     }
 
-    Ok("".to_string())
+    Ok(account_string)
 }
 
 fn process_deploy(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1265,7 +1265,7 @@ fn process_show_account(
         use_lamports_unit,
     };
 
-    config.output_format.formatted_print(&cli_account);
+    println!("{}", config.output_format.formatted_string(&cli_account));
 
     if config.output_format == OutputFormat::Display {
         if let Some(output_file) = output_file {

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -26,20 +26,14 @@ pub enum OutputFormat {
 }
 
 impl OutputFormat {
-    pub fn formatted_print<T>(&self, item: &T)
+    pub fn formatted_string<T>(&self, item: &T) -> String
     where
         T: Serialize + fmt::Display,
     {
         match self {
-            OutputFormat::Display => {
-                println!("{}", item);
-            }
-            OutputFormat::Json => {
-                println!("{}", serde_json::to_string_pretty(item).unwrap());
-            }
-            OutputFormat::JsonCompact => {
-                println!("{}", serde_json::to_value(item).unwrap());
-            }
+            OutputFormat::Display => format!("{}", item),
+            OutputFormat::Json => serde_json::to_string_pretty(item).unwrap(),
+            OutputFormat::JsonCompact => serde_json::to_value(item).unwrap().to_string(),
         }
     }
 }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -529,8 +529,7 @@ pub fn process_cluster_date(rpc_client: &RpcClient, config: &CliConfig) -> Proce
             slot: result.context.slot,
             timestamp: clock.unix_timestamp,
         };
-        config.output_format.formatted_print(&block_time);
-        Ok("".to_string())
+        Ok(config.output_format.formatted_string(&block_time))
     } else {
         Err(format!("AccountNotFound: pubkey={}", sysvar::clock::id()).into())
     }
@@ -597,8 +596,7 @@ pub fn process_get_block_time(
     };
     let timestamp = rpc_client.get_block_time(slot)?;
     let block_time = CliBlockTime { slot, timestamp };
-    config.output_format.formatted_print(&block_time);
-    Ok("".to_string())
+    Ok(config.output_format.formatted_string(&block_time))
 }
 
 pub fn process_get_epoch_info(
@@ -609,8 +607,7 @@ pub fn process_get_epoch_info(
     let epoch_info: CliEpochInfo = rpc_client
         .get_epoch_info_with_commitment(commitment_config.clone())?
         .into();
-    config.output_format.formatted_print(&epoch_info);
-    Ok("".to_string())
+    Ok(config.output_format.formatted_string(&epoch_info))
 }
 
 pub fn process_get_genesis_hash(rpc_client: &RpcClient) -> ProcessResult {
@@ -792,8 +789,7 @@ pub fn process_show_block_production(
         individual_slot_status,
         verbose: config.verbose,
     };
-    config.output_format.formatted_print(&block_production);
-    Ok("".to_string())
+    Ok(config.output_format.formatted_string(&block_production))
 }
 
 pub fn process_total_supply(
@@ -1122,10 +1118,9 @@ pub fn process_show_stakes(
             }
         }
     }
-    config
+    Ok(config
         .output_format
-        .formatted_print(&CliStakeVec::new(stake_accounts));
-    Ok("".to_string())
+        .formatted_string(&CliStakeVec::new(stake_accounts)))
 }
 
 pub fn process_show_validators(
@@ -1169,8 +1164,7 @@ pub fn process_show_validators(
         delinquent_validators,
         use_lamports_unit,
     };
-    config.output_format.formatted_print(&cli_validators);
-    Ok("".to_string())
+    Ok(config.output_format.formatted_string(&cli_validators))
 }
 
 pub fn process_transaction_history(

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -590,8 +590,7 @@ pub fn process_show_nonce_account(
             nonce_account.authority = Some(data.authority.to_string());
         }
 
-        config.output_format.formatted_print(&nonce_account);
-        Ok("".to_string())
+        Ok(config.output_format.formatted_string(&nonce_account))
     };
     match state_from_account(&nonce_account)? {
         State::Uninitialized => print_account(None),

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1316,8 +1316,7 @@ pub fn process_show_stake_account(
     match stake_account.state() {
         Ok(stake_state) => {
             let state = build_stake_state(stake_account.lamports, &stake_state, use_lamports_unit);
-            config.output_format.formatted_print(&state);
-            Ok("".to_string())
+            Ok(config.output_format.formatted_string(&state))
         }
         Err(err) => Err(CliError::RpcRequestError(format!(
             "Account data could not be deserialized to stake state: {}",
@@ -1345,8 +1344,7 @@ pub fn process_show_stake_history(
         entries,
         use_lamports_unit,
     };
-    config.output_format.formatted_print(&stake_history_output);
-    Ok("".to_string())
+    Ok(config.output_format.formatted_string(&stake_history_output))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -410,10 +410,9 @@ pub fn process_get_validator_info(
             info: validator_info,
         });
     }
-    config
+    Ok(config
         .output_format
-        .formatted_print(&CliValidatorInfoVec::new(validator_info_list));
-    Ok("".to_string())
+        .formatted_string(&CliValidatorInfoVec::new(validator_info_list)))
 }
 
 #[cfg(test)]

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -586,8 +586,7 @@ pub fn process_show_vote_account(
         use_lamports_unit,
     };
 
-    config.output_format.formatted_print(&vote_account_data);
-    Ok("".to_string())
+    Ok(config.output_format.formatted_string(&vote_account_data))
 }
 
 pub fn process_withdraw_from_vote_account(


### PR DESCRIPTION
#### Problem
The Cli `process_command()` method returns a String, which is printed in main.rs. In times past, every cli method populated this String, but as users wanted more complex and informative prints, they implemented those prints in the respective `process_` method and returned `Ok("".to_string())` to main.rs.

However, #9478 implemented Display for most of these complex prints, providing the opportunity to re-populate those empty Strings.

#### Summary of Changes
- Update OutputFormat to return a formatted String, instead of doing the print itself.
- Return formatted Strings from `process_command()`

Enables #9650 without the duplicated signature-prints
