### PR TITLE
Lower owner hashing activation slot for devnet

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1212,7 +1212,7 @@ impl AccountsDB {
         // Account hashing will be updated to include owner at this slot on the devnet.
         // For testnet, it fully transitioned already thanks to eager rent collection,
         // so, this check is irrelevant, strictly speaking.
-        slot >= 6_500_000
+        slot >= 5_800_000
     }
 
     pub fn hash_account_data(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1209,8 +1209,10 @@ impl AccountsDB {
     }
 
     pub fn include_owner_in_hash(slot: Slot) -> bool {
-        // Account hashing updated to include owner activates at this slot on the testnet
-        slot >= 14_000_000
+        // Account hashing will be updated to include owner at this slot on the devnet.
+        // For testnet, it fully transitioned already thanks to eager rent collection,
+        // so, this check is irrelevant, strictly speaking.
+        slot >= 6_500_000
     }
 
     pub fn hash_account_data(


### PR DESCRIPTION
#### Problem

devnet hasn't enabled owner-included hashing due to its relatively low slot (5_850_000).

testnet (tds) has fully transitioned to the new hashing.

#### Summary of Changes

Lower the activation slot to gradually transition to the new hashing on devnet. This should take 2-4 days on devnet.

Contexts:

- https://github.com/solana-labs/solana/pull/10166/files#r428900953
- https://github.com/solana-labs/solana/issues/10163#issuecomment-632604747

Fixes #10163 

After devnet fully transitioned, we can address this: #10227.