### PR TITLE
Add commitment parameter to getFeeCalculatorForBlockhash (#10255)

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -671,12 +671,28 @@ impl RpcClient {
         &self,
         blockhash: &Hash,
     ) -> ClientResult<Option<FeeCalculator>> {
-        let Response { value, .. } = self.send::<Response<Option<RpcFeeCalculator>>>(
+        Ok(self
+            .get_fee_calculator_for_blockhash_with_commitment(
+                blockhash,
+                CommitmentConfig::default(),
+            )?
+            .value)
+    }
+
+    pub fn get_fee_calculator_for_blockhash_with_commitment(
+        &self,
+        blockhash: &Hash,
+        commitment_config: CommitmentConfig,
+    ) -> RpcResult<Option<FeeCalculator>> {
+        let Response { context, value } = self.send::<Response<Option<RpcFeeCalculator>>>(
             RpcRequest::GetFeeCalculatorForBlockhash,
-            json!([blockhash.to_string()]),
+            json!([blockhash.to_string(), commitment_config]),
         )?;
 
-        Ok(value.map(|rf| rf.fee_calculator))
+        Ok(Response {
+            context,
+            value: value.map(|rf| rf.fee_calculator),
+        })
     }
 
     pub fn get_fee_rate_governor(&self) -> RpcResult<FeeRateGovernor> {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -226,8 +226,9 @@ impl JsonRpcRequestProcessor {
     fn get_fee_calculator_for_blockhash(
         &self,
         blockhash: &Hash,
+        commitment: Option<CommitmentConfig>,
     ) -> RpcResponse<Option<RpcFeeCalculator>> {
-        let bank = &*self.bank(None)?;
+        let bank = &*self.bank(commitment)?;
         let fee_calculator = bank.get_fee_calculator(blockhash);
         new_response(
             bank,
@@ -821,6 +822,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         blockhash: String,
+        commitment: Option<CommitmentConfig>,
     ) -> RpcResponse<Option<RpcFeeCalculator>>;
 
     #[rpc(meta, name = "getFeeRateGovernor")]
@@ -1162,6 +1164,7 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         blockhash: String,
+        commitment: Option<CommitmentConfig>,
     ) -> RpcResponse<Option<RpcFeeCalculator>> {
         debug!("get_fee_calculator_for_blockhash rpc request received");
         let blockhash =
@@ -1169,7 +1172,7 @@ impl RpcSol for RpcSolImpl {
         meta.request_processor
             .read()
             .unwrap()
-            .get_fee_calculator_for_blockhash(&blockhash)
+            .get_fee_calculator_for_blockhash(&blockhash, commitment)
     }
 
     fn get_fee_rate_governor(&self, meta: Self::Metadata) -> RpcResponse<RpcFeeRateGovernor> {

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -491,7 +491,8 @@ Returns the fee calculator associated with the query blockhash, or `null` if the
 
 #### Parameters:
 
-* `blockhash: <string>`, query blockhash as a Base58 encoded string
+* `<string>` - query blockhash as a Base58 encoded string
+* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
 
 #### Results:
 


### PR DESCRIPTION
Backport of low risk https://github.com/solana-labs/solana/pull/10255 (also needs to be on v1.1) to keep the master rpc_client compatible with {dev,mainnet-beta,test}net

