### PR TITLE
Trigger all CI jobs for Dockerfile changes

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -209,8 +209,8 @@ pull_or_push_steps() {
     all_test_steps
   fi
 
-  # doc/ changes:
-  if affects ^docs/; then
+  # doc/ and dockerized mdbook version changes:
+  if affects ^docs/ ^ci/docker-rust-nightly/Dockerfile; then
     command_step docs ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image docs/build.sh" 5
   fi
 

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -25,7 +25,8 @@ annotate() {
 }
 
 # Checks if a CI pull request affects one or more path patterns.  Each
-# argument is checked in series.
+# pattern argument is checked in series. If one of them found to be affected,
+# return immediately as such.
 #
 # Bash regular expressions are permitted in the pattern:
 #     affects .rs$    -- any file or directory ending in .rs

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -42,7 +42,8 @@ affects() {
     # the worse (affected)
     return 0
   fi
-  for pattern in "$@"; do
+  # Assume everyting needs to be tested when any Dockerfile changes
+  for pattern in ^ci/docker-rust/Dockerfile ^ci/docker-rust-nightly/Dockerfile "$@"; do
     if [[ ${pattern:0:1} = "!" ]]; then
       for file in "${affected_files[@]}"; do
         if [[ ! $file =~ ${pattern:1} ]]; then
@@ -210,8 +211,8 @@ pull_or_push_steps() {
     all_test_steps
   fi
 
-  # doc/ and dockerized mdbook version changes:
-  if affects ^docs/ ^ci/docker-rust-nightly/Dockerfile; then
+  # doc/ changes:
+  if affects ^docs/; then
     command_step docs ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image docs/build.sh" 5
   fi
 

--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,5 +1,3 @@
-##### test
-
 FROM solanalabs/rust:1.44.0
 ARG date
 

--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,3 +1,5 @@
+##### test
+
 FROM solanalabs/rust:1.44.0
 ARG date
 


### PR DESCRIPTION
## problem

I was completely blind of incompatibility of #10585 and the CI `docs` job... Causing some noises: #10633, #10634, #10640.

## solution

~Run the docs job when we're updating nightly docker image!~ _I broadened yet more to re-test all the jobs._