### PR TITLE
Carve a solana-program-interface crate out of solana-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,6 +4441,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-program-interface"
+version = "1.3.0"
+dependencies = [
+ "bincode",
+ "bs58 0.3.1",
+ "hex 0.4.2",
+ "num-derive 0.3.0",
+ "num-traits",
+ "rustc_version",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "thiserror",
+]
+
+[[package]]
 name = "solana-ramp-tps"
 version = "1.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "metrics",
     "net-shaper",
     "notifier",
+    "program-interface",
     "programs/bpf_loader",
     "programs/budget",
     "programs/btc_spv",

--- a/program-interface/.gitignore
+++ b/program-interface/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/farf/

--- a/program-interface/Cargo.toml
+++ b/program-interface/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "solana-program-interface"
+version = "1.3.0"
+description = "Solana Program Interface"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+homepage = "https://solana.com/"
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+bincode = "1.2.1"
+bs58 = "0.3.1"
+hex = "0.4.2"
+num-derive = { version = "0.3" }
+num-traits = { version = "0.2" }
+serde = "1.0.112"
+serde_bytes = "0.11"
+serde_derive = "1.0.103"
+thiserror = "1.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[build-dependencies]
+rustc_version = "0.2"

--- a/program-interface/src/account_info.rs
+++ b/program-interface/src/account_info.rs
@@ -1,0 +1,156 @@
+use crate::{clock::Epoch, program_error::ProgramError, pubkey::Pubkey};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    cmp, fmt,
+    rc::Rc,
+};
+
+/// Account information
+#[derive(Clone)]
+pub struct AccountInfo<'a> {
+    /// Public key of the account
+    pub key: &'a Pubkey,
+    // Was the transaction signed by this account's public key?
+    pub is_signer: bool,
+    // Is the account writable?
+    pub is_writable: bool,
+    /// Account members that are mutable by the program
+    pub lamports: Rc<RefCell<&'a mut u64>>,
+    /// Account members that are mutable by the program
+    pub data: Rc<RefCell<&'a mut [u8]>>,
+    /// Program that owns this account
+    pub owner: &'a Pubkey,
+    /// This account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+    /// The epoch at which this account will next owe rent
+    pub rent_epoch: Epoch,
+}
+
+impl<'a> fmt::Debug for AccountInfo<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data_len = cmp::min(64, self.data_len());
+        let data_str = if data_len > 0 {
+            format!(
+                " data: {} ...",
+                hex::encode(self.data.borrow()[..data_len].to_vec())
+            )
+        } else {
+            "".to_string()
+        };
+        write!(
+            f,
+            "AccountInfo {{ key: {} owner: {} is_signer: {} is_writable: {} executable: {} rent_epoch: {} lamports: {} data.len: {} {} }}",
+            self.key,
+            self.owner,
+            self.is_signer,
+            self.is_writable,
+            self.executable,
+            self.rent_epoch,
+            self.lamports(),
+            self.data_len(),
+            data_str,
+        )
+    }
+}
+
+impl<'a> AccountInfo<'a> {
+    pub fn signer_key(&self) -> Option<&Pubkey> {
+        if self.is_signer {
+            Some(self.key)
+        } else {
+            None
+        }
+    }
+
+    pub fn unsigned_key(&self) -> &Pubkey {
+        self.key
+    }
+
+    pub fn lamports(&self) -> u64 {
+        **self.lamports.borrow()
+    }
+
+    pub fn try_lamports(&self) -> Result<u64, ProgramError> {
+        Ok(**self.try_borrow_lamports()?)
+    }
+
+    pub fn data_len(&self) -> usize {
+        self.data.borrow().len()
+    }
+
+    pub fn try_data_len(&self) -> Result<usize, ProgramError> {
+        Ok(self.try_borrow_data()?.len())
+    }
+
+    pub fn data_is_empty(&self) -> bool {
+        self.data.borrow().is_empty()
+    }
+
+    pub fn try_data_is_empty(&self) -> Result<bool, ProgramError> {
+        Ok(self.try_borrow_data()?.is_empty())
+    }
+
+    pub fn try_borrow_lamports(&self) -> Result<Ref<&mut u64>, ProgramError> {
+        self.lamports
+            .try_borrow()
+            .map_err(|_| ProgramError::AccountBorrowFailed)
+    }
+
+    pub fn try_borrow_mut_lamports(&self) -> Result<RefMut<&'a mut u64>, ProgramError> {
+        self.lamports
+            .try_borrow_mut()
+            .map_err(|_| ProgramError::AccountBorrowFailed)
+    }
+
+    pub fn try_borrow_data(&self) -> Result<Ref<&mut [u8]>, ProgramError> {
+        self.data
+            .try_borrow()
+            .map_err(|_| ProgramError::AccountBorrowFailed)
+    }
+
+    pub fn try_borrow_mut_data(&self) -> Result<RefMut<&'a mut [u8]>, ProgramError> {
+        self.data
+            .try_borrow_mut()
+            .map_err(|_| ProgramError::AccountBorrowFailed)
+    }
+
+    pub fn new(
+        key: &'a Pubkey,
+        is_signer: bool,
+        is_writable: bool,
+        lamports: &'a mut u64,
+        data: &'a mut [u8],
+        owner: &'a Pubkey,
+        executable: bool,
+        rent_epoch: Epoch,
+    ) -> Self {
+        Self {
+            key,
+            is_signer,
+            is_writable,
+            lamports: Rc::new(RefCell::new(lamports)),
+            data: Rc::new(RefCell::new(data)),
+            owner,
+            executable,
+            rent_epoch,
+        }
+    }
+
+    pub fn deserialize_data<T: serde::de::DeserializeOwned>(&self) -> Result<T, bincode::Error> {
+        bincode::deserialize(&self.data.borrow())
+    }
+
+    pub fn serialize_data<T: serde::Serialize>(&mut self, state: &T) -> Result<(), bincode::Error> {
+        if bincode::serialized_size(state)? > self.data_len() as u64 {
+            return Err(Box::new(bincode::ErrorKind::SizeLimit));
+        }
+        bincode::serialize_into(&mut self.data.borrow_mut()[..], state)
+    }
+}
+
+/// Return the next AccountInfo or a NotEnoughAccountKeys error
+pub fn next_account_info<'a, 'b, I: Iterator<Item = &'a AccountInfo<'b>>>(
+    iter: &mut I,
+) -> Result<I::Item, ProgramError> {
+    iter.next().ok_or(ProgramError::NotEnoughAccountKeys)
+}

--- a/program-interface/src/clock.rs
+++ b/program-interface/src/clock.rs
@@ -1,0 +1,90 @@
+//! Provides information about the network's clock which is made up of ticks, slots, etc...
+
+// The default tick rate that the cluster attempts to achieve.  Note that the actual tick
+// rate at any given time should be expected to drift
+pub const DEFAULT_TICKS_PER_SECOND: u64 = 160;
+
+pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
+
+// At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
+// every 400 ms. A fast voting cadence ensures faster finality and convergence
+pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;
+
+// GCP n1-standard hardware and also a xeon e5-2520 v4 are about this rate of hashes/s
+pub const DEFAULT_HASHES_PER_SECOND: u64 = 2_000_000;
+
+// 1 Dev Epoch = 400 ms * 8192 ~= 55 minutes
+pub const DEFAULT_DEV_SLOTS_PER_EPOCH: u64 = 8192;
+
+pub const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
+pub const TICKS_PER_DAY: u64 = DEFAULT_TICKS_PER_SECOND * SECONDS_PER_DAY;
+
+// 1 Epoch ~= 2 days
+pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 2 * TICKS_PER_DAY / DEFAULT_TICKS_PER_SLOT;
+
+// leader schedule is governed by this
+pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
+
+pub const DEFAULT_MS_PER_SLOT: u64 = 1_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
+
+/// The time window of recent block hash values that the bank will track the signatures
+/// of over. Once the bank discards a block hash, it will reject any transactions that use
+/// that `recent_blockhash` in a transaction. Lowering this value reduces memory consumption,
+/// but requires clients to update its `recent_blockhash` more frequently. Raising the value
+/// lengthens the time a client must wait to be certain a missing transaction will
+/// not be processed by the network.
+pub const MAX_HASH_AGE_IN_SECONDS: usize = 120;
+
+// Number of maximum recent blockhashes (one blockhash per slot)
+pub const MAX_RECENT_BLOCKHASHES: usize =
+    MAX_HASH_AGE_IN_SECONDS * DEFAULT_TICKS_PER_SECOND as usize / DEFAULT_TICKS_PER_SLOT as usize;
+
+// The maximum age of a blockhash that will be accepted by the leader
+pub const MAX_PROCESSING_AGE: usize = MAX_RECENT_BLOCKHASHES / 2;
+
+/// This is maximum time consumed in forwarding a transaction from one node to next, before
+/// it can be processed in the target node
+pub const MAX_TRANSACTION_FORWARDING_DELAY_GPU: usize = 2;
+
+/// More delay is expected if CUDA is not enabled (as signature verification takes longer)
+pub const MAX_TRANSACTION_FORWARDING_DELAY: usize = 6;
+
+/// Slot is a unit of time given to a leader for encoding,
+///  is some some number of Ticks long.
+pub type Slot = u64;
+
+/// Epoch is a unit of time a given leader schedule is honored,
+///  some number of Slots.
+pub type Epoch = u64;
+
+/// SlotIndex is an index to the slots of a epoch
+pub type SlotIndex = u64;
+
+/// SlotCount is the number of slots in a epoch
+pub type SlotCount = u64;
+
+/// UnixTimestamp is an approximate measure of real-world time,
+/// expressed as Unix time (ie. seconds since the Unix epoch)
+pub type UnixTimestamp = i64;
+
+/// Clock represents network time.  Members of Clock start from 0 upon
+///  network boot.  The best way to map Clock to wallclock time is to use
+///  current Slot, as Epochs vary in duration (they start short and grow
+///  as the network progresses).
+///
+#[repr(C)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+pub struct Clock {
+    /// the current network/bank Slot
+    pub slot: Slot,
+    /// unused
+    pub unused: u64,
+    /// the bank Epoch
+    pub epoch: Epoch,
+    /// the future Epoch for which the leader schedule has
+    ///  most recently been calculated
+    pub leader_schedule_epoch: Epoch,
+    /// computed from genesis creation time and network time
+    ///  in slots, drifts!
+    pub unix_timestamp: UnixTimestamp,
+}

--- a/program-interface/src/decode_error.rs
+++ b/program-interface/src/decode_error.rs
@@ -1,0 +1,38 @@
+use num_traits::FromPrimitive;
+
+/// Allows custome errors to be decoded back to their original enum
+pub trait DecodeError<E> {
+    fn decode_custom_error_to_enum(custom: u32) -> Option<E>
+    where
+        E: FromPrimitive,
+    {
+        E::from_u32(custom)
+    }
+    fn type_of() -> &'static str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_derive::FromPrimitive;
+
+    #[test]
+    fn test_decode_custom_error_to_enum() {
+        #[derive(Debug, FromPrimitive, PartialEq)]
+        enum TestEnum {
+            A,
+            B,
+            C,
+        }
+        impl<T> DecodeError<T> for TestEnum {
+            fn type_of() -> &'static str {
+                "TestEnum"
+            }
+        }
+        assert_eq!(TestEnum::decode_custom_error_to_enum(0), Some(TestEnum::A));
+        assert_eq!(TestEnum::decode_custom_error_to_enum(1), Some(TestEnum::B));
+        assert_eq!(TestEnum::decode_custom_error_to_enum(2), Some(TestEnum::C));
+        let option: Option<TestEnum> = TestEnum::decode_custom_error_to_enum(3);
+        assert_eq!(option, None);
+    }
+}

--- a/program-interface/src/entrypoint.rs
+++ b/program-interface/src/entrypoint.rs
@@ -1,0 +1,135 @@
+//! @brief Solana Rust-based BPF program entry point
+
+extern crate alloc;
+use crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
+use alloc::vec::Vec;
+use std::{
+    cell::RefCell,
+    mem::size_of,
+    rc::Rc,
+    // Hide Result from bindgen gets confused about generics in non-generic type declarations
+    result::Result as ResultGeneric,
+    slice::{from_raw_parts, from_raw_parts_mut},
+};
+
+pub type ProgramResult = ResultGeneric<(), ProgramError>;
+
+/// User implemented function to process an instruction
+///
+/// program_id: Program ID of the currently executing program
+/// accounts: Accounts passed as part of the instruction
+/// instruction_data: Instruction data
+pub type ProcessInstruction =
+    fn(program_id: &Pubkey, accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult;
+
+/// Programs indicate success with a return value of 0
+pub const SUCCESS: u64 = 0;
+
+/// Declare the entry point of the program.
+///
+/// Deserialize the program input arguments and call
+/// the user defined `process_instruction` function.
+/// Users must call this macro otherwise an entry point for
+/// their program will not be created.
+#[macro_export]
+macro_rules! entrypoint {
+    ($process_instruction:ident) => {
+        /// # Safety
+        #[no_mangle]
+        pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
+            let (program_id, accounts, instruction_data) =
+                unsafe { $crate::entrypoint::deserialize(input) };
+            match $process_instruction(&program_id, &accounts, &instruction_data) {
+                Ok(()) => $crate::entrypoint::SUCCESS,
+                Err(error) => error.into(),
+            }
+        }
+    };
+}
+
+/// Deserialize the input arguments
+///
+/// # Safety
+#[allow(clippy::type_complexity)]
+pub unsafe fn deserialize<'a>(input: *mut u8) -> (&'a Pubkey, Vec<AccountInfo<'a>>, &'a [u8]) {
+    let mut offset: usize = 0;
+
+    // Number of accounts present
+
+    #[allow(clippy::cast_ptr_alignment)]
+    let num_accounts = *(input.add(offset) as *const u64) as usize;
+    offset += size_of::<u64>();
+
+    // Account Infos
+
+    let mut accounts = Vec::with_capacity(num_accounts);
+    for _ in 0..num_accounts {
+        let dup_info = *(input.add(offset) as *const u8);
+        offset += size_of::<u8>();
+        if dup_info == std::u8::MAX {
+            #[allow(clippy::cast_ptr_alignment)]
+            let is_signer = *(input.add(offset) as *const u8) != 0;
+            offset += size_of::<u8>();
+
+            #[allow(clippy::cast_ptr_alignment)]
+            let is_writable = *(input.add(offset) as *const u8) != 0;
+            offset += size_of::<u8>();
+
+            let key: &Pubkey = &*(input.add(offset) as *const Pubkey);
+            offset += size_of::<Pubkey>();
+
+            #[allow(clippy::cast_ptr_alignment)]
+            let lamports = Rc::new(RefCell::new(&mut *(input.add(offset) as *mut u64)));
+            offset += size_of::<u64>();
+
+            #[allow(clippy::cast_ptr_alignment)]
+            let data_len = *(input.add(offset) as *const u64) as usize;
+            offset += size_of::<u64>();
+
+            let data = Rc::new(RefCell::new({
+                from_raw_parts_mut(input.add(offset), data_len)
+            }));
+            offset += data_len;
+
+            let owner: &Pubkey = &*(input.add(offset) as *const Pubkey);
+            offset += size_of::<Pubkey>();
+
+            #[allow(clippy::cast_ptr_alignment)]
+            let executable = *(input.add(offset) as *const u8) != 0;
+            offset += size_of::<u8>();
+
+            #[allow(clippy::cast_ptr_alignment)]
+            let rent_epoch = *(input.add(offset) as *const u64);
+            offset += size_of::<u64>();
+
+            accounts.push(AccountInfo {
+                is_signer,
+                is_writable,
+                key,
+                lamports,
+                data,
+                owner,
+                executable,
+                rent_epoch,
+            });
+        } else {
+            // Duplicate account, clone the original
+            accounts.push(accounts[dup_info as usize].clone());
+        }
+    }
+
+    // Instruction data
+
+    #[allow(clippy::cast_ptr_alignment)]
+    let instruction_data_len = *(input.add(offset) as *const u64) as usize;
+    offset += size_of::<u64>();
+
+    let instruction_data = { from_raw_parts(input.add(offset), instruction_data_len) };
+    offset += instruction_data_len;
+
+    // Program Id
+
+    let program_id: &Pubkey = &*(input.add(offset) as *const Pubkey);
+
+    (program_id, accounts, instruction_data)
+}

--- a/program-interface/src/lib.rs
+++ b/program-interface/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod account_info;
+pub mod clock;
+pub mod decode_error;
+pub mod entrypoint;
+pub mod log;
+pub mod program_error;
+pub mod pubkey;
+pub mod sanitize;
+
+#[macro_use]
+extern crate serde_derive;

--- a/program-interface/src/log.rs
+++ b/program-interface/src/log.rs
@@ -1,0 +1,98 @@
+//! @brief Solana Rust-based BPF program logging
+
+use crate::{account_info::AccountInfo, pubkey::Pubkey};
+
+/// Prints a string
+/// There are two forms and are fast
+/// 1. Single string
+/// 2. 5 integers
+#[macro_export]
+macro_rules! info {
+    ($msg:expr) => {
+        $crate::log::sol_log($msg)
+    };
+    ($arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
+        $crate::log::sol_log_64(
+            $arg1 as u64,
+            $arg2 as u64,
+            $arg3 as u64,
+            $arg4 as u64,
+            $arg5 as u64,
+        )
+    }; // `format!()` is not supported yet, Issue #3099
+       // `format!()` incurs a very large runtime overhead so it should be used with care
+       // ($($arg:tt)*) => ($crate::log::sol_log(&format!($($arg)*)));
+}
+
+/// Prints a string to stdout
+///
+/// @param message - Message to print
+#[inline]
+pub fn sol_log(message: &str) {
+    unsafe {
+        sol_log_(message.as_ptr(), message.len() as u64);
+    }
+}
+extern "C" {
+    fn sol_log_(message: *const u8, len: u64);
+}
+
+/// Prints 64 bit values represented as hexadecimal to stdout
+///
+/// @param argx - integer arguments to print
+
+#[inline]
+pub fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+    unsafe {
+        sol_log_64_(arg1, arg2, arg3, arg4, arg5);
+    }
+}
+extern "C" {
+    fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64);
+}
+
+/// Prints the hexadecimal representation of a slice
+///
+/// @param slice - The array to print
+#[allow(dead_code)]
+pub fn sol_log_slice(slice: &[u8]) {
+    for (i, s) in slice.iter().enumerate() {
+        info!(0, 0, 0, i, *s);
+    }
+}
+
+/// Prints a pubkey
+pub trait Log {
+    fn log(&self);
+}
+impl Log for Pubkey {
+    fn log(&self) {
+        for (i, k) in self.to_bytes().iter().enumerate() {
+            info!(0, 0, 0, i, *k);
+        }
+    }
+}
+
+/// Prints the hexadecimal representation of the program's input parameters
+///
+/// @param ka - A pointer to an array of `AccountInfo` to print
+/// @param data - A pointer to the instruction data to print
+#[allow(dead_code)]
+pub fn sol_log_params(accounts: &[AccountInfo], data: &[u8]) {
+    for (i, account) in accounts.iter().enumerate() {
+        info!("AccountInfo");
+        info!(0, 0, 0, 0, i);
+        info!("- Is signer");
+        info!(0, 0, 0, 0, account.is_signer);
+        info!("- Key");
+        account.key.log();
+        info!("- Lamports");
+        info!(0, 0, 0, 0, account.lamports());
+        info!("- Account data length");
+        info!(0, 0, 0, 0, account.data_len());
+        info!("- Owner");
+        account.owner.log();
+    }
+    info!("Instruction data");
+    sol_log_slice(data);
+}

--- a/program-interface/src/program_error.rs
+++ b/program-interface/src/program_error.rs
@@ -1,0 +1,137 @@
+use crate::decode_error::DecodeError;
+use num_traits::FromPrimitive;
+use thiserror::Error;
+
+use crate::info;
+
+/// Reasons the program may fail
+#[derive(Clone, Debug, Deserialize, Eq, Error, PartialEq, Serialize)]
+pub enum ProgramError {
+    /// Allows on-chain programs to implement program-specific error types and see them returned
+    /// by the Solana runtime. A program-specific error may be any type that is represented as
+    /// or serialized to a u32 integer.
+    #[error("Custom program error: {0:#x}")]
+    Custom(u32),
+    #[error("The arguments provided to a program instruction where invalid")]
+    InvalidArgument,
+    #[error("An instruction's data contents was invalid")]
+    InvalidInstructionData,
+    #[error("An account's data contents was invalid")]
+    InvalidAccountData,
+    #[error("An account's data was too small")]
+    AccountDataTooSmall,
+    #[error("An account's balance was too small to complete the instruction")]
+    InsufficientFunds,
+    #[error("The account did not have the expected program id")]
+    IncorrectProgramId,
+    #[error("A signature was required but not found")]
+    MissingRequiredSignature,
+    #[error("An initialize instruction was sent to an account that has already been initialized")]
+    AccountAlreadyInitialized,
+    #[error("An attempt to operate on an account that hasn't been initialized")]
+    UninitializedAccount,
+    #[error("The instruction expected additional account keys")]
+    NotEnoughAccountKeys,
+    #[error("Failed to borrow a reference to account data, already borrowed")]
+    AccountBorrowFailed,
+}
+
+pub trait PrintProgramError {
+    fn print<E>(&self)
+    where
+        E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive;
+}
+
+impl PrintProgramError for ProgramError {
+    fn print<E>(&self)
+    where
+        E: 'static + std::error::Error + DecodeError<E> + PrintProgramError + FromPrimitive,
+    {
+        match self {
+            Self::Custom(error) => {
+                if let Some(custom_error) = E::decode_custom_error_to_enum(*error) {
+                    custom_error.print::<E>();
+                } else {
+                    info!("Error: Unknown");
+                }
+            }
+            Self::InvalidArgument => info!("Error: InvalidArgument"),
+            Self::InvalidInstructionData => info!("Error: InvalidInstructionData"),
+            Self::InvalidAccountData => info!("Error: InvalidAccountData"),
+            Self::AccountDataTooSmall => info!("Error: AccountDataTooSmall"),
+            Self::InsufficientFunds => info!("Error: InsufficientFunds"),
+            Self::IncorrectProgramId => info!("Error: IncorrectProgramId"),
+            Self::MissingRequiredSignature => info!("Error: MissingRequiredSignature"),
+            Self::AccountAlreadyInitialized => info!("Error: AccountAlreadyInitialized"),
+            Self::UninitializedAccount => info!("Error: UninitializedAccount"),
+            Self::NotEnoughAccountKeys => info!("Error: NotEnoughAccountKeys"),
+            Self::AccountBorrowFailed => info!("Error: AccountBorrowFailed"),
+        }
+    }
+}
+
+/// Builtin return values occupy the upper 32 bits
+const BUILTIN_BIT_SHIFT: usize = 32;
+macro_rules! to_builtin {
+    ($error:expr) => {
+        ($error as u64) << BUILTIN_BIT_SHIFT
+    };
+}
+
+const CUSTOM_ZERO: u64 = to_builtin!(1);
+const INVALID_ARGUMENT: u64 = to_builtin!(2);
+const INVALID_INSTRUCTION_DATA: u64 = to_builtin!(3);
+const INVALID_ACCOUNT_DATA: u64 = to_builtin!(4);
+const ACCOUNT_DATA_TOO_SMALL: u64 = to_builtin!(5);
+const INSUFFICIENT_FUNDS: u64 = to_builtin!(6);
+const INCORRECT_PROGRAM_ID: u64 = to_builtin!(7);
+const MISSING_REQUIRED_SIGNATURES: u64 = to_builtin!(8);
+const ACCOUNT_ALREADY_INITIALIZED: u64 = to_builtin!(9);
+const UNINITIALIZED_ACCOUNT: u64 = to_builtin!(10);
+const NOT_ENOUGH_ACCOUNT_KEYS: u64 = to_builtin!(11);
+const ACCOUNT_BORROW_FAILED: u64 = to_builtin!(12);
+
+impl From<ProgramError> for u64 {
+    fn from(error: ProgramError) -> Self {
+        match error {
+            ProgramError::InvalidArgument => INVALID_ARGUMENT,
+            ProgramError::InvalidInstructionData => INVALID_INSTRUCTION_DATA,
+            ProgramError::InvalidAccountData => INVALID_ACCOUNT_DATA,
+            ProgramError::AccountDataTooSmall => ACCOUNT_DATA_TOO_SMALL,
+            ProgramError::InsufficientFunds => INSUFFICIENT_FUNDS,
+            ProgramError::IncorrectProgramId => INCORRECT_PROGRAM_ID,
+            ProgramError::MissingRequiredSignature => MISSING_REQUIRED_SIGNATURES,
+            ProgramError::AccountAlreadyInitialized => ACCOUNT_ALREADY_INITIALIZED,
+            ProgramError::UninitializedAccount => UNINITIALIZED_ACCOUNT,
+            ProgramError::NotEnoughAccountKeys => NOT_ENOUGH_ACCOUNT_KEYS,
+            ProgramError::AccountBorrowFailed => ACCOUNT_BORROW_FAILED,
+            ProgramError::Custom(error) => {
+                if error == 0 {
+                    CUSTOM_ZERO
+                } else {
+                    error as u64
+                }
+            }
+        }
+    }
+}
+
+impl From<u64> for ProgramError {
+    fn from(error: u64) -> Self {
+        match error {
+            INVALID_ARGUMENT => ProgramError::InvalidArgument,
+            INVALID_INSTRUCTION_DATA => ProgramError::InvalidInstructionData,
+            INVALID_ACCOUNT_DATA => ProgramError::InvalidAccountData,
+            ACCOUNT_DATA_TOO_SMALL => ProgramError::AccountDataTooSmall,
+            INSUFFICIENT_FUNDS => ProgramError::InsufficientFunds,
+            INCORRECT_PROGRAM_ID => ProgramError::IncorrectProgramId,
+            MISSING_REQUIRED_SIGNATURES => ProgramError::MissingRequiredSignature,
+            ACCOUNT_ALREADY_INITIALIZED => ProgramError::AccountAlreadyInitialized,
+            UNINITIALIZED_ACCOUNT => ProgramError::UninitializedAccount,
+            NOT_ENOUGH_ACCOUNT_KEYS => ProgramError::NotEnoughAccountKeys,
+            ACCOUNT_BORROW_FAILED => ProgramError::AccountBorrowFailed,
+            CUSTOM_ZERO => ProgramError::Custom(0),
+            _ => ProgramError::Custom(error as u32),
+        }
+    }
+}

--- a/program-interface/src/pubkey.rs
+++ b/program-interface/src/pubkey.rs
@@ -1,0 +1,131 @@
+use crate::decode_error::DecodeError;
+use num_derive::{FromPrimitive, ToPrimitive};
+use std::{convert::TryFrom, fmt, mem, str::FromStr};
+use thiserror::Error;
+
+pub use bs58;
+
+/// maximum length of derived pubkey seed
+pub const MAX_SEED_LEN: usize = 32;
+
+#[derive(Error, Debug, Serialize, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+pub enum PubkeyError {
+    #[error("length of requested seed is too long")]
+    MaxSeedLengthExceeded,
+}
+impl<T> DecodeError<T> for PubkeyError {
+    fn type_of() -> &'static str {
+        "PubkeyError"
+    }
+}
+
+#[repr(transparent)]
+#[derive(Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Pubkey([u8; 32]);
+
+impl crate::sanitize::Sanitize for Pubkey {}
+
+#[derive(Error, Debug, Serialize, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+pub enum ParsePubkeyError {
+    #[error("String is the wrong size")]
+    WrongSize,
+    #[error("Invalid Base58 string")]
+    Invalid,
+}
+impl<T> DecodeError<T> for ParsePubkeyError {
+    fn type_of() -> &'static str {
+        "ParsePubkeyError"
+    }
+}
+
+impl FromStr for Pubkey {
+    type Err = ParsePubkeyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let pubkey_vec = bs58::decode(s)
+            .into_vec()
+            .map_err(|_| ParsePubkeyError::Invalid)?;
+        if pubkey_vec.len() != mem::size_of::<Pubkey>() {
+            Err(ParsePubkeyError::WrongSize)
+        } else {
+            Ok(Pubkey::new(&pubkey_vec))
+        }
+    }
+}
+
+impl Pubkey {
+    pub fn new(pubkey_vec: &[u8]) -> Self {
+        Self(
+            <[u8; 32]>::try_from(<&[u8]>::clone(&pubkey_vec))
+                .expect("Slice must be the same length as a Pubkey"),
+        )
+    }
+
+    pub const fn new_from_array(pubkey_array: [u8; 32]) -> Self {
+        Self(pubkey_array)
+    }
+
+    pub fn to_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for Pubkey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl fmt::Debug for Pubkey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", bs58::encode(self.0).into_string())
+    }
+}
+
+impl fmt::Display for Pubkey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", bs58::encode(self.0).into_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pubkey_fromstr() {
+        let pubkey = Pubkey::new(&[
+            11, 22, 33, 44, 55, 66, 77, 88, 99, 00, 11, 22, 33, 44, 55, 66, 77, 88, 99, 00, 11, 22,
+            33, 44, 55, 66, 77, 88, 99, 00, 11, 22,
+        ]);
+
+        let mut pubkey_base58_str = bs58::encode(pubkey.0).into_string();
+
+        assert_eq!(pubkey_base58_str.parse::<Pubkey>(), Ok(pubkey));
+
+        pubkey_base58_str.push_str(&bs58::encode(pubkey.0).into_string());
+        assert_eq!(
+            pubkey_base58_str.parse::<Pubkey>(),
+            Err(ParsePubkeyError::WrongSize)
+        );
+
+        pubkey_base58_str.truncate(pubkey_base58_str.len() / 2);
+        assert_eq!(pubkey_base58_str.parse::<Pubkey>(), Ok(pubkey));
+
+        pubkey_base58_str.truncate(pubkey_base58_str.len() / 2);
+        assert_eq!(
+            pubkey_base58_str.parse::<Pubkey>(),
+            Err(ParsePubkeyError::WrongSize)
+        );
+
+        let mut pubkey_base58_str = bs58::encode(pubkey.0).into_string();
+        assert_eq!(pubkey_base58_str.parse::<Pubkey>(), Ok(pubkey));
+
+        // throw some non-base58 stuff in there
+        pubkey_base58_str.replace_range(..1, "I");
+        assert_eq!(
+            pubkey_base58_str.parse::<Pubkey>(),
+            Err(ParsePubkeyError::Invalid)
+        );
+    }
+}

--- a/program-interface/src/sanitize.rs
+++ b/program-interface/src/sanitize.rs
@@ -1,0 +1,33 @@
+use thiserror::Error;
+
+#[derive(PartialEq, Debug, Error, Eq, Clone)]
+pub enum SanitizeError {
+    #[error("index out of bounds")]
+    IndexOutOfBounds,
+    #[error("value out of bounds")]
+    ValueOutOfBounds,
+    #[error("invalid value")]
+    InvalidValue,
+}
+
+/// Trait for sanitizing values and members of over the wire messages.
+/// Implementation should recursively decent through the data structure
+/// and sanitize all struct members and enum clauses.  Sanitize excludes
+/// signature verification checks, those are handled by another pass.
+/// Sanitize checks should include but are not limited too:
+///   * All index values are in range
+///   * All values are within their static max/min bounds
+pub trait Sanitize {
+    fn sanitize(&self) -> Result<(), SanitizeError> {
+        Ok(())
+    }
+}
+
+impl<T: Sanitize> Sanitize for Vec<T> {
+    fn sanitize(&self) -> Result<(), SanitizeError> {
+        for x in self.iter() {
+            x.sanitize()?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
#### Problem

#### Summary of Changes

This is the first cut to `solana-program-interface` crate and does not yet touch `solana-sdk`.  The token and memo programs have been verified to build against `solana-program-interface`.
 

Fixes #
