### PR TITLE
Add switch threshold local cluster tests + fix `check_switch_threshold`

### DIFF
--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -1,4 +1,7 @@
-use crate::cluster::{Cluster, ClusterValidatorInfo, ValidatorInfo};
+use crate::{
+    cluster::{Cluster, ClusterValidatorInfo, ValidatorInfo},
+    cluster_tests,
+};
 use itertools::izip;
 use log::*;
 use solana_client::thin_client::{create_client, ThinClient};
@@ -334,6 +337,25 @@ impl LocalCluster {
             VALIDATOR_PORT_RANGE,
         );
         Self::transfer_with_client(&client, source_keypair, dest_pubkey, lamports)
+    }
+
+    pub fn check_for_new_roots(&self, num_new_roots: usize, test_name: &str) {
+        let alive_node_contact_infos: Vec<_> = self
+            .validators
+            .values()
+            .map(|v| v.info.contact_info.clone())
+            .collect();
+        assert!(!alive_node_contact_infos.is_empty());
+        info!("{} discovering nodes", test_name);
+        let cluster_nodes = discover_cluster(
+            &alive_node_contact_infos[0].gossip,
+            alive_node_contact_infos.len(),
+        )
+        .unwrap();
+        info!("{} discovered {} nodes", test_name, cluster_nodes.len());
+        info!("{} looking for new roots on all nodes", test_name);
+        cluster_tests::check_for_new_roots(num_new_roots, &alive_node_contact_infos);
+        info!("{} done waiting for roots", test_name);
     }
 
     fn transfer_with_client(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -354,7 +354,26 @@ impl LocalCluster {
         .unwrap();
         info!("{} discovered {} nodes", test_name, cluster_nodes.len());
         info!("{} looking for new roots on all nodes", test_name);
-        cluster_tests::check_for_new_roots(num_new_roots, &alive_node_contact_infos);
+        cluster_tests::check_for_new_roots(num_new_roots, &alive_node_contact_infos, test_name);
+        info!("{} done waiting for roots", test_name);
+    }
+
+    pub fn check_no_new_roots(&self, num_slots_to_wait: usize, test_name: &str) {
+        let alive_node_contact_infos: Vec<_> = self
+            .validators
+            .values()
+            .map(|v| v.info.contact_info.clone())
+            .collect();
+        assert!(!alive_node_contact_infos.is_empty());
+        info!("{} discovering nodes", test_name);
+        let cluster_nodes = discover_cluster(
+            &alive_node_contact_infos[0].gossip,
+            alive_node_contact_infos.len(),
+        )
+        .unwrap();
+        info!("{} discovered {} nodes", test_name, cluster_nodes.len());
+        info!("{} making sure no new roots on any nodes", test_name);
+        cluster_tests::check_no_new_roots(num_slots_to_wait, &alive_node_contact_infos, test_name);
         info!("{} done waiting for roots", test_name);
     }
 


### PR DESCRIPTION
#### Problem
1) No local cluster integration tests for switch threshold logic
2) https://github.com/solana-labs/solana/blob/master/core/src/consensus.rs#L451-L454 is not longer a correct check because `BankForks.ancestors()` can now return with `keys < root`.
3) https://github.com/solana-labs/solana/blob/master/core/src/consensus.rs#L415 to check only tips of forks can cause liveness problems if the tip of the fork is not frozen/lockouts not computed

#### Summary of Changes
1) Add local cluster tests to check switch threshold success/failure when there is less than and greater than maximal failures
2) Fix `check_switch_threshold` checks, update unit tests

Fixes #
