### PR TITLE
Remove hash field from account

### DIFF
--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -93,7 +93,6 @@ impl RpcAccount {
             })?,
             executable: self.executable,
             rent_epoch: self.rent_epoch,
-            ..Account::default()
         })
     }
 }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -13,7 +13,6 @@ use solana_sdk::{
     bpf_loader,
     entrypoint::SUCCESS,
     entrypoint_native::InvokeContext,
-    hash::Hash,
     instruction::{AccountMeta, Instruction, InstructionError},
     message::Message,
     program_error::ProgramError,
@@ -399,7 +398,6 @@ impl<'a> SyscallProcessInstruction<'a> for SyscallProcessInstructionRust<'a> {
                         executable: account_info.executable,
                         owner: *owner,
                         rent_epoch: account_info.rent_epoch,
-                        hash: Hash::default(),
                     })));
                     refs.push((lamports_ref, data));
                     continue 'root;
@@ -599,7 +597,6 @@ impl<'a> SyscallProcessInstruction<'a> for SyscallProcessSolInstructionC<'a> {
                         executable: account_info.executable,
                         owner: *owner,
                         rent_epoch: account_info.rent_epoch,
-                        hash: Hash::default(),
                     })));
                     refs.push((lamports_ref, data));
                     continue 'root;

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -75,7 +75,6 @@ impl<'a> StoredAccount<'a> {
             executable: self.account_meta.executable,
             rent_epoch: self.account_meta.rent_epoch,
             data: self.data.to_vec(),
-            hash: *self.hash,
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -550,16 +550,7 @@ impl Bank {
         F: Fn(&Option<Account>) -> Account,
     {
         let old_account = self.get_sysvar_account(pubkey);
-        let mut new_account = updater(&old_account);
-
-        // Normally, just use the hash from parent slot. However, use the
-        // existing stored hash if any for the sake of bank hash's idempotent.
-        if let Some((modified_account, _)) = self.get_account_modified_since_parent(pubkey) {
-            new_account.hash = modified_account.hash;
-        } else if let Some(old_account) = old_account {
-            new_account.hash = old_account.hash;
-        }
-
+        let new_account = updater(&old_account);
         self.store_account(pubkey, &new_account);
     }
 
@@ -4518,7 +4509,6 @@ mod tests {
             .create_account(1)
         });
         let current_account = bank2.get_account(&dummy_clock_id).unwrap();
-        //let added_bank_hash = BankHash::from_hash(&current_account.hash);
         assert_eq!(
             expected_next_slot,
             Clock::from_account(&current_account).unwrap().slot

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -1,4 +1,4 @@
-use crate::{clock::Epoch, hash::Hash, instruction::InstructionError, pubkey::Pubkey};
+use crate::{clock::Epoch, instruction::InstructionError, pubkey::Pubkey};
 use std::{
     cell::{Ref, RefCell, RefMut},
     cmp, fmt,
@@ -8,7 +8,7 @@ use std::{
 
 /// An Account with data that is stored on chain
 #[repr(C)]
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Account {
     /// lamports in the account
@@ -22,25 +22,7 @@ pub struct Account {
     pub executable: bool,
     /// the epoch at which this account will next owe rent
     pub rent_epoch: Epoch,
-    /// Hash of this account's state, skip serializing as to not expose to external api
-    /// Used for keeping the accounts state hash updated.
-    #[serde(skip)]
-    pub hash: Hash,
 }
-
-/// skip comparison of account.hash, since it is only meaningful when the account is loaded in a
-/// given fork and some tests do not have that.
-impl PartialEq for Account {
-    fn eq(&self, other: &Self) -> bool {
-        self.lamports == other.lamports
-            && self.data == other.data
-            && self.owner == other.owner
-            && self.executable == other.executable
-            && self.rent_epoch == other.rent_epoch
-    }
-}
-
-impl Eq for Account {}
 
 impl fmt::Debug for Account {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -52,14 +34,13 @@ impl fmt::Debug for Account {
         };
         write!(
             f,
-            "Account {{ lamports: {} data.len: {} owner: {} executable: {} rent_epoch: {}{} hash: {} }}",
+            "Account {{ lamports: {} data.len: {} owner: {} executable: {} rent_epoch: {}{} }}",
             self.lamports,
             self.data.len(),
             self.owner,
             self.executable,
             self.rent_epoch,
             data_str,
-            self.hash,
         )
     }
 }

--- a/sdk/src/native_loader.rs
+++ b/sdk/src/native_loader.rs
@@ -1,4 +1,4 @@
-use crate::{account::Account, hash::Hash};
+use crate::account::Account;
 
 crate::declare_id!("NativeLoader1111111111111111111111111111111");
 
@@ -10,6 +10,5 @@ pub fn create_loadable_account(name: &str) -> Account {
         data: name.as_bytes().to_vec(),
         executable: true,
         rent_epoch: 0,
-        hash: Hash::default(),
     }
 }


### PR DESCRIPTION
#### Problem
There is no need to carry along the `hash` information for an account (except for debugging). Updating the `hash` field on an account has no effect because we never store it directly, we always recompute the hash. 

#### Summary of Changes
* Remove `hash` field from the `Account` struct
* Adjust bank hash stats to track `updated_accounts` instead of `added_accounts` 