### PR TITLE
Don't reuse executable accounts between instructions

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6942,7 +6942,7 @@ mod tests {
 
         let instruction = Instruction::new(program2_pubkey, &10, vec![]);
         let tx = Transaction::new_signed_with_payer(
-            &[instruction.clone(), instruction.clone()],
+            &[instruction.clone(), instruction],
             Some(&mint_keypair.pubkey()),
             &[&mint_keypair],
             bank.last_blockhash(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6915,7 +6915,7 @@ mod tests {
     }
 
     #[test]
-    fn test_same_program_id_reuses_executable_accounts() {
+    fn test_same_program_id_uses_unqiue_executable_accounts() {
         fn nested_processor(
             _program_id: &Pubkey,
             keyed_accounts: &[KeyedAccount],

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6913,4 +6913,42 @@ mod tests {
             bank = Arc::new(new_from_parent(&bank));
         }
     }
+
+    #[test]
+    fn test_same_program_id_reuses_executable_accounts() {
+        fn nested_processor(
+            _program_id: &Pubkey,
+            keyed_accounts: &[KeyedAccount],
+            _data: &[u8],
+        ) -> result::Result<(), InstructionError> {
+            assert_eq!(42, keyed_accounts[0].lamports().unwrap());
+            let mut account = keyed_accounts[0].try_account_ref_mut()?;
+            account.lamports += 1;
+            Ok(())
+        }
+
+        let (genesis_config, mint_keypair) = create_genesis_config(50000);
+        let mut bank = Bank::new(&genesis_config);
+
+        // Add a new program
+        let program1_pubkey = Pubkey::new_rand();
+        bank.add_builtin_program("program", program1_pubkey, nested_processor);
+
+        // Add a new program owned by the first
+        let program2_pubkey = Pubkey::new_rand();
+        let mut program2_account = Account::new(42, 1, &program1_pubkey);
+        program2_account.executable = true;
+        bank.store_account(&program2_pubkey, &program2_account);
+
+        let instruction = Instruction::new(program2_pubkey, &10, vec![]);
+        let tx = Transaction::new_signed_with_payer(
+            &[instruction.clone(), instruction.clone()],
+            Some(&mint_keypair.pubkey()),
+            &[&mint_keypair],
+            bank.last_blockhash(),
+        );
+        assert!(bank.process_transaction(&tx).is_ok());
+        assert_eq!(1, bank.get_balance(&program1_pubkey));
+        assert_eq!(42, bank.get_balance(&program2_pubkey));
+    }
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -516,15 +516,10 @@ impl MessageProcessor {
         rent_collector: &RentCollector,
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
-            let executable_index = message
-                .program_position(instruction.program_id_index as usize)
-                .ok_or(TransactionError::InvalidAccountIndex)?;
-            let executable_accounts = &loaders[executable_index];
-
             self.execute_instruction(
                 message,
                 instruction,
-                executable_accounts,
+                &loaders[instruction_index],
                 accounts,
                 rent_collector,
             )


### PR DESCRIPTION
#### Problem

An executable chain is loaded for each instruction but the message processor is re-using another instructions chain if the chains match.  This can lead to one instruction modifying an executable of another.  This exploit is only exposed to native programs now but if/when new loaders are addable by users the exploit would also be exposed to those loaders.

#### Summary of Changes

Each instruction gets a unique chain of executable accounts

Fixes #10390
