### PR TITLE
Remove the faucet redirect from JSON RPC

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -38,7 +38,6 @@ pub enum RpcRequest {
     GetVersion,
     GetVoteAccounts,
     RegisterNode,
-    RequestAirdrop,
     SendTransaction,
     SimulateTransaction,
     SignVote,
@@ -83,7 +82,6 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetVersion => "getVersion",
             RpcRequest::GetVoteAccounts => "getVoteAccounts",
             RpcRequest::RegisterNode => "registerNode",
-            RpcRequest::RequestAirdrop => "requestAirdrop",
             RpcRequest::SendTransaction => "sendTransaction",
             RpcRequest::SimulateTransaction => "simulateTransaction",
             RpcRequest::SignVote => "signVote",
@@ -167,10 +165,6 @@ mod tests {
         let test_request = RpcRequest::GetTransactionCount;
         let request = test_request.build_request_json(1, Value::Null);
         assert_eq!(request["method"], "getTransactionCount");
-
-        let test_request = RpcRequest::RequestAirdrop;
-        let request = test_request.build_request_json(1, Value::Null);
-        assert_eq!(request["method"], "requestAirdrop");
 
         let test_request = RpcRequest::SendTransaction;
         let request = test_request.build_request_json(1, Value::Null);

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -48,7 +48,6 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getVersion](jsonrpc-api.md#getversion)
 * [getVoteAccounts](jsonrpc-api.md#getvoteaccounts)
 * [minimumLedgerSlot](jsonrpc-api.md#minimumledgerslot)
-* [requestAirdrop](jsonrpc-api.md#requestairdrop)
 * [sendTransaction](jsonrpc-api.md#sendtransaction)
 * [simulateTransaction](jsonrpc-api.md#simulatetransaction)
 * [setLogFilter](jsonrpc-api.md#setlogfilter)
@@ -1071,30 +1070,6 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":1234,"id":1}
-```
-
-### requestAirdrop
-
-Requests an airdrop of lamports to a Pubkey
-
-#### Parameters:
-
-* `<string>` - Pubkey of account to receive lamports, as base-58 encoded string
-* `<integer>` - lamports, as a u64
-* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) (used for retrieving blockhash and verifying airdrop success)
-
-#### Results:
-
-* `<string>` - Transaction Signature of airdrop, as base-58 encoded string
-
-#### Example:
-
-```bash
-// Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"requestAirdrop", "params":["83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri", 50]}' http://localhost:8899
-
-// Result
-{"jsonrpc":"2.0","result":"5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW","id":1}
 ```
 
 ### sendTransaction

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -614,14 +614,6 @@ pub fn main() {
                 .help("Enable historical transaction info over JSON RPC, including the 'getConfirmedBlock' API.  This will cause an increase in disk usage and IOPS"),
         )
         .arg(
-            Arg::with_name("rpc_faucet_addr")
-                .long("rpc-faucet-address")
-                .value_name("HOST:PORT")
-                .takes_value(true)
-                .validator(solana_net_utils::is_host_port)
-                .help("Enable the JSON RPC 'requestAirdrop' API with this faucet address."),
-        )
-        .arg(
             Arg::with_name("signer_addr")
                 .long("vote-signer-address")
                 .value_name("HOST:PORT")
@@ -871,9 +863,6 @@ pub fn main() {
             enable_set_log_filter: matches.is_present("enable_rpc_set_log_filter"),
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
             identity_pubkey: identity_keypair.pubkey(),
-            faucet_addr: matches.value_of("rpc_faucet_addr").map(|address| {
-                solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")
-            }),
         },
         rpc_ports: value_t!(matches, "rpc_port", u16)
             .ok()


### PR DESCRIPTION
Attempt 2 https://github.com/solana-labs/solana/pull/3403

More of a reminder to delete the dependencies from example web-wallet and tic-tac-toe.  @mvines, anything change there?

Fixes #1830