### PR TITLE
fix docs makefile

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,10 @@ Install dependencies, build, and test the docs:
 
 ```bash
 $ brew install coreutils
-$ cargo install svgbob_cli
 $ brew install mscgen
-$ brew install mdbook
+$ cargo install svgbob_cli
+$ cargo install mdbook-linkcheck
+$ cargo install mdbook
 $ ./build.sh
 ```
 

--- a/docs/makefile
+++ b/docs/makefile
@@ -8,7 +8,6 @@ TARGET=html/index.html
 TEST_STAMP=src/tests.ok
 
 all: $(TARGET)
-	./set-solana-release-tag.sh
 
 svg: $(SVG_IMGS)
 
@@ -16,6 +15,7 @@ test: $(TEST_STAMP)
 
 open: $(TEST_STAMP)
 	mdbook build --open
+	./set-solana-release-tag.sh
 
 watch: $(SVG_IMGS)
 	mdbook watch
@@ -44,6 +44,7 @@ $(TEST_STAMP): $(TARGET)
 
 $(TARGET): $(SVG_IMGS) $(MD_SRCS)
 	mdbook build
+	./set-solana-release-tag.sh
 
 clean:
 	rm -f $(SVG_IMGS) src/tests.ok


### PR DESCRIPTION
#### Problem

Solana version not substituted in final rendered HTML files when issuing `make open`

#### Summary of Changes

- Do the replacement after building the HTML files.
- update the dependencies

Fixes #
