### PR TITLE
Panic if no valid fee-payer

### DIFF
--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -481,7 +481,7 @@ mod tests {
         hash::{hash, Hash},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
-        system_instruction, system_transaction,
+        system_transaction,
         transaction::Transaction,
     };
 
@@ -684,8 +684,7 @@ mod tests {
     #[test]
     fn test_verify_tick_hash_count() {
         let hashes_per_tick = 10;
-        let ix = system_instruction::transfer(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
-        let tx = Transaction::new_unsigned_instructions(&[ix]);
+        let tx = Transaction::new_with_payer(&[], Some(&Pubkey::default()));
         let tx_entry = Entry::new(&Hash::default(), 1, vec![tx]);
         let full_tick_entry = Entry::new_tick(hashes_per_tick, &Hash::default());
         let partial_tick_entry = Entry::new_tick(hashes_per_tick - 1, &Hash::default());

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -479,9 +479,9 @@ mod tests {
     use solana_budget_program::budget_instruction;
     use solana_sdk::{
         hash::{hash, Hash},
-        message::Message,
+        pubkey::Pubkey,
         signature::{Keypair, Signer},
-        system_transaction,
+        system_instruction, system_transaction,
         transaction::Transaction,
     };
 
@@ -684,8 +684,8 @@ mod tests {
     #[test]
     fn test_verify_tick_hash_count() {
         let hashes_per_tick = 10;
-        let keypairs: Vec<&Keypair> = Vec::new();
-        let tx: Transaction = Transaction::new(&keypairs, Message::new(&[]), Hash::default());
+        let ix = system_instruction::transfer(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
+        let tx = Transaction::new_unsigned_instructions(&[ix]);
         let tx_entry = Entry::new(&Hash::default(), 1, vec![tx]);
         let full_tick_entry = Entry::new_tick(hashes_per_tick, &Hash::default());
         let partial_tick_entry = Entry::new_tick(hashes_per_tick - 1, &Hash::default());

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -608,7 +608,7 @@ mod tests {
         for owned_index in (1..depth_reached).rev() {
             let not_owned_index = owned_index - 1;
             let metas = vec![
-                AccountMeta::new(keys[not_owned_index], false),
+                AccountMeta::new(keys[not_owned_index], true),
                 AccountMeta::new(keys[owned_index], false),
             ];
             let message =
@@ -620,7 +620,7 @@ mod tests {
                 .verify_and_update(
                     &message,
                     &message.instructions[0],
-                    &[],
+                    &[keys[not_owned_index]],
                     &accounts[not_owned_index..owned_index + 1],
                 )
                 .unwrap();
@@ -636,7 +636,7 @@ mod tests {
                 invoke_context.verify_and_update(
                     &message,
                     &message.instructions[0],
-                    &[],
+                    &[keys[not_owned_index]],
                     &accounts[not_owned_index..owned_index + 1],
                 ),
                 Err(InstructionError::ExternalAccountDataModified)
@@ -1431,7 +1431,7 @@ mod tests {
             vec![owned_preaccount, not_owned_preaccount],
         );
         let metas = vec![
-            AccountMeta::new(owned_key, false),
+            AccountMeta::new(owned_key, true),
             AccountMeta::new(not_owned_key, false),
         ];
 
@@ -1447,7 +1447,7 @@ mod tests {
                 &message,
                 &executable_accounts,
                 &accounts,
-                &[],
+                &[owned_key],
                 mock_process_instruction,
                 &mut invoke_context,
             ),
@@ -1476,7 +1476,7 @@ mod tests {
                     &message,
                     &executable_accounts,
                     &accounts,
-                    &[],
+                    &[owned_key],
                     mock_process_instruction,
                     &mut invoke_context,
                 ),

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
-        let tx = Transaction::new_signed_instructions(&[&Keypair::new(); 0], &[], Hash::default());
+        let tx = Transaction::new_with_payer(&[], Some(&Pubkey::default()));
         assert!(transaction_uses_durable_nonce(&tx).is_none());
     }
 

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -182,18 +182,15 @@ mod tests {
 
     #[test]
     fn test_fee_calculator_calculate_fee() {
-        // Default: no fee.
-        let message = Message::new(&[]);
-        assert_eq!(FeeCalculator::default().calculate_fee(&message), 0);
-
-        // No signature, no fee.
-        assert_eq!(FeeCalculator::new(1).calculate_fee(&message), 0);
-
-        // One signature, a fee.
         let pubkey0 = Pubkey::new(&[0; 32]);
         let pubkey1 = Pubkey::new(&[1; 32]);
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
         let message = Message::new(&[ix0]);
+
+        // Default: no fee.
+        assert_eq!(FeeCalculator::default().calculate_fee(&message), 0);
+
+        // One signature, a fee.
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 2);
 
         // Two signatures, double the fee.

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -48,8 +48,6 @@ pub enum Error {
     PickleDbError(#[from] pickledb::error::Error),
     #[error("Transport error")]
     TransportError(#[from] TransportError),
-    #[error("Signature not found")]
-    SignatureNotFound,
 }
 
 fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
@@ -600,7 +598,7 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
 mod tests {
     use super::*;
     use solana_runtime::{bank::Bank, bank_client::BankClient};
-    use solana_sdk::{genesis_config::create_genesis_config, transaction::Transaction};
+    use solana_sdk::genesis_config::create_genesis_config;
 
     #[test]
     fn test_process_distribute_tokens() {
@@ -674,9 +672,7 @@ mod tests {
         let transaction_infos = vec![TransactionInfo {
             recipient: bob,
             amount: 1.0,
-            new_stake_account_address: None,
-            finalized_date: None,
-            transaction: Transaction::new_unsigned_instructions(&[]),
+            ..TransactionInfo::default()
         }];
         apply_previous_transactions(&mut allocations, &transaction_infos);
         assert_eq!(allocations.len(), 1);

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -25,8 +25,7 @@ struct SignedTransactionInfo {
 
 impl Default for TransactionInfo {
     fn default() -> Self {
-        let mut transaction = Transaction::new_unsigned_instructions(&[]);
-        transaction.signatures.push(Signature::default());
+        let transaction = Transaction::new_with_payer(&[], Some(&Pubkey::default()));
         Self {
             recipient: Pubkey::default(),
             amount: 0.0,


### PR DESCRIPTION
#### Problem

The `Message` library allows users to construct messages with no valid fee-payer.

```rust
Message::new(&[])
```

Also one where the fee-payer is a read-only account. For example, the nonce_authority
in this message:

```rust
Message::new_with_nonce(&[], None, nonce_account, nonce_authority)
```

#### Summary of Changes

Make fee-payer a required parameter of `get_keys()`, such that the burden of expressing a default is hoisted up to the Message constructors.  When no fee-payer is provided, it looks through the instructions for a writable signer, and panics if it can't find one.

cc #9946
