### PR TITLE
Add unique_signers() to SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4648,7 +4648,6 @@ name = "solana-stake-accounts"
 version = "1.2.0"
 dependencies = [
  "clap",
- "itertools 0.9.0",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",
@@ -4743,7 +4742,6 @@ dependencies = [
  "dirs 2.0.2",
  "indexmap",
  "indicatif",
- "itertools 0.9.0",
  "pickledb",
  "serde",
  "solana-clap-utils",

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -3,6 +3,7 @@
 use crate::{pubkey::Pubkey, transaction::TransactionError};
 use generic_array::{typenum::U64, GenericArray};
 use hmac::Hmac;
+use itertools::Itertools;
 use rand::{rngs::OsRng, CryptoRng, RngCore};
 use std::{
     borrow::{Borrow, Cow},
@@ -153,6 +154,11 @@ impl std::fmt::Debug for dyn Signer {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(fmt, "Signer: {:?}", self.pubkey())
     }
+}
+
+/// Remove duplicates signers while preserving order. O(n²)
+pub fn unique_signers<'a>(signers: Vec<&'a dyn Signer>) -> Vec<&'a dyn Signer> {
+    signers.into_iter().unique_by(|s| s.pubkey()).collect()
 }
 
 impl Signer for Keypair {
@@ -552,5 +558,19 @@ mod tests {
         assert_eq!(keypair, presigner);
         let presigner2 = Presigner::new(&pubkey, &sig);
         assert_eq!(presigner, presigner2);
+    }
+
+    fn pubkeys(signers: &[&dyn Signer]) -> Vec<Pubkey> {
+        signers.into_iter().map(|x| x.pubkey()).collect()
+    }
+
+    #[test]
+    fn test_unique_signers() {
+        let alice = Keypair::new();
+        let bob = Keypair::new();
+        assert_eq!(
+            pubkeys(&unique_signers(vec![&alice, &bob, &alice])),
+            pubkeys(&[&alice, &bob])
+        );
     }
 }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -157,7 +157,7 @@ impl std::fmt::Debug for dyn Signer {
 }
 
 /// Remove duplicates signers while preserving order. O(n²)
-pub fn unique_signers<'a>(signers: Vec<&'a dyn Signer>) -> Vec<&'a dyn Signer> {
+pub fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
     signers.into_iter().unique_by(|s| s.pubkey()).collect()
 }
 

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://solana.com/"
 
 [dependencies]
 clap = "2.33.1"
-itertools = "0.9.0"
 solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-cli-config = { path = "../cli-config", version = "1.2.0" }
 solana-client = { path = "../client", version = "1.2.0" }

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -6,7 +6,6 @@ use crate::arg_parser::parse_args;
 use crate::args::{
     resolve_command, AuthorizeArgs, Command, MoveArgs, NewArgs, RebaseArgs, SetLockupArgs,
 };
-use itertools::Itertools;
 use solana_cli_config::Config;
 use solana_client::client_error::ClientError;
 use solana_client::rpc_client::RpcClient;
@@ -14,7 +13,7 @@ use solana_sdk::{
     message::Message,
     native_token::lamports_to_sol,
     pubkey::Pubkey,
-    signature::{Signature, Signer},
+    signature::{unique_signers, Signature, Signer},
     signers::Signers,
     transaction::Transaction,
 };
@@ -63,10 +62,6 @@ fn get_lockups(
         .into_iter()
         .map(|pubkey| get_lockup(client, &pubkey).map(|bal| (pubkey, bal)))
         .collect()
-}
-
-fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
-    signers.into_iter().unique_by(|s| s.pubkey()).collect_vec()
 }
 
 fn process_new_stake_account(

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -16,7 +16,6 @@ csv = "1.1.3"
 dirs = "2.0.2"
 indexmap = "1.3.2"
 indicatif = "0.14.0"
-itertools = "0.9.0"
 pickledb = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
 solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -5,13 +5,12 @@ use console::style;
 use csv::{ReaderBuilder, Trim};
 use indexmap::IndexMap;
 use indicatif::{ProgressBar, ProgressStyle};
-use itertools::Itertools;
 use pickledb::PickleDb;
 use serde::{Deserialize, Serialize};
 use solana_sdk::{
     message::Message,
     native_token::{lamports_to_sol, sol_to_lamports},
-    signature::{Signature, Signer},
+    signature::{unique_signers, Signature, Signer},
     system_instruction,
     transport::TransportError,
 };
@@ -50,10 +49,6 @@ pub enum Error {
     TransportError(#[from] TransportError),
     #[error("Signature not found")]
     SignatureNotFound,
-}
-
-fn unique_signers(signers: Vec<&dyn Signer>) -> Vec<&dyn Signer> {
-    signers.into_iter().unique_by(|s| s.pubkey()).collect_vec()
 }
 
 fn merge_allocations(allocations: &[Allocation]) -> Vec<Allocation> {
@@ -343,11 +338,11 @@ fn update_finalized_transactions<T: Client>(
             }
         })
         .collect();
-    let unconfirmed_signatures = unconfirmed_transactions
+    let unconfirmed_signatures: Vec<_> = unconfirmed_transactions
         .iter()
         .map(|tx| tx.signatures[0])
         .filter(|sig| *sig != Signature::default()) // Filter out dry-run signatures
-        .collect_vec();
+        .collect();
     let transaction_statuses = client.get_signature_statuses(&unconfirmed_signatures)?;
     let recent_blockhashes = client.get_recent_blockhashes()?;
 

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -47,8 +47,6 @@ pub enum Error {
     PickleDbError(#[from] pickledb::error::Error),
     #[error("Transport error")]
     TransportError(#[from] TransportError),
-    #[error("Signature not found")]
-    SignatureNotFound,
 }
 
 fn merge_allocations(allocations: &[Allocation]) -> Vec<Allocation> {


### PR DESCRIPTION
#### Problem

CLI apps need to get the list of unique signers, but the CLI app only exposes a function `generate_unique_signers` that also injects a default signer.  Also, it requires the trait objects be boxed.

`solana-tokens` and `solana-stake-accounts` worked around by adding a private function `unique_signers`, but now there's duplication.

#### Summary of Changes

Move `unique_signers` into `solana_sdk::signature` to get rid of the duplication and make it available to other CLI tooling that doesn't want to inject a default signer.

