### PR TITLE
validator: Forge a confirmed root before halting for RPC inspection

### DIFF
--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -180,7 +180,6 @@ impl BlockCommitmentCache {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn set_get_largest_confirmed_root(&mut self, root: Slot) {
         self.largest_confirmed_root = root;
     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -304,6 +304,13 @@ impl Validator {
         );
 
         if config.dev_halt_at_slot.is_some() {
+            // Simulate a confirmed root to avoid RPC errors with CommitmentmentConfig::max() and
+            // to ensure RPC endpoints like getConfirmedBlock, which require a confirmed root, work
+            block_commitment_cache
+                .write()
+                .unwrap()
+                .set_get_largest_confirmed_root(bank_forks.read().unwrap().root());
+
             // Park with the RPC service running, ready for inspection!
             warn!("Validator halted");
             std::thread::park();


### PR DESCRIPTION
`solana block-production`, amongst others, didn't work when `--dev-halt-at-slot` is used to park a validator for RPC inspection due to the lack of a confirmed root (that is, all `CommitmentConfig::max()` RPC requests fail)
