### PR TITLE
Fix bad rent in Bank::deposit as if since epoch 0

### DIFF
--- a/docs/src/implemented-proposals/rent.md
+++ b/docs/src/implemented-proposals/rent.md
@@ -14,6 +14,14 @@ Currently, the rent cost is fixed at the genesis. However, it's anticipated to b
 
 There are two timings of collecting rent from accounts: \(1\) when referenced by a transaction, \(2\) periodically once an epoch. \(1\) includes the transaction to create the new account itself, and it happens during the normal transaction processing by the bank as part of the load phase. \(2\) exists to ensure to collect rents from stale accounts, which aren't referenced in recent epochs at all. \(2\) requires the whole scan of accounts and is spread over an epoch based on account address prefix to avoid load spikes due to this rent collection.
 
+On the contrary, rent collection isn't applied to accounts that are directly manipulated by any of protocol-level bookkeeping processes including:
+
+- The distribution of rent collection itself (Otherwise, it may cause recursive rent collection handling)
+- The distribution of staking rewards at the start of every epoch (To reduce as much as processing spike at the start of new epoch)
+- The distribution of transaction fee at the end of every epoch
+
+Even if those processes are out of scope of rent collection, all of manipulated accounts will eventually be handled by the \(2\) mechanism.
+
 ## Actual processing of collecting rent
 
 Rent is due for one epoch's worth of time, and accounts always have `Account::rent_epoch` of `current_epoch + 1`.

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -140,7 +140,8 @@ impl Accounts {
                             AccountsDB::load(storage, ancestors, accounts_index, key)
                                 .map(|(mut account, _)| {
                                     if message.is_writable(i) && !account.executable {
-                                        let rent_due = rent_collector.update(&key, &mut account);
+                                        let rent_due = rent_collector
+                                            .from_existing_account(&key, &mut account);
                                         (account, rent_due)
                                     } else {
                                         (account, 0)
@@ -736,8 +737,7 @@ impl Accounts {
                 );
                 if message.is_writable(i) {
                     if account.rent_epoch == 0 {
-                        account.rent_epoch = rent_collector.epoch;
-                        acc.2 += rent_collector.update(&key, account);
+                        acc.2 += rent_collector.from_created_account(&key, account);
                     }
                     accounts.push((key, &*account));
                 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -139,7 +139,7 @@ impl Accounts {
                         let (account, rent) =
                             AccountsDB::load(storage, ancestors, accounts_index, key)
                                 .map(|(mut account, _)| {
-                                    if message.is_writable(i) && !account.executable {
+                                    if message.is_writable(i) {
                                         let rent_due = rent_collector
                                             .from_existing_account(&key, &mut account);
                                         (account, rent_due)

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -141,7 +141,7 @@ impl Accounts {
                                 .map(|(mut account, _)| {
                                     if message.is_writable(i) {
                                         let rent_due = rent_collector
-                                            .from_existing_account(&key, &mut account);
+                                            .collect_from_existing_account(&key, &mut account);
                                         (account, rent_due)
                                     } else {
                                         (account, 0)
@@ -737,7 +737,7 @@ impl Accounts {
                 );
                 if message.is_writable(i) {
                     if account.rent_epoch == 0 {
-                        acc.2 += rent_collector.from_created_account(&key, account);
+                        acc.2 += rent_collector.collect_from_created_account(&key, account);
                     }
                     accounts.push((key, &*account));
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2066,7 +2066,7 @@ impl Bank {
         for (pubkey, mut account) in accounts {
             rent += self
                 .rent_collector
-                .from_existing_account(&pubkey, &mut account);
+                .collect_from_existing_account(&pubkey, &mut account);
             // Store all of them unconditionally to purge old AppendVec,
             // even if collected rent is 0 (= not updated).
             self.store_account(&pubkey, &account);
@@ -2504,7 +2504,8 @@ impl Bank {
     pub fn deposit(&self, pubkey: &Pubkey, lamports: u64) {
         let mut account = self.get_account(pubkey);
         self.collected_rent.fetch_add(
-            self.rent_collector.from_account(pubkey, &mut account),
+            self.rent_collector
+                .collect_from_account(pubkey, &mut account),
             Ordering::Relaxed,
         );
         // at this point, account is ensured to be Some

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1155,18 +1155,13 @@ impl Bank {
             .unwrap()
             .genesis_hash(&genesis_config.hash(), &self.fee_calculator);
 
-        self.hashes_per_tick = genesis_config.poh_config.hashes_per_tick;
-        self.ticks_per_slot = genesis_config.ticks_per_slot;
-        self.ns_per_slot = genesis_config.poh_config.target_tick_duration.as_nanos()
-            * genesis_config.ticks_per_slot as u128;
+        self.hashes_per_tick = genesis_config.hashes_per_tick();
+        self.ticks_per_slot = genesis_config.ticks_per_slot();
+        self.ns_per_slot = genesis_config.ns_per_slot();
         self.genesis_creation_time = genesis_config.creation_time;
         self.unused = genesis_config.unused;
         self.max_tick_height = (self.slot + 1) * self.ticks_per_slot;
-        self.slots_per_year = years_as_slots(
-            1.0,
-            &genesis_config.poh_config.target_tick_duration,
-            self.ticks_per_slot,
-        );
+        self.slots_per_year = genesis_config.slots_per_year();
 
         self.epoch_schedule = genesis_config.epoch_schedule;
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2497,11 +2497,7 @@ impl Bank {
     }
 
     pub fn deposit(&self, pubkey: &Pubkey, lamports: u64) {
-        let account = self.get_account(pubkey);
-        let created = account.is_none();
-
-        let mut account = account.unwrap_or_default();
-        account.lamports += lamports;
+        let mut account = self.get_account(pubkey).unwrap_or_default();
 
         let should_be_in_new_behavior = match self.operating_mode() {
             OperatingMode::Development => true,
@@ -2509,16 +2505,19 @@ impl Bank {
             OperatingMode::Stable => self.epoch() >= Epoch::max_value(),
         };
 
-        // previously we're too much collecting rents as if rent duration is since epoch 0...
-        let rent = if created && should_be_in_new_behavior {
-            self.rent_collector
-                .collect_from_created_account(pubkey, &mut account)
-        } else {
-            self.rent_collector
-                .collect_from_existing_account(pubkey, &mut account)
-        };
-        self.collected_rent.fetch_add(rent, Ordering::Relaxed);
+        // don't collect rents if we're in the new behavior;
+        // in genral, it's not worthwhile to account for rents outside the runtime (transactions)
+        // there are too many and subtly nuanced modification codepaths
+        if !should_be_in_new_behavior {
+            // previously we're too much collecting rents as if it existed since epoch 0...
+            self.collected_rent.fetch_add(
+                self.rent_collector
+                    .collect_from_existing_account(pubkey, &mut account),
+                Ordering::Relaxed,
+            );
+        }
 
+        account.lamports += lamports;
         self.store_account(pubkey, &account);
     }
 
@@ -5176,67 +5175,6 @@ mod tests {
         // Existing account
         bank.deposit(&key.pubkey(), 3);
         assert_eq!(bank.get_balance(&key.pubkey()), 13);
-    }
-
-    #[test]
-    fn test_bank_deposit_with_rent() {
-        impl Bank {
-            fn get_rent_epoch(&self, pubkey: &Pubkey) -> Epoch {
-                self.get_account(pubkey).unwrap().rent_epoch
-            }
-
-            fn collected_rent(&self) -> Epoch {
-                self.collected_rent.load(Ordering::Relaxed)
-            }
-        }
-
-        let (genesis_config, _mint_keypair) = create_genesis_config(100);
-        let bank = Arc::new(Bank::new(&genesis_config));
-        let leader = Pubkey::default();
-        // forward time somewhat to induce rent
-        let bank = Arc::new(Bank::new_from_parent(&bank, &leader, bank.slot() + 100));
-
-        let pubkey = Pubkey::new_rand();
-
-        let new_account_tester = |bank: &Arc<Bank>, deposit_amount: u64, rent_amount: u64| {
-            bank.deposit(&pubkey, deposit_amount);
-
-            let existing_balance = bank.get_balance(&pubkey);
-            assert_eq!(existing_balance, deposit_amount - rent_amount);
-            assert_eq!(bank.get_rent_epoch(&pubkey), bank.epoch() + 1);
-        };
-
-        // Test as new account
-        new_account_tester(&bank, 10, 1);
-        let existing_balance = bank.get_balance(&pubkey);
-
-        // Test as existing account
-        bank.deposit(&pubkey, 3);
-        assert_eq!(bank.get_balance(&pubkey), existing_balance + 3);
-        let existing_balance = bank.get_balance(&pubkey);
-        assert_eq!(bank.get_rent_epoch(&pubkey), bank.epoch() + 1);
-
-        // further forward time to induce another rent
-        let bank = Arc::new(Bank::new_from_parent(&bank, &leader, bank.slot() + 300));
-
-        let collected_rent_before = bank.collected_rent();
-        bank.deposit(&pubkey, 3);
-        let collected_rent_after = bank.collected_rent();
-
-        let rent_delta = collected_rent_after - collected_rent_before;
-        assert!(rent_delta > 0);
-        assert_eq!(bank.get_balance(&pubkey), existing_balance + 3 - rent_delta);
-        let existing_balance = bank.get_balance(&pubkey);
-        assert_eq!(bank.get_rent_epoch(&pubkey), bank.epoch() + 1);
-
-        // even further forward time to cause rent-deliquent
-        let bank = Arc::new(Bank::new_from_parent(&bank, &leader, bank.slot() + 30000));
-        bank.deposit(&pubkey, 7);
-        assert_eq!(bank.get_account(&pubkey), None);
-        assert_eq!(bank.collected_rent(), existing_balance + 7);
-
-        // Test as new account again (the rent amount should be for an epoch worth)
-        new_account_tester(&bank, 300, 185);
     }
 
     #[test]

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -36,7 +36,7 @@ impl RentCollector {
     // updates this account's lamports and status and returns
     //  the account rent collected, if any
     //
-    pub fn from_existing_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
+    pub fn collect_from_existing_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
         if account.executable
             || account.rent_epoch > self.epoch
             || sysvar::check_id(&account.owner)
@@ -76,18 +76,18 @@ impl RentCollector {
         }
     }
 
-    pub fn from_created_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
+    pub fn collect_from_created_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
         // initialize rent_epoch as created at this epoch
         account.rent_epoch = self.epoch;
-        self.from_existing_account(address, account)
+        self.collect_from_existing_account(address, account)
     }
 
-    pub fn from_account(&self, address: &Pubkey, account: &mut Option<Account>) -> u64 {
+    pub fn collect_from_account(&self, address: &Pubkey, account: &mut Option<Account>) -> u64 {
         if let Some(account) = account {
-            self.from_existing_account(address, account)
+            self.collect_from_existing_account(address, account)
         } else {
             *account = Some(Account::default());
-            self.from_created_account(address, &mut account.as_mut().unwrap())
+            self.collect_from_created_account(address, &mut account.as_mut().unwrap())
         }
     }
 }

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -95,16 +95,6 @@ impl RentCollector {
         account.rent_epoch = self.epoch;
         self.collect_from_existing_account(address, account)
     }
-
-    #[must_use = "add to Bank::collected_rent"]
-    pub fn collect_from_account(&self, address: &Pubkey, account: &mut Option<Account>) -> u64 {
-        if let Some(account) = account {
-            self.collect_from_existing_account(address, account)
-        } else {
-            *account = Some(Account::default());
-            self.collect_from_created_account(address, &mut account.as_mut().unwrap())
-        }
-    }
 }
 
 #[cfg(test)]

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -36,7 +36,7 @@ impl RentCollector {
     // updates this account's lamports and status and returns
     //  the account rent collected, if any
     //
-    pub fn update(&self, address: &Pubkey, account: &mut Account) -> u64 {
+    pub fn from_existing_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
         if account.executable
             || account.rent_epoch > self.epoch
             || sysvar::check_id(&account.owner)
@@ -73,6 +73,21 @@ impl RentCollector {
                 // maybe collect rent later, leave account alone
                 0
             }
+        }
+    }
+
+    pub fn from_created_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
+        // initialize rent_epoch as created at this epoch
+        account.rent_epoch = self.epoch;
+        self.from_existing_account(address, account)
+    }
+
+    pub fn from_account(&self, address: &Pubkey, account: &mut Option<Account>) -> u64 {
+        if let Some(account) = account {
+            self.from_existing_account(address, account)
+        } else {
+            *account = Some(Account::default());
+            self.from_created_account(address, &mut account.as_mut().unwrap())
         }
     }
 }

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -14,6 +14,7 @@ use crate::{
     shred_version::compute_shred_version,
     signature::{Keypair, Signer},
     system_program,
+    timing::years_as_slots,
 };
 use bincode::{deserialize, serialize};
 use chrono::{TimeZone, Utc};
@@ -182,6 +183,26 @@ impl GenesisConfig {
 
     pub fn add_rewards_pool(&mut self, pubkey: Pubkey, account: Account) {
         self.rewards_pools.insert(pubkey, account);
+    }
+
+    pub fn hashes_per_tick(&self) -> Option<u64> {
+        self.poh_config.hashes_per_tick
+    }
+
+    pub fn ticks_per_slot(&self) -> u64 {
+        self.ticks_per_slot
+    }
+
+    pub fn ns_per_slot(&self) -> u128 {
+        self.poh_config.target_tick_duration.as_nanos() * self.ticks_per_slot() as u128
+    }
+
+    pub fn slots_per_year(&self) -> f64 {
+        years_as_slots(
+            1.0,
+            &self.poh_config.target_tick_duration,
+            self.ticks_per_slot(),
+        )
     }
 }
 


### PR DESCRIPTION
#### Problem

When an account is created via `Bank::deposit()`, `Bank` charges too much rent on it: all the epochs since genesis **if the account doesn't exist yet**.... In other words, it collects rent for the number of epochs.

Also, the rent timing was wrongly delayed: https://github.com/solana-labs/solana/pull/10468#discussion_r462385554

Mostly, this only affects tests. The only case which hits the production is `collector_id`'s fee distribution because it uses `Bank::deposit()`. So the impact should be fairly small.

This should be a rolling update, otherwise this is a DOS vulnerability. These old/new behaviors are themselves consistent across validators.

#### Summary of Changes

~Calculate rent for newly-funded accounts since the current epoch not epoch 0~

I've changed mind: Disable rent collection entirely; for the reasoning, see the comments and document updates.


- [x] gating logic (ugh)
- [x] unit test

#### context

found while finishing #10099 
FYI: @mvines (About rolling update).