### PR TITLE
v1.1: Always enable nonce slot/owner-in-hash

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -50,7 +50,7 @@ pub const SIZE_OF_NONCE_DATA_SHRED_PAYLOAD: usize =
 pub const OFFSET_OF_SHRED_SLOT: usize = SIZE_OF_SIGNATURE + SIZE_OF_SHRED_TYPE;
 pub const OFFSET_OF_SHRED_INDEX: usize = OFFSET_OF_SHRED_SLOT + SIZE_OF_SHRED_SLOT;
 pub const NONCE_SHRED_PAYLOAD_SIZE: usize = PACKET_DATA_SIZE - SIZE_OF_NONCE;
-pub const UNLOCK_NONCE_SLOT: Slot = 14_780_256;
+pub const UNLOCK_NONCE_SLOT: Slot = 5_000_000;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1330,10 +1330,8 @@ impl AccountsDB {
         hasher.result()
     }
 
-    pub fn include_owner_in_hash(slot: Slot) -> bool {
-        // Account hashing updated to include owner activates at this slot on the testnet
-        // DANGER: Remove this guard ABSOLUTELY before the mainnet-beta transitions to v1.1.
-        slot >= 14_000_000
+    pub fn include_owner_in_hash(_slot: Slot) -> bool {
+        true
     }
 
     pub fn hash_account_data(
@@ -3532,7 +3530,7 @@ pub mod tests {
                 let loaded_account = db.load_slow(&ancestors, key).unwrap().0;
                 assert_eq!(
                     loaded_account.hash,
-                    AccountsDB::hash_account(some_slot, &account, &key, false)
+                    AccountsDB::hash_account(some_slot, &account, &key, true)
                 );
             }
         }


### PR DESCRIPTION
With these two rolling updates now active on testnet, they should be always enabled on the v1.1 line in support of the v1.0 -> v1.1 migration of mainnet-beta