### PR TITLE
Improve BPF SDK dependency caching

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -9,16 +9,24 @@ else
 fi
 
 download() {
-  declare url=$1
+  set -e
+  declare url="$1/$2/$3"
   declare version=$2
   declare filename=$3
-  declare progress=$4
+  declare dirname=$4
+  declare progress=$5
   declare cache_directory=~/.cache/"$version"
-  declare cache_filename=$cache_directory/${filename//:\//_}
+  declare cache_dirname=$cache_directory/${dirname//:\//_}
 
-  if [[ -r $cache_filename ]]; then
-    ln -s "$cache_filename" "$filename"
-    return
+  link() {
+    set -e
+    ln -sf "$cache_dirname" "$dirname"
+    ln -sf "$cache_directory/$dirname-$version.md" "$dirname-$version.md"
+  }
+
+  if [[ -r $cache_dirname ]]; then
+    link
+    return 0
   fi
 
   declare args=(
@@ -27,9 +35,49 @@ download() {
     "--retry-connrefused"
     "--read-timeout=30"
   )
+  set -x
+  mkdir -p "$cache_dirname"
+  pushd "$cache_dirname"
   if wget "${args[@]}"; then
-    mkdir -p "$cache_directory"
-    cp "$filename" "$cache_filename"
+    tar --strip-components 1 -jxf "$filename"
+    rm -rf "$filename"
+    echo "$url" >"../$dirname-$version.md"
+    popd
+    link
+    return 0
+  fi
+  popd
+  rm -rf "$cache_dirname"
+  return 1
+}
+
+clone() {
+  set -e
+  declare url=$1
+  declare version=$2
+  declare dirname=$3
+  declare cache_directory=~/.cache/"$version"
+  declare cache_dirname=$cache_directory/${dirname//:\//_}
+
+  link() {
+    set -e
+    ln -sf "$cache_dirname" "$dirname"
+    ln -sf "$cache_directory/$dirname-$version.md" "$dirname-$version.md"
+  }
+
+  if [[ -r $cache_dirname ]]; then
+    link
+    return 0
+  fi
+
+  set -x
+  mkdir -p "$cache_directory"
+  pushd "$cache_directory"
+  cmd="git clone --recursive --depth 1 --single-branch --branch $version $url"
+  if $cmd; then
+    echo "$cmd" >"$dirname-$version.md"
+    popd
+    link
     return 0
   fi
   return 1
@@ -44,7 +92,7 @@ download() {
   else
     cargo install xargo
   fi
-  xargo --version > xargo.md 2>&1
+  xargo --version >xargo.md 2>&1
 )
 # shellcheck disable=SC2181
 if [[ $? -ne 0 ]]; then
@@ -53,107 +101,85 @@ fi
 
 # Install Criterion
 version=v2.3.2
-if [[ ! -r criterion-$machine-$version.md ]]; then
+if [[ ! -e criterion-$version.md ]]; then
   (
-    filename=criterion-$version-$machine-x86_64.tar.bz2
-
-    set -ex
+    set -e
     rm -rf criterion*
-    mkdir criterion
-    cd criterion
-
-    base=https://github.com/Snaipe/Criterion/releases
-    download $base/download/$version/$filename $version $filename mega
-    tar --strip-components 1 -jxf $filename
-    rm -rf $filename
-
-    echo "$base/tag/$version" > ../criterion-$machine-$version.md
+    download "https://github.com/Snaipe/Criterion/releases/download" \
+      $version \
+      "criterion-$version-$machine-x86_64.tar.bz2" \
+      criterion \
+      mega
   )
-  # shellcheck disable=SC2181
-  if [[ $? -ne 0 ]]; then
-    rm -rf criterion
+  exitcode=$?
+  if [[ $exitcode -ne 0 ]]; then
+    rm -rf criterion-$version.md
     exit 1
   fi
 fi
 
 # Install LLVM
 version=v0.0.15
-if [[ ! -f llvm-native-$machine-$version.md ]]; then
+if [[ ! -e llvm-native-$version.md ]]; then
   (
-    filename=solana-llvm-$machine.tar.bz2
-
-    set -ex
+    set -e
     rm -rf llvm-native*
     rm -rf xargo
-    mkdir -p llvm-native
-    cd llvm-native
-
-    base=https://github.com/solana-labs/llvm-builder/releases
-    download $base/download/$version/$filename $version $filename giga
-    tar -jxf $filename
-    rm -rf $filename
-
-    echo "$base/tag/$version" > ../llvm-native-$machine-$version.md
+    download "https://github.com/solana-labs/llvm-builder/releases/download" \
+      $version \
+      "solana-llvm-$machine.tar.bz2" \
+      llvm-native \
+      giga
   )
   exitcode=$?
   if [[ $exitcode -ne 0 ]]; then
-    rm -rf llvm-native
+    rm -rf llvm-native-$version.md
     exit 1
   fi
 fi
 
 # Install Rust-BPF
 version=v0.2.3
-if [[ ! -f rust-bpf-$machine-$version.md ]]; then
+if [[ ! -e rust-bpf-$version.md ]]; then
   (
-    filename=solana-rust-bpf-$machine.tar.bz2
-
-    set -ex
+    set -e
     rm -rf rust-bpf
     rm -rf rust-bpf-$machine-*
     rm -rf xargo
-    mkdir -p rust-bpf
-    pushd rust-bpf
-
-    base=https://github.com/solana-labs/rust-bpf-builder/releases
-    download $base/download/$version/$filename $version $filename giga
-    tar -jxf $filename
-    rm -rf $filename
-    popd
+    download "https://github.com/solana-labs/rust-bpf-builder/releases/download" \
+      $version \
+      "solana-rust-bpf-$machine.tar.bz2" \
+      rust-bpf \
+      giga
 
     set -ex
     ./rust-bpf/bin/rustc --print sysroot
-
     set +e
     rustup toolchain uninstall bpf
     set -e
     rustup toolchain link bpf rust-bpf
-
-    echo "$base/tag/$version" > rust-bpf-$machine-$version.md
   )
   exitcode=$?
   if [[ $exitcode -ne 0 ]]; then
-    rm -rf rust-bpf
+    rm -rf rust-bpf-$version.md
     exit 1
   fi
 fi
 
 # Install Rust-BPF Sysroot sources
 version=v0.12
-if [[ ! -f rust-bpf-sysroot-$version.md ]]; then
-
+if [[ ! -e rust-bpf-sysroot-$version.md ]]; then
   (
-    set -ex
+    set -e
     rm -rf rust-bpf-sysroot*
     rm -rf xargo
-    cmd="git clone --recursive --depth 1 --single-branch --branch $version https://github.com/solana-labs/rust-bpf-sysroot.git"
-    $cmd
-
-    echo "$cmd" > rust-bpf-sysroot-$version.md
+    clone "https://github.com/solana-labs/rust-bpf-sysroot.git" \
+      $version \
+      rust-bpf-sysroot
   )
   exitcode=$?
   if [[ $exitcode -ne 0 ]]; then
-    rm -rf rust-bpf-sysroot
+    rm -rf rust-bpf-sysroot-$version.md
     exit 1
   fi
 fi


### PR DESCRIPTION
#### Problem

BPF dependencies can be expensive to download/untar/clone

#### Summary of Changes

Improve dependency caching by:
- Avoid copying by downloading directly to the cache
- Reduce untar time by untaring into cache
- Cache cloned repos

Fixes #10369
