### PR TITLE
Add Vote PubSub endpoint for live gossip votes.

### DIFF
--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -1,6 +1,6 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
 
-use crate::rpc_subscriptions::{RpcSubscriptions, SlotInfo};
+use crate::rpc_subscriptions::{RpcSubscriptions, RpcVote, SlotInfo};
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::{typed::Subscriber, Session, SubscriptionId};
@@ -12,7 +12,6 @@ use solana_ledger::{bank_forks::BankForks, blockstore::Blockstore};
 use solana_sdk::{
     clock::Slot, commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature,
 };
-use solana_vote_program::vote_state::Vote;
 #[cfg(test)]
 use std::sync::RwLock;
 use std::{
@@ -117,7 +116,7 @@ pub trait RpcSolPubSub {
 
     // Get notification when vote is encountered
     #[pubsub(subscription = "voteNotification", subscribe, name = "voteSubscribe")]
-    fn vote_subscribe(&self, meta: Self::Metadata, subscriber: Subscriber<Vote>);
+    fn vote_subscribe(&self, meta: Self::Metadata, subscriber: Subscriber<RpcVote>);
 
     // Unsubscribe from vote notification subscription.
     #[pubsub(
@@ -308,7 +307,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         }
     }
 
-    fn vote_subscribe(&self, _meta: Self::Metadata, subscriber: Subscriber<Vote>) {
+    fn vote_subscribe(&self, _meta: Self::Metadata, subscriber: Subscriber<RpcVote>) {
         info!("vote_subscribe");
         let id = self.uid.fetch_add(1, atomic::Ordering::Relaxed);
         let sub_id = SubscriptionId::Number(id as u64);
@@ -947,7 +946,7 @@ mod tests {
         let (response, _) = robust_poll_or_panic(receiver);
         assert_eq!(
             response,
-            r#"{"jsonrpc":"2.0","method":"voteNotification","params":{"result":{"hash":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"slots":[1,2],"timestamp":null},"subscription":0}}"#
+            r#"{"jsonrpc":"2.0","method":"voteNotification","params":{"result":{"hash":"11111111111111111111111111111111","slots":[1,2],"timestamp":null},"subscription":0}}"#
         );
     }
 

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -8,6 +8,7 @@ use crate::{
     cluster_info_vote_listener::{ClusterInfoVoteListener, VoteTracker},
     fetch_stage::FetchStage,
     poh_recorder::{PohRecorder, WorkingBankEntry},
+    rpc_subscriptions::RpcSubscriptions,
     sigverify::TransactionSigVerifier,
     sigverify_stage::SigVerifyStage,
 };
@@ -43,6 +44,7 @@ impl Tpu {
         transactions_sockets: Vec<UdpSocket>,
         tpu_forwards_sockets: Vec<UdpSocket>,
         broadcast_sockets: Vec<UdpSocket>,
+        subscriptions: &Arc<RpcSubscriptions>,
         transaction_status_sender: Option<TransactionStatusSender>,
         blockstore: &Arc<Blockstore>,
         broadcast_type: &BroadcastStageType,
@@ -74,6 +76,7 @@ impl Tpu {
             &poh_recorder,
             vote_tracker,
             bank_forks,
+            subscriptions.clone(),
         );
 
         let banking_stage = BankingStage::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -455,6 +455,7 @@ impl Validator {
             node.sockets.tpu,
             node.sockets.tpu_forwards,
             node.sockets.broadcast,
+            &subscriptions,
             transaction_status_sender,
             &blockstore,
             &config.broadcast_stage_type,

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1482,7 +1482,7 @@ None
 The result is the latest vote, containing its hash, a list of voted slots, and an optional timestamp.
 
 ```bash
-{"jsonrpc": "2.0","method": "voteNotification", "params": {"result": {"hash": [102,205,10,23,101,60,158,240,47,137,212,157,223,132,197,111,73,100,235,194,114,113,245,111,171,117,228,36,207,203,10,70], "slots": [93], "timestamp": null}, "subscription": 0}}
+{"jsonrpc":"2.0","method":"voteNotification","params":{"result":{"hash":"8Rshv2oMkPu5E4opXTRyuyBeZBqQ4S477VG26wUTFxUM","slots":[1,2],"timestamp":null},"subscription":0}}
 ```
 
 ### voteUnsubscribe

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1452,3 +1452,57 @@ Unsubscribe from root notifications
 // Result
 {"jsonrpc": "2.0","result": true,"id": 1}
 ```
+
+### voteSubscribe
+
+Subscribe to receive notification anytime a new vote is observed in gossip.
+These votes are pre-consensus therefore there is no guarantee these votes will
+enter the ledger.
+
+#### Parameters:
+
+None
+
+#### Results:
+
+* `integer` - subscription id \(needed to unsubscribe\)
+
+#### Example:
+
+```bash
+// Request
+{"jsonrpc":"2.0", "id":1, "method":"voteSubscribe"}
+
+// Result
+{"jsonrpc": "2.0","result": 0,"id": 1}
+```
+
+#### Notification Format:
+
+The result is the latest vote, containing its hash, a list of voted slots, and an optional timestamp.
+
+```bash
+{"jsonrpc": "2.0","method": "voteNotification", "params": {"result": {"hash": [102,205,10,23,101,60,158,240,47,137,212,157,223,132,197,111,73,100,235,194,114,113,245,111,171,117,228,36,207,203,10,70], "slots": [93], "timestamp": null}, "subscription": 0}}
+```
+
+### voteUnsubscribe
+
+Unsubscribe from vote notifications
+
+#### Parameters:
+
+* `<integer>` - subscription id to cancel
+
+#### Results:
+
+* `<bool>` - unsubscribe success message
+
+#### Example:
+
+```bash
+// Request
+{"jsonrpc":"2.0", "id":1, "method":"voteUnsubscribe", "params":[0]}
+
+// Result
+{"jsonrpc": "2.0","result": true,"id": 1}
+```


### PR DESCRIPTION
#### Problem

Current RPC methods don't provide fine grained details about votes.

#### Summary of Changes

* Adds a new PubSub RPC endpoint to subscribe to votes.
* Votes are published as soon as they are verified in `cluster_info_vote_listener.rs`.
* Subscriptions made available in `cluster_info_vote_listener.rs` to enable the above.
* Pending updated tests.
