### PR TITLE
Ignore Break program in the slack watchtower.

### DIFF
--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -154,6 +154,9 @@ fn get_config() -> Config {
 }
 
 fn process_confirmed_block(notifier: &Notifier, slot: Slot, confirmed_block: ConfirmedBlock) {
+    let break_program_id = "BrEAK7zGZ6dM71zUDACDqJnekihmwF15noTddWTsknjC"
+        .parse::<Pubkey>()
+        .unwrap();
     let mut vote_transactions = 0;
 
     for rpc_transaction in &confirmed_block.transactions {
@@ -173,6 +176,9 @@ fn process_confirmed_block(notifier: &Notifier, slot: Slot, confirmed_block: Con
                             vote_transactions += 1;
                             notify = false;
                         }
+                    }
+                    if program_pubkey == break_program_id {
+                        notify = false;
                     }
                 }
 


### PR DESCRIPTION
#### Problem

Break causes to many slack notifications

#### Summary of Changes

Ignore break.

Fixes #
