### PR TITLE
Add clap-utils to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "bench-tps",
     "accounts-bench",
     "banking-bench",
+    "clap-utils",
     "cli-config",
     "client",
     "core",


### PR DESCRIPTION
#### Problem

[Rust Analyzer](https://rust-analyzer.github.io) reports `solana_clap_utils` is not found.

#### Summary of Changes

Add "clap-utils" to the workspace
