### PR TITLE
fix: improve send and confirm options ergonomics

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -42,12 +42,12 @@ declare module '@solana/web3.js' {
   };
 
   export type SendOptions = {
-    skipPreflight: boolean;
+    skipPreflight?: boolean;
   };
 
   export type ConfirmOptions = {
-    confirmations: number;
-    skipPreflight: boolean;
+    confirmations?: number;
+    skipPreflight?: boolean;
   };
 
   export type RpcResponseAndContext<T> = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -55,12 +55,12 @@ declare module '@solana/web3.js' {
   };
 
   declare export type SendOptions = {
-    skipPreflight: boolean,
+    skipPreflight: ?boolean,
   };
 
   declare export type ConfirmOptions = {
-    confirmations: number,
-    skipPreflight: boolean,
+    confirmations: ?number,
+    skipPreflight: ?boolean,
   };
 
   declare export type RpcResponseAndContext<T> = {

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -38,22 +38,22 @@ type Context = {
  * Options for sending transactions
  *
  * @typedef {Object} SendOptions
- * @property {boolean} skipPreflight disable transaction verification step
+ * @property {boolean | undefined} skipPreflight disable transaction verification step
  */
 export type SendOptions = {
-  skipPreflight: boolean,
+  skipPreflight: ?boolean,
 };
 
 /**
  * Options for confirming transactions
  *
  * @typedef {Object} ConfirmOptions
- * @property {boolean} skipPreflight disable transaction verification step
- * @property {number} confirmations desired number of cluster confirmations
+ * @property {boolean | undefined} skipPreflight disable transaction verification step
+ * @property {number | undefined} confirmations desired number of cluster confirmations
  */
 export type ConfirmOptions = {
-  confirmations: number,
-  skipPreflight: boolean,
+  skipPreflight: ?boolean,
+  confirmations: ?number,
 };
 
 /**


### PR DESCRIPTION
#### Problem
`SendOptions` and `ConfirmOptions` require all options to be specified. They should allow options to be unspecified for default behaviour 

#### Summary of Changes
Change `SendOptions` and `ConfirmOptions` types to allow undefined / missing options.

Fixes #
