### PR TITLE
validator: Add more logging while unpacking snapshots

### DIFF
--- a/ledger/src/hardened_unpack.rs
+++ b/ledger/src/hardened_unpack.rs
@@ -77,6 +77,8 @@ where
     let mut total_size: u64 = 0;
     let mut total_count: u64 = 0;
 
+    let mut total_entries = 0;
+    let mut last_log_update = Instant::now();
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?;
@@ -110,8 +112,15 @@ where
 
         // unpack_in does its own sanitization
         // ref: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack_in
-        check_unpack_result(entry.unpack_in(&unpack_dir)?, path_str)?
+        check_unpack_result(entry.unpack_in(&unpack_dir)?, path_str)?;
+        total_entries += 1;
+        let now = Instant::now();
+        if now.duration_since(last_log_update).as_secs() >= 10 {
+            info!("unpacked {} entries so far...", total_entries);
+            last_log_update = now;
+        }
     }
+    info!("unpacked {} entries total", total_entries);
 
     Ok(())
 }

--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -17,6 +17,7 @@ use solana_runtime::{
 use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash, pubkey::Pubkey};
 use std::{
     cmp::Ordering,
+    fmt,
     fs::{self, File},
     io::{BufReader, BufWriter, Error as IOError, ErrorKind, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
@@ -295,7 +296,7 @@ pub fn archive_snapshot_package(snapshot_package: &AccountsPackage) -> Result<()
 
 pub fn get_snapshot_paths<P: AsRef<Path>>(snapshot_path: P) -> Vec<SlotSnapshotPaths>
 where
-    P: std::fmt::Debug,
+    P: fmt::Debug,
 {
     match fs::read_dir(&snapshot_path) {
         Ok(paths) => {


### PR DESCRIPTION
Devnet current takes an hour or more to load, with very little log output to gain insight into what's going on.   Add more logging (which highlights that AccountsDb::() generate_index appears to be running in non-linear time wrt. the slots it's loading)