### PR TITLE
Fix unstable test after eager rent collection

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4147,6 +4147,11 @@ mod tests {
 
             ..GenesisConfig::default()
         }));
+
+        // enable lazy rent collection because this test depends on rent-due accounts
+        // not being eagerly-collected for exact rewards calculation
+        bank.lazy_rent_collection.store(true, Ordering::Relaxed);
+
         assert_eq!(bank.capitalization(), 42 * 1_000_000_000);
         assert_eq!(bank.rewards, None);
 


### PR DESCRIPTION
Sorry I've introduced some flakiness after #9527 

This is like this:
- https://buildkite.com/solana-labs/solana/builds/24223#935a4018-c8a5-48f6-bcfd-af2c13bb35da/397-1615
- https://buildkite.com/solana-labs/solana/builds/24213#0edbea23-c9c3-43ac-a6a7-fa0a6d7b57cd/77-3587

FYI: @sakridge 