### PR TITLE
Limit performance testcases to 40k TPS client

### DIFF
--- a/system-test/partition-testcases/gce-5-node-3-partition.yml
+++ b/system-test/partition-testcases/gce-5-node-3-partition.yml
@@ -8,8 +8,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
+++ b/system-test/partition-testcases/gce-partition-once-then-stabilize.yml
@@ -8,8 +8,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/aws-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/aws-cpu-only-perf-10-node.yml
@@ -11,7 +11,7 @@ steps:
       # Up to 3.1 GHz Intel Xeon® Platinum 8175, 16 vCPU, 64GB RAM
       VALIDATOR_NODE_MACHINE_TYPE: "m5.4xlarge"
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 80000 --thread-batch-sleep-ms 1000"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west-1a,us-west-1c,us-east-1a,eu-west-1a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""

--- a/system-test/performance-testcases/aws-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/aws-cpu-only-perf-5-node.yml
@@ -10,8 +10,8 @@ steps:
       ENABLE_GPU: "false"
       # Up to 3.1 GHz Intel Xeon® Platinum 8175, 16 vCPU, 64GB RAM
       VALIDATOR_NODE_MACHINE_TYPE: "m5.4xlarge"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west-1a,us-west-1c,us-east-1a,eu-west-1a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""

--- a/system-test/performance-testcases/azure-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/azure-cpu-only-perf-5-node.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "Standard_D16s_v3"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "westus"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: ""

--- a/system-test/performance-testcases/colo-cpu-only-perf-4-val-1-client.yml
+++ b/system-test/performance-testcases/colo-cpu-only-perf-4-val-1-client.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 3
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 40000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/colo-gpu-perf-4-val-1-client.yml
+++ b/system-test/performance-testcases/colo-gpu-perf-4-val-1-client.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 3
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 40000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/colo-gpu-perf-high-txcount-4-val-1-client.yml
+++ b/system-test/performance-testcases/colo-gpu-perf-high-txcount-4-val-1-client.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 600
       NUMBER_OF_VALIDATOR_NODES: 3
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 60000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 20000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-10-node.yml
@@ -10,7 +10,7 @@ steps:
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 80000 --thread-batch-sleep-ms 1000"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-cpu-only-perf-5-node.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node-single-region.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 10
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/gce-gpu-perf-10-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-10-node.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 10
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node-single-region.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 25
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/gce-gpu-perf-25-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-25-node.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 25
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node-single-region.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/gce-gpu-perf-5-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-5-node.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 5
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 20000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       USE_PUBLIC_IP_ADDRESSES: "true"
       ADDITIONAL_FLAGS: "--dedicated"

--- a/system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node-single-region.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 50
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       ALLOW_BOOT_FAILURES: "true"
       USE_PUBLIC_IP_ADDRESSES: "true"

--- a/system-test/performance-testcases/gce-gpu-perf-50-node.yml
+++ b/system-test/performance-testcases/gce-gpu-perf-50-node.yml
@@ -9,8 +9,8 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 50
       ENABLE_GPU: "true"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16 --accelerator count=2,type=nvidia-tesla-v100"
-      NUMBER_OF_CLIENT_NODES: 2
-      CLIENT_OPTIONS: "bench-tps=2=--tx_count 15000 --thread-batch-sleep-ms 250"
+      NUMBER_OF_CLIENT_NODES: 1
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a,us-west1-b,us-central1-a,europe-west4-a"
       ALLOW_BOOT_FAILURES: "true"
       USE_PUBLIC_IP_ADDRESSES: "true"


### PR DESCRIPTION
#### Problem
Perf tests are stalling under high bench TPS loads due to https://github.com/solana-labs/solana/issues/9739

#### Summary of Changes
Until #9739 is resolved, limit all perf/partition tests to bench TPS clients pushing no more than 40k TPS.
