### PR TITLE
Testnet automation: Fix slot query

### DIFF
--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -86,7 +86,7 @@ function wait_for_bootstrap_validator_stake_drop {
 function get_slot {
   source "${REPO_ROOT}"/net/common.sh
   loadConfigFile
-  ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana slot'
+  ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana --url http://127.0.0.1:8899 slot'
 }
 
 function get_bootstrap_validator_ip_address {


### PR DESCRIPTION
#### Problem

Testnet automation queries the cluster's current slot without specifying the RPC URL. `solana` falls back to the default, that is "mainnet-beta"

#### Summary of Changes

Specify the localhost RPC URL when querying slots