### PR TITLE
Fix up a couple cli commands that fail when a node is in the `--wait-for-supermajority` state

### DIFF
--- a/clap-utils/src/commitment.rs
+++ b/clap-utils/src/commitment.rs
@@ -8,11 +8,15 @@ pub const COMMITMENT_ARG: ArgConstant<'static> = ArgConstant {
 };
 
 pub fn commitment_arg<'a, 'b>() -> Arg<'a, 'b> {
+    commitment_arg_with_default("recent")
+}
+
+pub fn commitment_arg_with_default<'a, 'b>(default_value: &'static str) -> Arg<'a, 'b> {
     Arg::with_name(COMMITMENT_ARG.name)
         .long(COMMITMENT_ARG.long)
         .takes_value(true)
         .possible_values(&["recent", "root", "max"])
-        .default_value("recent")
+        .default_value(default_value)
         .value_name("COMMITMENT_LEVEL")
         .help(COMMITMENT_ARG.help)
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -16,9 +16,12 @@ use num_traits::FromPrimitive;
 use serde_json::{self, json, Value};
 use solana_budget_program::budget_instruction::{self, BudgetError};
 use solana_clap_utils::{
-    input_parsers::*, input_validators::*, keypair::signer_from_path, offline::SIGN_ONLY_ARG,
-    ArgConstant,
     commitment::{commitment_arg_with_default, COMMITMENT_ARG},
+    input_parsers::*,
+    input_validators::*,
+    keypair::signer_from_path,
+    offline::SIGN_ONLY_ARG,
+    ArgConstant,
 };
 use solana_client::{
     client_error::{ClientErrorKind, Result as ClientResult},
@@ -1195,7 +1198,9 @@ fn process_balance(
     } else {
         config.pubkey()?
     };
-    let balance = rpc_client.get_balance_with_commitment(&pubkey, commitment_config)?.value;
+    let balance = rpc_client
+        .get_balance_with_commitment(&pubkey, commitment_config)?
+        .value;
     Ok(build_balance_message(balance, use_lamports_unit, true))
 }
 
@@ -2137,7 +2142,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             pubkey,
             use_lamports_unit,
             commitment_config,
-        } => process_balance(&rpc_client, config, &pubkey, *use_lamports_unit, *commitment_config),
+        } => process_balance(
+            &rpc_client,
+            config,
+            &pubkey,
+            *use_lamports_unit,
+            *commitment_config,
+        ),
         // Cancel a contract by contract Pubkey
         CliCommand::Cancel(pubkey) => process_cancel(&rpc_client, config, &pubkey),
         // Confirm the last client transaction by signature
@@ -2801,7 +2812,7 @@ mod tests {
                 command: CliCommand::Balance {
                     pubkey: Some(keypair.pubkey()),
                     use_lamports_unit: false,
-                        commitment_config: CommitmentConfig::default(),
+                    commitment_config: CommitmentConfig::default(),
                 },
                 signers: vec![],
             }
@@ -2817,8 +2828,8 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey: Some(keypair.pubkey()),
-                    use_lamports_unit: true
-                        commitment_config: CommitmentConfig::default(),
+                    use_lamports_unit: true,
+                    commitment_config: CommitmentConfig::default(),
                 },
                 signers: vec![],
             }
@@ -2832,8 +2843,8 @@ mod tests {
             CliCommandInfo {
                 command: CliCommand::Balance {
                     pubkey: None,
-                    use_lamports_unit: true
-                        commitment_config: CommitmentConfig::default(),
+                    use_lamports_unit: true,
+                    commitment_config: CommitmentConfig::default(),
                 },
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
             }
@@ -3303,14 +3314,14 @@ mod tests {
         config.command = CliCommand::Balance {
             pubkey: None,
             use_lamports_unit: true,
-                        commitment_config: CommitmentConfig::default(),
+            commitment_config: CommitmentConfig::default(),
         };
         assert_eq!(process_command(&config).unwrap(), "50 lamports");
 
         config.command = CliCommand::Balance {
             pubkey: None,
             use_lamports_unit: false,
-                        commitment_config: CommitmentConfig::default(),
+            commitment_config: CommitmentConfig::default(),
         };
         assert_eq!(process_command(&config).unwrap(), "0.00000005 SOL");
 
@@ -3544,7 +3555,7 @@ mod tests {
         config.command = CliCommand::Balance {
             pubkey: None,
             use_lamports_unit: false,
-                        commitment_config: CommitmentConfig::default(),
+            commitment_config: CommitmentConfig::default(),
         };
         assert!(process_command(&config).is_err());
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -671,7 +671,7 @@ pub fn process_show_block_production(
     slot_limit: Option<u64>,
 ) -> ProcessResult {
     let epoch_schedule = rpc_client.get_epoch_schedule()?;
-    let epoch_info = rpc_client.get_epoch_info_with_commitment(CommitmentConfig::max())?;
+    let epoch_info = rpc_client.get_epoch_info_with_commitment(CommitmentConfig::root())?;
 
     let epoch = epoch.unwrap_or(epoch_info.epoch);
     if epoch > epoch_info.epoch {
@@ -730,7 +730,7 @@ pub fn process_show_block_production(
 
     progress_bar.set_message(&format!("Fetching leader schedule for epoch {}...", epoch));
     let leader_schedule = rpc_client
-        .get_leader_schedule_with_commitment(Some(start_slot), CommitmentConfig::max())?;
+        .get_leader_schedule_with_commitment(Some(start_slot), CommitmentConfig::root())?;
     if leader_schedule.is_none() {
         return Err(format!("Unable to fetch leader schedule for slot {}", start_slot).into());
     }


### PR DESCRIPTION
While testnet.solana.com is waiting for 80%:
```
$ solana balance
Error: rpc request error: RPC Error response: {"code":-32000,"message":"Cluster largest_confirmed_root 11972501 does not exist on node. Node root: 11972503"}
$ solana block-production
Error: rpc request error: RPC Error response: {"code":-32000,"message":"Cluster largest_confirmed_root 11972501 does not exist on node. Node root: 11972503"}
```

Fix this up by adding a `--commitment` arg to `solana balance`, and reworking `solana block-production` to use root commitment instead of max (which is totally fine for this command)

