### PR TITLE
v1.1: Activate eager rent collection and BPF loader on mainnet-beta epoch 34

### DIFF
--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -72,9 +72,7 @@ pub fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Option<Vec<(
             }
         }
         OperatingMode::Stable => {
-            if epoch == std::u64::MAX - 1 {
-                // The epoch of std::u64::MAX - 1 is a placeholder and is expected to be reduced in
-                // a future hard fork.
+            if epoch == 34 {
                 Some(vec![solana_bpf_loader_program!()])
             } else if epoch == std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected to be reduced in a
@@ -163,7 +161,7 @@ mod tests {
     #[test]
     fn test_softlaunch_programs() {
         assert_eq!(get_programs(OperatingMode::Stable, 1), None);
-        assert!(get_programs(OperatingMode::Stable, std::u64::MAX - 1).is_some());
+        assert!(get_programs(OperatingMode::Stable, 34).is_some());
         assert!(get_programs(OperatingMode::Stable, std::u64::MAX).is_some());
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -860,8 +860,7 @@ impl Bank {
             // DANGER: Adjust this guard after tds has transitioned to the eager rent
             // collection and ABSOLUTELY after the mainnet-beta transitions to v1.1.
             if !(self.operating_mode() == OperatingMode::Preview && self.epoch() < 47
-                || self.operating_mode() == OperatingMode::Stable
-                    && self.epoch() < Epoch::max_value())
+                || self.operating_mode() == OperatingMode::Stable && self.epoch() < 34)
             {
                 self.collect_rent_eagerly();
             }


### PR DESCRIPTION
Roll out eager rent collection and BPF loader on mainnet-beta as a part of the v1.1 upgrade

Fixes https://github.com/solana-labs/solana/issues/10226
Fixes https://github.com/solana-labs/solana/issues/10225
