### PR TITLE
Add --warp-slot argument to |solana-ledger-tool create-snapshot|

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -33,6 +33,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --gossip-port ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 = --dev-halt-at-slot ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = --dynamic-port-range ]]; then
       args+=("$1" "$2")
       shift 2


### PR DESCRIPTION
Usage example: start the bootstrap validator at slot 10000000000 instead of slot 0.
```
$ ./multinode-demo/setup.sh 
$ solana-ledger-tool -l config/bootstrap-validator \
      create-snapshot 0 config/bootstrap-validator/ --warp-slot 10000000000
$ ./multinode-demo/bootstrap-validator.sh
```
