### PR TITLE
Increase gossip rpc url timeout

### DIFF
--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .long("timeout")
                         .value_name("SECONDS")
                         .takes_value(true)
-                        .default_value("5")
+                        .default_value("15")
                         .help("Timeout in seconds"),
                 )
                 .setting(AppSettings::DisableVersion),


### PR DESCRIPTION
#### Problem

Sometimes 5 seconds is not long enough to get data from gossip due to throttling outbound gossip data.

#### Summary of Changes

Increase to 15 seconds wait for get-rpc-url.

Fixes #
