### PR TITLE
Deactivate legacy_system_instruction_processor0 at epoch 58/38 (preview/stable)

### DIFF
--- a/runtime/src/builtin_programs.rs
+++ b/runtime/src/builtin_programs.rs
@@ -22,8 +22,8 @@ impl BuiltinProgram {
 pub(crate) fn new_system_program_activation_epoch(operating_mode: OperatingMode) -> Epoch {
     match operating_mode {
         OperatingMode::Development => 0,
-        OperatingMode::Preview => 1_000_000,
-        OperatingMode::Stable => 1_000_000,
+        OperatingMode::Preview => 58,
+        OperatingMode::Stable => 38,
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/solana-labs/solana/issues/10400
Fixes https://github.com/solana-labs/solana/issues/10399

cc: #10401