### PR TITLE
Wait until bank is frozen before sending RPC notifications

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -277,6 +277,7 @@ impl ReplayStage {
                         transaction_status_sender.clone(),
                         &verify_recyclers,
                         &mut heaviest_subtree_fork_choice,
+                        &subscriptions,
                     );
                     Self::report_memory(&allocated, "replay_active_banks", start);
 
@@ -1103,6 +1104,7 @@ impl ReplayStage {
         transaction_status_sender: Option<TransactionStatusSender>,
         verify_recyclers: &VerifyRecyclers,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
+        subscriptions: &Arc<RpcSubscriptions>,
     ) -> bool {
         let mut did_complete_bank = false;
         let mut tx_count = 0;
@@ -1172,6 +1174,7 @@ impl ReplayStage {
                 bank.freeze();
                 heaviest_subtree_fork_choice
                     .add_new_leaf_slot(bank.slot(), Some(bank.parent_slot()));
+                subscriptions.notify_frozen(bank.slot());
             } else {
                 trace!(
                     "bank {} not completed tick_height: {}, max_tick_height: {}",


### PR DESCRIPTION
#### Problem
It's possible for a block to reach single confirmation in gossip before the RPC node processes the bank itself. When this happens, the RPC subscriptions service may notify for a slot that hasn't been fully processed yet.

#### Summary of Changes
1. Before processing gossip confirmed slots, check that the bank is frozen
2. When the bank isn't frozen yet, queue the notifications
3. Every time replay stage freezes a bank, notify RPC subscriptions service and check the queue
4. Purge old queued notifications if for some reason the node chooses a different fork 

Fixes https://github.com/solana-labs/solana/issues/10619
