### PR TITLE
RpcClient::send_and_confirm_transaction() no longer needs a keypair

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1343,8 +1343,7 @@ fn process_deploy(
     )?;
 
     trace!("Creating program account");
-    let result =
-        rpc_client.send_and_confirm_transaction_with_spinner(&mut create_account_tx, &signers);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&create_account_tx);
     log_instruction_custom_error::<SystemError>(result, &config).map_err(|_| {
         CliError::DynamicProgramError("Program account allocation failed".to_string())
     })?;
@@ -1358,7 +1357,7 @@ fn process_deploy(
 
     trace!("Finalizing program account");
     rpc_client
-        .send_and_confirm_transaction_with_spinner(&mut finalize_tx, &signers)
+        .send_and_confirm_transaction_with_spinner(&finalize_tx)
         .map_err(|e| {
             CliError::DynamicProgramError(format!("Finalizing program account failed: {}", e))
         })?;
@@ -1423,8 +1422,7 @@ fn process_pay(
                 &fee_calculator,
                 &tx.message,
             )?;
-            let result =
-                rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+            let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
             log_instruction_custom_error::<SystemError>(result, &config)
         }
     } else if *witnesses == None {
@@ -1459,10 +1457,7 @@ fn process_pay(
                 &fee_calculator,
                 &tx.message,
             )?;
-            let result = rpc_client.send_and_confirm_transaction_with_spinner(
-                &mut tx,
-                &[config.signers[0], &contract_state],
-            );
+            let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
             let signature = log_instruction_custom_error::<BudgetError>(result, &config)?;
             Ok(json!({
                 "signature": signature,
@@ -1498,10 +1493,7 @@ fn process_pay(
             return_signers(&tx, &config)
         } else {
             tx.try_sign(&[config.signers[0], &contract_state], blockhash)?;
-            let result = rpc_client.send_and_confirm_transaction_with_spinner(
-                &mut tx,
-                &[config.signers[0], &contract_state],
-            );
+            let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
             check_account_for_fee(
                 rpc_client,
                 &config.signers[0].pubkey(),
@@ -1536,8 +1528,7 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0]]);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<BudgetError>(result, &config)
 }
 
@@ -1560,8 +1551,7 @@ fn process_time_elapsed(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0]]);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<BudgetError>(result, &config)
 }
 
@@ -1623,7 +1613,7 @@ fn process_transfer(
         let result = if no_wait {
             rpc_client.send_transaction(&tx)
         } else {
-            rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers)
+            rpc_client.send_and_confirm_transaction_with_spinner(&tx)
         };
         log_instruction_custom_error::<SystemError>(result, &config)
     }
@@ -1647,8 +1637,7 @@ fn process_witness(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0]]);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<BudgetError>(result, &config)
 }
 
@@ -2279,8 +2268,8 @@ pub fn request_and_confirm_airdrop(
             sleep(Duration::from_secs(1));
         }
     }?;
-    let mut tx = keypair.airdrop_transaction();
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[&keypair]);
+    let tx = keypair.airdrop_transaction();
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -446,7 +446,7 @@ pub fn process_authorize_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<NonceError>(result, &config)
 }
 
@@ -523,7 +523,7 @@ pub fn process_create_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 
@@ -564,8 +564,7 @@ pub fn process_new_nonce(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client
-        .send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0], nonce_authority]);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 
@@ -624,7 +623,7 @@ pub fn process_withdraw_from_nonce_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<NonceError>(result, &config)
 }
 

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -869,7 +869,7 @@ pub fn process_create_stake_account(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
         log_instruction_custom_error::<SystemError>(result, &config)
     }
 }
@@ -934,7 +934,7 @@ pub fn process_stake_authorize(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -988,7 +988,7 @@ pub fn process_deactivate_stake_account(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -1051,7 +1051,7 @@ pub fn process_withdraw_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
         log_instruction_custom_error::<SystemError>(result, &config)
     }
 }
@@ -1185,7 +1185,7 @@ pub fn process_split_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -1242,7 +1242,7 @@ pub fn process_stake_set_lockup(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -1450,7 +1450,7 @@ pub fn process_delegate_stake(
             &fee_calculator,
             &tx.message,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }

--- a/cli/src/storage.rs
+++ b/cli/src/storage.rs
@@ -242,7 +242,7 @@ pub fn process_create_storage_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 
@@ -266,7 +266,7 @@ pub fn process_claim_storage_reward(
         &fee_calculator,
         &tx.message,
     )?;
-    let signature = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &signers)?;
+    let signature = rpc_client.send_and_confirm_transaction_with_spinner(&tx)?;
     Ok(signature.to_string())
 }
 

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -367,7 +367,7 @@ pub fn process_set_validator_info(
         &fee_calculator,
         &tx.message,
     )?;
-    let signature_str = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &signers)?;
+    let signature_str = rpc_client.send_and_confirm_transaction_with_spinner(&tx)?;
 
     println!("Success! Validator info published at: {:?}", info_pubkey);
     println!("{}", signature_str);

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -437,7 +437,7 @@ pub fn process_create_vote_account(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 
@@ -477,8 +477,7 @@ pub fn process_vote_authorize(
         &fee_calculator,
         &tx.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &[config.signers[0]]);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<VoteError>(result, &config)
 }
 
@@ -511,7 +510,7 @@ pub fn process_vote_update_validator(
         &fee_calculator,
         &tx.message,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&mut tx, &config.signers);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<VoteError>(result, &config)
 }
 
@@ -616,8 +615,7 @@ pub fn process_withdraw_from_vote_account(
         &fee_calculator,
         &transaction.message,
     )?;
-    let result =
-        rpc_client.send_and_confirm_transaction_with_spinner(&mut transaction, &config.signers);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&transaction);
     log_instruction_custom_error::<VoteError>(result, &config)
 }
 

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -221,8 +221,7 @@ fn new_update_manifest(
         let mut transaction = Transaction::new_unsigned_instructions(&instructions);
         let signers = [from_keypair, update_manifest_keypair];
         transaction.sign(&signers, recent_blockhash);
-
-        rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
+        rpc_client.send_and_confirm_transaction(&transaction)?;
     }
     Ok(())
 }
@@ -245,8 +244,8 @@ fn store_update_manifest(
     );
 
     let message = Message::new_with_payer(&[instruction], Some(&from_keypair.pubkey()));
-    let mut transaction = Transaction::new(&signers, message, recent_blockhash);
-    rpc_client.send_and_confirm_transaction(&mut transaction, &[from_keypair])?;
+    let transaction = Transaction::new(&signers, message, recent_blockhash);
+    rpc_client.send_and_confirm_transaction(&transaction)?;
     Ok(())
 }
 

--- a/ramp-tps/src/voters.rs
+++ b/ramp-tps/src/voters.rs
@@ -138,7 +138,7 @@ fn delegate_stake(
             }
         };
 
-        let mut transaction = Transaction::new_signed_instructions(
+        let transaction = Transaction::new_signed_instructions(
             &[faucet_keypair, &stake_account_keypair],
             &stake_instruction::create_account_and_delegate_stake(
                 &faucet_keypair.pubkey(),
@@ -160,10 +160,7 @@ fn delegate_stake(
             }
         }
 
-        if let Err(err) = rpc_client.send_and_confirm_transaction(
-            &mut transaction,
-            &[faucet_keypair, &stake_account_keypair],
-        ) {
+        if let Err(err) = rpc_client.send_and_confirm_transaction(&transaction) {
             error!(
                 "Failed to delegate stake (retries: {}): {}",
                 retry_count, err

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -214,7 +214,7 @@ fn send_message<S: Signers>(
     if no_wait {
         client.send_transaction(&transaction)
     } else {
-        client.send_and_confirm_transaction_with_spinner(&mut transaction, signers)
+        client.send_and_confirm_transaction_with_spinner(&transaction)
     }
 }
 


### PR DESCRIPTION
It only needs a keypair to handle `TransactionError::AccountInUse` errors.  But that logic was added for program loading.  But program loading uses `send_and_confirm_transactions_with_spinner()`, not `send_and_confirm_transaction()` or `send_and_confirm_transaction_with_spinner()`.  