### PR TITLE
Remove redundant BankForks parameter

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -169,7 +169,7 @@ fn main() {
     let (verified_sender, verified_receiver) = unbounded();
     let (vote_sender, vote_receiver) = unbounded();
     let bank0 = Bank::new(&genesis_config);
-    let mut bank_forks = BankForks::new(0, bank0);
+    let mut bank_forks = BankForks::new(bank0);
     let mut bank = bank_forks.working_bank();
 
     info!("threads: {} txs: {}", num_threads, total_num_transactions);

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -49,7 +49,7 @@ fn bench_retransmitter(bencher: &mut Bencher) {
 
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
     let bank0 = Bank::new(&genesis_config);
-    let bank_forks = BankForks::new(0, bank0);
+    let bank_forks = BankForks::new(bank0);
     let bank = bank_forks.working_bank();
     let bank_forks = Arc::new(RwLock::new(bank_forks));
     let (packet_sender, packet_receiver) = channel();

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -948,7 +948,7 @@ mod tests {
             );
         let bank = Bank::new(&genesis_config);
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = BankForks::new(0, bank);
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.get(0).unwrap().clone();
         let vote_tracker = VoteTracker::new(&bank);
         let ledger_path = get_tmp_ledger_path!();
@@ -1058,7 +1058,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let vote_tracker = VoteTracker::new(&bank);
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = BankForks::new(0, bank);
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.get(0).unwrap().clone();
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -988,7 +988,7 @@ pub mod test {
             0,
             ForkProgress::new(bank0.last_blockhash(), None, None, 0, 0),
         );
-        let bank_forks = BankForks::new(0, bank0);
+        let bank_forks = BankForks::new(bank0);
         let heaviest_subtree_fork_choice =
             HeaviestSubtreeForkChoice::new_from_bank_forks(&bank_forks);
         (bank_forks, progress, heaviest_subtree_fork_choice)

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1852,7 +1852,7 @@ pub(crate) mod tests {
             );
             let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank0));
             let exit = Arc::new(AtomicBool::new(false));
-            let mut bank_forks = BankForks::new(0, bank0);
+            let mut bank_forks = BankForks::new(bank0);
 
             // Insert a non-root bank so that the propagation logic will update this
             // bank
@@ -1961,7 +1961,7 @@ pub(crate) mod tests {
     fn test_handle_new_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank0)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
         let root = 3;
         let mut heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new(root);
         let root_bank = Bank::new_from_parent(
@@ -1992,7 +1992,7 @@ pub(crate) mod tests {
     fn test_handle_new_root_ahead_of_largest_confirmed_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank0)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
         let confirmed_root = 1;
         let fork = 2;
         let bank1 = Bank::new_from_parent(
@@ -3360,10 +3360,9 @@ pub(crate) mod tests {
 
         // If the root is 3, this filters out slot 2 from the progress map,
         // which implies confirmation
-        let mut bank_forks = BankForks::new(
-            3,
-            Bank::new(&genesis_config::create_genesis_config(10000).0),
-        );
+        let bank0 = Bank::new(&genesis_config::create_genesis_config(10000).0);
+        let bank3 = Bank::new_from_parent(&Arc::new(bank0), &Pubkey::default(), 3);
+        let mut bank_forks = BankForks::new(bank3);
         let bank5 = Bank::new_from_parent(bank_forks.get(3).unwrap(), &Pubkey::default(), 5);
         bank_forks.insert(bank5);
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2906,7 +2906,7 @@ pub mod tests {
 
         let bank = Bank::new(&genesis_config);
         (
-            Arc::new(RwLock::new(BankForks::new(bank.slot(), bank))),
+            Arc::new(RwLock::new(BankForks::new(bank))),
             mint_keypair,
             voting_keypair,
         )

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -420,7 +420,7 @@ mod tests {
         let bob_pubkey = bob.pubkey();
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let rpc = RpcSolPubSubImpl {
@@ -471,7 +471,7 @@ mod tests {
         let bob_pubkey = Pubkey::new_rand();
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
 
@@ -528,7 +528,7 @@ mod tests {
         let budget_program_id = solana_budget_program::id();
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -638,7 +638,7 @@ mod tests {
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, Bank::new(&genesis_config))));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::new(&genesis_config))));
 
         let mut io = PubSubHandler::default();
         let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
@@ -680,7 +680,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(1, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bob = Keypair::new();
@@ -731,7 +731,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -807,7 +807,7 @@ mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
         let session = create_session();
         let (subscriber, _id_receiver, receiver) = Subscriber::new_test("slotNotification");
@@ -837,7 +837,7 @@ mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
         let session = create_session();
         let (subscriber, _id_receiver, receiver) = Subscriber::new_test("slotNotification");
@@ -884,7 +884,7 @@ mod tests {
             create_genesis_config_with_vote_accounts(10_000, &validator_voting_keypairs, 100);
         let exit = Arc::new(AtomicBool::new(false));
         let bank = Bank::new(&genesis_config);
-        let bank_forks = BankForks::new(0, bank);
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.get(0).unwrap().clone();
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
@@ -943,7 +943,7 @@ mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
         let session = create_session();
         let (subscriber, _id_receiver, _) = Subscriber::new_test("voteNotification");

--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -93,7 +93,7 @@ mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,
             bank_forks,

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -374,7 +374,7 @@ mod tests {
             ip_addr,
             solana_net_utils::find_available_port_in_range(ip_addr, (10000, 65535)).unwrap(),
         );
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank.slot(), bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let block_commitment_cache = Arc::new(RwLock::new(
@@ -412,7 +412,7 @@ mod tests {
     fn create_bank_forks() -> Arc<RwLock<BankForks>> {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
-        Arc::new(RwLock::new(BankForks::new(bank.slot(), bank)))
+        Arc::new(RwLock::new(BankForks::new(bank)))
     }
 
     #[test]

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -880,7 +880,7 @@ pub(crate) mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -974,7 +974,7 @@ pub(crate) mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let alice = Keypair::new();
         let tx = system_transaction::create_account(
             &mint_keypair,
@@ -1062,7 +1062,7 @@ pub(crate) mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let mut bank_forks = BankForks::new(0, bank);
+        let mut bank_forks = BankForks::new(bank);
         let alice = Keypair::new();
 
         let past_bank_tx =
@@ -1218,7 +1218,7 @@ pub(crate) mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks,
@@ -1270,7 +1270,7 @@ pub(crate) mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks,
@@ -1368,7 +1368,7 @@ pub(crate) mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -127,7 +127,7 @@ pub mod tests {
         let bank =
             Bank::new(&create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config);
         let cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let bf = Arc::new(RwLock::new(BankForks::new(0, bank)));
+        let bf = Arc::new(RwLock::new(BankForks::new(bank)));
         let verifier = ShredSigVerifier::new(bf, cache);
 
         let mut batch = vec![Packets::default()];

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -256,7 +256,7 @@ pub mod tests {
         let starting_balance = 10_000;
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(starting_balance);
 
-        let bank_forks = BankForks::new(0, Bank::new(&genesis_config));
+        let bank_forks = BankForks::new(Bank::new(&genesis_config));
 
         //start cluster_info1
         let cluster_info1 = ClusterInfo::new_with_invalid_keypair(target1.info.clone());

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -49,7 +49,7 @@ mod tests {
             &[],
         );
         bank0.freeze();
-        let mut bank_forks = BankForks::new(0, bank0);
+        let mut bank_forks = BankForks::new(bank0);
         bank_forks.accounts_hash_interval_slots = snapshot_interval_slots;
 
         let snapshot_config = SnapshotConfig {

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -96,7 +96,7 @@ fn test_slot_subscription() {
     let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new(&genesis_config);
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(0, bank)));
+    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
     let subscriptions = Arc::new(RpcSubscriptions::new(
         &exit,
         bank_forks,


### PR DESCRIPTION
#### Problem

I don't grok why `BankForks::new` requires both a bank slot and a bank.

#### Summary of Changes

* Try to set the bank slot with `bank.slot()` and see if I learn something new.
* Also implement `BankForks::new` using `BankForks::new_with_banks`