### PR TITLE
Optimize banking processing of AccountInUse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,10 +3687,12 @@ dependencies = [
 name = "solana-banking-bench"
 version = "1.2.0"
 dependencies = [
+ "clap",
  "crossbeam-channel",
  "log 0.4.8",
  "rand 0.7.3",
  "rayon",
+ "solana-clap-utils",
  "solana-core",
  "solana-ledger",
  "solana-logger",
@@ -3699,6 +3701,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-streamer",
+ "solana-version",
 ]
 
 [[package]]

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -8,9 +8,13 @@ license = "Apache-2.0"
 homepage = "https://solana.com/"
 
 [dependencies]
+clap = "2.33.1"
+crossbeam-channel = "0.4"
 log = "0.4.6"
+rand = "0.7.0"
 rayon = "1.3.0"
 solana-core = { path = "../core", version = "1.2.0" }
+solana-clap-utils = { path = "../clap-utils", version = "1.2.0" }
 solana-streamer = { path = "../streamer", version = "1.2.0" }
 solana-perf = { path = "../perf", version = "1.2.0" }
 solana-ledger = { path = "../ledger", version = "1.2.0" }
@@ -18,8 +22,7 @@ solana-logger = { path = "../logger", version = "1.2.0" }
 solana-runtime = { path = "../runtime", version = "1.2.0" }
 solana-measure = { path = "../measure", version = "1.2.0" }
 solana-sdk = { path = "../sdk", version = "1.2.0" }
-rand = "0.7.0"
-crossbeam-channel = "0.4"
+solana-version = { path = "../version", version = "1.2.0" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem

In the case where the banking stage has significant conflicting transactions in it's processing queue, they are inefficiently processed at the rate of at most 1/10ms because we wait for new transactions on the channel with a 10ms timeout.

#### Summary of Changes

Rework process buffered loop to immediately keep retrying transaction processing if it is making progress on the current transaction buffer.

This helps get a saturated Break program down to ~400ms latency consistently.

*edit: upping bank threads hurt performance, so backing that out for now.

Fixes #
