### PR TITLE
Panic if no fee-payer found via Message::new()

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -169,7 +169,7 @@ mod tests {
         assert_eq!(calculate_fee(&fee_calculator, &[]), 0);
 
         // No signatures, no fee.
-        let message = Message::new_with_payer(&[], None);
+        let message = Message::default();
         assert_eq!(calculate_fee(&fee_calculator, &[&message, &message]), 0);
 
         // One message w/ one signature, a fee.

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -169,7 +169,7 @@ mod tests {
         assert_eq!(calculate_fee(&fee_calculator, &[]), 0);
 
         // No signatures, no fee.
-        let message = Message::new(&[]);
+        let message = Message::new_with_payer(&[], None);
         assert_eq!(calculate_fee(&fee_calculator, &[&message, &message]), 0);
 
         // One message w/ one signature, a fee.

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -685,7 +685,11 @@ mod tests {
     fn test_verify_tick_hash_count() {
         let hashes_per_tick = 10;
         let keypairs: Vec<&Keypair> = Vec::new();
-        let tx: Transaction = Transaction::new(&keypairs, Message::new(&[]), Hash::default());
+        let tx: Transaction = Transaction::new(
+            &keypairs,
+            Message::new_with_payer(&[], None),
+            Hash::default(),
+        );
         let tx_entry = Entry::new(&Hash::default(), 1, vec![tx]);
         let full_tick_entry = Entry::new_tick(hashes_per_tick, &Hash::default());
         let partial_tick_entry = Entry::new_tick(hashes_per_tick - 1, &Hash::default());

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -479,7 +479,6 @@ mod tests {
     use solana_budget_program::budget_instruction;
     use solana_sdk::{
         hash::{hash, Hash},
-        message::Message,
         signature::{Keypair, Signer},
         system_transaction,
         transaction::Transaction,
@@ -684,12 +683,7 @@ mod tests {
     #[test]
     fn test_verify_tick_hash_count() {
         let hashes_per_tick = 10;
-        let keypairs: Vec<&Keypair> = Vec::new();
-        let tx: Transaction = Transaction::new(
-            &keypairs,
-            Message::new_with_payer(&[], None),
-            Hash::default(),
-        );
+        let tx = Transaction::default();
         let tx_entry = Entry::new(&Hash::default(), 1, vec![tx]);
         let full_tick_entry = Entry::new_tick(hashes_per_tick, &Hash::default());
         let partial_tick_entry = Entry::new_tick(hashes_per_tick - 1, &Hash::default());

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -689,7 +689,7 @@ fn call<'a>(
     // Translate data passed from the VM
 
     let instruction = syscall.translate_instruction(instruction_addr, ro_regions)?;
-    let message = Message::new(&[instruction]);
+    let message = Message::new_with_payer(&[instruction], None);
     let callee_program_id_index = message.instructions[0].program_id_index as usize;
     let callee_program_id = message.account_keys[callee_program_id_index];
     let caller_program_id = invoke_context

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5455,12 +5455,8 @@ mod tests {
         let mut transfer_instruction =
             system_instruction::transfer(&mint_keypair.pubkey(), &key.pubkey(), 0);
         transfer_instruction.accounts[0].is_signer = false;
-
-        let tx = Transaction::new_signed_instructions(
-            &Vec::<&Keypair>::new(),
-            &[transfer_instruction],
-            bank.last_blockhash(),
-        );
+        let message = Message::new_with_payer(&[transfer_instruction], None);
+        let tx = Transaction::new(&[&Keypair::new(); 0], message, bank.last_blockhash());
 
         assert_eq!(
             bank.process_transaction(&tx),

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -611,8 +611,10 @@ mod tests {
                 AccountMeta::new(keys[not_owned_index], false),
                 AccountMeta::new(keys[owned_index], false),
             ];
-            let message =
-                Message::new(&[Instruction::new(program_ids[owned_index], &[0_u8], metas)]);
+            let message = Message::new_with_payer(
+                &[Instruction::new(program_ids[owned_index], &[0_u8], metas)],
+                None,
+            );
 
             // modify account owned by the program
             accounts[owned_index].borrow_mut().data[0] = (MAX_DEPTH + owned_index) as u8;
@@ -1437,11 +1439,12 @@ mod tests {
 
         // not owned account modified by the caller (before the invoke)
         accounts[0].borrow_mut().data[0] = 1;
-        let message = Message::new(&[Instruction::new(
+        let instruction = Instruction::new(
             callee_program_id,
             &MockInstruction::NoopSuccess,
             metas.clone(),
-        )]);
+        );
+        let message = Message::new_with_payer(&[instruction], None);
         assert_eq!(
             MessageProcessor::process_cross_program_instruction(
                 &message,
@@ -1469,8 +1472,8 @@ mod tests {
         ];
 
         for case in cases {
-            let message =
-                Message::new(&[Instruction::new(callee_program_id, &case.0, metas.clone())]);
+            let instruction = Instruction::new(callee_program_id, &case.0, metas.clone());
+            let message = Message::new_with_payer(&[instruction], None);
             assert_eq!(
                 MessageProcessor::process_cross_program_instruction(
                     &message,

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -93,6 +93,7 @@ mod tests {
         account_utils::State as AccountUtilsState,
         hash::Hash,
         instruction::InstructionError,
+        message::Message,
         nonce::{self, account::with_test_keyed_account, Account as NonceAccount, State},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
@@ -125,7 +126,8 @@ mod tests {
 
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
-        let tx = Transaction::new_signed_instructions(&[&Keypair::new(); 0], &[], Hash::default());
+        let message = Message::new_with_payer(&[], None);
+        let tx = Transaction::new(&[&Keypair::new(); 0], message, Hash::default());
         assert!(transaction_uses_durable_nonce(&tx).is_none());
     }
 

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -93,7 +93,6 @@ mod tests {
         account_utils::State as AccountUtilsState,
         hash::Hash,
         instruction::InstructionError,
-        message::Message,
         nonce::{self, account::with_test_keyed_account, Account as NonceAccount, State},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
@@ -126,9 +125,7 @@ mod tests {
 
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
-        let message = Message::new_with_payer(&[], None);
-        let tx = Transaction::new(&[&Keypair::new(); 0], message, Hash::default());
-        assert!(transaction_uses_durable_nonce(&tx).is_none());
+        assert!(transaction_uses_durable_nonce(&Transaction::default()).is_none());
     }
 
     #[test]

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn test_fee_calculator_calculate_fee() {
         // Default: no fee.
-        let message = Message::new_with_payer(&[], None);
+        let message = Message::default();
         assert_eq!(FeeCalculator::default().calculate_fee(&message), 0);
 
         // No signature, no fee.

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn test_fee_calculator_calculate_fee() {
         // Default: no fee.
-        let message = Message::new(&[]);
+        let message = Message::new_with_payer(&[], None);
         assert_eq!(FeeCalculator::default().calculate_fee(&message), 0);
 
         // No signature, no fee.

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -57,6 +57,18 @@ impl InstructionKeys {
     }
 }
 
+/// Return the pubkey of the first writable signer in the given set of instructions.
+fn find_writable_signer(instructions: &[Instruction]) -> Option<&Pubkey> {
+    for instruction in instructions {
+        for account in &instruction.accounts {
+            if account.is_signer && account.is_writable {
+                return Some(&account.pubkey);
+            }
+        }
+    }
+    None
+}
+
 /// Return pubkeys referenced by all instructions, with the ones needing signatures first. If the
 /// payer key is provided, it is always placed first in the list of signed keys. Read-only signed
 /// accounts are placed last in the set of signed accounts. Read-only unsigned accounts,
@@ -221,7 +233,8 @@ impl Message {
     }
 
     pub fn new(instructions: &[Instruction]) -> Self {
-        Self::new_with_payer(instructions, None)
+        let payer = find_writable_signer(instructions).expect("no suitable key for fee-payer");
+        Self::new_with_payer(instructions, Some(payer))
     }
 
     pub fn new_with_payer(instructions: &[Instruction], payer: Option<&Pubkey>) -> Self {
@@ -465,7 +478,7 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]);
-        let message = Message::new(&[ix]);
+        let message = Message::new_with_payer(&[ix], None);
         assert_eq!(message.header.num_required_signatures, 0);
 
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -155,7 +155,7 @@ pub struct MessageHeader {
     pub num_readonly_unsigned_accounts: u8,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Message {
     /// The message header, identifying signed and read-only `account_keys`

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -80,7 +80,7 @@ impl std::fmt::Display for TransactionError {
 }
 
 /// An atomic transaction
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Default, Eq, Clone, Serialize, Deserialize)]
 pub struct Transaction {
     /// A set of digital signatures of `account_keys`, `program_ids`, `recent_blockhash`, and `instructions`, signed by the first
     /// signatures.len() keys of account_keys

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -605,7 +605,7 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
 mod tests {
     use super::*;
     use solana_runtime::{bank::Bank, bank_client::BankClient};
-    use solana_sdk::{genesis_config::create_genesis_config};
+    use solana_sdk::genesis_config::create_genesis_config;
 
     #[test]
     fn test_process_distribute_tokens() {

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -605,7 +605,7 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
 mod tests {
     use super::*;
     use solana_runtime::{bank::Bank, bank_client::BankClient};
-    use solana_sdk::{genesis_config::create_genesis_config, transaction::Transaction};
+    use solana_sdk::{genesis_config::create_genesis_config};
 
     #[test]
     fn test_process_distribute_tokens() {
@@ -679,9 +679,7 @@ mod tests {
         let transaction_infos = vec![TransactionInfo {
             recipient: bob,
             amount: 1.0,
-            new_stake_account_address: None,
-            finalized_date: None,
-            transaction: Transaction::new_unsigned_instructions(&[]),
+            ..TransactionInfo::default()
         }];
         apply_previous_transactions(&mut allocations, &transaction_infos);
         assert_eq!(allocations.len(), 1);

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -1,7 +1,9 @@
 use chrono::prelude::*;
 use pickledb::{error::Error, PickleDb, PickleDbDumpPolicy};
 use serde::{Deserialize, Serialize};
-use solana_sdk::{hash::Hash, pubkey::Pubkey, signature::Signature, transaction::Transaction};
+use solana_sdk::{
+    hash::Hash, message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
+};
 use solana_transaction_status::TransactionStatus;
 use std::{cmp::Ordering, fs, io, path::Path};
 
@@ -25,7 +27,8 @@ struct SignedTransactionInfo {
 
 impl Default for TransactionInfo {
     fn default() -> Self {
-        let mut transaction = Transaction::new_unsigned_instructions(&[]);
+        let message = Message::new_with_payer(&[], None);
+        let mut transaction = Transaction::new_unsigned(message);
         transaction.signatures.push(Signature::default());
         Self {
             recipient: Pubkey::default(),

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -1,9 +1,7 @@
 use chrono::prelude::*;
 use pickledb::{error::Error, PickleDb, PickleDbDumpPolicy};
 use serde::{Deserialize, Serialize};
-use solana_sdk::{
-    hash::Hash, message::Message, pubkey::Pubkey, signature::Signature, transaction::Transaction,
-};
+use solana_sdk::{hash::Hash, pubkey::Pubkey, signature::Signature, transaction::Transaction};
 use solana_transaction_status::TransactionStatus;
 use std::{cmp::Ordering, fs, io, path::Path};
 
@@ -27,9 +25,10 @@ struct SignedTransactionInfo {
 
 impl Default for TransactionInfo {
     fn default() -> Self {
-        let message = Message::new_with_payer(&[], None);
-        let mut transaction = Transaction::new_unsigned(message);
-        transaction.signatures.push(Signature::default());
+        let transaction = Transaction {
+            signatures: vec![Signature::default()],
+            ..Transaction::default()
+        };
         Self {
             recipient: Pubkey::default(),
             amount: 0.0,


### PR DESCRIPTION
#### Problem

`Message::new(instructions)` means, "find a suitable fee-payer in the given instructions, unless none exists, in which case the transaction will be silently dropped by the cluster". Allowing the error to propagate to the server means more debugging time for no good reason.

#### Summary of Changes

* Simplify `Message::new(instructions)` to mean, "find a suitable fee-payer in the given instructions and immediately panic if none exists".

Where needed, `Message::new_with_payer(instructions, None)` implements the original behavior.

A simpler alternative to #9948. In this PR, `None` means "no fee-payer", whereas in that one, `None` meant "find a suitable fee-payer", which was problematic for cross-program invocation which has a legitimate use for fee-payer-free messages.
