### PR TITLE
No longer allow create-account to add funds to an existing account

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -208,8 +208,13 @@ pub fn split(
     split_stake_pubkey: &Pubkey,
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate(split_stake_pubkey, std::mem::size_of::<StakeState>() as u64),
-        system_instruction::assign(split_stake_pubkey, &id()),
+        system_instruction::create_account(
+            authorized_pubkey, // Sending 0, so any signer will suffice
+            split_stake_pubkey,
+            0,
+            std::mem::size_of::<StakeState>() as u64,
+            &id(),
+        ),
         _split(
             stake_pubkey,
             authorized_pubkey,
@@ -228,10 +233,12 @@ pub fn split_with_seed(
     seed: &str,                  // seed
 ) -> Vec<Instruction> {
     vec![
-        system_instruction::allocate_with_seed(
+        system_instruction::create_account_with_seed(
+            authorized_pubkey, // Sending 0, so any signer will suffice
             split_stake_pubkey,
             base,
             seed,
+            0,
             std::mem::size_of::<StakeState>() as u64,
             &id(),
         ),
@@ -489,7 +496,7 @@ mod tests {
                     &Pubkey::default(),
                     100,
                     &Pubkey::default()
-                )[2]
+                )[1]
             ),
             Err(InstructionError::InvalidAccountData),
         );


### PR DESCRIPTION
#### Problem

* It's currently possible to add tokens to an existing account with `SystemInstruction::CreateAccount`, which is counter-intuitive
* The CLI's `split-stake` and `split-stake-with-seed` commands allow the user to promote a System account into a Stake account, which probably isn't their intent

#### Summary of Changes

* Change the System instruction processor to fail if creating an account when that address already has tokens.  The existing behavior is probably an artifact of the days when `Transfer` was implemented with `CreateAccount`.
* Change `StakeInstruction::Split` and `SplitWithSeed` to fail if splitting to an address that already has tokens.
