### PR TITLE
Build docs: Throw error if no release version found

### DIFF
--- a/docs/set-solana-release-tag.sh
+++ b/docs/set-solana-release-tag.sh
@@ -13,6 +13,11 @@ else
   )
 fi
 
+if [[ -z "$LATEST_SOLANA_RELEASE_VERSION" ]]; then
+  echo Error: release version not defined
+  exit 1
+fi
+
 set -x
 find html/ -name \*.html -exec sed -i "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
 if [[ -n $CI ]]; then


### PR DESCRIPTION
#### Problem
If `docs/set-solana-release-tag.sh` cannot get the latest release version (eg. rate-limited by github), it happily continues and replaces the version var with an empty string:
```
./set-solana-release-tag.sh
curl: (22) The requested URL returned error: 403 rate limit exceeded
+ find html/ -name '*.html' -exec sed -i s/LATEST_SOLANA_RELEASE_VERSION//g '{}' ';'
+ [[ -n 1 ]]
+ find src/ -name '*.md' -exec sed -i s/LATEST_SOLANA_RELEASE_VERSION//g '{}' ';'
```

#### Summary of Changes
Throw an error and exit publish-docs if `LATEST_SOLANA_RELEASE_VERSION` is not populated 

