### PR TITLE
Advertise node software version in gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,6 +4081,7 @@ dependencies = [
  "solana-streamer",
  "solana-sys-tuner",
  "solana-transaction-status",
+ "solana-version",
  "solana-vote-program",
  "solana-vote-signer",
  "systemstat",
@@ -4854,6 +4855,15 @@ dependencies = [
  "solana-sdk",
  "solana-vote-program",
  "solana-vote-signer",
+]
+
+[[package]]
+name = "solana-version"
+version = "1.2.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,6 +3700,7 @@ dependencies = [
  "solana-metrics",
  "solana-net-utils",
  "solana-sdk",
+ "solana-version",
 ]
 
 [[package]]
@@ -3790,6 +3791,7 @@ dependencies = [
  "solana-net-utils",
  "solana-runtime",
  "solana-sdk",
+ "solana-version",
 ]
 
 [[package]]
@@ -3801,6 +3803,7 @@ dependencies = [
  "solana-logger",
  "solana-net-utils",
  "solana-streamer",
+ "solana-version",
 ]
 
 [[package]]
@@ -3829,6 +3832,7 @@ dependencies = [
  "solana-net-utils",
  "solana-runtime",
  "solana-sdk",
+ "solana-version",
 ]
 
 [[package]]
@@ -3966,6 +3970,7 @@ dependencies = [
  "solana-stake-program",
  "solana-storage-program",
  "solana-transaction-status",
+ "solana-version",
  "solana-vote-program",
  "solana-vote-signer",
  "tempfile",
@@ -4132,6 +4137,7 @@ dependencies = [
  "solana-net-utils",
  "solana-runtime",
  "solana-sdk",
+ "solana-version",
 ]
 
 [[package]]
@@ -4188,6 +4194,7 @@ dependencies = [
  "solana-logger",
  "solana-metrics",
  "solana-sdk",
+ "solana-version",
  "tokio 0.1.22",
  "tokio-codec",
 ]
@@ -4209,6 +4216,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-storage-program",
+ "solana-version",
  "solana-vote-program",
  "tempfile",
 ]
@@ -4238,6 +4246,7 @@ dependencies = [
  "solana-logger",
  "solana-net-utils",
  "solana-sdk",
+ "solana-version",
 ]
 
 [[package]]
@@ -4265,6 +4274,7 @@ dependencies = [
  "solana-config-program",
  "solana-logger",
  "solana-sdk",
+ "solana-version",
  "tar",
  "tempdir",
  "url 2.1.1",
@@ -4284,6 +4294,7 @@ dependencies = [
  "solana-cli-config",
  "solana-remote-wallet",
  "solana-sdk",
+ "solana-version",
  "tiny-bip39",
 ]
 
@@ -4354,6 +4365,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-transaction-status",
+ "solana-version",
  "solana-vote-program",
  "tempfile",
 ]
@@ -4411,6 +4423,7 @@ dependencies = [
  "serde_json",
  "solana-clap-utils",
  "solana-logger",
+ "solana-version",
 ]
 
 [[package]]
@@ -4513,6 +4526,7 @@ dependencies = [
  "socket2",
  "solana-clap-utils",
  "solana-logger",
+ "solana-version",
  "tokio 0.1.22",
  "tokio-codec",
 ]
@@ -4743,6 +4757,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-transaction-status",
+ "solana-version",
  "tempfile",
 ]
 
@@ -4805,6 +4820,7 @@ dependencies = [
  "nix",
  "solana-clap-utils",
  "solana-logger",
+ "solana-version",
  "sysctl",
  "unix_socket2",
  "users",
@@ -4853,6 +4869,7 @@ dependencies = [
  "solana-perf",
  "solana-runtime",
  "solana-sdk",
+ "solana-version",
  "solana-vote-program",
  "solana-vote-signer",
 ]
@@ -4910,6 +4927,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-metrics",
  "solana-sdk",
+ "solana-version",
 ]
 
 [[package]]
@@ -4929,6 +4947,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-transaction-status",
+ "solana-version",
  "solana-vote-program",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
     "transaction-status",
     "upload-perf",
     "net-utils",
+    "version",
     "vote-signer",
     "cli",
     "rayon-threadlimit",

--- a/archiver/Cargo.toml
+++ b/archiver/Cargo.toml
@@ -17,7 +17,7 @@ solana-metrics = { path = "../metrics", version = "1.2.0" }
 solana-archiver-lib = { path = "../archiver-lib", version = "1.2.0" }
 solana-net-utils = { path = "../net-utils", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
-
+solana-version = { path = "../version", version = "1.2.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/archiver/src/main.rs
+++ b/archiver/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("identity_keypair")
                 .short("i")
@@ -105,7 +105,7 @@ fn main() {
     println!(
         "{} version {} (branch={}, commit={})",
         style(crate_name!()).bold(),
-        solana_clap_utils::version!(),
+        solana_version::version!(),
         option_env!("CI_BRANCH").unwrap_or("unknown"),
         option_env!("CI_COMMIT").unwrap_or("unknown")
     );

--- a/bench-exchange/Cargo.toml
+++ b/bench-exchange/Cargo.toml
@@ -29,6 +29,7 @@ solana-metrics = { path = "../metrics", version = "1.2.0" }
 solana-net-utils = { path = "../net-utils", version = "1.2.0" }
 solana-runtime = { path = "../runtime", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 
 [dev-dependencies]
 solana-local-cluster = { path = "../local-cluster", version = "1.2.0" }

--- a/bench-exchange/src/main.rs
+++ b/bench-exchange/src/main.rs
@@ -11,7 +11,7 @@ fn main() {
     solana_logger::setup();
     solana_metrics::set_panic_hook("bench-exchange");
 
-    let matches = cli::build_args(solana_clap_utils::version!()).get_matches();
+    let matches = cli::build_args(solana_version::version!()).get_matches();
     let cli_config = cli::extract_args(&matches);
 
     let cli::Config {

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -13,6 +13,7 @@ solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-streamer = { path = "../streamer", version = "1.2.0" }
 solana-logger = { path = "../logger", version = "1.2.0" }
 solana-net-utils = { path = "../net-utils", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("num-recv-sockets")
                 .long("num-recv-sockets")

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -27,6 +27,7 @@ solana-net-utils = { path = "../net-utils", version = "1.2.0" }
 solana-runtime = { path = "../runtime", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
 solana-move-loader-program = { path = "../programs/move_loader", version = "1.2.0", optional = true }
+solana-version = { path = "../version", version = "1.2.0" }
 
 [dev-dependencies]
 serial_test = "0.4.0"

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     solana_logger::setup_with_default("solana=info");
     solana_metrics::set_panic_hook("bench-tps");
 
-    let matches = cli::build_args(solana_clap_utils::version!()).get_matches();
+    let matches = cli::build_args(solana_version::version!()).get_matches();
     let cli_config = cli::extract_args(&matches);
 
     let cli::Config {

--- a/clap-utils/src/lib.rs
+++ b/clap-utils/src/lib.rs
@@ -1,24 +1,5 @@
 use thiserror::Error;
 
-#[macro_export]
-macro_rules! version {
-    () => {
-        &*format!(
-            "{}{}",
-            env!("CARGO_PKG_VERSION"),
-            if option_env!("CI_TAG").unwrap_or("").is_empty() {
-                format!(
-                    " [channel={} commit={}]",
-                    option_env!("CHANNEL").unwrap_or("unknown"),
-                    option_env!("CI_COMMIT").unwrap_or("unknown"),
-                )
-            } else {
-                "".to_string()
-            },
-        )
-    };
-}
-
 pub struct ArgConstant<'a> {
     pub long: &'a str,
     pub name: &'a str,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -41,6 +41,7 @@ solana-sdk = { path = "../sdk", version = "1.2.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.2.0" }
 solana-storage-program = { path = "../programs/storage", version = "1.2.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.2.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.2.0" }
 thiserror = "1.0.15"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -156,7 +156,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = app(
         crate_name!(),
         crate_description!(),
-        solana_clap_utils::version!(),
+        solana_version::version!(),
     )
     .arg({
         let arg = Arg::with_name("config_file")

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,6 +61,7 @@ solana-sdk = { path = "../sdk", version = "1.2.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.2.0" }
 solana-storage-program = { path = "../programs/storage", version = "1.2.0" }
 solana-streamer = { path = "../streamer", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.2.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.2.0" }
 solana-sys-tuner = { path = "../sys-tuner", version = "1.2.0" }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1445,7 +1445,7 @@ impl RpcSol for RpcSolImpl {
 
     fn get_version(&self, _: Self::Metadata) -> Result<RpcVersionInfo> {
         Ok(RpcVersionInfo {
-            solana_core: solana_clap_utils::version!().to_string(),
+            solana_core: solana_version::Version::default().to_string(),
         })
     }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2608,7 +2608,7 @@ pub mod tests {
         let expected = json!({
             "jsonrpc": "2.0",
             "result": {
-                "solana-core": solana_clap_utils::version!().to_string()
+                "solana-core": solana_version::version!().to_string()
             },
             "id": 1
         });

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -46,7 +46,7 @@ fn test_rpc_client() {
 
     assert_eq!(
         client.get_version().unwrap().solana_core,
-        solana_clap_utils::version!()
+        solana_version::version!()
     );
 
     assert!(client.get_account(&bob_pubkey).is_err());

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -19,6 +19,7 @@ solana-logger = { path = "../logger", version = "1.2.0" }
 solana-net-utils = { path = "../net-utils", version = "1.2.0" }
 solana-runtime = { path = "../runtime", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -94,7 +94,7 @@ fn main() {
     solana_logger::setup_with_default("solana=info");
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("entrypoint")
                 .long("entrypoint")

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -8,9 +8,6 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 edition = "2018"
 
-
-
-
 [dependencies]
 bincode = "1.2.1"
 byteorder = "1.3.4"
@@ -23,6 +20,7 @@ solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-logger = { path = "../logger", version = "1.2.0" }
 solana-metrics = { path = "../metrics", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 tokio = "0.1"
 tokio-codec = "0.1"
 

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     solana_metrics::set_panic_hook("faucet");
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("keypair")
                 .short("k")

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -23,12 +23,12 @@ solana-sdk = { path = "../sdk", version = "1.2.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.2.0" }
 solana-storage-program = { path = "../programs/storage", version = "1.2.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 tempfile = "3.1.0"
 
 [[bin]]
 name = "solana-genesis"
 path = "src/main.rs"
-
 
 [lib]
 name = "solana_genesis"

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -128,7 +128,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("creation_time")
                 .long("creation-time")

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -16,9 +16,7 @@ solana-client = { path = "../client", version = "1.2.0" }
 solana-logger = { path = "../logger", version = "1.2.0" }
 solana-net-utils = { path = "../net-utils", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
-
-
-
+solana-version = { path = "../version", version = "1.2.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
             SubCommand::with_name("rpc-url")

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -29,6 +29,7 @@ solana-client = { path = "../client", version = "1.2.0" }
 solana-config-program = { path = "../programs/config", version = "1.2.0" }
 solana-logger = { path = "../logger", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 semver = "0.9.0"
 tar = "0.4.26"
 tempdir = "0.3.7"

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -84,7 +84,7 @@ pub fn main() -> Result<(), String> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg({
             let arg = Arg::with_name("config_file")
@@ -268,7 +268,7 @@ pub fn main_init() -> Result<(), String> {
 
     let matches = App::new("solana-install-init")
         .about("initializes a new installation")
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg({
             let arg = Arg::with_name("config_file")
                 .short("c")

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -17,6 +17,7 @@ solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-cli-config = { path = "../cli-config", version = "1.2.0" }
 solana-remote-wallet = { path = "../remote-wallet", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 tiny-bip39 = "0.7.0"
 
 [[bin]]

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -208,7 +208,7 @@ fn grind_parse_args(
 fn main() -> Result<(), Box<dyn error::Error>> {
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg({
             let arg = Arg::with_name("config_file")

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -22,6 +22,7 @@ solana-runtime = { path = "../runtime", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.2.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.2.0" }
 tempfile = "3.1.0"
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -631,7 +631,7 @@ fn main() {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("ledger_path")
                 .short("l")

--- a/log-analyzer/Cargo.toml
+++ b/log-analyzer/Cargo.toml
@@ -16,6 +16,7 @@ serde = "1.0.110"
 serde_json = "1.0.53"
 solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-logger = { path = "../logger", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 
 [[bin]]
 name = "solana-log-analyzer"

--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -200,7 +200,7 @@ fn main() {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .subcommand(
             SubCommand::with_name("iftop")
                 .about("Process iftop log file")

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -20,6 +20,7 @@ serde_derive = "1.0.103"
 socket2 = "0.3.12"
 solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-logger = { path = "../logger", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 tokio = "0.1"
 tokio-codec = "0.1"
 

--- a/net-utils/src/bin/ip_address.rs
+++ b/net-utils/src/bin/ip_address.rs
@@ -3,7 +3,7 @@ use clap::{App, Arg};
 fn main() {
     solana_logger::setup();
     let matches = App::new("solana-ip-address")
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("host_port")
                 .index(1)

--- a/net-utils/src/bin/ip_address_server.rs
+++ b/net-utils/src/bin/ip_address_server.rs
@@ -4,7 +4,7 @@ use std::net::{SocketAddr, TcpListener};
 fn main() {
     solana_logger::setup();
     let matches = App::new("solana-ip-address-server")
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("port")
                 .index(1)

--- a/stake-monitor/Cargo.toml
+++ b/stake-monitor/Cargo.toml
@@ -22,6 +22,7 @@ solana-metrics = { path = "../metrics", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.2.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 
 [dev-dependencies]
 serial_test = "0.4.0"

--- a/stake-monitor/src/main.rs
+++ b/stake-monitor/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(
             Arg::with_name("data_file")

--- a/sys-tuner/Cargo.toml
+++ b/sys-tuner/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.8"
 libc = "0.2.69"
 solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-logger = { path = "../logger", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 
 [target."cfg(unix)".dependencies]
 unix_socket2 = "0.5.4"

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -101,7 +101,7 @@ fn main() {
     solana_logger::setup();
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("user")
                 .long("user")

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -27,6 +27,7 @@ solana-metrics = { path = "../metrics", version = "1.2.0" }
 solana-net-utils = { path = "../net-utils", version = "1.2.0" }
 solana-runtime = { path = "../runtime", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.2.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.2.0" }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -472,7 +472,7 @@ pub fn main() {
     let default_genesis_archive_unpacked_size = &MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name(SKIP_SEED_PHRASE_VALIDATION_ARG.name)
                 .long(SKIP_SEED_PHRASE_VALIDATION_ARG.long)
@@ -1017,7 +1017,7 @@ pub fn main() {
         env::set_var("RUST_BACKTRACE", "1")
     }
 
-    info!("{} {}", crate_name!(), solana_clap_utils::version!());
+    info!("{} {}", crate_name!(), solana_version::version!());
     info!("Starting validator with: {:#?}", std::env::args_os());
 
     solana_metrics::set_host_id(identity_keypair.pubkey().to_string());

--- a/version/.gitignore
+++ b/version/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/farf/

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "solana-version"
+version = "1.2.0"
+description = "Solana Version"
+authors = ["Solana Maintainers <maintainers@solana.com>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+serde = "1.0.110"
+serde_derive = "1.0.103"
+solana-sdk = { path = "../sdk", version = "1.2.0" }
+
+[lib]
+name = "solana_version"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/version/src/lib.rs
+++ b/version/src/lib.rs
@@ -1,0 +1,49 @@
+extern crate serde_derive;
+use serde_derive::{Deserialize, Serialize};
+use solana_sdk::sanitize::Sanitize;
+use std::fmt;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Version {
+    major: u16,
+    minor: u16,
+    patch: u16,
+    commit: Option<u32>, // first 4 bytes of the sha1 commit hash
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Self {
+            major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
+            minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
+            patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
+            commit: option_env!("CI_COMMIT")
+                .map(|sha1| u32::from_str_radix(&sha1[..8], 16).unwrap()),
+        }
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}.{}.{} {}",
+            self.major,
+            self.minor,
+            self.patch,
+            match self.commit {
+                None => "devbuild".to_string(),
+                Some(commit) => format!("{:08x}", commit),
+            }
+        )
+    }
+}
+
+impl Sanitize for Version {}
+
+#[macro_export]
+macro_rules! version {
+    () => {
+        &*format!("{}", $crate::Version::default())
+    };
+}

--- a/vote-signer/Cargo.toml
+++ b/vote-signer/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0.53"
 solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-metrics = { path = "../metrics", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 
 [lib]
 crate-type = ["lib"]

--- a/vote-signer/src/bin/main.rs
+++ b/vote-signer/src/bin/main.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .arg(
             Arg::with_name("port")
                 .long("port")

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -22,6 +22,7 @@ solana-logger = { path = "../logger", version = "1.2.0" }
 solana-metrics = { path = "../metrics", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.2.0" }
+solana-version = { path = "../version", version = "1.2.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.2.0" }
 
 [[bin]]

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -38,7 +38,7 @@ struct Config {
 fn get_config() -> Config {
     let matches = App::new(crate_name!())
         .about(crate_description!())
-        .version(solana_clap_utils::version!())
+        .version(solana_version::version!())
         .after_help("ADDITIONAL HELP:
         To receive a Slack, Discord and/or Telegram notification on sanity failure,
         define environment variables before running `solana-watchtower`:


### PR DESCRIPTION
With RPC disabled by default, it's too hard to monitor the software version that all validators are running.  
Motivating example: do we need to start panicking because a rolling update is about to enable and less then 2/3+ of the stake has updated?

 The first commit will be backported to v1.0/v1.1, the "Remove solana_clap_utils::version! macro" commit is too much churn and will only land on master.