### PR TITLE
Stalebot: Exempt 'blocked' label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,6 +9,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - security
+  - blocked
 
 # Label to use when marking a pull request as stale
 staleLabel: stale


### PR DESCRIPTION
#### Problem

Stalebot considers known blocked PRs

#### Summary of Changes

Add `blocked` label to exempt list