### PR TITLE
Don't resolve mainnet-beta in the test suite

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3241,6 +3241,7 @@ mod tests {
         // Success cases
         let mut config = CliConfig::default();
         config.rpc_client = Some(RpcClient::new_mock("succeeds".to_string()));
+        config.json_rpc_url = "http://127.0.0.1:8899".to_string();
 
         let keypair = Keypair::new();
         let pubkey = keypair.pubkey().to_string();


### PR DESCRIPTION
#### Problem

I changed the URL in `CliConfig::default`. Since then, folks may have noticed CI failures any time mainnet-beta was unreachable. 1c73f3e100513325f05c372f0e48f94c1368ef9a

#### Summary of Changes

Don't resolve mainnet-beta in the airdrop unit-test.
