### PR TITLE
Re-enable move in docker-solana

### DIFF
--- a/sdk/docker-solana/build.sh
+++ b/sdk/docker-solana/build.sh
@@ -21,7 +21,7 @@ fi
 cd "$(dirname "$0")"
 rm -rf usr/
 ../../ci/docker-run.sh "$rust_stable_docker_image" \
-  scripts/cargo-install-all.sh sdk/docker-solana/usr
+  scripts/cargo-install-all.sh --use-move sdk/docker-solana/usr
 
 cp -f ../../run.sh usr/bin/solana-run.sh
 


### PR DESCRIPTION
#### Problem

Move loader program is not released in docker-solana and thus unavailable to the move example

#### Summary of Changes

Re-enable it

Fixes #
