### PR TITLE
Move commitment to CliConfig to enable faster integration tests

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -93,7 +93,7 @@ pub fn check_account_for_balance_with_commitment(
     let lamports = rpc_client
         .get_balance_with_commitment(account_pubkey, commitment)?
         .value;
-    if lamports >= balance {
+    if lamports != 0 && lamports >= balance {
         return Ok(true);
     }
     Ok(false)

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -93,7 +93,7 @@ pub fn check_account_for_balance_with_commitment(
     let lamports = rpc_client
         .get_balance_with_commitment(account_pubkey, commitment)?
         .value;
-    if lamports != 0 && lamports >= balance {
+    if lamports >= balance {
         return Ok(true);
     }
     Ok(false)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1420,6 +1420,7 @@ fn process_deploy(
     rpc_client
         .send_and_confirm_transaction_with_spinner_and_config(
             &finalize_tx,
+            config.commitment,
             RpcSendTransactionConfig {
                 skip_preflight: true,
             },

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -378,7 +378,6 @@ pub enum CliCommand {
     ShowVoteAccount {
         pubkey: Pubkey,
         use_lamports_unit: bool,
-        commitment_config: CommitmentConfig,
     },
     WithdrawFromVoteAccount {
         vote_account_pubkey: Pubkey,
@@ -2117,13 +2116,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::ShowVoteAccount {
             pubkey: vote_account_pubkey,
             use_lamports_unit,
-            commitment_config,
         } => process_show_vote_account(
             &rpc_client,
             config,
             &vote_account_pubkey,
             *use_lamports_unit,
-            *commitment_config,
         ),
         CliCommand::WithdrawFromVoteAccount {
             vote_account_pubkey,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1633,11 +1633,12 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
     let message = Message::new(&[ix]);
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
-    check_account_for_fee(
+    check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
+        config.commitment,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,
@@ -1662,11 +1663,12 @@ fn process_time_elapsed(
     let message = Message::new(&[ix]);
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
-    check_account_for_fee(
+    check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
+        config.commitment,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,
@@ -1763,11 +1765,12 @@ fn process_witness(
     let message = Message::new(&[ix]);
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
-    check_account_for_fee(
+    check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
+        config.commitment,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1705,10 +1705,6 @@ fn process_transfer(
         }
 
         tx.try_sign(&config.signers, recent_blockhash)?;
-        if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
-            check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
-        }
         let result = if no_wait {
             rpc_client.send_transaction(&tx)
         } else {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1363,7 +1363,9 @@ fn process_deploy(
 
     // Build transactions to calculate fees
     let mut messages: Vec<&Message> = Vec::new();
-    let (blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
+    let (blockhash, fee_calculator, _) = rpc_client
+        .get_recent_blockhash_with_commitment(config.commitment)?
+        .value;
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(program_data.len())?;
     let ix = system_instruction::create_account(
         &config.signers[0].pubkey(),
@@ -1409,9 +1411,10 @@ fn process_deploy(
     )?;
 
     trace!("Creating program account");
-    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_commitment(
+    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &create_account_tx,
         config.commitment,
+        config.send_transaction_config,
     );
     log_instruction_custom_error::<SystemError>(result, &config).map_err(|_| {
         CliError::DynamicProgramError("Program account allocation failed".to_string())

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -497,6 +497,7 @@ pub struct CliConfig<'a> {
     pub verbose: bool,
     pub output_format: OutputFormat,
     pub commitment: CommitmentConfig,
+    pub send_transaction_config: RpcSendTransactionConfig,
 }
 
 impl CliConfig<'_> {
@@ -573,6 +574,15 @@ impl CliConfig<'_> {
             ))
         }
     }
+
+    pub fn recent_for_tests() -> Self {
+        let mut config = Self::default();
+        config.commitment = CommitmentConfig::recent();
+        config.send_transaction_config = RpcSendTransactionConfig {
+            skip_preflight: true,
+        };
+        config
+    }
 }
 
 impl Default for CliConfig<'_> {
@@ -591,6 +601,7 @@ impl Default for CliConfig<'_> {
             verbose: false,
             output_format: OutputFormat::Display,
             commitment: CommitmentConfig::default(),
+            send_transaction_config: RpcSendTransactionConfig::default(),
         }
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -512,6 +512,7 @@ pub struct CliConfig<'a> {
     pub rpc_client: Option<RpcClient>,
     pub verbose: bool,
     pub output_format: OutputFormat,
+    pub commitment: CommitmentConfig,
 }
 
 impl CliConfig<'_> {
@@ -605,6 +606,7 @@ impl Default for CliConfig<'_> {
             rpc_client: None,
             verbose: false,
             output_format: OutputFormat::Display,
+            commitment: CommitmentConfig::default(),
         }
     }
 }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -900,6 +900,7 @@ pub fn process_ping(
             &fee_calculator,
             &config.signers[0].pubkey(),
             build_message,
+            config.commitment,
         )?;
         let mut tx = Transaction::new_unsigned(message);
         tx.try_sign(&config.signers, blockhash)?;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -7,10 +7,7 @@ use crate::{
 use clap::{value_t, value_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand};
 use console::{style, Emoji};
 use solana_clap_utils::{
-    commitment::{commitment_arg, COMMITMENT_ARG},
-    input_parsers::*,
-    input_validators::*,
-    keypair::signer_from_path,
+    commitment::commitment_arg, input_parsers::*, input_validators::*, keypair::signer_from_path,
 };
 use solana_client::{
     pubsub_client::{PubsubClient, SlotInfoMessage},
@@ -296,13 +293,11 @@ pub fn parse_catchup(
 ) -> Result<CliCommandInfo, CliError> {
     let node_pubkey = pubkey_of_signer(matches, "node_pubkey", wallet_manager)?.unwrap();
     let node_json_rpc_url = value_t!(matches, "node_json_rpc_url", String).ok();
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
     let follow = matches.is_present("follow");
     Ok(CliCommandInfo {
         command: CliCommand::Catchup {
             node_pubkey,
             node_json_rpc_url,
-            commitment_config,
             follow,
         },
         signers: vec![],
@@ -322,14 +317,12 @@ pub fn parse_cluster_ping(
         None
     };
     let timeout = Duration::from_secs(value_t_or_exit!(matches, "timeout", u64));
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
     Ok(CliCommandInfo {
         command: CliCommand::Ping {
             lamports,
             interval,
             count,
             timeout,
-            commitment_config,
         },
         signers: vec![signer_from_path(
             matches,
@@ -348,32 +341,28 @@ pub fn parse_get_block_time(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, 
     })
 }
 
-pub fn parse_get_epoch_info(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
+pub fn parse_get_epoch(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     Ok(CliCommandInfo {
-        command: CliCommand::GetEpochInfo { commitment_config },
+        command: CliCommand::GetEpoch,
         signers: vec![],
     })
 }
 
-pub fn parse_get_slot(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
+pub fn parse_get_epoch_info(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     Ok(CliCommandInfo {
-        command: CliCommand::GetSlot { commitment_config },
+        command: CliCommand::GetEpochInfo,
         signers: vec![],
     })
 }
 
-pub fn parse_get_epoch(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
+pub fn parse_get_slot(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     Ok(CliCommandInfo {
-        command: CliCommand::GetEpoch { commitment_config },
+        command: CliCommand::GetSlot,
         signers: vec![],
     })
 }
 
 pub fn parse_largest_accounts(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
     let filter = if matches.is_present("circulating") {
         Some(RpcLargestAccountsFilter::Circulating)
     } else if matches.is_present("non_circulating") {
@@ -382,38 +371,29 @@ pub fn parse_largest_accounts(matches: &ArgMatches<'_>) -> Result<CliCommandInfo
         None
     };
     Ok(CliCommandInfo {
-        command: CliCommand::LargestAccounts {
-            commitment_config,
-            filter,
-        },
+        command: CliCommand::LargestAccounts { filter },
         signers: vec![],
     })
 }
 
 pub fn parse_supply(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
     let print_accounts = matches.is_present("print_accounts");
     Ok(CliCommandInfo {
-        command: CliCommand::Supply {
-            commitment_config,
-            print_accounts,
-        },
+        command: CliCommand::Supply { print_accounts },
         signers: vec![],
     })
 }
 
-pub fn parse_total_supply(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
+pub fn parse_total_supply(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     Ok(CliCommandInfo {
-        command: CliCommand::TotalSupply { commitment_config },
+        command: CliCommand::TotalSupply,
         signers: vec![],
     })
 }
 
-pub fn parse_get_transaction_count(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
+pub fn parse_get_transaction_count(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     Ok(CliCommandInfo {
-        command: CliCommand::GetTransactionCount { commitment_config },
+        command: CliCommand::GetTransactionCount,
         signers: vec![],
     })
 }
@@ -437,13 +417,9 @@ pub fn parse_show_stakes(
 
 pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let use_lamports_unit = matches.is_present("lamports");
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
 
     Ok(CliCommandInfo {
-        command: CliCommand::ShowValidators {
-            use_lamports_unit,
-            commitment_config,
-        },
+        command: CliCommand::ShowValidators { use_lamports_unit },
         signers: vec![],
     })
 }
@@ -468,9 +444,9 @@ pub fn parse_transaction_history(
 
 pub fn process_catchup(
     rpc_client: &RpcClient,
+    config: &CliConfig,
     node_pubkey: &Pubkey,
     node_json_rpc_url: &Option<String>,
-    commitment_config: CommitmentConfig,
     follow: bool,
 ) -> ProcessResult {
     let sleep_interval = 5;
@@ -519,8 +495,8 @@ pub fn process_catchup(
     let mut previous_rpc_slot = std::u64::MAX;
     let mut previous_slot_distance = 0;
     loop {
-        let rpc_slot = rpc_client.get_slot_with_commitment(commitment_config)?;
-        let node_slot = node_client.get_slot_with_commitment(commitment_config)?;
+        let rpc_slot = rpc_client.get_slot_with_commitment(config.commitment)?;
+        let node_slot = node_client.get_slot_with_commitment(config.commitment)?;
         if !follow && node_slot > std::cmp::min(previous_rpc_slot, rpc_slot) {
             progress_bar.finish_and_clear();
             return Ok(format!(
@@ -653,13 +629,14 @@ pub fn process_get_block_time(
     Ok(config.output_format.formatted_string(&block_time))
 }
 
-pub fn process_get_epoch_info(
-    rpc_client: &RpcClient,
-    config: &CliConfig,
-    commitment_config: CommitmentConfig,
-) -> ProcessResult {
+pub fn process_get_epoch(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+    let epoch_info = rpc_client.get_epoch_info_with_commitment(config.commitment)?;
+    Ok(epoch_info.epoch.to_string())
+}
+
+pub fn process_get_epoch_info(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
     let epoch_info: CliEpochInfo = rpc_client
-        .get_epoch_info_with_commitment(commitment_config)?
+        .get_epoch_info_with_commitment(config.commitment)?
         .into();
     Ok(config.output_format.formatted_string(&epoch_info))
 }
@@ -669,20 +646,9 @@ pub fn process_get_genesis_hash(rpc_client: &RpcClient) -> ProcessResult {
     Ok(genesis_hash.to_string())
 }
 
-pub fn process_get_slot(
-    rpc_client: &RpcClient,
-    commitment_config: CommitmentConfig,
-) -> ProcessResult {
-    let slot = rpc_client.get_slot_with_commitment(commitment_config)?;
+pub fn process_get_slot(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+    let slot = rpc_client.get_slot_with_commitment(config.commitment)?;
     Ok(slot.to_string())
-}
-
-pub fn process_get_epoch(
-    rpc_client: &RpcClient,
-    commitment_config: CommitmentConfig,
-) -> ProcessResult {
-    let epoch_info = rpc_client.get_epoch_info_with_commitment(commitment_config)?;
-    Ok(epoch_info.epoch.to_string())
 }
 
 pub fn parse_show_block_production(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
@@ -849,12 +815,11 @@ pub fn process_show_block_production(
 pub fn process_largest_accounts(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    commitment_config: CommitmentConfig,
     filter: Option<RpcLargestAccountsFilter>,
 ) -> ProcessResult {
     let accounts = rpc_client
         .get_largest_accounts_with_config(RpcLargestAccountsConfig {
-            commitment: Some(commitment_config),
+            commitment: Some(config.commitment),
             filter,
         })?
         .value;
@@ -865,28 +830,21 @@ pub fn process_largest_accounts(
 pub fn process_supply(
     rpc_client: &RpcClient,
     config: &CliConfig,
-    commitment_config: CommitmentConfig,
     print_accounts: bool,
 ) -> ProcessResult {
-    let supply_response = rpc_client.supply_with_commitment(commitment_config)?;
+    let supply_response = rpc_client.supply_with_commitment(config.commitment)?;
     let mut supply: CliSupply = supply_response.value.into();
     supply.print_accounts = print_accounts;
     Ok(config.output_format.formatted_string(&supply))
 }
 
-pub fn process_total_supply(
-    rpc_client: &RpcClient,
-    commitment_config: CommitmentConfig,
-) -> ProcessResult {
-    let total_supply = rpc_client.total_supply_with_commitment(commitment_config)?;
+pub fn process_total_supply(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+    let total_supply = rpc_client.total_supply_with_commitment(config.commitment)?;
     Ok(format!("{} SOL", lamports_to_sol(total_supply)))
 }
 
-pub fn process_get_transaction_count(
-    rpc_client: &RpcClient,
-    commitment_config: CommitmentConfig,
-) -> ProcessResult {
-    let transaction_count = rpc_client.get_transaction_count_with_commitment(commitment_config)?;
+pub fn process_get_transaction_count(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+    let transaction_count = rpc_client.get_transaction_count_with_commitment(config.commitment)?;
     Ok(transaction_count.to_string())
 }
 
@@ -897,7 +855,6 @@ pub fn process_ping(
     interval: &Duration,
     count: &Option<u64>,
     timeout: &Duration,
-    commitment_config: CommitmentConfig,
 ) -> ProcessResult {
     println_name_value("Source Account:", &config.signers[0].pubkey().to_string());
     println!();
@@ -952,7 +909,7 @@ pub fn process_ping(
                 let transaction_sent = Instant::now();
                 loop {
                     let signature_status = rpc_client
-                        .get_signature_status_with_commitment(&signature, commitment_config)?;
+                        .get_signature_status_with_commitment(&signature, config.commitment)?;
                     let elapsed_time = Instant::now().duration_since(transaction_sent);
                     if let Some(transaction_status) = signature_status {
                         match transaction_status {
@@ -1235,10 +1192,9 @@ pub fn process_show_validators(
     rpc_client: &RpcClient,
     config: &CliConfig,
     use_lamports_unit: bool,
-    commitment_config: CommitmentConfig,
 ) -> ProcessResult {
-    let epoch_info = rpc_client.get_epoch_info_with_commitment(commitment_config)?;
-    let vote_accounts = rpc_client.get_vote_accounts_with_commitment(commitment_config)?;
+    let epoch_info = rpc_client.get_epoch_info_with_commitment(config.commitment)?;
+    let vote_accounts = rpc_client.get_vote_accounts_with_commitment(config.commitment)?;
     let total_active_stake = vote_accounts
         .current
         .iter()
@@ -1379,15 +1335,24 @@ mod tests {
             }
         );
 
+        let test_get_epoch = test_commands
+            .clone()
+            .get_matches_from(vec!["test", "epoch"]);
+        assert_eq!(
+            parse_command(&test_get_epoch, &default_keypair_file, &mut None).unwrap(),
+            CliCommandInfo {
+                command: CliCommand::GetEpoch,
+                signers: vec![],
+            }
+        );
+
         let test_get_epoch_info = test_commands
             .clone()
             .get_matches_from(vec!["test", "epoch-info"]);
         assert_eq!(
             parse_command(&test_get_epoch_info, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::GetEpochInfo {
-                    commitment_config: CommitmentConfig::recent(),
-                },
+                command: CliCommand::GetEpochInfo,
                 signers: vec![],
             }
         );
@@ -1407,22 +1372,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_get_slot, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::GetSlot {
-                    commitment_config: CommitmentConfig::recent(),
-                },
-                signers: vec![],
-            }
-        );
-
-        let test_get_epoch = test_commands
-            .clone()
-            .get_matches_from(vec!["test", "epoch"]);
-        assert_eq!(
-            parse_command(&test_get_epoch, &default_keypair_file, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::GetEpoch {
-                    commitment_config: CommitmentConfig::recent(),
-                },
+                command: CliCommand::GetSlot,
                 signers: vec![],
             }
         );
@@ -1433,9 +1383,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_total_supply, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::TotalSupply {
-                    commitment_config: CommitmentConfig::recent(),
-                },
+                command: CliCommand::TotalSupply,
                 signers: vec![],
             }
         );
@@ -1446,9 +1394,7 @@ mod tests {
         assert_eq!(
             parse_command(&test_transaction_count, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
-                command: CliCommand::GetTransactionCount {
-                    commitment_config: CommitmentConfig::recent(),
-                },
+                command: CliCommand::GetTransactionCount,
                 signers: vec![],
             }
         );
@@ -1473,7 +1419,6 @@ mod tests {
                     interval: Duration::from_secs(1),
                     count: Some(2),
                     timeout: Duration::from_secs(3),
-                    commitment_config: CommitmentConfig::max(),
                 },
                 signers: vec![default_keypair.into()],
             }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,7 @@ use solana_cli::{
     display::{println_name_value, println_name_value_or},
 };
 use solana_cli_config::{Config, CONFIG_FILE};
+use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use std::{error, sync::Arc};
 
@@ -154,6 +155,7 @@ pub fn parse_args<'a>(
             verbose: matches.is_present("verbose"),
             output_format,
             commitment,
+            send_transaction_config: RpcSendTransactionConfig::default(),
         },
         signers,
     ))

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,8 @@ use clap::{crate_description, crate_name, AppSettings, Arg, ArgGroup, ArgMatches
 use console::style;
 
 use solana_clap_utils::{
-    input_validators::is_url, keypair::SKIP_SEED_PHRASE_VALIDATION_ARG, DisplayError,
+    commitment::COMMITMENT_ARG, input_parsers::commitment_of, input_validators::is_url,
+    keypair::SKIP_SEED_PHRASE_VALIDATION_ARG, DisplayError,
 };
 use solana_cli::{
     cli::{app, parse_command, process_command, CliCommandInfo, CliConfig, CliSigners},
@@ -136,6 +137,12 @@ pub fn parse_args<'a>(
         })
         .unwrap_or(OutputFormat::Display);
 
+    let commitment = matches
+        .subcommand_name()
+        .and_then(|name| matches.subcommand_matches(name))
+        .and_then(|sub_matches| commitment_of(sub_matches, COMMITMENT_ARG.long))
+        .unwrap_or_default();
+
     Ok((
         CliConfig {
             command,
@@ -146,6 +153,7 @@ pub fn parse_args<'a>(
             rpc_client: None,
             verbose: matches.is_present("verbose"),
             output_format,
+            commitment,
         },
         signers,
     ))

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1,12 +1,12 @@
 use crate::{
-    checks::{check_account_for_fee, check_unique_pubkeys},
+    checks::{check_account_for_fee_with_commitment, check_unique_pubkeys},
     cli::{
         fee_payer_arg, generate_unique_signers, log_instruction_custom_error, nonce_authority_arg,
         return_signers, CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult,
         SignerIndex, FEE_PAYER_ARG,
     },
     cli_output::{CliStakeHistory, CliStakeHistoryEntry, CliStakeState, CliStakeType},
-    nonce::{check_nonce_account, nonce_arg, NONCE_ARG, NONCE_AUTHORITY_ARG},
+    nonce::{self, check_nonce_account, nonce_arg, NONCE_ARG, NONCE_AUTHORITY_ARG},
     offline::{blockhash_query::BlockhashQuery, *},
     spend_utils::{resolve_spend_tx_and_check_account_balances, SpendAmount},
 };
@@ -934,7 +934,8 @@ pub fn process_create_stake_account(
         }
 
         if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
+            let nonce_account =
+                nonce::get_account_with_commitment(rpc_client, nonce_account, config.commitment)?;
             check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
     }
@@ -945,7 +946,11 @@ pub fn process_create_stake_account(
         return_signers(&tx, &config)
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<SystemError>(result, &config)
     }
 }
@@ -1001,16 +1006,22 @@ pub fn process_stake_authorize(
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
+            let nonce_account =
+                nonce::get_account_with_commitment(rpc_client, nonce_account, config.commitment)?;
             check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
-        check_account_for_fee(
+        check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
             &fee_calculator,
             &tx.message,
+            config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -1055,16 +1066,22 @@ pub fn process_deactivate_stake_account(
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
+            let nonce_account =
+                nonce::get_account_with_commitment(rpc_client, nonce_account, config.commitment)?;
             check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
-        check_account_for_fee(
+        check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
             &fee_calculator,
             &tx.message,
+            config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -1118,16 +1135,22 @@ pub fn process_withdraw_stake(
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
+            let nonce_account =
+                nonce::get_account_with_commitment(rpc_client, nonce_account, config.commitment)?;
             check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
-        check_account_for_fee(
+        check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
             &fee_calculator,
             &tx.message,
+            config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<SystemError>(result, &config)
     }
 }
@@ -1252,16 +1275,22 @@ pub fn process_split_stake(
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
+            let nonce_account =
+                nonce::get_account_with_commitment(rpc_client, nonce_account, config.commitment)?;
             check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
-        check_account_for_fee(
+        check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
             &fee_calculator,
             &tx.message,
+            config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -1345,16 +1374,22 @@ pub fn process_merge_stake(
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
+            let nonce_account =
+                nonce::get_account_with_commitment(rpc_client, nonce_account, config.commitment)?;
             check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
-        check_account_for_fee(
+        check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
             &fee_calculator,
             &tx.message,
+            config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -1402,16 +1437,22 @@ pub fn process_stake_set_lockup(
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
+            let nonce_account =
+                nonce::get_account_with_commitment(rpc_client, nonce_account, config.commitment)?;
             check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
-        check_account_for_fee(
+        check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
             &fee_calculator,
             &tx.message,
+            config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }
@@ -1599,14 +1640,23 @@ pub fn process_delegate_stake(
     if !sign_only {
         // Sanity check the vote account to ensure it is attached to a validator that has recently
         // voted at the tip of the ledger
-        let vote_account_data = rpc_client
-            .get_account_data(vote_account_pubkey)
+        let vote_account = rpc_client
+            .get_account_with_commitment(vote_account_pubkey, config.commitment)
             .map_err(|_| {
                 CliError::RpcRequestError(format!(
                     "Vote account not found: {}",
                     vote_account_pubkey
                 ))
             })?;
+        let vote_account_data = if let Some(account) = vote_account.value {
+            account.data
+        } else {
+            return Err(CliError::RpcRequestError(format!(
+                "Vote account not found: {}",
+                vote_account_pubkey
+            ))
+            .into());
+        };
 
         let vote_state = VoteState::deserialize(&vote_account_data).map_err(|_| {
             CliError::RpcRequestError(
@@ -1672,16 +1722,22 @@ pub fn process_delegate_stake(
     } else {
         tx.try_sign(&config.signers, recent_blockhash)?;
         if let Some(nonce_account) = &nonce_account {
-            let nonce_account = rpc_client.get_account(nonce_account)?;
+            let nonce_account =
+                nonce::get_account_with_commitment(rpc_client, nonce_account, config.commitment)?;
             check_nonce_account(&nonce_account, &nonce_authority.pubkey(), &recent_blockhash)?;
         }
-        check_account_for_fee(
+        check_account_for_fee_with_commitment(
             rpc_client,
             &tx.message.account_keys[0],
             &fee_calculator,
             &tx.message,
+            config.commitment,
         )?;
-        let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
+        let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
+            &tx,
+            config.commitment,
+            config.send_transaction_config,
+        );
         log_instruction_custom_error::<StakeError>(result, &config)
     }
 }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -896,7 +896,7 @@ pub fn process_create_stake_account(
     };
 
     let (recent_blockhash, fee_calculator) =
-        blockhash_query.get_blockhash_and_fee_calculator(rpc_client)?;
+        blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
 
     let (message, lamports) = resolve_spend_tx_and_check_account_balances(
         rpc_client,
@@ -906,6 +906,7 @@ pub fn process_create_stake_account(
         &from.pubkey(),
         &fee_payer.pubkey(),
         build_message,
+        config.commitment,
     )?;
 
     if !sign_only {
@@ -977,7 +978,7 @@ pub fn process_stake_authorize(
     }
 
     let (recent_blockhash, fee_calculator) =
-        blockhash_query.get_blockhash_and_fee_calculator(rpc_client)?;
+        blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
 
     let nonce_authority = config.signers[nonce_authority];
     let fee_payer = config.signers[fee_payer];
@@ -1027,7 +1028,7 @@ pub fn process_deactivate_stake_account(
     fee_payer: SignerIndex,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
-        blockhash_query.get_blockhash_and_fee_calculator(rpc_client)?;
+        blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
     let stake_authority = config.signers[stake_authority];
     let ixs = vec![stake_instruction::deactivate_stake(
         stake_account_pubkey,
@@ -1084,7 +1085,7 @@ pub fn process_withdraw_stake(
     fee_payer: SignerIndex,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
-        blockhash_query.get_blockhash_and_fee_calculator(rpc_client)?;
+        blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
     let withdraw_authority = config.signers[withdraw_authority];
     let custodian = custodian.map(|index| config.signers[index]);
 
@@ -1211,7 +1212,7 @@ pub fn process_split_stake(
     }
 
     let (recent_blockhash, fee_calculator) =
-        blockhash_query.get_blockhash_and_fee_calculator(rpc_client)?;
+        blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
 
     let ixs = if let Some(seed) = split_stake_account_seed {
         stake_instruction::split_with_seed(
@@ -1316,7 +1317,7 @@ pub fn process_merge_stake(
     }
 
     let (recent_blockhash, fee_calculator) =
-        blockhash_query.get_blockhash_and_fee_calculator(rpc_client)?;
+        blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
 
     let ixs = stake_instruction::merge(
         &stake_account_pubkey,
@@ -1372,7 +1373,7 @@ pub fn process_stake_set_lockup(
     fee_payer: SignerIndex,
 ) -> ProcessResult {
     let (recent_blockhash, fee_calculator) =
-        blockhash_query.get_blockhash_and_fee_calculator(rpc_client)?;
+        blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
     let custodian = config.signers[custodian];
 
     let ixs = vec![stake_instruction::set_lockup(
@@ -1643,7 +1644,7 @@ pub fn process_delegate_stake(
     }
 
     let (recent_blockhash, fee_calculator) =
-        blockhash_query.get_blockhash_and_fee_calculator(rpc_client)?;
+        blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
 
     let ixs = vec![stake_instruction::delegate_stake(
         stake_account_pubkey,

--- a/cli/src/test_utils.rs
+++ b/cli/src/test_utils.rs
@@ -1,10 +1,13 @@
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 use std::{thread::sleep, time::Duration};
 
-pub fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
+pub fn check_recent_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
     (0..5).for_each(|tries| {
-        let balance = client.get_balance(pubkey).unwrap();
+        let balance = client
+            .get_balance_with_commitment(pubkey, CommitmentConfig::recent())
+            .unwrap()
+            .value;
         if balance == expected_balance {
             return;
         }
@@ -13,4 +16,14 @@ pub fn check_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey)
         }
         sleep(Duration::from_millis(500));
     });
+}
+
+pub fn check_ready(rpc_client: &RpcClient) {
+    while rpc_client
+        .get_slot_with_commitment(CommitmentConfig::recent())
+        .unwrap()
+        < 5
+    {
+        sleep(Duration::from_millis(400));
+    }
 }

--- a/cli/src/test_utils.rs
+++ b/cli/src/test_utils.rs
@@ -1,5 +1,5 @@
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
+use solana_sdk::{clock::DEFAULT_MS_PER_SLOT, commitment_config::CommitmentConfig, pubkey::Pubkey};
 use std::{thread::sleep, time::Duration};
 
 pub fn check_recent_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
@@ -24,6 +24,6 @@ pub fn check_ready(rpc_client: &RpcClient) {
         .unwrap()
         < 5
     {
-        sleep(Duration::from_millis(400));
+        sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));
     }
 }

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -372,6 +372,7 @@ pub fn process_set_validator_info(
         &fee_calculator,
         &config.signers[0].pubkey(),
         build_message,
+        config.commitment,
     )?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&signers, recent_blockhash)?;

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -493,6 +493,7 @@ pub fn process_create_vote_account(
         &fee_calculator,
         &config.signers[0].pubkey(),
         build_message,
+        config.commitment,
     )?;
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -8,11 +8,7 @@ use crate::{
     spend_utils::{resolve_spend_tx_and_check_account_balance, SpendAmount},
 };
 use clap::{value_t_or_exit, App, Arg, ArgMatches, SubCommand};
-use solana_clap_utils::{
-    commitment::{commitment_arg, COMMITMENT_ARG},
-    input_parsers::*,
-    input_validators::*,
-};
+use solana_clap_utils::{commitment::commitment_arg, input_parsers::*, input_validators::*};
 use solana_client::rpc_client::RpcClient;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
@@ -373,12 +369,10 @@ pub fn parse_vote_get_account_command(
     let vote_account_pubkey =
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
     let use_lamports_unit = matches.is_present("lamports");
-    let commitment_config = commitment_of(matches, COMMITMENT_ARG.long).unwrap();
     Ok(CliCommandInfo {
         command: CliCommand::ShowVoteAccount {
             pubkey: vote_account_pubkey,
             use_lamports_unit,
-            commitment_config,
         },
         signers: vec![],
     })
@@ -639,10 +633,9 @@ pub fn process_show_vote_account(
     config: &CliConfig,
     vote_account_pubkey: &Pubkey,
     use_lamports_unit: bool,
-    commitment_config: CommitmentConfig,
 ) -> ProcessResult {
     let (vote_account, vote_state) =
-        get_vote_account(rpc_client, vote_account_pubkey, commitment_config)?;
+        get_vote_account(rpc_client, vote_account_pubkey, config.commitment)?;
 
     let epoch_schedule = rpc_client.get_epoch_schedule()?;
 

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1,5 +1,5 @@
 use crate::{
-    checks::{check_account_for_fee, check_unique_pubkeys},
+    checks::{check_account_for_fee_with_commitment, check_unique_pubkeys},
     cli::{
         generate_unique_signers, log_instruction_custom_error, CliCommand, CliCommandInfo,
         CliConfig, CliError, ProcessResult, SignerIndex,
@@ -543,11 +543,12 @@ pub fn process_vote_authorize(
     let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
-    check_account_for_fee(
+    check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
+        config.commitment,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,
@@ -582,11 +583,12 @@ pub fn process_vote_update_validator(
     let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
-    check_account_for_fee(
+    check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
+        config.commitment,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,
@@ -615,11 +617,12 @@ pub fn process_vote_update_commission(
     let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
-    check_account_for_fee(
+    check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
         &fee_calculator,
         &tx.message,
+        config.commitment,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &tx,
@@ -743,11 +746,12 @@ pub fn process_withdraw_from_vote_account(
     let message = Message::new_with_payer(&[ix], Some(&config.signers[0].pubkey()));
     let mut transaction = Transaction::new_unsigned(message);
     transaction.try_sign(&config.signers, recent_blockhash)?;
-    check_account_for_fee(
+    check_account_for_fee_with_commitment(
         rpc_client,
         &config.signers[0].pubkey(),
         &fee_calculator,
         &transaction.message,
+        config.commitment,
     )?;
     let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
         &transaction,

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -17,7 +17,7 @@ use solana_sdk::{
         Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT,
         MAX_HASH_AGE_IN_SECONDS,
     },
-    commitment_config::CommitmentConfig,
+    commitment_config::{CommitmentConfig, CommitmentLevel},
     epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -831,6 +831,19 @@ impl RpcClient {
     ) -> ClientResult<Signature> {
         self.send_and_confirm_transaction_with_spinner_and_config(
             transaction,
+            CommitmentConfig::default(),
+            RpcSendTransactionConfig::default(),
+        )
+    }
+
+    pub fn send_and_confirm_transaction_with_spinner_and_commitment(
+        &self,
+        transaction: &Transaction,
+        commitment: CommitmentConfig,
+    ) -> ClientResult<Signature> {
+        self.send_and_confirm_transaction_with_spinner_and_config(
+            transaction,
+            commitment,
             RpcSendTransactionConfig::default(),
         )
     }
@@ -838,8 +851,13 @@ impl RpcClient {
     pub fn send_and_confirm_transaction_with_spinner_and_config(
         &self,
         transaction: &Transaction,
+        commitment: CommitmentConfig,
         config: RpcSendTransactionConfig,
     ) -> ClientResult<Signature> {
+        let desired_confirmations = match commitment.commitment {
+            CommitmentLevel::Max | CommitmentLevel::Root => MAX_LOCKOUT_HISTORY + 1,
+            _ => 1,
+        };
         let mut confirmations = 0;
 
         let progress_bar = new_spinner_progress_bar();
@@ -848,9 +866,7 @@ impl RpcClient {
         let signature = loop {
             progress_bar.set_message(&format!(
                 "[{}/{}] Finalizing transaction {}",
-                confirmations,
-                MAX_LOCKOUT_HISTORY + 1,
-                transaction.signatures[0],
+                confirmations, desired_confirmations, transaction.signatures[0],
             ));
             let mut status_retries = 15;
             let (signature, status) = loop {
@@ -904,17 +920,30 @@ impl RpcClient {
         };
         let now = Instant::now();
         loop {
-            // Return when default (max) commitment is reached
-            // Failed transactions have already been eliminated, `is_some` check is sufficient
-            if self.get_signature_status(&signature)?.is_some() {
-                progress_bar.set_message("Transaction confirmed");
-                progress_bar.finish_and_clear();
-                return Ok(signature);
+            match commitment.commitment {
+                CommitmentLevel::Max | CommitmentLevel::Root =>
+                // Return when default (max) commitment is reached
+                // Failed transactions have already been eliminated, `is_some` check is sufficient
+                {
+                    if self.get_signature_status(&signature)?.is_some() {
+                        progress_bar.set_message("Transaction confirmed");
+                        progress_bar.finish_and_clear();
+                        return Ok(signature);
+                    }
+                }
+                _ => {
+                    // Return when one confirmation has been reached
+                    if confirmations >= desired_confirmations {
+                        progress_bar.set_message("Transaction reached commitment");
+                        progress_bar.finish_and_clear();
+                        return Ok(signature);
+                    }
+                }
             }
             progress_bar.set_message(&format!(
                 "[{}/{}] Finalizing transaction {}",
                 confirmations + 1,
-                MAX_LOCKOUT_HISTORY + 1,
+                desired_confirmations,
                 signature,
             ));
             sleep(Duration::from_millis(500));

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -870,7 +870,7 @@ impl RpcClient {
             ));
             let mut status_retries = 15;
             let (signature, status) = loop {
-                let signature = self.send_transaction_with_config(transaction, config.clone())?;
+                let signature = self.send_transaction_with_config(transaction, config)?;
 
                 // Get recent commitment in order to count confirmations for successful transactions
                 let status = self

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -6,7 +6,7 @@ pub struct RpcSignatureStatusConfig {
     pub search_transaction_history: bool,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcSendTransactionConfig {
     pub skip_preflight: bool,


### PR DESCRIPTION
#### Problem
The Cli integrations tests take way too long. Those tests are testing cluster finality over and over again, which doesn't improve CLI quality at all.

#### Summary of Changes
- Add commitment to CliConfig struct to allow integration tests to be configured with Recent commitment; this also simplifies various CliCommands that expose the commitment param
- Use `send_and_confirm_transaction_with_spinner_and_config` in Cli commands so that integration tests don't wait for finality, and bypass preflight checkes
- Add various `with_commitment` helper functions to keep commitment consistent across all integration-test queries
- Also A-Z a few of the cluster-query methods

Before this change:
```
$ cd cli && cargo test
real	14m32.731s
user	137m41.153s
sys	9m28.251s
```

After:
```
$ cd cli && cargo test
real	1m17.568s
user	10m57.484s
sys	1m14.846s
```

Fixes #9225
CC: @garious 
