### PR TITLE
Fix link in TdS registration docs page

### DIFF
--- a/docs/src/tour-de-sol/registration/how-to-register.md
+++ b/docs/src/tour-de-sol/registration/how-to-register.md
@@ -1,11 +1,24 @@
 # How To Register
 
-1. **Registration Form** Submit the form [here](https://forms.gle/gGS2z4jTXq6hAZ2X9). Once the form is submitted, our team will review the information and insert the information into a publicly viewable spreadsheet for tracking.
-2. **KYC/AML**
-   Complete KYC/AML [here](https://tsm.coinlist.co/solana-tour-de-sol/new). \(**Ignore all the references to investment** on the portal; we just used their default template. Apologies for the confusion!\)
+#### 1) Registration Form
+[Submit the registration form here](https://forms.gle/gQYLozj5u7yKU3HG6)
 
-   We have prepared a guide to the KYC/AML process [here](https://docs.google.com/presentation/d/1gz8e34piUzzwzCMKwVrKKbZiPXV64Uq2-Izt4-VcMR4/edit?usp=sharing). Note that KYC/AML is mandatory **before** participating in any stage, and compensation is conditional upon you passing KYC/AML.
+#### 2) KYC/AML (via Coinlist)
+[Register for KYC/AML + Participation Agreement here](https://tsm.coinlist.co/solana-staking)
 
-3. **Participation Agreement** Instructions for completing the participation agreement W-9 will be emailed out to the email you provided, to be filled out and returned to us.
-4. **Tax Documents: W-8 BEN or W9** Once your Coinlist KYC application is approved, our team will send either a W-8 BEN for international participants or a W9 via DocuSign. Fill out the form with the same information you used with CoinList.
-5. **Status** The status of your participation agreement will be tracked along with the other registration information. We’ll also try to notify you upon completion or rejection of any submitted participation agreements.
+*If you’ve completed KYC/AML previously for either SLP or TdS with the same
+entity/individual then you will not need to go through this again.
+We do not accept U.S. entities or individuals.*
+
+#### 3) Join Our Discord
+**Required** for all Tour de SOL validators, as this is our primary
+communication channel: https://discord.gg/N3mqAfa
+
+### Next Steps
+ - Check out our documentation to start getting familiar with how to
+[Run a Validator](../../running-validator/README.md)
+
+ - After you've finished the registration and KYC, you will receive an email
+with instructions to finish your on-boarding process.
+
+ - See you on Discord!


### PR DESCRIPTION
#### Problem
TdS Registration link points to outdated Google form

#### Summary of Changes
Point at the correct form link