### PR TITLE
move builtin programs out of bank

### DIFF
--- a/bench-exchange/tests/bench_exchange.rs
+++ b/bench-exchange/tests/bench_exchange.rs
@@ -86,7 +86,7 @@ fn test_exchange_bank_client() {
     solana_logger::setup();
     let (genesis_config, identity) = create_genesis_config(100_000_000_000_000);
     let mut bank = Bank::new(&genesis_config);
-    bank.add_static_program("exchange_program", id(), process_instruction);
+    bank.add_builtin_program("exchange_program", id(), process_instruction);
     let clients = vec![BankClient::new(bank)];
 
     let mut config = Config::default();

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -238,7 +238,7 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_static_program("budget_program", id(), process_instruction);
+        bank.add_builtin_program("budget_program", id(), process_instruction);
         (bank, mint_keypair)
     }
 

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -578,7 +578,7 @@ mod test {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_static_program("exchange_program", id(), process_instruction);
+        bank.add_builtin_program("exchange_program", id(), process_instruction);
         (bank, mint_keypair)
     }
 

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -71,7 +71,7 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_static_program("ownable_program", crate::id(), process_instruction);
+        bank.add_builtin_program("ownable_program", crate::id(), process_instruction);
         (bank, mint_keypair)
     }
 

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -161,7 +161,7 @@ mod tests {
     fn create_bank(lamports: u64) -> (Bank, Keypair) {
         let (genesis_config, mint_keypair) = create_genesis_config(lamports);
         let mut bank = Bank::new(&genesis_config);
-        bank.add_static_program("vest_program", id(), process_instruction);
+        bank.add_builtin_program("vest_program", id(), process_instruction);
         (bank, mint_keypair)
     }
 

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -122,7 +122,7 @@ fn do_bench_transactions(
     let (mut genesis_config, mint_keypair) = create_genesis_config(100_000_000);
     genesis_config.ticks_per_slot = 100;
     let mut bank = Bank::new(&genesis_config);
-    bank.add_static_program(
+    bank.add_builtin_program(
         "builtin_program",
         Pubkey::new(&BUILTIN_PROGRAM_ID),
         process_instruction,

--- a/runtime/src/builtin_programs.rs
+++ b/runtime/src/builtin_programs.rs
@@ -1,0 +1,42 @@
+use crate::{message_processor::ProcessInstruction, system_instruction_processor};
+use solana_sdk::{pubkey::Pubkey, system_program};
+
+pub struct BuiltinProgram {
+    pub name: String,
+    pub id: Pubkey,
+    pub process_instruction: ProcessInstruction,
+}
+impl BuiltinProgram {
+    pub fn new(name: &str, id: Pubkey, process_instruction: ProcessInstruction) -> Self {
+        Self {
+            name: name.to_string(),
+            id,
+            process_instruction,
+        }
+    }
+}
+
+pub fn get_builtin_programs() -> Vec<BuiltinProgram> {
+    vec![
+        BuiltinProgram::new(
+            "system_program",
+            system_program::id(),
+            system_instruction_processor::process_instruction,
+        ),
+        BuiltinProgram::new(
+            "config_program",
+            solana_config_program::id(),
+            solana_config_program::config_processor::process_instruction,
+        ),
+        BuiltinProgram::new(
+            "stake_program",
+            solana_stake_program::id(),
+            solana_stake_program::stake_instruction::process_instruction,
+        ),
+        BuiltinProgram::new(
+            "vote_program",
+            solana_vote_program::id(),
+            solana_vote_program::vote_instruction::process_instruction,
+        ),
+    ]
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bank;
 pub mod bank_client;
 mod blockhash_queue;
 pub mod bloom;
+pub mod builtin_programs;
 pub mod epoch_stakes;
 pub mod genesis_utils;
 pub mod loader_utils;


### PR DESCRIPTION
#### Problem

The list of builtin programs is defined in the bank, move out to a common place that others can draw from.  Needed to support cross-program invocations to native programs.

#### Summary of Changes

Move it out of bank

Fixes #
