### PR TITLE
Fix web3 CI builds

### DIFF
--- a/web3.js/.flowconfig
+++ b/web3.js/.flowconfig
@@ -14,6 +14,3 @@ module.system.node.resolve_dirname=./src
 module.use_strict=true
 experimental.const_params=true
 include_warnings=true
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
-suppress_comment=\\(.\\|\n\\)*\\$FlowIgnore

--- a/web3.js/.travis/script.sh
+++ b/web3.js/.travis/script.sh
@@ -1,5 +1,7 @@
 # |source| this file
 
+set -ex
+
 ls -l lib
 test -r lib/index.iife.js
 test -r lib/index.cjs.js

--- a/web3.js/examples/bpf-rust-noop/Cargo.toml
+++ b/web3.js/examples/bpf-rust-noop/Cargo.toml
@@ -17,9 +17,6 @@ num-traits = "0.2"
 solana-sdk = { git = "https://github.com/solana-labs/solana", default-features = false }
 thiserror = "1.0"
 
-[dev_dependencies]
-solana-sdk-bpf-test = { path = "../../bpf-sdk/rust/test"}
-
 [features]
 program = ["solana-sdk/program"]
 default = ["program"]

--- a/web3.js/test/cluster.test.js
+++ b/web3.js/test/cluster.test.js
@@ -3,7 +3,7 @@ import {clusterApiUrl} from '../src/util/cluster';
 
 test('invalid', () => {
   expect(() => {
-    // $FlowIgnore
+    // $FlowExpectedError
     clusterApiUrl('abc123');
   }).toThrow();
 });


### PR DESCRIPTION
#### Problem
Web3 CI build fails when using `xargo` to build an example rust program with a git dependency for `solana-sdk`. This is because it crawls the full repo tree and errors out because `web3.js/examples/bpf-rust-noop/Cargo.toml` has a missing path dependency.

This issue has been fixed in `cargo` but apparently `xargo` doesn't include this fix: https://github.com/rust-lang/cargo/issues/1423.

This not only affects CI but would also affect any program using `xargo` that has a git dependency on the `solana-sdk`.

#### Summary of Changes
- Change the problematic `Cargo.toml` to depend on the test crate located in `sdk/` in the monorepo
- TODO: Patch the mirror web3 repository by reverting this change

Fixes this CI failure: https://travis-ci.com/github/solana-labs/solana/jobs/349093333
