### PR TITLE
Expose last-valid-slot to BankClient and ThinClient users

### DIFF
--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -449,7 +449,7 @@ fn swapper<T>(
             }
             account_group = (account_group + 1) % account_groups as usize;
 
-            let (blockhash, _fee_calculator) = client
+            let (blockhash, _fee_calculator, _last_valid_slot) = client
                 .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
                 .expect("Failed to get blockhash");
             let to_swap_txs: Vec<_> = to_swap
@@ -577,7 +577,7 @@ fn trader<T>(
         }
         account_group = (account_group + 1) % account_groups as usize;
 
-        let (blockhash, _fee_calculator) = client
+        let (blockhash, _fee_calculator, _last_valid_slot) = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .expect("Failed to get blockhash");
 
@@ -776,7 +776,7 @@ pub fn fund_keys<T: Client>(client: &T, source: &Keypair, dests: &[Arc<Keypair>]
                     to_fund_txs.len(),
                 );
 
-                let (blockhash, _fee_calculator) = client
+                let (blockhash, _fee_calculator, _last_valid_slot) = client
                     .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
                     .expect("blockhash");
                 to_fund_txs.par_iter_mut().for_each(|(k, tx)| {
@@ -868,7 +868,7 @@ pub fn create_token_accounts<T: Client>(
 
             let mut retries = 0;
             while !to_create_txs.is_empty() {
-                let (blockhash, _fee_calculator) = client
+                let (blockhash, _fee_calculator, _last_valid_slot) = client
                     .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
                     .expect("Failed to get blockhash");
                 to_create_txs
@@ -997,7 +997,7 @@ pub fn airdrop_lamports<T: Client>(
 
     let mut tries = 0;
     loop {
-        let (blockhash, _fee_calculator) = client
+        let (blockhash, _fee_calculator, _last_valid_slot) = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .expect("Failed to get blockhash");
         match request_airdrop_transaction(&faucet_addr, &id.pubkey(), amount_to_drop, blockhash) {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -55,7 +55,9 @@ type LibraKeys = (Keypair, Pubkey, Pubkey, Vec<Keypair>);
 fn get_recent_blockhash<T: Client>(client: &T) -> (Hash, FeeCalculator) {
     loop {
         match client.get_recent_blockhash_with_commitment(CommitmentConfig::recent()) {
-            Ok((blockhash, fee_calculator)) => return (blockhash, fee_calculator),
+            Ok((blockhash, fee_calculator, _last_valid_slot)) => {
+                return (blockhash, fee_calculator)
+            }
             Err(err) => {
                 info!("Couldn't get recent blockhash: {:?}", err);
                 sleep(Duration::from_secs(1));

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -9,7 +9,7 @@ use log::*;
 use solana_sdk::{
     account::Account,
     client::{AsyncClient, Client, SyncClient},
-    clock::MAX_PROCESSING_AGE,
+    clock::{Slot, MAX_PROCESSING_AGE},
     commitment_config::CommitmentConfig,
     epoch_info::EpochInfo,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -398,7 +398,7 @@ impl SyncClient for ThinClient {
     fn get_recent_blockhash_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> TransportResult<(Hash, FeeCalculator, u64)> {
+    ) -> TransportResult<(Hash, FeeCalculator, Slot)> {
         let index = self.optimizer.experiment();
         let now = Instant::now();
         let recent_blockhash =

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -390,13 +390,15 @@ impl SyncClient for ThinClient {
     }
 
     fn get_recent_blockhash(&self) -> TransportResult<(Hash, FeeCalculator)> {
-        self.get_recent_blockhash_with_commitment(CommitmentConfig::default())
+        let (blockhash, fee_calculator, _last_valid_slot) =
+            self.get_recent_blockhash_with_commitment(CommitmentConfig::default())?;
+        Ok((blockhash, fee_calculator))
     }
 
     fn get_recent_blockhash_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> TransportResult<(Hash, FeeCalculator)> {
+    ) -> TransportResult<(Hash, FeeCalculator, u64)> {
         let index = self.optimizer.experiment();
         let now = Instant::now();
         let recent_blockhash =
@@ -404,7 +406,7 @@ impl SyncClient for ThinClient {
         match recent_blockhash {
             Ok(Response { value, .. }) => {
                 self.optimizer.report(index, duration_as_ms(&now.elapsed()));
-                Ok((value.0, value.1))
+                Ok((value.0, value.1, value.2))
             }
             Err(e) => {
                 self.optimizer.report(index, std::u64::MAX);

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -57,7 +57,7 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
             .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert!(bal > 0);
-        let (blockhash, _fee_calculator) = client
+        let (blockhash, _fee_calculator, _last_valid_slot) = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
         let mut transaction =
@@ -103,7 +103,7 @@ pub fn send_many_transactions(
             .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
             .expect("balance in source");
         assert!(bal > 0);
-        let (blockhash, _fee_calculator) = client
+        let (blockhash, _fee_calculator, _last_valid_slot) = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
         let transfer_amount = thread_rng().gen_range(1, max_tokens_per_transfer);
@@ -242,7 +242,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
             }
 
             let random_keypair = Keypair::new();
-            let (blockhash, _fee_calculator) = client
+            let (blockhash, _fee_calculator, _last_valid_slot) = client
                 .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
                 .unwrap();
             let mut transaction = system_transaction::transfer(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -365,7 +365,7 @@ impl LocalCluster {
         lamports: u64,
     ) -> u64 {
         trace!("getting leader blockhash");
-        let (blockhash, _fee_calculator) = client
+        let (blockhash, _fee_calculator, _last_valid_slot) = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
         let mut tx =

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -597,7 +597,7 @@ fn generate_frozen_account_panic(mut cluster: LocalCluster, frozen_account: Arc<
     let mut i = 0;
     while !solana_runtime::accounts_db::FROZEN_ACCOUNT_PANIC.load(Ordering::Relaxed) {
         // Transfer from frozen account
-        let (blockhash, _fee_calculator) = client
+        let (blockhash, _fee_calculator, _last_valid_slot) = client
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
         client

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -134,8 +134,13 @@ impl SyncClient for BankClient {
     fn get_recent_blockhash_with_commitment(
         &self,
         _commitment_config: CommitmentConfig,
-    ) -> Result<(Hash, FeeCalculator)> {
-        Ok(self.bank.last_blockhash_with_fee_calculator())
+    ) -> Result<(Hash, FeeCalculator, u64)> {
+        let (blockhash, fee_calculator) = self.bank.last_blockhash_with_fee_calculator();
+        let last_valid_slot = self
+            .bank
+            .get_blockhash_last_valid_slot(&blockhash)
+            .expect("bank blockhash queue should contain blockhash");
+        Ok((blockhash, fee_calculator, last_valid_slot))
     }
 
     fn get_fee_calculator_for_blockhash(&self, blockhash: &Hash) -> Result<Option<FeeCalculator>> {

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -70,7 +70,7 @@ pub trait SyncClient {
     fn get_recent_blockhash_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> Result<(Hash, FeeCalculator)>;
+    ) -> Result<(Hash, FeeCalculator, u64)>;
 
     /// Get `Some(FeeCalculator)` associated with `blockhash` if it is still in
     /// the BlockhashQueue`, otherwise `None`

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -70,7 +70,7 @@ pub trait SyncClient {
     fn get_recent_blockhash_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
-    ) -> Result<(Hash, FeeCalculator, u64)>;
+    ) -> Result<(Hash, FeeCalculator, Slot)>;
 
     /// Get `Some(FeeCalculator)` associated with `blockhash` if it is still in
     /// the BlockhashQueue`, otherwise `None`

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -160,7 +160,7 @@ fn distribute_tokens<T: Client>(
         let fee_payer_pubkey = args.fee_payer.pubkey();
         let message = Message::new_with_payer(&instructions, Some(&fee_payer_pubkey));
         match client.send_message(message, &signers) {
-            Ok(transaction) => {
+            Ok((transaction, _last_valid_slot)) => {
                 db::set_transaction_info(
                     db,
                     &allocation.recipient.parse().unwrap(),
@@ -411,7 +411,7 @@ use tempfile::{tempdir, NamedTempFile};
 pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_keypair: Keypair) {
     let thin_client = ThinClient::new(client, false);
     let fee_payer = Keypair::new();
-    let transaction = thin_client
+    let (transaction, _last_valid_slot) = thin_client
         .transfer(sol_to_lamports(1.0), &sender_keypair, &fee_payer.pubkey())
         .unwrap();
     thin_client
@@ -486,7 +486,7 @@ pub fn test_process_distribute_tokens_with_client<C: Client>(client: C, sender_k
 pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_keypair: Keypair) {
     let thin_client = ThinClient::new(client, false);
     let fee_payer = Keypair::new();
-    let transaction = thin_client
+    let (transaction, _last_valid_slot) = thin_client
         .transfer(sol_to_lamports(1.0), &sender_keypair, &fee_payer.pubkey())
         .unwrap();
     thin_client

--- a/tokens/src/thin_client.rs
+++ b/tokens/src/thin_client.rs
@@ -3,6 +3,7 @@ use solana_runtime::bank_client::BankClient;
 use solana_sdk::{
     account::Account,
     client::{AsyncClient, SyncClient},
+    commitment_config::CommitmentConfig,
     fee_calculator::FeeCalculator,
     hash::Hash,
     message::Message,
@@ -26,7 +27,7 @@ pub trait Client {
         signatures: &[Signature],
     ) -> Result<Vec<Option<TransactionStatus>>>;
     fn get_balance1(&self, pubkey: &Pubkey) -> Result<u64>;
-    fn get_recent_blockhash1(&self) -> Result<(Hash, FeeCalculator)>;
+    fn get_fees1(&self) -> Result<(Hash, FeeCalculator, u64)>;
     fn get_account1(&self, pubkey: &Pubkey) -> Result<Option<Account>>;
 }
 
@@ -55,9 +56,11 @@ impl Client for RpcClient {
             .map_err(|e| TransportError::Custom(e.to_string()))
     }
 
-    fn get_recent_blockhash1(&self) -> Result<(Hash, FeeCalculator)> {
-        self.get_recent_blockhash()
-            .map_err(|e| TransportError::Custom(e.to_string()))
+    fn get_fees1(&self) -> Result<(Hash, FeeCalculator, u64)> {
+        let result = self
+            .get_recent_blockhash_with_commitment(CommitmentConfig::default())
+            .map_err(|e| TransportError::Custom(e.to_string()))?;
+        Ok(result.value)
     }
 
     fn get_account1(&self, pubkey: &Pubkey) -> Result<Option<Account>> {
@@ -95,8 +98,8 @@ impl Client for BankClient {
         self.get_balance(pubkey)
     }
 
-    fn get_recent_blockhash1(&self) -> Result<(Hash, FeeCalculator)> {
-        self.get_recent_blockhash()
+    fn get_fees1(&self) -> Result<(Hash, FeeCalculator, u64)> {
+        self.get_recent_blockhash_with_commitment(CommitmentConfig::default())
     }
 
     fn get_account1(&self, pubkey: &Pubkey) -> Result<Option<Account>> {
@@ -135,14 +138,19 @@ impl<C: Client> ThinClient<C> {
         self.client.get_signature_statuses1(signatures)
     }
 
-    pub fn send_message<S: Signers>(&self, message: Message, signers: &S) -> Result<Transaction> {
+    pub fn send_message<S: Signers>(
+        &self,
+        message: Message,
+        signers: &S,
+    ) -> Result<(Transaction, u64)> {
         if self.dry_run {
-            return Ok(Transaction::new_unsigned(message));
+            return Ok((Transaction::new_unsigned(message), std::u64::MAX));
         }
-        let (blockhash, _fee_caluclator) = self.get_recent_blockhash()?;
+        let (blockhash, _fee_caluclator, last_valid_slot) = self.get_fees()?;
+
         let transaction = Transaction::new(signers, message, blockhash);
         self.send_transaction(transaction.clone())?;
-        Ok(transaction)
+        Ok((transaction, last_valid_slot))
     }
 
     pub fn transfer<S: Signer>(
@@ -150,15 +158,15 @@ impl<C: Client> ThinClient<C> {
         lamports: u64,
         sender_keypair: &S,
         to_pubkey: &Pubkey,
-    ) -> Result<Transaction> {
+    ) -> Result<(Transaction, u64)> {
         let create_instruction =
             system_instruction::transfer(&sender_keypair.pubkey(), &to_pubkey, lamports);
         let message = Message::new(&[create_instruction]);
         self.send_message(message, &[sender_keypair])
     }
 
-    pub fn get_recent_blockhash(&self) -> Result<(Hash, FeeCalculator)> {
-        self.client.get_recent_blockhash1()
+    pub fn get_fees(&self) -> Result<(Hash, FeeCalculator, u64)> {
+        self.client.get_fees1()
     }
 
     pub fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {


### PR DESCRIPTION
#### Problem

The last-valid-slot is only available to Bank and RpcClient users, not BankClient or ThinClient. `solana-tokens` needs it in `BankClient`, which uses the `Client` trait, which needs to move in lockstep with `client::thin_client::ThinClient`.

#### Summary of Changes

Plumb it through.
