### PR TITLE
Track non-switching votes from gossip

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -655,7 +655,7 @@ mod tests {
         bank::Bank,
         genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs},
     };
-    use solana_sdk::hash::Hash;
+    use solana_sdk::hash::{self, Hash};
     use solana_sdk::signature::Signature;
     use solana_sdk::signature::{Keypair, Signer};
     use solana_vote_program::vote_transaction;
@@ -1366,5 +1366,31 @@ mod tests {
     fn test_bad_vote() {
         run_test_bad_vote(None);
         run_test_bad_vote(Some(Hash::default()));
+    }
+
+    fn run_test_parse_vote_transaction(input_hash: Option<Hash>) {
+        let node_keypair = Keypair::new();
+        let vote_keypair = Keypair::new();
+        let auth_voter_keypair = Keypair::new();
+        let bank_hash = Hash::default();
+        let vote_tx = vote_transaction::new_vote_transaction(
+            vec![42],
+            bank_hash,
+            Hash::default(),
+            &node_keypair,
+            &vote_keypair,
+            &auth_voter_keypair,
+            input_hash,
+        );
+        let (key, vote, hash) = ClusterInfoVoteListener::parse_vote_transaction(&vote_tx).unwrap();
+        assert_eq!(hash, input_hash);
+        assert_eq!(vote, Vote::new(vec![42], bank_hash));
+        assert_eq!(key, vote_keypair.pubkey());
+    }
+
+    #[test]
+    fn test_parse_vote_transaction() {
+        run_test_parse_vote_transaction(None);
+        run_test_parse_vote_transaction(Some(hash::hash(&[42u8])));
     }
 }

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,6 +1,5 @@
 use crate::{
     cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS},
-    consensus::VOTE_THRESHOLD_SIZE,
     crds_value::CrdsValueLabel,
     poh_recorder::PohRecorder,
     pubkey_references::LockedPubkeyReferences,
@@ -17,10 +16,7 @@ use log::*;
 use solana_ledger::bank_forks::BankForks;
 use solana_metrics::inc_new_counter_debug;
 use solana_perf::packet::{self, Packets};
-use solana_runtime::{
-    bank::Bank,
-    epoch_stakes::{EpochAuthorizedVoters, EpochStakes},
-};
+use solana_runtime::{bank::Bank, epoch_stakes::EpochAuthorizedVoters};
 use solana_sdk::{
     clock::{Epoch, Slot},
     epoch_schedule::EpochSchedule,
@@ -49,7 +45,6 @@ pub type VerifiedVoteTransactionsReceiver = CrossbeamReceiver<Vec<Transaction>>;
 pub struct SlotVoteTracker {
     voted: HashSet<Arc<Pubkey>>,
     updates: Option<Vec<Arc<Pubkey>>>,
-    total_stake: u64,
 }
 
 impl SlotVoteTracker {
@@ -379,14 +374,12 @@ impl ClusterInfoVoteListener {
 
             let root_bank = bank_forks.read().unwrap().root_bank().clone();
             vote_tracker.process_new_root_bank(&root_bank);
-            let epoch_stakes = root_bank.epoch_stakes(root_bank.epoch());
 
             if let Err(e) = Self::get_and_process_votes(
                 &vote_txs_receiver,
                 &vote_tracker,
                 root_bank.slot(),
                 &subscriptions,
-                epoch_stakes,
             ) {
                 match e {
                     Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => {
@@ -408,13 +401,7 @@ impl ClusterInfoVoteListener {
         last_root: Slot,
         subscriptions: &RpcSubscriptions,
     ) -> Result<()> {
-        Self::get_and_process_votes(
-            vote_txs_receiver,
-            vote_tracker,
-            last_root,
-            subscriptions,
-            None,
-        )
+        Self::get_and_process_votes(vote_txs_receiver, vote_tracker, last_root, subscriptions)
     }
 
     fn get_and_process_votes(
@@ -422,20 +409,13 @@ impl ClusterInfoVoteListener {
         vote_tracker: &VoteTracker,
         last_root: Slot,
         subscriptions: &RpcSubscriptions,
-        epoch_stakes: Option<&EpochStakes>,
     ) -> Result<()> {
         let timer = Duration::from_millis(200);
         let mut vote_txs = vote_txs_receiver.recv_timeout(timer)?;
         while let Ok(new_txs) = vote_txs_receiver.try_recv() {
             vote_txs.extend(new_txs);
         }
-        Self::process_votes(
-            vote_tracker,
-            vote_txs,
-            last_root,
-            subscriptions,
-            epoch_stakes,
-        );
+        Self::process_votes(vote_tracker, vote_txs, last_root, subscriptions);
         Ok(())
     }
 
@@ -444,7 +424,6 @@ impl ClusterInfoVoteListener {
         vote_txs: Vec<Transaction>,
         root: Slot,
         subscriptions: &RpcSubscriptions,
-        epoch_stakes: Option<&EpochStakes>,
     ) {
         let mut diff: HashMap<Slot, HashSet<Arc<Pubkey>>> = HashMap::new();
         {
@@ -532,66 +511,21 @@ impl ClusterInfoVoteListener {
                 if w_slot_tracker.updates.is_none() {
                     w_slot_tracker.updates = Some(vec![]);
                 }
-                let mut current_stake = 0;
-                for pubkey in slot_diff {
-                    Self::sum_stake(&mut current_stake, epoch_stakes, &pubkey);
-
-                    w_slot_tracker.voted.insert(pubkey.clone());
-                    w_slot_tracker.updates.as_mut().unwrap().push(pubkey);
+                for pk in slot_diff {
+                    w_slot_tracker.voted.insert(pk.clone());
+                    w_slot_tracker.updates.as_mut().unwrap().push(pk);
                 }
-                Self::notify_for_stake_change(
-                    current_stake,
-                    w_slot_tracker.total_stake,
-                    &subscriptions,
-                    epoch_stakes,
-                    slot,
-                );
-                w_slot_tracker.total_stake += current_stake;
             } else {
-                let mut total_stake = 0;
-                let voted: HashSet<_> = slot_diff
-                    .into_iter()
-                    .map(|pubkey| {
-                        Self::sum_stake(&mut total_stake, epoch_stakes, &pubkey);
-                        pubkey
-                    })
-                    .collect();
-                Self::notify_for_stake_change(total_stake, 0, &subscriptions, epoch_stakes, slot);
+                let voted: HashSet<_> = slot_diff.into_iter().collect();
                 let new_slot_tracker = SlotVoteTracker {
                     voted: voted.clone(),
                     updates: Some(voted.into_iter().collect()),
-                    total_stake,
                 };
                 vote_tracker
                     .slot_vote_trackers
                     .write()
                     .unwrap()
                     .insert(slot, Arc::new(RwLock::new(new_slot_tracker)));
-            }
-        }
-    }
-
-    fn notify_for_stake_change(
-        current_stake: u64,
-        previous_stake: u64,
-        subscriptions: &RpcSubscriptions,
-        epoch_stakes: Option<&EpochStakes>,
-        slot: Slot,
-    ) {
-        if let Some(stakes) = epoch_stakes {
-            let supermajority_stake = (stakes.total_stake() as f64 * VOTE_THRESHOLD_SIZE) as u64;
-            if previous_stake < supermajority_stake
-                && (previous_stake + current_stake) > supermajority_stake
-            {
-                subscriptions.notify_gossip_subscribers(slot);
-            }
-        }
-    }
-
-    fn sum_stake(sum: &mut u64, epoch_stakes: Option<&EpochStakes>, pubkey: &Pubkey) {
-        if let Some(stakes) = epoch_stakes {
-            if let Some(vote_account) = stakes.stakes().vote_accounts().get(pubkey) {
-                *sum += vote_account.0;
             }
         }
     }
@@ -805,7 +739,6 @@ mod tests {
             &vote_tracker,
             0,
             &subscriptions,
-            None,
         )
         .unwrap();
         for vote_slot in vote_slots {
@@ -855,7 +788,6 @@ mod tests {
             &vote_tracker,
             0,
             &subscriptions,
-            None,
         )
         .unwrap();
         for (i, keyset) in validator_voting_keypairs.chunks(2).enumerate() {
@@ -974,7 +906,7 @@ mod tests {
             &validator0_keypairs.vote_keypair,
         )];
 
-        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_tx, 0, &subscriptions, None);
+        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_tx, 0, &subscriptions);
         let ref_count = Arc::strong_count(
             &vote_tracker
                 .keys
@@ -1025,7 +957,7 @@ mod tests {
             })
             .collect();
 
-        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_txs, 0, &subscriptions, None);
+        ClusterInfoVoteListener::process_votes(&vote_tracker, vote_txs, 0, &subscriptions);
 
         let ref_count = Arc::strong_count(
             &vote_tracker

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -522,7 +522,7 @@ impl ClusterInfoVoteListener {
                         let unduplicated_pubkey = vote_tracker.keys.get_or_insert(vote_pubkey);
                         let should_update_switch = (slot == last_vote_slot) && !is_switch_vote;
                         if should_update_switch
-                            || !diff
+                            || diff
                                 .entry(*slot)
                                 .or_default()
                                 .insert(unduplicated_pubkey.clone())
@@ -616,6 +616,7 @@ mod tests {
             &node_keypair,
             &vote_keypair,
             &vote_keypair,
+            Some(Hash::default()),
         );
 
         use bincode::serialized_size;
@@ -626,8 +627,7 @@ mod tests {
         assert_eq!(msgs.len(), 1);
     }
 
-    #[test]
-    fn vote_contains_authorized_voter() {
+    fn run_vote_contains_authorized_voter(hash: Option<Hash>) {
         let node_keypair = Keypair::new();
         let vote_keypair = Keypair::new();
         let authorized_voter = Keypair::new();
@@ -639,6 +639,7 @@ mod tests {
             &node_keypair,
             &vote_keypair,
             &authorized_voter,
+            hash,
         );
 
         // Check that the two signing keys pass the check
@@ -666,6 +667,7 @@ mod tests {
             &node_keypair,
             &vote_keypair,
             &vote_keypair,
+            hash,
         );
 
         // Check that the node_keypair and vote keypair pass the authorized voter check
@@ -679,11 +681,17 @@ mod tests {
             &vote_keypair.pubkey()
         ));
 
-        // The other keypair should not pss the cchecck
+        // The other keypair should not pass the check
         assert!(!VoteTracker::vote_contains_authorized_voter(
             &vote_tx,
             &authorized_voter.pubkey()
         ));
+    }
+
+    #[test]
+    fn vote_contains_authorized_voter() {
+        run_vote_contains_authorized_voter(None);
+        run_vote_contains_authorized_voter(Some(Hash::default()));
     }
 
     #[test]
@@ -768,8 +776,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_process_votes() {
+    fn run_test_process_votes(hash: Option<Hash>) {
         // Create some voters at genesis
         let (vote_tracker, _, validator_voting_keypairs, subscriptions) = setup();
         let (votes_sender, votes_receiver) = unbounded();
@@ -785,6 +792,7 @@ mod tests {
                 node_keypair,
                 vote_keypair,
                 vote_keypair,
+                hash,
             );
             votes_sender.send(vec![vote_tx]).unwrap();
         });
@@ -808,8 +816,29 @@ mod tests {
                     .as_ref()
                     .unwrap()
                     .contains(&Arc::new(pubkey)));
+                // 1) Only the last vote in the stack of votes should count toward
+                // the `no_switching` vote set
+                // 2) Should only count toward the `no_switching` vote set if the
+                // vote was a `no-switching` vote
+                if vote_slot == 2 && hash.is_none() {
+                    assert!(r_slot_vote_tracker
+                        .voted_no_switching
+                        .voted
+                        .contains(&pubkey));
+                } else {
+                    assert!(!r_slot_vote_tracker
+                        .voted_no_switching
+                        .voted
+                        .contains(&pubkey));
+                }
             }
         }
+    }
+
+    #[test]
+    fn test_process_votes() {
+        run_test_process_votes(None);
+        run_test_process_votes(Some(Hash::default()));
     }
 
     #[test]
@@ -832,6 +861,7 @@ mod tests {
                         node_keypair,
                         vote_keypair,
                         vote_keypair,
+                        None,
                     )
                 })
                 .collect();
@@ -857,6 +887,12 @@ mod tests {
                     .as_ref()
                     .unwrap()
                     .contains(&Arc::new(pubkey)));
+                // All the votes were single votes, so theey should all count towards
+                // the non-switching vote set
+                assert!(r_slot_vote_tracker
+                    .voted_no_switching
+                    .voted
+                    .contains(&pubkey));
             }
         }
     }
@@ -920,8 +956,8 @@ mod tests {
     fn test_vote_tracker_references() {
         // The number of references that get stored for a pubkey every time
         // a vote is made. One stored in the SlotVoteTracker.voted, one in
-        // SlotVoteTracker.updates
-        let ref_count_per_vote = 2;
+        // SlotVoteTracker.updates, one in SlotVoteTracker.voted_no_switching
+        let ref_count_per_vote = 3;
 
         // Create some voters at genesis
         let validator_voting_keypairs: Vec<_> = (0..2)
@@ -960,6 +996,7 @@ mod tests {
             &validator0_keypairs.node_keypair,
             &validator0_keypairs.vote_keypair,
             &validator0_keypairs.vote_keypair,
+            None,
         )];
 
         ClusterInfoVoteListener::process_votes(&vote_tracker, vote_tx, 0, &subscriptions);
@@ -1009,6 +1046,7 @@ mod tests {
                     &validator0_keypairs.node_keypair,
                     &validator0_keypairs.vote_keypair,
                     &validator0_keypairs.vote_keypair,
+                    None,
                 )
             })
             .collect();
@@ -1104,7 +1142,7 @@ mod tests {
         assert_eq!(num_packets, ref_value);
     }
 
-    fn test_vote_tx() -> Transaction {
+    fn test_vote_tx(hash: Option<Hash>) -> Transaction {
         let node_keypair = Keypair::new();
         let vote_keypair = Keypair::new();
         let auth_voter_keypair = Keypair::new();
@@ -1115,12 +1153,12 @@ mod tests {
             &node_keypair,
             &vote_keypair,
             &auth_voter_keypair,
+            hash,
         )
     }
 
-    #[test]
-    fn test_verify_votes_1_pass() {
-        let vote_tx = test_vote_tx();
+    fn run_test_verify_votes_1_pass(hash: Option<Hash>) {
+        let vote_tx = test_vote_tx(hash);
         let votes = vec![vote_tx];
         let labels = vec![CrdsValueLabel::Vote(0, Pubkey::new_rand())];
         let (vote_txs, packets) = ClusterInfoVoteListener::verify_votes(votes, labels);
@@ -1129,8 +1167,13 @@ mod tests {
     }
 
     #[test]
-    fn test_bad_vote() {
-        let vote_tx = test_vote_tx();
+    fn test_verify_votes_1_pass() {
+        run_test_verify_votes_1_pass(None);
+        run_test_verify_votes_1_pass(Some(Hash::default()));
+    }
+
+    fn run_test_bad_vote(hash: Option<Hash>) {
+        let vote_tx = test_vote_tx(hash);
         let mut bad_vote = vote_tx.clone();
         bad_vote.signatures[0] = Signature::default();
         let votes = vec![vote_tx.clone(), bad_vote, vote_tx];
@@ -1139,5 +1182,11 @@ mod tests {
         let (vote_txs, packets) = ClusterInfoVoteListener::verify_votes(votes, labels);
         assert_eq!(vote_txs.len(), 2);
         verify_packets_len(&packets, 2);
+    }
+
+    #[test]
+    fn test_bad_vote() {
+        run_test_bad_vote(None);
+        run_test_bad_vote(Some(Hash::default()));
     }
 }

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -439,7 +439,7 @@ impl ClusterInfoVoteListener {
         root_bank: &Bank,
         subscriptions: &RpcSubscriptions,
     ) -> Result<Vec<(Slot, Hash)>> {
-        Self::get_and_process_votes(vote_txs_receiver, vote_tracker, last_root, subscriptions)
+        Self::get_and_process_votes(vote_txs_receiver, vote_tracker, root_bank, subscriptions)
     }
 
     fn get_and_process_votes(
@@ -858,7 +858,7 @@ mod tests {
         let vote_slots = vec![1, 2];
         let bank_hash = Hash::default();
         send_vote_txs(
-            vote_slots.clone(),
+            vote_slots,
             &validator_voting_keypairs,
             None,
             &votes_sender,
@@ -883,7 +883,7 @@ mod tests {
             .get_first_slot_in_epoch(unknown_epoch);
         let vote_slots = vec![first_slot_in_unknown_epoch, first_slot_in_unknown_epoch + 1];
         send_vote_txs(
-            vote_slots.clone(),
+            vote_slots,
             &validator_voting_keypairs,
             None,
             &votes_sender,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -710,6 +710,7 @@ pub mod test {
                             &keypairs.node_keypair,
                             &keypairs.vote_keypair,
                             &keypairs.vote_keypair,
+                            None,
                         );
                         info!("voting {} {}", parent_bank.slot(), parent_bank.hash());
                         new_bank.process_transaction(&vote_tx).unwrap();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,6 +59,7 @@ pub mod transaction_status_service;
 pub mod tvu;
 pub mod validator;
 pub mod verified_vote_packets;
+pub mod vote_stake_tracker;
 pub mod weighted_shuffle;
 pub mod window_service;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod gossip_service;
 pub mod ledger_cleanup_service;
 pub mod local_vote_signer_service;
 pub mod non_circulating_supply;
+pub mod optimistic_confirmation_verifier;
 pub mod poh_recorder;
 pub mod poh_service;
 pub mod progress_map;

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -1,0 +1,276 @@
+use crate::cluster_info_vote_listener::VoteTracker;
+use solana_ledger::blockstore::Blockstore;
+use solana_runtime::bank::Bank;
+use solana_sdk::clock::Slot;
+use std::{collections::BTreeSet, time::Instant};
+
+pub struct OptimisticConfirmationVerifier {
+    snapshot_start_slot: Slot,
+    unchecked_slots: BTreeSet<Slot>,
+    last_optimistic_slot_ts: Instant,
+}
+
+impl OptimisticConfirmationVerifier {
+    pub fn new(snapshot_start_slot: Slot) -> Self {
+        Self {
+            snapshot_start_slot,
+            unchecked_slots: BTreeSet::default(),
+            last_optimistic_slot_ts: Instant::now(),
+        }
+    }
+
+    // Returns any optimistic slots that were not rooted
+    pub fn check_optimistic_slots_rooted(
+        &mut self,
+        root_bank: &Bank,
+        blockstore: &Blockstore,
+    ) -> Vec<Slot> {
+        let root = root_bank.slot();
+        let root_ancestors = &root_bank.ancestors;
+        let mut slots_before_root = self.unchecked_slots.split_off(&(root + 1));
+        // `slots_before_root` now contains all slots <= root
+        std::mem::swap(&mut slots_before_root, &mut self.unchecked_slots);
+        slots_before_root
+            .into_iter()
+            .filter(|optimistic_slot| {
+                !root_ancestors.contains_key(&optimistic_slot) &&
+            // In this second part of the `and`, we account for the possibility that 
+            // there was some other root `rootX` set in BankForks where:
+            //
+            // `root` > `rootX` > `optimistic_slot`
+            //
+            // in which case `root` may  not contain the ancestor information for
+            // slots < `rootX`, so we also have to check if `optimistic_slot` was rooted
+            // through blockstore.
+            !blockstore.is_root(*optimistic_slot)
+            })
+            .collect()
+    }
+
+    pub fn add_new_optimistic_confirmed_slots(&mut self, new_optimistic_slots: &[Slot]) {
+        if new_optimistic_slots.is_empty() {
+            return;
+        }
+
+        datapoint_info!(
+            "optimistic_slot_elapsed",
+            (
+                "average_elapsed_ms",
+                self.last_optimistic_slot_ts.elapsed().as_millis() as i64
+                    / new_optimistic_slots.len() as i64,
+                i64
+            ),
+        );
+
+        // We don't have any information about ancestors before the snapshot root,
+        // so ignore those slots
+        for new_optimistic_slot in new_optimistic_slots {
+            if *new_optimistic_slot > self.snapshot_start_slot {
+                datapoint_warn!("optimistic_slot", ("slot", *new_optimistic_slot, i64),);
+                self.unchecked_slots.insert(*new_optimistic_slot);
+            }
+        }
+
+        self.last_optimistic_slot_ts = Instant::now();
+    }
+
+    pub fn log_unrooted_optimistic_slots(
+        root_bank: &Bank,
+        vote_tracker: &VoteTracker,
+        unrooted_optimistic_slots: &[Slot],
+    ) {
+        let root = root_bank.slot();
+        for optimistic_slot in unrooted_optimistic_slots.iter() {
+            let epoch = root_bank.epoch_schedule().get_epoch(*optimistic_slot);
+            let epoch_stakes = root_bank.epoch_stakes(epoch);
+            let total_epoch_stake = epoch_stakes.map(|e| e.total_stake()).unwrap_or(0);
+            let voted_stake = {
+                let slot_tracker = vote_tracker.get_slot_vote_tracker(*optimistic_slot);
+                let r_slot_tracker = slot_tracker.as_ref().map(|s| s.read().unwrap());
+                let voted_stake = r_slot_tracker
+                    .as_ref()
+                    .map(|s| s.voted_no_switching().stake())
+                    .unwrap_or(0);
+
+                warn!(
+                    "Optimistic slot {}, epoch: {} was not rooted, voted keys: {:?}, root: {}, voted stake: {},
+                    total epoch stake: {}, pct: {}",
+                    optimistic_slot,
+                    epoch,
+                    r_slot_tracker.as_ref().map(|s| s.voted_no_switching().voted()),
+                    root,
+                    voted_stake,
+                    total_epoch_stake,
+                    voted_stake as f64 / total_epoch_stake as f64,
+                );
+                voted_stake
+            };
+
+            datapoint_warn!(
+                "optimistic_slot_not_rooted",
+                ("slot", *optimistic_slot, i64),
+                ("epoch", epoch, i64),
+                ("root", root, i64),
+                ("voted_stake", voted_stake, i64),
+                ("total_epoch_stake", total_epoch_stake, i64),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::consensus::test::VoteSimulator;
+    use solana_ledger::get_tmp_ledger_path;
+    use solana_runtime::bank::Bank;
+    use solana_sdk::pubkey::Pubkey;
+    use std::collections::HashMap;
+    use trees::tr;
+
+    #[test]
+    fn test_add_new_optimistic_confirmed_slots() {
+        let snapshot_start_slot = 10;
+        let mut optimistic_confirmation_verifier =
+            OptimisticConfirmationVerifier::new(snapshot_start_slot);
+        optimistic_confirmation_verifier
+            .add_new_optimistic_confirmed_slots(&[snapshot_start_slot - 1]);
+        optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&[snapshot_start_slot]);
+        optimistic_confirmation_verifier
+            .add_new_optimistic_confirmed_slots(&[snapshot_start_slot + 1]);
+        assert_eq!(optimistic_confirmation_verifier.unchecked_slots.len(), 1);
+        assert!(optimistic_confirmation_verifier
+            .unchecked_slots
+            .contains(&(snapshot_start_slot + 1)));
+    }
+
+    #[test]
+    fn test_check_optimistic_slots_rooted() {
+        let snapshot_start_slot = 0;
+        let mut optimistic_confirmation_verifier =
+            OptimisticConfirmationVerifier::new(snapshot_start_slot);
+        let blockstore_path = get_tmp_ledger_path!();
+        {
+            let blockstore = Blockstore::open(&blockstore_path).unwrap();
+            let mut vote_simulator = setup_forks();
+            let optimistic_slots = vec![1, 3, 5];
+
+            // If root is on same fork, nothing should be returned
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            let bank5 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(5)
+                .cloned()
+                .unwrap();
+            assert!(optimistic_confirmation_verifier
+                .check_optimistic_slots_rooted(&bank5, &blockstore)
+                .is_empty());
+            // 5 is >= than all the unchecked slots, so should clear everything
+            assert!(optimistic_confirmation_verifier.unchecked_slots.is_empty());
+
+            // If root is on same fork, nothing should be returned
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            let bank3 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(3)
+                .cloned()
+                .unwrap();
+            assert!(optimistic_confirmation_verifier
+                .check_optimistic_slots_rooted(&bank3, &blockstore)
+                .is_empty());
+            // 3 is bigger than only slot 1, so slot 5 should be left over
+            assert_eq!(optimistic_confirmation_verifier.unchecked_slots.len(), 1);
+            assert!(optimistic_confirmation_verifier
+                .unchecked_slots
+                .contains(&5));
+
+            // If root is on different fork, the slots < root on different fork should
+            // be returned
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            let bank4 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(4)
+                .cloned()
+                .unwrap();
+            assert_eq!(
+                optimistic_confirmation_verifier.check_optimistic_slots_rooted(&bank4, &blockstore),
+                vec![3]
+            );
+            // 4 is bigger than only slots 1 and 3, so slot 5 should be left over
+            assert_eq!(optimistic_confirmation_verifier.unchecked_slots.len(), 1);
+            assert!(optimistic_confirmation_verifier
+                .unchecked_slots
+                .contains(&5));
+
+            // Now set a root at slot 5, purging BankForks of slots < 5
+            vote_simulator.set_root(5);
+
+            // Add a new bank 7 that descends from 6
+            let bank6 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(6)
+                .cloned()
+                .unwrap();
+            vote_simulator
+                .bank_forks
+                .write()
+                .unwrap()
+                .insert(Bank::new_from_parent(&bank6, &Pubkey::default(), 7));
+            let bank7 = vote_simulator
+                .bank_forks
+                .read()
+                .unwrap()
+                .get(7)
+                .unwrap()
+                .clone();
+            assert!(!bank7.ancestors.contains_key(&3));
+
+            // Should return slots 1, 3 as part of the rooted fork because there's no
+            // ancestry information
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            assert_eq!(
+                optimistic_confirmation_verifier.check_optimistic_slots_rooted(&bank7, &blockstore),
+                vec![1, 3]
+            );
+            assert!(optimistic_confirmation_verifier.unchecked_slots.is_empty());
+
+            // If we know set the root in blockstore, should return nothing
+            blockstore.set_roots(&[1, 3]).unwrap();
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(&optimistic_slots);
+            assert!(optimistic_confirmation_verifier
+                .check_optimistic_slots_rooted(&bank7, &blockstore)
+                .is_empty());
+            assert!(optimistic_confirmation_verifier.unchecked_slots.is_empty());
+        }
+        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
+    }
+
+    fn setup_forks() -> VoteSimulator {
+        /*
+            Build fork structure:
+                 slot 0
+                   |
+                 slot 1
+                 /    \
+            slot 2    |
+               |    slot 3
+            slot 4    |
+                    slot 5
+                      |
+                    slot 6
+        */
+        let forks = tr(0) / (tr(1) / (tr(2) / (tr(4))) / (tr(3) / (tr(5) / (tr(6)))));
+
+        let mut vote_simulator = VoteSimulator::new(1);
+        vote_simulator.fill_bank_forks(forks, &HashMap::new());
+        vote_simulator
+    }
+}

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -157,7 +157,7 @@ mod test {
         assert_eq!(optimistic_confirmation_verifier.unchecked_slots.len(), 1);
         assert!(optimistic_confirmation_verifier
             .unchecked_slots
-            .contains(&((snapshot_start_slot + 1, bank_hash))));
+            .contains(&(snapshot_start_slot + 1, bank_hash)));
     }
 
     #[test]
@@ -170,8 +170,7 @@ mod test {
         {
             let blockstore = Blockstore::open(&blockstore_path).unwrap();
             let optimistic_slots = vec![(1, bad_bank_hash), (3, Hash::default())];
-            optimistic_confirmation_verifier
-                .add_new_optimistic_confirmed_slots(optimistic_slots.clone());
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(optimistic_slots);
             let vote_simulator = setup_forks();
             let bank1 = vote_simulator
                 .bank_forks
@@ -265,7 +264,7 @@ mod test {
                 .unwrap();
             assert_eq!(
                 optimistic_confirmation_verifier.check_optimistic_slots_rooted(&bank4, &blockstore),
-                vec![optimistic_slots[1].clone()]
+                vec![optimistic_slots[1]]
             );
             // 4 is bigger than only slots 1 and 3, so slot 5 should be left over
             assert_eq!(optimistic_confirmation_verifier.unchecked_slots.len(), 1);
@@ -310,8 +309,7 @@ mod test {
 
             // If we know set the root in blockstore, should return nothing
             blockstore.set_roots(&[1, 3]).unwrap();
-            optimistic_confirmation_verifier
-                .add_new_optimistic_confirmed_slots(optimistic_slots.clone());
+            optimistic_confirmation_verifier.add_new_optimistic_confirmed_slots(optimistic_slots);
             assert!(optimistic_confirmation_verifier
                 .check_optimistic_slots_rooted(&bank7, &blockstore)
                 .is_empty());

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -1033,6 +1033,7 @@ mod test {
             &keypairs.node_keypair,
             &keypairs.vote_keypair,
             &keypairs.vote_keypair,
+            None,
         );
         bank9.process_transaction(&vote_tx).unwrap();
         assert!(bank9.get_signature_status(&vote_tx.signatures[0]).is_some());

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2890,6 +2890,7 @@ pub(crate) mod tests {
             &my_keypairs.node_keypair,
             &my_keypairs.vote_keypair,
             &my_keypairs.vote_keypair,
+            None,
         );
 
         let bank_forks = RwLock::new(bank_forks);

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -916,6 +916,7 @@ mod tests {
                 node_keypair,
                 vote_keypair,
                 vote_keypair,
+                None,
             );
             votes_sender.send(vec![vote_tx]).unwrap();
         });

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -925,7 +925,7 @@ mod tests {
         ClusterInfoVoteListener::get_and_process_votes_for_tests(
             &votes_receiver,
             &vote_tracker,
-            0,
+            &bank,
             &rpc.subscriptions,
         )
         .unwrap();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -77,6 +77,7 @@ impl Tpu {
             vote_tracker,
             bank_forks,
             subscriptions.clone(),
+            blockstore.clone(),
         );
 
         let banking_stage = BankingStage::new(

--- a/core/src/vote_stake_tracker.rs
+++ b/core/src/vote_stake_tracker.rs
@@ -1,0 +1,68 @@
+use crate::consensus::VOTE_THRESHOLD_SIZE;
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::HashSet, sync::Arc};
+
+#[derive(Default)]
+pub struct VoteStakeTracker {
+    voted: HashSet<Arc<Pubkey>>,
+    stake: u64,
+}
+
+impl VoteStakeTracker {
+    // Returns true if the stake that has voted has just crosssed the supermajority
+    // of stake
+    pub fn add_vote_pubkey(
+        &mut self,
+        vote_pubkey: Arc<Pubkey>,
+        stake: u64,
+        total_epoch_stake: u64,
+    ) -> bool {
+        if !self.voted.contains(&vote_pubkey) {
+            self.voted.insert(vote_pubkey);
+            let ratio_before = self.stake as f64 / total_epoch_stake as f64;
+            self.stake += stake;
+            let ratio_now = self.stake as f64 / total_epoch_stake as f64;
+
+            ratio_before <= VOTE_THRESHOLD_SIZE && ratio_now > VOTE_THRESHOLD_SIZE
+        } else {
+            false
+        }
+    }
+
+    pub fn voted(&self) -> &HashSet<Arc<Pubkey>> {
+        &self.voted
+    }
+
+    pub fn stake(&self) -> u64 {
+        self.stake
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_add_vote_pubkey() {
+        let total_epoch_stake = 10;
+        let mut vote_stake_tracker = VoteStakeTracker::default();
+        for i in 0..10 {
+            let pubkey = Arc::new(Pubkey::new_rand());
+            let res = vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
+            let stake = vote_stake_tracker.stake();
+            vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
+            let stake2 = vote_stake_tracker.stake();
+
+            // Stake should not change from adding same pubkey twice
+            assert_eq!(stake, stake2);
+
+            // at i == 7, the voted stake is 70%, which is the first time crossing
+            // the supermajority threshold
+            if i == 6 {
+                assert!(res);
+            } else {
+                assert!(!res);
+            }
+        }
+    }
+}

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -171,7 +171,7 @@ mod tests {
     }
 
     fn emit_stats(
-        time_initial: &Instant,
+        time_initial: Instant,
         time_previous: &mut Instant,
         storage_previous: &mut u64,
         start_slot: u64,
@@ -187,7 +187,7 @@ mod tests {
 
         println!(
             "{},{},{},{},{},{},{},{},{},{},{}",
-            time_now.duration_since(*time_initial).as_millis(),
+            time_now.duration_since(time_initial).as_millis(),
             time_now.duration_since(*time_previous).as_millis(),
             start_slot,
             batch_size,
@@ -249,7 +249,7 @@ mod tests {
 
         emit_header();
         emit_stats(
-            &time_initial,
+            time_initial,
             &mut time_previous,
             &mut storage_previous,
             0,
@@ -273,7 +273,7 @@ mod tests {
             sender.send(x).unwrap();
 
             emit_stats(
-                &time_initial,
+                time_initial,
                 &mut time_previous,
                 &mut storage_previous,
                 x,
@@ -303,7 +303,7 @@ mod tests {
         sender.send(benchmark_slots).unwrap();
 
         emit_stats(
-            &time_initial,
+            time_initial,
             &mut time_previous,
             &mut storage_previous,
             benchmark_slots,
@@ -324,7 +324,7 @@ mod tests {
         }
 
         emit_stats(
-            &time_initial,
+            time_initial,
             &mut time_previous,
             &mut storage_previous,
             benchmark_slots,

--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -1548,6 +1548,117 @@
       }
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "$datasource",
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 5,
+        "x": 0,
+        "y": 6
+      },
+      "id": 65,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"average_elapsed_ms\") FROM \"$testnet\".\"autogen\".\"optimistic_slot_elapsed\" WHERE $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Average Optimistic Confirmation Elapsed",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
       "aliasColors": {},
       "bars": true,
       "dashLength": 10,
@@ -1558,7 +1669,7 @@
         "h": 9,
         "w": 14,
         "x": 0,
-        "y": 6
+        "y": 8
       },
       "id": 14,
       "legend": {
@@ -1936,7 +2047,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 17
       },
       "id": 16,
       "panels": [],
@@ -1954,7 +2065,7 @@
         "h": 3,
         "w": 8,
         "x": 0,
-        "y": 16
+        "y": 18
       },
       "id": 17,
       "legend": {
@@ -2110,7 +2221,7 @@
         "h": 6,
         "w": 7,
         "x": 8,
-        "y": 16
+        "y": 18
       },
       "id": 18,
       "legend": {
@@ -2346,7 +2457,7 @@
         "h": 2,
         "w": 4,
         "x": 15,
-        "y": 16
+        "y": 18
       },
       "id": 19,
       "interval": null,
@@ -2457,7 +2568,7 @@
         "h": 2,
         "w": 3,
         "x": 19,
-        "y": 16
+        "y": 18
       },
       "id": 20,
       "interval": null,
@@ -2568,7 +2679,7 @@
         "h": 2,
         "w": 2,
         "x": 22,
-        "y": 16
+        "y": 18
       },
       "id": 21,
       "interval": null,
@@ -2668,7 +2779,7 @@
         "h": 4,
         "w": 5,
         "x": 15,
-        "y": 18
+        "y": 20
       },
       "id": 22,
       "legend": {
@@ -2786,7 +2897,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 18
+        "y": 20
       },
       "id": 23,
       "legend": {
@@ -2904,7 +3015,7 @@
         "h": 3,
         "w": 8,
         "x": 0,
-        "y": 19
+        "y": 21
       },
       "id": 24,
       "legend": {
@@ -3057,7 +3168,7 @@
         "h": 6,
         "w": 15,
         "x": 0,
-        "y": 22
+        "y": 24
       },
       "id": 25,
       "links": [],
@@ -3145,7 +3256,7 @@
         "h": 6,
         "w": 9,
         "x": 15,
-        "y": 22
+        "y": 24
       },
       "id": 26,
       "legend": {
@@ -3626,7 +3737,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 28
+        "y": 30
       },
       "id": 27,
       "links": [],
@@ -3711,7 +3822,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 28
+        "y": 30
       },
       "id": 28,
       "links": [],
@@ -3796,7 +3907,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 28
+        "y": 30
       },
       "id": 29,
       "links": [],
@@ -3879,7 +3990,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 36
       },
       "id": 30,
       "panels": [],
@@ -3897,7 +4008,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 35
+        "y": 37
       },
       "id": 31,
       "legend": {
@@ -4136,7 +4247,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 35
+        "y": 37
       },
       "id": 32,
       "legend": {
@@ -4418,7 +4529,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 35
+        "y": 37
       },
       "id": 33,
       "legend": {
@@ -4629,7 +4740,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 41
+        "y": 43
       },
       "id": 34,
       "legend": {
@@ -4996,7 +5107,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 41
+        "y": 43
       },
       "id": 35,
       "legend": {
@@ -5168,7 +5279,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 41
+        "y": 43
       },
       "id": 36,
       "legend": {
@@ -5489,7 +5600,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 47
+        "y": 49
       },
       "id": 37,
       "legend": {
@@ -5919,7 +6030,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 47
+        "y": 49
       },
       "id": 38,
       "legend": {
@@ -6152,7 +6263,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 47
+        "y": 49
       },
       "id": 39,
       "legend": {
@@ -6478,7 +6589,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 53
+        "y": 55
       },
       "id": 40,
       "legend": {
@@ -6780,7 +6891,7 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 53
+        "y": 55
       },
       "id": 41,
       "legend": {
@@ -6933,7 +7044,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 53
+        "y": 55
       },
       "id": 42,
       "legend": {
@@ -7050,7 +7161,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 58
+        "y": 60
       },
       "id": 43,
       "legend": {
@@ -7209,7 +7320,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 58
+        "y": 60
       },
       "id": 44,
       "legend": {
@@ -7325,7 +7436,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 58
+        "y": 60
       },
       "id": 45,
       "legend": {
@@ -7436,7 +7547,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 66
       },
       "id": 46,
       "panels": [],
@@ -7459,7 +7570,7 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 65
+        "y": 67
       },
       "id": 47,
       "legend": {
@@ -7619,7 +7730,7 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 65
+        "y": 67
       },
       "id": 48,
       "legend": {
@@ -7779,7 +7890,7 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 65
+        "y": 67
       },
       "id": 49,
       "legend": {
@@ -7959,12 +8070,258 @@
       }
     },
     {
+      "aliasColors": {
+        "cluster-info.repair": "#ba43a9",
+        "replay_stage-new_leader.last": "#00ffbb",
+        "tower-vote.last": "#00ffbb",
+        "window-service.receive": "#b7dbab",
+        "window-stage.consumed": "#5195ce"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 72
+      },
+      "id": 68,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT last(\"slot\") FROM \"$testnet\".\"autogen\".\"optimistic_slot\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Optimistic Slots ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "cluster-info.repair": "#ba43a9",
+        "replay_stage-new_leader.last": "#00ffbb",
+        "tower-vote.last": "#00ffbb",
+        "window-service.receive": "#b7dbab",
+        "window-stage.consumed": "#5195ce"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 72
+      },
+      "id": 69,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT last(\"slot\") FROM \"$testnet\".\"autogen\".\"optimistic_slot_not_rooted\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Unrooted Optimistic Slots ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 77
       },
       "id": 50,
       "panels": [],
@@ -7983,7 +8340,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 71
+        "y": 78
       },
       "id": 51,
       "legend": {
@@ -8216,7 +8573,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 71
+        "y": 78
       },
       "id": 52,
       "legend": {
@@ -8369,7 +8726,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 83
       },
       "id": 53,
       "panels": [],
@@ -8387,7 +8744,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 77
+        "y": 84
       },
       "id": 54,
       "legend": {
@@ -8589,7 +8946,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 77
+        "y": 84
       },
       "id": 55,
       "legend": {
@@ -8738,7 +9095,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 89
       },
       "id": 56,
       "panels": [],
@@ -8756,7 +9113,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 83
+        "y": 90
       },
       "id": 57,
       "legend": {
@@ -8948,7 +9305,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 83
+        "y": 90
       },
       "id": 58,
       "legend": {
@@ -9216,7 +9573,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 83
+        "y": 90
       },
       "id": 59,
       "legend": {

--- a/programs/vote/src/vote_transaction.rs
+++ b/programs/vote/src/vote_transaction.rs
@@ -14,13 +14,23 @@ pub fn new_vote_transaction(
     node_keypair: &Keypair,
     vote_keypair: &Keypair,
     authorized_voter_keypair: &Keypair,
+    switch_proof_hash: Option<Hash>,
 ) -> Transaction {
     let votes = Vote::new(slots, bank_hash);
-    let vote_ix = vote_instruction::vote(
-        &vote_keypair.pubkey(),
-        &authorized_voter_keypair.pubkey(),
-        votes,
-    );
+    let vote_ix = if let Some(switch_proof_hash) = switch_proof_hash {
+        vote_instruction::vote_switch(
+            &vote_keypair.pubkey(),
+            &authorized_voter_keypair.pubkey(),
+            votes,
+            switch_proof_hash,
+        )
+    } else {
+        vote_instruction::vote(
+            &vote_keypair.pubkey(),
+            &authorized_voter_keypair.pubkey(),
+            votes,
+        )
+    };
 
     let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
 


### PR DESCRIPTION
#### Problem
No detection/tracking of non-switching votes in gossip, needed for signaling optimistic confirmation
#### Summary of Changes
1) Updated `ClusterInfoVoteListener` in `cluster_info_vote_listener.rs` to track non-switch votes, signal when optimistic conf is achieved: https://github.com/solana-labs/solana/pull/10217/files#diff-c38da5b23679761df905a00ee4d2688dR407-R430
2) Added a `OptimisticConfirmationVerifier` to check if optimistically-confirmed slots are ever not rooted:
3) Added dashboards/metrics to track optimistic slots/violations:
Fixes #
