### PR TITLE
CLI: Don't display inactive stake lockups

### DIFF
--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -516,19 +516,25 @@ impl fmt::Display for CliStakeState {
             writeln!(f, "Withdraw Authority: {}", authorized.withdrawer)?;
             Ok(())
         }
-        fn show_lockup(f: &mut fmt::Formatter, lockup: &CliLockup) -> fmt::Result {
-            writeln!(
-                f,
-                "Lockup Timestamp: {} (UnixTimestamp: {})",
-                DateTime::<Utc>::from_utc(
-                    NaiveDateTime::from_timestamp(lockup.unix_timestamp, 0),
-                    Utc
-                )
-                .to_rfc3339_opts(SecondsFormat::Secs, true),
-                lockup.unix_timestamp
-            )?;
-            writeln!(f, "Lockup Epoch: {}", lockup.epoch)?;
-            writeln!(f, "Lockup Custodian: {}", lockup.custodian)?;
+        fn show_lockup(f: &mut fmt::Formatter, lockup: Option<&CliLockup>) -> fmt::Result {
+            if let Some(lockup) = lockup {
+                if lockup.unix_timestamp != UnixTimestamp::default() {
+                    writeln!(
+                        f,
+                        "Lockup Timestamp: {} (UnixTimestamp: {})",
+                        DateTime::<Utc>::from_utc(
+                            NaiveDateTime::from_timestamp(lockup.unix_timestamp, 0),
+                            Utc
+                        )
+                        .to_rfc3339_opts(SecondsFormat::Secs, true),
+                        lockup.unix_timestamp
+                    )?;
+                }
+                if lockup.epoch != Epoch::default() {
+                    writeln!(f, "Lockup Epoch: {}", lockup.epoch)?;
+                }
+                writeln!(f, "Lockup Custodian: {}", lockup.custodian)?;
+            }
             Ok(())
         }
 
@@ -552,7 +558,7 @@ impl fmt::Display for CliStakeState {
             CliStakeType::Initialized => {
                 writeln!(f, "Stake account is undelegated")?;
                 show_authorized(f, self.authorized.as_ref().unwrap())?;
-                show_lockup(f, self.lockup.as_ref().unwrap())?;
+                show_lockup(f, self.lockup.as_ref())?;
             }
             CliStakeType::Stake => {
                 let show_delegation = {
@@ -650,7 +656,7 @@ impl fmt::Display for CliStakeState {
                     writeln!(f, "Stake account is undelegated")?;
                 }
                 show_authorized(f, self.authorized.as_ref().unwrap())?;
-                show_lockup(f, self.lockup.as_ref().unwrap())?;
+                show_lockup(f, self.lockup.as_ref())?;
             }
         }
         Ok(())

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1190,9 +1190,13 @@ pub fn process_show_stakes(
     let all_stake_accounts = rpc_client.get_program_accounts(&solana_stake_program::id())?;
     let stake_history_account = rpc_client.get_account(&stake_history::id())?;
     progress_bar.finish_and_clear();
+    let clock_account = rpc_client.get_account(&sysvar::clock::id())?;
 
     let stake_history = StakeHistory::from_account(&stake_history_account).ok_or_else(|| {
         CliError::RpcRequestError("Failed to deserialize stake history".to_string())
+    })?;
+    let clock: Clock = Sysvar::from_account(&clock_account).ok_or_else(|| {
+        CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string())
     })?;
 
     let mut stake_accounts: Vec<CliKeyedStakeState> = vec![];
@@ -1208,6 +1212,7 @@ pub fn process_show_stakes(
                                 &stake_state,
                                 use_lamports_unit,
                                 &stake_history,
+                                &clock,
                             ),
                         });
                     }
@@ -1225,6 +1230,7 @@ pub fn process_show_stakes(
                                 &stake_state,
                                 use_lamports_unit,
                                 &stake_history,
+                                &clock,
                             ),
                         });
                     }


### PR DESCRIPTION
#### Problem

CLI displays lockup parameters for stake accounts with no lockout in effect

#### Summary of Changes

Only display lockups for which `Lockup::is_in_force()` is `true`

Fixes #10265
