### PR TITLE
Fix another unstable test after eager rent

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5829,6 +5829,7 @@ mod tests {
     fn test_bank_get_program_accounts() {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let parent = Arc::new(Bank::new(&genesis_config));
+        parent.lazy_rent_collection.store(true, Ordering::Relaxed);
 
         let genesis_accounts: Vec<_> = parent.get_program_accounts(None);
         assert!(


### PR DESCRIPTION
#### Problem
`test_bank_get_program_accounts` is flaky since eager rent was implemented.

```
thread 'bank::tests::test_bank_get_program_accounts' panicked at 'assertion failed: `(left == right)`
left: `[(2ENdwbDcvnewdQZwY4mAJ9sApwCMBo3AmXoQnUzG3m8p, Account { lamports: 1 data.len: 0 owner: 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR executable: false rent_epoch: 0 })]`,
right: `[]`', runtime/src/bank.rs:5868:9
```

#### Summary of Changes
Preserve lazy rent for this test, seems to resolve the flakiness (about 40 local runs succeeded, compared with failures every 3-6).

However, @ryoqun, I would like your insight as to whether (a) it is correct that this account should show that it was modified since parent, even though the balance hasn't changes; (b) this is the right solution.
Turning off rent seems like another option, since this test is meant to detect non-rent account changes. (It does fix the flakiness)

I'm actually a bit surprised there aren't more flaky tests like this, but I guess there aren't any other tests using a chain of banks and expecting accounts to stay unchanged in this way. I did a quick scan through bank.rs and didn't see any.

Fyi @mvines 
