### PR TITLE
cli: Add version information to `solana gossip` and `solana validators`

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1094,10 +1094,10 @@ pub fn process_show_gossip(rpc_client: &RpcClient) -> ProcessResult {
     }
 
     let s: Vec<_> = cluster_nodes
-        .iter()
+        .into_iter()
         .map(|node| {
             format!(
-                "{:15} | {:44} | {:6} | {:5} | {:5}",
+                "{:15} | {:44} | {:6} | {:5} | {:5} | {}",
                 node.gossip
                     .map(|addr| addr.ip().to_string())
                     .unwrap_or_else(|| "none".to_string()),
@@ -1105,15 +1105,16 @@ pub fn process_show_gossip(rpc_client: &RpcClient) -> ProcessResult {
                 format_port(node.gossip),
                 format_port(node.tpu),
                 format_port(node.rpc),
+                node.version.unwrap_or_else(||"-".to_string()),
             )
         })
         .collect();
 
     Ok(format!(
         "IP Address      | Node identifier                              \
-         | Gossip | TPU   | RPC\n\
+         | Gossip | TPU   | RPC   | Version\n\
          ----------------+----------------------------------------------+\
-         --------+-------+-------\n\
+         --------+-------+-------+----------------\n\
          {}\n\
          Nodes: {}",
         s.join("\n"),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -33,7 +33,7 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -1105,7 +1105,7 @@ pub fn process_show_gossip(rpc_client: &RpcClient) -> ProcessResult {
                 format_port(node.gossip),
                 format_port(node.tpu),
                 format_port(node.rpc),
-                node.version.unwrap_or_else(||"-".to_string()),
+                node.version.unwrap_or_else(|| "unknown".to_string()),
             )
         })
         .collect();
@@ -1197,6 +1197,18 @@ pub fn process_show_validators(
 ) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info_with_commitment(config.commitment)?;
     let vote_accounts = rpc_client.get_vote_accounts_with_commitment(config.commitment)?;
+
+    let mut node_version = HashMap::new();
+    let unknown_version = "unknown".to_string();
+    for contact_info in rpc_client.get_cluster_nodes()? {
+        node_version.insert(
+            contact_info.pubkey,
+            contact_info
+                .version
+                .unwrap_or_else(|| unknown_version.clone()),
+        );
+    }
+
     let total_active_stake = vote_accounts
         .current
         .iter()
@@ -1215,14 +1227,44 @@ pub fn process_show_validators(
     current.sort_by(|a, b| b.activated_stake.cmp(&a.activated_stake));
     let current_validators: Vec<CliValidator> = current
         .iter()
-        .map(|vote_account| CliValidator::new(vote_account, epoch_info.epoch))
+        .map(|vote_account| {
+            CliValidator::new(
+                vote_account,
+                epoch_info.epoch,
+                node_version
+                    .get(&vote_account.node_pubkey)
+                    .unwrap_or(&unknown_version)
+                    .clone(),
+            )
+        })
         .collect();
     let mut delinquent = vote_accounts.delinquent;
     delinquent.sort_by(|a, b| b.activated_stake.cmp(&a.activated_stake));
     let delinquent_validators: Vec<CliValidator> = delinquent
         .iter()
-        .map(|vote_account| CliValidator::new(vote_account, epoch_info.epoch))
+        .map(|vote_account| {
+            CliValidator::new(
+                vote_account,
+                epoch_info.epoch,
+                node_version
+                    .get(&vote_account.node_pubkey)
+                    .unwrap_or(&unknown_version)
+                    .clone(),
+            )
+        })
         .collect();
+
+    let mut stake_by_version: BTreeMap<_, (usize, u64)> = BTreeMap::new();
+    for validator in current_validators
+        .iter()
+        .chain(delinquent_validators.iter())
+    {
+        let mut entry = stake_by_version
+            .entry(validator.version.clone())
+            .or_default();
+        entry.0 += 1;
+        entry.1 += validator.activated_stake;
+    }
 
     let cli_validators = CliValidators {
         total_active_stake,
@@ -1230,6 +1272,7 @@ pub fn process_show_validators(
         total_deliquent_stake,
         current_validators,
         delinquent_validators,
+        stake_by_version,
         use_lamports_unit,
     };
     Ok(config.output_format.formatted_string(&cli_validators))


### PR DESCRIPTION
It's too hard to figure out what version everybody is running.

Using devnet as an example here's the new output

1. `solana gossip`, note the version column on the right:
```
IP Address      | Node identifier                              | Gossip | TPU   | RPC   | Version
----------------+----------------------------------------------+--------+-------+-------+----------------
34.82.57.86     | da1JbwL6WSXGpuhWC49ctNT6CfbxdLV6gwSXeXYZ3AF  | 8001   | 8004  | 8899  | 1.2.2 f13498b4
34.83.179.199   | 47Sbuv6jL7CViK9F2NMW51aQGhfdpUu7WNvKyH645Rfi | 8001   | 8004  | 8899  | 1.2.2 f13498b4
34.83.120.171   | dw1LDntRdPR1RMLqfVoXLQAT3r9b6VoWRHQTXVjmZvr  | 8001   | 8004  | 8899  | 1.2.2 f13498b4
Nodes: 3
```

2. `solana validators`, note the "Active Stake By Version:" table and the new version column:
```
Active Stake: 509104.9885856 SOL
Current Stake: 509103.99086848 SOL (100.00%)
Delinquent Stake: 0.99771712 SOL (0.00%)

Active Stake By Version:
1.2.2 f13498b4 x 1 = 100.00%
unknown x 1 = 0.00%

  Identity Pubkey                               Vote Account Pubkey                     Commission  Last Vote  Root Block     Credits            Version  Active Stake
  47Sbuv6jL7CViK9F2NMW51aQGhfdpUu7WNvKyH645Rfi  5MMCR4NbTZqjthjLGywmeT66iwE9J9f7kjtxzJjwfUx2  100%    8689035     8689004     8688559     1.2.2 f13498b4  509103.99086848 SOL (100.00%)
⚠️ 28rBywsDVovYrLStu2JpgAWxr7KsUgGMcpy2mjDx8hsF  3wmqR6Wrf5cikjLcTHqCXUikhSz9AnL9QWPD7UZigeHW  100%    2452611     2452580           0            unknown  0.99771712 SOL (0.00%)
```
