### PR TITLE
CLI: Improve stake (de)activation display

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -202,7 +202,7 @@ impl Delegation {
     }
 
     #[allow(clippy::comparison_chain)]
-    fn stake_activating_and_deactivating(
+    pub fn stake_activating_and_deactivating(
         &self,
         epoch: Epoch,
         history: Option<&StakeHistory>,


### PR DESCRIPTION
#### Problem

CLI does a poor job of communicating the status of stake as it is (de)activating, confusing those new to staking.

#### Summary of Changes

Display the portions of stake that are delegated, active, activating, deactivating and inactive as is relevant.
Don't display _any_ stake amounts for accounts that are destaked

Sample outputs...

New account
```
Balance: 0.5 SOL
Rent Exempt Reserve: 0.00228288 SOL
Stake account is undelegated
Stake Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Withdraw Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Lockup Timestamp: 1970-01-01T00:00:00Z (UnixTimestamp: 0)
Lockup Epoch: 0
Lockup Custodian: 11111111111111111111111111111111
```

Post-delegate command
```
Balance: 0.5 SOL
Rent Exempt Reserve: 0.00228288 SOL
Delegated Stake: 0.49771712 SOL
Active Stake: 0 SOL
Activating Stake: 0.49771712 SOL
Stake activates starting from epoch: 40
Delegated Vote Account Address: Em2kVr7EhEMVpN6DyTjs5YyXbaPBEU7LekLUtwTFpxEt
Stake Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Withdraw Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Lockup Timestamp: 1970-01-01T00:00:00Z (UnixTimestamp: 0)
Lockup Epoch: 0
Lockup Custodian: 11111111111111111111111111111111
```

Mid-delegation
```
Balance: 0.5 SOL
Rent Exempt Reserve: 0.00228288 SOL
Delegated Stake: 0.49771712 SOL
Active Stake: 0.27996588 SOL
Activating Stake: 0.21775124 SOL
Stake activates starting from epoch: 40
Delegated Vote Account Address: Em2kVr7EhEMVpN6DyTjs5YyXbaPBEU7LekLUtwTFpxEt
Stake Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Withdraw Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Lockup Timestamp: 1970-01-01T00:00:00Z (UnixTimestamp: 0)
Lockup Epoch: 0
Lockup Custodian: 11111111111111111111111111111111
```

Delegated
```
Balance: 0.5 SOL
Rent Exempt Reserve: 0.00228288 SOL
Delegated Stake: 0.49771712 SOL
Active Stake: 0.49771712 SOL
Delegated Vote Account Address: Em2kVr7EhEMVpN6DyTjs5YyXbaPBEU7LekLUtwTFpxEt
Stake Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Withdraw Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Lockup Timestamp: 1970-01-01T00:00:00Z (UnixTimestamp: 0)
Lockup Epoch: 0
Lockup Custodian: 11111111111111111111111111111111
```

Post-deactivation command
```
Balance: 0.5 SOL
Rent Exempt Reserve: 0.00228288 SOL
Delegated Stake: 0.49771712 SOL
Active Stake: 0.49771712 SOL
Stake deactivates starting from epoch: 44
Delegated Vote Account Address: Em2kVr7EhEMVpN6DyTjs5YyXbaPBEU7LekLUtwTFpxEt
Stake Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Withdraw Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Lockup Timestamp: 1970-01-01T00:00:00Z (UnixTimestamp: 0)
Lockup Epoch: 0
Lockup Custodian: 11111111111111111111111111111111
```

Mid-deactivation
```
Balance: 0.5 SOL
Rent Exempt Reserve: 0.00228288 SOL
Delegated Stake: 0.49771712 SOL
Inactive Stake: 0.24885856 SOL
Deactivating Stake: 0.24885856 SOL
Stake deactivates starting from epoch: 44
Delegated Vote Account Address: Em2kVr7EhEMVpN6DyTjs5YyXbaPBEU7LekLUtwTFpxEt
Stake Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Withdraw Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Lockup Timestamp: 1970-01-01T00:00:00Z (UnixTimestamp: 0)
Lockup Epoch: 0
Lockup Custodian: 11111111111111111111111111111111
```

Deactivated
```
Balance: 0.5 SOL
Rent Exempt Reserve: 0.00228288 SOL
Stake account is undelegated
Stake Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Withdraw Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Lockup Timestamp: 1970-01-01T00:00:00Z (UnixTimestamp: 0)
Lockup Epoch: 0
Lockup Custodian: 11111111111111111111111111111111
```

Post-deactivation command, while activating
```
Balance: 0.5 SOL
Rent Exempt Reserve: 0.00228288 SOL
Delegated Stake: 0.49771712 SOL
Active Stake: 0.27996588 SOL
Stake deactivates starting from epoch: 51
Delegated Vote Account Address: Em2kVr7EhEMVpN6DyTjs5YyXbaPBEU7LekLUtwTFpxEt
Stake Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Withdraw Authority: 5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC
Lockup Timestamp: 1970-01-01T00:00:00Z (UnixTimestamp: 0)
Lockup Epoch: 0
Lockup Custodian: 11111111111111111111111111111111
```

JSON
```
{
  "stakeType": "Stake",
  "accountBalance": 500000000,
  "delegatedStake": 497717120,
  "delegatedVoteAccountAddress": "Em2kVr7EhEMVpN6DyTjs5YyXbaPBEU7LekLUtwTFpxEt",
  "activationEpoch": 55,
  "staker": "5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC",
  "withdrawer": "5cKPv2BptAChBzxPFnWCSW1xMqU3Dna6HMWbw2f8NqmC",
  "unixTimestamp": 0,
  "epoch": 0,
  "custodian": "11111111111111111111111111111111",
  "rentExemptReserve": 2282880,
  "activeStake": 124429280,
  "activatingStake": 373287840
}
```
Fixes #9538, fixes #7864
