### PR TITLE
Check the whole range of commits in the topic branch

### DIFF
--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -5,8 +5,14 @@ cd "$(dirname "$0")/.."
 
 source ci/_
 
-# Look for failed mergify.io backports
-_ git show HEAD --check --oneline
+# Look for failed mergify.io backports by searching leftover conflict markers
+# Also check for any trailing whitespaces!
+if [[ -n $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]]; then
+  base_branch=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
+else
+  base_branch=$BUILDKITE_BRANCH
+fi
+_ git show $(git merge-base HEAD "origin/$base_branch")..HEAD --check --oneline
 
 _ ci/nits.sh
 _ ci/check-ssh-keys.sh

--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -5,6 +5,8 @@ cd "$(dirname "$0")/.."
 
 source ci/_
 
+echo --- prepare git show --check
+
 (
   set -x
   # Look for failed mergify.io backports by searching leftover conflict markers
@@ -14,6 +16,7 @@ source ci/_
   else
     base_branch=$BUILDKITE_BRANCH
   fi
+  _ git fetch origin "$base_branch"
   _ git show "$(git merge-base HEAD "origin/$base_branch")..HEAD" --check --oneline
 )
 

--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -5,14 +5,17 @@ cd "$(dirname "$0")/.."
 
 source ci/_
 
-# Look for failed mergify.io backports by searching leftover conflict markers
-# Also check for any trailing whitespaces!
-if [[ -n $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]]; then
-  base_branch=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
-else
-  base_branch=$BUILDKITE_BRANCH
-fi
-_ git show "$(git merge-base HEAD "origin/$base_branch")..HEAD" --check --oneline
+(
+  set -x
+  # Look for failed mergify.io backports by searching leftover conflict markers
+  # Also check for any trailing whitespaces!
+  if [[ -n $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]]; then
+    base_branch=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
+  else
+    base_branch=$BUILDKITE_BRANCH
+  fi
+  _ git show "$(git merge-base HEAD "origin/$base_branch")..HEAD" --check --oneline
+)
 
 _ ci/nits.sh
 _ ci/check-ssh-keys.sh

--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -12,7 +12,7 @@ if [[ -n $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]]; then
 else
   base_branch=$BUILDKITE_BRANCH
 fi
-_ git show $(git merge-base HEAD "origin/$base_branch")..HEAD --check --oneline
+_ git show "$(git merge-base HEAD "origin/$base_branch")..HEAD" --check --oneline
 
 _ ci/nits.sh
 _ ci/check-ssh-keys.sh


### PR DESCRIPTION
#### Problem

CI does check for the trailing whitespace problem in half-baked way. Namely, it only checks the only 
latest single commit on the topic branch, not all the commits. So after merging, it's possible the whitespace problem to occur if the trailing whitespace is laying in one of the not-latest commits.

And, it looks like our people's editor isn't configured to prune any trailing whitespaces. Too often. ;)

There are some precedents:
- #10509 (fixed by #10558)
- #10440 (fixed by #10554)
- #8549 (fixed by f0028b6972a24728071f8004cb05b98dfa6995f3)

#### Summary of Changes

Improve the ci detection.