### PR TITLE
Implement Validator Groups

### DIFF
--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -19,8 +19,9 @@ use test::Bencher;
 #[bench]
 fn broadcast_shreds_bench(bencher: &mut Bencher) {
     solana_logger::setup();
+    let leader_id_pubkey = Pubkey::new_rand();
     let leader_pubkey = Pubkey::new_rand();
-    let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
+    let leader_info = Node::new_localhost_with_pubkey(&leader_id_pubkey, &leader_pubkey);
     let cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info.clone());
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
 

--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -30,8 +30,9 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     let mut stakes = HashMap::new();
     const NUM_PEERS: usize = 200;
     for _ in 0..NUM_PEERS {
-        let id = Pubkey::new_rand();
-        let contact_info = ContactInfo::new_localhost(&id, timestamp());
+        let validator_id = Pubkey::new_rand();
+        let node_id = Pubkey::new_rand();
+        let contact_info = ContactInfo::new_localhost(&validator_id, &node_id, timestamp());
         cluster_info.insert_info(contact_info);
         stakes.insert(id, thread_rng().gen_range(1, NUM_PEERS) as u64);
     }

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -33,9 +33,10 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     const NUM_PEERS: usize = 4;
     let mut peer_sockets = Vec::new();
     for _ in 0..NUM_PEERS {
+        let validator_id = Pubkey::new_rand();
         let id = Pubkey::new_rand();
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-        let mut contact_info = ContactInfo::new_localhost(&id, timestamp());
+        let mut contact_info = ContactInfo::new_localhost(&validator_id, &id, timestamp());
         contact_info.tvu = socket.local_addr().unwrap();
         contact_info.tvu.set_ip("127.0.0.1".parse().unwrap());
         contact_info.tvu_forwards = contact_info.tvu;

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -184,9 +184,11 @@ mod tests {
 
     #[test]
     fn test_should_halt() {
+        let validator_keypair = Keypair::new();
         let keypair = Keypair::new();
 
-        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        let contact_info =
+            ContactInfo::new_localhost(&validator_keypair.pubkey(), &keypair.pubkey(), 0);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(contact_info);
         let cluster_info = Arc::new(cluster_info);
 
@@ -219,9 +221,11 @@ mod tests {
         solana_logger::setup();
         use std::path::PathBuf;
         use tempfile::TempDir;
-        let keypair = Keypair::new();
+        let validator_keypair = Keypair::new();
+        let node_keypair = Keypair::new();
 
-        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
+        let contact_info =
+            ContactInfo::new_localhost(&validator_keypair.pubkey(), &node_keypair.pubkey(), 0);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(contact_info);
         let cluster_info = Arc::new(cluster_info);
 
@@ -254,7 +258,7 @@ mod tests {
             );
         }
         let cluster_hashes = cluster_info
-            .get_accounts_hash_for_node(&keypair.pubkey(), |c| c.clone())
+            .get_accounts_hash_for_node(&node_keypair.pubkey(), |c| c.clone())
             .unwrap();
         info!("{:?}", cluster_hashes);
         assert_eq!(hashes.len(), MAX_SNAPSHOT_HASHES);

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -330,8 +330,9 @@ impl BankingStage {
                         .leader_after_n_slots(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET);
                     next_leader.map_or((), |leader_pubkey| {
                         let leader_addr = {
-                            cluster_info
-                                .lookup_contact_info(&leader_pubkey, |leader| leader.tpu_forwards)
+                            cluster_info.lookup_contact_info(&leader_pubkey, |leader_nodes| {
+                                leader_nodes.get(0).map(|node| node.tpu_forwards)
+                            })
                         };
 
                         leader_addr.map_or((), |leader_addr| {

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -69,7 +69,7 @@ impl BroadcastStageType {
         blockstore: &Arc<Blockstore>,
         shred_version: u16,
     ) -> BroadcastStage {
-        let keypair = cluster_info.keypair.clone();
+        let keypair = cluster_info.id_keypair.clone();
         match self {
             BroadcastStageType::Standard => BroadcastStage::new(
                 sock,
@@ -579,6 +579,7 @@ pub mod test {
     }
 
     fn setup_dummy_broadcast_service(
+        leader_id_pubkey: &Pubkey,
         leader_pubkey: &Pubkey,
         ledger_path: &Path,
         entry_receiver: Receiver<WorkingBankEntry>,
@@ -588,11 +589,13 @@ pub mod test {
         let blockstore = Arc::new(Blockstore::open(ledger_path).unwrap());
 
         // Make the leader node and scheduler
-        let leader_info = Node::new_localhost_with_pubkey(leader_pubkey);
+        let leader_info = Node::new_localhost_with_pubkey(leader_id_pubkey, leader_pubkey);
 
         // Make a node to broadcast to
+        let buddy_id_keypair = Keypair::new();
         let buddy_keypair = Keypair::new();
-        let broadcast_buddy = Node::new_localhost_with_pubkey(&buddy_keypair.pubkey());
+        let broadcast_buddy =
+            Node::new_localhost_with_pubkey(&buddy_id_keypair.pubkey(), &buddy_keypair.pubkey());
 
         // Fill the cluster_info with the buddy's info
         let cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info.clone());
@@ -630,11 +633,13 @@ pub mod test {
 
         {
             // Create the leader scheduler
+            let leader_validator_keypair = Keypair::new();
             let leader_keypair = Keypair::new();
 
             let (entry_sender, entry_receiver) = channel();
             let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
             let broadcast_service = setup_dummy_broadcast_service(
+                &leader_validator_keypair.pubkey(),
                 &leader_keypair.pubkey(),
                 &ledger_path,
                 entry_receiver,

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -147,6 +147,7 @@ mod tests {
     fn test_tvu_peers_ordering() {
         let cluster = ClusterInfo::new_with_invalid_keypair(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         ));
         cluster.insert_info(ContactInfo::new_with_socketaddr(&SocketAddr::new(

--- a/core/src/broadcast_stage/standard_broadcast_run.rs
+++ b/core/src/broadcast_stage/standard_broadcast_run.rs
@@ -422,9 +422,11 @@ mod test {
         let blockstore = Arc::new(
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
         );
+        let leader_id_keypair = Arc::new(Keypair::new());
+        let leader_id_pubkey = leader_id_keypair.pubkey();
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
-        let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
+        let leader_info = Node::new_localhost_with_pubkey(&leader_id_pubkey, &leader_pubkey);
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(leader_info.info));
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let mut genesis_config = create_genesis_config(10_000).genesis_config;

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -12,6 +12,9 @@ use std::net::{IpAddr, SocketAddr};
 /// Structure representing a node on the network
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ContactInfo {
+    /// validator identity
+    pub validator_id: Pubkey,
+    /// gossip identity
     pub id: Pubkey,
     /// gossip address
     pub gossip: SocketAddr,
@@ -88,6 +91,7 @@ macro_rules! socketaddr_any {
 impl Default for ContactInfo {
     fn default() -> Self {
         ContactInfo {
+            validator_id: Pubkey::default(),
             id: Pubkey::default(),
             gossip: socketaddr_any!(),
             tvu: socketaddr_any!(),
@@ -106,8 +110,9 @@ impl Default for ContactInfo {
 }
 
 impl ContactInfo {
-    pub fn new_localhost(id: &Pubkey, now: u64) -> Self {
+    pub fn new_localhost(validator_id: &Pubkey, id: &Pubkey, now: u64) -> Self {
         Self {
+            validator_id: *validator_id,
             id: *id,
             gossip: socketaddr!("127.0.0.1:1234"),
             tvu: socketaddr!("127.0.0.1:1235"),
@@ -130,6 +135,7 @@ impl ContactInfo {
         let addr = socketaddr!("224.0.1.255:1000");
         assert!(addr.ip().is_multicast());
         Self {
+            validator_id: Pubkey::new_rand(),
             id: Pubkey::new_rand(),
             gossip: addr,
             tvu: addr,
@@ -147,7 +153,11 @@ impl ContactInfo {
     }
 
     #[cfg(test)]
-    pub(crate) fn new_with_pubkey_socketaddr(pubkey: &Pubkey, bind_addr: &SocketAddr) -> Self {
+    pub(crate) fn new_with_pubkey_socketaddr(
+        validator_id: &Pubkey,
+        id: &Pubkey,
+        bind_addr: &SocketAddr,
+    ) -> Self {
         fn next_port(addr: &SocketAddr, nxt: u16) -> SocketAddr {
             let mut nxt_addr = *addr;
             nxt_addr.set_port(addr.port() + nxt);
@@ -164,7 +174,8 @@ impl ContactInfo {
         let rpc_pubsub = SocketAddr::new(bind_addr.ip(), rpc_port::DEFAULT_RPC_PUBSUB_PORT);
         let serve_repair = next_port(&bind_addr, 6);
         Self {
-            id: *pubkey,
+            validator_id: *validator_id,
+            id: *id,
             gossip,
             tvu,
             tvu_forwards,
@@ -182,8 +193,9 @@ impl ContactInfo {
 
     #[cfg(test)]
     pub(crate) fn new_with_socketaddr(bind_addr: &SocketAddr) -> Self {
+        let validator_keypair = Keypair::new();
         let keypair = Keypair::new();
-        Self::new_with_pubkey_socketaddr(&keypair.pubkey(), bind_addr)
+        Self::new_with_pubkey_socketaddr(&validator_keypair.pubkey(), &keypair.pubkey(), bind_addr)
     }
 
     // Construct a ContactInfo that's only usable for gossip
@@ -292,8 +304,10 @@ mod tests {
 
     #[test]
     fn replayed_data_new_with_socketaddr_with_pubkey() {
+        let validator_keypair = Keypair::new();
         let keypair = Keypair::new();
         let d1 = ContactInfo::new_with_pubkey_socketaddr(
+            &validator_keypair.pubkey(),
             &keypair.pubkey(),
             &socketaddr!("127.0.0.1:1234"),
         );

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -203,10 +203,12 @@ mod test {
         let mut crds = Crds::default();
         let original = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::default(),
+            &Pubkey::default(),
             0,
         )));
         assert_matches!(crds.insert(original.clone(), 0), Ok(_));
         let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::default(),
             &Pubkey::default(),
             1,
         )));
@@ -220,6 +222,7 @@ mod test {
     fn test_update_timestamp() {
         let mut crds = Crds::default();
         let val = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::default(),
             &Pubkey::default(),
             0,
         )));
@@ -332,11 +335,13 @@ mod test {
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
                 &Pubkey::default(),
+                &Pubkey::default(),
                 0,
             ))),
         );
         let v2 = VersionedCrdsValue::new(1, {
-            let mut contact_info = ContactInfo::new_localhost(&Pubkey::default(), 0);
+            let mut contact_info =
+                ContactInfo::new_localhost(&Pubkey::default(), &Pubkey::default(), 0);
             contact_info.rpc = socketaddr!("0.0.0.0:0");
             CrdsValue::new_unsigned(CrdsData::ContactInfo(contact_info))
         });
@@ -367,12 +372,14 @@ mod test {
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
                 &Pubkey::default(),
+                &Pubkey::default(),
                 1,
             ))),
         );
         let v2 = VersionedCrdsValue::new(
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+                &Pubkey::default(),
                 &Pubkey::default(),
                 0,
             ))),
@@ -392,12 +399,14 @@ mod test {
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
                 &Pubkey::new_rand(),
+                &Pubkey::new_rand(),
                 0,
             ))),
         );
         let v2 = VersionedCrdsValue::new(
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+                &Pubkey::new_rand(),
                 &Pubkey::new_rand(),
                 0,
             ))),

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -245,7 +245,7 @@ mod test {
         let mut crds_gossip = CrdsGossip::default();
         crds_gossip.id = Pubkey::new(&[0; 32]);
         let id = crds_gossip.id;
-        let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), 0);
+        let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), &Pubkey::new(&[1; 32]), 0);
         let prune_pubkey = Pubkey::new(&[2; 32]);
         crds_gossip
             .crds

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -392,11 +392,13 @@ mod test {
         let node = CrdsGossipPull::default();
         let me = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         crds.insert(me.clone(), 0).unwrap();
         for i in 1..=30 {
             let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+                &Pubkey::new_rand(),
                 &Pubkey::new_rand(),
                 0,
             )));
@@ -480,6 +482,7 @@ mod test {
         let mut crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let id = entry.label().pubkey();
@@ -497,6 +500,7 @@ mod test {
 
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         crds.insert(new.clone(), 0).unwrap();
@@ -511,6 +515,7 @@ mod test {
         let mut crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
@@ -518,10 +523,12 @@ mod test {
         crds.insert(entry.clone(), 0).unwrap();
         let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         crds.insert(old.clone(), 0).unwrap();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -551,12 +558,14 @@ mod test {
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
         let node = CrdsGossipPull::default();
         node_crds.insert(entry, 0).unwrap();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -597,6 +606,7 @@ mod test {
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
@@ -605,21 +615,27 @@ mod test {
 
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         node_crds.insert(new, 0).unwrap();
 
         let mut dest = CrdsGossipPull::default();
         let mut dest_crds = Crds::default();
+        let new_validator_id = Pubkey::new_rand();
         let new_id = Pubkey::new_rand();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &new_id, 1,
+            &new_validator_id,
+            &new_id,
+            1,
         )));
         dest_crds.insert(new.clone(), 0).unwrap();
 
         // node contains a key from the dest node, but at an older local timestamp
         let same_key = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &new_id, 0,
+            &new_validator_id,
+            &new_id,
+            0,
         )));
         assert_eq!(same_key.label(), new.label());
         assert!(same_key.wallclock() < new.wallclock());
@@ -690,6 +706,7 @@ mod test {
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let node_label = entry.label();
@@ -697,6 +714,7 @@ mod test {
         let mut node = CrdsGossipPull::default();
         node_crds.insert(entry, 0).unwrap();
         let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -809,9 +827,10 @@ mod test {
         let mut node_crds = Crds::default();
         let mut node = CrdsGossipPull::default();
 
+        let peer_validator_pubkey = Pubkey::new_rand();
         let peer_pubkey = Pubkey::new_rand();
         let peer_entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(
-            ContactInfo::new_localhost(&peer_pubkey, 0),
+            ContactInfo::new_localhost(&peer_validator_pubkey, &peer_pubkey, 0),
         ));
         let mut timeouts = HashMap::new();
         timeouts.insert(Pubkey::default(), node.crds_timeout);
@@ -831,7 +850,7 @@ mod test {
 
         let mut node_crds = Crds::default();
         let unstaked_peer_entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(
-            ContactInfo::new_localhost(&peer_pubkey, 0),
+            ContactInfo::new_localhost(&peer_validator_pubkey, &peer_pubkey, 0),
         ));
         // check that old contact infos fail if they are too old, regardless of "timeouts"
         assert_eq!(

--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -364,12 +364,15 @@ mod test {
         let mut stakes = HashMap::new();
 
         let self_id = Pubkey::new_rand();
+        let validator_origin = Pubkey::new_rand();
         let origin = Pubkey::new_rand();
         stakes.insert(self_id, 100);
         stakes.insert(origin, 100);
 
         let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &origin, 0,
+            &validator_origin,
+            &origin,
+            0,
         )));
         let label = value.label();
         let low_staked_peers = (0..10).map(|_| Pubkey::new_rand());
@@ -414,6 +417,7 @@ mod test {
         let mut push = CrdsGossipPush::default();
         let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         let label = value.label();
@@ -434,7 +438,7 @@ mod test {
     fn test_process_push_old_version() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
         ci.wallclock = 1;
         let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone()));
 
@@ -457,7 +461,7 @@ mod test {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
         let timeout = push.msg_timeout;
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
 
         // push a version to far in the future
         ci.wallclock = timeout + 1;
@@ -479,7 +483,7 @@ mod test {
     fn test_process_push_update() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
         ci.wallclock = 0;
         let value_old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone()));
 
@@ -514,6 +518,7 @@ mod test {
         let mut push = CrdsGossipPush::default();
         let value1 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
 
@@ -522,6 +527,7 @@ mod test {
 
         assert!(push.active_set.get(&value1.label().pubkey()).is_some());
         let value2 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -537,7 +543,7 @@ mod test {
 
         for _ in 0..push.num_active {
             let value2 = CrdsValue::new_unsigned(CrdsData::ContactInfo(
-                ContactInfo::new_localhost(&Pubkey::new_rand(), 0),
+                ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
             ));
             assert_eq!(crds.insert(value2.clone(), 0), Ok(None));
         }
@@ -552,6 +558,7 @@ mod test {
         let mut stakes = HashMap::new();
         for i in 1..=100 {
             let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+                &Pubkey::new_rand(),
                 &Pubkey::new_rand(),
                 time,
             )));
@@ -634,12 +641,14 @@ mod test {
         let mut push = CrdsGossipPush::default();
         let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer.clone(), 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), &Pubkey::default(), 0, 1, 1);
 
         let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -656,17 +665,23 @@ mod test {
     fn test_personalized_push_messages() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
+        let peer_1_key = Pubkey::new_rand();
         let peer_1 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &peer_1_key,
             &Pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer_1.clone(), 0), Ok(None));
+        let peer_2_key = Pubkey::new_rand();
         let peer_2 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &peer_2_key,
             &Pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer_2.clone(), 0), Ok(None));
+        let peer_3_key = Pubkey::new_rand();
         let peer_3 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &peer_3_key,
             &Pubkey::new_rand(),
             0,
         )));
@@ -678,6 +693,7 @@ mod test {
 
         // push 3's contact info to 1 and 2 and 3
         let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &peer_3_key,
             &peer_3.pubkey(),
             0,
         )));
@@ -693,12 +709,14 @@ mod test {
         let mut push = CrdsGossipPush::default();
         let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer.clone(), 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), &Pubkey::default(), 0, 1, 1);
 
         let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
             &Pubkey::new_rand(),
             0,
         )));
@@ -716,12 +734,13 @@ mod test {
         let mut push = CrdsGossipPush::default();
         let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer, 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), &Pubkey::default(), 0, 1, 1);
 
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
         ci.wallclock = 1;
         let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
         let expected = HashMap::new();
@@ -737,7 +756,7 @@ mod test {
     fn test_purge_old_received_cache() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
         ci.wallclock = 0;
         let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
         let label = value.label();

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -507,9 +507,11 @@ mod test {
 
     #[test]
     fn test_signature() {
+        let validator_keypair = Keypair::new();
         let keypair = Keypair::new();
         let wrong_keypair = Keypair::new();
         let mut v = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &validator_keypair.pubkey(),
             &keypair.pubkey(),
             timestamp(),
         )));

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -822,7 +822,7 @@ mod test {
 
     #[test]
     pub fn test_update_lowest_slot() {
-        let node_info = Node::new_localhost_with_pubkey(&Pubkey::default());
+        let node_info = Node::new_localhost_with_pubkey(&Pubkey::default(), &Pubkey::default());
         let cluster_info = ClusterInfo::new_with_invalid_keypair(node_info.info);
         RepairService::update_lowest_slot(&Pubkey::default(), 5, &cluster_info);
         let lowest = cluster_info

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -975,7 +975,7 @@ impl ReplayStage {
             }
             Some(authorized_voter_keypair) => authorized_voter_keypair,
         };
-        let node_keypair = cluster_info.keypair.clone();
+        let node_keypair = cluster_info.id_keypair.clone();
 
         // Send our last few votes along with the new one
         let vote_ix = vote_instruction::vote(

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -429,7 +429,7 @@ mod tests {
         let leader_schedule_cache = Arc::new(cached_leader_schedule);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
-        let mut me = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut me = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
         let ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let port = find_available_port_in_range(ip_addr, (8000, 10000)).unwrap();
         let me_retransmit = UdpSocket::bind(format!("127.0.0.1:{}", port)).unwrap();
@@ -441,7 +441,7 @@ mod tests {
             .local_addr()
             .unwrap();
 
-        let other = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let other = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(other);
         cluster_info.insert_info(me);
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1766,6 +1766,7 @@ pub mod tests {
 
         cluster_info.insert_info(ContactInfo::new_with_pubkey_socketaddr(
             &leader_pubkey,
+            &leader_pubkey,
             &socketaddr!("127.0.0.1:1234"),
         ));
 

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -91,7 +91,12 @@ impl ServeRepair {
     }
 
     pub fn new(cluster_info: Arc<ClusterInfo>) -> Self {
-        let (keypair, my_info) = { (cluster_info.keypair.clone(), cluster_info.my_contact_info()) };
+        let (keypair, my_info) = {
+            (
+                cluster_info.id_keypair.clone(),
+                cluster_info.my_contact_info(),
+            )
+        };
         Self {
             keypair,
             my_info,
@@ -642,6 +647,7 @@ mod tests {
         {
             let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
             let me = ContactInfo {
+                validator_id: Pubkey::new_rand(),
                 id: Pubkey::new_rand(),
                 gossip: socketaddr!("127.0.0.1:1234"),
                 tvu: socketaddr!("127.0.0.1:1235"),
@@ -712,7 +718,7 @@ mod tests {
     #[test]
     fn window_index_request() {
         let cluster_slots = ClusterSlots::default();
-        let me = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let me = ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), timestamp());
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(me));
         let serve_repair = ServeRepair::new(cluster_info.clone());
         let rv = serve_repair.repair_request(
@@ -725,6 +731,7 @@ mod tests {
 
         let serve_repair_addr = socketaddr!([127, 0, 0, 1], 1243);
         let nxt = ContactInfo {
+            validator_id: Pubkey::new_rand(),
             id: Pubkey::new_rand(),
             gossip: socketaddr!([127, 0, 0, 1], 1234),
             tvu: socketaddr!([127, 0, 0, 1], 1235),
@@ -753,6 +760,7 @@ mod tests {
 
         let serve_repair_addr2 = socketaddr!([127, 0, 0, 2], 1243);
         let nxt = ContactInfo {
+            validator_id: Pubkey::new_rand(),
             id: Pubkey::new_rand(),
             gossip: socketaddr!([127, 0, 0, 1], 1234),
             tvu: socketaddr!([127, 0, 0, 1], 1235),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -98,7 +98,7 @@ impl Tvu {
         retransmit_slots_sender: RetransmitSlotsSender,
         tvu_config: TvuConfig,
     ) -> Self {
-        let keypair: Arc<Keypair> = cluster_info.keypair.clone();
+        let keypair: Arc<Keypair> = cluster_info.id_keypair.clone();
 
         let Sockets {
             repair: repair_socket,
@@ -250,8 +250,12 @@ pub mod tests {
     fn test_tvu_exit() {
         solana_logger::setup();
         let leader = Node::new_localhost();
+        let target1_id_keypair = Keypair::new();
         let target1_keypair = Keypair::new();
-        let target1 = Node::new_localhost_with_pubkey(&target1_keypair.pubkey());
+        let target1 = Node::new_localhost_with_pubkey(
+            &target1_id_keypair.pubkey(),
+            &target1_keypair.pubkey(),
+        );
 
         let starting_balance = 10_000;
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(starting_balance);

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -75,22 +75,23 @@ fn stakes(network: &Network) -> HashMap<Pubkey, u64> {
 fn star_network_create(num: usize) -> Network {
     let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
         &Pubkey::new_rand(),
+        &Pubkey::new_rand(),
         0,
     )));
-    let mut network: HashMap<_, _> = (1..num)
-        .map(|_| {
-            let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
-                0,
-            )));
-            let id = new.label().pubkey();
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), 0).unwrap();
-            node.crds.insert(entry.clone(), 0).unwrap();
-            node.set_self(&id);
-            (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
-        })
-        .collect();
+    let mut network: HashMap<_, _> =
+        (1..num)
+            .map(|_| {
+                let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(
+                    ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
+                ));
+                let id = new.label().pubkey();
+                let mut node = CrdsGossip::default();
+                node.crds.insert(new.clone(), 0).unwrap();
+                node.crds.insert(entry.clone(), 0).unwrap();
+                node.set_self(&id);
+                (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
+            })
+            .collect();
     let mut node = CrdsGossip::default();
     let id = entry.label().pubkey();
     node.crds.insert(entry, 0).unwrap();
@@ -102,44 +103,45 @@ fn star_network_create(num: usize) -> Network {
 fn rstar_network_create(num: usize) -> Network {
     let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
         &Pubkey::new_rand(),
+        &Pubkey::new_rand(),
         0,
     )));
     let mut origin = CrdsGossip::default();
     let id = entry.label().pubkey();
     origin.crds.insert(entry, 0).unwrap();
     origin.set_self(&id);
-    let mut network: HashMap<_, _> = (1..num)
-        .map(|_| {
-            let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
-                0,
-            )));
-            let id = new.label().pubkey();
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), 0).unwrap();
-            origin.crds.insert(new.clone(), 0).unwrap();
-            node.set_self(&id);
-            (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
-        })
-        .collect();
+    let mut network: HashMap<_, _> =
+        (1..num)
+            .map(|_| {
+                let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(
+                    ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
+                ));
+                let id = new.label().pubkey();
+                let mut node = CrdsGossip::default();
+                node.crds.insert(new.clone(), 0).unwrap();
+                origin.crds.insert(new.clone(), 0).unwrap();
+                node.set_self(&id);
+                (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
+            })
+            .collect();
     network.insert(id, Node::new(Arc::new(Mutex::new(origin))));
     Network::new(network)
 }
 
 fn ring_network_create(num: usize) -> Network {
-    let mut network: HashMap<_, _> = (0..num)
-        .map(|_| {
-            let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
-                0,
-            )));
-            let id = new.label().pubkey();
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), 0).unwrap();
-            node.set_self(&id);
-            (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
-        })
-        .collect();
+    let mut network: HashMap<_, _> =
+        (0..num)
+            .map(|_| {
+                let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(
+                    ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
+                ));
+                let id = new.label().pubkey();
+                let mut node = CrdsGossip::default();
+                node.crds.insert(new.clone(), 0).unwrap();
+                node.set_self(&id);
+                (new.label().pubkey(), Node::new(Arc::new(Mutex::new(node))))
+            })
+            .collect();
     let keys: Vec<Pubkey> = network.keys().cloned().collect();
     for k in 0..keys.len() {
         let start_info = {
@@ -161,22 +163,22 @@ fn ring_network_create(num: usize) -> Network {
 
 fn connected_staked_network_create(stakes: &[u64]) -> Network {
     let num = stakes.len();
-    let mut network: HashMap<_, _> = (0..num)
-        .map(|n| {
-            let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
-                0,
-            )));
-            let id = new.label().pubkey();
-            let mut node = CrdsGossip::default();
-            node.crds.insert(new.clone(), 0).unwrap();
-            node.set_self(&id);
-            (
-                new.label().pubkey(),
-                Node::staked(Arc::new(Mutex::new(node)), stakes[n]),
-            )
-        })
-        .collect();
+    let mut network: HashMap<_, _> =
+        (0..num)
+            .map(|n| {
+                let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(
+                    ContactInfo::new_localhost(&Pubkey::new_rand(), &Pubkey::new_rand(), 0),
+                ));
+                let id = new.label().pubkey();
+                let mut node = CrdsGossip::default();
+                node.crds.insert(new.clone(), 0).unwrap();
+                node.set_self(&id);
+                (
+                    new.label().pubkey(),
+                    Node::staked(Arc::new(Mutex::new(node)), stakes[n]),
+                )
+            })
+            .collect();
 
     let keys: Vec<Pubkey> = network.keys().cloned().collect();
     let start_entries: Vec<_> = keys
@@ -574,7 +576,7 @@ fn test_prune_errors() {
     let mut crds_gossip = CrdsGossip::default();
     crds_gossip.id = Pubkey::new(&[0; 32]);
     let id = crds_gossip.id;
-    let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), 0);
+    let ci = ContactInfo::new_localhost(&Pubkey::new(&[1; 32]), &Pubkey::new(&[1; 32]), 0);
     let prune_pubkey = Pubkey::new(&[2; 32]);
     crds_gossip
         .crds

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -174,7 +174,11 @@ pub mod test {
 
     #[test]
     fn test_dos() {
-        let nodes = [ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp())];
+        let nodes = [ContactInfo::new_localhost(
+            &Pubkey::new_rand(),
+            &Pubkey::new_rand(),
+            timestamp(),
+        )];
         let entrypoint_addr = nodes[0].gossip;
         run_dos(
             &nodes,

--- a/local-cluster/src/cluster.rs
+++ b/local-cluster/src/cluster.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 pub struct ValidatorInfo {
+    pub validator_keypair: Arc<Keypair>,
     pub keypair: Arc<Keypair>,
     pub voting_keypair: Arc<Keypair>,
     pub ledger_path: PathBuf,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -46,7 +46,7 @@ pub struct ClusterConfig {
     /// Number of nodes that are unstaked and not voting (a.k.a listening)
     pub num_listeners: u64,
     /// The specific pubkeys of each node if specified
-    pub validator_keys: Option<Vec<Arc<Keypair>>>,
+    pub validator_keys: Option<Vec<(Arc<Keypair>, Arc<Keypair>)>>,
     /// The stakes of each node
     pub node_stakes: Vec<u64>,
     /// The total lamports available to the cluster
@@ -109,15 +109,18 @@ impl LocalCluster {
                 assert_eq!(config.validator_configs.len(), keys.len());
                 keys.clone()
             } else {
-                iter::repeat_with(|| Arc::new(Keypair::new()))
+                iter::repeat_with(|| (Arc::new(Keypair::new()), Arc::new(Keypair::new())))
                     .take(config.validator_configs.len())
                     .collect()
             }
         };
 
-        let leader_keypair = &validator_keys[0];
+        let leader_keypair = &validator_keys[0].0;
         let leader_pubkey = leader_keypair.pubkey();
-        let leader_node = Node::new_localhost_with_pubkey(&leader_pubkey);
+        let leader_node_keypair = &validator_keys[0].1;
+        let leader_node_pubkey = leader_node_keypair.pubkey();
+
+        let leader_node = Node::new_localhost_with_pubkey(&leader_pubkey, &leader_node_pubkey);
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,
@@ -172,6 +175,7 @@ impl LocalCluster {
         let leader_server = Validator::new(
             leader_node,
             &leader_keypair,
+            &leader_node_keypair,
             &leader_ledger_path,
             &leader_voting_keypair.pubkey(),
             vec![leader_voting_keypair.clone()],
@@ -183,7 +187,8 @@ impl LocalCluster {
         let mut validators = HashMap::new();
         error!("leader_pubkey: {}", leader_pubkey);
         let leader_info = ValidatorInfo {
-            keypair: leader_keypair.clone(),
+            validator_keypair: leader_keypair.clone(),
+            keypair: leader_node_keypair.clone(),
             voting_keypair: leader_voting_keypair,
             ledger_path: leader_ledger_path,
             contact_info: leader_contact_info.clone(),
@@ -209,7 +214,7 @@ impl LocalCluster {
             config.validator_configs[1..].iter(),
             validator_keys[1..].iter(),
         ) {
-            cluster.add_validator(validator_config, *stake, key.clone());
+            cluster.add_validator(validator_config, *stake, key.0.clone(), key.1.clone());
         }
 
         let listener_config = ValidatorConfig {
@@ -217,7 +222,12 @@ impl LocalCluster {
             ..config.validator_configs[0].clone()
         };
         (0..config.num_listeners).for_each(|_| {
-            cluster.add_validator(&listener_config, 0, Arc::new(Keypair::new()));
+            cluster.add_validator(
+                &listener_config,
+                0,
+                Arc::new(Keypair::new()),
+                Arc::new(Keypair::new()),
+            );
         });
 
         discover_cluster(
@@ -253,6 +263,7 @@ impl LocalCluster {
         validator_config: &ValidatorConfig,
         stake: u64,
         validator_keypair: Arc<Keypair>,
+        node_keypair: Arc<Keypair>,
     ) -> Pubkey {
         let client = create_client(
             self.entry_point_info.client_facing_addr(),
@@ -262,7 +273,8 @@ impl LocalCluster {
         // Must have enough tokens to fund vote account and set delegate
         let voting_keypair = Keypair::new();
         let validator_pubkey = validator_keypair.pubkey();
-        let validator_node = Node::new_localhost_with_pubkey(&validator_keypair.pubkey());
+        let validator_node =
+            Node::new_localhost_with_pubkey(&validator_keypair.pubkey(), &node_keypair.pubkey());
         let contact_info = validator_node.info.clone();
         let (ledger_path, _blockhash) = create_new_tmp_ledger!(&self.genesis_config);
 
@@ -300,6 +312,7 @@ impl LocalCluster {
         let validator_server = Validator::new(
             validator_node,
             &validator_keypair,
+            &node_keypair,
             &ledger_path,
             &voting_keypair.pubkey(),
             vec![voting_keypair.clone()],
@@ -311,7 +324,8 @@ impl LocalCluster {
         let validator_pubkey = validator_keypair.pubkey();
         let validator_info = ClusterValidatorInfo::new(
             ValidatorInfo {
-                keypair: validator_keypair,
+                validator_keypair,
+                keypair: node_keypair,
                 voting_keypair,
                 ledger_path,
                 contact_info,
@@ -514,15 +528,16 @@ impl Cluster for LocalCluster {
         node
     }
 
-    fn restart_node(&mut self, pubkey: &Pubkey, mut cluster_validator_info: ClusterValidatorInfo) {
+    fn restart_node(&mut self, id: &Pubkey, mut cluster_validator_info: ClusterValidatorInfo) {
         // Update the stored ContactInfo for this node
-        let node = Node::new_localhost_with_pubkey(&pubkey);
+        let validator_id = cluster_validator_info.info.contact_info.validator_id;
+        let node = Node::new_localhost_with_pubkey(&validator_id, &id);
         cluster_validator_info.info.contact_info = node.info.clone();
         cluster_validator_info.config.rpc_ports =
             Some((node.info.rpc.port(), node.info.rpc_pubsub.port()));
 
         let entry_point_info = {
-            if *pubkey == self.entry_point_info.id {
+            if *id == self.entry_point_info.id {
                 self.entry_point_info = node.info.clone();
                 None
             } else {
@@ -535,6 +550,7 @@ impl Cluster for LocalCluster {
 
         let restarted_node = Validator::new(
             node,
+            &validator_info.validator_keypair,
             &validator_info.keypair,
             &validator_info.ledger_path,
             &validator_info.voting_keypair.pubkey(),
@@ -545,7 +561,7 @@ impl Cluster for LocalCluster {
         );
 
         cluster_validator_info.validator = Some(restarted_node);
-        self.validators.insert(*pubkey, cluster_validator_info);
+        self.validators.insert(*id, cluster_validator_info);
     }
 
     fn exit_restart_node(&mut self, pubkey: &Pubkey, validator_config: ValidatorConfig) {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -209,7 +209,7 @@ fn test_leader_failure_4() {
 #[allow(clippy::cognitive_complexity)]
 fn run_cluster_partition(
     partitions: &[&[(usize, bool)]],
-    leader_schedule: Option<(LeaderSchedule, Vec<Arc<Keypair>>)>,
+    leader_schedule: Option<(LeaderSchedule, Vec<(Arc<Keypair>, Arc<Keypair>)>)>,
 ) {
     solana_logger::setup();
     info!("PARTITION_TEST!");
@@ -244,7 +244,7 @@ fn run_cluster_partition(
             )
         } else {
             (
-                iter::repeat_with(|| Arc::new(Keypair::new()))
+                iter::repeat_with(|| (Arc::new(Keypair::new()), Arc::new(Keypair::new())))
                     .take(partitions.len())
                     .collect(),
                 10_000,
@@ -252,7 +252,7 @@ fn run_cluster_partition(
         }
     };
 
-    let validator_pubkeys: Vec<_> = validator_keys.iter().map(|v| v.pubkey()).collect();
+    let validator_pubkeys: Vec<_> = validator_keys.iter().map(|v| v.1.pubkey()).collect();
     let config = ClusterConfig {
         cluster_lamports,
         node_stakes,
@@ -388,9 +388,10 @@ fn test_kill_partition() {
     let mut leader_schedule = vec![];
     let num_slots_per_validator = 8;
     let partitions: [&[(usize, bool)]; 3] = [&[(9, true)], &[(10, false)], &[(10, false)]];
-    let validator_keys: Vec<_> = iter::repeat_with(|| Arc::new(Keypair::new()))
-        .take(partitions.len())
-        .collect();
+    let validator_keys: Vec<_> =
+        iter::repeat_with(|| (Arc::new(Keypair::new()), Arc::new(Keypair::new())))
+            .take(partitions.len())
+            .collect();
     for (i, k) in validator_keys.iter().enumerate() {
         let num_slots = {
             if i == 0 {
@@ -401,7 +402,7 @@ fn test_kill_partition() {
             }
         };
         for _ in 0..num_slots {
-            leader_schedule.push(k.pubkey())
+            leader_schedule.push(k.1.pubkey())
         }
     }
     info!("leader_schedule: {}", leader_schedule.len());
@@ -631,9 +632,10 @@ fn test_frozen_account_from_genesis() {
     solana_logger::setup();
     let validator_identity =
         Arc::new(solana_sdk::signature::keypair_from_seed(&[0u8; 32]).unwrap());
+    let identity = Arc::new(solana_sdk::signature::keypair_from_seed(&[0u8; 32]).unwrap());
 
     let config = ClusterConfig {
-        validator_keys: Some(vec![validator_identity.clone()]),
+        validator_keys: Some(vec![(validator_identity.clone(), identity.clone())]),
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
         validator_configs: vec![
@@ -655,13 +657,14 @@ fn test_frozen_account_from_snapshot() {
     solana_logger::setup();
     let validator_identity =
         Arc::new(solana_sdk::signature::keypair_from_seed(&[0u8; 32]).unwrap());
+    let identity = Arc::new(solana_sdk::signature::keypair_from_seed(&[0u8; 32]).unwrap());
 
     let mut snapshot_test_config = setup_snapshot_validator_config(5, 1);
     // Freeze the validator identity account
-    snapshot_test_config.validator_config.frozen_accounts = vec![validator_identity.pubkey()];
+    snapshot_test_config.validator_config.frozen_accounts = vec![identity.pubkey()];
 
     let config = ClusterConfig {
-        validator_keys: Some(vec![validator_identity.clone()]),
+        validator_keys: Some(vec![(validator_identity.clone(), identity.clone())]),
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
         validator_configs: vec![snapshot_test_config.validator_config.clone()],
@@ -736,6 +739,7 @@ fn test_consistency_halt() {
     cluster.add_validator(
         &validator_snapshot_test_config.validator_config,
         validator_stake as u64,
+        Arc::new(Keypair::new()),
         Arc::new(Keypair::new()),
     );
     let num_nodes = 2;
@@ -830,6 +834,7 @@ fn test_snapshot_download() {
     cluster.add_validator(
         &validator_snapshot_test_config.validator_config,
         stake,
+        Arc::new(Keypair::new()),
         Arc::new(Keypair::new()),
     );
 }
@@ -966,6 +971,7 @@ fn test_snapshots_blockstore_floor() {
     cluster.add_validator(
         &validator_snapshot_test_config.validator_config,
         validator_stake,
+        Arc::new(Keypair::new()),
         Arc::new(Keypair::new()),
     );
     let all_pubkeys = cluster.get_node_pubkeys();

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -134,6 +134,7 @@ fn get_trusted_snapshot_hashes(
 }
 
 fn start_gossip_node(
+    validator_identity_keypair: &Arc<Keypair>,
     identity_keypair: &Arc<Keypair>,
     entrypoint_gossip: &SocketAddr,
     gossip_addr: &SocketAddr,
@@ -142,10 +143,12 @@ fn start_gossip_node(
 ) -> (Arc<ClusterInfo>, Arc<AtomicBool>, GossipService) {
     let cluster_info = ClusterInfo::new(
         ClusterInfo::gossip_contact_info(
+            &validator_identity_keypair.pubkey(),
             &identity_keypair.pubkey(),
             *gossip_addr,
             expected_shred_version.unwrap_or(0),
         ),
+        validator_identity_keypair.clone(),
         identity_keypair.clone(),
     );
     cluster_info.set_entrypoint(ContactInfo::new_gossip_entry_point(entrypoint_gossip));
@@ -819,6 +822,7 @@ pub fn main() {
         .get_matches();
 
     let identity_keypair = Arc::new(keypair_of(&matches, "identity").unwrap_or_else(Keypair::new));
+    let node_keypair = Arc::new(keypair_of(&matches, "node").unwrap_or_else(Keypair::new));
 
     let authorized_voter_keypairs = keypairs_of(&matches, "authorized_voter_keypairs")
         .map(|keypairs| keypairs.into_iter().map(Arc::new).collect())
@@ -1076,6 +1080,7 @@ pub fn main() {
 
     let mut node = Node::new_with_external_ip(
         &identity_keypair.pubkey(),
+        &node_keypair.pubkey(),
         &gossip_addr,
         dynamic_port_range,
         bind_address,
@@ -1122,6 +1127,7 @@ pub fn main() {
         if !no_genesis_fetch {
             let (cluster_info, gossip_exit_flag, gossip_service) = start_gossip_node(
                 &identity_keypair,
+                &node_keypair,
                 &cluster_entrypoint.gossip,
                 &node.info.gossip,
                 node.sockets.gossip.try_clone().unwrap(),
@@ -1248,6 +1254,7 @@ pub fn main() {
     let validator = Validator::new(
         node,
         &identity_keypair,
+        &node_keypair,
         &ledger_path,
         &vote_account,
         authorized_voter_keypairs,


### PR DESCRIPTION
#### Problem

This PR is updated from #9356, updated to fit with recent changes to gossip and validator setup. Also to go along-side the proposal in #10024 -- in particular addressing some of the concerns in the previous PR which grew stale with changes over TdS.

#### Summary of Changes

- [ ] Treats the identity keypair as a group identifier in Gossip
- [ ] When a validator is running only a single node, re-uses identity as node key.
- [ ] Allows multiple nodes to exist at the same time with the same identity (group) key.
