### PR TITLE
Add Copy trait to FeeCalculator

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1408,7 +1408,7 @@ fn process_deploy(
     check_account_for_multiple_fees_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &messages,
         config.commitment,
     )?;
@@ -1491,7 +1491,7 @@ fn process_pay(
             rpc_client,
             sign_only,
             amount,
-            &fee_calculator,
+            fee_calculator,
             &config.signers[0].pubkey(),
             build_message,
             config.commitment,
@@ -1545,7 +1545,7 @@ fn process_pay(
             rpc_client,
             sign_only,
             amount,
-            &fee_calculator,
+            fee_calculator,
             &config.signers[0].pubkey(),
             build_message,
             config.commitment,
@@ -1596,7 +1596,7 @@ fn process_pay(
             rpc_client,
             sign_only,
             amount,
-            &fee_calculator,
+            fee_calculator,
             &config.signers[0].pubkey(),
             build_message,
             config.commitment,
@@ -1639,7 +1639,7 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;
@@ -1669,7 +1669,7 @@ fn process_time_elapsed(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;
@@ -1722,7 +1722,7 @@ fn process_transfer(
         rpc_client,
         sign_only,
         amount,
-        &fee_calculator,
+        fee_calculator,
         &from.pubkey(),
         &fee_payer.pubkey(),
         build_message,
@@ -1771,7 +1771,7 @@ fn process_witness(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -898,7 +898,7 @@ pub fn process_ping(
             rpc_client,
             false,
             SpendAmount::Some(lamports),
-            &fee_calculator,
+            fee_calculator,
             &config.signers[0].pubkey(),
             build_message,
             config.commitment,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -460,7 +460,7 @@ pub fn process_authorize_nonce_account(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;
@@ -523,7 +523,7 @@ pub fn process_create_nonce_account(
         rpc_client,
         false,
         amount,
-        &fee_calculator,
+        fee_calculator,
         &config.signers[0].pubkey(),
         build_message,
         config.commitment,
@@ -606,7 +606,7 @@ pub fn process_new_nonce(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;
@@ -673,7 +673,7 @@ pub fn process_withdraw_from_nonce_account(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;

--- a/cli/src/offline/blockhash_query.rs
+++ b/cli/src/offline/blockhash_query.rs
@@ -280,13 +280,13 @@ mod tests {
             context: RpcResponseContext { slot: 1 },
             value: json!((
                 Value::String(rpc_blockhash.to_string()),
-                serde_json::to_value(rpc_fee_calc.clone()).unwrap()
+                serde_json::to_value(rpc_fee_calc).unwrap()
             )),
         });
         let get_fee_calculator_for_blockhash_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
             value: json!(RpcFeeCalculator {
-                fee_calculator: rpc_fee_calc.clone()
+                fee_calculator: rpc_fee_calc
             }),
         });
         let mut mocks = HashMap::new();
@@ -299,7 +299,7 @@ mod tests {
             BlockhashQuery::default()
                 .get_blockhash_and_fee_calculator(&rpc_client, CommitmentConfig::default())
                 .unwrap(),
-            (rpc_blockhash, rpc_fee_calc.clone()),
+            (rpc_blockhash, rpc_fee_calc),
         );
         let mut mocks = HashMap::new();
         mocks.insert(
@@ -339,7 +339,7 @@ mod tests {
         let data = nonce::state::Data {
             authority: Pubkey::new(&[3u8; 32]),
             blockhash: nonce_blockhash,
-            fee_calculator: nonce_fee_calc.clone(),
+            fee_calculator: nonce_fee_calc,
         };
         let nonce_account = Account::new_data_with_space(
             42,
@@ -362,7 +362,7 @@ mod tests {
             BlockhashQuery::All(Source::NonceAccount(nonce_pubkey))
                 .get_blockhash_and_fee_calculator(&rpc_client, CommitmentConfig::default())
                 .unwrap(),
-            (nonce_blockhash, nonce_fee_calc.clone()),
+            (nonce_blockhash, nonce_fee_calc),
         );
         let mut mocks = HashMap::new();
         mocks.insert(RpcRequest::GetAccountInfo, get_account_response.clone());

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -47,7 +47,7 @@ pub fn resolve_spend_tx_and_check_account_balance<F>(
     rpc_client: &RpcClient,
     sign_only: bool,
     amount: SpendAmount,
-    fee_calculator: &FeeCalculator,
+    fee_calculator: FeeCalculator,
     from_pubkey: &Pubkey,
     build_message: F,
     commitment: CommitmentConfig,
@@ -71,7 +71,7 @@ pub fn resolve_spend_tx_and_check_account_balances<F>(
     rpc_client: &RpcClient,
     sign_only: bool,
     amount: SpendAmount,
-    fee_calculator: &FeeCalculator,
+    fee_calculator: FeeCalculator,
     from_pubkey: &Pubkey,
     fee_pubkey: &Pubkey,
     build_message: F,
@@ -124,7 +124,7 @@ where
 
 fn resolve_spend_message<F>(
     amount: SpendAmount,
-    fee_calculator: &FeeCalculator,
+    fee_calculator: FeeCalculator,
     from_balance: u64,
     from_pubkey: &Pubkey,
     fee_pubkey: &Pubkey,

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -902,7 +902,7 @@ pub fn process_create_stake_account(
         rpc_client,
         sign_only,
         amount,
-        &fee_calculator,
+        fee_calculator,
         &from.pubkey(),
         &fee_payer.pubkey(),
         build_message,
@@ -1013,7 +1013,7 @@ pub fn process_stake_authorize(
         check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
-            &fee_calculator,
+            fee_calculator,
             &tx.message,
             config.commitment,
         )?;
@@ -1073,7 +1073,7 @@ pub fn process_deactivate_stake_account(
         check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
-            &fee_calculator,
+            fee_calculator,
             &tx.message,
             config.commitment,
         )?;
@@ -1142,7 +1142,7 @@ pub fn process_withdraw_stake(
         check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
-            &fee_calculator,
+            fee_calculator,
             &tx.message,
             config.commitment,
         )?;
@@ -1282,7 +1282,7 @@ pub fn process_split_stake(
         check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
-            &fee_calculator,
+            fee_calculator,
             &tx.message,
             config.commitment,
         )?;
@@ -1381,7 +1381,7 @@ pub fn process_merge_stake(
         check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
-            &fee_calculator,
+            fee_calculator,
             &tx.message,
             config.commitment,
         )?;
@@ -1444,7 +1444,7 @@ pub fn process_stake_set_lockup(
         check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
-            &fee_calculator,
+            fee_calculator,
             &tx.message,
             config.commitment,
         )?;
@@ -1729,7 +1729,7 @@ pub fn process_delegate_stake(
         check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
-            &fee_calculator,
+            fee_calculator,
             &tx.message,
             config.commitment,
         )?;

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -369,7 +369,7 @@ pub fn process_set_validator_info(
         rpc_client,
         false,
         SpendAmount::Some(lamports),
-        &fee_calculator,
+        fee_calculator,
         &config.signers[0].pubkey(),
         build_message,
         config.commitment,

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -496,7 +496,7 @@ pub fn process_create_vote_account(
         rpc_client,
         false,
         amount,
-        &fee_calculator,
+        fee_calculator,
         &config.signers[0].pubkey(),
         build_message,
         config.commitment,
@@ -546,7 +546,7 @@ pub fn process_vote_authorize(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;
@@ -586,7 +586,7 @@ pub fn process_vote_update_validator(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;
@@ -620,7 +620,7 @@ pub fn process_vote_update_commission(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &tx.message,
         config.commitment,
     )?;
@@ -749,7 +749,7 @@ pub fn process_withdraw_from_vote_account(
     check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
-        &fee_calculator,
+        fee_calculator,
         &transaction.message,
         config.commitment,
     )?;

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -301,9 +301,7 @@ impl Accounts {
                         Some(HashAgeKind::DurableNonce(_, account)) => {
                             nonce_utils::fee_calculator_of(account)
                         }
-                        _ => hash_queue
-                            .get_fee_calculator(&tx.message().recent_blockhash)
-                            .cloned(),
+                        _ => hash_queue.get_fee_calculator(&tx.message().recent_blockhash),
                     };
                     let fee = if let Some(fee_calculator) = fee_calculator {
                         fee_calculator.calculate_fee(tx.message())
@@ -798,12 +796,12 @@ mod tests {
     fn load_accounts_with_fee_and_rent(
         tx: Transaction,
         ka: &[(Pubkey, Account)],
-        fee_calculator: &FeeCalculator,
+        fee_calculator: FeeCalculator,
         rent_collector: &RentCollector,
         error_counters: &mut ErrorCounters,
     ) -> Vec<(Result<TransactionLoadResult>, Option<HashAgeKind>)> {
         let mut hash_queue = BlockhashQueue::new(100);
-        hash_queue.register_hash(&tx.message().recent_blockhash, &fee_calculator);
+        hash_queue.register_hash(&tx.message().recent_blockhash, fee_calculator);
         let accounts = Accounts::new(Vec::new());
         for ka in ka.iter() {
             accounts.store_slow(0, &ka.0, &ka.1);
@@ -824,7 +822,7 @@ mod tests {
     fn load_accounts_with_fee(
         tx: Transaction,
         ka: &[(Pubkey, Account)],
-        fee_calculator: &FeeCalculator,
+        fee_calculator: FeeCalculator,
         error_counters: &mut ErrorCounters,
     ) -> Vec<(Result<TransactionLoadResult>, Option<HashAgeKind>)> {
         let rent_collector = RentCollector::default();
@@ -837,7 +835,7 @@ mod tests {
         error_counters: &mut ErrorCounters,
     ) -> Vec<(Result<TransactionLoadResult>, Option<HashAgeKind>)> {
         let fee_calculator = FeeCalculator::default();
-        load_accounts_with_fee(tx, ka, &fee_calculator, error_counters)
+        load_accounts_with_fee(tx, ka, fee_calculator, error_counters)
     }
 
     #[test]
@@ -957,7 +955,7 @@ mod tests {
         assert_eq!(fee_calculator.calculate_fee(tx.message()), 10);
 
         let loaded_accounts =
-            load_accounts_with_fee(tx, &accounts, &fee_calculator, &mut error_counters);
+            load_accounts_with_fee(tx, &accounts, fee_calculator, &mut error_counters);
 
         assert_eq!(error_counters.insufficient_funds, 1);
         assert_eq!(loaded_accounts.len(), 1);
@@ -1042,7 +1040,7 @@ mod tests {
         let loaded_accounts = load_accounts_with_fee_and_rent(
             tx.clone(),
             &accounts,
-            &fee_calculator,
+            fee_calculator,
             &rent_collector,
             &mut error_counters,
         );
@@ -1056,7 +1054,7 @@ mod tests {
         let loaded_accounts = load_accounts_with_fee_and_rent(
             tx.clone(),
             &accounts,
-            &fee_calculator,
+            fee_calculator,
             &rent_collector,
             &mut error_counters,
         );
@@ -1069,7 +1067,7 @@ mod tests {
         let loaded_accounts = load_accounts_with_fee_and_rent(
             tx,
             &accounts,
-            &fee_calculator,
+            fee_calculator,
             &rent_collector,
             &mut error_counters,
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -945,7 +945,9 @@ impl Bank {
         let last_hash = blockhash_queue.last_hash();
         (
             last_hash,
-            blockhash_queue.get_fee_calculator(&last_hash).unwrap(),
+            blockhash_queue
+                .get_fee_calculator(&last_hash)
+                .unwrap_or_default(),
         )
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -945,10 +945,7 @@ impl Bank {
         let last_hash = blockhash_queue.last_hash();
         (
             last_hash,
-            blockhash_queue
-                .get_fee_calculator(&last_hash)
-                .unwrap()
-                .clone(),
+            *blockhash_queue.get_fee_calculator(&last_hash).unwrap(),
         )
     }
 

--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -74,7 +74,7 @@ impl BlockhashQueue {
         self.ages.insert(
             *hash,
             HashAge {
-                fee_calculator: fee_calculator.clone(),
+                fee_calculator: *fee_calculator,
                 hash_height: 0,
                 timestamp: timestamp(),
             },
@@ -101,7 +101,7 @@ impl BlockhashQueue {
         self.ages.insert(
             *hash,
             HashAge {
-                fee_calculator: fee_calculator.clone(),
+                fee_calculator: *fee_calculator,
                 hash_height,
                 timestamp: timestamp(),
             },

--- a/runtime/src/legacy_system_instruction_processor0.rs
+++ b/runtime/src/legacy_system_instruction_processor0.rs
@@ -348,7 +348,7 @@ mod tests {
         RefCell::new(sysvar::recent_blockhashes::create_account_with_data(
             1,
             vec![
-                IterItem(0u64, &Hash::default(), &FeeCalculator::default());
+                IterItem(0u64, &Hash::default(), FeeCalculator::default());
                 sysvar::recent_blockhashes::MAX_ENTRIES
             ]
             .into_iter(),
@@ -1175,7 +1175,7 @@ mod tests {
                     IterItem(
                         0u64,
                         &hash(&serialize(&0).unwrap()),
-                        &FeeCalculator::default()
+                        FeeCalculator::default()
                     );
                     sysvar::recent_blockhashes::MAX_ENTRIES
                 ]

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -28,10 +28,7 @@ impl RentCollector {
     }
 
     pub fn clone_with_epoch(&self, epoch: Epoch) -> Self {
-        Self {
-            epoch,
-            ..self.clone()
-        }
+        Self { epoch, ..*self }
     }
     // updates this account's lamports and status and returns
     //  the account rent collected, if any

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -342,7 +342,7 @@ mod tests {
         RefCell::new(sysvar::recent_blockhashes::create_account_with_data(
             1,
             vec![
-                IterItem(0u64, &Hash::default(), &FeeCalculator::default());
+                IterItem(0u64, &Hash::default(), FeeCalculator::default());
                 sysvar::recent_blockhashes::MAX_ENTRIES
             ]
             .into_iter(),
@@ -1178,7 +1178,7 @@ mod tests {
                     IterItem(
                         0u64,
                         &hash(&serialize(&0).unwrap()),
-                        &FeeCalculator::default()
+                        FeeCalculator::default()
                     );
                     sysvar::recent_blockhashes::MAX_ENTRIES
                 ]

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -25,7 +25,7 @@ impl FeeCalculator {
         }
     }
 
-    pub fn calculate_fee(&self, message: &Message) -> u64 {
+    pub fn calculate_fee(self, message: &Message) -> u64 {
         self.lamports_per_signature * u64::from(message.header.num_required_signatures)
     }
 }

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -2,7 +2,7 @@ use crate::clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT};
 use crate::message::Message;
 use log::*;
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct FeeCalculator {
     // The current cost of a signature  This amount may increase/decrease over time based on

--- a/sdk/src/nonce/account.rs
+++ b/sdk/src/nonce/account.rs
@@ -60,7 +60,7 @@ impl<'a> Account for KeyedAccount<'a> {
 
                 let new_data = nonce::state::Data {
                     blockhash: recent_blockhash,
-                    fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                    fee_calculator: recent_blockhashes[0].fee_calculator,
                     ..data
                 };
                 self.set_state(&Versions::new_current(State::Initialized(new_data)))
@@ -128,7 +128,7 @@ impl<'a> Account for KeyedAccount<'a> {
                 let data = nonce::state::Data {
                     authority: *nonce_authority,
                     blockhash: recent_blockhashes[0].blockhash,
-                    fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                    fee_calculator: recent_blockhashes[0].fee_calculator,
                 };
                 self.set_state(&Versions::new_current(State::Initialized(data)))
             }
@@ -227,7 +227,7 @@ mod test {
                 .convert_to_current();
             let data = nonce::state::Data {
                 blockhash: recent_blockhashes[0].blockhash,
-                fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                fee_calculator: recent_blockhashes[0].fee_calculator,
                 ..data
             };
             // First nonce instruction drives state from Uninitialized to Initialized
@@ -241,7 +241,7 @@ mod test {
                 .convert_to_current();
             let data = nonce::state::Data {
                 blockhash: recent_blockhashes[0].blockhash,
-                fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                fee_calculator: recent_blockhashes[0].fee_calculator,
                 ..data
             };
             // Second nonce instruction consumes and replaces stored nonce
@@ -255,7 +255,7 @@ mod test {
                 .convert_to_current();
             let data = nonce::state::Data {
                 blockhash: recent_blockhashes[0].blockhash,
-                fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                fee_calculator: recent_blockhashes[0].fee_calculator,
                 ..data
             };
             // Third nonce instruction for fun and profit
@@ -307,7 +307,7 @@ mod test {
             let data = nonce::state::Data {
                 authority,
                 blockhash: recent_blockhashes[0].blockhash,
-                fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                fee_calculator: recent_blockhashes[0].fee_calculator,
             };
             assert_eq!(state, State::Initialized(data));
             let signers = HashSet::new();
@@ -596,7 +596,7 @@ mod test {
             let data = nonce::state::Data {
                 authority,
                 blockhash: recent_blockhashes[0].blockhash,
-                fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                fee_calculator: recent_blockhashes[0].fee_calculator,
             };
             assert_eq!(state, State::Initialized(data.clone()));
             with_test_keyed_account(42, false, |to_keyed| {
@@ -618,7 +618,7 @@ mod test {
                     .convert_to_current();
                 let data = nonce::state::Data {
                     blockhash: recent_blockhashes[0].blockhash,
-                    fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                    fee_calculator: recent_blockhashes[0].fee_calculator,
                     ..data.clone()
                 };
                 assert_eq!(state, State::Initialized(data));
@@ -754,7 +754,7 @@ mod test {
             let data = nonce::state::Data {
                 authority,
                 blockhash: recent_blockhashes[0].blockhash,
-                fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                fee_calculator: recent_blockhashes[0].fee_calculator,
             };
             assert_eq!(result, Ok(()));
             let state = AccountUtilsState::<Versions>::state(keyed_account)
@@ -837,7 +837,7 @@ mod test {
             let data = nonce::state::Data {
                 authority,
                 blockhash: recent_blockhashes[0].blockhash,
-                fee_calculator: recent_blockhashes[0].fee_calculator.clone(),
+                fee_calculator: recent_blockhashes[0].fee_calculator,
             };
             let result = nonce_account.authorize_nonce_account(&Pubkey::default(), &signers);
             assert_eq!(result, Ok(()));

--- a/sdk/src/sysvar/fees.rs
+++ b/sdk/src/sysvar/fees.rs
@@ -14,7 +14,7 @@ impl Sysvar for Fees {}
 
 pub fn create_account(lamports: u64, fee_calculator: &FeeCalculator) -> Account {
     Fees {
-        fee_calculator: fee_calculator.clone(),
+        fee_calculator: *fee_calculator,
     }
     .create_account(lamports)
 }

--- a/sdk/src/sysvar/fees.rs
+++ b/sdk/src/sysvar/fees.rs
@@ -12,11 +12,8 @@ pub struct Fees {
 
 impl Sysvar for Fees {}
 
-pub fn create_account(lamports: u64, fee_calculator: &FeeCalculator) -> Account {
-    Fees {
-        fee_calculator: *fee_calculator,
-    }
-    .create_account(lamports)
+pub fn create_account(lamports: u64, fee_calculator: FeeCalculator) -> Account {
+    Fees { fee_calculator }.create_account(lamports)
 }
 
 #[cfg(test)]
@@ -26,7 +23,7 @@ mod tests {
     #[test]
     fn test_fees_create_account() {
         let lamports = 42;
-        let account = create_account(lamports, &FeeCalculator::default());
+        let account = create_account(lamports, FeeCalculator::default());
         let fees = Fees::from_account(&account).unwrap();
         assert_eq!(fees.fee_calculator, FeeCalculator::default());
     }

--- a/sdk/src/sysvar/recent_blockhashes.rs
+++ b/sdk/src/sysvar/recent_blockhashes.rs
@@ -25,7 +25,7 @@ impl Entry {
     pub fn new(blockhash: &Hash, fee_calculator: &FeeCalculator) -> Self {
         Self {
             blockhash: *blockhash,
-            fee_calculator: fee_calculator.clone(),
+            fee_calculator: *fee_calculator,
         }
     }
 }

--- a/sdk/src/sysvar/recent_blockhashes.rs
+++ b/sdk/src/sysvar/recent_blockhashes.rs
@@ -22,16 +22,16 @@ pub struct Entry {
 }
 
 impl Entry {
-    pub fn new(blockhash: &Hash, fee_calculator: &FeeCalculator) -> Self {
+    pub fn new(blockhash: &Hash, fee_calculator: FeeCalculator) -> Self {
         Self {
             blockhash: *blockhash,
-            fee_calculator: *fee_calculator,
+            fee_calculator,
         }
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct IterItem<'a>(pub u64, pub &'a Hash, pub &'a FeeCalculator);
+pub struct IterItem<'a>(pub u64, pub &'a Hash, pub FeeCalculator);
 
 impl<'a> Eq for IterItem<'a> {}
 
@@ -154,7 +154,7 @@ pub fn create_test_recent_blockhashes(start: usize) -> RecentBlockhashes {
         .collect();
     let bhq: Vec<_> = blocks
         .iter()
-        .map(|(i, hash, fee_calc)| IterItem(*i, hash, fee_calc))
+        .map(|(i, hash, fee_calc)| IterItem(*i, hash, *fee_calc))
         .collect();
     RecentBlockhashes::from_iter(bhq.into_iter())
 }
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_size_of() {
-        let entry = Entry::new(&Hash::default(), &FeeCalculator::default());
+        let entry = Entry::new(&Hash::default(), FeeCalculator::default());
         assert_eq!(
             bincode::serialized_size(&RecentBlockhashes(vec![entry; MAX_ENTRIES])).unwrap()
                 as usize,
@@ -196,7 +196,7 @@ mod tests {
         let def_fees = FeeCalculator::default();
         let account = create_account_with_data(
             42,
-            vec![IterItem(0u64, &def_hash, &def_fees); MAX_ENTRIES].into_iter(),
+            vec![IterItem(0u64, &def_hash, def_fees); MAX_ENTRIES].into_iter(),
         );
         let recent_blockhashes = RecentBlockhashes::from_account(&account).unwrap();
         assert_eq!(recent_blockhashes.len(), MAX_ENTRIES);
@@ -208,7 +208,7 @@ mod tests {
         let def_fees = FeeCalculator::default();
         let account = create_account_with_data(
             42,
-            vec![IterItem(0u64, &def_hash, &def_fees); MAX_ENTRIES + 1].into_iter(),
+            vec![IterItem(0u64, &def_hash, def_fees); MAX_ENTRIES + 1].into_iter(),
         );
         let recent_blockhashes = RecentBlockhashes::from_account(&account).unwrap();
         assert_eq!(recent_blockhashes.len(), MAX_ENTRIES);
@@ -233,13 +233,13 @@ mod tests {
             42,
             unsorted_blocks
                 .iter()
-                .map(|(i, hash)| IterItem(*i, hash, &def_fees)),
+                .map(|(i, hash)| IterItem(*i, hash, def_fees)),
         );
         let recent_blockhashes = RecentBlockhashes::from_account(&account).unwrap();
 
         let mut unsorted_recent_blockhashes: Vec<_> = unsorted_blocks
             .iter()
-            .map(|(i, hash)| IterItem(*i, hash, &def_fees))
+            .map(|(i, hash)| IterItem(*i, hash, def_fees))
             .collect();
         unsorted_recent_blockhashes.sort();
         unsorted_recent_blockhashes.reverse();


### PR DESCRIPTION
#### Problem
FeeCalculator is a small struct (8 bytes) comprised solely of one primitive type

#### Summary of Changes
Add Copy trait to FeeCalculator
Pass FeeCalculator instances by value
Fixup all clippy warnings