### PR TITLE
Support cross-program invocation to native programs

### DIFF
--- a/programs/bpf/c/src/invoked/invoked.c
+++ b/programs/bpf/c/src/invoked/invoked.c
@@ -100,8 +100,12 @@ extern uint64_t entrypoint(const uint8_t *input) {
     const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                         arguments, SOL_ARRAY_SIZE(arguments),
                                         data, SOL_ARRAY_SIZE(data)};
-    const SolSignerSeed seeds1[] = {{"Lil'", 4}, {"Bits", 4}};
-    const SolSignerSeed seeds2[] = {{"Gar Ma Nar Nar", 14}};
+    char seed1[] = "Lil'";
+    char seed2[] = "Bits";
+    char seed3[] = "Gar Ma Nar Nar";
+    const SolSignerSeed seeds1[] = {{seed1, sol_strlen(seed1)},
+                                    {seed2, sol_strlen(seed2)}};
+    const SolSignerSeed seeds2[] = {{seed3, sol_strlen(seed3)}};
     const SolSignerSeeds signers_seeds[] = {{seeds1, SOL_ARRAY_SIZE(seeds1)},
                                             {seeds2, SOL_ARRAY_SIZE(seeds2)}};
 

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -25,7 +25,7 @@ const INVOKED_PROGRAM_DUP_INDEX: usize = 4;
 const DERIVED_KEY1_INDEX: usize = 6;
 const DERIVED_KEY2_INDEX: usize = 7;
 const DERIVED_KEY3_INDEX: usize = 8;
-const SYSTEM_PROGRAM_INDEX: usize = 9;
+// const SYSTEM_PROGRAM_INDEX: usize = 9;
 const FROM_INDEX: usize = 10;
 
 entrypoint!(process_instruction);
@@ -40,11 +40,8 @@ fn process_instruction(
     {
         assert_eq!(accounts[FROM_INDEX].lamports(), 43);
         assert_eq!(accounts[ARGUMENT_INDEX].lamports(), 41);
-        let instruction = system_instruction::transfer(
-            accounts[FROM_INDEX].key,
-            accounts[ARGUMENT_INDEX].key,
-            1,
-        );
+        let instruction =
+            system_instruction::transfer(accounts[FROM_INDEX].key, accounts[ARGUMENT_INDEX].key, 1);
         invoke(&instruction, accounts)?;
         assert_eq!(accounts[FROM_INDEX].lamports(), 42);
         assert_eq!(accounts[ARGUMENT_INDEX].lamports(), 42);

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -13,6 +13,7 @@ use solana_sdk::{
     program::{invoke, invoke_signed},
     program_error::ProgramError,
     pubkey::Pubkey,
+    system_instruction,
 };
 
 // const MINT_INDEX: usize = 0;
@@ -24,6 +25,8 @@ const INVOKED_PROGRAM_DUP_INDEX: usize = 4;
 const DERIVED_KEY1_INDEX: usize = 6;
 const DERIVED_KEY2_INDEX: usize = 7;
 const DERIVED_KEY3_INDEX: usize = 8;
+const SYSTEM_PROGRAM_INDEX: usize = 9;
+const FROM_INDEX: usize = 10;
 
 entrypoint!(process_instruction);
 fn process_instruction(
@@ -32,6 +35,20 @@ fn process_instruction(
     _instruction_data: &[u8],
 ) -> ProgramResult {
     info!("invoke Rust program");
+
+    info!("Call system program");
+    {
+        assert_eq!(accounts[FROM_INDEX].lamports(), 43);
+        assert_eq!(accounts[ARGUMENT_INDEX].lamports(), 41);
+        let instruction = system_instruction::transfer(
+            accounts[FROM_INDEX].key,
+            accounts[ARGUMENT_INDEX].key,
+            1,
+        );
+        invoke(&instruction, accounts)?;
+        assert_eq!(accounts[FROM_INDEX].lamports(), 42);
+        assert_eq!(accounts[ARGUMENT_INDEX].lamports(), 42);
+    }
 
     info!("Test data translation");
     {


### PR DESCRIPTION
#### Problem

Cross-program invocation only supported invocation to other BPF programs.

#### Summary of Changes

Extend cross-program invocations from BPF programs to all other programs (builtin, native)

TODO: support cross-program invocations from native programs

Fixes #
