### PR TITLE
Add ability for ledger-tool to dump ledger transactions to CSV

### DIFF
--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -13,7 +13,7 @@ bs58 = "0.3.0"
 clap = "2.33.0"
 csv = "1.1.3"
 histogram = "*"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
 serde_json = "1.0.46"
 serde_yaml = "0.8.11"
 solana-clap-utils = { path = "../clap-utils", version = "1.0.25" }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -11,7 +11,9 @@ homepage = "https://solana.com/"
 [dependencies]
 bs58 = "0.3.0"
 clap = "2.33.0"
+csv = "1.1.3"
 histogram = "*"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.46"
 serde_yaml = "0.8.11"
 solana-clap-utils = { path = "../clap-utils", version = "1.0.25" }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -152,29 +152,23 @@ fn build_instruction_info(
         ..Default::default()
     };
 
-    // Need to figure out how to decode program instruction to String
-    instruction_info.program_instruction = Some("foo".to_string());
-//    instruction_info.program_instruction =
-//                Some(std::str::from_utf8(&instruction.data).unwrap().to_string());
-
-
-//    if program_pubkey == solana_stake_program::id() {
-//        if let Ok(stake_instruction) = limited_deserialize::<
-//            solana_stake_program::stake_instruction::StakeInstruction,
-//        >(&instruction.data)
-//        {
-//            instruction_info.program_instruction =
-//                Some(std::str::from_utf8(&stake_instruction).unwrap().to_string());
-//        }
-//    } else if program_pubkey == solana_sdk::system_program::id() {
-//        if let Ok(system_instruction) = limited_deserialize::<
-//            solana_sdk::system_instruction::SystemInstruction,
-//        >(&instruction.data)
-//        {
-//            instruction_info.program_instruction =
-//                Some(std::str::from_utf8(&system_instruction).unwrap().to_string());
-//        }
-//    }
+    if program_pubkey == solana_stake_program::id() {
+        if let Ok(stake_instruction) = limited_deserialize::<
+            solana_stake_program::stake_instruction::StakeInstruction,
+        >(&instruction.data)
+        {
+            instruction_info.program_instruction =
+                Some(format!("{:?}",stake_instruction));
+        }
+    } else if program_pubkey == solana_sdk::system_program::id() {
+        if let Ok(system_instruction) = limited_deserialize::<
+            solana_sdk::system_instruction::SystemInstruction,
+        >(&instruction.data)
+        {
+            instruction_info.program_instruction =
+                Some(format!("{:?}", system_instruction));
+        }
+    }
 
 
     for account in &instruction.accounts {
@@ -185,7 +179,6 @@ fn build_instruction_info(
                 .account_keys[*account as usize])
                 .into_string())
     }
-
     instruction_info
 }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -118,7 +118,6 @@ fn output_slot_to_csv(
                 let instruction_info = build_instruction_info(
                     &instruction,
                     &transaction,
-                    &transaction_status
                 );
                 instruction_wtr.serialize(&instruction_info);
             }
@@ -140,7 +139,6 @@ fn output_slot_to_csv(
 fn build_instruction_info(
     instruction: &CompiledInstruction,
     transaction: &Transaction,
-    transaction_status: &Option<RpcTransactionStatusMeta>
 ) -> InstructionInfo {
     let program_pubkey = transaction
         .message
@@ -323,7 +321,7 @@ fn output_ledger_to_csv(blockstore: &Blockstore,
         .from_path(instruction_csv_file)
         .unwrap();
 
-    for (slot, slot_meta) in rooted_slot_iterator {
+    for (slot, _slot_meta) in rooted_slot_iterator {
         output_slot_to_csv(
             blockstore,
             slot,


### PR DESCRIPTION
#### Problem
No tooling exists to create or index a database-like structure from the rocksDB history.

#### Summary of Changes
Add two subcommands `slot-csv` and `print-csv` to `solana-ledger-tool`, to print a single slot, or a range of slots (up to the entire contents of a rocksDB ledger), respectively.

Commands generate two related CSVs, the first "transactions file" contains txn information, accounts involved and any pre/post account balances.  One txn per row.  The second "instructions file" contains details of each instruction contained within any transaction.  One instruction per row.  Instruction rows contain the txn signature they came from to use as a key to index between the two files.

Related to #10149, but here using the ledger tool on a local rocksDB instead of querying whatever history the RPC node has.  The output style is probably workable for the related issue.