### PR TITLE
Fix race in remove_unrooted_slot

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -762,7 +762,7 @@ impl AccountsDB {
         dead_slots_w: Option<RwLockWriteGuard<'a, HashSet<Slot>>>,
     ) {
         let empty = HashSet::new();
-        let mut dead_slots_w = dead_slots_w.unwrap_or(self.dead_slots.write().unwrap());
+        let mut dead_slots_w = dead_slots_w.unwrap_or_else(|| self.dead_slots.write().unwrap());
         let dead_slots = std::mem::replace(&mut *dead_slots_w, empty);
         drop(dead_slots_w);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2569,7 +2569,7 @@ impl Bank {
     }
 
     pub fn process_dead_slots(&self) {
-        self.rc.accounts.accounts_db.process_dead_slots();
+        self.rc.accounts.accounts_db.process_dead_slots(None);
     }
 
     pub fn shrink_all_slots(&self) {


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/10553
#### Summary of Changes
Introduce new function `handle_reclaims_locked` that parallels `handle_reclaims`, only difference being it now holds lock through adding a dead slot to `dead_slots` set and processing the dead slot in the call to `process_dead_slots`

Fixes #
