### PR TITLE
fix: avoid double spend in sendAndConfirmTransaction

### DIFF
--- a/web3.js/src/timing.js
+++ b/web3.js/src/timing.js
@@ -6,9 +6,20 @@
 /**
  * @ignore
  */
-export const NUM_TICKS_PER_SECOND = 10;
+export const NUM_TICKS_PER_SECOND = 160;
 
 /**
  * @ignore
  */
-export const DEFAULT_TICKS_PER_SLOT = 8;
+export const DEFAULT_TICKS_PER_SLOT = 64;
+
+/**
+ * @ignore
+ */
+export const NUM_SLOTS_PER_SECOND =
+  NUM_TICKS_PER_SECOND / DEFAULT_TICKS_PER_SLOT;
+
+/**
+ * @ignore
+ */
+export const MS_PER_SLOT = 1000 / NUM_SLOTS_PER_SECOND;

--- a/web3.js/src/transaction.js
+++ b/web3.js/src/transaction.js
@@ -210,7 +210,9 @@ export class Transaction {
     let numReadonlySignedAccounts = 0;
     let numReadonlyUnsignedAccounts = 0;
 
-    const accountKeys = this.signatures.map(({publicKey}) => publicKey.toString());
+    const accountKeys = this.signatures.map(({publicKey}) =>
+      publicKey.toString(),
+    );
     const programIds: string[] = [];
     const accountMetas: AccountMeta[] = [];
     this.instructions.forEach(instruction => {

--- a/web3.js/src/util/send-and-confirm-raw-transaction.js
+++ b/web3.js/src/util/send-and-confirm-raw-transaction.js
@@ -6,6 +6,13 @@ import type {ConfirmOptions} from '../connection';
 
 /**
  * Send and confirm a raw transaction
+ *
+ * If `confirmations` count is not specified, wait for transaction to be finalized.
+ *
+ * @param {Connection} connection
+ * @param {Buffer} rawTransaction
+ * @param {ConfirmOptions} [options]
+ * @returns {Promise<TransactionSignature>}
  */
 export async function sendAndConfirmRawTransaction(
   connection: Connection,

--- a/web3.js/src/util/send-and-confirm-transaction.js
+++ b/web3.js/src/util/send-and-confirm-transaction.js
@@ -2,17 +2,20 @@
 
 import {Connection} from '../connection';
 import {Transaction} from '../transaction';
-import {sleep} from './sleep';
 import type {Account} from '../account';
 import type {ConfirmOptions} from '../connection';
 import type {TransactionSignature} from '../transaction';
-
-const NUM_SEND_RETRIES = 10;
 
 /**
  * Sign, send and confirm a transaction.
  *
  * If `confirmations` count is not specified, wait for transaction to be finalized.
+ *
+ * @param {Connection} connection
+ * @param {Transaction} transaction
+ * @param {Array<Account>} signers
+ * @param {ConfirmOptions} [options]
+ * @returns {Promise<TransactionSignature>}
  */
 export async function sendAndConfirmTransaction(
   connection: Connection,
@@ -21,34 +24,25 @@ export async function sendAndConfirmTransaction(
   options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
   const start = Date.now();
-  let sendRetries = NUM_SEND_RETRIES;
+  const signature = await connection.sendTransaction(
+    transaction,
+    signers,
+    options,
+  );
+  const status = (
+    await connection.confirmTransaction(
+      signature,
+      options && options.confirmations,
+    )
+  ).value;
 
-  for (;;) {
-    const signature = await connection.sendTransaction(
-      transaction,
-      signers,
-      options,
-    );
-    const status = (
-      await connection.confirmTransaction(
-        signature,
-        options && options.confirmations,
-      )
-    ).value;
-
-    if (status) {
-      if (status.err) {
-        throw new Error(
-          `Transaction ${signature} failed (${JSON.stringify(status)})`,
-        );
-      }
-      return signature;
+  if (status) {
+    if (status.err) {
+      throw new Error(
+        `Transaction ${signature} failed (${JSON.stringify(status)})`,
+      );
     }
-
-    if (--sendRetries <= 0) break;
-
-    // Retry in 0..100ms to try to avoid another AccountInUse collision
-    await sleep(Math.random() * 100);
+    return signature;
   }
 
   const duration = (Date.now() - start) / 1000;


### PR DESCRIPTION
#### Problem
Now that RPC retries transactions, it's more likely that the `sendAndConfirmTransaction` web3 api inadvertently does a double spend. This is because `sendAndConfirmTransaction` sends a new transaction if `connection.confirmTransaction` times out and `connection.sendTransaction` always fetches a new blockhash for a duplicate transaction.

#### Summary of Changes
- Remove retry loop from sendAndConfirmTransaction
- Update stale timing constants
- Increase wait timeout in confirmTransaction
- Fix up docs

Fixes #
