### PR TITLE
Fix deserialize reference tick

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1357,7 +1357,6 @@ impl Blockstore {
             // the tick that will be used to figure out the timeout for this hole
             let reference_tick = u64::from(Shred::reference_tick_from_data(
                 &db_iterator.value().expect("couldn't read value"),
-                current_slot,
             ));
 
             if ticks_since_first_insert < reference_tick + MAX_TURBINE_DELAY_IN_TICKS {


### PR DESCRIPTION
#### Problem
`reference_tick_from_data` incorrectly deserializes the reference tick incorrectly; the original calculation of the position of the `flags` field `let flags = data[SIZE_OF_COMMON_SHRED_HEADER + SIZE_OF_DATA_SHRED_HEADER - size_of::<u8>()];` doesn't actually need to change as the `size` field in the `DataShredHeader` comes after `flags` field.

The bug isn't critical because the `size` field is at most `1139`, so reading out the last `8` bytes of that is at most `4`. This means `reference_tick_from_data` will always be `<=4` after `UNLOCK_NONCE_SLOT` so repairs will happen a little more aggressively, but should not introduce any correctness issues

#### Summary of Changes

Fixes #
