### PR TITLE
Don't discard transaction record when blockhash not found

### DIFF
--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -127,9 +127,10 @@ pub fn update_finalized_transaction(
 ) -> Result<Option<usize>, Error> {
     if opt_transaction_status.is_none() {
         if !recent_blockhashes.contains(blockhash) {
-            eprintln!("Signature not found {} and blockhash expired", signature);
-            eprintln!("Discarding transaction record");
-            db.rem(&signature.to_string())?;
+            eprintln!("Signature not found {} and blockhash not found, likely expired", signature);
+            // Don't discard the transaction, because we are not certain the
+            // blockhash is expired. Instead, return None to signal that
+            // we don't need to wait for confirmations.
             return Ok(None);
         }
 
@@ -245,8 +246,11 @@ mod tests {
             None
         );
 
-        // Ensure TransactionInfo has been purged.
-        assert_eq!(db.get::<TransactionInfo>(&signature.to_string()), None);
+        // Ensure TransactionInfo has not been purged.
+        assert_eq!(
+            db.get::<TransactionInfo>(&signature.to_string()).unwrap(),
+            transaction_info
+        );
     }
 
     #[test]

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -127,7 +127,10 @@ pub fn update_finalized_transaction(
 ) -> Result<Option<usize>, Error> {
     if opt_transaction_status.is_none() {
         if !recent_blockhashes.contains(blockhash) {
-            eprintln!("Signature not found {} and blockhash not found, likely expired", signature);
+            eprintln!(
+                "Signature not found {} and blockhash not found, likely expired",
+                signature
+            );
             // Don't discard the transaction, because we are not certain the
             // blockhash is expired. Instead, return None to signal that
             // we don't need to wait for confirmations.


### PR DESCRIPTION
#### Problem

`solana-tokens` discards transaction records when it is convinced the transaction's blockhash has expired. Unfortunately, `get_recent_blockhashes()` only returns enough blockhashes to know when the leader will reject the current blockhash. It doesn't return enough to be certain the transaction isn't still in flight to validators.

#### Summary of Changes

Don't discard the transaction record. `solana-tokens` won't send a resigned transaction to that recipient until manually removing the record.