### PR TITLE
Pull in hardened BPF virtual machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,15 +35,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ar"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579681b3fecd1e9d6b5ce6969e05f9feb913f296eddaf595be1166a5ca597bc4"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "arc-swap"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,7 +196,7 @@ dependencies = [
  "cfg-if",
  "clang-sys",
  "clap",
- "env_logger 0.7.1",
+ "env_logger",
  "lazy_static",
  "lazycell",
  "log 0.4.8",
@@ -226,12 +217,6 @@ checksum = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 dependencies = [
  "bit-vec 0.5.1",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 
 [[package]]
 name = "bit-vec"
@@ -257,9 +242,9 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
 dependencies = [
- "byte-tools 0.3.1",
+ "byte-tools",
  "crypto-mac",
- "digest 0.8.1",
+ "digest",
  "opaque-debug",
 ]
 
@@ -276,22 +261,12 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
-dependencies = [
- "arrayref",
- "byte-tools 0.2.0",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
- "byte-tools 0.3.1",
+ "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
 ]
@@ -302,16 +277,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
- "byte-tools 0.3.1",
-]
-
-[[package]]
-name = "bloom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
-dependencies = [
- "bit-vec 0.4.4",
+ "byte-tools",
 ]
 
 [[package]]
@@ -364,12 +330,6 @@ dependencies = [
  "feature-probe",
  "serde",
 ]
-
-[[package]]
-name = "byte-tools"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 
 [[package]]
 name = "byte-tools"
@@ -507,7 +467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
- "num-traits 0.2.11",
+ "num-traits",
  "serde",
  "time",
 ]
@@ -518,7 +478,7 @@ version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
 dependencies = [
- "glob 0.3.0",
+ "glob",
  "libc",
  "libloading 0.5.2",
 ]
@@ -586,17 +546,6 @@ checksum = "ab081a14ab8f9598ce826890fe896d0addee68c7a58ab49008369ccbb51510a8"
 dependencies = [
  "codespan",
  "termcolor",
-]
-
-[[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -693,7 +642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "387df94cb74ada1b33e10ce034bb0d9360cc73edb5063e7d7d4120a40ee1c9d2"
 dependencies = [
  "cast",
- "num-traits 0.2.11",
+ "num-traits",
  "num_cpus",
  "rand 0.4.6",
  "thread-scoped",
@@ -835,7 +784,7 @@ checksum = "8b7dcd30ba50cdf88b55b033456138b7c0ac4afdc436d82e1b79f370f24cc66d"
 dependencies = [
  "byteorder",
  "clear_on_drop",
- "digest 0.8.1",
+ "digest",
  "rand_core 0.3.1",
  "subtle 2.2.2",
 ]
@@ -847,7 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 dependencies = [
  "byteorder",
- "digest 0.8.1",
+ "digest",
  "rand_core 0.5.1",
  "subtle 2.2.2",
  "zeroize",
@@ -892,15 +841,6 @@ name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
-name = "digest"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-dependencies = [
- "generic-array 0.9.0",
-]
 
 [[package]]
 name = "digest"
@@ -1010,7 +950,7 @@ dependencies = [
  "curve25519-dalek 2.0.0",
  "rand 0.7.3",
  "serde",
- "sha2 0.8.1",
+ "sha2",
 ]
 
 [[package]]
@@ -1018,33 +958,6 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-
-[[package]]
-name = "elfkit"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f182eda16a7360c80a2f8638d0726e9d5478173058f1505c42536ca666ecd2"
-dependencies = [
- "ar",
- "bit-vec 0.5.1",
- "bitflags",
- "bloom",
- "byteorder",
- "clap",
- "colored",
- "enum-primitive-derive",
- "env_logger 0.5.13",
- "fnv",
- "glob 0.2.11",
- "indexmap",
- "itertools 0.7.11",
- "log 0.4.8",
- "num-traits 0.2.11",
- "pretty_env_logger",
- "rayon",
- "sha2 0.7.1",
- "tempfile",
-]
 
 [[package]]
 name = "ena"
@@ -1075,30 +988,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enum-primitive-derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
-dependencies = [
- "num-traits 0.1.43",
- "quote 0.3.15",
- "syn 0.11.11",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
-dependencies = [
- "atty",
- "humantime 1.3.0",
- "log 0.4.8",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "env_logger"
@@ -1342,15 +1231,6 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
@@ -1413,12 +1293,6 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-
-[[package]]
-name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
@@ -1434,6 +1308,17 @@ dependencies = [
  "fnv",
  "log 0.4.8",
  "regex",
+]
+
+[[package]]
+name = "goblin"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd5e3132801a1ac34ac53b97acde50c4685414dd2f291b9ea52afa6f07468c8"
+dependencies = [
+ "log 0.4.8",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -1561,7 +1446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac",
- "digest 0.8.1",
+ "digest",
 ]
 
 [[package]]
@@ -1795,15 +1680,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
@@ -2020,7 +1896,7 @@ dependencies = [
  "regex-syntax",
  "serde",
  "serde_derive",
- "sha2 0.8.1",
+ "sha2",
  "string_cache",
  "term 0.5.2",
  "unicode-xid 0.1.0",
@@ -2086,7 +1962,7 @@ checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
 dependencies = [
  "bindgen",
  "cc",
- "glob 0.3.0",
+ "glob",
  "libc",
 ]
 
@@ -2389,16 +2265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
- "num-traits 0.2.11",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.11",
+ "num-traits",
 ]
 
 [[package]]
@@ -2549,7 +2416,7 @@ dependencies = [
  "bytes 0.4.12",
  "rand 0.6.5",
  "sha-1",
- "sha2 0.8.1",
+ "sha2",
  "sha3",
  "unsigned-varint",
 ]
@@ -2744,6 +2611,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,18 +2659,6 @@ name = "pretty-hex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be91bcc43e73799dc46a6c194a55e7aae1d86cc867c860fd4a436019af21bd8c"
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8d1e63042e889b85228620629b51c011d380eed2c7e0015f8a644def280c28"
-dependencies = [
- "ansi_term",
- "chrono",
- "env_logger 0.5.13",
- "log 0.4.8",
-]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2887,7 +2748,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "lazy_static",
- "num-traits 0.2.11",
+ "num-traits",
  "quick-error",
  "rand 0.6.5",
  "rand_chacha 0.1.1",
@@ -2965,12 +2826,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -3487,6 +3342,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scroll"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.1",
+ "syn 1.0.18",
+]
+
+[[package]]
 name = "sct"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,8 +3501,8 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
+ "block-buffer",
+ "digest",
  "fake-simd",
  "opaque-debug",
 ]
@@ -3640,24 +3515,12 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
-dependencies = [
- "block-buffer 0.3.3",
- "byte-tools 0.2.0",
- "digest 0.7.6",
- "fake-simd",
-]
-
-[[package]]
-name = "sha2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
+ "block-buffer",
+ "digest",
  "fake-simd",
  "opaque-debug",
 ]
@@ -3668,9 +3531,9 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
 dependencies = [
- "block-buffer 0.7.3",
- "byte-tools 0.3.1",
- "digest 0.8.1",
+ "block-buffer",
+ "byte-tools",
+ "digest",
  "keccak",
  "opaque-debug",
 ]
@@ -3910,7 +3773,7 @@ dependencies = [
  "itertools 0.9.0",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "rand 0.7.3",
  "rayon",
  "serde_json",
@@ -3977,7 +3840,8 @@ dependencies = [
  "jemalloc-sys",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
+ "rand 0.7.3",
  "solana-logger",
  "solana-runtime",
  "solana-sdk",
@@ -3993,7 +3857,7 @@ dependencies = [
  "hex 0.4.2",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "serde",
  "serde_derive",
  "solana-sdk",
@@ -4007,7 +3871,7 @@ dependencies = [
  "chrono",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "serde",
  "serde_derive",
  "solana-runtime",
@@ -4081,7 +3945,7 @@ dependencies = [
  "humantime 2.0.0",
  "indicatif",
  "log 0.4.8",
- "num-traits 0.2.11",
+ "num-traits",
  "pretty-hex",
  "reqwest",
  "serde",
@@ -4184,7 +4048,7 @@ dependencies = [
  "jsonrpc-ws-server",
  "log 0.4.8",
  "matches",
- "num-traits 0.2.11",
+ "num-traits",
  "num_cpus",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -4290,7 +4154,7 @@ dependencies = [
  "bincode",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "serde",
  "serde_derive",
  "solana-logger",
@@ -4450,7 +4314,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_bytes",
- "sha2 0.8.1",
+ "sha2",
  "solana-budget-program",
  "solana-genesis-programs",
  "solana-logger",
@@ -4552,7 +4416,7 @@ dependencies = [
 name = "solana-logger"
 version = "1.2.0"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "lazy_static",
  "log 0.4.8",
 ]
@@ -4581,7 +4445,7 @@ dependencies = [
 name = "solana-metrics"
 version = "1.2.0"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "gethostname",
  "lazy_static",
  "log 0.4.8",
@@ -4600,7 +4464,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -4667,7 +4531,7 @@ version = "1.2.0"
 dependencies = [
  "bincode",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "solana-runtime",
  "solana-sdk",
  "thiserror",
@@ -4756,7 +4620,7 @@ dependencies = [
  "log 0.4.8",
  "memmap",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "num_cpus",
  "rand 0.7.3",
  "rayon",
@@ -4802,7 +4666,7 @@ dependencies = [
  "log 0.4.8",
  "memmap",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "pbkdf2",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -4810,7 +4674,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2 0.8.1",
+ "sha2",
  "solana-crate-features",
  "solana-logger",
  "solana-sdk-macro",
@@ -4888,7 +4752,7 @@ dependencies = [
  "bincode",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "serde",
  "serde_derive",
  "solana-config-program",
@@ -4907,7 +4771,7 @@ dependencies = [
  "bincode",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "rand 0.7.3",
  "serde",
  "serde_derive",
@@ -4999,7 +4863,7 @@ dependencies = [
  "bincode",
  "chrono",
  "num-derive 0.2.5",
- "num-traits 0.2.11",
+ "num-traits",
  "serde",
  "serde_derive",
  "solana-config-program",
@@ -5015,7 +4879,7 @@ dependencies = [
  "bincode",
  "log 0.4.8",
  "num-derive 0.3.0",
- "num-traits 0.2.11",
+ "num-traits",
  "serde",
  "serde_derive",
  "solana-metrics",
@@ -5129,7 +4993,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "curve25519-dalek 1.2.3",
- "digest 0.8.1",
+ "digest",
  "ed25519-dalek",
  "hex 0.3.2",
  "hmac",
@@ -5139,7 +5003,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "serde",
- "sha2 0.8.1",
+ "sha2",
  "sha3",
  "solana_libra_canonical_serialization",
  "solana_libra_crypto-derive",
@@ -5393,7 +5257,7 @@ dependencies = [
  "bit-vec 0.6.1",
  "lazy_static",
  "proptest",
- "sha2 0.8.1",
+ "sha2",
  "solana_libra_canonical_serialization",
  "solana_libra_crypto",
  "solana_libra_failure_ext",
@@ -5403,17 +5267,18 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6bee545321a2fed2f9a24066bf7bf08f9b814fd48865b7c629ee40f33f3207"
+checksum = "e7baa2550500e75413f031f239fe0c4da2d477ae1b1ff7cb671eba483f963d91"
 dependencies = [
  "byteorder",
  "combine",
- "elfkit",
+ "goblin",
  "hash32",
  "libc",
  "log 0.4.8",
- "num-traits 0.2.11",
+ "rand 0.7.3",
+ "scroll",
  "thiserror",
  "time",
 ]
@@ -5529,17 +5394,6 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -5569,15 +5423,6 @@ dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.1",
  "syn 1.0.18",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -5808,7 +5653,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.8.1",
+ "sha2",
  "unicode-normalization",
 ]
 
@@ -6196,12 +6041,6 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
@@ -6673,6 +6512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89719b034dc22d240d5b407fb0a3fe6d29952c181cff9a9f95c0bd40b4f8f7d8"
 dependencies = [
  "cc",
- "glob 0.3.0",
+ "glob",
  "libc",
 ]

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -9,27 +9,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ar"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "ascii"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,28 +69,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bit-vec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "block-buffer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "block-buffer"
@@ -133,14 +93,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bloom"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bs58"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,11 +110,6 @@ dependencies = [
  "feature-probe 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "byte-tools"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byte-tools"
@@ -220,20 +167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,16 +180,6 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -356,14 +279,6 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -401,59 +316,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "elfkit"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ar 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bloom 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pretty_env_logger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "enum-primitive-derive"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -584,14 +451,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "typenum 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -627,9 +486,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.2.11"
+name = "goblin"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "h2"
@@ -775,14 +639,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1015,14 +871,6 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-traits"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1135,20 +983,14 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.6"
+name = "plain"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.2.5"
+name = "ppv-lite86"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1179,11 +1021,6 @@ dependencies = [
 [[package]]
 name = "quick-error"
 version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
-version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1404,6 +1241,24 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "scroll"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scroll_derive 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sct"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,17 +1350,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sha2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1546,7 +1390,7 @@ dependencies = [
  "solana-logger 1.2.0",
  "solana-runtime 1.2.0",
  "solana-sdk 1.2.0",
- "solana_rbpf 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1561,7 +1405,7 @@ dependencies = [
  "solana-logger 1.2.0",
  "solana-runtime 1.2.0",
  "solana-sdk 1.2.0",
- "solana_rbpf 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana_rbpf 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1915,16 +1759,17 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "elfkit 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash32 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1932,11 +1777,6 @@ dependencies = [
 [[package]]
 name = "spin"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1948,16 +1788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subtle"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "syn"
@@ -1977,14 +1807,6 @@ dependencies = [
  "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2017,14 +1839,6 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2312,16 +2126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,11 +2149,6 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "version_check"
@@ -2529,9 +2328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum ar 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "579681b3fecd1e9d6b5ce6969e05f9feb913f296eddaf595be1166a5ca597bc4"
-"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
@@ -2540,17 +2336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace-sys 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
-"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-"checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-"checksum bloom 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
 "checksum bs58 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
 "checksum bumpalo 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 "checksum bv 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
-"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
@@ -2559,10 +2350,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)" = "e450b8da92aa6f274e7c6437692f9f2ce6d701fb73bacfcf87897b3f89a4c20e"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
-"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 "checksum combine 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 "checksum core-foundation-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
@@ -2573,16 +2362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
-"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4841de15dbe0e49b9b62a417589299e3be0d557e0900d36acb87e6dae47197f5"
-"checksum elfkit 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "02f182eda16a7360c80a2f8638d0726e9d5478173058f1505c42536ca666ecd2"
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
-"checksum enum-primitive-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b90e520ec62c1864c8c78d637acbfe8baf5f63240f2fb8165b8325c07812dd"
-"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum failure 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
 "checksum failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
@@ -2602,10 +2387,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-array 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
-"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum gethostname 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum goblin 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ddd5e3132801a1ac34ac53b97acde50c4685414dd2f291b9ea52afa6f07468c8"
 "checksum h2 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "377038bf3c89d18d6ca1431e7a5027194fbd724ca10592b9487ede5e8e144f42"
 "checksum hash32 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
 "checksum hermit-abi 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
@@ -2620,7 +2404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum jemalloc-ctl 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
@@ -2648,7 +2431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
 "checksum num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
-"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
@@ -2663,14 +2445,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pin-project-internal 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
 "checksum pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 "checksum pin-utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+"checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-"checksum pretty_env_logger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8d1e63042e889b85228620629b51c011d380eed2c7e0015f8a644def280c28"
 "checksum proc-macro-hack 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
 "checksum proc-macro-nested 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2693,6 +2474,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum schannel 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+"checksum scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
+"checksum scroll_derive 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 "checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 "checksum security-framework 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
 "checksum security-framework-sys 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
@@ -2703,24 +2486,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 "checksum serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)" = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
-"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
-"checksum solana_rbpf 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "1d6bee545321a2fed2f9a24066bf7bf08f9b814fd48865b7c629ee40f33f3207"
+"checksum solana_rbpf 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "e7baa2550500e75413f031f239fe0c4da2d477ae1b1ff7cb671eba483f963d91"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
-"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
-"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
 "checksum thiserror-impl 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
@@ -2747,13 +2525,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
-"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum untrusted 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
-"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -26,7 +26,7 @@ solana-bpf-loader-program = { path = "../bpf_loader", version = "1.2.0" }
 solana-logger = { path = "../../logger", version = "1.2.0" }
 solana-runtime = { path = "../../runtime", version = "1.2.0" }
 solana-sdk = { path = "../../sdk", version = "1.2.0" }
-solana_rbpf = "=0.1.26"
+solana_rbpf = "=0.1.27"
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -93,7 +93,7 @@ mod bpf {
                 .native_instruction_processors
                 .push(solana_bpf_loader_program!());
             let bank = Arc::new(Bank::new(&genesis_config));
-            // Create bank with specific slot, used by solana_bpf_rust_sysvar test
+            // Create bank with a specific slot, used by solana_bpf_rust_sysvar test
             let bank =
                 Bank::new_from_parent(&bank, &Pubkey::default(), DEFAULT_SLOTS_PER_EPOCH + 1);
             let bank_client = BankClient::new(bank);

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -18,8 +18,11 @@ num-traits = { version = "0.2" }
 solana-logger = { path = "../../logger", version = "1.2.0" }
 solana-runtime = { path = "../../runtime", version = "1.2.0" }
 solana-sdk = { path = "../../sdk", version = "1.2.0" }
-solana_rbpf = "=0.1.26"
+solana_rbpf = "=0.1.27"
 thiserror = "1.0"
+
+[dev-dependencies]
+rand = "0.7.3"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/programs/bpf_loader/src/allocator_bump.rs
+++ b/programs/bpf_loader/src/allocator_bump.rs
@@ -25,7 +25,7 @@ impl BPFAllocator {
 
 impl Alloc for BPFAllocator {
     fn alloc(&mut self, layout: Layout) -> Result<u64, AllocErr> {
-        if self.pos + layout.size() as u64 <= self.len {
+        if self.pos.saturating_add(layout.size() as u64) <= self.len {
             let addr = self.start + self.pos;
             self.pos += layout.size() as u64;
             Ok(addr)

--- a/programs/bpf_loader/src/bpf_verifier.rs
+++ b/programs/bpf_loader/src/bpf_verifier.rs
@@ -2,36 +2,56 @@ use crate::BPFError;
 use solana_rbpf::ebpf;
 use thiserror::Error;
 
+/// Error definitions
 #[derive(Debug, Error)]
 pub enum VerifierError {
+    /// ProgramLengthNotMultiple
     #[error("program length must be a multiple of {} octets", ebpf::INSN_SIZE)]
     ProgramLengthNotMultiple,
+    /// ProgramTooLarge
     #[error("program too big, max {}, is {}", ebpf::PROG_MAX_INSNS, .0)]
     ProgramTooLarge(usize),
+    /// NoProgram
     #[error("no program set, call prog_set() to load one")]
     NoProgram,
     #[error("division by 0 (insn #{0})")]
     DivisionByZero(usize),
+    /// UnsupportedLEBEArgument
     #[error("unsupported argument for LE/BE (insn #{0})")]
     UnsupportedLEBEArgument(usize),
+    /// LDDWCannotBeLast
     #[error("LD_DW instruction cannot be last in program")]
     LDDWCannotBeLast,
+    /// IncompleteLDDW
     #[error("incomplete LD_DW instruction (insn #{0})")]
     IncompleteLDDW(usize),
+    /// InfiniteLoop
     #[error("infinite loop (insn #{0})")]
     InfiniteLoop(usize),
+    /// JumpOutOfCode
     #[error("jump out of code to #{0} (insn #{1})")]
     JumpOutOfCode(usize, usize),
+    /// JumpToMiddleOfLDDW
     #[error("jump to middle of LD_DW at #{0} (insn #{1})")]
     JumpToMiddleOfLDDW(usize, usize),
+    /// InvalidSourceRegister
     #[error("invalid source register (insn #{0})")]
     InvalidSourceRegister(usize),
+    /// CannotWriteR10
     #[error("cannot write into register r10 (insn #{0})")]
     CannotWriteR10(usize),
+    /// InvalidDestinationRegister
     #[error("invalid destination register (insn #{0})")]
     InvalidDestinationRegister(usize),
+    /// UnknownOpCode
     #[error("unknown eBPF opcode {0:#2x} (insn #{1:?})")]
     UnknownOpCode(u8, usize),
+    /// Shift with overflow
+    #[error("Shift with overflow at instruction {0}")]
+    ShiftWithOverflow(usize),
+    /// Invalid register specified
+    #[error("Invalid register specified at instruction {0}")]
+    InvalidRegister(usize),
 }
 
 fn check_prog_len(prog: &[u8]) -> Result<(), BPFError> {
@@ -102,6 +122,23 @@ fn check_registers(insn: &ebpf::Insn, store: bool, insn_ptr: usize) -> Result<()
     }
 }
 
+/// Check that the imm is a valid shift operand
+fn check_imm_shift(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), VerifierError> {
+    if insn.imm < 0 || insn.imm as u64 >= 64 {
+        return Err(VerifierError::ShiftWithOverflow(insn_ptr));
+    }
+    Ok(())
+}
+
+/// Check that the imm is a valid register number
+fn check_imm_register(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), VerifierError> {
+    if insn.imm < 0 || insn.imm > 10 {
+        return Err(VerifierError::InvalidRegister(insn_ptr));
+    }
+    Ok(())
+}
+
+#[rustfmt::skip]
 pub fn check(prog: &[u8]) -> Result<(), BPFError> {
     check_prog_len(prog)?;
 
@@ -111,189 +148,126 @@ pub fn check(prog: &[u8]) -> Result<(), BPFError> {
         let mut store = false;
 
         match insn.opc {
-            // BPF_LD class
-            ebpf::LD_ABS_B => {}
-            ebpf::LD_ABS_H => {}
-            ebpf::LD_ABS_W => {}
-            ebpf::LD_ABS_DW => {}
-            ebpf::LD_IND_B => {}
-            ebpf::LD_IND_H => {}
-            ebpf::LD_IND_W => {}
-            ebpf::LD_IND_DW => {}
 
-            ebpf::LD_DW_IMM => {
+            // BPF_LD class
+            ebpf::LD_ABS_B   => {},
+            ebpf::LD_ABS_H   => {},
+            ebpf::LD_ABS_W   => {},
+            ebpf::LD_ABS_DW  => {},
+            ebpf::LD_IND_B   => {},
+            ebpf::LD_IND_H   => {},
+            ebpf::LD_IND_W   => {},
+            ebpf::LD_IND_DW  => {},
+
+            ebpf::LD_DW_IMM  => {
                 store = true;
                 check_load_dw(prog, insn_ptr)?;
                 insn_ptr += 1;
-            }
+            },
 
             // BPF_LDX class
-            ebpf::LD_B_REG => {}
-            ebpf::LD_H_REG => {}
-            ebpf::LD_W_REG => {}
-            ebpf::LD_DW_REG => {}
+            ebpf::LD_B_REG   => {},
+            ebpf::LD_H_REG   => {},
+            ebpf::LD_W_REG   => {},
+            ebpf::LD_DW_REG  => {},
 
             // BPF_ST class
-            ebpf::ST_B_IMM => store = true,
-            ebpf::ST_H_IMM => store = true,
-            ebpf::ST_W_IMM => store = true,
-            ebpf::ST_DW_IMM => store = true,
+            ebpf::ST_B_IMM   => store = true,
+            ebpf::ST_H_IMM   => store = true,
+            ebpf::ST_W_IMM   => store = true,
+            ebpf::ST_DW_IMM  => store = true,
 
             // BPF_STX class
-            ebpf::ST_B_REG => store = true,
-            ebpf::ST_H_REG => store = true,
-            ebpf::ST_W_REG => store = true,
-            ebpf::ST_DW_REG => store = true,
-            ebpf::ST_W_XADD => {
-                unimplemented!();
-            }
-            ebpf::ST_DW_XADD => {
-                unimplemented!();
-            }
+            ebpf::ST_B_REG   => store = true,
+            ebpf::ST_H_REG   => store = true,
+            ebpf::ST_W_REG   => store = true,
+            ebpf::ST_DW_REG  => store = true,
 
             // BPF_ALU class
-            ebpf::ADD32_IMM => {}
-            ebpf::ADD32_REG => {}
-            ebpf::SUB32_IMM => {}
-            ebpf::SUB32_REG => {}
-            ebpf::MUL32_IMM => {}
-            ebpf::MUL32_REG => {}
-            ebpf::DIV32_IMM => {
-                check_imm_nonzero(&insn, insn_ptr)?;
-            }
-            ebpf::DIV32_REG => {}
-            ebpf::OR32_IMM => {}
-            ebpf::OR32_REG => {}
-            ebpf::AND32_IMM => {}
-            ebpf::AND32_REG => {}
-            ebpf::LSH32_IMM => {}
-            ebpf::LSH32_REG => {}
-            ebpf::RSH32_IMM => {}
-            ebpf::RSH32_REG => {}
-            ebpf::NEG32 => {}
-            ebpf::MOD32_IMM => {
-                check_imm_nonzero(&insn, insn_ptr)?;
-            }
-            ebpf::MOD32_REG => {}
-            ebpf::XOR32_IMM => {}
-            ebpf::XOR32_REG => {}
-            ebpf::MOV32_IMM => {}
-            ebpf::MOV32_REG => {}
-            ebpf::ARSH32_IMM => {}
-            ebpf::ARSH32_REG => {}
-            ebpf::LE => {
-                check_imm_endian(&insn, insn_ptr)?;
-            }
-            ebpf::BE => {
-                check_imm_endian(&insn, insn_ptr)?;
-            }
+            ebpf::ADD32_IMM  => {},
+            ebpf::ADD32_REG  => {},
+            ebpf::SUB32_IMM  => {},
+            ebpf::SUB32_REG  => {},
+            ebpf::MUL32_IMM  => {},
+            ebpf::MUL32_REG  => {},
+            ebpf::DIV32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+            ebpf::DIV32_REG  => {},
+            ebpf::OR32_IMM   => {},
+            ebpf::OR32_REG   => {},
+            ebpf::AND32_IMM  => {},
+            ebpf::AND32_REG  => {},
+            ebpf::LSH32_IMM  => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::LSH32_REG  => {},
+            ebpf::RSH32_IMM  => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::RSH32_REG  => {},
+            ebpf::NEG32      => {},
+            ebpf::MOD32_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+            ebpf::MOD32_REG  => {},
+            ebpf::XOR32_IMM  => {},
+            ebpf::XOR32_REG  => {},
+            ebpf::MOV32_IMM  => {},
+            ebpf::MOV32_REG  => {},
+            ebpf::ARSH32_IMM => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::ARSH32_REG => {},
+            ebpf::LE         => { check_imm_endian(&insn, insn_ptr)?; },
+            ebpf::BE         => { check_imm_endian(&insn, insn_ptr)?; },
 
             // BPF_ALU64 class
-            ebpf::ADD64_IMM => {}
-            ebpf::ADD64_REG => {}
-            ebpf::SUB64_IMM => {}
-            ebpf::SUB64_REG => {}
-            ebpf::MUL64_IMM => {
-                check_imm_nonzero(&insn, insn_ptr)?;
-            }
-            ebpf::MUL64_REG => {}
-            ebpf::DIV64_IMM => {
-                check_imm_nonzero(&insn, insn_ptr)?;
-            }
-            ebpf::DIV64_REG => {}
-            ebpf::OR64_IMM => {}
-            ebpf::OR64_REG => {}
-            ebpf::AND64_IMM => {}
-            ebpf::AND64_REG => {}
-            ebpf::LSH64_IMM => {}
-            ebpf::LSH64_REG => {}
-            ebpf::RSH64_IMM => {}
-            ebpf::RSH64_REG => {}
-            ebpf::NEG64 => {}
-            ebpf::MOD64_IMM => {}
-            ebpf::MOD64_REG => {}
-            ebpf::XOR64_IMM => {}
-            ebpf::XOR64_REG => {}
-            ebpf::MOV64_IMM => {}
-            ebpf::MOV64_REG => {}
-            ebpf::ARSH64_IMM => {}
-            ebpf::ARSH64_REG => {}
+            ebpf::ADD64_IMM  => {},
+            ebpf::ADD64_REG  => {},
+            ebpf::SUB64_IMM  => {},
+            ebpf::SUB64_REG  => {},
+            ebpf::MUL64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+            ebpf::MUL64_REG  => {},
+            ebpf::DIV64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+            ebpf::DIV64_REG  => {},
+            ebpf::OR64_IMM   => {},
+            ebpf::OR64_REG   => {},
+            ebpf::AND64_IMM  => {},
+            ebpf::AND64_REG  => {},
+            ebpf::LSH64_IMM  => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::LSH64_REG  => {},
+            ebpf::RSH64_IMM  => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::RSH64_REG  => {},
+            ebpf::NEG64      => {},
+            ebpf::MOD64_IMM  => { check_imm_nonzero(&insn, insn_ptr)?; },
+            ebpf::MOD64_REG  => {},
+            ebpf::XOR64_IMM  => {},
+            ebpf::XOR64_REG  => {},
+            ebpf::MOV64_IMM  => {},
+            ebpf::MOV64_REG  => {},
+            ebpf::ARSH64_IMM => { check_imm_shift(&insn, insn_ptr)?; },
+            ebpf::ARSH64_REG => {},
 
             // BPF_JMP class
-            ebpf::JA => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JEQ_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JEQ_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JGT_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JGT_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JGE_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JGE_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JLT_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JLT_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JLE_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JLE_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSET_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSET_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JNE_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JNE_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSGT_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSGT_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSGE_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSGE_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSLT_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSLT_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSLE_IMM => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::JSLE_REG => {
-                check_jmp_offset(prog, insn_ptr)?;
-            }
-            ebpf::CALL_IMM => {}
-            ebpf::CALL_REG => {}
-            ebpf::EXIT => {}
+            ebpf::JA         => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JEQ_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JEQ_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JGT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JGT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JGE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JGE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JLT_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JLT_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JLE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JLE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSET_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSET_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JNE_IMM    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JNE_REG    => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSGT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSGT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSGE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSGE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSLT_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSLT_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSLE_IMM   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::JSLE_REG   => { check_jmp_offset(prog, insn_ptr)?; },
+            ebpf::CALL_IMM   => {},
+            ebpf::CALL_REG   => { check_imm_register(&insn, insn_ptr)?; },
+            ebpf::EXIT       => {},
 
-            _ => {
+            _                => {
                 return Err(VerifierError::UnknownOpCode(insn.opc, insn_ptr).into());
             }
         }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -255,10 +255,11 @@ pub fn process_instruction(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::Rng;
     use solana_sdk::{
         account::Account, instruction::CompiledInstruction, message::Message, rent::Rent,
     };
-    use std::{cell::RefCell, fs::File, io::Read, rc::Rc};
+    use std::{cell::RefCell, fs::File, io::Read, ops::Range, rc::Rc};
 
     #[derive(Debug, Default)]
     pub struct MockInvokeContext {}
@@ -504,6 +505,71 @@ mod tests {
                 &vec![],
                 &mut MockInvokeContext::default()
             )
+        );
+    }
+
+    /// fuzzing utility function
+    fn fuzz<F>(
+        bytes: &[u8],
+        outer_iters: usize,
+        inner_iters: usize,
+        offset: Range<usize>,
+        value: Range<u8>,
+        work: F,
+    ) where
+        F: Fn(&mut [u8]),
+    {
+        let mut rng = rand::thread_rng();
+        for _ in 0..outer_iters {
+            let mut mangled_bytes = bytes.to_vec();
+            for _ in 0..inner_iters {
+                let offset = rng.gen_range(offset.start, offset.end);
+                let value = rng.gen_range(value.start, value.end);
+                mangled_bytes[offset] = value;
+                work(&mut mangled_bytes);
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn test_fuzz() {
+        let program_id = Pubkey::new_rand();
+        let program_key = Pubkey::new_rand();
+
+        // Create program account
+        let mut file = File::open("test_elfs/noop.so").expect("file open failed");
+        let mut elf = Vec::new();
+        file.read_to_end(&mut elf).unwrap();
+
+        println!("mangle the whole file");
+        fuzz(
+            &elf,
+            1_000_000_000,
+            100,
+            0..elf.len(),
+            0..255,
+            |bytes: &mut [u8]| {
+                let program_account = Account::new_ref(1, 0, &program_id);
+                program_account.borrow_mut().data = bytes.to_vec();
+                program_account.borrow_mut().executable = true;
+
+                let parameter_account = Account::new_ref(1, 0, &program_id);
+                let keyed_accounts = vec![
+                    KeyedAccount::new(&program_key, false, &program_account),
+                    KeyedAccount::new(&program_key, false, &parameter_account),
+                ];
+
+                let _result = process_instruction(
+                    &bpf_loader::id(),
+                    &keyed_accounts,
+                    &vec![],
+                    &mut MockInvokeContext::default(),
+                );
+                // if result.is_err() {
+                //     println!("{:?}", result);
+                // }
+            },
         );
     }
 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -542,7 +542,7 @@ mod tests {
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
 
-        println!("mangle the whole file");
+        info!("mangle the whole file");
         fuzz(
             &elf,
             1_000_000_000,
@@ -566,9 +566,6 @@ mod tests {
                     &vec![],
                     &mut MockInvokeContext::default(),
                 );
-                // if result.is_err() {
-                //     println!("{:?}", result);
-                // }
             },
         );
     }


### PR DESCRIPTION
#### Problem

The BPF ELF loader and virtual machine rely on a package that may panic if invalid ELFs are presented.  The virtual machine also contains operations that may panic or misbehave.

#### Summary of Changes

- Switch dependencies over to the Goblin ELF crate which is more robust and has been fuzzed
- Tighten up the virtual machine to perform safe operations and exit gracefully
- Performed long term fuzzing at multiple layers to confirm the hardening

Fixes #1913
Fixes #9829
