### PR TITLE
Cleanup error type mapping in serde_snapshot

### DIFF
--- a/ledger/src/snapshot_utils.rs
+++ b/ledger/src/snapshot_utils.rs
@@ -88,7 +88,7 @@ pub enum SnapshotError {
     IO(#[from] std::io::Error),
 
     #[error("serialization error")]
-    Serialize(#[from] Box<bincode::ErrorKind>),
+    Serialize(#[from] bincode::Error),
 
     #[error("file system error")]
     FsExtra(#[from] fs_extra::error::Error),

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -92,10 +92,10 @@ impl<'a> TypeContext<'a> for Context {
 
     fn deserialize_accounts_db_fields<R>(
         mut stream: &mut BufReader<R>,
-    ) -> Result<AccountDBFields<Self::SerializableAccountStorageEntry>, IoError>
+    ) -> Result<AccountDBFields<Self::SerializableAccountStorageEntry>, Error>
     where
         R: Read,
     {
-        deserialize_from(&mut stream).map_err(accountsdb_to_io_error)
+        deserialize_from(&mut stream)
     }
 }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -57,7 +57,7 @@ fn context_accountsdb_from_stream<'a, C, R, P>(
     stream: &mut BufReader<R>,
     account_paths: &[PathBuf],
     stream_append_vecs_path: P,
-) -> Result<AccountsDB, IoError>
+) -> Result<AccountsDB, Error>
 where
     C: TypeContext<'a>,
     R: Read,
@@ -77,7 +77,7 @@ fn accountsdb_from_stream<R, P>(
     stream: &mut BufReader<R>,
     account_paths: &[PathBuf],
     stream_append_vecs_path: P,
-) -> Result<AccountsDB, IoError>
+) -> Result<AccountsDB, Error>
 where
     R: Read,
     P: AsRef<Path>,
@@ -103,7 +103,7 @@ fn accountsdb_to_stream<W>(
     accounts_db: &AccountsDB,
     slot: Slot,
     account_storage_entries: &[SnapshotStorage],
-) -> Result<(), IoError>
+) -> Result<(), Error>
 where
     W: Write,
 {
@@ -116,8 +116,7 @@ where
                 account_storage_entries,
                 phantom: std::marker::PhantomData::default(),
             },
-        )
-        .map_err(bankrc_to_io_error),
+        ),
         SerdeStyle::OLDER => serialize_into(
             stream,
             &SerializableAccountsDB::<TypeContextLegacy> {
@@ -126,8 +125,7 @@ where
                 account_storage_entries,
                 phantom: std::marker::PhantomData::default(),
             },
-        )
-        .map_err(bankrc_to_io_error),
+        ),
     }
 }
 


### PR DESCRIPTION
#### Problem
Excessive explicit error type mapping is unclear

#### Summary of Changes
Rework error types to allow use of '?' operator without explicit map_err() calls