### PR TITLE
AVX2 runtime check

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -767,6 +767,15 @@ fn report_target_features() {
                 process::exit(1);
             }
         }
+        #[target_feature(enable = "avx2")]
+        {
+            if is_x86_feature_detected!("avx2") {
+                info!("AVX2 detected");
+            } else {
+                error!("Your machine does not have AVX2 support, please rebuild from source on your machine");
+                process::exit(1);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem

Our release binaries are built with AVX2 support, but we only check that AVX is available at runtime.  This has lead to some confusing from TdS new comers, as the validator panics with a fairly technical message

#### Summary of Changes

Extend the AVX runtime check to AVX2