### PR TITLE
solana-keygen: Write non-error output to stdout

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -74,7 +74,7 @@ fn output_keypair(
         write_keypair(&keypair, &mut stdout)?;
     } else {
         write_keypair_file(&keypair, outfile)?;
-        eprintln!("Wrote {} keypair to {}", source, outfile);
+        println!("Wrote {} keypair to {}", source, outfile);
     }
     Ok(())
 }
@@ -434,7 +434,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
             let passphrase = if matches.is_present("no_passphrase") {
                 NO_PASSPHRASE.to_string()
             } else {
-                eprintln!("Generating a new keypair");
+                println!("Generating a new keypair");
                 prompt_passphrase(
                     "For added security, enter a passphrase (empty for no passphrase): ",
                 )?
@@ -451,7 +451,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
             if !silent {
                 let phrase: &str = mnemonic.phrase();
                 let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
-                eprintln!(
+                println!(
                     "{}\npubkey: {}\n{}\nSave this seed phrase to recover your new keypair:\n{}\n{}",
                     &divider, keypair.pubkey(), &divider, phrase, &divider
                 );


### PR DESCRIPTION
https://github.com/solana-labs/solana/issues/9958 points out that some of the non-error `solana-keygen` output ends up on stderr instead of stdout.  

Fixes https://github.com/solana-labs/solana/issues/9958