### PR TITLE
Prevent privilege escalation

### DIFF
--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -80,7 +80,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
     let mut invoke_context = MockInvokeContext::default();
 
     let elf = load_elf().unwrap();
-    let (mut vm, _) = solana_bpf_loader_program::create_vm(&elf, &mut invoke_context).unwrap();
+    let (mut vm, _) = solana_bpf_loader_program::create_vm(&elf, &[], &mut invoke_context).unwrap();
 
     println!("Interpreted:");
     assert_eq!(
@@ -145,7 +145,6 @@ impl InvokeContext for MockInvokeContext {
         &mut self,
         _message: &Message,
         _instruction: &CompiledInstruction,
-        _signers: &[Pubkey],
         _accounts: &[Rc<RefCell<Account>>],
     ) -> Result<(), InstructionError> {
         Ok(())

--- a/programs/bpf/c/src/invoked/instruction.h
+++ b/programs/bpf/c/src/invoked/instruction.h
@@ -2,9 +2,12 @@
  * @brief Instruction definitions for the invoked program
  */
 
-const int TEST_VERIFY_TRANSLATIONS = 0;
-const int TEST_RETURN_ERROR = 1;
-const int TEST_DERIVED_SIGNERS = 2;
-const int TEST_VERIFY_NESTED_SIGNERS = 3;
-const int TEST_VERIFY_WRITER = 4;
-const int TEST_NESTED_INVOKE = 5;
+#include <solana_sdk.h>
+
+const uint8_t TEST_VERIFY_TRANSLATIONS = 0;
+const uint8_t TEST_RETURN_ERROR = 1;
+const uint8_t TEST_DERIVED_SIGNERS = 2;
+const uint8_t TEST_VERIFY_NESTED_SIGNERS = 3;
+const uint8_t TEST_VERIFY_WRITER = 4;
+const uint8_t TEST_VERIFY_PRIVILEGE_ESCALATION = 5;
+const uint8_t TEST_NESTED_INVOKE = 6;

--- a/programs/bpf/c/src/invoked/invoked.c
+++ b/programs/bpf/c/src/invoked/invoked.c
@@ -136,6 +136,9 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_assert(accounts[ARGUMENT_INDEX].is_writable);
     break;
   }
+  case TEST_VERIFY_PRIVILEGE_ESCALATION: {
+    sol_log("Success");
+  }
   case TEST_NESTED_INVOKE: {
     sol_log("invoke");
 

--- a/programs/bpf/rust/invoked/src/instruction.rs
+++ b/programs/bpf/rust/invoked/src/instruction.rs
@@ -10,7 +10,8 @@ pub const TEST_RETURN_ERROR: u8 = 1;
 pub const TEST_DERIVED_SIGNERS: u8 = 2;
 pub const TEST_VERIFY_NESTED_SIGNERS: u8 = 3;
 pub const TEST_VERIFY_WRITER: u8 = 4;
-pub const TEST_NESTED_INVOKE: u8 = 5;
+pub const TEST_VERIFY_PRIVILEGE_ESCALATION: u8 = 5;
+pub const TEST_NESTED_INVOKE: u8 = 6;
 
 pub fn create_instruction(
     program_id: Pubkey,

--- a/programs/bpf/rust/invoked/src/lib.rs
+++ b/programs/bpf/rust/invoked/src/lib.rs
@@ -151,6 +151,9 @@ fn process_instruction(
 
             assert!(!accounts[ARGUMENT_INDEX].is_writable);
         }
+        TEST_VERIFY_PRIVILEGE_ESCALATION => {
+            info!("Success");
+        }
         TEST_NESTED_INVOKE => {
             info!("nested invoke");
 

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -309,6 +309,10 @@ mod bpf {
     fn test_program_bpf_invoke() {
         solana_logger::setup();
 
+        const TEST_SUCCESS: u8 = 1;
+        const TEST_PRIVILEGE_ESCALATION_SIGNER: u8 = 2;
+        const TEST_PRIVILEGE_ESCALATION_WRITABLE: u8 = 3;
+
         let mut programs = Vec::new();
         #[cfg(feature = "bpf_c")]
         {
@@ -369,15 +373,68 @@ mod bpf {
                 AccountMeta::new(from_keypair.pubkey(), true),
             ];
 
-            let instruction = Instruction::new(invoke_program_id, &1u8, account_metas);
-            let message = Message::new(&[instruction]);
+            // success cases
 
+            let instruction =
+                Instruction::new(invoke_program_id, &TEST_SUCCESS, account_metas.clone());
+            let message = Message::new(&[instruction]);
             assert!(bank_client
                 .send_message(
-                    &[&mint_keypair, &argument_keypair, &invoked_argument_keypair, &from_keypair],
+                    &[
+                        &mint_keypair,
+                        &argument_keypair,
+                        &invoked_argument_keypair,
+                        &from_keypair
+                    ],
                     message,
                 )
                 .is_ok());
+
+            // failure cases
+
+            let instruction = Instruction::new(
+                invoke_program_id,
+                &TEST_PRIVILEGE_ESCALATION_SIGNER,
+                account_metas.clone(),
+            );
+            let message = Message::new(&[instruction]);
+            assert_eq!(
+                bank_client
+                    .send_message(
+                        &[
+                            &mint_keypair,
+                            &argument_keypair,
+                            &invoked_argument_keypair,
+                            &from_keypair
+                        ],
+                        message,
+                    )
+                    .unwrap_err()
+                    .unwrap(),
+                TransactionError::InstructionError(0, InstructionError::Custom(194969602))
+            );
+
+            let instruction = Instruction::new(
+                invoke_program_id,
+                &TEST_PRIVILEGE_ESCALATION_WRITABLE,
+                account_metas.clone(),
+            );
+            let message = Message::new(&[instruction]);
+            assert_eq!(
+                bank_client
+                    .send_message(
+                        &[
+                            &mint_keypair,
+                            &argument_keypair,
+                            &invoked_argument_keypair,
+                            &from_keypair
+                        ],
+                        message,
+                    )
+                    .unwrap_err()
+                    .unwrap(),
+                TransactionError::InstructionError(0, InstructionError::Custom(194969602))
+            );
         }
     }
 }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -9,6 +9,7 @@ use solana_rbpf::{
 use solana_runtime::{builtin_programs::get_builtin_programs, message_processor::MessageProcessor};
 use solana_sdk::{
     account::Account,
+    account::KeyedAccount,
     account_info::AccountInfo,
     bpf_loader,
     entrypoint::SUCCESS,
@@ -48,6 +49,8 @@ pub enum SyscallError {
     ProgramNotSupported,
     #[error("{0}")]
     InstructionError(InstructionError),
+    #[error("Cross-program invocation with unauthorized signer or writable account")]
+    PrivilegeEscalation,
 }
 impl From<SyscallError> for EbpfError<BPFError> {
     fn from(error: SyscallError) -> Self {
@@ -69,6 +72,7 @@ const DEFAULT_HEAP_SIZE: usize = 32 * 1024;
 
 pub fn register_syscalls<'a>(
     vm: &mut EbpfVm<'a, BPFError>,
+    callers_keyed_accounts: &'a [KeyedAccount<'a>],
     invoke_context: &'a mut dyn InvokeContext,
 ) -> Result<MemoryRegion, EbpfError<BPFError>> {
     // Syscall function common across languages
@@ -83,12 +87,14 @@ pub fn register_syscalls<'a>(
         vm.register_syscall_with_context_ex(
             "sol_invoke_signed_c",
             Box::new(SyscallProcessSolInstructionC {
+                callers_keyed_accounts,
                 invoke_context: invoke_context.clone(),
             }),
         )?;
         vm.register_syscall_with_context_ex(
             "sol_invoke_signed_rust",
             Box::new(SyscallProcessInstructionRust {
+                callers_keyed_accounts,
                 invoke_context: invoke_context.clone(),
             }),
         )?;
@@ -301,6 +307,7 @@ pub type TranslatedAccounts<'a> = (Vec<Rc<RefCell<Account>>>, Vec<(&'a mut u64, 
 /// Implemented by language specific data structure translators
 trait SyscallProcessInstruction<'a> {
     fn get_context_mut(&self) -> Result<RefMut<&'a mut dyn InvokeContext>, EbpfError<BPFError>>;
+    fn get_callers_keyed_accounts(&self) -> &'a [KeyedAccount<'a>];
     fn translate_instruction(
         &self,
         addr: u64,
@@ -325,6 +332,7 @@ trait SyscallProcessInstruction<'a> {
 
 /// Cross-program invocation called from Rust
 pub struct SyscallProcessInstructionRust<'a> {
+    callers_keyed_accounts: &'a [KeyedAccount<'a>],
     invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
 }
 impl<'a> SyscallProcessInstruction<'a> for SyscallProcessInstructionRust<'a> {
@@ -332,6 +340,9 @@ impl<'a> SyscallProcessInstruction<'a> for SyscallProcessInstructionRust<'a> {
         self.invoke_context
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
+    }
+    fn get_callers_keyed_accounts(&self) -> &'a [KeyedAccount<'a>] {
+        self.callers_keyed_accounts
     }
     fn translate_instruction(
         &self,
@@ -519,6 +530,7 @@ struct SolSignerSeedsC {
 
 /// Cross-program invocation called from C
 pub struct SyscallProcessSolInstructionC<'a> {
+    callers_keyed_accounts: &'a [KeyedAccount<'a>],
     invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
 }
 impl<'a> SyscallProcessInstruction<'a> for SyscallProcessSolInstructionC<'a> {
@@ -527,7 +539,9 @@ impl<'a> SyscallProcessInstruction<'a> for SyscallProcessSolInstructionC<'a> {
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
     }
-
+    fn get_callers_keyed_accounts(&self) -> &'a [KeyedAccount<'a>] {
+        self.callers_keyed_accounts
+    }
     fn translate_instruction(
         &self,
         addr: u64,
@@ -673,6 +687,44 @@ impl<'a> SyscallObject<BPFError> for SyscallProcessSolInstructionC<'a> {
     }
 }
 
+fn verify_instruction<'a>(
+    syscall: &dyn SyscallProcessInstruction<'a>,
+    instruction: &Instruction,
+    signers: &[Pubkey],
+) -> Result<(), EbpfError<BPFError>> {
+    let callers_keyed_accounts = syscall.get_callers_keyed_accounts();
+
+    // Check for privilege escalation
+    for account in instruction.accounts.iter() {
+        let keyed_account = callers_keyed_accounts
+            .iter()
+            .find_map(|keyed_account| {
+                if &account.pubkey == keyed_account.unsigned_key() {
+                    Some(keyed_account)
+                } else {
+                    None
+                }
+            })
+            .ok_or(SyscallError::InstructionError(
+                InstructionError::MissingAccount,
+            ))?;
+        // Readonly account cannot become writable
+        if account.is_writable && !keyed_account.is_writable() {
+            return Err(SyscallError::PrivilegeEscalation.into());
+        }
+
+        if account.is_signer && // If message indicates account is signed
+        !( // one of the following needs to be true:
+            keyed_account.signer_key().is_some() // Signed in the parent instruction
+            || signers.contains(&account.pubkey) // Signed by the program
+        ) {
+            return Err(SyscallError::PrivilegeEscalation.into());
+        }
+    }
+
+    Ok(())
+}
+
 /// Call process instruction, common to both Rust and C
 fn call<'a>(
     syscall: &mut dyn SyscallProcessInstruction<'a>,
@@ -689,24 +741,25 @@ fn call<'a>(
     // Translate data passed from the VM
 
     let instruction = syscall.translate_instruction(instruction_addr, ro_regions)?;
-    let message = Message::new_with_payer(&[instruction], None);
-    let callee_program_id_index = message.instructions[0].program_id_index as usize;
-    let callee_program_id = message.account_keys[callee_program_id_index];
     let caller_program_id = invoke_context
         .get_caller()
         .map_err(SyscallError::InstructionError)?;
+    let signers = syscall.translate_signers(
+        caller_program_id,
+        signers_seeds_addr,
+        signers_seeds_len as usize,
+        ro_regions,
+    )?;
+    verify_instruction(syscall, &instruction, &signers)?;
+    let message = Message::new_with_payer(&[instruction], None);
+    let callee_program_id_index = message.instructions[0].program_id_index as usize;
+    let callee_program_id = message.account_keys[callee_program_id_index];
     let (accounts, refs) = syscall.translate_accounts(
         &message,
         account_infos_addr,
         account_infos_len as usize,
         ro_regions,
         rw_regions,
-    )?;
-    let signers = syscall.translate_signers(
-        caller_program_id,
-        signers_seeds_addr,
-        signers_seeds_len as usize,
-        ro_regions,
     )?;
 
     // Process instruction
@@ -725,7 +778,6 @@ fn call<'a>(
         &message,
         &executable_accounts,
         &accounts,
-        &signers,
         *(&mut *invoke_context),
     ) {
         Ok(()) => (),

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -154,7 +154,6 @@ pub trait InvokeContext {
         &mut self,
         message: &Message,
         instruction: &CompiledInstruction,
-        signers: &[Pubkey],
         accounts: &[Rc<RefCell<Account>>],
     ) -> Result<(), InstructionError>;
     fn get_caller(&self) -> Result<&Pubkey, InstructionError>;

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -140,14 +140,6 @@ pub enum InstructionError {
     #[error("Unsupported program id")]
     UnsupportedProgramId,
 
-    /// Writable bit on account info changed, but shouldn't have
-    #[error("Writable bit on account info changed, but shouldn't have")]
-    WritableModified,
-
-    /// Signer bit on account info changed, but shouldn't have
-    #[error("Signer bit on account info changed, but shouldn't have")]
-    SignerModified,
-
     /// Cross-program invocation call depth too deep
     #[error("Cross-program invocation call depth too deep")]
     CallDepth,


### PR DESCRIPTION
#### Problem

Cross-program invocations refer to the original transaction to enforce the `is_signer` and `is_writable` attributes of invoked instructions.  Doing so respects the original transaction's privileges but allows a privilege escalation between programs.  Even though the original transaction authorizes the behavior, it is a large foot gun because it relies on a careful review of the programs being invoked.

#### Summary of Changes

Enforce invoked instructions privileges against the calling instruction's privileges rather than the original transaction's.

Fixes #
