### PR TITLE
Do not run buildkite tests if gitbook config modified

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -207,7 +207,7 @@ pull_or_push_steps() {
 
   # Run the full test suite by default, skipping only if modifications are local
   # to some particular areas of the tree
-  if affects_other_than ^.buildkite ^.travis .md$ ^docs/ ^web3.js/ ^explorer/; then
+  if affects_other_than ^.buildkite ^.travis .md$ ^docs/ ^web3.js/ ^explorer/ ^.gitbook; then
     all_test_steps
   fi
 


### PR DESCRIPTION
#### Problem
Touching .gitbook.yaml in a PR triggers all CI tests.  This file only impacts docs structure.

#### Summary of Changes
Bypass CI tests if .gitbook.yaml is modified.
