### PR TITLE
RPC/cli: Clean up delinquency slot distance computation

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -103,6 +103,9 @@ pub const NUM_LARGEST_ACCOUNTS: usize = 20;
 pub const MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS: usize = 256;
 pub const MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE: u64 = 10_000;
 
+// Validators that are this number of slots behind are considered delinquent
+pub const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 128;
+
 impl RpcRequest {
     pub(crate) fn build_request_json(self, id: u64, params: Value) -> Value {
         let jsonrpc = "2.0";

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -16,7 +16,7 @@ use jsonrpc_derive::rpc;
 use solana_client::{
     rpc_config::*,
     rpc_request::{
-        MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE,
+        DELINQUENT_VALIDATOR_SLOT_DISTANCE, MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE,
         MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS, NUM_LARGEST_ACCOUNTS,
     },
     rpc_response::*,
@@ -420,8 +420,9 @@ impl JsonRpcRequestProcessor {
                 }
             })
             .partition(|vote_account_info| {
-                if bank.slot() >= MAX_LOCKOUT_HISTORY as u64 {
-                    vote_account_info.last_vote > bank.slot() - MAX_LOCKOUT_HISTORY as u64
+                if bank.slot() >= DELINQUENT_VALIDATOR_SLOT_DISTANCE as u64 {
+                    vote_account_info.last_vote
+                        > bank.slot() - DELINQUENT_VALIDATOR_SLOT_DISTANCE as u64
                 } else {
                     vote_account_info.last_vote > 0
                 }
@@ -1588,7 +1589,7 @@ pub mod tests {
     };
 
     const TEST_MINT_LAMPORTS: u64 = 1_000_000;
-    const TEST_SLOTS_PER_EPOCH: u64 = 50;
+    const TEST_SLOTS_PER_EPOCH: u64 = DELINQUENT_VALIDATOR_SLOT_DISTANCE + 1;
 
     struct RpcHandler {
         io: MetaIoHandler<JsonRpcRequestProcessor>,

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -22,9 +22,6 @@ pub const TICKS_PER_DAY: u64 = DEFAULT_TICKS_PER_SECOND * SECONDS_PER_DAY;
 // 1 Epoch ~= 2 days
 pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 2 * TICKS_PER_DAY / DEFAULT_TICKS_PER_SLOT;
 
-// 4 times longer than the max_lockout to allow enough time for PoRep (128 slots)
-pub const DEFAULT_SLOTS_PER_TURN: u64 = 32 * 4;
-
 // leader schedule is governed by this
 pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 


### PR DESCRIPTION
Problems:
* RPC used `MAX_LOCKOUT_HISTORY` to compute delinquency
* `solana delegate-stake` used `DEFAULT_SLOTS_PER_TURN` to compute delinquency
* `solana delegate-stake` delinquency error message was confusing and caused a Discord inquiry to occur.  Not self service!

Improve the state of the art by:
* Defining a common `DELINQUENT_VALIDATOR_SLOT_DISTANCE` constant used by both
* Improve `solana delegate-stake` error message