### PR TITLE
Trigger RPC notifications after block commitment cache update

### DIFF
--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -1,7 +1,7 @@
 use crate::consensus::VOTE_THRESHOLD_SIZE;
 use solana_ledger::blockstore::Blockstore;
 use solana_measure::measure::Measure;
-use solana_metrics::inc_new_counter_info;
+use solana_metrics::datapoint_info;
 use solana_runtime::bank::Bank;
 use solana_sdk::clock::Slot;
 use solana_vote_program::{vote_state::VoteState, vote_state::MAX_LOCKOUT_HISTORY};
@@ -289,9 +289,13 @@ impl AggregateCommitmentService {
 
             std::mem::swap(&mut *w_block_commitment_cache, &mut new_block_commitment);
             aggregate_commitment_time.stop();
-            inc_new_counter_info!(
-                "aggregate-commitment-ms",
-                aggregate_commitment_time.as_ms() as usize
+            datapoint_info!(
+                "block-commitment-cache",
+                (
+                    "aggregate-commitment-ms",
+                    aggregate_commitment_time.as_ms() as i64,
+                    i64
+                )
             );
         }
     }

--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -180,7 +180,7 @@ impl BlockCommitmentCache {
         }
     }
 
-    pub(crate) fn set_get_largest_confirmed_root(&mut self, root: Slot) {
+    pub(crate) fn set_largest_confirmed_root(&mut self, root: Slot) {
         self.largest_confirmed_root = root;
     }
 }

--- a/core/src/commitment.rs
+++ b/core/src/commitment.rs
@@ -123,7 +123,7 @@ impl BlockCommitmentCache {
         self.root
     }
 
-    fn highest_slot_with_confirmation(&self, confirmation_count: usize) -> Slot {
+    fn highest_slot_with_confirmation_count(&self, confirmation_count: usize) -> Slot {
         assert!(confirmation_count > 0 && confirmation_count <= MAX_LOCKOUT_HISTORY);
         for slot in (self.root()..self.slot()).rev() {
             if let Some(count) = self.get_confirmation_count(slot) {
@@ -135,8 +135,8 @@ impl BlockCommitmentCache {
         self.root
     }
 
-    pub fn highest_slot_with_single_confirmation(&self) -> Slot {
-        self.highest_slot_with_confirmation(1)
+    pub fn highest_confirmed_slot(&self) -> Slot {
+        self.highest_slot_with_confirmation_count(1)
     }
 
     pub fn get_confirmation_count(&self, slot: Slot) -> Option<usize> {
@@ -501,7 +501,7 @@ mod tests {
     }
 
     #[test]
-    fn test_highest_slot_with_single_confirmation() {
+    fn test_highest_confirmed_slot() {
         let bank = Arc::new(Bank::new(&GenesisConfig::default()));
         let bank_slot_5 = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 5));
         let ledger_path = get_tmp_ledger_path!();
@@ -536,10 +536,7 @@ mod tests {
             0,
         );
 
-        assert_eq!(
-            block_commitment_cache.highest_slot_with_single_confirmation(),
-            2
-        );
+        assert_eq!(block_commitment_cache.highest_confirmed_slot(), 2);
 
         // Build map with multiple slots at conf 1
         let mut block_commitment = HashMap::new();
@@ -555,10 +552,7 @@ mod tests {
             0,
         );
 
-        assert_eq!(
-            block_commitment_cache.highest_slot_with_single_confirmation(),
-            2
-        );
+        assert_eq!(block_commitment_cache.highest_confirmed_slot(), 2);
 
         // Build map with slot gaps
         let mut block_commitment = HashMap::new();
@@ -574,10 +568,7 @@ mod tests {
             0,
         );
 
-        assert_eq!(
-            block_commitment_cache.highest_slot_with_single_confirmation(),
-            3
-        );
+        assert_eq!(block_commitment_cache.highest_confirmed_slot(), 3);
 
         // Build map with no conf 1 slots, but one higher
         let mut block_commitment = HashMap::new();
@@ -593,10 +584,7 @@ mod tests {
             0,
         );
 
-        assert_eq!(
-            block_commitment_cache.highest_slot_with_single_confirmation(),
-            1
-        );
+        assert_eq!(block_commitment_cache.highest_confirmed_slot(), 1);
 
         // Build map with no conf 1 or higher slots
         let mut block_commitment = HashMap::new();
@@ -612,10 +600,7 @@ mod tests {
             0,
         );
 
-        assert_eq!(
-            block_commitment_cache.highest_slot_with_single_confirmation(),
-            0
-        );
+        assert_eq!(block_commitment_cache.highest_confirmed_slot(), 0);
     }
 
     #[test]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -176,8 +176,11 @@ impl ReplayStage {
         let mut tower = Tower::new(&my_pubkey, &vote_account, &bank_forks.read().unwrap());
 
         // Start the replay stage loop
-        let (lockouts_sender, commitment_service) =
-            AggregateCommitmentService::new(&exit, block_commitment_cache.clone());
+        let (lockouts_sender, commitment_service) = AggregateCommitmentService::new(
+            &exit,
+            block_commitment_cache.clone(),
+            subscriptions.clone(),
+        );
 
         #[allow(clippy::cognitive_complexity)]
         let t_replay = Builder::new()
@@ -353,8 +356,6 @@ impl ReplayStage {
 
                     // Vote on a fork
                     if let Some(ref vote_bank) = vote_bank {
-                        subscriptions
-                            .notify_subscribers(block_commitment_cache.read().unwrap().slot());
                         if let Some(votable_leader) =
                             leader_schedule_cache.slot_leader_at(vote_bank.slot(), Some(vote_bank))
                         {
@@ -2595,13 +2596,6 @@ pub(crate) mod tests {
 
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore),
-        ));
-        let (lockouts_sender, _) = AggregateCommitmentService::new(
-            &Arc::new(AtomicBool::new(false)),
-            block_commitment_cache.clone(),
-        );
 
         let leader_pubkey = Pubkey::new_rand();
         let leader_lamports = 3;
@@ -2621,6 +2615,18 @@ pub(crate) mod tests {
             &[arc_bank0.clone()],
             0,
         )));
+
+        let exit = Arc::new(AtomicBool::new(false));
+        let block_commitment_cache = Arc::new(RwLock::new(
+            BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
+        ));
+        let subscriptions = Arc::new(RpcSubscriptions::new(
+            &exit,
+            bank_forks.clone(),
+            block_commitment_cache.clone(),
+        ));
+        let (lockouts_sender, _) =
+            AggregateCommitmentService::new(&exit, block_commitment_cache.clone(), subscriptions);
 
         assert!(block_commitment_cache
             .read()

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1586,6 +1586,7 @@ pub mod tests {
             bank.clone(),
             blockstore.clone(),
             0,
+            0,
         )));
 
         // Add timestamp vote to blockstore
@@ -2635,6 +2636,7 @@ pub mod tests {
             42,
             bank_forks.read().unwrap().working_bank(),
             blockstore.clone(),
+            0,
             0,
         )));
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2822,7 +2822,7 @@ pub mod tests {
         block_commitment_cache
             .write()
             .unwrap()
-            .set_get_largest_confirmed_root(8);
+            .set_largest_confirmed_root(8);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getConfirmedBlocks","params":[0]}"#;
         let res = io.handle_request_sync(&req, meta.clone());
@@ -2878,7 +2878,7 @@ pub mod tests {
         block_commitment_cache
             .write()
             .unwrap()
-            .set_get_largest_confirmed_root(7);
+            .set_largest_confirmed_root(7);
 
         let slot_duration = slot_duration_from_slots_per_year(bank.slots_per_year());
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -87,6 +87,15 @@ impl JsonRpcRequestProcessor {
             let slot = r_bank_forks.root();
             debug!("RPC using node root: {:?}", slot);
             Ok(r_bank_forks.get(slot).cloned().unwrap())
+        } else if commitment.is_some() && commitment.unwrap().commitment == CommitmentLevel::Single
+        {
+            let slot = self
+                .block_commitment_cache
+                .read()
+                .unwrap()
+                .highest_slot_with_single_confirmation();
+            debug!("RPC using confirmed slot: {:?}", slot);
+            Ok(r_bank_forks.get(slot).cloned().unwrap())
         } else {
             let cluster_root = self
                 .block_commitment_cache

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -93,7 +93,7 @@ impl JsonRpcRequestProcessor {
                 .block_commitment_cache
                 .read()
                 .unwrap()
-                .highest_slot_with_single_confirmation();
+                .highest_confirmed_slot();
             debug!("RPC using confirmed slot: {:?}", slot);
             Ok(r_bank_forks.get(slot).cloned().unwrap())
         } else {

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -1,6 +1,6 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
 
-use crate::commitment::BlockCommitmentCache;
+use crate::commitment::{BlockCommitmentCache, CacheSlotInfo};
 use core::hash::Hash;
 use jsonrpc_core::futures::Future;
 use jsonrpc_pubsub::{
@@ -56,7 +56,7 @@ enum NotificationEntry {
     Slot(SlotInfo),
     Vote(Vote),
     Root(Slot),
-    Bank(Slot),
+    Bank(CacheSlotInfo),
 }
 
 impl std::fmt::Debug for NotificationEntry {
@@ -65,9 +65,11 @@ impl std::fmt::Debug for NotificationEntry {
             NotificationEntry::Root(root) => write!(f, "Root({})", root),
             NotificationEntry::Vote(vote) => write!(f, "Vote({:?})", vote),
             NotificationEntry::Slot(slot_info) => write!(f, "Slot({:?})", slot_info),
-            NotificationEntry::Bank(current_slot) => {
-                write!(f, "Bank({{current_slot: {:?}}})", current_slot)
-            }
+            NotificationEntry::Bank(cache_slot_info) => write!(
+                f,
+                "Bank({{current_slot: {:?}}})",
+                cache_slot_info.current_slot
+            ),
         }
     }
 }
@@ -142,7 +144,7 @@ fn check_commitment_and_notify<K, S, B, F, X>(
     subscriptions: &HashMap<K, HashMap<SubscriptionId, SubscriptionData<Response<S>>>>,
     hashmap_key: &K,
     bank_forks: &Arc<RwLock<BankForks>>,
-    block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
+    cache_slot_info: &CacheSlotInfo,
     bank_method: B,
     filter_results: F,
     notifier: &RpcNotifier,
@@ -154,13 +156,6 @@ where
     F: Fn(X, Slot) -> (Box<dyn Iterator<Item = S>>, Slot),
     X: Clone + Serialize + Default,
 {
-    let r_block_commitment_cache = block_commitment_cache.read().unwrap();
-    let current_slot = r_block_commitment_cache.slot();
-    let node_root = r_block_commitment_cache.root();
-    let largest_confirmed_root = r_block_commitment_cache.largest_confirmed_root();
-    let single_confirmation_slot = r_block_commitment_cache.highest_confirmed_slot();
-    drop(r_block_commitment_cache);
-
     let mut notified_set: HashSet<SubscriptionId> = HashSet::new();
     if let Some(hashmap) = subscriptions.get(hashmap_key) {
         for (
@@ -173,10 +168,10 @@ where
         ) in hashmap.iter()
         {
             let slot = match commitment.commitment {
-                CommitmentLevel::Max => largest_confirmed_root,
-                CommitmentLevel::Recent => current_slot,
-                CommitmentLevel::Root => node_root,
-                CommitmentLevel::Single => single_confirmation_slot,
+                CommitmentLevel::Max => cache_slot_info.largest_confirmed_root,
+                CommitmentLevel::Recent => cache_slot_info.current_slot,
+                CommitmentLevel::Root => cache_slot_info.node_root,
+                CommitmentLevel::Single => cache_slot_info.highest_confirmed_slot,
             };
             let results = {
                 let bank_forks = bank_forks.read().unwrap();
@@ -334,7 +329,6 @@ impl RpcSubscriptions {
                     notification_receiver,
                     _subscriptions,
                     _bank_forks,
-                    _block_commitment_cache,
                 );
             })
             .unwrap();
@@ -366,16 +360,16 @@ impl RpcSubscriptions {
     fn check_account(
         pubkey: &Pubkey,
         bank_forks: &Arc<RwLock<BankForks>>,
-        block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
         account_subscriptions: Arc<RpcAccountSubscriptions>,
         notifier: &RpcNotifier,
+        cache_slot_info: &CacheSlotInfo,
     ) {
         let subscriptions = account_subscriptions.read().unwrap();
         check_commitment_and_notify(
             &subscriptions,
             pubkey,
             bank_forks,
-            block_commitment_cache,
+            cache_slot_info,
             Bank::get_account_modified_slot,
             filter_account_result,
             notifier,
@@ -385,16 +379,16 @@ impl RpcSubscriptions {
     fn check_program(
         program_id: &Pubkey,
         bank_forks: &Arc<RwLock<BankForks>>,
-        block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
         program_subscriptions: Arc<RpcProgramSubscriptions>,
         notifier: &RpcNotifier,
+        cache_slot_info: &CacheSlotInfo,
     ) {
         let subscriptions = program_subscriptions.read().unwrap();
         check_commitment_and_notify(
             &subscriptions,
             program_id,
             bank_forks,
-            block_commitment_cache,
+            cache_slot_info,
             Bank::get_program_accounts_modified_since_parent,
             filter_program_results,
             notifier,
@@ -404,16 +398,16 @@ impl RpcSubscriptions {
     fn check_signature(
         signature: &Signature,
         bank_forks: &Arc<RwLock<BankForks>>,
-        block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
         signature_subscriptions: Arc<RpcSignatureSubscriptions>,
         notifier: &RpcNotifier,
+        cache_slot_info: &CacheSlotInfo,
     ) {
         let mut subscriptions = signature_subscriptions.write().unwrap();
         let notified_ids = check_commitment_and_notify(
             &subscriptions,
             signature,
             bank_forks,
-            block_commitment_cache,
+            cache_slot_info,
             Bank::get_signature_status_processed_since_parent,
             filter_signature_result,
             notifier,
@@ -525,8 +519,8 @@ impl RpcSubscriptions {
 
     /// Notify subscribers of changes to any accounts or new signatures since
     /// the bank's last checkpoint.
-    pub fn notify_subscribers(&self, current_slot: Slot) {
-        self.enqueue_notification(NotificationEntry::Bank(current_slot));
+    pub fn notify_subscribers(&self, cache_slot_info: CacheSlotInfo) {
+        self.enqueue_notification(NotificationEntry::Bank(cache_slot_info));
     }
 
     pub fn add_slot_subscription(&self, sub_id: SubscriptionId, subscriber: Subscriber<SlotInfo>) {
@@ -600,7 +594,6 @@ impl RpcSubscriptions {
         notification_receiver: Receiver<NotificationEntry>,
         subscriptions: Subscriptions,
         bank_forks: Arc<RwLock<BankForks>>,
-        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     ) {
         loop {
             if exit.load(Ordering::Relaxed) {
@@ -633,7 +626,7 @@ impl RpcSubscriptions {
                             notifier.notify(root, sink);
                         }
                     }
-                    NotificationEntry::Bank(_current_slot) => {
+                    NotificationEntry::Bank(cache_slot_info) => {
                         let pubkeys: Vec<_> = {
                             let subs = subscriptions.account_subscriptions.read().unwrap();
                             subs.keys().cloned().collect()
@@ -642,9 +635,9 @@ impl RpcSubscriptions {
                             Self::check_account(
                                 pubkey,
                                 &bank_forks,
-                                &block_commitment_cache,
                                 subscriptions.account_subscriptions.clone(),
                                 &notifier,
+                                &cache_slot_info,
                             );
                         }
 
@@ -656,9 +649,9 @@ impl RpcSubscriptions {
                             Self::check_program(
                                 program_id,
                                 &bank_forks,
-                                &block_commitment_cache,
                                 subscriptions.program_subscriptions.clone(),
                                 &notifier,
+                                &cache_slot_info,
                             );
                         }
 
@@ -670,9 +663,9 @@ impl RpcSubscriptions {
                             Self::check_signature(
                                 signature,
                                 &bank_forks,
-                                &block_commitment_cache,
                                 subscriptions.signature_subscriptions.clone(),
                                 &notifier,
+                                &cache_slot_info,
                             );
                         }
                     }
@@ -809,7 +802,9 @@ pub(crate) mod tests {
             .unwrap()
             .process_transaction(&tx)
             .unwrap();
-        subscriptions.notify_subscribers(1);
+        let mut cache_slot_info = CacheSlotInfo::default();
+        cache_slot_info.current_slot = 1;
+        subscriptions.notify_subscribers(cache_slot_info);
         let (response, _) = robust_poll_or_panic(transport_receiver);
         let expected = json!({
            "jsonrpc": "2.0",
@@ -894,7 +889,7 @@ pub(crate) mod tests {
             .unwrap()
             .contains_key(&solana_budget_program::id()));
 
-        subscriptions.notify_subscribers(0);
+        subscriptions.notify_subscribers(CacheSlotInfo::default());
         let (response, _) = robust_poll_or_panic(transport_receiver);
         let expected = json!({
            "jsonrpc": "2.0",
@@ -976,7 +971,7 @@ pub(crate) mod tests {
         block_commitment.entry(0).or_insert(cache0);
         block_commitment.entry(1).or_insert(cache1);
         let block_commitment_cache =
-            BlockCommitmentCache::new(block_commitment, 0, 10, bank1, blockstore, 0);
+            BlockCommitmentCache::new(block_commitment, 0, 10, bank1, blockstore, 0, 0);
 
         let exit = Arc::new(AtomicBool::new(false));
         let subscriptions = RpcSubscriptions::new(
@@ -1027,8 +1022,9 @@ pub(crate) mod tests {
             assert!(sig_subs.contains_key(&unprocessed_tx.signatures[0]));
             assert!(sig_subs.contains_key(&processed_tx.signatures[0]));
         }
-
-        subscriptions.notify_subscribers(1);
+        let mut cache_slot_info = CacheSlotInfo::default();
+        cache_slot_info.current_slot = 1;
+        subscriptions.notify_subscribers(cache_slot_info);
         let expected_res = RpcSignatureResult { err: None };
 
         struct Notification {

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -158,6 +158,7 @@ where
     let current_slot = r_block_commitment_cache.slot();
     let node_root = r_block_commitment_cache.root();
     let largest_confirmed_root = r_block_commitment_cache.largest_confirmed_root();
+    let single_confirmation_slot = r_block_commitment_cache.highest_slot_with_single_confirmation();
     drop(r_block_commitment_cache);
 
     let mut notified_set: HashSet<SubscriptionId> = HashSet::new();
@@ -175,6 +176,7 @@ where
                 CommitmentLevel::Max => largest_confirmed_root,
                 CommitmentLevel::Recent => current_slot,
                 CommitmentLevel::Root => node_root,
+                CommitmentLevel::Single => single_confirmation_slot,
             };
             let results = {
                 let bank_forks = bank_forks.read().unwrap();
@@ -443,6 +445,11 @@ impl RpcSubscriptions {
                 .largest_confirmed_root(),
             CommitmentLevel::Recent => self.block_commitment_cache.read().unwrap().slot(),
             CommitmentLevel::Root => self.block_commitment_cache.read().unwrap().root(),
+            CommitmentLevel::Single => self
+                .block_commitment_cache
+                .read()
+                .unwrap()
+                .highest_slot_with_single_confirmation(),
         };
         let last_notified_slot = if let Some((_account, slot)) = self
             .bank_forks

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -158,7 +158,7 @@ where
     let current_slot = r_block_commitment_cache.slot();
     let node_root = r_block_commitment_cache.root();
     let largest_confirmed_root = r_block_commitment_cache.largest_confirmed_root();
-    let single_confirmation_slot = r_block_commitment_cache.highest_slot_with_single_confirmation();
+    let single_confirmation_slot = r_block_commitment_cache.highest_confirmed_slot();
     drop(r_block_commitment_cache);
 
     let mut notified_set: HashSet<SubscriptionId> = HashSet::new();
@@ -449,7 +449,7 @@ impl RpcSubscriptions {
                 .block_commitment_cache
                 .read()
                 .unwrap()
-                .highest_slot_with_single_confirmation(),
+                .highest_confirmed_slot(),
         };
         let last_notified_slot = if let Some((_account, slot)) = self
             .bank_forks

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -309,7 +309,7 @@ impl Validator {
             block_commitment_cache
                 .write()
                 .unwrap()
-                .set_get_largest_confirmed_root(bank_forks.read().unwrap().root());
+                .set_largest_confirmed_root(bank_forks.read().unwrap().root());
 
             // Park with the RPC service running, ready for inspection!
             warn!("Validator halted");

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -98,7 +98,8 @@ Solana nodes choose which bank state to query based on a commitment requirement
 set by the client. Clients may specify either:
 * `{"commitment":"max"}` - the node will query the most recent bank confirmed by the cluster as having reached `MAX_LOCKOUT_HISTORY` confirmations
 * `{"commitment":"root"}` - the node will query the most recent bank having reached `MAX_LOCKOUT_HISTORY` confirmations on this node
-* `{"commitment":"recent"}` - the node will query its most recent bank state
+* `{"commitment":"single"}` - the node will query the most recent bank having reached 1 confirmation
+* `{"commitment":"recent"}` - the node will query its most recent bank
 
 The commitment parameter should be included as the last element in the `params` array:
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1164,25 +1164,11 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ### Subscription Websocket
 
-After connect to the RPC PubSub websocket at `ws://<ADDRESS>/`:
+After connecting to the RPC PubSub websocket at `ws://<ADDRESS>/`:
 
 * Submit subscription requests to the websocket using the methods below
 * Multiple subscriptions may be active at once
-* All subscriptions take an optional `confirmations` parameter, which defines
-
-  how many confirmed blocks the node should wait before sending a notification.
-
-  The greater the number, the more likely the notification is to represent
-
-  consensus across the cluster, and the less likely it is to be affected by
-
-  forking or rollbacks. If unspecified, the default value is 0; the node will
-
-  send a notification as soon as it witnesses the event. The maximum
-
-  `confirmations` wait length is the cluster's `MAX_LOCKOUT_HISTORY`, which
-
-  represents the economic finality of the chain.
+* Many subscriptions take the optional [`commitment` parameter](jsonrpc-api.md#configuring-state-commitment), defining how . For subscriptions, if commitment is unspecified, the default value is `recent`.
 
 ### accountSubscribe
 
@@ -1191,7 +1177,7 @@ Subscribe to an account to receive notifications when the lamports or data for a
 #### Parameters:
 
 * `<string>` - account Pubkey, as base-58 encoded string
-* `<u64>` - optional, number of confirmed blocks to wait before notification.
+* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
   Default: 0, Max: `MAX_LOCKOUT_HISTORY` \(greater integers rounded down\)
 
@@ -1246,7 +1232,7 @@ Subscribe to a program to receive notifications when the lamports or data for a 
 #### Parameters:
 
 * `<string>` - program\_id Pubkey, as base-58 encoded string
-* `<u64>` - optional, number of confirmed blocks to wait before notification.
+* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
   Default: 0, Max: `MAX_LOCKOUT_HISTORY` \(greater integers rounded down\)
 
@@ -1304,7 +1290,7 @@ Subscribe to a transaction signature to receive notification when the transactio
 #### Parameters:
 
 * `<string>` - Transaction Signature, as base-58 encoded string
-* `<integer>` - optional, number of confirmed blocks to wait before notification.
+* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
   Default: 0, Max: `MAX_LOCKOUT_HISTORY` \(greater integers rounded down\)
 

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -31,6 +31,12 @@ impl CommitmentConfig {
         }
     }
 
+    pub fn single() -> Self {
+        Self {
+            commitment: CommitmentLevel::Single,
+        }
+    }
+
     pub fn ok(self) -> Option<Self> {
         if self == Self::default() {
             None
@@ -46,4 +52,5 @@ pub enum CommitmentLevel {
     Max,
     Recent,
     Root,
+    Single,
 }


### PR DESCRIPTION
#### Problem
As discussed in #9138 , RPC bank notifications are typically at least one slot behind.
This is the order of events in ReplayStage:
1. Decide to vote on a bank
2. Async start notifying subscribers
3. Async update block commitment cache

Notifying subscribers uses the block commitment cache to determine which bank slots to query. Since notifications start first, this means they are typically using the previous block commitment cache.

Also, Break needs notification when a change slot has received one confirmation.

#### Summary of Changes
- Pass subscriptions into the AggregateCommitmentService and trigger Bank notifications as soon as aggregation is complete
- Add a commitment level for a single confirmation
