### PR TITLE
Ignore test_tvu_exit

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -244,6 +244,7 @@ pub mod tests {
     use solana_runtime::bank::Bank;
     use std::sync::atomic::Ordering;
 
+    #[ignore]
     #[test]
     #[serial]
     fn test_tvu_exit() {


### PR DESCRIPTION
`test_tvu_exit` continues to be flaky and doesn't really seem to be even testing anything interesting.  Ignore it
