### PR TITLE
Avoid AccountInUse errors when simulating transactions

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1049,6 +1049,13 @@ impl Bank {
         TransactionBatch::new(results, &self, txs, iteration_order)
     }
 
+    pub fn prepare_simulation_batch<'a, 'b>(
+        &'a self,
+        txs: &'b [Transaction],
+    ) -> TransactionBatch<'a, 'b> {
+        TransactionBatch::new(vec![Ok(()); txs.len()], &self, txs, None)
+    }
+
     pub fn unlock_accounts(&self, batch: &mut TransactionBatch) {
         if batch.needs_unlock {
             batch.needs_unlock = false;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1053,7 +1053,9 @@ impl Bank {
         &'a self,
         txs: &'b [Transaction],
     ) -> TransactionBatch<'a, 'b> {
-        TransactionBatch::new(vec![Ok(()); txs.len()], &self, txs, None)
+        let mut batch = TransactionBatch::new(vec![Ok(()); txs.len()], &self, txs, None);
+        batch.needs_unlock = false;
+        batch
     }
 
     pub fn unlock_accounts(&self, batch: &mut TransactionBatch) {

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -81,6 +81,23 @@ mod tests {
         assert!(batch2.lock_results().iter().all(|x| x.is_ok()));
     }
 
+    #[test]
+    fn test_simulation_batch() {
+        let (bank, txs) = setup();
+
+        // Prepare batch without locks
+        let batch = bank.prepare_simulation_batch(&txs);
+        assert!(batch.lock_results().iter().all(|x| x.is_ok()));
+
+        // Grab locks
+        let batch2 = bank.prepare_batch(&txs, None);
+        assert!(batch2.lock_results().iter().all(|x| x.is_ok()));
+
+        // Prepare another batch without locks
+        let batch3 = bank.prepare_simulation_batch(&txs);
+        assert!(batch3.lock_results().iter().all(|x| x.is_ok()));
+    }
+
     fn setup() -> (Bank, Vec<Transaction>) {
         let dummy_leader_pubkey = Pubkey::new_rand();
         let GenesisConfigInfo {


### PR DESCRIPTION
#### Problem
RPC transaction simulation locks accounts when checking if a transaction could succeed and therefore can encounter `AccountInUse` transaction errors during simulation. `AccountInUse` errors are never helpful for simulation.

#### Summary of Changes
Since simulation doesn't commit accounts, we don't need write locks for accounts. This change introduces a batch creation method that skips the lock step.

Fixes #
