### PR TITLE
Plumb `--warp-slot` through net scripts

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -99,6 +99,7 @@ Operate a configured testnet
    --operating-mode development|softlaunch
                                       - Specify whether or not to launch the cluster in "development" mode with all features enabled at epoch 0,
                                         or "softlaunch" mode with some features disabled at epoch 0 (default: development)
+   --warp-slot WARP_SLOT              - Boot from a snapshot that has warped ahead to WARP_SLOT rather than a slot 0 genesis.
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
    -o noInstallCheck    - Skip solana-install sanity
@@ -284,6 +285,7 @@ startBootstrapLeader() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority\" \
          \"$gpuMode\" \
          \"$GEOLOCATION_API_KEY\" \
+         \"$maybeWarpSlot\" \
       "
 
   ) >> "$logFile" 2>&1 || {
@@ -353,6 +355,7 @@ startNode() {
          \"$maybeNoSnapshot $maybeSkipLedgerVerify $maybeLimitLedgerSize $maybeWaitForSupermajority\" \
          \"$gpuMode\" \
          \"$GEOLOCATION_API_KEY\" \
+         \"$maybeWarpSlot\" \
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!
@@ -744,6 +747,7 @@ netemConfigFile=""
 netemCommand="add"
 clientDelayStart=0
 netLogDir=
+maybeWarpSlot=
 
 command=$1
 [[ -n $command ]] || usage
@@ -846,6 +850,9 @@ while [[ -n $1 ]]; do
       shift 2
     elif [[ $1 == --wait-for-supermajority ]]; then
       maybeWaitForSupermajority="$1 $2"
+      shift 2
+    elif [[ $1 == --warp-slot ]]; then
+      maybeWarpSlot="$1 $2"
       shift 2
     else
       usage "Unknown long option: $1"

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -26,6 +26,7 @@ genesisOptions="${17}"
 extraNodeArgs="${18}"
 gpuMode="${19:-auto}"
 GEOLOCATION_API_KEY="${20}"
+maybeWarpSlot="${21}"
 set +x
 
 missing() {
@@ -228,6 +229,11 @@ EOF
         export BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR=net/keypairs/bootstrap-validator-identity.json
       fi
       multinode-demo/setup.sh "${args[@]}"
+
+      if [[ -n "$maybeWarpSlot" ]]; then
+        # shellcheck disable=SC2086 # Do not want to quote $maybeWarSlot
+        solana-ledger-tool -l config/bootstrap-validator create-snapshot 0 config/bootstrap-validator $maybeWarpSlot
+      fi
 
       solana-ledger-tool -l config/bootstrap-validator shred-version --max-genesis-archive-unpacked-size 1073741824 | tee config/shred-version
     fi

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -124,11 +124,16 @@ function launch_testnet() {
   declare -g version_args
   get_net_launch_software_version_launch_args "$CHANNEL" "solana-release" version_args
 
+  declare maybeWarpSlot
+  if [[ -n "$WARP_SLOT" ]]; then
+    maybeWarpSlot="--warp-slot $WARP_SLOT"
+  fi
+
   # shellcheck disable=SC2068
   # shellcheck disable=SC2086
   "${REPO_ROOT}"/net/net.sh start $version_args \
     -c idle=$NUMBER_OF_CLIENT_NODES $maybeStartAllowBootFailures \
-    --gpu-mode $startGpuMode
+    --gpu-mode $startGpuMode $maybeWarpSlot
 
   execution_step "Waiting for bootstrap validator's stake to fall below ${BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD}%"
   wait_for_bootstrap_validator_stake_drop "$BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD"


### PR DESCRIPTION
#### Problem

`solana-ledger-tool`'s `--warp-slot` argument isn't plumbed through net scripts

#### Summary of Changes

Plumb it