### PR TITLE
Clean up --output help

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -210,10 +210,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     .arg(
         Arg::with_name("output_format")
             .long("output")
+            .value_name("FORMAT")
             .global(true)
             .takes_value(true)
             .possible_values(&["json", "json-compact"])
-            .help("Return information in specified output format. Supports: json, json-compact"),
+            .help("Return information in specified output format"),
     )
     .arg(
         Arg::with_name(SKIP_SEED_PHRASE_VALIDATION_ARG.name)


### PR DESCRIPTION
#### Problem

Inconsistent value name and duplicate information in CLI help message for new `--output` option

#### Summary of Changes

Was:
```
        --output <output_format>    Return information in specified output format. Supports: json, json-compact
                                    [possible values: json, json-compact]
 ```

Now:
```
        --output <FORMAT>      Return information in specified output format [possible values: json, json-compact]
```

