### PR TITLE
Add CLI options and runtime support for selection of output snapshot version

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -176,6 +176,7 @@ mod tests {
     use crate::cluster_info::make_accounts_hashes_message;
     use crate::contact_info::ContactInfo;
     use solana_runtime::bank_forks::CompressionType;
+    use solana_runtime::snapshot_utils::SnapshotVersion;
     use solana_sdk::{
         hash::hash,
         signature::{Keypair, Signer},
@@ -238,6 +239,7 @@ mod tests {
                 tar_output_file: PathBuf::from("."),
                 storages: vec![],
                 compression: CompressionType::Bzip2,
+                snapshot_version: SnapshotVersion::default(),
             };
 
             AccountsHashVerifier::process_accounts_package(

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -353,7 +353,9 @@ mod tests {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         get_tmp_ledger_path,
     };
-    use solana_runtime::{bank::Bank, bank_forks::CompressionType};
+    use solana_runtime::{
+        bank::Bank, bank_forks::CompressionType, snapshot_utils::SnapshotVersion,
+    };
     use solana_sdk::signature::Signer;
     use std::net::{IpAddr, Ipv4Addr};
 
@@ -445,6 +447,7 @@ mod tests {
                 snapshot_package_output_path: PathBuf::from("/"),
                 snapshot_path: PathBuf::from("/"),
                 compression: CompressionType::Bzip2,
+                snapshot_version: SnapshotVersion::default(),
             }),
             bank_forks,
             RpcHealth::stub(),

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -83,7 +83,7 @@ mod tests {
         bank::BankSlotDelta,
         bank_forks::CompressionType,
         snapshot_package::AccountsPackage,
-        snapshot_utils::{self, SNAPSHOT_STATUS_CACHE_FILE_NAME},
+        snapshot_utils::{self, SnapshotVersion, SNAPSHOT_STATUS_CACHE_FILE_NAME},
     };
     use solana_sdk::hash::Hash;
     use std::{
@@ -174,6 +174,7 @@ mod tests {
             output_tar_path.clone(),
             Hash::default(),
             CompressionType::Bzip2,
+            SnapshotVersion::default(),
         );
 
         // Make tarball from packageable snapshot

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -3,7 +3,7 @@ use clap::{
     ArgMatches, SubCommand,
 };
 use serde_json::json;
-use solana_clap_utils::input_validators::is_slot;
+use solana_clap_utils::input_validators::{is_parsable, is_slot};
 use solana_ledger::{
     bank_forks_utils,
     blockstore::Blockstore,
@@ -16,6 +16,7 @@ use solana_runtime::{
     bank_forks::{BankForks, CompressionType, SnapshotConfig},
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
     snapshot_utils,
+    snapshot_utils::SnapshotVersion,
 };
 use solana_sdk::{
     clock::Slot, genesis_config::GenesisConfig, native_token::lamports_to_sol, pubkey::Pubkey,
@@ -574,6 +575,7 @@ fn load_bank_forks(
             snapshot_package_output_path: ledger_path.clone(),
             snapshot_path,
             compression: CompressionType::Bzip2,
+            snapshot_version: SnapshotVersion::default(),
         })
     };
     let account_paths = if let Some(account_paths) = arg_matches.value_of("account_paths") {
@@ -654,7 +656,13 @@ fn main() {
         .takes_value(true)
         .default_value(&default_genesis_archive_unpacked_size)
         .help("maximum total uncompressed size of unpacked genesis archive");
-
+    let snapshot_version_arg = Arg::with_name("snapshot_version")
+        .long("snapshot-version")
+        .value_name("SNAPSHOT_VERSION")
+        .validator(is_parsable::<SnapshotVersion>)
+        .takes_value(true)
+        .default_value(SnapshotVersion::default().into())
+        .help("Output snapshot version");
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
@@ -775,6 +783,7 @@ fn main() {
             .arg(&account_paths_arg)
             .arg(&hard_forks_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
+            .arg(&snapshot_version_arg)
             .arg(
                 Arg::with_name("snapshot_slot")
                     .index(1)
@@ -1049,7 +1058,15 @@ fn main() {
             let snapshot_slot = value_t_or_exit!(arg_matches, "snapshot_slot", Slot);
             let output_directory = value_t_or_exit!(arg_matches, "output_directory", String);
             let warp_slot = value_t!(arg_matches, "warp_slot", Slot).ok();
-
+            let snapshot_version =
+                arg_matches
+                    .value_of("snapshot_version")
+                    .map_or(SnapshotVersion::default(), |s| {
+                        s.parse::<SnapshotVersion>().unwrap_or_else(|e| {
+                            eprintln!("Error: {}", e);
+                            exit(1)
+                        })
+                    });
             let process_options = ProcessOptions {
                 dev_halt_at_slot: Some(snapshot_slot),
                 new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
@@ -1083,7 +1100,11 @@ fn main() {
                         bank
                     };
 
-                    println!("Creating a snapshot of slot {}", bank.slot());
+                    println!(
+                        "Creating a version {} snapshot of slot {}",
+                        snapshot_version,
+                        bank.slot(),
+                    );
                     assert!(bank.is_complete());
                     bank.squash();
                     bank.clean_accounts();
@@ -1095,7 +1116,7 @@ fn main() {
                     });
 
                     let storages: Vec<_> = bank.get_snapshot_storages();
-                    snapshot_utils::add_snapshot(&temp_dir, &bank, &storages)
+                    snapshot_utils::add_snapshot(&temp_dir, &bank, &storages, snapshot_version)
                         .and_then(|slot_snapshot_paths| {
                             snapshot_utils::package_snapshot(
                                 &bank,
@@ -1105,6 +1126,7 @@ fn main() {
                                 output_directory,
                                 storages,
                                 CompressionType::Bzip2,
+                                snapshot_version,
                             )
                         })
                         .and_then(|package| {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1210,6 +1210,7 @@ fn setup_snapshot_validator_config(
         snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
         snapshot_path: PathBuf::from(snapshot_dir.path()),
         compression: CompressionType::Bzip2,
+        snapshot_version: snapshot_utils::SnapshotVersion::default(),
     };
 
     // Create the account paths

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -16,6 +16,8 @@ use std::{
 };
 use thiserror::Error;
 
+pub use crate::snapshot_utils::SnapshotVersion;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CompressionType {
     Bzip2,
@@ -36,6 +38,9 @@ pub struct SnapshotConfig {
     pub snapshot_path: PathBuf,
 
     pub compression: CompressionType,
+
+    // Snapshot version to generate
+    pub snapshot_version: SnapshotVersion,
 }
 
 #[derive(Error, Debug)]
@@ -302,7 +307,12 @@ impl BankForks {
 
         let storages: Vec<_> = bank.get_snapshot_storages();
         let mut add_snapshot_time = Measure::start("add-snapshot-ms");
-        snapshot_utils::add_snapshot(&config.snapshot_path, &bank, &storages)?;
+        snapshot_utils::add_snapshot(
+            &config.snapshot_path,
+            &bank,
+            &storages,
+            config.snapshot_version,
+        )?;
         add_snapshot_time.stop();
         inc_new_counter_info!("add-snapshot-ms", add_snapshot_time.as_ms() as usize);
 
@@ -321,6 +331,7 @@ impl BankForks {
             &config.snapshot_package_output_path,
             storages,
             config.compression.clone(),
+            config.snapshot_version,
         )?;
 
         accounts_package_sender.send(package)?;

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,4 +1,5 @@
 use crate::bank_forks::CompressionType;
+use crate::snapshot_utils::SnapshotVersion;
 use crate::{accounts_db::SnapshotStorages, bank::BankSlotDelta};
 use solana_sdk::clock::Slot;
 use solana_sdk::hash::Hash;
@@ -22,6 +23,7 @@ pub struct AccountsPackage {
     pub tar_output_file: PathBuf,
     pub hash: Hash,
     pub compression: CompressionType,
+    pub snapshot_version: SnapshotVersion,
 }
 
 impl AccountsPackage {
@@ -34,6 +36,7 @@ impl AccountsPackage {
         tar_output_file: PathBuf,
         hash: Hash,
         compression: CompressionType,
+        snapshot_version: SnapshotVersion,
     ) -> Self {
         Self {
             root,
@@ -44,6 +47,7 @@ impl AccountsPackage {
             tar_output_file,
             hash,
             compression,
+            snapshot_version,
         }
     }
 }


### PR DESCRIPTION
This PR adds an optional `--snapshot-version` command line argument to `solana-validator` and `solana-ledger-tool create-snapshot` to allow configuration of the snapshot format version used in generated snapshots.