### PR TITLE
fix clock bankhash mismatch

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -597,10 +597,15 @@ impl Bank {
         old_account.as_ref().map(|a| a.lamports).unwrap_or(1)
     }
 
+    /// Unused conversion
+    pub fn get_unused_from_slot(rooted_slot: Slot, unused: u64) -> u64 {
+        (rooted_slot + (unused - 1)) / unused
+    }
+
     pub fn clock(&self) -> sysvar::clock::Clock {
         sysvar::clock::Clock {
             slot: self.slot,
-            unused: 0,
+            unused: Self::get_unused_from_slot(self.slot, self.unused),
             epoch: self.epoch_schedule.get_epoch(self.slot),
             leader_schedule_epoch: self.epoch_schedule.get_leader_schedule_epoch(self.slot),
             unix_timestamp: self.unix_timestamp(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7010,4 +7010,46 @@ mod tests {
         }
         info!("results: {:?}", results);
     }
+
+    #[test]
+    fn test_bank_hash_consistency() {
+        let mut genesis_config = GenesisConfig::new(
+            &[(
+                Pubkey::new(&[42; 32]),
+                Account::new(1_000_000_000_000, 0, &system_program::id()),
+            )],
+            &[],
+        );
+        genesis_config.creation_time = 0;
+        let mut bank = Arc::new(Bank::new(&genesis_config));
+        loop {
+            goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+            if bank.slot == 0 {
+                assert_eq!(
+                    bank.hash().to_string(),
+                    "7MKHH6P7J5aQNN29Cr6aZQbEpQcXe8KTgchd4Suk9NCG"
+                );
+            }
+            if bank.slot == 1 {
+                assert_eq!(
+                    bank.hash().to_string(),
+                    "CH6byTy6GEXyQk2EHpqfvw35Vi3ddxJA6QP6XMgtiqwe"
+                );
+            }
+            if bank.slot == 3 {
+                assert_eq!(
+                    bank.hash().to_string(),
+                    "4kUw6sn94XLCjh5dBhtJec5W6qbzSuTHfzvXKbXtJtc7"
+                );
+            }
+            if bank.slot == 4 {
+                assert_eq!(
+                    bank.hash().to_string(),
+                    "v6toDvZNfd2XWD3mNrZTBkyvji13PiBLeDDR5hfQLZ2"
+                );
+                break;
+            }
+            bank = Arc::new(new_from_parent(&bank));
+        }
+    }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7022,6 +7022,8 @@ mod tests {
         );
         genesis_config.creation_time = 0;
         let mut bank = Arc::new(Bank::new(&genesis_config));
+        // Check a few slots, cross an epoch boundary
+        assert_eq!(bank.get_slots_in_epoch(0), 32);
         loop {
             goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
             if bank.slot == 0 {
@@ -7030,22 +7032,22 @@ mod tests {
                     "7MKHH6P7J5aQNN29Cr6aZQbEpQcXe8KTgchd4Suk9NCG"
                 );
             }
-            if bank.slot == 1 {
+            if bank.slot == 32 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "CH6byTy6GEXyQk2EHpqfvw35Vi3ddxJA6QP6XMgtiqwe"
+                    "3AxuV6GGcoqRi6pksN6btNEmeJCTesLbjgA88QZt9a8Q"
                 );
             }
-            if bank.slot == 3 {
+            if bank.slot == 64 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "4kUw6sn94XLCjh5dBhtJec5W6qbzSuTHfzvXKbXtJtc7"
+                    "B32ZLAzeCW5FueeauiGYnujh8Efmxvpeac74W9JU68oB"
                 );
             }
-            if bank.slot == 4 {
+            if bank.slot == 128 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "v6toDvZNfd2XWD3mNrZTBkyvji13PiBLeDDR5hfQLZ2"
+                    "A2tCz2EqryRZ7tHpw9H2918RZLCbqnSGzRWUqbnnESGz"
                 );
                 break;
             }


### PR DESCRIPTION
#### Problem

Deprecating segment from the clock sysval broke bankhash

#### Summary of Changes

Continue to calculate the correct values

follow-up to: #9992 
