### PR TITLE
Abort if the open fd limit cannot be increased

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -56,6 +56,7 @@ pub enum BlockstoreError {
     FsExtraError(#[from] fs_extra::error::Error),
     SlotCleanedUp,
     UnpackError(#[from] UnpackError),
+    UnableToSetOpenFileDescriptorLimit,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 


### PR DESCRIPTION
While we emit an error log when the fd limit can't be increased, the validator/ledger-tool still trucks on and will likely generate an unexpected failure sometime later in execution.  Better to fail fast and make the user deal with the issue up front.