### PR TITLE
Add v0 REST APIs for circulating and total supply

### DIFF
--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -8,7 +8,7 @@ pub struct NonCirculatingSupply {
     pub accounts: Vec<Pubkey>,
 }
 
-pub fn calculate_non_circulating_supply(bank: Arc<Bank>) -> NonCirculatingSupply {
+pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> NonCirculatingSupply {
     debug!("Updating Bank supply, epoch: {}", bank.epoch());
     let mut non_circulating_accounts_set: HashSet<Pubkey> = HashSet::new();
 
@@ -149,7 +149,7 @@ mod tests {
             (num_genesis_accounts + num_non_circulating_accounts + num_stake_accounts) * balance
         );
 
-        let non_circulating_supply = calculate_non_circulating_supply(bank.clone());
+        let non_circulating_supply = calculate_non_circulating_supply(&bank);
         assert_eq!(
             non_circulating_supply.lamports,
             (num_non_circulating_accounts + num_stake_accounts) * balance
@@ -164,7 +164,7 @@ mod tests {
         for key in non_circulating_accounts {
             bank.store_account(&key, &Account::new(new_balance, 0, &Pubkey::default()));
         }
-        let non_circulating_supply = calculate_non_circulating_supply(bank.clone());
+        let non_circulating_supply = calculate_non_circulating_supply(&bank);
         assert_eq!(
             non_circulating_supply.lamports,
             (num_non_circulating_accounts * new_balance) + (num_stake_accounts * balance)
@@ -179,7 +179,7 @@ mod tests {
             bank = Arc::new(new_from_parent(&bank));
         }
         assert_eq!(bank.epoch(), 1);
-        let non_circulating_supply = calculate_non_circulating_supply(bank);
+        let non_circulating_supply = calculate_non_circulating_supply(&bank);
         assert_eq!(
             non_circulating_supply.lamports,
             num_non_circulating_accounts * new_balance

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -290,7 +290,7 @@ impl JsonRpcRequestProcessor {
         let config = config.unwrap_or_default();
         let bank = self.bank(config.commitment)?;
         let (addresses, address_filter) = if let Some(filter) = config.filter {
-            let non_circulating_supply = calculate_non_circulating_supply(bank.clone());
+            let non_circulating_supply = calculate_non_circulating_supply(&bank);
             let addresses = non_circulating_supply.accounts.into_iter().collect();
             let address_filter = match filter {
                 RpcLargestAccountsFilter::Circulating => AccountAddressFilter::Exclude,
@@ -314,7 +314,7 @@ impl JsonRpcRequestProcessor {
 
     fn get_supply(&self, commitment: Option<CommitmentConfig>) -> RpcResponse<RpcSupply> {
         let bank = self.bank(commitment)?;
-        let non_circulating_supply = calculate_non_circulating_supply(bank.clone());
+        let non_circulating_supply = calculate_non_circulating_supply(&bank);
         let total_supply = bank.capitalization();
         new_response(
             &bank,

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -260,8 +260,7 @@ fn process_rest(bank_forks: &Arc<RwLock<BankForks>>, path: &str) -> Option<Strin
             let bank = r_bank_forks.root_bank();
             let total_supply = bank.capitalization();
             let non_circulating_supply =
-                crate::non_circulating_supply::calculate_non_circulating_supply(bank.clone())
-                    .lamports;
+                crate::non_circulating_supply::calculate_non_circulating_supply(&bank).lamports;
             Some(format!("{}", total_supply - non_circulating_supply))
         }
         "/v0/total-supply" => {


### PR DESCRIPTION
Some users would like a simple HTTP GET method to fetch the circulating and total supply, and sending an HTTP POST is apparently too much.   

The [RestApi](https://paritytech.github.io/jsonrpc/jsonrpc_http_server/enum.RestApi.html) translation feature of the jsonrpc_http_server looks tempting but is insufficient as it also only responds to HTTP POST requests.  

In lieu of stepping into the longer term API rework (cc: #https://github.com/solana-labs/solana/issues/7866), I went for creating one-off REST APIs at:
```
$ curl localhost:8899/v0/circulating-supply
683635295413590363
$ curl localhost:8899/v0/total-supply
1000000103431784983
```

These APIs are:
1) Intentionally scary looking, `/v0/...`
2) Intentionally not advertised in the documentation.