### PR TITLE
Unforced avx and avx2 features

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -774,7 +774,7 @@ fn report_target_features() {
         // Validator binaries built on a machine with AVX support will generate invalid opcodes
         // when run on machines without AVX causing a non-obvious process abort.  Instead detect
         // the mismatch and error cleanly.
-        #[target_feature(enable = "avx")]
+        #[cfg(target_feature = "avx")]
         {
             if is_x86_feature_detected!("avx") {
                 info!("AVX detected");
@@ -783,7 +783,7 @@ fn report_target_features() {
                 process::exit(1);
             }
         }
-        #[target_feature(enable = "avx2")]
+        #[cfg(target_feature = "avx2")]
         {
             if is_x86_feature_detected!("avx2") {
                 info!("AVX2 detected");

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -51,6 +51,8 @@ fi
 installDir="$(mkdir -p "$installDir"; cd "$installDir"; pwd)"
 mkdir -p "$installDir/bin/deps"
 cargo=cargo
+# Trigger the selection of the correct set of processor features such as AVX2.
+RUSTFLAGS="$RUSTFLAGS -C target-cpu=native"
 
 echo "Install location: $installDir ($buildVariant)"
 


### PR DESCRIPTION
#### Problem

AVX and AVX2 features were forced on x86 instead of being enabled when available on the target.

#### Summary of Changes

Flag checks are run only if the flags are enabled in `RUSTFLAGS`:
```
RUSTFLAGS="-C target-cpu=native" cargo build --release --all
```
or
```
RUSTFLAGS="-C target-feature=+avx -C target-feature=+avx2" cargo build --release --all
```

Fixes #10126 

#### Outstanding issues

Scripts and docs should be updated unless there is a better method without using `RUSTFLAGS`.