### PR TITLE
Check slot cleaned up for RPC blockstore/slot queries

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,6 +40,7 @@ mod result;
 pub mod retransmit_stage;
 pub mod rewards_recorder_service;
 pub mod rpc;
+pub mod rpc_error;
 pub mod rpc_pubsub;
 pub mod rpc_pubsub_service;
 pub mod rpc_service;

--- a/core/src/rpc_error.rs
+++ b/core/src/rpc_error.rs
@@ -1,0 +1,26 @@
+use jsonrpc_core::{Error, ErrorCode};
+use solana_sdk::clock::Slot;
+
+const JSON_RPC_SERVER_ERROR_0: i64 = -32000;
+
+pub enum RpcCustomError {
+    NonexistentClusterRoot { cluster_root: Slot, node_root: Slot },
+}
+
+impl From<RpcCustomError> for Error {
+    fn from(e: RpcCustomError) -> Self {
+        match e {
+            RpcCustomError::NonexistentClusterRoot {
+                cluster_root,
+                node_root,
+            } => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_0),
+                message: format!(
+                    "Cluster largest_confirmed_root {} does not exist on node. Node root: {}",
+                    cluster_root, node_root,
+                ),
+                data: None,
+            },
+        }
+    }
+}

--- a/core/src/rpc_error.rs
+++ b/core/src/rpc_error.rs
@@ -2,9 +2,17 @@ use jsonrpc_core::{Error, ErrorCode};
 use solana_sdk::clock::Slot;
 
 const JSON_RPC_SERVER_ERROR_0: i64 = -32000;
+const JSON_RPC_SERVER_ERROR_1: i64 = -32001;
 
 pub enum RpcCustomError {
-    NonexistentClusterRoot { cluster_root: Slot, node_root: Slot },
+    NonexistentClusterRoot {
+        cluster_root: Slot,
+        node_root: Slot,
+    },
+    BlockCleanedUp {
+        slot: Slot,
+        first_available_block: Slot,
+    },
 }
 
 impl From<RpcCustomError> for Error {
@@ -18,6 +26,17 @@ impl From<RpcCustomError> for Error {
                 message: format!(
                     "Cluster largest_confirmed_root {} does not exist on node. Node root: {}",
                     cluster_root, node_root,
+                ),
+                data: None,
+            },
+            RpcCustomError::BlockCleanedUp {
+                slot,
+                first_available_block,
+            } => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_1),
+                message: format!(
+                    "Block {} cleaned up, does not exist on node. First available block: {}",
+                    slot, first_available_block,
                 ),
                 data: None,
             },


### PR DESCRIPTION
#### Problem
Since #7993 , the rpc service can distinguish slots that are missing because they were purged. While `getFirstAvailableBlock` endpoint now exists, rpc endpoints querying blockstore for specific blocks should return a result that distinguishes between purged and missing blocks to save clients an extra call.

#### Summary of Changes
For `getConfirmedBlock` and `getBlockTime`, if blockstore query errors, check if slot cleaned up, and return RpcCustomError as necessary.
Also moves rpc custom server errors to separate module, to make it easier to extend in the future.

Fixes #8000
