### PR TITLE
Disable linkcheck for now

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,5 +8,3 @@ create-missing = false
 
 [output.html]
 theme = "theme"
-
-[output.linkcheck]


### PR DESCRIPTION
#### Problem

CI is broken because mdbook-linkcheck 0.6.0 started behave differentally.... And the ci job didn't run on PRs...

#### Summary of Changes

Fix CI breakage for now. I'll push a proper pr later.