### PR TITLE
cli: transaction-history now searches over the entire history by default

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -244,8 +244,8 @@ pub enum CliCommand {
     },
     TransactionHistory {
         address: Pubkey,
-        end_slot: Option<Slot>, // None == latest slot
-        slot_limit: u64,
+        end_slot: Option<Slot>,  // None == latest slot
+        slot_limit: Option<u64>, // None == search full history
     },
     // Nonce commands
     AuthorizeNonceAccount {


### PR DESCRIPTION
`solana transaction-history` unnecessarily limits the history it will fetch to the maximum number of slots supported by a single RPC call.  

Old output:
```
$ solana transaction-history Ei3QUne6zzvVR1RWkJj9Pr7DcZqN2K8w4KgZZC7Rx68h 
Transactions affecting Ei3QUne6zzvVR1RWkJj9Pr7DcZqN2K8w4KgZZC7Rx68h within slots [14562308,14572308]
oPQXZ6z9amXdh7tF3LLc4mHd8bag2xzqe5RLFbDn8cy1A8PweWaea9n7QVx9fpej6foSCASd1HMj7fTqf4c7Bmp
1 transactions found
```

But there exists a thing called a loop and we can much better.   New output:
```
$ solana transaction-history Ei3QUne6zzvVR1RWkJj9Pr7DcZqN2K8w4KgZZC7Rx68h 
Transactions affecting Ei3QUne6zzvVR1RWkJj9Pr7DcZqN2K8w4KgZZC7Rx68h within slots [12961040,14572367]
66QziDhWi8EPV7eXpaNJSyMkvNr6FMBRjGFDMda6fDCuV2DovZh6wgV4GSizQDXEAc7bonM78BJih334NparN3M6
5mo5UaaggHvrNMpuHbtqXL7abmSPRRThCLNMsQNdRzVBx6nFKxJSvcjuMTBCdPFTBscZXFAEe8UeLJKJ9cEctm4d
3EDHpd94b1Js7SBCPrp5LD9dYJbfMk6c1i4CEahedsAk5BAwGsdB3WB5TqYpUaL4CY3Hv7DLt5jLmyNg3KNmSQ3C
4T9JBBtqu6D4gYqYj55THK5kXuij2aBt3m1y7GqwzErbhB6rfZb9ZN5o1n9fDgSZ4qRE2eVHbq4QMUXqLeoPeRXm
41SttciRoZ8Y1VdSRXC6gd1ZtrqSpWzYENa4ATwiyMBu7h8cavB1JMWnEFaLsdFFWkU1n1Rz1SwoEdiUcqy6y8eL
bTNXgk161F3cLj3yUa2R4ydjcsHCTA1Y8v6GfprBAPQwXyC4LMEygocjzxNQnP27YDAoujC15dQU5pP2ZtWsSeV
5M9uhggSbu2PfdrFNJfckDcm1mouMeVUwUzoxeM973icVFhAuU19VmfjjvuCUdYrcjvyEE925SrF8M956kzroBeP
S5QF3XxG6d2hA1tBh8B6o723CFcHCNNJCDrypq1ZAjLpXW13YQb5f7hrvw2ojhfUF7yFKshby3vjnYyWsEG2VXN
3Qz7ptsFFLAPWXrwznJry4kV8HyPfzCZfXNoyJtMN6NrDQg9rbwFjTzWQVKqQn1ibbh5dJrv6tX44XEKwVQkwLkY
4ZkUNB6C8dfHj55zzV2QBqoAdcMHBD8qt871hMmTJQj3NrBQ1AqPAhrmSYcAZDXsWMMdnRpiPkJ1VXUXgizSpykT
2orqxbEQaXJYczQzZANZppxWzH3cmu6zHj1Z6F7ksJ5DedEKrrSZCXSAjX3quBf8fjaz8T3GasFHixNMo2Afz9HU
2eEzKr8WQJvf8AaAhS5Tvx3CspVpz4Ge62J138orDqevguidgxH6ATwQip4xcd3k4BrtcWvGC4fysYNiYQJf7Egq
3b8GzbKdPbqJSQQ3WxD8UHHsBwd8s7ZnSnEf93mT9fpZQoFbVKpsGZgN5X8vSZdxoW3Q97NJxK5vNUMJ6ipmbU5X
4YZEZ8c4jr9ttbbarHWRXzA7roCsgwc9snFAKVCC29qJvfgrwNyk7G18XoE59W3bixJe3q1ejenufpwvZzrq2xFK
oPQXZ6z9amXdh7tF3LLc4mHd8bag2xzqe5RLFbDn8cy1A8PweWaea9n7QVx9fpej6foSCASd1HMj7fTqf4c7Bmp
15 transactions found
```
