### PR TITLE
Revert "Reduce UNLOCK_NONCE_SLOT to ensure it is active on all three clusters (#10223)"

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -50,7 +50,7 @@ pub const SIZE_OF_NONCE_DATA_SHRED_PAYLOAD: usize =
 pub const OFFSET_OF_SHRED_SLOT: usize = SIZE_OF_SIGNATURE + SIZE_OF_SHRED_TYPE;
 pub const OFFSET_OF_SHRED_INDEX: usize = OFFSET_OF_SHRED_SLOT + SIZE_OF_SHRED_SLOT;
 pub const NONCE_SHRED_PAYLOAD_SIZE: usize = PACKET_DATA_SIZE - SIZE_OF_NONCE;
-pub const UNLOCK_NONCE_SLOT: Slot = 14_780_256;
+pub const UNLOCK_NONCE_SLOT: Slot = 13_115_515;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -50,7 +50,7 @@ pub const SIZE_OF_NONCE_DATA_SHRED_PAYLOAD: usize =
 pub const OFFSET_OF_SHRED_SLOT: usize = SIZE_OF_SIGNATURE + SIZE_OF_SHRED_TYPE;
 pub const OFFSET_OF_SHRED_INDEX: usize = OFFSET_OF_SHRED_SLOT + SIZE_OF_SHRED_SLOT;
 pub const NONCE_SHRED_PAYLOAD_SIZE: usize = PACKET_DATA_SIZE - SIZE_OF_NONCE;
-pub const UNLOCK_NONCE_SLOT: Slot = 5_000_000;
+pub const UNLOCK_NONCE_SLOT: Slot = 14_780_256;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())


### PR DESCRIPTION
This reverts commit 9adf8b4fc86ce82af30f0d81aad34625fff8124c.

Fixes mainnet-beta transaction history older than slot 13,115,516