### PR TITLE
Add arg to specify address-signer for solana deploy

### DIFF
--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -3,7 +3,11 @@ use solana_cli::cli::{process_command, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_core::validator::TestValidator;
 use solana_faucet::faucet::run_local_faucet;
-use solana_sdk::{bpf_loader, pubkey::Pubkey, signature::Keypair};
+use solana_sdk::{
+    bpf_loader,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+};
 use std::{
     fs::{remove_dir_all, File},
     io::Read,
@@ -50,12 +54,15 @@ fn test_cli_deploy_program() {
         faucet_host: None,
         faucet_port: faucet_addr.port(),
         pubkey: None,
-        lamports: minimum_balance_for_rent_exemption + 1, // min balance for rent exemption + leftover for tx processing
+        lamports: 3 * minimum_balance_for_rent_exemption, // min balance for rent exemption for two programs + leftover for tx processing
     };
     config.signers = vec![&keypair];
     process_command(&config).unwrap();
 
-    config.command = CliCommand::Deploy(pathbuf.to_str().unwrap().to_string());
+    config.command = CliCommand::Deploy {
+        program_location: pathbuf.to_str().unwrap().to_string(),
+        address: None,
+    };
 
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -67,16 +74,35 @@ fn test_cli_deploy_program() {
         .as_str()
         .unwrap();
     let program_id = Pubkey::from_str(&program_id_str).unwrap();
-    let account = rpc_client.get_account(&program_id).unwrap();
-    assert_eq!(account.lamports, minimum_balance_for_rent_exemption);
-    assert_eq!(account.owner, bpf_loader::id());
-    assert_eq!(account.executable, true);
+    let account0 = rpc_client.get_account(&program_id).unwrap();
+    assert_eq!(account0.lamports, minimum_balance_for_rent_exemption);
+    assert_eq!(account0.owner, bpf_loader::id());
+    assert_eq!(account0.executable, true);
 
     let mut file = File::open(pathbuf.to_str().unwrap().to_string()).unwrap();
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
 
-    assert_eq!(account.data, elf);
+    assert_eq!(account0.data, elf);
+
+    // Test custom address
+    let custom_address_keypair = Keypair::new();
+    config.signers = vec![&keypair, &custom_address_keypair];
+    config.command = CliCommand::Deploy {
+        program_location: pathbuf.to_str().unwrap().to_string(),
+        address: Some(1),
+    };
+    process_command(&config).unwrap();
+    let account1 = rpc_client
+        .get_account(&custom_address_keypair.pubkey())
+        .unwrap();
+    assert_eq!(account1.lamports, minimum_balance_for_rent_exemption);
+    assert_eq!(account1.owner, bpf_loader::id());
+    assert_eq!(account1.executable, true);
+    assert_eq!(account0.data, account1.data);
+
+    // Attempt to redeploy to the same address
+    process_command(&config).unwrap_err();
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();


### PR DESCRIPTION
#### Problem
`solana deploy` always creates a new Keypair to create and populate the program account, resulting in a new, random address on every use. Users may want to load a program to a specific account, like a vanity address for example.

#### Summary of Changes
Add optional arg to `solana deploy` to pass a Signer to create/address the program account. 

Technically, any Signer will be parsed successfully, but a Keypair file is the only really practical option right now. A Ledger would require individual approval of all the loader transactions (84 for the small memo program I've just written), as we don't support batch signing right now. Also, it would require blind signing, as our Ledger app does not support `loader_instruction::write` Instructions.
