### PR TITLE
Add confirmed slots to EpochSlots

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -3031,7 +3031,7 @@ mod tests {
         assert_eq!(update_slots, range);
 
         // Test with fewer epoch slots than needed, modified EpochSlots should wrap around
-        let (_, _, since) = get_modified_epoch_slots(
+        let _ = get_modified_epoch_slots(
             &cluster_info,
             &range,
             crds_value::MAX_COMPLETED_EPOCH_SLOTS,
@@ -3060,7 +3060,13 @@ mod tests {
             since = new_since;
             let first = range[0];
             // Find last instance of `first`, that must be where the write started
-            let begin_index = update_slots.len() - update_slots.iter().rev().position(|slot| *slot == first).unwrap() - 1;
+            let begin_index = update_slots.len()
+                - update_slots
+                    .iter()
+                    .rev()
+                    .position(|slot| *slot == first)
+                    .unwrap()
+                - 1;
             update_slots.rotate_left(begin_index);
             update_slots.truncate(range.len());
             assert_eq!(update_slots, range);

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -22,6 +22,7 @@ use std::{
 
 pub const VOTE_THRESHOLD_DEPTH: usize = 8;
 pub const VOTE_THRESHOLD_SIZE: f64 = 2f64 / 3f64;
+pub const SUPERMINORITY_THRESHOLD: f64 = 1f64 / 3f64;
 pub const SWITCH_FORK_THRESHOLD: f64 = 0.38;
 
 #[derive(Default, Debug, Clone)]

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -25,6 +25,7 @@ pub const MAX_VOTES: VoteIndex = 32;
 
 pub type EpochSlotsIndex = u8;
 pub const MAX_EPOCH_SLOTS: EpochSlotsIndex = 255;
+pub const MAX_COMPLETED_EPOCH_SLOTS: EpochSlotsIndex = 128;
 
 /// CrdsValue that is replicated across the cluster
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -366,9 +367,9 @@ impl CrdsValue {
         }
     }
 
-    pub fn epoch_slots(&self) -> Option<&EpochSlots> {
+    pub fn epoch_slots(&self) -> Option<(EpochSlotsIndex, &EpochSlots)> {
         match &self.data {
-            CrdsData::EpochSlots(_, slots) => Some(slots),
+            CrdsData::EpochSlots(i, slots) => Some((*i, slots)),
             _ => None,
         }
     }

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -1,7 +1,8 @@
 use crate::{
-    cluster_info_vote_listener::SlotVoteTracker, cluster_slots::SlotPubkeys,
-    consensus::StakeLockout, pubkey_references::PubkeyReferences,
-    replay_stage::SUPERMINORITY_THRESHOLD,
+    cluster_info_vote_listener::SlotVoteTracker,
+    cluster_slots::SlotPubkeys,
+    consensus::{StakeLockout, SUPERMINORITY_THRESHOLD},
+    pubkey_references::PubkeyReferences,
 };
 use solana_ledger::{
     bank_forks::BankForks,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -6,7 +6,7 @@ use crate::{
     cluster_info_vote_listener::VoteTracker,
     cluster_slots::ClusterSlots,
     commitment::{AggregateCommitmentService, BlockCommitmentCache, CommitmentAggregationData},
-    consensus::{StakeLockout, Tower},
+    consensus::{StakeLockout, Tower, SUPERMINORITY_THRESHOLD},
     poh_recorder::{PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
     progress_map::{ForkProgress, ForkStats, ProgressMap, PropagatedStats},
     pubkey_references::PubkeyReferences,
@@ -53,7 +53,6 @@ use std::{
 };
 
 pub const MAX_ENTRY_RECV_PER_ITER: usize = 512;
-pub const SUPERMINORITY_THRESHOLD: f64 = 1f64 / 3f64;
 pub const MAX_UNCONFIRMED_SLOTS: usize = 5;
 
 #[derive(PartialEq, Debug)]
@@ -1250,7 +1249,7 @@ impl ReplayStage {
             .clone();
 
         if cluster_slot_pubkeys.is_none() {
-            cluster_slot_pubkeys = cluster_slots.lookup(slot);
+            cluster_slot_pubkeys = cluster_slots.lookup_completed(slot);
             progress
                 .get_propagated_stats_mut(slot)
                 .expect("All frozen banks must exist in the Progress map")

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -3,8 +3,8 @@
 use crate::{
     cluster_info::{compute_retransmit_peers, ClusterInfo, DATA_PLANE_FANOUT},
     cluster_slots::ClusterSlots,
-    repair_service::DuplicateSlotsResetSender,
     repair_service::RepairInfo,
+    repair_service::{ConfirmedSlotsReceiver, DuplicateSlotsResetSender},
     result::{Error, Result},
     window_service::{should_retransmit_and_persist, WindowService},
 };
@@ -341,6 +341,7 @@ impl RetransmitStage {
         shred_version: u16,
         cluster_slots: Arc<ClusterSlots>,
         duplicate_slots_reset_sender: DuplicateSlotsResetSender,
+        confirmed_slots_receiver: ConfirmedSlotsReceiver,
     ) -> Self {
         let (retransmit_sender, retransmit_receiver) = channel();
 
@@ -358,6 +359,7 @@ impl RetransmitStage {
             completed_slots_receiver,
             epoch_schedule,
             duplicate_slots_reset_sender,
+            confirmed_slots_receiver,
         };
         let leader_schedule_cache = leader_schedule_cache.clone();
         let window_service = WindowService::new(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -130,6 +130,7 @@ impl Tvu {
         );
 
         let cluster_slots = Arc::new(ClusterSlots::default());
+        let (confirmed_slots_sender, confirmed_slots_receiver) = unbounded();
         let (duplicate_slots_reset_sender, duplicate_slots_reset_receiver) = unbounded();
         let retransmit_stage = RetransmitStage::new(
             bank_forks.clone(),
@@ -146,6 +147,7 @@ impl Tvu {
             tvu_config.shred_version,
             cluster_slots.clone(),
             duplicate_slots_reset_sender,
+            confirmed_slots_receiver,
         );
 
         let (ledger_cleanup_slot_sender, ledger_cleanup_slot_receiver) = channel();
@@ -195,6 +197,7 @@ impl Tvu {
             cluster_slots,
             retransmit_slots_sender,
             duplicate_slots_reset_receiver,
+            confirmed_slots_sender,
         );
 
         let ledger_cleanup_service = tvu_config.max_ledger_shreds.map(|max_ledger_shreds| {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -74,7 +74,7 @@ const TIMESTAMP_SLOT_RANGE: usize = 16;
 // (32K shreds per slot * 4 TX per shred * 2.5 slots per sec)
 pub const MAX_DATA_SHREDS_PER_SLOT: usize = 32_768;
 
-pub type CompletedSlotsReceiver = Receiver<Vec<u64>>;
+pub type CompletedSlotsReceiver = Receiver<Vec<Slot>>;
 
 // ledger window
 pub struct Blockstore {


### PR DESCRIPTION
#### Problem
Dead slots are still marked as complete in `ClusterSlots` and repaired: https://github.com/solana-labs/solana/issues/10082

#### Summary of Changes
Use later half of `EpochSlots` indexed `128..=255` to hold slots confirmed by the cluster. Confirmed slots are well suited for compression because they are usually monotonically increasing. This way unconfirmed dead slots with errors like `InvalidTickCouont` need not even attempt to be repaired.

1) Solves https://github.com/solana-labs/solana/issues/10082
2) Contributes towards: https://github.com/solana-labs/solana/issues/10245 
3) Aids in detecting future duplicate slots that have been confirmed and thus need to be replayed

Fixes #
