### PR TITLE
Optimize stale slot shrinking for previously cleaned roots

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -929,10 +929,11 @@ impl AccountsDB {
 
     pub fn process_stale_slot(&self) -> usize {
         let mut measure = Measure::start("stale_slot_shrink-ms");
-        let mut count = 0;
-        if let Some(slot) = self.next_shrink_slot() {
-            count = self.shrink_stale_slot(slot);
-        }
+        let count = if let Some(slot) = self.next_shrink_slot() {
+            self.shrink_stale_slot(slot)
+        } else {
+            0
+        };
         measure.stop();
         inc_new_counter_info!("stale_slot_shrink-ms", measure.as_ms() as usize);
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -909,9 +909,12 @@ impl AccountsDB {
     }
 
     pub fn process_stale_slot(&self) {
+        let mut measure = Measure::start("stale_slot_shrink-ms");
         if let Some(slot) = self.next_shrink_slot() {
             self.shrink_stale_slot(slot);
         }
+        measure.stop();
+        inc_new_counter_info!("stale_slot_shrink-ms", measure.as_ms() as usize);
     }
 
     pub fn shrink_all_stale_slots(&self) {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -542,13 +542,11 @@ impl AccountsDB {
     }
 
     fn reset_uncleaned_roots(&self) {
-        let previous_roots = {
-            let mut accounts_index = self.accounts_index.write().unwrap();
-            accounts_index.reset_uncleaned_roots()
-        };
-
-        let mut candidates = self.shrink_candidate_slots.lock().unwrap();
-        candidates.extend(previous_roots);
+        let previous_roots = self.accounts_index.write().unwrap().reset_uncleaned_roots();
+        self.shrink_candidate_slots
+            .lock()
+            .unwrap()
+            .extend(previous_roots);
     }
 
     fn inc_store_counts(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -911,7 +911,7 @@ impl AccountsDB {
     pub fn process_stale_slot(&self) {
         let mut measure = Measure::start("stale_slot_shrink-ms");
         if let Some(slot) = self.next_shrink_slot() {
-            self.shrink_stale_slot(slot);
+            //self.shrink_stale_slot(slot);
         }
         measure.stop();
         inc_new_counter_info!("stale_slot_shrink-ms", measure.as_ms() as usize);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -914,7 +914,7 @@ impl AccountsDB {
     // Infinitely returns rooted roots in cyclic order
     fn next_shrink_slot(&self) -> Option<Slot> {
         // hold a lock to keep reset_uncleaned_roots() from updating candidates;
-        // we might update in this fn it if it's empty
+        // we might update it in this fn if it's empty
         let mut candidates = self.shrink_candidate_slots.lock().unwrap();
         let next = candidates.pop();
 
@@ -3881,14 +3881,12 @@ pub mod tests {
         actual_slots.sort();
         assert_eq!(actual_slots, vec![0, 1, 2]);
 
-        let mut actual_slots = (0..6)
+        accounts.accounts_index.write().unwrap().roots.clear();
+        let mut actual_slots = (0..5)
             .map(|_| accounts.next_shrink_slot())
             .collect::<Vec<_>>();
         actual_slots.sort();
-        assert_eq!(
-            actual_slots,
-            vec![Some(0), Some(0), Some(1), Some(1), Some(2), Some(2)],
-        );
+        assert_eq!(actual_slots, vec![None, None, Some(0), Some(1), Some(2)],);
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -175,7 +175,6 @@ pub struct AccountStorageEntry {
     ///
     /// This is used as a rough estimate for slot shrinking. As such a relaxed
     /// use case, this value ARE NOT strictly synchronized with count_and_status!
-    #[serde(skip)]
     approx_store_count: AtomicUsize,
 }
 
@@ -186,6 +185,7 @@ impl Default for AccountStorageEntry {
             slot: 0,
             accounts: AppendVec::new_empty_map(0),
             count_and_status: RwLock::new((0, AccountStorageStatus::Available)),
+            approx_store_count: AtomicUsize::new(0),
         }
     }
 }
@@ -211,6 +211,7 @@ impl AccountStorageEntry {
             slot: 0,
             accounts: AppendVec::new_empty_map(accounts_current_len),
             count_and_status: RwLock::new((0, AccountStorageStatus::Available)),
+            approx_store_count: AtomicUsize::new(0),
         }
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -178,18 +178,6 @@ pub struct AccountStorageEntry {
     approx_store_count: AtomicUsize,
 }
 
-impl Default for AccountStorageEntry {
-    fn default() -> Self {
-        Self {
-            id: 0,
-            slot: 0,
-            accounts: AppendVec::new_empty_map(0),
-            count_and_status: RwLock::new((0, AccountStorageStatus::Available)),
-            approx_store_count: AtomicUsize::new(0),
-        }
-    }
-}
-
 impl AccountStorageEntry {
     pub fn new(path: &Path, slot: Slot, id: usize, file_size: u64) -> Self {
         let tail = AppendVec::new_relative_path(slot, id);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -168,6 +168,9 @@ pub struct AccountStorageEntry {
     /// status corresponding to the storage, lets us know that
     ///  the append_vec, once maxed out, then emptied, can be reclaimed
     count_and_status: RwLock<(usize, AccountStorageStatus)>,
+
+    #[serde(skip)]
+    store_count: AtomicUsize,
 }
 
 impl Default for AccountStorageEntry {
@@ -192,6 +195,7 @@ impl AccountStorageEntry {
             slot,
             accounts,
             count_and_status: RwLock::new((0, AccountStorageStatus::Available)),
+            store_count: AtomicUsize::new(0),
         }
     }
 
@@ -233,6 +237,10 @@ impl AccountStorageEntry {
         self.count_and_status.read().unwrap().0
     }
 
+    pub fn stored_count(&self) -> usize {
+        self.store_count.load(Ordering::Relaxed)
+    }
+
     pub fn has_accounts(&self) -> bool {
         self.count() > 0
     }
@@ -252,6 +260,7 @@ impl AccountStorageEntry {
     fn add_account(&self) {
         let mut count_and_status = self.count_and_status.write().unwrap();
         *count_and_status = (count_and_status.0 + 1, count_and_status.1);
+        self.store_count.fetch_add(1, Ordering::Relaxed);
     }
 
     fn try_available(&self) -> bool {
@@ -769,9 +778,17 @@ impl AccountsDB {
         );
     }
 
+    fn shrink_stale_slot(&self, slot: Slot) -> usize {
+        self.do_shrink_slot(slot, false)
+    }
+
+    fn shrink_slot_forced(&self, slot: Slot) {
+        self.do_shrink_slot(slot, true);
+    }
+
     // Reads all accounts in given slot's AppendVecs and filter only to alive,
-    // then create a minimum AppendVed filled with the alive.
-    fn shrink_stale_slot(&self, slot: Slot) {
+    // then create a minimum AppendVec filled with the alive.
+    fn do_shrink_slot(&self, slot: Slot, forced: bool) -> usize {
         trace!("shrink_stale_slot: slot: {}", slot);
 
         let mut stored_accounts = vec![];
@@ -779,8 +796,20 @@ impl AccountsDB {
             let storage = self.storage.read().unwrap();
             if let Some(stores) = storage.0.get(&slot) {
                 let mut alive_count = 0;
+                let mut stored_count = 0;
                 for store in stores.values() {
                     alive_count += store.count();
+                    stored_count += store.stored_count();
+                }
+                if (alive_count as f32 / stored_count as f32) >= 0.80 && !forced {
+                    trace!(
+                        "shrink_stale_slot: not enough space to shrink: {} / {}",
+                        alive_count,
+                        stored_count,
+                    );
+                    return 0;
+                }
+                for store in stores.values() {
                     let mut start = 0;
                     while let Some((account, next)) = store.accounts.get_account(start) {
                         stored_accounts.push((
@@ -793,14 +822,6 @@ impl AccountsDB {
                         ));
                         start = next;
                     }
-                }
-                if (alive_count as f32 / stored_accounts.len() as f32) >= 0.80 {
-                    trace!(
-                        "shrink_stale_slot: not enough space to shrink: {} / {}",
-                        alive_count,
-                        stored_accounts.len()
-                    );
-                    return;
                 }
             }
         }
@@ -853,7 +874,8 @@ impl AccountsDB {
             let mut hashes = Vec::with_capacity(alive_accounts.len());
             let mut write_versions = Vec::with_capacity(alive_accounts.len());
 
-            for (pubkey, account, account_hash, _size, _location, write_version) in alive_accounts {
+            for (pubkey, account, account_hash, _size, _location, write_version) in &alive_accounts
+            {
                 accounts.push((pubkey, account));
                 hashes.push(*account_hash);
                 write_versions.push(*write_version);
@@ -880,6 +902,8 @@ impl AccountsDB {
                 slot_storage.retain(|_key, store| store.count() > 0);
             }
         }
+
+        alive_accounts.len()
     }
 
     // Infinitely returns rooted roots in cyclic order
@@ -908,18 +932,21 @@ impl AccountsDB {
         storage.0.keys().cloned().collect()
     }
 
-    pub fn process_stale_slot(&self) {
+    pub fn process_stale_slot(&self) -> usize {
         let mut measure = Measure::start("stale_slot_shrink-ms");
+        let mut count = 0;
         if let Some(slot) = self.next_shrink_slot() {
-            //self.shrink_stale_slot(slot);
+            count = self.shrink_stale_slot(slot);
         }
         measure.stop();
         inc_new_counter_info!("stale_slot_shrink-ms", measure.as_ms() as usize);
+
+        count
     }
 
-    pub fn shrink_all_stale_slots(&self) {
+    pub fn shrink_all_slots(&self) {
         for slot in self.all_slots_in_storage() {
-            self.shrink_stale_slot(slot);
+            self.shrink_slot_forced(slot);
         }
     }
 
@@ -1885,9 +1912,11 @@ impl AccountsDB {
                         store.count_and_status.read().unwrap().0
                     );
                     store.count_and_status.write().unwrap().0 = *count;
+                    store.store_count.store(*count, Ordering::Relaxed);
                 } else {
                     trace!("id: {} clearing count", id);
                     store.count_and_status.write().unwrap().0 = 0;
+                    store.store_count.store(0, Ordering::Relaxed);
                 }
             }
         }
@@ -3732,14 +3761,14 @@ pub mod tests {
     }
 
     #[test]
-    fn test_shrink_stale_slots_none() {
+    fn test_shrink_slots_none() {
         let accounts = AccountsDB::new_single();
 
         for _ in 0..10 {
             accounts.process_stale_slot();
         }
 
-        accounts.shrink_all_stale_slots();
+        accounts.shrink_all_slots();
     }
 
     #[test]
@@ -3817,7 +3846,7 @@ pub mod tests {
             pubkey_count,
             accounts.all_account_count_in_append_vec(shrink_slot)
         );
-        accounts.shrink_all_stale_slots();
+        accounts.shrink_all_slots();
         assert_eq!(
             pubkey_count_after_shrink,
             accounts.all_account_count_in_append_vec(shrink_slot)
@@ -3835,7 +3864,7 @@ pub mod tests {
             .unwrap();
 
         // repeating should be no-op
-        accounts.shrink_all_stale_slots();
+        accounts.shrink_all_slots();
         assert_eq!(
             pubkey_count_after_shrink,
             accounts.all_account_count_in_append_vec(shrink_slot)
@@ -3881,7 +3910,7 @@ pub mod tests {
             pubkey_count,
             accounts.all_account_count_in_append_vec(shrink_slot)
         );
-        accounts.shrink_all_stale_slots();
+        accounts.shrink_all_slots();
         assert_eq!(
             pubkey_count,
             accounts.all_account_count_in_append_vec(shrink_slot)

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -230,7 +230,6 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
     pub fn add_root(&mut self, slot: Slot) {
         self.roots.insert(slot);
         self.uncleaned_roots.insert(slot);
-        self.previous_uncleaned_roots.insert(slot);
     }
     /// Remove the slot when the storage for the slot is freed
     /// Accounts no longer reference this slot.
@@ -243,6 +242,7 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
     pub fn reset_uncleaned_roots(&mut self) -> Vec<Slot> {
         let empty = HashSet::new();
         let new_previous = std::mem::replace(&mut self.uncleaned_roots, empty);
+        dbg!("{:?}", &new_previous);
         std::mem::replace(&mut self.previous_uncleaned_roots, new_previous)
             .into_iter()
             .collect()
@@ -370,10 +370,33 @@ mod tests {
     fn test_clean_and_unclean_slot() {
         let mut index = AccountsIndex::<bool>::default();
         assert_eq!(0, index.uncleaned_roots.len());
+        index.add_root(0);
         index.add_root(1);
-        assert_eq!(1, index.uncleaned_roots.len());
-        index.clean_dead_slot(1);
+        assert_eq!(2, index.uncleaned_roots.len());
+
+        assert_eq!(0, index.previous_uncleaned_roots.len());
+        index.reset_uncleaned_roots();
+        assert_eq!(2, index.roots.len());
         assert_eq!(0, index.uncleaned_roots.len());
+        assert_eq!(2, index.previous_uncleaned_roots.len());
+
+        index.add_root(2);
+        index.add_root(3);
+        assert_eq!(4, index.roots.len());
+        assert_eq!(2, index.uncleaned_roots.len());
+        assert_eq!(2, index.previous_uncleaned_roots.len());
+
+        index.clean_dead_slot(1);
+        assert_eq!(3, index.roots.len());
+        assert_eq!(2, index.uncleaned_roots.len());
+        //eprintln!("{:?}", &index.previous_uncleaned_roots);
+        assert_eq!(1, index.previous_uncleaned_roots.len());
+
+        index.clean_dead_slot(2);
+        assert_eq!(2, index.roots.len());
+        assert_eq!(1, index.uncleaned_roots.len());
+        //eprintln!("{:?}", &index.previous_uncleaned_roots);
+        assert_eq!(1, index.previous_uncleaned_roots.len());
     }
 
     #[test]

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -239,12 +239,10 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
         self.previous_uncleaned_roots.remove(&slot);
     }
 
-    pub fn reset_uncleaned_roots(&mut self) -> Vec<Slot> {
+    pub fn reset_uncleaned_roots(&mut self) -> HashSet<Slot> {
         let empty = HashSet::new();
         let new_previous = std::mem::replace(&mut self.uncleaned_roots, empty);
         std::mem::replace(&mut self.previous_uncleaned_roots, new_previous)
-            .into_iter()
-            .collect()
     }
 }
 

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -19,6 +19,7 @@ pub struct AccountsIndex<T> {
 
     pub roots: HashSet<Slot>,
     pub uncleaned_roots: HashSet<Slot>,
+    pub previous_uncleaned_roots: HashSet<Slot>,
 }
 
 impl<'a, T: 'a + Clone> AccountsIndex<T> {
@@ -229,12 +230,22 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
     pub fn add_root(&mut self, slot: Slot) {
         self.roots.insert(slot);
         self.uncleaned_roots.insert(slot);
+        self.previous_uncleaned_roots.insert(slot);
     }
     /// Remove the slot when the storage for the slot is freed
     /// Accounts no longer reference this slot.
     pub fn clean_dead_slot(&mut self, slot: Slot) {
         self.roots.remove(&slot);
         self.uncleaned_roots.remove(&slot);
+        self.previous_uncleaned_roots.remove(&slot);
+    }
+
+    pub fn reset_uncleaned_roots(&mut self) -> Vec<Slot> {
+        let empty = HashSet::new();
+        let new_previous = std::mem::replace(&mut self.uncleaned_roots, empty);
+        std::mem::replace(&mut self.previous_uncleaned_roots, new_previous)
+            .into_iter()
+            .collect()
     }
 }
 

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -242,7 +242,6 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
     pub fn reset_uncleaned_roots(&mut self) -> Vec<Slot> {
         let empty = HashSet::new();
         let new_previous = std::mem::replace(&mut self.uncleaned_roots, empty);
-        dbg!("{:?}", &new_previous);
         std::mem::replace(&mut self.previous_uncleaned_roots, new_previous)
             .into_iter()
             .collect()
@@ -389,13 +388,11 @@ mod tests {
         index.clean_dead_slot(1);
         assert_eq!(3, index.roots.len());
         assert_eq!(2, index.uncleaned_roots.len());
-        //eprintln!("{:?}", &index.previous_uncleaned_roots);
         assert_eq!(1, index.previous_uncleaned_roots.len());
 
         index.clean_dead_slot(2);
         assert_eq!(2, index.roots.len());
         assert_eq!(1, index.uncleaned_roots.len());
-        //eprintln!("{:?}", &index.previous_uncleaned_roots);
         assert_eq!(1, index.previous_uncleaned_roots.len());
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2538,10 +2538,6 @@ impl Bank {
         self.rc.accounts.accounts_db.process_dead_slots();
     }
 
-    fn process_stale_slot(&self) -> usize {
-        self.rc.accounts.accounts_db.process_stale_slot()
-    }
-
     pub fn shrink_all_slots(&self) {
         self.rc.accounts.accounts_db.shrink_all_slots();
     }
@@ -2552,7 +2548,7 @@ impl Bank {
         budget_recovery_delta: usize,
     ) -> usize {
         if consumed_budget == 0 {
-            let shrunken_account_count = self.process_stale_slot();
+            let shrunken_account_count = self.rc.accounts.accounts_db.process_stale_slot();
             if shrunken_account_count > 0 {
                 datapoint_info!(
                     "stale_slot_shrink",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2542,6 +2542,10 @@ impl Bank {
         self.rc.accounts.accounts_db.process_stale_slot()
     }
 
+    pub fn shrink_all_slots(&self) {
+        self.rc.accounts.accounts_db.shrink_all_slots();
+    }
+
     pub fn process_stale_slot_with_budget(
         &self,
         mut consumed_budget: usize,
@@ -2558,10 +2562,6 @@ impl Bank {
             }
         }
         consumed_budget.saturating_sub(budget_recovery_delta)
-    }
-
-    pub fn shrink_all_slots(&self) {
-        self.rc.accounts.accounts_db.shrink_all_slots();
     }
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2538,8 +2538,26 @@ impl Bank {
         self.rc.accounts.accounts_db.process_dead_slots();
     }
 
-    pub fn process_stale_slot(&self) -> usize {
+    fn process_stale_slot(&self) -> usize {
         self.rc.accounts.accounts_db.process_stale_slot()
+    }
+
+    pub fn process_stale_slot_with_budget(
+        &self,
+        mut consumed_budget: usize,
+        budget_recovery_delta: usize,
+    ) -> usize {
+        if consumed_budget == 0 {
+            let shrunken_account_count = self.process_stale_slot();
+            if shrunken_account_count > 0 {
+                datapoint_info!(
+                    "stale_slot_shrink",
+                    ("accounts", shrunken_account_count, i64)
+                );
+                consumed_budget += shrunken_account_count;
+            }
+        }
+        consumed_budget.saturating_sub(budget_recovery_delta)
     }
 
     pub fn shrink_all_slots(&self) {
@@ -7043,5 +7061,46 @@ mod tests {
         assert!(bank.process_transaction(&tx).is_ok());
         assert_eq!(1, bank.get_balance(&program1_pubkey));
         assert_eq!(42, bank.get_balance(&program2_pubkey));
+    }
+
+    #[test]
+    fn test_process_stale_slot_with_budget() {
+        solana_logger::setup();
+
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000_000);
+        let pubkey1 = Pubkey::new_rand();
+        let pubkey2 = Pubkey::new_rand();
+
+        let bank = Arc::new(Bank::new(&genesis_config));
+        bank.lazy_rent_collection.store(true, Ordering::Relaxed);
+        assert_eq!(bank.process_stale_slot_with_budget(0, 0), 0);
+        assert_eq!(bank.process_stale_slot_with_budget(133, 0), 133);
+
+        assert_eq!(bank.process_stale_slot_with_budget(0, 100), 0);
+        assert_eq!(bank.process_stale_slot_with_budget(33, 100), 0);
+        assert_eq!(bank.process_stale_slot_with_budget(133, 100), 33);
+
+        bank.squash();
+
+        let some_lamports = 123;
+        let bank = Arc::new(new_from_parent(&bank));
+        bank.deposit(&pubkey1, some_lamports);
+        bank.deposit(&pubkey2, some_lamports);
+
+        let bank = Arc::new(new_from_parent(&bank));
+        bank.deposit(&pubkey1, some_lamports);
+        bank.squash();
+        bank.clean_accounts();
+        let force_to_return_alive_account = 0;
+        assert_eq!(
+            bank.process_stale_slot_with_budget(22, force_to_return_alive_account),
+            22
+        );
+
+        let mut consumed_budgets = (0..3)
+            .map(|_| bank.process_stale_slot_with_budget(0, force_to_return_alive_account))
+            .collect::<Vec<_>>();
+        consumed_budgets.sort();
+        assert_eq!(consumed_budgets, vec![0, 1, 8]);
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2289,7 +2289,7 @@ impl Bank {
     /// calculation and could shield other real accounts.
     pub fn verify_snapshot_bank(&self) -> bool {
         self.clean_accounts();
-        self.shrink_all_stale_slots();
+        self.shrink_all_slots();
         // Order and short-circuiting is significant; verify_hash requires a valid bank hash
         self.verify_bank_hash() && self.verify_hash()
     }
@@ -2538,12 +2538,12 @@ impl Bank {
         self.rc.accounts.accounts_db.process_dead_slots();
     }
 
-    pub fn process_stale_slot(&self) {
-        self.rc.accounts.accounts_db.process_stale_slot();
+    pub fn process_stale_slot(&self) -> usize {
+        self.rc.accounts.accounts_db.process_stale_slot()
     }
 
-    pub fn shrink_all_stale_slots(&self) {
-        self.rc.accounts.accounts_db.shrink_all_stale_slots();
+    pub fn shrink_all_slots(&self) {
+        self.rc.accounts.accounts_db.shrink_all_slots();
     }
 }
 


### PR DESCRIPTION
### Problem

There are several problems for eager rent collection and stale slot shrinking...

#### stale slot shrinking (perf. degradation)

Shrinking is causing trouble under load or benchmark.

First, shrinking (reading & writing accounts) a slot full of account updates isn't a light-weight background task in any way, even not _stale_ at all. But, that's constantly happening too often while benchmarking. That's partly because supposedly our bench is repeatedly updating same accounts from some limited (large) number of test account sets. So, that heavy slot is wrongly passing the existing _stale_ check too easily. (20% of accounts are outdated, meaning unused/empty/shrinkable). Yeah, that's plain bug when stale slot shrinking was introduced. Sorry...

Also, bench might not be representational real world work load. But, this still bothers us and indeed exposes the potential perf problem in stale slot shrinking. And, shrinking probably will be hurting the performance under real-world saturating tps situation.



#### eager rent collection (bloated snapshot)

The snapshots are too prone to grow when there are theoretically maximum number of alive `AppendVec`s. This is currently happening only on devnet, because there are so many rent-exempt accounts on devnet (1.5 million accounts; I counted from a sample recent snapshot). That huge number of AppendVec is a side-effect of the fact eager rent collection is spreading those accounts over 2 days worth of slots (an epoch on tds/mainnet-beta), so thinly (well, that's intended design...).

When, there is such large number of AppendVecs, the stale slot shrinking works poorly because the traversing algorithm is simplistic. It was originally exactly designed for the _stale_ slots. However, eager rent collection creates fresh AppendVecs periodically now on devnet at too fast pace, making the _stale_ assumption obsolete.

The algorithm is like this: grab all of rooted alive slot set from AccountsIndex at a time and loop over the set (without fetching new roots) until the end of the set at 100ms interval, and repeat the process infinitely. This means when there are 400K slots, it doesn't shrink newly- (and constantly- by eager rent collection) created slots for 11 hours.

Eager rent collection constantly creates 4MB `AppendVec`s with few rent-collected accounts, which should be shrunk but not done, causing bloated snapshot. Those few accounts prevents the AppendVec from being reclaimed quickly (usually reclaimed for the idling cluster before eager rent collection). Then, the outdated garbage sysvars in the AppendVec is nightmare for `bzip2`; 130kb of slightly changing bits for each `AppendVec`.

stale slot shrinking got a bit obsoleted by the introduction of eager rent collection because stale slots doesn't exist anymore. there is only a single epoch aged slots (AppendVecs) at most now. That's because all of accounts will be updated over an epoch regardless of rent-exempt. (This is like super long-timed DIMM memory refreshing, we are necessitating all account data be equally _hot_ for uniform rent fee and incentive structure.)

### Summary of Changes

#### eager rent collection

To fix the above problems, let's make stale slot shrinking to prioritize recently rooted slots (to fix bloated snapshot) and to optimize for idling cluster (to avoid shinking when benchmarking).

For that, firstly create a shortcut codepath from the recently-rooted to the slot shrink.

Reason of not immediate but previous parent: immediate roots may be too hot. let it cool down a bit for some time like snapshot interval. Also, sysvars in the most recent root slot can not be reclaimed (yet). Also, I anticipate slightly older root slots will be dead more often without needing to shrink first of all. Reclaiming dead slots are a lot faster/simpler.

I chosen this over making AppendVec's default size dynamic because to compress well, we actually need to shrink AppendVec to strip sysvars.

#### stale slot shrinking

- Add simplistic yet adaptive budget scheme for stale slot shrinking; 250 account update / sec.
- Introduce `AccountStorageEntry.approx_store_count` for more quick bailout (well this could be done immediately after #9219 )
- (extra) Fully shrink slots when loaded from snapshot.

I found deciding the proper fixed or dynamic/adaptive threadhold is hard. Specifically, what criteria could be stale in the light of the above problems, considering the variable number of votes per slot (these almost instantly becomes overwritten, accounting for empty in slot; candidate for shrinking), unbound tps assumption, heterogeneous nature of our validators machine spec, ideal sensitivity to sudden peak tps. Simplicity of implementation. Also, assumed heterogeneous work load and account sizes in the real world.

For example, lowering the shrink threshold to _90% shrinkable_ from _20% shrinkable_ doesn't quite work for the idling case, where there is not so many accounts to begin with. (1 (stale) eager rent collect account + 7 (outdated) sysvar accounts + 1 (outdatd) vote account on devnet).

Instead, I focused on two extreme mode of operation in mind when designing the new shrinking strategy: idling cluster and peak cluster.

I wanted something like this:

When the cluster is idling, the validator shrinks every slots without delay. When the cluster is in high load, as soon as a big stale slot is shrunken, the subsequent stale slot shrinking is paused for some time, proportional to the number of shrunken accounts.

Ultimately, my design turned out like this: pseudo peak load detection via actual shrunken account count.

This limits the upper bound of shrunken accounts to 43200000 (250 * 3600 * 24 * 2) for an epoch (= eager rent collection cycle). That's fine because stale slot shrinking is optional to begin with. And the number is large enough for us for now. When there are more accounts than the limit, snapshot again starts to bloat. But at that time, there will be different practical difficulty for monolithic single snapshot for everything...

The downside of this strategy is that reaction latency is rather long: after processing peaked capacity tps in a slot.

Also, I didn't make the background thread's priority lower because this will cause a priority inversion too easily without proper handling...

follow up to: #9527.