### PR TITLE
ci/test-checks.sh: Only force up-to-date lock files on edge

### DIFF
--- a/ci/docker-run.sh
+++ b/ci/docker-run.sh
@@ -73,6 +73,7 @@ ARGS+=(
   --env BUILDKITE_JOB_ID
   --env CI
   --env CI_BRANCH
+  --env CI_BASE_BRANCH
   --env CI_TAG
   --env CI_BUILD_ID
   --env CI_COMMIT

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -8,6 +8,7 @@ if [[ -n $CI ]]; then
   export CI=1
   if [[ -n $TRAVIS ]]; then
     export CI_BRANCH=$TRAVIS_BRANCH
+    export CI_BASE_BRANCH=$TRAVIS_BRANCH
     export CI_BUILD_ID=$TRAVIS_BUILD_ID
     export CI_COMMIT=$TRAVIS_COMMIT
     export CI_JOB_ID=$TRAVIS_JOB_ID
@@ -28,8 +29,10 @@ if [[ -n $CI ]]; then
     # to how solana-ci-gate is used to trigger PR builds rather than using the
     # standard Buildkite PR trigger.
     if [[ $CI_BRANCH =~ pull/* ]]; then
+      export CI_BASE_BRANCH=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
       export CI_PULL_REQUEST=true
     else
+      export CI_BASE_BRANCH=$BUILDKITE_BRANCH
       export CI_PULL_REQUEST=
     fi
     export CI_OS_NAME=linux

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -7,6 +7,7 @@ cd "$(dirname "$0")/.."
 source ci/_
 source ci/rust-version.sh stable
 source ci/rust-version.sh nightly
+eval "$(ci/channel-info.sh)"
 
 echo --- build environment
 (
@@ -28,15 +29,21 @@ echo --- build environment
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings"
 
-# Exclude --benches as it's not available in rust stable yet
-if _ scripts/cargo-for-all-lock-files.sh +"$rust_stable" check --locked --tests --bins --examples; then
-  true
+# Only force up-to-date lock files on edge
+if [[ $CI_BASE_BRANCH = "$EDGE_CHANNEL" ]]; then
+  # Exclude --benches as it's not available in rust stable yet
+  if _ scripts/cargo-for-all-lock-files.sh +"$rust_stable" check --locked --tests --bins --examples; then
+    true
+  else
+    check_status=$?
+    echo "Some Cargo.lock might be outdated; update them (or just be a compilation error?)"
+    echo "protip: you can use ./scripts/cargo-for-all-lock-files.sh [check|update] ..."
+    exit "$check_status"
+  fi
 else
-  check_status=$?
-  echo "Some Cargo.lock might be outdated; update them (or just be a compilation error?)"
-  echo "protip: you can use ./scripts/cargo-for-all-lock-files.sh [check|update] ..."
-  exit "$check_status"
+  echo "Note: cargo-for-all-lock-files.sh skipped because $CI_BASE_BRANCH != $EDGE_CHANNEL"
 fi
+
 # Ensure nightly and --benches
 _ scripts/cargo-for-all-lock-files.sh +"$rust_nightly" check --locked --all-targets
 

--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -10,13 +10,8 @@ source ci/_
   set -x
   # Look for failed mergify.io backports by searching leftover conflict markers
   # Also check for any trailing whitespaces!
-  if [[ -n $BUILDKITE_PULL_REQUEST_BASE_BRANCH ]]; then
-    base_branch=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
-  else
-    base_branch=$BUILDKITE_BRANCH
-  fi
-  git fetch origin "$base_branch"
-  git diff "$(git merge-base HEAD "origin/$base_branch")..HEAD" --check --oneline
+  git fetch origin "$CI_BASE_BRANCH"
+  git diff "$(git merge-base HEAD "origin/$CI_BASE_BRANCH")..HEAD" --check --oneline
 )
 
 echo


### PR DESCRIPTION
We want edge to always have the latest dependencies, but it's not desirable to force that for the release channels where we want to carefully manage code churn

(v1.2 version landing via https://github.com/solana-labs/solana/pull/10695 where I first stubbed my toe on this)