### PR TITLE
Reduce stable jobs

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -39,9 +39,9 @@ test -d target/release/bpf && find target/release/bpf -name '*.d' -delete
 rm -rf target/xargo # Issue #3105
 
 # Limit compiler jobs to reduce memory usage
-# on machines with 1gb/thread of memory
+# on machines with 2gb/thread of memory
 NPROC=$(nproc)
-NPROC=$((NPROC>16 ? 16 : NPROC))
+NPROC=$((NPROC>14 ? 14 : NPROC))
 
 echo "Executing $testName"
 case $testName in


### PR DESCRIPTION
#### Problem

Frequent link time OOMs on valverde causing failed CI stable runs.  This is the only CI machine with 32GB RAM.  The others with 64GB, peak ~53% free memory during stable

#### Summary of Changes

Reduce stable jobs until we can get some more RAM installed