### PR TITLE
Revert "AVX2 runtime check"

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -759,15 +759,6 @@ fn report_target_features() {
                 process::exit(1);
             }
         }
-        #[target_feature(enable = "avx2")]
-        {
-            if is_x86_feature_detected!("avx2") {
-                info!("AVX2 detected");
-            } else {
-                error!("Your machine does not have AVX2 support, please rebuild from source on your machine");
-                process::exit(1);
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Reverts solana-labs/solana#10033, it's broken.  Real fix at https://github.com/solana-labs/solana/pull/10156