### PR TITLE
Add/track switch vs. non switch vote instructions

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2772,13 +2772,14 @@ mod tests {
         let keypair = Arc::new(Keypair::new());
 
         // Create the biggest possible vote transaction
-        let vote_ix = vote_instruction::vote_switch(
+        let vote_ix = vote_instruction::vote(&keypair.pubkey(), &keypair.pubkey(), vote);
+        let add_switch_proof_ix = vote_instruction::add_switch_proof(
             &keypair.pubkey(),
             &keypair.pubkey(),
-            vote,
             Hash::default(),
         );
-        let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&keypair.pubkey()));
+        let mut vote_tx =
+            Transaction::new_with_payer(&[vote_ix, add_switch_proof_ix], Some(&keypair.pubkey()));
 
         vote_tx.partial_sign(&[keypair.as_ref()], Hash::default());
         vote_tx.partial_sign(&[keypair.as_ref()], Hash::default());

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -7,16 +7,17 @@ use crate::{
     rpc_subscriptions::RpcSubscriptions,
     sigverify,
     verified_vote_packets::VerifiedVotePackets,
+    vote_stake_tracker::VoteStakeTracker,
 };
 use crossbeam_channel::{
     unbounded, Receiver as CrossbeamReceiver, RecvTimeoutError, Sender as CrossbeamSender,
 };
 use itertools::izip;
 use log::*;
-use solana_ledger::bank_forks::BankForks;
+use solana_ledger::{bank_forks::BankForks, blockstore::Blockstore};
 use solana_metrics::inc_new_counter_debug;
 use solana_perf::packet::{self, Packets};
-use solana_runtime::{bank::Bank, epoch_stakes::EpochAuthorizedVoters};
+use solana_runtime::{bank::Bank, epoch_stakes::EpochAuthorizedVoters, stakes::Stakes};
 use solana_sdk::{
     clock::{Epoch, Slot},
     epoch_schedule::EpochSchedule,
@@ -40,29 +41,6 @@ pub type VerifiedVotePacketsSender = CrossbeamSender<Vec<(CrdsValueLabel, Packet
 pub type VerifiedVotePacketsReceiver = CrossbeamReceiver<Vec<(CrdsValueLabel, Packets)>>;
 pub type VerifiedVoteTransactionsSender = CrossbeamSender<Vec<Transaction>>;
 pub type VerifiedVoteTransactionsReceiver = CrossbeamReceiver<Vec<Transaction>>;
-
-#[derive(Default)]
-pub struct VoteStakeTracker {
-    voted: HashSet<Arc<Pubkey>>,
-    stake: u64,
-}
-
-impl VoteStakeTracker {
-    pub fn add_vote_pubkey(&mut self, vote_pubkey: Arc<Pubkey>, stake: u64) {
-        if !self.voted.contains(&vote_pubkey) {
-            self.voted.insert(vote_pubkey);
-            self.stake += stake;
-        }
-    }
-
-    pub fn voted(&self) -> &HashSet<Arc<Pubkey>> {
-        &self.voted
-    }
-
-    pub fn stake(&self) -> u64 {
-        self.stake
-    }
-}
 
 #[derive(Default)]
 pub struct SlotVoteTracker {
@@ -230,6 +208,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
         subscriptions: Arc<RpcSubscriptions>,
+        blockstore: Arc<Blockstore>,
     ) -> Self {
         let exit_ = exit.clone();
 
@@ -271,6 +250,7 @@ impl ClusterInfoVoteListener {
                     vote_tracker,
                     &bank_forks,
                     subscriptions,
+                    &blockstore,
                 );
             })
             .unwrap();
@@ -394,6 +374,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: Arc<VoteTracker>,
         bank_forks: &RwLock<BankForks>,
         subscriptions: Arc<RpcSubscriptions>,
+        blockstore: &Blockstore,
     ) -> Result<()> {
         loop {
             if exit.load(Ordering::Relaxed) {
@@ -402,13 +383,14 @@ impl ClusterInfoVoteListener {
 
             let root_bank = bank_forks.read().unwrap().root_bank().clone();
             vote_tracker.process_new_root_bank(&root_bank);
-
-            if let Err(e) = Self::get_and_process_votes(
+            let optimistic_confirmed_slots = Self::get_and_process_votes(
                 &vote_txs_receiver,
                 &vote_tracker,
                 &root_bank,
                 &subscriptions,
-            ) {
+            );
+
+            if let Err(e) = optimistic_confirmed_slots {
                 match e {
                     Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => {
                         return Ok(());
@@ -428,7 +410,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: &Arc<VoteTracker>,
         last_root: &Bank,
         subscriptions: &RpcSubscriptions,
-    ) -> Result<()> {
+    ) -> Result<Vec<Slot>> {
         Self::get_and_process_votes(vote_txs_receiver, vote_tracker, last_root, subscriptions)
     }
 
@@ -437,14 +419,18 @@ impl ClusterInfoVoteListener {
         vote_tracker: &Arc<VoteTracker>,
         root_bank: &Bank,
         subscriptions: &RpcSubscriptions,
-    ) -> Result<()> {
+    ) -> Result<Vec<Slot>> {
         let timer = Duration::from_millis(200);
         let mut vote_txs = vote_txs_receiver.recv_timeout(timer)?;
+
+        // Should not early return from this point onwards until `process_votes()`
+        // returns below to avoid missing any potential `optimistic_confirmed_slots`
         while let Ok(new_txs) = vote_txs_receiver.try_recv() {
             vote_txs.extend(new_txs);
         }
-        Self::process_votes(vote_tracker, vote_txs, root_bank, subscriptions);
-        Ok(())
+        let optimistic_confirmed_slots =
+            Self::process_votes(vote_tracker, vote_txs, root_bank, subscriptions);
+        Ok(optimistic_confirmed_slots)
     }
 
     fn process_votes(
@@ -452,8 +438,9 @@ impl ClusterInfoVoteListener {
         vote_txs: Vec<Transaction>,
         root_bank: &Bank,
         subscriptions: &RpcSubscriptions,
-    ) {
+    ) -> Vec<Slot> {
         let mut diff: HashMap<Slot, HashSet<Arc<Pubkey>>> = HashMap::new();
+        let mut new_optimistic_confirmed_slots = vec![];
         {
             let all_slot_trackers = &vote_tracker.slot_vote_trackers;
             for tx in vote_txs {
@@ -509,12 +496,14 @@ impl ClusterInfoVoteListener {
                     for slot in &vote.slots {
                         // If slot is before the root, or so far ahead we don't have
                         // stake information, then ignore it
-                        let epoch_vote_accounts = root_bank
-                            .epoch_vote_accounts(root_bank.epoch_schedule().get_epoch(*slot));
-                        if *slot <= root || epoch_vote_accounts.is_none() {
+                        let epoch = root_bank.epoch_schedule().get_epoch(*slot);
+                        let epoch_stakes = root_bank.epoch_stakes(epoch);
+                        if *slot <= root || epoch_stakes.is_none() {
                             continue;
                         }
-                        let epoch_vote_accounts = epoch_vote_accounts.unwrap();
+                        let epoch_stakes = epoch_stakes.unwrap();
+                        let epoch_vote_accounts = Stakes::vote_accounts(epoch_stakes.stakes());
+                        let total_epoch_stake = epoch_stakes.total_stake();
 
                         // Don't insert if we already have marked down this pubkey
                         // voting for this slot
@@ -526,6 +515,9 @@ impl ClusterInfoVoteListener {
                             }
                         }
                         let unduplicated_pubkey = vote_tracker.keys.get_or_insert(vote_pubkey);
+
+                        // The vote for the greatest slot in the stack of votes in a non-switching vote
+                        // qualifies for optimistic confirmation.
                         let should_update_switch = if (slot == last_vote_slot) && !is_switch_vote {
                             let stake = epoch_vote_accounts
                                 .get(vote_pubkey)
@@ -535,19 +527,25 @@ impl ClusterInfoVoteListener {
                         } else {
                             None
                         };
+
+                        // 1) If this vote for this slot qualifies for optimistic confirmation or
+                        // 2) the (slot, unduplicated_pubkey) combination wasn't already inserted
+                        // then process that the `unduplicated_pubkey` voted for the slot.
                         if should_update_switch.is_some()
                             || diff
                                 .entry(*slot)
                                 .or_default()
                                 .insert(unduplicated_pubkey.clone())
                         {
-                            // If the value wasn't already inserted, insert it
-                            Self::add_vote(
+                            if Self::add_vote(
                                 vote_tracker,
                                 *slot,
                                 unduplicated_pubkey,
                                 should_update_switch,
-                            );
+                                total_epoch_stake,
+                            ) {
+                                new_optimistic_confirmed_slots.push(*slot);
+                            }
                         }
                     }
 
@@ -555,14 +553,17 @@ impl ClusterInfoVoteListener {
                 }
             }
         }
+        new_optimistic_confirmed_slots
     }
 
+    // Returns if the slot was optimistically confirmed
     fn add_vote(
         vote_tracker: &VoteTracker,
         slot: Slot,
         pubkey: Arc<Pubkey>,
         should_update_switch: Option<u64>,
-    ) {
+        total_epoch_stake: u64,
+    ) -> bool {
         let mut slot_tracker = vote_tracker
             .slot_vote_trackers
             .read()
@@ -583,6 +584,9 @@ impl ClusterInfoVoteListener {
             slot_tracker = Some(new_slot_tracker);
         }
         let slot_tracker = slot_tracker.unwrap();
+
+        // Update that the given pubkey voted for the
+        // given slot
         let mut w_slot_tracker = slot_tracker.write().unwrap();
         if w_slot_tracker.updates.is_none() {
             w_slot_tracker.updates = Some(vec![]);
@@ -593,11 +597,18 @@ impl ClusterInfoVoteListener {
             .as_mut()
             .unwrap()
             .push(pubkey.clone());
-        if let Some(stake) = should_update_switch {
-            w_slot_tracker
-                .voted_no_switching
-                .add_vote_pubkey(pubkey.clone(), stake);
-        }
+
+        // If this was a no-switching vote, check for optimistic
+        // confirmation
+        should_update_switch
+            .map(|stake| {
+                w_slot_tracker.voted_no_switching.add_vote_pubkey(
+                    pubkey.clone(),
+                    stake,
+                    total_epoch_stake,
+                )
+            })
+            .unwrap_or(false)
     }
 }
 
@@ -924,18 +935,18 @@ mod tests {
                 if vote_slot == 2 && hash.is_none() {
                     assert!(r_slot_vote_tracker
                         .voted_no_switching
-                        .voted
+                        .voted()
                         .contains(&pubkey));
                     assert_eq!(
-                        r_slot_vote_tracker.voted_no_switching.stake,
+                        r_slot_vote_tracker.voted_no_switching.stake(),
                         stake_per_validator * validator_voting_keypairs.len() as u64
                     );
                 } else {
                     assert!(!r_slot_vote_tracker
                         .voted_no_switching
-                        .voted
+                        .voted()
                         .contains(&pubkey));
-                    assert_eq!(r_slot_vote_tracker.voted_no_switching.stake, 0);
+                    assert_eq!(r_slot_vote_tracker.voted_no_switching.stake(), 0);
                 }
             }
         }
@@ -1011,10 +1022,10 @@ mod tests {
                 // the non-switching vote set
                 assert!(r_slot_vote_tracker
                     .voted_no_switching
-                    .voted
+                    .voted()
                     .contains(&pubkey));
                 assert_eq!(
-                    r_slot_vote_tracker.voted_no_switching.stake,
+                    r_slot_vote_tracker.voted_no_switching.stake(),
                     num_voters_per_slot as u64 * stake_per_validator
                 );
             }
@@ -1175,8 +1186,14 @@ mod tests {
             })
             .collect();
 
-        let new_root_bank = Bank::new_from_parent(&bank, &Pubkey::default(), first_slot_in_new_epoch - 2);
-        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_txs, &new_root_bank, &subscriptions);
+        let new_root_bank =
+            Bank::new_from_parent(&bank, &Pubkey::default(), first_slot_in_new_epoch - 2);
+        ClusterInfoVoteListener::process_votes(
+            &vote_tracker,
+            vote_txs,
+            &new_root_bank,
+            &subscriptions,
+        );
 
         let ref_count = Arc::strong_count(
             &vote_tracker

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -22,6 +22,7 @@ use solana_runtime::{bank::Bank, epoch_stakes::EpochAuthorizedVoters, stakes::St
 use solana_sdk::{
     clock::{Epoch, Slot},
     epoch_schedule::EpochSchedule,
+    hash::Hash,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
     transaction::Transaction,
@@ -46,7 +47,7 @@ pub type VerifiedVoteTransactionsReceiver = CrossbeamReceiver<Vec<Transaction>>;
 #[derive(Default)]
 pub struct SlotVoteTracker {
     voted: HashSet<Arc<Pubkey>>,
-    voted_no_switching: VoteStakeTracker,
+    optimistic_votes_tracker: HashMap<Hash, VoteStakeTracker>,
     updates: Option<Vec<Arc<Pubkey>>>,
 }
 
@@ -56,8 +57,11 @@ impl SlotVoteTracker {
         self.updates.take()
     }
 
-    pub fn voted_no_switching(&self) -> &VoteStakeTracker {
-        &self.voted_no_switching
+    pub fn get_or_insert_optimistic_votes_tracker(&mut self, hash: Hash) -> &mut VoteStakeTracker {
+        self.optimistic_votes_tracker.entry(hash).or_default()
+    }
+    pub fn optimistic_votes_tracker(&self, hash: &Hash) -> Option<&VoteStakeTracker> {
+        self.optimistic_votes_tracker.get(hash)
     }
 }
 
@@ -419,8 +423,11 @@ impl ClusterInfoVoteListener {
                 }
             } else {
                 let optimistic_confirmed_slots = optimistic_confirmed_slots.unwrap();
+                for (slot, _) in optimistic_confirmed_slots.iter() {
+                    subscriptions.notify_gossip_subscribers(*slot);
+                }
                 optimistic_confirmation_verifier
-                    .add_new_optimistic_confirmed_slots(&optimistic_confirmed_slots);
+                    .add_new_optimistic_confirmed_slots(optimistic_confirmed_slots);
             }
         }
     }
@@ -431,7 +438,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: &Arc<VoteTracker>,
         last_root: &Bank,
         subscriptions: &RpcSubscriptions,
-    ) -> Result<Vec<Slot>> {
+    ) -> Result<Vec<(Slot, Hash)>> {
         Self::get_and_process_votes(vote_txs_receiver, vote_tracker, last_root, subscriptions)
     }
 
@@ -440,7 +447,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: &Arc<VoteTracker>,
         root_bank: &Bank,
         subscriptions: &RpcSubscriptions,
-    ) -> Result<Vec<Slot>> {
+    ) -> Result<Vec<(Slot, Hash)>> {
         let timer = Duration::from_millis(200);
         let mut vote_txs = vote_txs_receiver.recv_timeout(timer)?;
 
@@ -459,7 +466,7 @@ impl ClusterInfoVoteListener {
         vote_txs: Vec<Transaction>,
         root_bank: &Bank,
         subscriptions: &RpcSubscriptions,
-    ) -> Vec<Slot> {
+    ) -> Vec<(Slot, Hash)> {
         let mut diff: HashMap<Slot, HashSet<Arc<Pubkey>>> = HashMap::new();
         let mut new_optimistic_confirmed_slots = vec![];
         {
@@ -514,6 +521,7 @@ impl ClusterInfoVoteListener {
                     }
 
                     let root = root_bank.slot();
+                    let last_vote_hash = vote.hash;
                     for slot in &vote.slots {
                         // If slot is before the root, or so far ahead we don't have
                         // stake information, then ignore it
@@ -526,8 +534,6 @@ impl ClusterInfoVoteListener {
                         let epoch_vote_accounts = Stakes::vote_accounts(epoch_stakes.stakes());
                         let total_epoch_stake = epoch_stakes.total_stake();
 
-                        // Don't insert if we already have marked down this pubkey
-                        // voting for this slot
                         let maybe_slot_tracker =
                             all_slot_trackers.read().unwrap().get(slot).cloned();
                         if let Some(slot_tracker) = maybe_slot_tracker {
@@ -544,7 +550,7 @@ impl ClusterInfoVoteListener {
                                 .get(vote_pubkey)
                                 .map(|(stake, _)| *stake)
                                 .unwrap_or(0);
-                            Some(stake)
+                            Some((stake, last_vote_hash))
                         } else {
                             None
                         };
@@ -565,7 +571,7 @@ impl ClusterInfoVoteListener {
                                 total_epoch_stake,
                             )
                         {
-                            new_optimistic_confirmed_slots.push(*slot);
+                            new_optimistic_confirmed_slots.push((*slot, last_vote_hash));
                         }
                     }
 
@@ -581,7 +587,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: &VoteTracker,
         slot: Slot,
         pubkey: Arc<Pubkey>,
-        should_update_switch: Option<u64>,
+        should_update_switch: Option<(u64, Hash)>,
         total_epoch_stake: u64,
     ) -> bool {
         let mut slot_tracker = vote_tracker
@@ -593,7 +599,7 @@ impl ClusterInfoVoteListener {
         if slot_tracker.is_none() {
             let new_slot_tracker = Arc::new(RwLock::new(SlotVoteTracker {
                 voted: HashSet::new(),
-                voted_no_switching: VoteStakeTracker::default(),
+                optimistic_votes_tracker: HashMap::default(),
                 updates: None,
             }));
             vote_tracker
@@ -621,12 +627,10 @@ impl ClusterInfoVoteListener {
         // If this was a no-switching vote, check for optimistic
         // confirmation
         should_update_switch
-            .map(|stake| {
-                w_slot_tracker.voted_no_switching.add_vote_pubkey(
-                    pubkey.clone(),
-                    stake,
-                    total_epoch_stake,
-                )
+            .map(|(stake, hash)| {
+                w_slot_tracker
+                    .get_or_insert_optimistic_votes_tracker(hash)
+                    .add_vote_pubkey(pubkey.clone(), stake, total_epoch_stake)
             })
             .unwrap_or(false)
     }
@@ -843,11 +847,13 @@ mod tests {
             3,
         ));
         let vote_slots = vec![1, 2];
+        let bank_hash = Hash::default();
         send_vote_txs(
             vote_slots.clone(),
             &validator_voting_keypairs,
             None,
             &votes_sender,
+            bank_hash,
         );
         ClusterInfoVoteListener::get_and_process_votes(
             &votes_receiver,
@@ -872,6 +878,7 @@ mod tests {
             &validator_voting_keypairs,
             None,
             &votes_sender,
+            bank_hash,
         );
         ClusterInfoVoteListener::get_and_process_votes(
             &votes_receiver,
@@ -890,13 +897,14 @@ mod tests {
         validator_voting_keypairs: &[ValidatorVoteKeypairs],
         hash: Option<Hash>,
         votes_sender: &VerifiedVoteTransactionsSender,
+        bank_hash: Hash,
     ) {
         validator_voting_keypairs.iter().for_each(|keypairs| {
             let node_keypair = &keypairs.node_keypair;
             let vote_keypair = &keypairs.vote_keypair;
             let vote_tx = vote_transaction::new_vote_transaction(
                 vote_slots.clone(),
-                Hash::default(),
+                bank_hash,
                 Hash::default(),
                 node_keypair,
                 vote_keypair,
@@ -921,12 +929,14 @@ mod tests {
             );
         let bank0 = Bank::new(&genesis_config);
 
+        let bank_hash = Hash::default();
         let vote_slots = vec![1, 2];
         send_vote_txs(
             vote_slots.clone(),
             &validator_voting_keypairs,
             hash,
             &votes_sender,
+            bank_hash,
         );
 
         // Check that all the votes were registered for each validator correctly
@@ -952,21 +962,17 @@ mod tests {
                 // the `no_switching` vote set
                 // 2) Should only count toward the `no_switching` vote set if the
                 // vote was a `no-switching` vote
+                let optimistic_votes_tracker =
+                    r_slot_vote_tracker.optimistic_votes_tracker(&bank_hash);
                 if vote_slot == 2 && hash.is_none() {
-                    assert!(r_slot_vote_tracker
-                        .voted_no_switching
-                        .voted()
-                        .contains(&pubkey));
+                    let optimistic_votes_tracker = optimistic_votes_tracker.unwrap();
+                    assert!(optimistic_votes_tracker.voted().contains(&pubkey));
                     assert_eq!(
-                        r_slot_vote_tracker.voted_no_switching.stake(),
+                        optimistic_votes_tracker.stake(),
                         stake_per_validator * validator_voting_keypairs.len() as u64
                     );
                 } else {
-                    assert!(!r_slot_vote_tracker
-                        .voted_no_switching
-                        .voted()
-                        .contains(&pubkey));
-                    assert_eq!(r_slot_vote_tracker.voted_no_switching.stake(), 0);
+                    assert!(optimistic_votes_tracker.is_none())
                 }
             }
         }
@@ -996,6 +1002,7 @@ mod tests {
         // Send some votes to process
         let (votes_sender, votes_receiver) = unbounded();
         let num_voters_per_slot = 2;
+        let bank_hash = Hash::default();
         for (i, keyset) in validator_voting_keypairs
             .chunks(num_voters_per_slot)
             .enumerate()
@@ -1007,7 +1014,7 @@ mod tests {
                     let vote_keypair = &keypairs.vote_keypair;
                     vote_transaction::new_vote_transaction(
                         vec![i as u64 + 1],
-                        Hash::default(),
+                        bank_hash,
                         Hash::default(),
                         node_keypair,
                         vote_keypair,
@@ -1040,12 +1047,12 @@ mod tests {
                     .contains(&Arc::new(pubkey)));
                 // All the votes were single votes, so they should all count towards
                 // the non-switching vote set
-                assert!(r_slot_vote_tracker
-                    .voted_no_switching
-                    .voted()
-                    .contains(&pubkey));
+                let optimistic_votes_tracker = r_slot_vote_tracker
+                    .optimistic_votes_tracker(&bank_hash)
+                    .unwrap();
+                assert!(optimistic_votes_tracker.voted().contains(&pubkey));
                 assert_eq!(
-                    r_slot_vote_tracker.voted_no_switching.stake(),
+                    optimistic_votes_tracker.stake(),
                     num_voters_per_slot as u64 * stake_per_validator
                 );
             }
@@ -1111,7 +1118,7 @@ mod tests {
     fn test_vote_tracker_references() {
         // The number of references that get stored for a pubkey every time
         // a vote is made. One stored in the SlotVoteTracker.voted, one in
-        // SlotVoteTracker.updates, one in SlotVoteTracker.voted_no_switching
+        // SlotVoteTracker.updates, one in SlotVoteTracker.optimistic_votes_tracker
         let ref_count_per_vote = 3;
 
         // Create some voters at genesis

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,6 +1,5 @@
 use crate::{
     cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS},
-    consensus::VOTE_THRESHOLD_SIZE,
     crds_value::CrdsValueLabel,
     poh_recorder::PohRecorder,
     pubkey_references::LockedPubkeyReferences,
@@ -17,10 +16,7 @@ use log::*;
 use solana_ledger::bank_forks::BankForks;
 use solana_metrics::inc_new_counter_debug;
 use solana_perf::packet::{self, Packets};
-use solana_runtime::{
-    bank::Bank,
-    epoch_stakes::{EpochAuthorizedVoters, EpochStakes},
-};
+use solana_runtime::{bank::Bank, epoch_stakes::EpochAuthorizedVoters};
 use solana_sdk::{
     clock::{Epoch, Slot},
     epoch_schedule::EpochSchedule,
@@ -49,7 +45,6 @@ pub type VerifiedVoteTransactionsReceiver = CrossbeamReceiver<Vec<Transaction>>;
 pub struct SlotVoteTracker {
     voted: HashSet<Arc<Pubkey>>,
     updates: Option<Vec<Arc<Pubkey>>>,
-    total_stake: u64,
 }
 
 impl SlotVoteTracker {
@@ -379,14 +374,12 @@ impl ClusterInfoVoteListener {
 
             let root_bank = bank_forks.read().unwrap().root_bank().clone();
             vote_tracker.process_new_root_bank(&root_bank);
-            let epoch_stakes = root_bank.epoch_stakes(root_bank.epoch());
 
             if let Err(e) = Self::get_and_process_votes(
                 &vote_txs_receiver,
                 &vote_tracker,
                 root_bank.slot(),
                 subscriptions.clone(),
-                epoch_stakes,
             ) {
                 match e {
                     Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => {
@@ -408,13 +401,7 @@ impl ClusterInfoVoteListener {
         last_root: Slot,
         subscriptions: Arc<RpcSubscriptions>,
     ) -> Result<()> {
-        Self::get_and_process_votes(
-            vote_txs_receiver,
-            vote_tracker,
-            last_root,
-            subscriptions,
-            None,
-        )
+        Self::get_and_process_votes(vote_txs_receiver, vote_tracker, last_root, subscriptions)
     }
 
     fn get_and_process_votes(
@@ -422,20 +409,13 @@ impl ClusterInfoVoteListener {
         vote_tracker: &Arc<VoteTracker>,
         last_root: Slot,
         subscriptions: Arc<RpcSubscriptions>,
-        epoch_stakes: Option<&EpochStakes>,
     ) -> Result<()> {
         let timer = Duration::from_millis(200);
         let mut vote_txs = vote_txs_receiver.recv_timeout(timer)?;
         while let Ok(new_txs) = vote_txs_receiver.try_recv() {
             vote_txs.extend(new_txs);
         }
-        Self::process_votes(
-            vote_tracker,
-            vote_txs,
-            last_root,
-            subscriptions,
-            epoch_stakes,
-        );
+        Self::process_votes(vote_tracker, vote_txs, last_root, subscriptions);
         Ok(())
     }
 
@@ -444,7 +424,6 @@ impl ClusterInfoVoteListener {
         vote_txs: Vec<Transaction>,
         root: Slot,
         subscriptions: Arc<RpcSubscriptions>,
-        epoch_stakes: Option<&EpochStakes>,
     ) {
         let mut diff: HashMap<Slot, HashSet<Arc<Pubkey>>> = HashMap::new();
         {
@@ -532,66 +511,21 @@ impl ClusterInfoVoteListener {
                 if w_slot_tracker.updates.is_none() {
                     w_slot_tracker.updates = Some(vec![]);
                 }
-                let mut current_stake = 0;
-                for pubkey in slot_diff {
-                    Self::sum_stake(&mut current_stake, epoch_stakes, &pubkey);
-
-                    w_slot_tracker.voted.insert(pubkey.clone());
-                    w_slot_tracker.updates.as_mut().unwrap().push(pubkey);
+                for pk in slot_diff {
+                    w_slot_tracker.voted.insert(pk.clone());
+                    w_slot_tracker.updates.as_mut().unwrap().push(pk);
                 }
-                Self::notify_for_stake_change(
-                    current_stake,
-                    w_slot_tracker.total_stake,
-                    &subscriptions,
-                    epoch_stakes,
-                    slot,
-                );
-                w_slot_tracker.total_stake += current_stake;
             } else {
-                let mut total_stake = 0;
-                let voted: HashSet<_> = slot_diff
-                    .into_iter()
-                    .map(|pubkey| {
-                        Self::sum_stake(&mut total_stake, epoch_stakes, &pubkey);
-                        pubkey
-                    })
-                    .collect();
-                Self::notify_for_stake_change(total_stake, 0, &subscriptions, epoch_stakes, slot);
+                let voted: HashSet<_> = slot_diff.into_iter().collect();
                 let new_slot_tracker = SlotVoteTracker {
                     voted: voted.clone(),
                     updates: Some(voted.into_iter().collect()),
-                    total_stake,
                 };
                 vote_tracker
                     .slot_vote_trackers
                     .write()
                     .unwrap()
                     .insert(slot, Arc::new(RwLock::new(new_slot_tracker)));
-            }
-        }
-    }
-
-    fn notify_for_stake_change(
-        current_stake: u64,
-        previous_stake: u64,
-        subscriptions: &Arc<RpcSubscriptions>,
-        epoch_stakes: Option<&EpochStakes>,
-        slot: Slot,
-    ) {
-        if let Some(stakes) = epoch_stakes {
-            let supermajority_stake = (stakes.total_stake() as f64 * VOTE_THRESHOLD_SIZE) as u64;
-            if previous_stake < supermajority_stake
-                && (previous_stake + current_stake) > supermajority_stake
-            {
-                subscriptions.notify_gossip_subscribers(slot);
-            }
-        }
-    }
-
-    fn sum_stake(sum: &mut u64, epoch_stakes: Option<&EpochStakes>, pubkey: &Pubkey) {
-        if let Some(stakes) = epoch_stakes {
-            if let Some(vote_account) = stakes.stakes().vote_accounts().get(pubkey) {
-                *sum += vote_account.0;
             }
         }
     }
@@ -805,7 +739,6 @@ mod tests {
             &vote_tracker,
             0,
             subscriptions,
-            None,
         )
         .unwrap();
         for vote_slot in vote_slots {
@@ -855,7 +788,6 @@ mod tests {
             &vote_tracker,
             0,
             subscriptions,
-            None,
         )
         .unwrap();
         for (i, keyset) in validator_voting_keypairs.chunks(2).enumerate() {
@@ -974,13 +906,7 @@ mod tests {
             &validator0_keypairs.vote_keypair,
         )];
 
-        ClusterInfoVoteListener::process_votes(
-            &vote_tracker,
-            vote_tx,
-            0,
-            subscriptions.clone(),
-            None,
-        );
+        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_tx, 0, subscriptions.clone());
         let ref_count = Arc::strong_count(
             &vote_tracker
                 .keys
@@ -1031,7 +957,7 @@ mod tests {
             })
             .collect();
 
-        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_txs, 0, subscriptions, None);
+        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_txs, 0, subscriptions);
 
         let ref_count = Arc::strong_count(
             &vote_tracker

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -406,8 +406,8 @@ impl ClusterInfoVoteListener {
             if let Err(e) = Self::get_and_process_votes(
                 &vote_txs_receiver,
                 &vote_tracker,
-                root_bank.slot(),
-                subscriptions.clone(),
+                &root_bank,
+                &subscriptions,
             ) {
                 match e {
                     Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => {
@@ -426,8 +426,8 @@ impl ClusterInfoVoteListener {
     pub fn get_and_process_votes_for_tests(
         vote_txs_receiver: &VerifiedVoteTransactionsReceiver,
         vote_tracker: &Arc<VoteTracker>,
-        last_root: Slot,
-        subscriptions: Arc<RpcSubscriptions>,
+        last_root: &Bank,
+        subscriptions: &RpcSubscriptions,
     ) -> Result<()> {
         Self::get_and_process_votes(vote_txs_receiver, vote_tracker, last_root, subscriptions)
     }
@@ -435,23 +435,23 @@ impl ClusterInfoVoteListener {
     fn get_and_process_votes(
         vote_txs_receiver: &VerifiedVoteTransactionsReceiver,
         vote_tracker: &Arc<VoteTracker>,
-        last_root: Slot,
-        subscriptions: Arc<RpcSubscriptions>,
+        root_bank: &Bank,
+        subscriptions: &RpcSubscriptions,
     ) -> Result<()> {
         let timer = Duration::from_millis(200);
         let mut vote_txs = vote_txs_receiver.recv_timeout(timer)?;
         while let Ok(new_txs) = vote_txs_receiver.try_recv() {
             vote_txs.extend(new_txs);
         }
-        Self::process_votes(vote_tracker, vote_txs, last_root, subscriptions);
+        Self::process_votes(vote_tracker, vote_txs, root_bank, subscriptions);
         Ok(())
     }
 
     fn process_votes(
         vote_tracker: &VoteTracker,
         vote_txs: Vec<Transaction>,
-        root: Slot,
-        subscriptions: Arc<RpcSubscriptions>,
+        root_bank: &Bank,
+        subscriptions: &RpcSubscriptions,
     ) {
         let mut diff: HashMap<Slot, HashSet<Arc<Pubkey>>> = HashMap::new();
         {
@@ -505,10 +505,16 @@ impl ClusterInfoVoteListener {
                         continue;
                     }
 
+                    let root = root_bank.slot();
                     for slot in &vote.slots {
-                        if *slot <= root {
+                        // If slot is before the root, or so far ahead we don't have
+                        // stake information, then ignore it
+                        let epoch_vote_accounts = root_bank
+                            .epoch_vote_accounts(root_bank.epoch_schedule().get_epoch(*slot));
+                        if *slot <= root || epoch_vote_accounts.is_none() {
                             continue;
                         }
+                        let epoch_vote_accounts = epoch_vote_accounts.unwrap();
 
                         // Don't insert if we already have marked down this pubkey
                         // voting for this slot
@@ -520,8 +526,16 @@ impl ClusterInfoVoteListener {
                             }
                         }
                         let unduplicated_pubkey = vote_tracker.keys.get_or_insert(vote_pubkey);
-                        let should_update_switch = (slot == last_vote_slot) && !is_switch_vote;
-                        if should_update_switch
+                        let should_update_switch = if (slot == last_vote_slot) && !is_switch_vote {
+                            let stake = epoch_vote_accounts
+                                .get(vote_pubkey)
+                                .map(|(stake, _)| *stake)
+                                .unwrap_or(0);
+                            Some(stake)
+                        } else {
+                            None
+                        };
+                        if should_update_switch.is_some()
                             || diff
                                 .entry(*slot)
                                 .or_default()
@@ -547,7 +561,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: &VoteTracker,
         slot: Slot,
         pubkey: Arc<Pubkey>,
-        should_update_switch: bool,
+        should_update_switch: Option<u64>,
     ) {
         let mut slot_tracker = vote_tracker
             .slot_vote_trackers
@@ -579,10 +593,10 @@ impl ClusterInfoVoteListener {
             .as_mut()
             .unwrap()
             .push(pubkey.clone());
-        if should_update_switch {
+        if let Some(stake) = should_update_switch {
             w_slot_tracker
                 .voted_no_switching
-                .add_vote_pubkey(pubkey.clone(), 0);
+                .add_vote_pubkey(pubkey.clone(), stake);
         }
     }
 }
@@ -776,12 +790,76 @@ mod tests {
         );
     }
 
-    fn run_test_process_votes(hash: Option<Hash>) {
+    #[test]
+    fn test_votes_in_range() {
         // Create some voters at genesis
+        let stake_per_validator = 100;
         let (vote_tracker, _, validator_voting_keypairs, subscriptions) = setup();
         let (votes_sender, votes_receiver) = unbounded();
 
+        let GenesisConfigInfo { genesis_config, .. } =
+            genesis_utils::create_genesis_config_with_vote_accounts(
+                10_000,
+                &validator_voting_keypairs,
+                stake_per_validator,
+            );
+
+        let bank0 = Bank::new(&genesis_config);
+        // Votes for slots less than the provided root bank's slot should not be processed
+        let bank3 = Arc::new(Bank::new_from_parent(
+            &Arc::new(bank0),
+            &Pubkey::default(),
+            3,
+        ));
         let vote_slots = vec![1, 2];
+        send_vote_txs(
+            vote_slots.clone(),
+            &validator_voting_keypairs,
+            None,
+            &votes_sender,
+        );
+        ClusterInfoVoteListener::get_and_process_votes(
+            &votes_receiver,
+            &vote_tracker,
+            &bank3,
+            &subscriptions,
+        )
+        .unwrap();
+
+        // Vote slots for slots greater than root bank's set of currently calculated epochs
+        // are ignored
+        let max_epoch = bank3.get_leader_schedule_epoch(bank3.slot());
+        assert!(bank3.epoch_stakes(max_epoch).is_some());
+        let unknown_epoch = max_epoch + 1;
+        assert!(bank3.epoch_stakes(unknown_epoch).is_none());
+        let first_slot_in_unknown_epoch = bank3
+            .epoch_schedule()
+            .get_first_slot_in_epoch(unknown_epoch);
+        let vote_slots = vec![first_slot_in_unknown_epoch, first_slot_in_unknown_epoch + 1];
+        send_vote_txs(
+            vote_slots.clone(),
+            &validator_voting_keypairs,
+            None,
+            &votes_sender,
+        );
+        ClusterInfoVoteListener::get_and_process_votes(
+            &votes_receiver,
+            &vote_tracker,
+            &bank3,
+            &subscriptions,
+        )
+        .unwrap();
+
+        // Should be no updates since everything was ignored
+        assert!(vote_tracker.slot_vote_trackers.read().unwrap().is_empty());
+    }
+
+    fn send_vote_txs(
+        vote_slots: Vec<Slot>,
+        validator_voting_keypairs: &[ValidatorVoteKeypairs],
+        hash: Option<Hash>,
+        votes_sender: &VerifiedVoteTransactionsSender,
+    ) {
         validator_voting_keypairs.iter().for_each(|keypairs| {
             let node_keypair = &keypairs.node_keypair;
             let vote_keypair = &keypairs.vote_keypair;
@@ -796,13 +874,36 @@ mod tests {
             );
             votes_sender.send(vec![vote_tx]).unwrap();
         });
+    }
+
+    fn run_test_process_votes(hash: Option<Hash>) {
+        // Create some voters at genesis
+        let stake_per_validator = 100;
+        let (vote_tracker, _, validator_voting_keypairs, subscriptions) = setup();
+        let (votes_sender, votes_receiver) = unbounded();
+
+        let GenesisConfigInfo { genesis_config, .. } =
+            genesis_utils::create_genesis_config_with_vote_accounts(
+                10_000,
+                &validator_voting_keypairs,
+                stake_per_validator,
+            );
+        let bank0 = Bank::new(&genesis_config);
+
+        let vote_slots = vec![1, 2];
+        send_vote_txs(
+            vote_slots.clone(),
+            &validator_voting_keypairs,
+            hash,
+            &votes_sender,
+        );
 
         // Check that all the votes were registered for each validator correctly
         ClusterInfoVoteListener::get_and_process_votes(
             &votes_receiver,
             &vote_tracker,
-            0,
-            subscriptions,
+            &bank0,
+            &subscriptions,
         )
         .unwrap();
         for vote_slot in vote_slots {
@@ -825,11 +926,16 @@ mod tests {
                         .voted_no_switching
                         .voted
                         .contains(&pubkey));
+                    assert_eq!(
+                        r_slot_vote_tracker.voted_no_switching.stake,
+                        stake_per_validator * validator_voting_keypairs.len() as u64
+                    );
                 } else {
                     assert!(!r_slot_vote_tracker
                         .voted_no_switching
                         .voted
                         .contains(&pubkey));
+                    assert_eq!(r_slot_vote_tracker.voted_no_switching.stake, 0);
                 }
             }
         }
@@ -845,10 +951,24 @@ mod tests {
     fn test_process_votes2() {
         // Create some voters at genesis
         let (vote_tracker, _, validator_voting_keypairs, subscriptions) = setup();
+
+        // Create bank with the voters
+        let stake_per_validator = 100;
+        let GenesisConfigInfo { genesis_config, .. } =
+            genesis_utils::create_genesis_config_with_vote_accounts(
+                10_000,
+                &validator_voting_keypairs,
+                stake_per_validator,
+            );
+        let bank0 = Bank::new(&genesis_config);
+
         // Send some votes to process
         let (votes_sender, votes_receiver) = unbounded();
-
-        for (i, keyset) in validator_voting_keypairs.chunks(2).enumerate() {
+        let num_voters_per_slot = 2;
+        for (i, keyset) in validator_voting_keypairs
+            .chunks(num_voters_per_slot)
+            .enumerate()
+        {
             let validator_votes: Vec<_> = keyset
                 .iter()
                 .map(|keypairs| {
@@ -872,8 +992,8 @@ mod tests {
         ClusterInfoVoteListener::get_and_process_votes(
             &votes_receiver,
             &vote_tracker,
-            0,
-            subscriptions,
+            &bank0,
+            &subscriptions,
         )
         .unwrap();
         for (i, keyset) in validator_voting_keypairs.chunks(2).enumerate() {
@@ -887,12 +1007,16 @@ mod tests {
                     .as_ref()
                     .unwrap()
                     .contains(&Arc::new(pubkey)));
-                // All the votes were single votes, so theey should all count towards
+                // All the votes were single votes, so they should all count towards
                 // the non-switching vote set
                 assert!(r_slot_vote_tracker
                     .voted_no_switching
                     .voted
                     .contains(&pubkey));
+                assert_eq!(
+                    r_slot_vote_tracker.voted_no_switching.stake,
+                    num_voters_per_slot as u64 * stake_per_validator
+                );
             }
         }
     }
@@ -977,13 +1101,13 @@ mod tests {
         let vote_tracker = VoteTracker::new(&bank);
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let subscriptions = Arc::new(RpcSubscriptions::new(
+        let subscriptions = RpcSubscriptions::new(
             &exit,
             Arc::new(RwLock::new(bank_forks)),
             Arc::new(RwLock::new(BlockCommitmentCache::default_with_blockstore(
                 blockstore.clone(),
             ))),
-        ));
+        );
 
         // Send a vote to process, should add a reference to the pubkey for that voter
         // in the tracker
@@ -999,7 +1123,7 @@ mod tests {
             None,
         )];
 
-        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_tx, 0, subscriptions.clone());
+        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_tx, &bank, &subscriptions);
         let ref_count = Arc::strong_count(
             &vote_tracker
                 .keys
@@ -1035,7 +1159,7 @@ mod tests {
 
         // Make 2 new votes in two different epochs, ref count should go up
         // by 2 * ref_count_per_vote
-        let vote_txs: Vec<_> = [bank.slot() + 2, first_slot_in_new_epoch]
+        let vote_txs: Vec<_> = [first_slot_in_new_epoch - 1, first_slot_in_new_epoch]
             .iter()
             .map(|slot| {
                 vote_transaction::new_vote_transaction(
@@ -1051,7 +1175,8 @@ mod tests {
             })
             .collect();
 
-        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_txs, 0, subscriptions);
+        let new_root_bank = Bank::new_from_parent(&bank, &Pubkey::default(), first_slot_in_new_epoch - 2);
+        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_txs, &new_root_bank, &subscriptions);
 
         let ref_count = Arc::strong_count(
             &vote_tracker

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -27,7 +27,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     transaction::Transaction,
 };
-use solana_vote_program::vote_instruction::VoteInstruction;
+use solana_vote_program::{vote_instruction::VoteInstruction, vote_state::Vote};
 use std::{
     collections::{HashMap, HashSet},
     sync::{
@@ -461,6 +461,54 @@ impl ClusterInfoVoteListener {
         Ok(optimistic_confirmed_slots)
     }
 
+    fn get_key_and_vote(tx: &Transaction) -> Option<(Pubkey, Vote)> {
+        // Check first instruction for a vote
+        tx.message
+            .instructions
+            .first()
+            .and_then(|first_instruction| {
+                first_instruction
+                    .accounts
+                    .first()
+                    .and_then(|first_account| {
+                        tx.message
+                            .account_keys
+                            .get(*first_account as usize)
+                            .and_then(|key| {
+                                let vote_instruction =
+                                    limited_deserialize(&first_instruction.data).ok();
+                                if let Some(VoteInstruction::Vote(vote)) = vote_instruction {
+                                    Some((*key, vote))
+                                } else {
+                                    None
+                                }
+                            })
+                    })
+            })
+    }
+
+    fn get_switch_proof_hash(tx: &Transaction) -> Option<Hash> {
+        if tx.message.instructions.len() < 2 {
+            return None;
+        }
+
+        let second_instruction = &tx.message.instructions[1];
+
+        let get_switch_proof_instruction = limited_deserialize(&second_instruction.data).ok();
+        if let Some(VoteInstruction::AddSwitchProof(switch_proof_hash)) =
+            get_switch_proof_instruction
+        {
+            Some(switch_proof_hash)
+        } else {
+            None
+        }
+    }
+
+    fn parse_vote_transaction(tx: &Transaction) -> Option<(Pubkey, Vote, Option<Hash>)> {
+        let key_and_vote = Self::get_key_and_vote(tx);
+        key_and_vote.map(|(key, vote)| (key, vote, Self::get_switch_proof_hash(tx)))
+    }
+
     fn process_votes(
         vote_tracker: &VoteTracker,
         vote_txs: Vec<Transaction>,
@@ -472,30 +520,10 @@ impl ClusterInfoVoteListener {
         {
             let all_slot_trackers = &vote_tracker.slot_vote_trackers;
             for tx in vote_txs {
-                if let (Some(vote_pubkey), Some(vote_instruction)) = tx
-                    .message
-                    .instructions
-                    .first()
-                    .and_then(|first_instruction| {
-                        first_instruction.accounts.first().map(|offset| {
-                            (
-                                tx.message.account_keys.get(*offset as usize),
-                                limited_deserialize(&first_instruction.data).ok(),
-                            )
-                        })
-                    })
-                    .unwrap_or((None, None))
+                if let Some((vote_pubkey, vote, switch_proof_hash)) =
+                    Self::parse_vote_transaction(&tx)
                 {
-                    let (vote, is_switch_vote) = {
-                        match vote_instruction {
-                            VoteInstruction::Vote(vote) => (vote, false),
-                            VoteInstruction::VoteSwitch(vote, _) => (vote, true),
-                            _ => {
-                                continue;
-                            }
-                        }
-                    };
-
+                    let is_switch_vote = switch_proof_hash.is_some();
                     if vote.slots.is_empty() {
                         continue;
                     }
@@ -537,17 +565,17 @@ impl ClusterInfoVoteListener {
                         let maybe_slot_tracker =
                             all_slot_trackers.read().unwrap().get(slot).cloned();
                         if let Some(slot_tracker) = maybe_slot_tracker {
-                            if slot_tracker.read().unwrap().voted.contains(vote_pubkey) {
+                            if slot_tracker.read().unwrap().voted.contains(&vote_pubkey) {
                                 continue;
                             }
                         }
-                        let unduplicated_pubkey = vote_tracker.keys.get_or_insert(vote_pubkey);
+                        let unduplicated_pubkey = vote_tracker.keys.get_or_insert(&vote_pubkey);
 
                         // The vote for the greatest slot in the stack of votes in a non-switching vote
                         // qualifies for optimistic confirmation.
                         let should_update_switch = if (slot == last_vote_slot) && !is_switch_vote {
                             let stake = epoch_vote_accounts
-                                .get(vote_pubkey)
+                                .get(&vote_pubkey)
                                 .map(|(stake, _)| *stake)
                                 .unwrap_or(0);
                             Some((stake, last_vote_hash))
@@ -738,7 +766,7 @@ mod tests {
     }
 
     #[test]
-    fn vote_contains_authorized_voter() {
+    fn test_vote_contains_authorized_voter() {
         run_vote_contains_authorized_voter(None);
         run_vote_contains_authorized_voter(Some(Hash::default()));
     }

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -674,7 +674,7 @@ mod tests {
         bank::Bank,
         genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs},
     };
-    use solana_sdk::hash::Hash;
+    use solana_sdk::hash::{self, Hash};
     use solana_sdk::signature::Signature;
     use solana_sdk::signature::{Keypair, Signer};
     use solana_vote_program::vote_transaction;
@@ -1385,5 +1385,31 @@ mod tests {
     fn test_bad_vote() {
         run_test_bad_vote(None);
         run_test_bad_vote(Some(Hash::default()));
+    }
+
+    fn run_test_parse_vote_transaction(input_hash: Option<Hash>) {
+        let node_keypair = Keypair::new();
+        let vote_keypair = Keypair::new();
+        let auth_voter_keypair = Keypair::new();
+        let bank_hash = Hash::default();
+        let vote_tx = vote_transaction::new_vote_transaction(
+            vec![42],
+            bank_hash,
+            Hash::default(),
+            &node_keypair,
+            &vote_keypair,
+            &auth_voter_keypair,
+            input_hash,
+        );
+        let (key, vote, hash) = ClusterInfoVoteListener::parse_vote_transaction(&vote_tx).unwrap();
+        assert_eq!(hash, input_hash);
+        assert_eq!(vote, Vote::new(vec![42], bank_hash));
+        assert_eq!(key, vote_keypair.pubkey());
+    }
+
+    #[test]
+    fn test_parse_vote_transaction() {
+        run_test_parse_vote_transaction(None);
+        run_test_parse_vote_transaction(Some(hash::hash(&[42u8])));
     }
 }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -680,6 +680,7 @@ pub mod test {
                             &keypairs.node_keypair,
                             &keypairs.vote_keypair,
                             &keypairs.vote_keypair,
+                            None,
                         );
                         info!("voting {} {}", parent_bank.slot(), parent_bank.hash());
                         new_bank.process_transaction(&vote_tx).unwrap();

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -20,6 +20,13 @@ use std::{
     sync::Arc,
 };
 
+#[derive(PartialEq, Clone, Debug)]
+pub enum SwitchForkDecision {
+    SwitchProof(Hash),
+    NoSwitch,
+    FailedSwitchThreshold,
+}
+
 pub const VOTE_THRESHOLD_DEPTH: usize = 8;
 pub const VOTE_THRESHOLD_SIZE: f64 = 2f64 / 3f64;
 pub const SWITCH_FORK_THRESHOLD: f64 = 0.38;
@@ -345,7 +352,7 @@ impl Tower {
         progress: &ProgressMap,
         total_stake: u64,
         epoch_vote_accounts: &HashMap<Pubkey, (u64, Account)>,
-    ) -> bool {
+    ) -> SwitchForkDecision {
         self.last_vote()
             .slots
             .last()
@@ -355,14 +362,18 @@ impl Tower {
 
                 if switch_slot == *last_vote || switch_slot_ancestors.contains(last_vote) {
                     // If the `switch_slot is a descendant of the last vote,
-                    // no switching proof is neceessary
-                    return true;
+                    // no switching proof is necessary
+                    return SwitchForkDecision::NoSwitch;
                 }
 
                 // Should never consider switching to an ancestor
                 // of your last vote
                 assert!(!last_vote_ancestors.contains(&switch_slot));
 
+                // By this point, we know the `switch_slot` is on a different fork
+                // (is neither an ancestor nor descendant of `last_vote`), so a
+                // switching proof is necessary
+                let switch_proof = Hash::default();
                 let mut locked_out_stake = 0;
                 let mut locked_out_vote_accounts = HashSet::new();
                 for (candidate_slot, descendants) in descendants.iter() {
@@ -423,9 +434,14 @@ impl Tower {
                         }
                     }
                 }
-                (locked_out_stake as f64 / total_stake as f64) > SWITCH_FORK_THRESHOLD
+
+                if (locked_out_stake as f64 / total_stake as f64) > SWITCH_FORK_THRESHOLD {
+                    SwitchForkDecision::SwitchProof(switch_proof)
+                } else {
+                    SwitchForkDecision::FailedSwitchThreshold
+                }
             })
-            .unwrap_or(true)
+            .unwrap_or(SwitchForkDecision::NoSwitch)
     }
 
     pub fn check_vote_stake_threshold(
@@ -975,85 +991,106 @@ pub mod test {
         tower.record_vote(47, Hash::default());
 
         // Trying to switch to a descendant of last vote should always work
-        assert!(tower.check_switch_threshold(
-            48,
-            &ancestors,
-            &descendants,
-            &vote_simulator.progress,
-            total_stake,
-            bank0.epoch_vote_accounts(0).unwrap(),
-        ));
+        assert_eq!(
+            tower.check_switch_threshold(
+                48,
+                &ancestors,
+                &descendants,
+                &vote_simulator.progress,
+                total_stake,
+                bank0.epoch_vote_accounts(0).unwrap(),
+            ),
+            SwitchForkDecision::NoSwitch
+        );
 
         // Trying to switch to another fork at 110 should fail
-        assert!(!tower.check_switch_threshold(
-            110,
-            &ancestors,
-            &descendants,
-            &vote_simulator.progress,
-            total_stake,
-            bank0.epoch_vote_accounts(0).unwrap(),
-        ));
+        assert_eq!(
+            tower.check_switch_threshold(
+                110,
+                &ancestors,
+                &descendants,
+                &vote_simulator.progress,
+                total_stake,
+                bank0.epoch_vote_accounts(0).unwrap(),
+            ),
+            SwitchForkDecision::FailedSwitchThreshold
+        );
 
         // Adding another validator lockout on a descendant of last vote should
         // not count toward the switch threshold
         vote_simulator.simulate_lockout_interval(50, (49, 100), &other_vote_account);
-        assert!(!tower.check_switch_threshold(
-            110,
-            &ancestors,
-            &descendants,
-            &vote_simulator.progress,
-            total_stake,
-            bank0.epoch_vote_accounts(0).unwrap(),
-        ));
+        assert_eq!(
+            tower.check_switch_threshold(
+                110,
+                &ancestors,
+                &descendants,
+                &vote_simulator.progress,
+                total_stake,
+                bank0.epoch_vote_accounts(0).unwrap(),
+            ),
+            SwitchForkDecision::FailedSwitchThreshold
+        );
 
         // Adding another validator lockout on an ancestor of last vote should
         // not count toward the switch threshold
         vote_simulator.simulate_lockout_interval(50, (45, 100), &other_vote_account);
-        assert!(!tower.check_switch_threshold(
-            110,
-            &ancestors,
-            &descendants,
-            &vote_simulator.progress,
-            total_stake,
-            bank0.epoch_vote_accounts(0).unwrap(),
-        ));
+        assert_eq!(
+            tower.check_switch_threshold(
+                110,
+                &ancestors,
+                &descendants,
+                &vote_simulator.progress,
+                total_stake,
+                bank0.epoch_vote_accounts(0).unwrap(),
+            ),
+            SwitchForkDecision::FailedSwitchThreshold
+        );
 
         // Adding another validator lockout on a different fork, but the lockout
         // doesn't cover the last vote, should not satisfy the switch threshold
         vote_simulator.simulate_lockout_interval(14, (12, 46), &other_vote_account);
-        assert!(!tower.check_switch_threshold(
-            110,
-            &ancestors,
-            &descendants,
-            &vote_simulator.progress,
-            total_stake,
-            bank0.epoch_vote_accounts(0).unwrap(),
-        ));
+        assert_eq!(
+            tower.check_switch_threshold(
+                110,
+                &ancestors,
+                &descendants,
+                &vote_simulator.progress,
+                total_stake,
+                bank0.epoch_vote_accounts(0).unwrap(),
+            ),
+            SwitchForkDecision::FailedSwitchThreshold
+        );
 
         // Adding another validator lockout on a different fork, and the lockout
         // covers the last vote, should satisfy the switch threshold
         vote_simulator.simulate_lockout_interval(14, (12, 47), &other_vote_account);
-        assert!(tower.check_switch_threshold(
-            110,
-            &ancestors,
-            &descendants,
-            &vote_simulator.progress,
-            total_stake,
-            bank0.epoch_vote_accounts(0).unwrap(),
-        ));
+        assert_eq!(
+            tower.check_switch_threshold(
+                110,
+                &ancestors,
+                &descendants,
+                &vote_simulator.progress,
+                total_stake,
+                bank0.epoch_vote_accounts(0).unwrap(),
+            ),
+            SwitchForkDecision::SwitchProof(Hash::default())
+        );
 
         // If we set a root, then any lockout intervals below the root shouldn't
         // count toward the switch threshold. This means the other validator's
         // vote lockout no longer counts
         vote_simulator.set_root(43);
-        assert!(!tower.check_switch_threshold(
-            110,
-            &vote_simulator.bank_forks.read().unwrap().ancestors(),
-            &vote_simulator.bank_forks.read().unwrap().descendants(),
-            &vote_simulator.progress,
-            total_stake,
-            bank0.epoch_vote_accounts(0).unwrap(),
-        ));
+        assert_eq!(
+            tower.check_switch_threshold(
+                110,
+                &vote_simulator.bank_forks.read().unwrap().ancestors(),
+                &vote_simulator.bank_forks.read().unwrap().descendants(),
+                &vote_simulator.progress,
+                total_stake,
+                bank0.epoch_vote_accounts(0).unwrap(),
+            ),
+            SwitchForkDecision::FailedSwitchThreshold
+        );
     }
 
     #[test]

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -9,10 +9,14 @@ use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},
     hash::Hash,
+    instruction::Instruction,
     pubkey::Pubkey,
 };
-use solana_vote_program::vote_state::{
-    BlockTimestamp, Lockout, Vote, VoteState, MAX_LOCKOUT_HISTORY, TIMESTAMP_SLOT_INTERVAL,
+use solana_vote_program::{
+    vote_instruction,
+    vote_state::{
+        BlockTimestamp, Lockout, Vote, VoteState, MAX_LOCKOUT_HISTORY, TIMESTAMP_SLOT_INTERVAL,
+    },
 };
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -25,6 +29,34 @@ pub enum SwitchForkDecision {
     SwitchProof(Hash),
     NoSwitch,
     FailedSwitchThreshold,
+}
+
+impl SwitchForkDecision {
+    pub fn to_vote_instructions(
+        &self,
+        vote: Vote,
+        vote_account_pubkey: &Pubkey,
+        authorized_voter_pubkey: &Pubkey,
+    ) -> Vec<Instruction> {
+        if let SwitchForkDecision::FailedSwitchThreshold = self {
+            vec![]
+        } else {
+            let mut instructions = vec![vote_instruction::vote(
+                vote_account_pubkey,
+                authorized_voter_pubkey,
+                vote,
+            )];
+
+            if let SwitchForkDecision::SwitchProof(switch_proof_hash) = self {
+                instructions.push(vote_instruction::add_switch_proof(
+                    vote_account_pubkey,
+                    authorized_voter_pubkey,
+                    *switch_proof_hash,
+                ));
+            }
+            instructions
+        }
+    }
 }
 
 pub const VOTE_THRESHOLD_DEPTH: usize = 8;
@@ -923,6 +955,36 @@ pub mod test {
             stakes.push((Pubkey::new_rand(), (*lamports, account)));
         }
         stakes
+    }
+
+    #[test]
+    fn test_to_vote_instructions() {
+        let vote = Vote::default();
+        let mut decision = SwitchForkDecision::FailedSwitchThreshold;
+        assert!(decision
+            .to_vote_instructions(vote.clone(), &Pubkey::default(), &Pubkey::default())
+            .is_empty());
+        decision = SwitchForkDecision::NoSwitch;
+        assert_eq!(
+            decision.to_vote_instructions(vote.clone(), &Pubkey::default(), &Pubkey::default()),
+            vec![vote_instruction::vote(
+                &Pubkey::default(),
+                &Pubkey::default(),
+                vote.clone(),
+            )]
+        );
+        decision = SwitchForkDecision::SwitchProof(Hash::default());
+        assert_eq!(
+            decision.to_vote_instructions(vote.clone(), &Pubkey::default(), &Pubkey::default()),
+            vec![
+                vote_instruction::vote(&Pubkey::default(), &Pubkey::default(), vote,),
+                vote_instruction::add_switch_proof(
+                    &Pubkey::default(),
+                    &Pubkey::default(),
+                    Hash::default()
+                )
+            ]
+        );
     }
 
     #[test]

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -599,7 +599,7 @@ pub mod test {
         cluster_info_vote_listener::VoteTracker,
         cluster_slots::ClusterSlots,
         progress_map::ForkProgress,
-        replay_stage::{HeaviestForkFailures, ReplayStage},
+        replay_stage::{HeaviestForkFailures, ReplayStage, SelectVoteAndResetForkResult},
     };
     use solana_ledger::bank_forks::BankForks;
     use solana_runtime::{
@@ -733,7 +733,10 @@ pub mod test {
 
             // Try to vote on the given slot
             let descendants = self.bank_forks.read().unwrap().descendants();
-            let (_, _, failure_reasons) = ReplayStage::select_vote_and_reset_forks(
+            let SelectVoteAndResetForkResult {
+                heaviest_fork_failures,
+                ..
+            } = ReplayStage::select_vote_and_reset_forks(
                 &Some(vote_bank.clone()),
                 &None,
                 &ancestors,
@@ -744,8 +747,8 @@ pub mod test {
 
             // Make sure this slot isn't locked out or failing threshold
             info!("Checking vote: {}", vote_bank.slot());
-            if !failure_reasons.is_empty() {
-                return failure_reasons;
+            if !heaviest_fork_failures.is_empty() {
+                return heaviest_fork_failures;
             }
             let vote = tower.new_vote_from_bank(&vote_bank, &my_vote_pubkey).0;
             if let Some(new_root) = tower.record_bank_vote(vote) {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod gossip_service;
 pub mod ledger_cleanup_service;
 pub mod local_vote_signer_service;
 pub mod non_circulating_supply;
+pub mod optimistic_confirmation_verifier;
 pub mod poh_recorder;
 pub mod poh_service;
 pub mod progress_map;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod transaction_status_service;
 pub mod tvu;
 pub mod validator;
 pub mod verified_vote_packets;
+pub mod vote_stake_tracker;
 pub mod weighted_shuffle;
 pub mod window_service;
 

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -1,0 +1,276 @@
+use crate::cluster_info_vote_listener::VoteTracker;
+use solana_ledger::blockstore::Blockstore;
+use solana_runtime::bank::Bank;
+use solana_sdk::clock::Slot;
+use std::{collections::BTreeSet, time::Instant};
+
+pub struct OptimisticConfirmationVerifier {
+    snapshot_start_slot: Slot,
+    unchecked_slots: BTreeSet<Slot>,
+    last_optimistic_slot_ts: Instant,
+}
+
+impl OptimisticConfirmationVerifier {
+    pub fn new(snapshot_start_slot: Slot) -> Self {
+        Self {
+            snapshot_start_slot,
+            unchecked_slots: BTreeSet::default(),
+            last_optimistic_slot_ts: Instant::now(),
+        }
+    }
+
+    // Returns any optimistic slots that were not rooted
+    pub fn check_optimistic_slots_rooted(
+        &mut self,
+        root_bank: &Bank,
+        blockstore: &Blockstore,
+    ) -> Vec<Slot> {
+        let root = root_bank.slot();
+        let root_ancestors = &root_bank.ancestors;
+        let mut slots_before_root = self.unchecked_slots.split_off(&(root + 1));
+        // `slots_before_root` now contains all slots <= root
+        std::mem::swap(&mut slots_before_root, &mut self.unchecked_slots);
+        slots_before_root
+            .into_iter()
+            .filter(|optimistic_slot| {
+                !root_ancestors.contains_key(&optimistic_slot) &&
+            // In this second part of the `and`, we account for the possibility that 
+            // there was some other root `rootX` set in BankForks where:
+            //
+            // `root` > `rootX` > `optimistic_slot`
+            //
+            // in which case `root` may  not contain the ancestor information for
+            // slots < `rootX`, so we also have to check if `optimistic_slot` was rooted
+            // through blockstore.
+            !blockstore.is_root(*optimistic_slot)
+            })
+            .collect()
+    }
+
+    pub fn add_new_optimistic_confirmed_slots(&mut self, new_optimistic_slots: &[Slot]) {
+        if new_optimistic_slots.is_empty() {
+            return;
+        }
+
+        datapoint_info!(
+            "optimistic_slot_elapsed",
+            (
+                "average_elapsed_ms",
+                self.last_optimistic_slot_ts.elapsed().as_millis() as i64
+                    / new_optimistic_slots.len() as i64,
+                i64
+            ),
+        );
+
+        // We don't have any information about ancestors before the snapshot root,
+        // so ignore those slots
+        for new_optimistic_slot in new_optimistic_slots {
+            if *new_optimistic_slot > self.snapshot_start_slot {
+                datapoint_warn!("optimistic_slot", ("slot", *new_optimistic_slot, i64),);
+                self.unchecked_slots.insert(*new_optimistic_slot);
+            }
+        }
+
+        self.last_optimistic_slot_ts = Instant::now();
+    }
+
+    pub fn log_unrooted_optimistic_slots(
+        root_bank: &Bank,
+        vote_tracker: &VoteTracker,
+        unrooted_optimistic_slots: &[Slot],
+    ) {
+        let root = root_bank.slot();
+        for optimistic_slot in unrooted_optimistic_slots.iter() {
+            let epoch = root_bank.epoch_schedule().get_epoch(*optimistic_slot);
+            let epoch_stakes = root_bank.epoch_stakes(epoch);
+            let total_epoch_stake = epoch_stakes.map(|e| e.total_stake()).unwrap_or(0);
+            let voted_stake = {
+                let slot_tracker = vote_tracker.get_slot_vote_tracker(*optimistic_slot);
+                let r_slot_tracker = slot_tracker.as_ref().map(|s| s.read().unwrap());
+                let voted_stake = r_slot_tracker
+                    .as_ref()
+                    .map(|s| s.voted_no_switching().stake())
+                    .unwrap_or(0);
+
+                warn!(
+                    "Optimistic slot {}, epoch: {} was not rooted, voted keys: {:?}, root: {}, voted stake: {},
+                    total epoch stake: {}, pct: {}",
+                    optimistic_slot,
+                    epoch,
+                    r_slot_tracker.as_ref().map(|s| s.voted_no_switching().voted()),
+                    root,
+                    voted_stake,
+                    total_epoch_stake,
+                    voted_stake as f64 / total_epoch_stake as f64,
+                );
+                voted_stake
+            };
+
+            datapoint_warn!(
+                "optimistic_slot_not_rooted",
+                ("slot", *optimistic_slot, i64),
+                ("epoch", epoch, i64),
+                ("root", root, i64),
+                ("voted_stake", voted_stake, i64),
+                ("total_epoch_stake", total_epoch_stake, i64),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::consensus::test::VoteSimulator;
+    use solana_ledger::get_tmp_ledger_path;
+    use solana_runtime::bank::Bank;
+    use solana_sdk::pubkey::Pubkey;
+    use std::collections::HashMap;
+    use trees::tr;
+
+    #[test]
+    fn test_add_new_optimistic_confirmed_slots() {
+        let snapshot_start_slot = 10;
+        let mut optimistic_confirmation_verifier =
+            OptimisticConfirmationVerifier::new(snapshot_start_slot);
+        optimistic_confirmation_verifier
+            .add_new_optimistic_confirmed_slots(&[snapshot_start_slot - 1]);
+        optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&[snapshot_start_slot]);
+        optimistic_confirmation_verifier
+            .add_new_optimistic_confirmed_slots(&[snapshot_start_slot + 1]);
+        assert_eq!(optimistic_confirmation_verifier.unchecked_slots.len(), 1);
+        assert!(optimistic_confirmation_verifier
+            .unchecked_slots
+            .contains(&(snapshot_start_slot + 1)));
+    }
+
+    #[test]
+    fn test_check_optimistic_slots_rooted() {
+        let snapshot_start_slot = 0;
+        let mut optimistic_confirmation_verifier =
+            OptimisticConfirmationVerifier::new(snapshot_start_slot);
+        let blockstore_path = get_tmp_ledger_path!();
+        {
+            let blockstore = Blockstore::open(&blockstore_path).unwrap();
+            let mut vote_simulator = setup_forks();
+            let optimistic_slots = vec![1, 3, 5];
+
+            // If root is on same fork, nothing should be returned
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            let bank5 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(5)
+                .cloned()
+                .unwrap();
+            assert!(optimistic_confirmation_verifier
+                .check_optimistic_slots_rooted(&bank5, &blockstore)
+                .is_empty());
+            // 5 is >= than all the unchecked slots, so should clear everything
+            assert!(optimistic_confirmation_verifier.unchecked_slots.is_empty());
+
+            // If root is on same fork, nothing should be returned
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            let bank3 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(3)
+                .cloned()
+                .unwrap();
+            assert!(optimistic_confirmation_verifier
+                .check_optimistic_slots_rooted(&bank3, &blockstore)
+                .is_empty());
+            // 3 is bigger than only slot 1, so slot 5 should be left over
+            assert_eq!(optimistic_confirmation_verifier.unchecked_slots.len(), 1);
+            assert!(optimistic_confirmation_verifier
+                .unchecked_slots
+                .contains(&5));
+
+            // If root is on different fork, the slots < root on different fork should
+            // be returned
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            let bank4 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(4)
+                .cloned()
+                .unwrap();
+            assert_eq!(
+                optimistic_confirmation_verifier.check_optimistic_slots_rooted(&bank4, &blockstore),
+                vec![3]
+            );
+            // 4 is bigger than only slots 1 and 3, so slot 5 should be left over
+            assert_eq!(optimistic_confirmation_verifier.unchecked_slots.len(), 1);
+            assert!(optimistic_confirmation_verifier
+                .unchecked_slots
+                .contains(&5));
+
+            // Now set a root at slot 5, purging BankForks of slots < 5
+            vote_simulator.set_root(5);
+
+            // Add a new bank 7 that descends from 6
+            let bank6 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(6)
+                .cloned()
+                .unwrap();
+            vote_simulator
+                .bank_forks
+                .write()
+                .unwrap()
+                .insert(Bank::new_from_parent(&bank6, &Pubkey::default(), 7));
+            let bank7 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(7)
+                .unwrap()
+                .clone();
+            assert!(!bank7.ancestors.contains_key(&3));
+
+            // Should return slots 1, 3 as part of the rooted fork because there's no
+            // ancestry information
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            assert_eq!(
+                optimistic_confirmation_verifier.check_optimistic_slots_rooted(&bank7, &blockstore),
+                vec![1, 3]
+            );
+            assert!(optimistic_confirmation_verifier.unchecked_slots.is_empty());
+
+            // If we know set the root in blockstore, should return nothing
+            blockstore.set_roots(&[1, 3]).unwrap();
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            assert!(optimistic_confirmation_verifier
+                .check_optimistic_slots_rooted(&bank7, &blockstore)
+                .is_empty());
+            assert!(optimistic_confirmation_verifier.unchecked_slots.is_empty());
+        }
+        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
+    }
+
+    fn setup_forks() -> VoteSimulator {
+        /*
+            Build fork structure:
+                 slot 0
+                   |
+                 slot 1
+                 /    \
+            slot 2    |
+               |    slot 3
+            slot 4    |
+                    slot 5
+                      |
+                    slot 6
+        */
+        let forks = tr(0) / (tr(1) / (tr(2) / (tr(4))) / (tr(3) / (tr(5) / (tr(6)))));
+
+        let mut vote_simulator = VoteSimulator::new(1);
+        vote_simulator.fill_bank_forks(forks, &HashMap::new());
+        vote_simulator
+    }
+}

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -1033,6 +1033,7 @@ mod test {
             &keypairs.node_keypair,
             &keypairs.vote_keypair,
             &keypairs.vote_keypair,
+            None,
         );
         bank9.process_transaction(&vote_tx).unwrap();
         assert!(bank9.get_signature_status(&vote_tx.signatures[0]).is_some());

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2869,6 +2869,7 @@ pub(crate) mod tests {
             &my_keypairs.node_keypair,
             &my_keypairs.vote_keypair,
             &my_keypairs.vote_keypair,
+            None,
         );
 
         let bank_forks = RwLock::new(bank_forks);

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -926,8 +926,8 @@ mod tests {
         ClusterInfoVoteListener::get_and_process_votes_for_tests(
             &votes_receiver,
             &vote_tracker,
-            0,
-            rpc.subscriptions.clone(),
+            &bank,
+            &rpc.subscriptions,
         )
         .unwrap();
 

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -917,6 +917,7 @@ mod tests {
                 node_keypair,
                 vote_keypair,
                 vote_keypair,
+                None,
             );
             votes_sender.send(vec![vote_tx]).unwrap();
         });

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -77,6 +77,7 @@ impl Tpu {
             vote_tracker,
             bank_forks,
             subscriptions.clone(),
+            blockstore.clone(),
         );
 
         let banking_stage = BankingStage::new(

--- a/core/src/vote_stake_tracker.rs
+++ b/core/src/vote_stake_tracker.rs
@@ -1,0 +1,68 @@
+use crate::consensus::VOTE_THRESHOLD_SIZE;
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::HashSet, sync::Arc};
+
+#[derive(Default)]
+pub struct VoteStakeTracker {
+    voted: HashSet<Arc<Pubkey>>,
+    stake: u64,
+}
+
+impl VoteStakeTracker {
+    // Returns true if the stake that has voted has just crosssed the supermajority
+    // of stake
+    pub fn add_vote_pubkey(
+        &mut self,
+        vote_pubkey: Arc<Pubkey>,
+        stake: u64,
+        total_epoch_stake: u64,
+    ) -> bool {
+        if !self.voted.contains(&vote_pubkey) {
+            self.voted.insert(vote_pubkey);
+            let ratio_before = self.stake as f64 / total_epoch_stake as f64;
+            self.stake += stake;
+            let ratio_now = self.stake as f64 / total_epoch_stake as f64;
+
+            ratio_before <= VOTE_THRESHOLD_SIZE && ratio_now > VOTE_THRESHOLD_SIZE
+        } else {
+            false
+        }
+    }
+
+    pub fn voted(&self) -> &HashSet<Arc<Pubkey>> {
+        &self.voted
+    }
+
+    pub fn stake(&self) -> u64 {
+        self.stake
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_add_vote_pubkey() {
+        let total_epoch_stake = 10;
+        let mut vote_stake_tracker = VoteStakeTracker::default();
+        for i in 0..10 {
+            let pubkey = Arc::new(Pubkey::new_rand());
+            let res = vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
+            let stake = vote_stake_tracker.stake();
+            vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
+            let stake2 = vote_stake_tracker.stake();
+
+            // Stake should not change from adding same pubkey twice
+            assert_eq!(stake, stake2);
+
+            // at i == 7, the voted stake is 70%, which is the first time crossing
+            // the supermajority threshold
+            if i == 6 {
+                assert!(res);
+            } else {
+                assert!(!res);
+            }
+        }
+    }
+}

--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -1548,6 +1548,117 @@
       }
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 0,
+        "y": 6
+      },
+      "id": 65,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"average_elapsed_ms\") FROM \"$testnet\".\"autogen\".\"optimistic_slot_elapsed\" WHERE $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Average Optimistic Confirmation Elapsed",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
       "aliasColors": {},
       "bars": true,
       "dashLength": 10,
@@ -1558,7 +1669,7 @@
         "h": 9,
         "w": 14,
         "x": 0,
-        "y": 6
+        "y": 8
       },
       "id": 14,
       "legend": {
@@ -1936,7 +2047,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 17
       },
       "id": 16,
       "panels": [],
@@ -1954,7 +2065,7 @@
         "h": 3,
         "w": 8,
         "x": 0,
-        "y": 16
+        "y": 18
       },
       "id": 17,
       "legend": {
@@ -2110,7 +2221,7 @@
         "h": 6,
         "w": 7,
         "x": 8,
-        "y": 16
+        "y": 18
       },
       "id": 18,
       "legend": {
@@ -2346,7 +2457,7 @@
         "h": 2,
         "w": 4,
         "x": 15,
-        "y": 16
+        "y": 18
       },
       "id": 19,
       "interval": null,
@@ -2457,7 +2568,7 @@
         "h": 2,
         "w": 3,
         "x": 19,
-        "y": 16
+        "y": 18
       },
       "id": 20,
       "interval": null,
@@ -2568,7 +2679,7 @@
         "h": 2,
         "w": 2,
         "x": 22,
-        "y": 16
+        "y": 18
       },
       "id": 21,
       "interval": null,
@@ -2668,7 +2779,7 @@
         "h": 4,
         "w": 5,
         "x": 15,
-        "y": 18
+        "y": 20
       },
       "id": 22,
       "legend": {
@@ -2786,7 +2897,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 18
+        "y": 20
       },
       "id": 23,
       "legend": {
@@ -2904,7 +3015,7 @@
         "h": 3,
         "w": 8,
         "x": 0,
-        "y": 19
+        "y": 21
       },
       "id": 24,
       "legend": {
@@ -3057,7 +3168,7 @@
         "h": 6,
         "w": 15,
         "x": 0,
-        "y": 22
+        "y": 24
       },
       "id": 25,
       "links": [],
@@ -3145,7 +3256,7 @@
         "h": 6,
         "w": 9,
         "x": 15,
-        "y": 22
+        "y": 24
       },
       "id": 26,
       "legend": {
@@ -3626,7 +3737,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 28
+        "y": 30
       },
       "id": 27,
       "links": [],
@@ -3711,7 +3822,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 28
+        "y": 30
       },
       "id": 28,
       "links": [],
@@ -3796,7 +3907,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 28
+        "y": 30
       },
       "id": 29,
       "links": [],
@@ -3879,7 +3990,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 36
       },
       "id": 30,
       "panels": [],
@@ -3897,7 +4008,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 35
+        "y": 37
       },
       "id": 31,
       "legend": {
@@ -4136,7 +4247,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 35
+        "y": 37
       },
       "id": 32,
       "legend": {
@@ -4418,7 +4529,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 35
+        "y": 37
       },
       "id": 33,
       "legend": {
@@ -4629,7 +4740,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 41
+        "y": 43
       },
       "id": 34,
       "legend": {
@@ -4996,9 +5107,9 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 41
+        "y": 43
       },
-      "id": 64,
+      "id": 35,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -5168,7 +5279,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 41
+        "y": 43
       },
       "id": 36,
       "legend": {
@@ -5489,7 +5600,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 47
+        "y": 49
       },
       "id": 37,
       "legend": {
@@ -5919,9 +6030,9 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 47
+        "y": 49
       },
-      "id": 35,
+      "id": 38,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -6152,7 +6263,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 47
+        "y": 49
       },
       "id": 39,
       "legend": {
@@ -6478,9 +6589,9 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 53
+        "y": 55
       },
-      "id": 41,
+      "id": 40,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -6780,9 +6891,9 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 53
+        "y": 55
       },
-      "id": 38,
+      "id": 41,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -6933,7 +7044,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 53
+        "y": 55
       },
       "id": 42,
       "legend": {
@@ -7050,7 +7161,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 58
+        "y": 60
       },
       "id": 43,
       "legend": {
@@ -7209,9 +7320,9 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 58
+        "y": 60
       },
-      "id": 40,
+      "id": 44,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -7325,9 +7436,9 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 58
+        "y": 60
       },
-      "id": 44,
+      "id": 45,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -7436,9 +7547,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 66
       },
-      "id": 45,
+      "id": 46,
       "panels": [],
       "title": "Tower Consensus",
       "type": "row"
@@ -7459,9 +7570,9 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 65
+        "y": 67
       },
-      "id": 46,
+      "id": 47,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -7619,9 +7730,9 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 65
+        "y": 67
       },
-      "id": 47,
+      "id": 48,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -7779,9 +7890,9 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 65
+        "y": 67
       },
-      "id": 48,
+      "id": 49,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -7959,14 +8070,260 @@
       }
     },
     {
+      "aliasColors": {
+        "cluster-info.repair": "#ba43a9",
+        "replay_stage-new_leader.last": "#00ffbb",
+        "tower-vote.last": "#00ffbb",
+        "window-service.receive": "#b7dbab",
+        "window-stage.consumed": "#5195ce"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 72
+      },
+      "id": 68,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT last(\"slot\") FROM \"$testnet\".\"autogen\".\"optimistic_slot\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Optimistic Slots ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "cluster-info.repair": "#ba43a9",
+        "replay_stage-new_leader.last": "#00ffbb",
+        "tower-vote.last": "#00ffbb",
+        "window-service.receive": "#b7dbab",
+        "window-stage.consumed": "#5195ce"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 72
+      },
+      "id": 69,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT last(\"slot\") FROM \"$testnet\".\"autogen\".\"optimistic_slot_not_rooted\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unrooted Optimistic Slots ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 77
       },
-      "id": 49,
+      "id": 50,
       "panels": [],
       "repeat": null,
       "title": "IP Network",
@@ -7983,9 +8340,9 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 71
+        "y": 78
       },
-      "id": 50,
+      "id": 51,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8216,9 +8573,9 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 71
+        "y": 78
       },
-      "id": 51,
+      "id": 52,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8369,9 +8726,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 83
       },
-      "id": 52,
+      "id": 53,
       "panels": [],
       "title": "Signature Verification",
       "type": "row"
@@ -8387,9 +8744,9 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 77
+        "y": 84
       },
-      "id": 53,
+      "id": 54,
       "legend": {
         "avg": false,
         "current": false,
@@ -8589,9 +8946,9 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 77
+        "y": 84
       },
-      "id": 54,
+      "id": 55,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8738,9 +9095,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 89
       },
-      "id": 55,
+      "id": 56,
       "panels": [],
       "title": "Snapshots",
       "type": "row"
@@ -8756,9 +9113,9 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 83
+        "y": 90
       },
-      "id": 56,
+      "id": 57,
       "legend": {
         "avg": false,
         "current": false,
@@ -8948,9 +9305,9 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 83
+        "y": 90
       },
-      "id": 57,
+      "id": 58,
       "legend": {
         "avg": false,
         "current": false,
@@ -9216,9 +9573,9 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 83
+        "y": 90
       },
-      "id": 58,
+      "id": 59,
       "legend": {
         "avg": false,
         "current": false,
@@ -9405,9 +9762,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 96
       },
-      "id": 59,
+      "id": 60,
       "panels": [],
       "title": "Bench TPS",
       "type": "row"
@@ -9423,9 +9780,9 @@
         "h": 5,
         "w": 7,
         "x": 0,
-        "y": 90
+        "y": 97
       },
-      "id": 60,
+      "id": 61,
       "legend": {
         "avg": false,
         "current": false,
@@ -9538,9 +9895,9 @@
         "h": 5,
         "w": 7,
         "x": 7,
-        "y": 90
+        "y": 97
       },
-      "id": 61,
+      "id": 62,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9763,9 +10120,9 @@
         "h": 5,
         "w": 10,
         "x": 14,
-        "y": 90
+        "y": 97
       },
-      "id": 62,
+      "id": 63,
       "links": [],
       "pageSize": null,
       "scroll": true,
@@ -9851,9 +10208,9 @@
         "h": 4,
         "w": 10,
         "x": 0,
-        "y": 95
+        "y": 102
       },
-      "id": 63,
+      "id": 64,
       "legend": {
         "avg": false,
         "current": false,

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -11,6 +11,7 @@ use serde_derive::{Deserialize, Serialize};
 use solana_metrics::inc_new_counter_info;
 use solana_sdk::{
     account::{get_signers, KeyedAccount},
+    hash::Hash,
     instruction::{AccountMeta, Instruction, InstructionError, WithSigner},
     program_utils::{limited_deserialize, next_keyed_account, DecodeError},
     pubkey::Pubkey,
@@ -95,6 +96,15 @@ pub enum VoteInstruction {
     ///    1 - New validator identity (node_pubkey)
     ///
     UpdateValidatorIdentity,
+
+    /// A Vote instruction with recent votes
+    ///    requires authorized voter signature
+    ///
+    /// Expects 3 Accounts:
+    ///    0 - Vote account to vote with
+    ///    1 - Slot hashes sysvar
+    ///    2 - Clock sysvar
+    VoteSwitch(Vote, Hash),
 }
 
 fn initialize_account(vote_pubkey: &Pubkey, vote_init: &VoteInit) -> Instruction {
@@ -195,6 +205,26 @@ pub fn vote(vote_pubkey: &Pubkey, authorized_voter_pubkey: &Pubkey, vote: Vote) 
     Instruction::new(id(), &VoteInstruction::Vote(vote), account_metas)
 }
 
+pub fn vote_switch(
+    vote_pubkey: &Pubkey,
+    authorized_voter_pubkey: &Pubkey,
+    vote: Vote,
+    proof_hash: Hash,
+) -> Instruction {
+    let account_metas = vec![
+        AccountMeta::new(*vote_pubkey, false),
+        AccountMeta::new_readonly(sysvar::slot_hashes::id(), false),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
+    ]
+    .with_signer(authorized_voter_pubkey);
+
+    Instruction::new(
+        id(),
+        &VoteInstruction::VoteSwitch(vote, proof_hash),
+        account_metas,
+    )
+}
+
 pub fn withdraw(
     vote_pubkey: &Pubkey,
     authorized_withdrawer_pubkey: &Pubkey,
@@ -245,7 +275,7 @@ pub fn process_instruction(
             next_keyed_account(keyed_accounts)?.unsigned_key(),
             &signers,
         ),
-        VoteInstruction::Vote(vote) => {
+        VoteInstruction::Vote(vote) | VoteInstruction::VoteSwitch(vote, _) => {
             inc_new_counter_info!("vote-native", 1);
             vote_state::process_vote(
                 me,
@@ -329,6 +359,15 @@ mod tests {
             Err(InstructionError::InvalidAccountData),
         );
         assert_eq!(
+            process_instruction(&vote_switch(
+                &Pubkey::default(),
+                &Pubkey::default(),
+                Vote::default(),
+                Hash::default(),
+            )),
+            Err(InstructionError::InvalidAccountData),
+        );
+        assert_eq!(
             process_instruction(&authorize(
                 &Pubkey::default(),
                 &Pubkey::default(),
@@ -389,5 +428,5 @@ mod tests {
             "Custom(0): VoteError::VoteTooOld - vote already recorded or not in slot hashes history",
             pretty_err::<VoteError>(VoteError::VoteTooOld.into())
         )
-    }
+    }   
 }

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -428,5 +428,5 @@ mod tests {
             "Custom(0): VoteError::VoteTooOld - vote already recorded or not in slot hashes history",
             pretty_err::<VoteError>(VoteError::VoteTooOld.into())
         )
-    }   
+    }
 }

--- a/programs/vote/src/vote_transaction.rs
+++ b/programs/vote/src/vote_transaction.rs
@@ -14,13 +14,23 @@ pub fn new_vote_transaction(
     node_keypair: &Keypair,
     vote_keypair: &Keypair,
     authorized_voter_keypair: &Keypair,
+    switch_proof_hash: Option<Hash>,
 ) -> Transaction {
     let votes = Vote::new(slots, bank_hash);
-    let vote_ix = vote_instruction::vote(
-        &vote_keypair.pubkey(),
-        &authorized_voter_keypair.pubkey(),
-        votes,
-    );
+    let vote_ix = if let Some(switch_proof_hash) = switch_proof_hash {
+        vote_instruction::vote_switch(
+            &vote_keypair.pubkey(),
+            &authorized_voter_keypair.pubkey(),
+            votes,
+            switch_proof_hash,
+        )
+    } else {
+        vote_instruction::vote(
+            &vote_keypair.pubkey(),
+            &authorized_voter_keypair.pubkey(),
+            votes,
+        )
+    };
 
     let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
 


### PR DESCRIPTION
#### Problem
1) No switch/vs non switch vote instructions
2) No way to count switch/vs non switching instructions to know when optimistic finality was achieved

#### Summary of Changes
1) Added switch/vs non switch vote instructions: https://github.com/solana-labs/solana/pull/10179/files#diff-0123bafd880584de694cec91df7ff542R100-R107
2) Updated ReplayStage to use switch/non-switch votes instructions: https://github.com/solana-labs/solana/pull/10179/files#diff-5984b6b0429f857c13a2a362669ab37cR1003-R1013
3) Updated `ClusterInfoVoteListener` in `cluster_info_vote_listener.rs` to track non-switch votes:
4) Added a `OptimisticConfirmationVerifier` to check if optimistcally-confirmed slots are ever not rooted: https://github.com/solana-labs/solana/pull/10179/files#diff-321520f0b6b657c299270b37ec62ce98R7
5) Added dashboards/metrics to track optimistic slots/violations:
<img width="1100" alt="Screen Shot 2020-05-21 at 6 50 55 PM" src="https://user-images.githubusercontent.com/3374799/82623033-13ed3800-9b94-11ea-99cd-727b044e50c6.png">

Currently running testnet with 2 min-long partitioning: https://metrics.solana.com:3000/d/monitor-edge/cluster-telemetry-edge?panelId=65&orgId=2&var-datasource=Solana%20Metrics%20(read-only)&var-testnet=testnet-dev-carllin&var-hostid=All&tab=metrics&from=1590110446144&to=1590112246144

TODO's: 
1) Chop up PR
2) Add a slot at which to transition over to using `switch` votes to maintain backwards compatibility
3) Some more tests


Fixes #
