### PR TITLE
run-sanity.sh: Wait for one slot to be produced

### DIFF
--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -19,6 +19,9 @@ while [[ ! -f config/run/init-completed ]]; do
   fi
 done
 
+while [[ $($solana_cli slot --commitment recent) -eq 0 ]]; do
+  sleep 1
+done
 curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' http://localhost:8899
 
 wait $pid


### PR DESCRIPTION
(v1.0 version of this landing in https://github.com/solana-labs/solana/pull/10252)

It's possible for the validator to exit before slot 1 is produced causing a failure in the following 
 `solana-ledger_tool create-snapshot config/ledger 1` step, as seen here:
https://buildkite.com/solana-labs/solana/builds/24848#c698706e-05d1-4445-9ba6-15a9930490e7
