### PR TITLE
TPS numbers reported by automation bot are lower than true value

### DIFF
--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -140,6 +140,9 @@ function launch_testnet() {
   if [[ $NUMBER_OF_CLIENT_NODES -gt 0 ]]; then
     execution_step "Starting ${NUMBER_OF_CLIENT_NODES} client nodes"
     "${REPO_ROOT}"/net/net.sh startclients "$maybeClientOptions" "$CLIENT_OPTIONS"
+    # It takes roughly 3 minutes from the time the client nodes return from starting to when they have finished loading the
+    # accounts file and actually start sending transactions
+    sleep 180
   fi
 
   SECONDS=0


### PR DESCRIPTION
#### Problem
Test automation is not waiting for clients to actually start sending transactions after the client nodes finish starting.  This results in mean TPS numbers looking lower than they actually are in the time windowed average stats reported by the results bot.  Results in grafana are not affected however.

#### Summary of Changes
Add a sleep to allow clients more time to start transmitting before setting the start time for the averaged-stats collection window.
