### PR TITLE
Remove lock around JsonRpcRequestProcessor

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -253,6 +253,12 @@ pub struct ClusterInfo {
     start_time: u64,
 }
 
+impl Default for ClusterInfo {
+    fn default() -> Self {
+        Self::new_with_invalid_keypair(ContactInfo::default())
+    }
+}
+
 #[derive(Default, Clone)]
 pub struct Locality {
     /// The bounds of the neighborhood represented by this locality

--- a/core/src/rpc_health.rs
+++ b/core/src/rpc_health.rs
@@ -104,9 +104,7 @@ impl RpcHealth {
     #[cfg(test)]
     pub(crate) fn stub() -> Arc<Self> {
         Arc::new(Self::new(
-            Arc::new(ClusterInfo::new_with_invalid_keypair(
-                crate::contact_info::ContactInfo::default(),
-            )),
+            Arc::new(ClusterInfo::default()),
             None,
             42,
             Arc::new(AtomicBool::new(false)),

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -30,7 +30,7 @@ pub struct JsonRpcService {
     thread_hdl: JoinHandle<()>,
 
     #[cfg(test)]
-    pub request_processor: Arc<RwLock<JsonRpcRequestProcessor>>, // Used only by test_rpc_new()...
+    pub request_processor: JsonRpcRequestProcessor, // Used only by test_rpc_new()...
 
     close_handle: Option<CloseHandle>,
 }
@@ -249,14 +249,14 @@ impl JsonRpcService {
             override_health_check,
         ));
 
-        let request_processor = Arc::new(RwLock::new(JsonRpcRequestProcessor::new(
+        let request_processor = JsonRpcRequestProcessor::new(
             config,
             bank_forks.clone(),
             block_commitment_cache,
             blockstore,
             validator_exit.clone(),
             health.clone(),
-        )));
+        );
 
         #[cfg(test)]
         let test_request_processor = request_processor.clone();
@@ -398,8 +398,6 @@ mod tests {
             10_000,
             rpc_service
                 .request_processor
-                .read()
-                .unwrap()
                 .get_balance(Ok(mint_keypair.pubkey()), None)
                 .unwrap()
                 .value

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -256,7 +256,7 @@ impl JsonRpcService {
             blockstore,
             validator_exit.clone(),
             health.clone(),
-            cluster_info.clone(),
+            cluster_info,
             genesis_hash,
         );
 
@@ -281,9 +281,7 @@ impl JsonRpcService {
                 );
                 let server = ServerBuilder::with_meta_extractor(
                     io,
-                    move |_req: &hyper::Request<hyper::Body>| Meta {
-                        request_processor: request_processor.clone(),
-                    },
+                    move |_req: &hyper::Request<hyper::Body>| request_processor.clone(),
                 )
                 .threads(num_cpus::get())
                 .cors(DomainsValidation::AllowOnly(vec![

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -256,6 +256,8 @@ impl JsonRpcService {
             blockstore,
             validator_exit.clone(),
             health.clone(),
+            cluster_info.clone(),
+            genesis_hash,
         );
 
         #[cfg(test)]
@@ -281,8 +283,6 @@ impl JsonRpcService {
                     io,
                     move |_req: &hyper::Request<hyper::Body>| Meta {
                         request_processor: request_processor.clone(),
-                        cluster_info: cluster_info.clone(),
-                        genesis_hash,
                     },
                 )
                 .threads(num_cpus::get())
@@ -339,7 +339,6 @@ impl JsonRpcService {
 mod tests {
     use super::*;
     use crate::{
-        contact_info::ContactInfo,
         crds_value::{CrdsData, CrdsValue, SnapshotHash},
         rpc::tests::create_validator_exit,
     };
@@ -365,7 +364,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(&exit);
         let bank = Bank::new(&genesis_config);
-        let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(ContactInfo::default()));
+        let cluster_info = Arc::new(ClusterInfo::default());
         let ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let rpc_addr = SocketAddr::new(
             ip_addr,
@@ -482,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_health_check_with_trusted_validators() {
-        let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(ContactInfo::default()));
+        let cluster_info = Arc::new(ClusterInfo::default());
         let health_check_slot_distance = 123;
         let override_health_check = Arc::new(AtomicBool::new(false));
         let trusted_validators = vec![Pubkey::new_rand(), Pubkey::new_rand(), Pubkey::new_rand()];


### PR DESCRIPTION
#### Problem

`JsonRpcRequestProcessor` has fields with locks and is wrapped with a lock.  Not clear why the lock is needed at both levels.

#### Summary of Changes

Attempt to remove the outer lock.  If we're able to remove this lock, then we can also move the remaining `Meta` fields into `JsonRpcRequestProcessor`, and make `JsonRpcRequestProcessor` implement `Metadata` instead.
