### PR TITLE
Add option to wait for a specific epoch length to bench-tps

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub multi_client: bool,
     pub use_move: bool,
     pub num_lamports_per_account: u64,
+    pub target_slots_per_epoch: u64,
 }
 
 impl Default for Config {
@@ -47,6 +48,7 @@ impl Default for Config {
             multi_client: true,
             use_move: false,
             num_lamports_per_account: NUM_LAMPORTS_PER_ACCOUNT_DEFAULT,
+            target_slots_per_epoch: 0,
         }
     }
 }
@@ -172,6 +174,15 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                     "Number of lamports per account.",
                 ),
         )
+        .arg(
+            Arg::with_name("target_slots_per_epoch")
+                .long("target-slots-per-epoch")
+                .value_name("SLOTS")
+                .takes_value(true)
+                .help(
+                    "Wait until epochs are this many slots long.",
+                ),
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -257,6 +268,13 @@ pub fn extract_args<'a>(matches: &ArgMatches<'a>) -> Config {
 
     if let Some(v) = matches.value_of("num_lamports_per_account") {
         args.num_lamports_per_account = v.to_string().parse().expect("can't parse lamports");
+    }
+
+    if let Some(t) = matches.value_of("target_slots_per_epoch") {
+        args.target_slots_per_epoch = t
+            .to_string()
+            .parse()
+            .expect("can't parse target slots per epoch");
     }
 
     args

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -5,10 +5,11 @@ use inflector::cases::titlecase::to_title_case;
 use serde::Serialize;
 use serde_json::{Map, Value};
 use solana_client::rpc_response::{
-    RpcAccountBalance, RpcEpochInfo, RpcKeyedAccount, RpcSupply, RpcVoteAccountInfo,
+    RpcAccountBalance, RpcKeyedAccount, RpcSupply, RpcVoteAccountInfo,
 };
 use solana_sdk::{
     clock::{self, Epoch, Slot, UnixTimestamp},
+    epoch_info::EpochInfo,
     native_token::lamports_to_sol,
     stake_history::StakeHistoryEntry,
 };
@@ -186,11 +187,11 @@ pub struct CliSlotStatus {
 #[serde(rename_all = "camelCase")]
 pub struct CliEpochInfo {
     #[serde(flatten)]
-    pub epoch_info: RpcEpochInfo,
+    pub epoch_info: EpochInfo,
 }
 
-impl From<RpcEpochInfo> for CliEpochInfo {
-    fn from(epoch_info: RpcEpochInfo) -> Self {
+impl From<EpochInfo> for CliEpochInfo {
+    fn from(epoch_info: EpochInfo) -> Self {
         Self { epoch_info }
     }
 }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -18,6 +18,7 @@ use solana_sdk::{
         MAX_HASH_AGE_IN_SECONDS,
     },
     commitment_config::CommitmentConfig,
+    epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     hash::Hash,
@@ -296,14 +297,14 @@ impl RpcClient {
             .map_err(|err| err.into_with_request(request))?
     }
 
-    pub fn get_epoch_info(&self) -> ClientResult<RpcEpochInfo> {
+    pub fn get_epoch_info(&self) -> ClientResult<EpochInfo> {
         self.get_epoch_info_with_commitment(CommitmentConfig::default())
     }
 
     pub fn get_epoch_info_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> ClientResult<RpcEpochInfo> {
+    ) -> ClientResult<EpochInfo> {
         self.send(RpcRequest::GetEpochInfo, json!([commitment_config]), 0)
     }
 

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -115,22 +115,6 @@ pub struct RpcContactInfo {
 pub type RpcLeaderSchedule = HashMap<String, Vec<usize>>;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcEpochInfo {
-    /// The current epoch
-    pub epoch: Epoch,
-
-    /// The current slot, relative to the start of the current epoch
-    pub slot_index: u64,
-
-    /// The number of slots in this epoch
-    pub slots_in_epoch: u64,
-
-    /// The absolute current slot
-    pub absolute_slot: Slot,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct RpcVersionInfo {
     /// The current version of solana-core

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -11,6 +11,7 @@ use solana_sdk::{
     client::{AsyncClient, Client, SyncClient},
     clock::MAX_PROCESSING_AGE,
     commitment_config::CommitmentConfig,
+    epoch_info::EpochInfo,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     hash::Hash,
     instruction::Instruction,
@@ -516,6 +517,10 @@ impl SyncClient for ThinClient {
                 )
             })?;
         Ok(slot)
+    }
+
+    fn get_epoch_info(&self) -> TransportResult<EpochInfo> {
+        self.rpc_client().get_epoch_info().map_err(|e| e.into())
     }
 
     fn get_transaction_count(&self) -> TransportResult<u64> {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -28,6 +28,7 @@ use solana_runtime::{accounts::AccountAddressFilter, bank::Bank};
 use solana_sdk::{
     clock::{Slot, UnixTimestamp},
     commitment_config::{CommitmentConfig, CommitmentLevel},
+    epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
     hash::Hash,
     inflation::Inflation,
@@ -744,7 +745,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         commitment: Option<CommitmentConfig>,
-    ) -> Result<RpcEpochInfo>;
+    ) -> Result<EpochInfo>;
 
     #[rpc(meta, name = "getBlockCommitment")]
     fn get_block_commitment(
@@ -1035,18 +1036,9 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         commitment: Option<CommitmentConfig>,
-    ) -> Result<RpcEpochInfo> {
+    ) -> Result<EpochInfo> {
         let bank = meta.request_processor.read().unwrap().bank(commitment)?;
-        let epoch_schedule = bank.epoch_schedule();
-
-        let slot = bank.slot();
-        let (epoch, slot_index) = epoch_schedule.get_epoch_and_slot_index(slot);
-        Ok(RpcEpochInfo {
-            epoch,
-            slot_index,
-            slots_in_epoch: epoch_schedule.get_slots_in_epoch(epoch),
-            absolute_slot: slot,
-        })
+        Ok(bank.get_epoch_info())
     }
 
     fn get_block_commitment(

--- a/ramp-tps/src/stake.rs
+++ b/ramp-tps/src/stake.rs
@@ -1,8 +1,9 @@
 use crate::utils;
 use log::*;
-use solana_client::{rpc_client::RpcClient, rpc_response::RpcEpochInfo};
+use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     clock::Epoch,
+    epoch_info::EpochInfo,
     genesis_config::GenesisConfig,
     stake_history::StakeHistoryEntry,
     sysvar::{
@@ -60,7 +61,7 @@ fn stake_history_entry(epoch: Epoch, rpc_client: &RpcClient) -> Option<StakeHist
 /// Wait until stake warms up and return the current epoch
 pub fn wait_for_warm_up(
     activation_epoch: Epoch,
-    mut epoch_info: RpcEpochInfo,
+    mut epoch_info: EpochInfo,
     rpc_client: &RpcClient,
     stake_config: &StakeConfig,
     genesis_config: &GenesisConfig,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -38,6 +38,7 @@ use solana_sdk::{
         Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, DEFAULT_TICKS_PER_SECOND,
         MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES, SECONDS_PER_DAY,
     },
+    epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     genesis_config::{GenesisConfig, OperatingMode},
@@ -2493,6 +2494,18 @@ impl Bank {
     ///
     pub fn get_epoch_and_slot_index(&self, slot: Slot) -> (Epoch, SlotIndex) {
         self.epoch_schedule.get_epoch_and_slot_index(slot)
+    }
+
+    pub fn get_epoch_info(&self) -> EpochInfo {
+        let absolute_slot = self.slot();
+        let (epoch, slot_index) = self.get_epoch_and_slot_index(absolute_slot);
+        let slots_in_epoch = self.get_slots_in_epoch(epoch);
+        EpochInfo {
+            epoch,
+            slot_index,
+            slots_in_epoch,
+            absolute_slot,
+        }
     }
 
     pub fn is_empty(&self) -> bool {

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -3,6 +3,7 @@ use solana_sdk::{
     account::Account,
     client::{AsyncClient, Client, SyncClient},
     commitment_config::CommitmentConfig,
+    epoch_info::EpochInfo,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     hash::Hash,
     instruction::Instruction,
@@ -240,6 +241,10 @@ impl SyncClient for BankClient {
                 "Unable to get new blockhash",
             )))
         }
+    }
+
+    fn get_epoch_info(&self) -> Result<EpochInfo> {
+        Ok(self.bank.get_epoch_info())
     }
 }
 

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -11,6 +11,7 @@ use crate::{
     account::Account,
     clock::Slot,
     commitment_config::CommitmentConfig,
+    epoch_info::EpochInfo,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     hash::Hash,
     instruction::Instruction,
@@ -105,6 +106,8 @@ pub trait SyncClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> Result<u64>;
+
+    fn get_epoch_info(&self) -> Result<EpochInfo>;
 
     /// Poll until the signature has been confirmed by at least `min_confirmed_blocks`
     fn poll_for_signature_confirmation(

--- a/sdk/src/epoch_info.rs
+++ b/sdk/src/epoch_info.rs
@@ -1,0 +1,17 @@
+use crate::clock::{Epoch, Slot};
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct EpochInfo {
+    /// The current epoch
+    pub epoch: Epoch,
+
+    /// The current slot, relative to the start of the current epoch
+    pub slot_index: u64,
+
+    /// The number of slots in this epoch
+    pub slots_in_epoch: u64,
+
+    /// The absolute current slot
+    pub absolute_slot: Slot,
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -7,6 +7,7 @@ pub mod bpf_loader;
 pub mod clock;
 pub mod commitment_config;
 pub mod entrypoint_native;
+pub mod epoch_info;
 pub mod epoch_schedule;
 pub mod fee_calculator;
 pub mod hash;


### PR DESCRIPTION
#### Problem

Bench-tps can start too soon causing forking when epochs are quite short and the network validators cannot recover.

#### Summary of Changes

Add an option to wait for a longer epoch length to start sending transactions.

Fixes #
