### PR TITLE
v1.2: Include account.owner into account hash (#9918)

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6882,25 +6882,25 @@ mod tests {
             if bank.slot == 0 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "7MKHH6P7J5aQNN29Cr6aZQbEpQcXe8KTgchd4Suk9NCG"
+                    "hRgSMcWvZVveC8TqHHBfeU3h6vkPy6qzR5bHXfDTCyd"
                 );
             }
             if bank.slot == 32 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "3AxuV6GGcoqRi6pksN6btNEmeJCTesLbjgA88QZt9a8Q"
+                    "C2isNuN27FB9wVFpR1txa6SsXi94td6WSy7Va5deGpX5"
                 );
             }
             if bank.slot == 64 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "B32ZLAzeCW5FueeauiGYnujh8Efmxvpeac74W9JU68oB"
+                    "2FJC56qpMyDFNtCvbr1MhyR2bawrhLtViaLVoBEMbj1n"
                 );
             }
             if bank.slot == 128 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "A2tCz2EqryRZ7tHpw9H2918RZLCbqnSGzRWUqbnnESGz"
+                    "GUae7X3qX6aRu5UJ6MTRmPEUNi94GP6thagRi9uFRHpG"
                 );
                 break;
             }


### PR DESCRIPTION
v1.2 is not compatible with v1.1 testnet due to an account.owner hashing mismatch.  Bring the v1.1 activation logic into v1.1