### PR TITLE
multinode-demo: Fetch rpc-url from the gossip entrypoint

### DIFF
--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -282,7 +282,7 @@ setup_validator_accounts() {
   return 0
 }
 
-rpc_url=$($solana_gossip rpc-url --entrypoint "$gossip_entrypoint" --any)
+rpc_url=$($solana_gossip rpc-url --entrypoint "$gossip_entrypoint")
 
 [[ -r "$identity" ]] || $solana_keygen new --no-passphrase -so "$identity"
 [[ -r "$vote_account" ]] || $solana_keygen new --no-passphrase -so "$vote_account"


### PR DESCRIPTION
Work around ci/localnet-sanity.sh instability in CI due to https://github.com/solana-labs/solana/issues/9921