### PR TITLE
Don't share same snapshot dir for secondary access

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -557,17 +557,22 @@ fn load_bank_forks(
     process_options: ProcessOptions,
     access_type: AccessType,
 ) -> bank_forks_utils::LoadResult {
+    let blockstore = open_blockstore(&ledger_path, access_type);
+    let snapshot_path = ledger_path.clone().join(if blockstore.is_primary_access() {
+        "snapshot"
+    } else {
+        "snapshot.ledger-tool"
+    });
     let snapshot_config = if arg_matches.is_present("no_snapshot") {
         None
     } else {
         Some(SnapshotConfig {
             snapshot_interval_slots: 0, // Value doesn't matter
             snapshot_package_output_path: ledger_path.clone(),
-            snapshot_path: ledger_path.clone().join("snapshot"),
+            snapshot_path,
             compression: CompressionType::Bzip2,
         })
     };
-    let blockstore = open_blockstore(&ledger_path, access_type);
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {
         if !blockstore.is_primary_access() {
             // Be defenstive, when default account dir is explicitly specified, it's still possible


### PR DESCRIPTION
#### Problem

When validator is creating a new snapshot, secondary `ledger-tool` use can cause the snapshot creation process to crash becuase of missing file, which is removed by the secondary:


```
[2020-06-03T07:15:23.428596880Z WARN  solana_ledger::snapshot_utils] tar command failed with exit code: exit code: 2
[2020-06-03T07:15:23.428623898Z WARN  solana_ledger::snapshot_utils] tar stdout: 
[2020-06-03T07:15:23.428639371Z WARN  solana_ledger::snapshot_utils] tar stderr:
    tar: snapshots: Cannot stat: No such file or directory
    tar: Exiting with failure status due to previous errors
    
[2020-06-03T07:15:24.851585353Z WARN  solana_core::snapshot_packager_service] Failed to create snapshot archive: archive generation failure exit code: 2
[2020-06-03T07:15:24.906626871Z WARN  solana_core::snapshot_packager_service] Failed to create snapshot archive: I/O error
```

Usually, new snapshot refers to the incorrectly shared directory via a symlink like this:

```
$ ls -l /tmp/.tmprqQiJo
total 1524
drwxrwxr-x 2 ryoqun ryoqun 1544192 Jun  3 16:24 accounts
lrwxrwxrwx 1 ryoqun ryoqun      66 Jun  3 16:24 snapshots -> /home/ryoqun/work/solana/testnet/snapshot/.tmpBTks9N
-rw-rw-r-- 1 ryoqun ryoqun       5 Jun  3 16:24 version
```

This problem is visible when doing like this:

```
while true; do RUST_LOG=warn ./target/release/solana-ledger-tool --ledger ./testnet/ graph /tmp/aaaa.pdf; sleep 5; done
```

Note that, there is still another problem which is found above one liner..

#### Summary of Changes

Don't share same directory `snapshot`.

CC: @mvines 