### PR TITLE
RPC simulateTransaction endpoint now returns program log output

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -129,7 +129,7 @@ impl RpcClient {
         &self,
         transaction: &Transaction,
         sig_verify: bool,
-    ) -> RpcResult<TransactionStatus> {
+    ) -> RpcResult<RpcSimulateTransactionResult> {
         let serialized_encoded = bs58::encode(serialize(transaction).unwrap()).into_string();
         self.send(
             RpcRequest::SimulateTransaction,

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -213,6 +213,13 @@ pub struct RpcSignatureConfirmation {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
+pub struct RpcSimulateTransactionResult {
+    pub err: Option<TransactionError>,
+    pub logs: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcStorageTurn {
     pub blockhash: String,
     pub slot: Slot,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -514,7 +514,7 @@ impl BankingStage {
             vec![]
         };
         let (mut loaded_accounts, results, mut retryable_txs, tx_count, signature_count) =
-            bank.load_and_execute_transactions(batch, MAX_PROCESSING_AGE);
+            bank.load_and_execute_transactions(batch, MAX_PROCESSING_AGE, None);
         load_execute_time.stop();
 
         let freeze_lock = bank.freeze_lock();

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1107,6 +1107,10 @@ Simulate sending a transaction
 #### Results:
 
 An RpcResponse containing a TransactionStatus object
+The result will be an RpcResponse JSON object with `value` set to a JSON object with the following fields:
+
+* `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
+* `logs: <array | null>` - Array of log messages the transaction instructions output during execution, null if simulation failed before the transaction was able to execute (for example due to an invalid blockhash or signature verification failure)
 
 #### Example:
 

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -155,4 +155,8 @@ impl InvokeContext for MockInvokeContext {
     fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)] {
         &[]
     }
+    fn log_enabled(&self) -> bool {
+        false
+    }
+    fn log(&mut self, _message: &str) {}
 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -267,6 +267,7 @@ mod tests {
     #[derive(Debug, Default)]
     pub struct MockInvokeContext {
         key: Pubkey,
+        pub log: Vec<String>,
     }
     impl InvokeContext for MockInvokeContext {
         fn push(&mut self, _key: &Pubkey) -> Result<(), InstructionError> {
@@ -286,6 +287,13 @@ mod tests {
         }
         fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)] {
             &[]
+        }
+        fn log_enabled(&self) -> bool {
+            true
+        }
+        fn log(&mut self, message: &str) {
+            info!("[MockInvokeContext::log] {}", message);
+            self.log.push(message.to_string());
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -11,6 +11,7 @@ pub mod epoch_stakes;
 pub mod genesis_utils;
 mod legacy_system_instruction_processor0;
 pub mod loader_utils;
+pub mod log_collector;
 pub mod message_processor;
 mod native_loader;
 pub mod nonce_utils;

--- a/runtime/src/log_collector.rs
+++ b/runtime/src/log_collector.rs
@@ -1,0 +1,16 @@
+use std::cell::RefCell;
+
+#[derive(Default)]
+pub struct LogCollector {
+    messages: RefCell<Vec<String>>,
+}
+
+impl LogCollector {
+    pub fn log(&self, message: &str) {
+        self.messages.borrow_mut().push(message.to_string())
+    }
+
+    pub fn output(self) -> Vec<String> {
+        self.messages.into_inner()
+    }
+}

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -160,4 +160,6 @@ pub trait InvokeContext {
     ) -> Result<(), InstructionError>;
     fn get_caller(&self) -> Result<&Pubkey, InstructionError>;
     fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)];
+    fn log_enabled(&self) -> bool;
+    fn log(&mut self, message: &str);
 }


### PR DESCRIPTION
To view program log output in the wild, the only option is to find a `solana-validator` log file to troll through.   Not exactly friendly for a front-end program developer/user.

Instead `simulateTransaction` now returns all `sol_log`, `sol_log_64` and `sol_panic` messages back to the user for easy viewing.

This required a touch of plumbing through bank/message_processor but `InvokeContext` is proving handy for more than just enabling cross-program support.  In the future more debug introspection facilities could probably be plumbed in along this same path.

This PR changes the RPC simulateTransaction signature slightly, but I doubt any existing RPC users will notice/care

Fixes #10364