### PR TITLE
Add Ledger error codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4640,6 +4640,8 @@ dependencies = [
  "dialoguer",
  "hidapi",
  "log 0.4.8",
+ "num-derive 0.3.0",
+ "num-traits",
  "parking_lot 0.10.2",
  "semver",
  "solana-sdk",

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -14,6 +14,8 @@ console = "0.10.1"
 dialoguer = "0.6.2"
 hidapi = { version = "1.2.1", default-features = false }
 log = "0.4.8"
+num-derive = { version = "0.3" }
+num-traits = { version = "0.2" }
 parking_lot = "0.10"
 semver = "0.9"
 solana-sdk = { path = "../sdk", version = "1.2.0" }

--- a/remote-wallet/src/ledger_error.rs
+++ b/remote-wallet/src/ledger_error.rs
@@ -1,0 +1,86 @@
+use num_derive::FromPrimitive;
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone, FromPrimitive, PartialEq)]
+pub enum LedgerError {
+    #[error("Solana app not open on Ledger device")]
+    NoAppResponse = 0x6700,
+
+    #[error("Ledger sdk exception")]
+    SdkException = 0x6801,
+
+    #[error("Ledger invalid parameter")]
+    SdkInvalidParameter = 0x6802,
+
+    #[error("Ledger overflow")]
+    SdkExceptionOverflow = 0x6803,
+
+    #[error("Ledger security exception")]
+    SdkExceptionSecurity = 0x6804,
+
+    #[error("Ledger invalid crc")]
+    SdkInvalidCrc = 0x6805,
+
+    #[error("Ledger invalid checksum")]
+    SdkInvalidChecksum = 0x6806,
+
+    #[error("Ledger invalid counter")]
+    SdkInvalidCounter = 0x6807,
+
+    #[error("Ledger blind signing of messages not supported")]
+    SdkNotSupported = 0x6808,
+
+    #[error("Ledger invalid state")]
+    SdkInvalidState = 0x6809,
+
+    #[error("Ledger timeout")]
+    SdkTimeout = 0x6810,
+
+    #[error("Ledger PIC exception")]
+    SdkExceptionPIC = 0x6811,
+
+    #[error("Ledger app exit exception")]
+    SdkExceptionAppExit = 0x6812,
+
+    #[error("Ledger IO overflow exception")]
+    SdkExceptionIoOverflow = 0x6813,
+
+    #[error("Ledger IO header exception")]
+    SdkExceptionIoHeader = 0x6814,
+
+    #[error("Ledger IO state exception")]
+    SdkExceptionIoState = 0x6815,
+
+    #[error("Ledger IO reset exception")]
+    SdkExceptionIoReset = 0x6816,
+
+    #[error("Ledger CX port exception")]
+    SdkExceptionCxPort = 0x6817,
+
+    #[error("Ledger system exception")]
+    SdkExceptionSystem = 0x6818,
+
+    #[error("Ledger out of space")]
+    SdkNotEnoughSpace = 0x6819,
+
+    #[error("Ledger invalid counter")]
+    NoApduReceived = 0x6982,
+
+    #[error("Ledger operation rejected by the user")]
+    UserCancel = 0x6985,
+
+    #[error("Ledger received invalid Solana message")]
+    SolanaInvalidMessage = 0x6a80,
+
+    #[error("Solana summary finalization failed on Ledger device")]
+    SolanaSummaryFinalizeFailed = 0x6f00,
+
+    #[error("Solana summary update failed on Ledger device")]
+    SolanaSummaryUpdateFailed = 0x6f01,
+
+    #[error("Ledger received unimplemented instruction")]
+    UnimplementedInstruction = 0x6d00,
+
+    #[error("Ledger received invalid CLA")]
+    InvalidCla = 0x6e00,
+}

--- a/remote-wallet/src/ledger_error.rs
+++ b/remote-wallet/src/ledger_error.rs
@@ -18,7 +18,7 @@ pub enum LedgerError {
     #[error("Ledger security exception")]
     SdkExceptionSecurity = 0x6804,
 
-    #[error("Ledger invalid crc")]
+    #[error("Ledger invalid CRC")]
     SdkInvalidCrc = 0x6805,
 
     #[error("Ledger invalid checksum")]
@@ -27,7 +27,7 @@ pub enum LedgerError {
     #[error("Ledger invalid counter")]
     SdkInvalidCounter = 0x6807,
 
-    #[error("Ledger blind signing of messages not supported")]
+    #[error("Ledger operation not supported")]
     SdkNotSupported = 0x6808,
 
     #[error("Ledger invalid state")]

--- a/remote-wallet/src/lib.rs
+++ b/remote-wallet/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod ledger;
+pub mod ledger_error;
 pub mod remote_keypair;
 pub mod remote_wallet;

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -97,34 +97,53 @@ impl RemoteWalletManager {
         let devices = usb.device_list();
         let num_prev_devices = self.devices.read().len();
 
-        let detected_devices = devices
+        let (detected_devices, errors) = devices
             .filter(|&device_info| {
                 is_valid_hid_device(device_info.usage_page(), device_info.interface_number())
             })
-            .fold(Vec::new(), |mut v, device_info| {
-                if is_valid_ledger(device_info.vendor_id(), device_info.product_id()) {
-                    match usb.open_path(&device_info.path()) {
-                        Ok(device) => {
-                            let mut ledger = LedgerWallet::new(device);
-                            if let Ok(info) = ledger.read_device(&device_info) {
-                                ledger.pretty_path = info.get_pretty_path();
-                                let path = device_info.path().to_str().unwrap().to_string();
-                                trace!("Found device: {:?}", info);
-                                v.push(Device {
-                                    path,
-                                    info,
-                                    wallet_type: RemoteWalletType::Ledger(Arc::new(ledger)),
-                                })
+            .fold(
+                (Vec::new(), Vec::new()),
+                |(mut devices, mut errors), device_info| {
+                    if is_valid_ledger(device_info.vendor_id(), device_info.product_id()) {
+                        match usb.open_path(&device_info.path()) {
+                            Ok(device) => {
+                                let mut ledger = LedgerWallet::new(device);
+                                let result = ledger.read_device(&device_info);
+                                match result {
+                                    Ok(info) => {
+                                        ledger.pretty_path = info.get_pretty_path();
+                                        let path = device_info.path().to_str().unwrap().to_string();
+                                        trace!("Found device: {:?}", info);
+                                        devices.push(Device {
+                                            path,
+                                            info,
+                                            wallet_type: RemoteWalletType::Ledger(Arc::new(ledger)),
+                                        })
+                                    }
+                                    Err(err) => {
+                                        error!(
+                                            "Error connecting to ledger device to read info: {}",
+                                            e
+                                        );
+                                        errors.push(err)
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                error!("Error connecting to ledger device to read info: {}", e)
                             }
                         }
-                        Err(e) => error!("Error connecting to ledger device to read info: {}", e),
                     }
-                }
-                v
-            });
+                    (devices, errors)
+                },
+            );
 
         let num_curr_devices = detected_devices.len();
         *self.devices.write() = detected_devices;
+
+        if num_curr_devices == 0 && !errors.is_empty() {
+            return Err(errors[0].clone());
+        }
 
         Ok(num_curr_devices - num_prev_devices)
     }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -220,7 +220,7 @@ pub enum SignerError {
     #[error("no device found")]
     NoDeviceFound,
 
-    #[error("device protocol error: {0}")]
+    #[error("{0}")]
     Protocol(String),
 
     #[error("{0}")]


### PR DESCRIPTION
#### Problem
The ledger-solana-app throws a number of exception codes that aren't recognized by the solana ledger.rs module, and all get translated to `RemoteWalletError::Protocol("Unknown error")`.

#### Summary of Changes
- Add a LedgerError enum to map error codes to descriptive rust errors, and parse apdu status on read.
- Also fixup wallet_manager initialization to return a device error, if there is such, when no devices can be read successfully