### PR TITLE
Use git diff instead of git show for --check

### DIFF
--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.."
 source ci/_
 
 (
-  echo --- git show --check
+  echo --- git diff --check
   set -x
   # Look for failed mergify.io backports by searching leftover conflict markers
   # Also check for any trailing whitespaces!
@@ -16,7 +16,7 @@ source ci/_
     base_branch=$BUILDKITE_BRANCH
   fi
   git fetch origin "$base_branch"
-  git show "$(git merge-base HEAD "origin/$base_branch")..HEAD" --check --oneline
+  git diff "$(git merge-base HEAD "origin/$base_branch")..HEAD" --check --oneline
 )
 
 echo


### PR DESCRIPTION
#### Problem

Well, `git show` still errors even when trailing whitespace is fixed with new commit:

```bash
$ git show f016ccdbb5661b8ef661f30e65be0bf746e90783..9e1f0653d0 --check --oneline
9e1f0653d0 fix trailing whitespace
851a133355 Fix bad buildkite grouping?
56be574c31 Fix labelling
db7329e0d7 Revert some
2a30bb4b84 trailing whitespace test
runtime/src/bank.rs:4: trailing whitespace.
+//! already been signed and verified. 
b1162c2e7d fix typo...
979d4b1745 Propagate this as well
4e82745e3b Fix conflict
df523b41cb (origin-pull/10563/head) Check the whole range of commits in the topic branch (#10560)
$ echo $?
2
```

#### Summary of Changes

use git diff

```bash
$ git diff f016ccdbb5661b8ef661f30e65be0bf746e90783..9e1f0653d0 --check --oneline
$ echo $?
0
```

Follow-up: #10560, #10565.