### PR TITLE
Reduce stability testcase throughput to 40k TPS

### DIFF
--- a/system-test/sanity-testcases/colo-cpu-only-quick-sanity-test.yml
+++ b/system-test/sanity-testcases/colo-cpu-only-quick-sanity-test.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 60
       NUMBER_OF_VALIDATOR_NODES: 1
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 40000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD: 99
       TEST_TYPE: "fixed_duration"

--- a/system-test/sanity-testcases/colo-partition-sanity-test.yml
+++ b/system-test/sanity-testcases/colo-partition-sanity-test.yml
@@ -8,7 +8,7 @@ steps:
       NUMBER_OF_VALIDATOR_NODES: 3
       ENABLE_GPU: "false"
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 15000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       APPLY_PARTITIONS: "true"
       NETEM_CONFIG_FILE: "system-test/netem-configs/partial-loss-three-partitions"

--- a/system-test/stability-testcases/colo-long-duration-cpu-only-perf.yml
+++ b/system-test/stability-testcases/colo-long-duration-cpu-only-perf.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 3600
       NUMBER_OF_VALIDATOR_NODES: 3
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 30000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/stability-testcases/colo-long-duration-gpu-perf.yml
+++ b/system-test/stability-testcases/colo-long-duration-gpu-perf.yml
@@ -9,7 +9,7 @@ steps:
       TEST_DURATION_SECONDS: 3600
       NUMBER_OF_VALIDATOR_NODES: 3
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 30000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       ADDITIONAL_FLAGS: ""
       TEST_TYPE: "fixed_duration"
     agents:

--- a/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
+++ b/system-test/stability-testcases/gce-perf-stability-5-node-single-region.yml
@@ -10,7 +10,7 @@ steps:
       ENABLE_GPU: "false"
       VALIDATOR_NODE_MACHINE_TYPE: "--machine-type n1-standard-16"
       NUMBER_OF_CLIENT_NODES: 1
-      CLIENT_OPTIONS: "bench-tps=1=--tx_count 20000 --thread-batch-sleep-ms 250"
+      CLIENT_OPTIONS: "bench-tps=1=--tx_count 10000 --thread-batch-sleep-ms 250"
       TESTNET_ZONES: "us-west1-a"
       USE_PUBLIC_IP_ADDRESSES: "false"
       ADDITIONAL_FLAGS: "--dedicated"


### PR DESCRIPTION
#### Problem
Stability test cases are pushing more TPS than the cluster can sustain without falling over.

#### Summary of Changes
Reduce bench-tps to pushing 40k TPS

Can revert, or work on increasing to next perf limit when https://github.com/solana-labs/solana/issues/9739 is fixed.