### PR TITLE
Enable more fine-grained control in local cluster partition tests

### DIFF
--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -284,7 +284,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
     }
 }
 
-pub fn check_for_new_roots(num_new_roots: usize, contact_infos: &[ContactInfo]) {
+pub fn check_for_new_roots(num_new_roots: usize, contact_infos: &[ContactInfo], test_name: &str) {
     let mut roots = vec![HashSet::new(); contact_infos.len()];
     let mut done = false;
     let mut last_print = Instant::now();
@@ -295,7 +295,7 @@ pub fn check_for_new_roots(num_new_roots: usize, contact_infos: &[ContactInfo]) 
             roots[i].insert(slot);
             let min_node = roots.iter().map(|r| r.len()).min().unwrap_or(0);
             if last_print.elapsed().as_secs() > 3 {
-                info!("PARTITION_TEST min observed roots {}/16", min_node);
+                info!("{} min observed roots {}/16", test_name, min_node);
                 last_print = Instant::now();
             }
             done = min_node >= num_new_roots;


### PR DESCRIPTION
#### Problem
`run_cluster_partition` is very monolithic and hard to adapt to new test cases/different integrity checks. Extracted from: https://github.com/solana-labs/solana/pull/10343

#### Summary of Changes
Give local cluster `run_cluster_partition` method on_partition_start` and `on_partition_end` event callbacks to give more flexibility in when to kill nodes/different types off integrity checks, etc.

Fixes #
