### PR TITLE
Add preflight checks to sendTransaction RPC method

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1,12 +1,11 @@
 use crate::{
     cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
     cli_output::*,
-    display::println_name_value,
+    display::{new_spinner_progress_bar, println_name_value},
     spend_utils::{resolve_spend_tx_and_check_account_balance, SpendAmount},
 };
 use clap::{value_t, value_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand};
 use console::{style, Emoji};
-use indicatif::{ProgressBar, ProgressStyle};
 use solana_clap_utils::{
     commitment::{commitment_arg, COMMITMENT_ARG},
     input_parsers::*,
@@ -465,15 +464,6 @@ pub fn parse_transaction_history(
         },
         signers: vec![],
     })
-}
-
-/// Creates a new process bar for processing that will take an unknown amount of time
-fn new_spinner_progress_bar() -> ProgressBar {
-    let progress_bar = ProgressBar::new(42);
-    progress_bar
-        .set_style(ProgressStyle::default_spinner().template("{spinner:.green} {wide_msg}"));
-    progress_bar.enable_steady_tick(100);
-    progress_bar
 }
 
 pub fn process_catchup(

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -1,5 +1,6 @@
 use crate::cli::SettingType;
 use console::style;
+use indicatif::{ProgressBar, ProgressStyle};
 use solana_sdk::{
     hash::Hash, native_token::lamports_to_sol, program_utils::limited_deserialize,
     transaction::Transaction,
@@ -199,4 +200,13 @@ pub fn println_transaction(
             print!("{}", s);
         }
     }
+}
+
+/// Creates a new process bar for processing that will take an unknown amount of time
+pub fn new_spinner_progress_bar() -> ProgressBar {
+    let progress_bar = ProgressBar::new(42);
+    progress_bar
+        .set_style(ProgressStyle::default_spinner().template("{spinner:.green} {wide_msg}"));
+    progress_bar.enable_steady_tick(100);
+    progress_bar
 }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -2,7 +2,7 @@ use crate::{
     client_error::{ClientError, ClientErrorKind, Result as ClientResult},
     http_sender::HttpSender,
     mock_sender::{MockSender, Mocks},
-    rpc_config::RpcLargestAccountsConfig,
+    rpc_config::{RpcLargestAccountsConfig, RpcSendTransactionConfig},
     rpc_request::{RpcError, RpcRequest},
     rpc_response::*,
     rpc_sender::RpcSender,
@@ -94,10 +94,20 @@ impl RpcClient {
     }
 
     pub fn send_transaction(&self, transaction: &Transaction) -> ClientResult<Signature> {
+        self.send_transaction_with_config(transaction, RpcSendTransactionConfig::default())
+    }
+
+    pub fn send_transaction_with_config(
+        &self,
+        transaction: &Transaction,
+        config: RpcSendTransactionConfig,
+    ) -> ClientResult<Signature> {
         let serialized_encoded = bs58::encode(serialize(transaction).unwrap()).into_string();
 
-        let signature_base58_str: String =
-            self.send(RpcRequest::SendTransaction, json!([serialized_encoded]))?;
+        let signature_base58_str: String = self.send(
+            RpcRequest::SendTransaction,
+            json!([serialized_encoded, config]),
+        )?;
 
         let signature = signature_base58_str
             .parse::<Signature>()

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -6,7 +6,13 @@ pub struct RpcSignatureStatusConfig {
     pub search_transaction_history: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcSendTransactionConfig {
+    pub skip_preflight: bool,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcSimulateTransactionConfig {
     pub sig_verify: bool,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,6 +43,7 @@ pub mod retransmit_stage;
 pub mod rewards_recorder_service;
 pub mod rpc;
 pub mod rpc_error;
+pub mod rpc_health;
 pub mod rpc_pubsub;
 pub mod rpc_pubsub_service;
 pub mod rpc_service;

--- a/core/src/rpc_error.rs
+++ b/core/src/rpc_error.rs
@@ -3,6 +3,7 @@ use solana_sdk::clock::Slot;
 
 const JSON_RPC_SERVER_ERROR_0: i64 = -32000;
 const JSON_RPC_SERVER_ERROR_1: i64 = -32001;
+const JSON_RPC_SERVER_ERROR_2: i64 = -32002;
 
 pub enum RpcCustomError {
     NonexistentClusterRoot {
@@ -12,6 +13,9 @@ pub enum RpcCustomError {
     BlockCleanedUp {
         slot: Slot,
         first_available_block: Slot,
+    },
+    SendTransactionPreflightFailure {
+        message: String,
     },
 }
 
@@ -38,6 +42,11 @@ impl From<RpcCustomError> for Error {
                     "Block {} cleaned up, does not exist on node. First available block: {}",
                     slot, first_available_block,
                 ),
+                data: None,
+            },
+            RpcCustomError::SendTransactionPreflightFailure { message } => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_2),
+                message,
                 data: None,
             },
         }

--- a/core/src/rpc_health.rs
+++ b/core/src/rpc_health.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
 };
 
+#[derive(PartialEq)]
 pub enum RpcHealthStatus {
     Ok,
     Behind, // Validator is behind its trusted validators
@@ -87,5 +88,17 @@ impl RpcHealth {
             // because it's running
             RpcHealthStatus::Ok
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stub() -> Arc<Self> {
+        Arc::new(Self::new(
+            Arc::new(ClusterInfo::new_with_invalid_keypair(
+                crate::contact_info::ContactInfo::default(),
+            )),
+            None,
+            42,
+            Arc::new(AtomicBool::new(false)),
+        ))
     }
 }

--- a/core/src/rpc_health.rs
+++ b/core/src/rpc_health.rs
@@ -1,0 +1,91 @@
+use crate::cluster_info::ClusterInfo;
+use solana_sdk::pubkey::Pubkey;
+use std::{
+    collections::HashSet,
+    sync::atomic::{AtomicBool, Ordering},
+    sync::Arc,
+};
+
+pub enum RpcHealthStatus {
+    Ok,
+    Behind, // Validator is behind its trusted validators
+}
+
+pub struct RpcHealth {
+    cluster_info: Arc<ClusterInfo>,
+    trusted_validators: Option<HashSet<Pubkey>>,
+    health_check_slot_distance: u64,
+    override_health_check: Arc<AtomicBool>,
+}
+
+impl RpcHealth {
+    pub fn new(
+        cluster_info: Arc<ClusterInfo>,
+        trusted_validators: Option<HashSet<Pubkey>>,
+        health_check_slot_distance: u64,
+        override_health_check: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            cluster_info,
+            trusted_validators,
+            health_check_slot_distance,
+            override_health_check,
+        }
+    }
+
+    pub fn check(&self) -> RpcHealthStatus {
+        if self.override_health_check.load(Ordering::Relaxed) {
+            RpcHealthStatus::Ok
+        } else if let Some(trusted_validators) = &self.trusted_validators {
+            let (latest_account_hash_slot, latest_trusted_validator_account_hash_slot) = {
+                (
+                    self.cluster_info
+                        .get_accounts_hash_for_node(&self.cluster_info.id(), |hashes| {
+                            hashes
+                                .iter()
+                                .max_by(|a, b| a.0.cmp(&b.0))
+                                .map(|slot_hash| slot_hash.0)
+                        })
+                        .flatten()
+                        .unwrap_or(0),
+                    trusted_validators
+                        .iter()
+                        .map(|trusted_validator| {
+                            self.cluster_info
+                                .get_accounts_hash_for_node(&trusted_validator, |hashes| {
+                                    hashes
+                                        .iter()
+                                        .max_by(|a, b| a.0.cmp(&b.0))
+                                        .map(|slot_hash| slot_hash.0)
+                                })
+                                .flatten()
+                                .unwrap_or(0)
+                        })
+                        .max()
+                        .unwrap_or(0),
+                )
+            };
+
+            // This validator is considered healthy if its latest account hash slot is within
+            // `health_check_slot_distance` of the latest trusted validator's account hash slot
+            if latest_account_hash_slot > 0
+                && latest_trusted_validator_account_hash_slot > 0
+                && latest_account_hash_slot
+                    > latest_trusted_validator_account_hash_slot
+                        .saturating_sub(self.health_check_slot_distance)
+            {
+                RpcHealthStatus::Ok
+            } else {
+                warn!(
+                    "health check: me={}, latest trusted_validator={}",
+                    latest_account_hash_slot, latest_trusted_validator_account_hash_slot
+                );
+                RpcHealthStatus::Behind
+            }
+        } else {
+            // No trusted validator point of reference available, so this validator is healthy
+            // because it's running
+            RpcHealthStatus::Ok
+        }
+    }
+}

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -1,7 +1,8 @@
 //! The `rpc_service` module implements the Solana JSON RPC service.
 
 use crate::{
-    cluster_info::ClusterInfo, commitment::BlockCommitmentCache, rpc::*, validator::ValidatorExit,
+    cluster_info::ClusterInfo, commitment::BlockCommitmentCache, rpc::*, rpc_health::*,
+    validator::ValidatorExit,
 };
 use jsonrpc_core::MetaIoHandler;
 use jsonrpc_http_server::{
@@ -19,7 +20,7 @@ use std::{
     collections::HashSet,
     net::SocketAddr,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::AtomicBool,
     sync::{mpsc::channel, Arc, RwLock},
     thread::{self, Builder, JoinHandle},
 };
@@ -38,22 +39,16 @@ struct RpcRequestMiddleware {
     ledger_path: PathBuf,
     snapshot_archive_path_regex: Regex,
     snapshot_config: Option<SnapshotConfig>,
-    cluster_info: Arc<ClusterInfo>,
-    trusted_validators: Option<HashSet<Pubkey>>,
     bank_forks: Arc<RwLock<BankForks>>,
-    health_check_slot_distance: u64,
-    override_health_check: Arc<AtomicBool>,
+    health: Arc<RpcHealth>,
 }
 
 impl RpcRequestMiddleware {
     pub fn new(
         ledger_path: PathBuf,
         snapshot_config: Option<SnapshotConfig>,
-        cluster_info: Arc<ClusterInfo>,
-        trusted_validators: Option<HashSet<Pubkey>>,
         bank_forks: Arc<RwLock<BankForks>>,
-        health_check_slot_distance: u64,
-        override_health_check: Arc<AtomicBool>,
+        health: Arc<RpcHealth>,
     ) -> Self {
         Self {
             ledger_path,
@@ -62,11 +57,8 @@ impl RpcRequestMiddleware {
             )
             .unwrap(),
             snapshot_config,
-            cluster_info,
-            trusted_validators,
             bank_forks,
-            health_check_slot_distance,
-            override_health_check,
+            health,
         }
     }
 
@@ -137,60 +129,10 @@ impl RpcRequestMiddleware {
     }
 
     fn health_check(&self) -> &'static str {
-        let response = if self.override_health_check.load(Ordering::Relaxed) {
-            "ok"
-        } else if let Some(trusted_validators) = &self.trusted_validators {
-            let (latest_account_hash_slot, latest_trusted_validator_account_hash_slot) = {
-                (
-                    self.cluster_info
-                        .get_accounts_hash_for_node(&self.cluster_info.id(), |hashes| {
-                            hashes
-                                .iter()
-                                .max_by(|a, b| a.0.cmp(&b.0))
-                                .map(|slot_hash| slot_hash.0)
-                        })
-                        .flatten()
-                        .unwrap_or(0),
-                    trusted_validators
-                        .iter()
-                        .map(|trusted_validator| {
-                            self.cluster_info
-                                .get_accounts_hash_for_node(&trusted_validator, |hashes| {
-                                    hashes
-                                        .iter()
-                                        .max_by(|a, b| a.0.cmp(&b.0))
-                                        .map(|slot_hash| slot_hash.0)
-                                })
-                                .flatten()
-                                .unwrap_or(0)
-                        })
-                        .max()
-                        .unwrap_or(0),
-                )
-            };
-
-            // This validator is considered healthy if its latest account hash slot is within
-            // `health_check_slot_distance` of the latest trusted validator's account hash slot
-            if latest_account_hash_slot > 0
-                && latest_trusted_validator_account_hash_slot > 0
-                && latest_account_hash_slot
-                    > latest_trusted_validator_account_hash_slot
-                        .saturating_sub(self.health_check_slot_distance)
-            {
-                "ok"
-            } else {
-                warn!(
-                    "health check: me={}, latest trusted_validator={}",
-                    latest_account_hash_slot, latest_trusted_validator_account_hash_slot
-                );
-                "behind"
-            }
-        } else {
-            // No trusted validator point of reference available, so this validator is healthy
-            // because it's running
-            "ok"
+        let response = match self.health.check() {
+            RpcHealthStatus::Ok => "ok",
+            RpcHealthStatus::Behind => "behind",
         };
-
         info!("health check: {}", response);
         response
     }
@@ -299,7 +241,14 @@ impl JsonRpcService {
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
-        let health_check_slot_distance = config.health_check_slot_distance;
+
+        let health = Arc::new(RpcHealth::new(
+            cluster_info.clone(),
+            trusted_validators,
+            config.health_check_slot_distance,
+            override_health_check,
+        ));
+
         let request_processor = Arc::new(RwLock::new(JsonRpcRequestProcessor::new(
             config,
             bank_forks.clone(),
@@ -324,11 +273,8 @@ impl JsonRpcService {
                 let request_middleware = RpcRequestMiddleware::new(
                     ledger_path,
                     snapshot_config,
-                    cluster_info.clone(),
-                    trusted_validators,
                     bank_forks.clone(),
-                    health_check_slot_distance,
-                    override_health_check,
+                    health.clone(),
                 );
                 let server = ServerBuilder::with_meta_extractor(
                     io,
@@ -403,7 +349,10 @@ mod tests {
     };
     use solana_runtime::bank::Bank;
     use solana_sdk::signature::Signer;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::atomic::Ordering,
+    };
 
     #[test]
     fn test_rpc_new() {
@@ -481,18 +430,16 @@ mod tests {
 
     #[test]
     fn test_is_file_get_path() {
-        let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(ContactInfo::default()));
         let bank_forks = create_bank_forks();
-
-        let rrm = RpcRequestMiddleware::new(
-            PathBuf::from("/"),
+        let health = Arc::new(RpcHealth::new(
+            Arc::new(ClusterInfo::new_with_invalid_keypair(ContactInfo::default())),
             None,
-            cluster_info.clone(),
-            None,
-            bank_forks.clone(),
             42,
             Arc::new(AtomicBool::new(false)),
-        );
+        ));
+
+        let rrm =
+            RpcRequestMiddleware::new(PathBuf::from("/"), None, bank_forks.clone(), health.clone());
         let rrm_with_snapshot_config = RpcRequestMiddleware::new(
             PathBuf::from("/"),
             Some(SnapshotConfig {
@@ -501,11 +448,8 @@ mod tests {
                 snapshot_path: PathBuf::from("/"),
                 compression: CompressionType::Bzip2,
             }),
-            cluster_info,
-            None,
             bank_forks,
-            42,
-            Arc::new(AtomicBool::new(false)),
+            health,
         );
 
         assert!(rrm.is_file_get_path("/genesis.tar.bz2"));
@@ -531,37 +475,32 @@ mod tests {
 
     #[test]
     fn test_health_check_with_no_trusted_validators() {
-        let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(ContactInfo::default()));
-
-        let rm = RpcRequestMiddleware::new(
-            PathBuf::from("/"),
+        let health = Arc::new(RpcHealth::new(
+            Arc::new(ClusterInfo::new_with_invalid_keypair(ContactInfo::default())),
             None,
-            cluster_info,
-            None,
-            create_bank_forks(),
             42,
             Arc::new(AtomicBool::new(false)),
-        );
+        ));
+
+        let rm = RpcRequestMiddleware::new(PathBuf::from("/"), None, create_bank_forks(), health);
         assert_eq!(rm.health_check(), "ok");
     }
 
     #[test]
     fn test_health_check_with_trusted_validators() {
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(ContactInfo::default()));
-
         let health_check_slot_distance = 123;
-
         let override_health_check = Arc::new(AtomicBool::new(false));
         let trusted_validators = vec![Pubkey::new_rand(), Pubkey::new_rand(), Pubkey::new_rand()];
-        let rm = RpcRequestMiddleware::new(
-            PathBuf::from("/"),
-            None,
+
+        let health = Arc::new(RpcHealth::new(
             cluster_info.clone(),
             Some(trusted_validators.clone().into_iter().collect()),
-            create_bank_forks(),
             health_check_slot_distance,
             override_health_check.clone(),
-        );
+        ));
+
+        let rm = RpcRequestMiddleware::new(PathBuf::from("/"), None, create_bank_forks(), health);
 
         // No account hashes for this node or any trusted validators == "behind"
         assert_eq!(rm.health_check(), "behind");

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1065,11 +1065,20 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ### sendTransaction
 
-Creates new transaction
+Submits a signed transaction to the cluster for processing.
+
+Before submitting, the following preflight checks are performed:
+1. The transaction signatures are verified
+2. The transaction is simulated against the latest max confirmed bank
+and on failure an error will be returned.  Preflight checks may be disabled if
+desired.
 
 #### Parameters:
 
 * `<string>` - fully-signed Transaction, as base-58 encoded string
+* `<object>` - (optional) Configuration object containing the following field:
+  * `skipPreflight: <bool>` - if true, skip the preflight transaction checks (default: false)
+
 
 #### Results:
 

--- a/tokens/src/thin_client.rs
+++ b/tokens/src/thin_client.rs
@@ -1,4 +1,4 @@
-use solana_client::rpc_client::RpcClient;
+use solana_client::{rpc_client::RpcClient, rpc_config::RpcSendTransactionConfig};
 use solana_runtime::bank_client::BankClient;
 use solana_sdk::{
     account::Account,
@@ -32,8 +32,13 @@ pub trait Client {
 
 impl Client for RpcClient {
     fn send_transaction1(&self, transaction: Transaction) -> Result<Signature> {
-        self.send_transaction(&transaction)
-            .map_err(|e| TransportError::Custom(e.to_string()))
+        self.send_transaction_with_config(
+            &transaction,
+            RpcSendTransactionConfig {
+                skip_preflight: true,
+            },
+        )
+        .map_err(|e| TransportError::Custom(e.to_string()))
     }
 
     fn get_signature_statuses1(


### PR DESCRIPTION
`sendTransaction` blindly dumps the transaction it receives into a TPU.  It can do better by:
1) Verify transaction signatures
2) Simulating the transaction against the latest max confirmed bank
and on failure, return an error to the caller.   If the RPC node is unhealthy it will refuse to run the simulation

Preflight checks may be disabled if desired with `sendTransaction`'s new `config` input parameter.  By default they are enabled for the convenience of existing API users.

Towards #10336