### PR TITLE
Add --max-genesis-archive-unpacked-size to capitalization

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -753,6 +753,7 @@ fn main() {
             .arg(&account_paths_arg)
             .arg(&halt_at_slot_arg)
             .arg(&hard_forks_arg)
+            .arg(&max_genesis_archive_unpacked_size_arg)
         ).subcommand(
             SubCommand::with_name("purge")
             .about("Purge the ledger at the block height")


### PR DESCRIPTION
#### Problem

#10327 missed to add `--max-genesis-archive-unpacked-size` to `solana-ledger-tool capitalization`.

#### Summary of Changes

Add it.

#### context

Found via last-minute testing for #10209 on the `v1.1` branch...

CC: @t-nelson 