### PR TITLE
Add RequestProcessor constructor to simplify testing

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -156,7 +156,7 @@ impl JsonRpcRequestProcessor {
     }
 
     // Useful for unit testing
-    fn new_from_bank(bank: Bank) -> Self {
+    pub fn new_from_bank(bank: Bank) -> Self {
         let genesis_hash = bank.hash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let working_bank = bank_forks.read().unwrap().working_bank();

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -347,7 +347,7 @@ mod tests {
     use super::*;
     use crate::{
         crds_value::{CrdsData, CrdsValue, SnapshotHash},
-        rpc::tests::create_validator_exit,
+        rpc::create_validator_exit,
     };
     use solana_ledger::{
         bank_forks::CompressionType,


### PR DESCRIPTION
#### Problem

Most tests in the RPC test suite use helper function `start_rpc_hander_with_tx` to create a sample validator state. Two problems:

1. Writing a unit test outside this crate requires copying all the code to create JsonRpcRequestProcessor
2. It's difficult to guess what any of these tests are actually testing since the input data isn't in the individual test. For example, you need to go dig into that helper function to see that "bob" is transferred 20 lamports or that the transaction count is correct because bob is transferred those tokens AND some vote transactions are added for another purpose.

Also, there's no constructor similar in spirit to `BankClient::new(Bank)` that captures the common case of initializing a bank so that you can execute some transactions and inspect account changes.

#### Summary of Changes

* Add a constructor that allows you to create a JsonRpcRequestProcessor from just a Bank.
* Use the new constructor in a handful of tests

