### PR TITLE
cli: Permit users to assign labels to account addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,6 +4639,7 @@ dependencies = [
  "log 0.4.8",
  "serde_yaml",
  "solana-clap-utils",
+ "solana-cli",
  "solana-cli-config",
  "solana-client",
  "solana-logger",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -56,6 +56,7 @@ use solana_stake_program::{
 use solana_transaction_status::{EncodedTransaction, TransactionEncoding};
 use solana_vote_program::vote_state::VoteAuthorize;
 use std::{
+    collections::HashMap,
     error,
     fmt::Write as FmtWrite,
     fs::File,
@@ -493,6 +494,7 @@ pub struct CliConfig<'a> {
     pub output_format: OutputFormat,
     pub commitment: CommitmentConfig,
     pub send_transaction_config: RpcSendTransactionConfig,
+    pub address_labels: HashMap<String, String>,
 }
 
 impl CliConfig<'_> {
@@ -596,6 +598,7 @@ impl Default for CliConfig<'_> {
             output_format: OutputFormat::Display,
             commitment: CommitmentConfig::default(),
             send_transaction_config: RpcSendTransactionConfig::default(),
+            address_labels: HashMap::new(),
         }
     }
 }
@@ -1837,7 +1840,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::ShowBlockProduction { epoch, slot_limit } => {
             process_show_block_production(&rpc_client, config, *epoch, *slot_limit)
         }
-        CliCommand::ShowGossip => process_show_gossip(&rpc_client),
+        CliCommand::ShowGossip => process_show_gossip(&rpc_client, config),
         CliCommand::ShowStakes {
             use_lamports_unit,
             vote_account_pubkeys,

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -1,4 +1,7 @@
-use crate::{cli::build_balance_message, display::writeln_name_value};
+use crate::{
+    cli::build_balance_message,
+    display::{format_labeled_address, writeln_name_value},
+};
 use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 use console::{style, Emoji};
 use inflector::cases::titlecase::to_title_case;
@@ -18,7 +21,11 @@ use solana_vote_program::{
     authorized_voters::AuthorizedVoters,
     vote_state::{BlockTimestamp, Lockout},
 };
-use std::{collections::BTreeMap, fmt, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+    time::Duration,
+};
 
 static WARNING: Emoji = Emoji("⚠️", "!");
 
@@ -404,10 +411,15 @@ pub struct CliValidator {
 }
 
 impl CliValidator {
-    pub fn new(vote_account: &RpcVoteAccountInfo, current_epoch: Epoch, version: String) -> Self {
+    pub fn new(
+        vote_account: &RpcVoteAccountInfo,
+        current_epoch: Epoch,
+        version: String,
+        address_labels: &HashMap<String, String>,
+    ) -> Self {
         Self {
-            identity_pubkey: vote_account.node_pubkey.to_string(),
-            vote_account_pubkey: vote_account.vote_pubkey.to_string(),
+            identity_pubkey: format_labeled_address(&vote_account.node_pubkey, address_labels),
+            vote_account_pubkey: format_labeled_address(&vote_account.vote_pubkey, address_labels),
             commission: vote_account.commission,
             last_vote: vote_account.last_vote,
             root_slot: vote_account.root_slot,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,7 @@
-use clap::{crate_description, crate_name, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand};
+use clap::{
+    crate_description, crate_name, value_t_or_exit, AppSettings, Arg, ArgGroup, ArgMatches,
+    SubCommand,
+};
 use console::style;
 
 use solana_clap_utils::{
@@ -13,15 +16,25 @@ use solana_cli::{
 use solana_cli_config::{Config, CONFIG_FILE};
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
-use std::{error, sync::Arc};
+use std::{collections::HashMap, error, path::PathBuf, sync::Arc};
 
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
     let parse_args = match matches.subcommand() {
-        ("config", Some(matches)) => match matches.subcommand() {
-            ("get", Some(subcommand_matches)) => {
-                if let Some(config_file) = matches.value_of("config_file") {
-                    let config = Config::load(config_file).unwrap_or_default();
+        ("config", Some(matches)) => {
+            let config_file = match matches.value_of("config_file") {
+                None => {
+                    println!(
+                        "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
+                        style("No config file found.").bold()
+                    );
+                    return Ok(false);
+                }
+                Some(config_file) => config_file,
+            };
+            let mut config = Config::load(config_file).unwrap_or_default();
 
+            match matches.subcommand() {
+                ("get", Some(subcommand_matches)) => {
                     let (url_setting_type, json_rpc_url) =
                         CliConfig::compute_json_rpc_url_setting("", &config.json_rpc_url);
                     let (ws_setting_type, websocket_url) = CliConfig::compute_websocket_url_setting(
@@ -47,17 +60,8 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                         println_name_value_or("WebSocket URL:", &websocket_url, ws_setting_type);
                         println_name_value_or("Keypair Path:", &keypair_path, keypair_setting_type);
                     }
-                } else {
-                    println!(
-                        "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
-                        style("No config file found.").bold()
-                    );
                 }
-                false
-            }
-            ("set", Some(subcommand_matches)) => {
-                if let Some(config_file) = matches.value_of("config_file") {
-                    let mut config = Config::load(config_file).unwrap_or_default();
+                ("set", Some(subcommand_matches)) => {
                     if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
                         config.json_rpc_url = url.to_string();
                         // Revert to a computed `websocket_url` value when `json_rpc_url` is
@@ -70,6 +74,7 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                     if let Some(keypair) = subcommand_matches.value_of("keypair") {
                         config.keypair_path = keypair.to_string();
                     }
+
                     config.save(config_file)?;
 
                     let (url_setting_type, json_rpc_url) =
@@ -87,16 +92,22 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                     println_name_value_or("RPC URL:", &json_rpc_url, url_setting_type);
                     println_name_value_or("WebSocket URL:", &websocket_url, ws_setting_type);
                     println_name_value_or("Keypair Path:", &keypair_path, keypair_setting_type);
-                } else {
-                    println!(
-                        "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
-                        style("No config file found.").bold()
-                    );
                 }
-                false
+                ("import-address-labels", Some(subcommand_matches)) => {
+                    let filename = value_t_or_exit!(subcommand_matches, "filename", PathBuf);
+                    config.import_address_labels(&filename)?;
+                    config.save(config_file)?;
+                    println!("Address labels imported from {:?}", filename);
+                }
+                ("export-address-labels", Some(subcommand_matches)) => {
+                    let filename = value_t_or_exit!(subcommand_matches, "filename", PathBuf);
+                    config.export_address_labels(&filename)?;
+                    println!("Address labels exported to {:?}", filename);
+                }
+                _ => unreachable!(),
             }
-            _ => unreachable!(),
-        },
+            false
+        }
         _ => true,
     };
     Ok(parse_args)
@@ -144,6 +155,12 @@ pub fn parse_args<'a>(
         .and_then(|sub_matches| commitment_of(sub_matches, COMMITMENT_ARG.long))
         .unwrap_or_default();
 
+    let address_labels = if matches.is_present("no_address_labels") {
+        HashMap::new()
+    } else {
+        config.address_labels
+    };
+
     Ok((
         CliConfig {
             command,
@@ -156,6 +173,7 @@ pub fn parse_args<'a>(
             output_format,
             commitment,
             send_transaction_config: RpcSendTransactionConfig::default(),
+            address_labels,
         },
         signers,
     ))
@@ -218,6 +236,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .help("Show additional information"),
     )
     .arg(
+        Arg::with_name("no_address_labels")
+            .long("no-address-labels")
+            .global(true)
+            .help("Do not use address labels in the output"),
+    )
+    .arg(
         Arg::with_name("output_format")
             .long("output")
             .value_name("FORMAT")
@@ -257,6 +281,28 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                             .args(&["json_rpc_url", "websocket_url", "keypair"])
                             .multiple(true)
                             .required(true),
+                    ),
+            )
+            .subcommand(
+                SubCommand::with_name("import-address-labels")
+                    .about("Import a list of address labels")
+                    .arg(
+                        Arg::with_name("filename")
+                            .index(1)
+                            .value_name("FILENAME")
+                            .takes_value(true)
+                            .help("YAML file of address labels"),
+                    ),
+            )
+            .subcommand(
+                SubCommand::with_name("export-address-labels")
+                    .about("Export the current address labels")
+                    .arg(
+                        Arg::with_name("filename")
+                            .index(1)
+                            .value_name("FILENAME")
+                            .takes_value(true)
+                            .help("YAML file to receive the current address labels"),
                     ),
             ),
     )

--- a/stake-o-matic/Cargo.toml
+++ b/stake-o-matic/Cargo.toml
@@ -15,6 +15,7 @@ serde_yaml = "0.8.13"
 solana-clap-utils = { path = "../clap-utils", version = "1.3.0" }
 solana-client = { path = "../client", version = "1.3.0" }
 solana-cli-config = { path = "../cli-config", version = "1.3.0" }
+solana-cli = { path = "../cli", version = "1.3.0" }
 solana-logger = { path = "../logger", version = "1.3.0" }
 solana-metrics = { path = "../metrics", version = "1.3.0" }
 solana-notifier = { path = "../notifier", version = "1.3.0" }


### PR DESCRIPTION
Memorizing pubkeys is hard, we can do better.

Given the file, `address-labels.yml`:
```yaml
---
"11111111111111111111111111111111": System Program
"7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2": "Solana Boot Node: bv1"
"GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ": "Solana Boot Node: bv2"
"DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ": "Solana Boot Node: bv3"
"CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S": "Solana Boot Node: bv4"
"47Sbuv6jL7CViK9F2NMW51aQGhfdpUu7WNvKyH645Rfi": "Devnet Validator"
"5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on": "testnet.solana.com"
````
first run `solana config import-address-labels ~/address-labels.yml`, and then run `solana gossip`, `solana validators`, or `solana block-production`.

Example output:
```
$ solana gossip
IP Address      | Node identifier                              | Gossip | TPU   | RPC   | Version
----------------+----------------------------------------------+--------+-------+-------+----------------
.
.
5.189.164.50    | D6pUrfgc5ZyXSfgtCBYozydRSz92pse1S7AZP58muEYk | 8000   | 8003  | none  | 1.1.18 bc808d78
34.90.36.12     | Solana Boot Node: bv3 (DE1b..XJsJ)           | 8001   | 8004  | 8899  | 1.1.18 bc808d78
35.233.222.140  | Solana Boot Node: bv1 (7Np4..T4K2)           | 8001   | 8004  | 8899  | 1.1.18 bc808d78
176.9.22.153    | 2NJZ1Ajcwtc7hZdVXTXrh2SAiAXnFkVm6MWcGjBZfPkS | 8000   | 8003  | none  | 1.1.18 bc808d78
.
.
Nodes: 107
```


```
$ solana validators
  .
  .
  Identity Pubkey                               Vote Account Pubkey                     Commission  Last Vote  Root Block     Credits            Version  Active Stake
  Solana Boot Node: bv2 (GdnS..UfiZ)            sCtiJieP8B3SwYnXemiLpRFRR8KJLMtsMVN25fAFWjW   100%   17496405    17496374    15856772    1.1.18 bc808d78  1005547.131192028 SOL (8.67%)
  Solana Boot Node: bv4 (Cakc..1D2S)            9bRDrYShoQ77MZKYTMoAsoCkU7dAR24mxYCBjXLpfEJx  100%   17496405    17496374    15736642    1.1.18 bc808d78  1000548.026262028 SOL (8.63%)
  Solana Boot Node: bv1 (7Np4..T4K2)            4785anyR2rYSas6cQGHtykgzwYEtChvFYhcEgdDw3gGL  100%   17496405    17496374    15781995    1.1.18 bc808d78  1000544.028544908 SOL (8.63%)
  Solana Boot Node: bv3 (DE1b..XJsJ)            8XgHUtBRY6qePVYERxosyX3MUq8NQkjtmFDSzQ2WpHTJ  100%   17496406    17496375    15861593    1.1.18 bc808d78  999346.028544908 SOL (8.62%)
  Dokia75SVtetShgapUBoVFfYjL99fQyr1twxKKyTZKa3  H3GhqPMwvGLdxWg3QJGjXDSkFSJCsFk3Wx9XBTdYZykc  100%   17496406    17496375   
  .
  .
```

`solana config export-address-labels ~/address-labels.yml` is also provided so you can share with your friends.

Address labels are also hooked up to watchtower and stake-o-matic