### PR TITLE
Adjust v1.0 CRDS version to be compatible with v1.1

### DIFF
--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -19,6 +19,9 @@ while [[ ! -f config/run/init-completed ]]; do
   fi
 done
 
+while [[ $($solana_cli slot --commitment recent) -eq 0 ]]; do
+  sleep 1
+done
 curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' http://localhost:8899
 
 wait $pid

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -71,6 +71,7 @@ pub enum CrdsData {
     EpochSlots(EpochSlotIndex, EpochSlots),
     SnapshotHashes(SnapshotHash),
     AccountsHashes(SnapshotHash),
+    NewEpochSlotsPlaceholder, // Reserve this enum entry for the v1.1 version of EpochSlots
     Version(Version),
 }
 
@@ -123,6 +124,7 @@ impl Sanitize for CrdsData {
                 }
                 val.sanitize()
             }
+            CrdsData::NewEpochSlotsPlaceholder => Err(SanitizeError::InvalidValue), // Not supported on v1.0
             CrdsData::Version(version) => version.sanitize(),
         }
     }
@@ -266,6 +268,7 @@ pub enum CrdsValueLabel {
     EpochSlots(Pubkey),
     SnapshotHashes(Pubkey),
     AccountsHashes(Pubkey),
+    NewEpochSlotsPlaceholder,
     Version(Pubkey),
 }
 
@@ -277,6 +280,7 @@ impl fmt::Display for CrdsValueLabel {
             CrdsValueLabel::EpochSlots(_) => write!(f, "EpochSlots({})", self.pubkey()),
             CrdsValueLabel::SnapshotHashes(_) => write!(f, "SnapshotHashes({})", self.pubkey()),
             CrdsValueLabel::AccountsHashes(_) => write!(f, "AccountsHashes({})", self.pubkey()),
+            CrdsValueLabel::NewEpochSlotsPlaceholder => write!(f, "NewEpochSlotsPlaceholder"),
             CrdsValueLabel::Version(_) => write!(f, "Version({})", self.pubkey()),
         }
     }
@@ -290,6 +294,7 @@ impl CrdsValueLabel {
             CrdsValueLabel::EpochSlots(p) => *p,
             CrdsValueLabel::SnapshotHashes(p) => *p,
             CrdsValueLabel::AccountsHashes(p) => *p,
+            CrdsValueLabel::NewEpochSlotsPlaceholder => Pubkey::default(),
             CrdsValueLabel::Version(p) => *p,
         }
     }
@@ -318,6 +323,7 @@ impl CrdsValue {
             CrdsData::EpochSlots(_, vote) => vote.wallclock,
             CrdsData::SnapshotHashes(hash) => hash.wallclock,
             CrdsData::AccountsHashes(hash) => hash.wallclock,
+            CrdsData::NewEpochSlotsPlaceholder => 0,
             CrdsData::Version(version) => version.wallclock,
         }
     }
@@ -328,6 +334,7 @@ impl CrdsValue {
             CrdsData::EpochSlots(_, slots) => slots.from,
             CrdsData::SnapshotHashes(hash) => hash.from,
             CrdsData::AccountsHashes(hash) => hash.from,
+            CrdsData::NewEpochSlotsPlaceholder => Pubkey::default(),
             CrdsData::Version(version) => version.from,
         }
     }
@@ -338,6 +345,7 @@ impl CrdsValue {
             CrdsData::EpochSlots(_, _) => CrdsValueLabel::EpochSlots(self.pubkey()),
             CrdsData::SnapshotHashes(_) => CrdsValueLabel::SnapshotHashes(self.pubkey()),
             CrdsData::AccountsHashes(_) => CrdsValueLabel::AccountsHashes(self.pubkey()),
+            CrdsData::NewEpochSlotsPlaceholder => CrdsValueLabel::NewEpochSlotsPlaceholder,
             CrdsData::Version(_) => CrdsValueLabel::Version(self.pubkey()),
         }
     }
@@ -456,6 +464,7 @@ mod test {
                 CrdsValueLabel::AccountsHashes(_) => hits[3] = true,
                 CrdsValueLabel::Version(_) => hits[4] = true,
                 CrdsValueLabel::Vote(ix, _) => hits[*ix as usize + 5] = true,
+                CrdsValueLabel::NewEpochSlotsPlaceholder => unreachable!(),
             }
         }
         assert!(hits.iter().all(|x| *x));


### PR DESCRIPTION
The ordinal value of the CrdsData::Version enum is different between v1.0 and v1.1.  This doesn't cause any major ill-effects, but does mean that a v1.1 `solana-gossip spy` doesn't see any version info for v1.0

v1.0:
https://github.com/solana-labs/solana/blob/8cde8a54ac6c27c648a505d8eccae05fbdc88af6/core/src/crds_value.rs#L68-L75
v1.1:
https://github.com/solana-labs/solana/blob/55a64c894589aa86aa348fef50aa0c2200472d54/core/src/crds_value.rs#L71-L79

Moving the v1.1 version of `EpochSlots` would likely break testnet, so the v1.0 version of `Version` needs to move instead.