### PR TITLE
multinode-demo/faucet.sh is no longer required

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -73,16 +73,15 @@ source scripts/configure-metrics.sh
 source multinode-demo/common.sh
 
 nodes=(
-  "multinode-demo/faucet.sh"
   "multinode-demo/bootstrap-validator.sh \
     --no-restart \
-    --init-complete-file init-complete-node1.log \
+    --init-complete-file init-complete-node0.log \
     --dynamic-port-range 8000-8050"
   "multinode-demo/validator.sh \
     --enable-rpc-exit \
     --no-restart \
     --dynamic-port-range 8050-8100
-    --init-complete-file init-complete-node2.log \
+    --init-complete-file init-complete-node1.log \
     --rpc-port 18899"
 )
 
@@ -95,7 +94,7 @@ if [[ extraNodes -gt 0 ]]; then
         --no-restart \
         --dynamic-port-range $portStart-$portEnd
         --label dyn$i \
-        --init-complete-file init-complete-node$((2 + i)).log"
+        --init-complete-file init-complete-node$((1 + i)).log"
     )
   done
 fi
@@ -160,11 +159,10 @@ startNodes() {
   for i in $(seq 0 $((${#nodes[@]} - 1))); do
     declare cmd=${nodes[$i]}
 
-    if [[ "$i" -ne 0 ]]; then # 0 == faucet, skip it
-      declare initCompleteFile="init-complete-node$i.log"
-      rm -f "$initCompleteFile"
-      initCompleteFiles+=("$initCompleteFile")
-    fi
+    declare initCompleteFile="init-complete-node$i.log"
+    rm -f "$initCompleteFile"
+    initCompleteFiles+=("$initCompleteFile")
+
     startNode "$i" "$cmd $maybeExpectedGenesisHash"
     if $addLogs; then
       logs+=("$(getNodeLogFile "$i" "$cmd")")

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -38,6 +38,7 @@ common_args=()
 label=
 airdrops_enabled=1
 maybe_force=
+keypair=
 
 positional_args=()
 while [[ -n $1 ]]; do
@@ -46,7 +47,7 @@ while [[ -n $1 ]]; do
       label="-$2"
       shift 2
     elif [[ $1 = --keypair || $1 = -k ]]; then
-      common_args+=("$1" "$2")
+      keypair="$2"
       shift 2
     elif [[ $1 = --force ]]; then
       maybe_force=--force
@@ -94,7 +95,15 @@ if [[ -f $stake_account ]]; then
 fi
 
 if ((airdrops_enabled)); then
-  $solana_cli "${common_args[@]}" airdrop "$stake_sol"
+  if [[ -z $keypair ]]; then
+    echo "--keypair argument must be provided"
+    exit 1
+  fi
+  $solana_cli "${common_args[@]}" --keypair "$SOLANA_CONFIG_DIR/faucet.json" transfer "$keypair" "$stake_sol"
+fi
+
+if [[ -n $keypair ]]; then
+  common_args+=(--keypair "$keypair")
 fi
 
 $solana_keygen new --no-passphrase -so "$stake_account"

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -265,7 +265,10 @@ setup_validator_accounts() {
   if ! wallet vote-account "$vote_account"; then
     if ((airdrops_enabled)); then
       echo "Adding $node_sol to validator identity account:"
-      wallet airdrop "$node_sol" || return $?
+      (
+        set -x
+        $solana_cli --keypair "$SOLANA_CONFIG_DIR/faucet.json" --url "$rpc_url" transfer "$identity" "$node_sol"
+      ) || return $?
     fi
 
     echo "Creating validator vote account"

--- a/net/net.sh
+++ b/net/net.sh
@@ -67,7 +67,7 @@ Operate a configured testnet
    --hashes-per-tick NUM_HASHES|sleep|auto
                                       - Override the default --hashes-per-tick for the cluster
    --no-airdrop
-                                      - If set, disables airdrops.  Nodes must be funded in genesis config when airdrops are disabled.
+                                      - If set, disables the faucet keypair.  Nodes must be funded in genesis config
    --faucet-lamports NUM_LAMPORTS_TO_MINT
                                       - Override the default 500000000000000000 lamports minted in genesis
    --internal-nodes-stake-lamports NUM_LAMPORTS_PER_NODE

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -271,6 +271,9 @@ EOF
       fi
       net/scripts/rsync-retry.sh -vPrc \
         "$entrypointIp":~/solana/config/shred-version config/shred-version
+
+      net/scripts/rsync-retry.sh -vPrc \
+        "$entrypointIp":~/solana/config/faucet.json config/faucet.json
     fi
 
     args=(
@@ -310,7 +313,6 @@ EOF
       # Typically the blockstreamer node has a static IP/DNS name for hosting
       # the blockexplorer web app, and is a location that somebody would expect
       # to be able to airdrop from
-      scp "$entrypointIp":~/solana/config/faucet.json config/
       if [[ $airdropsEnabled = true ]]; then
 cat >> ~/solana/on-reboot <<EOF
         multinode-demo/faucet.sh > faucet.log 2>&1 &

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -15,9 +15,7 @@ else
   args=("$@")
 fi
 
-keypair="target/wallet-sanity-keypair.json"
-$solana_keygen new --no-passphrase -sf -o $keypair
-args+=(--keypair "$keypair")
+args+=(--keypair "$SOLANA_CONFIG_DIR"/faucet.json)
 
 node_readiness=false
 timeout=60
@@ -38,12 +36,10 @@ fi
 (
   set -x
   $solana_cli "${args[@]}" address
-  $solana_cli "${args[@]}" airdrop 0.01
-  $solana_cli "${args[@]}" balance --lamports
+  $solana_cli "${args[@]}" balance
   $solana_cli "${args[@]}" ping --count 5 --interval 0
-  $solana_cli "${args[@]}" balance --lamports
+  $solana_cli "${args[@]}" balance
 )
-rm $keypair
 
 echo PASS
 exit 0


### PR DESCRIPTION
```
$ ./multinode-demo/setup.sh
$ ./multinode-demo/bootstrap-validator.sh 
$ ./multinode-demo/faucet.sh # <-------- THE PROBLEM
$ ./multinode-demo/validator.sh
```

Why do we need to run `solana-faucet` at all?  Turns out we don't because `config/faucet.json` is just sitting there waiting to be used.

Towards https://github.com/solana-labs/solana/issues/1830