### PR TITLE
solana validators: Split out current and delinquent validators

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1257,16 +1257,20 @@ pub fn process_show_validators(
         })
         .collect();
 
-    let mut stake_by_version: BTreeMap<_, (usize, u64)> = BTreeMap::new();
-    for validator in current_validators
-        .iter()
-        .chain(delinquent_validators.iter())
-    {
+    let mut stake_by_version: BTreeMap<_, CliValidatorsStakeByVersion> = BTreeMap::new();
+    for validator in current_validators.iter() {
         let mut entry = stake_by_version
             .entry(validator.version.clone())
             .or_default();
-        entry.0 += 1;
-        entry.1 += validator.activated_stake;
+        entry.current_validators += 1;
+        entry.current_active_stake += validator.activated_stake;
+    }
+    for validator in delinquent_validators.iter() {
+        let mut entry = stake_by_version
+            .entry(validator.version.clone())
+            .or_default();
+        entry.delinquent_validators += 1;
+        entry.delinquent_active_stake += validator.activated_stake;
     }
 
     let cli_validators = CliValidators {


### PR DESCRIPTION
During the current testnet restart, it was too hard to monitor which validators are online vs those still restarting.

New output:
```
$ solana validators | head -n10
Active Stake: 10394234.635163004 SOL
Current Stake: 8359670.360912723 SOL (80.43%)
Delinquent Stake: 2034564.274250281 SOL (19.57%)

Stake By Version:
1.2.2 f13498b4   -   1 current validators ( 0.04%)
1.2.4 58e6a5c2   -  62 current validators (44.03%),  15 delinquent validators (13.10%)
1.2.4 baadf00d   -   1 current validators (10.19%)
1.2.4 devbuild   -   2 current validators ( 8.09%)
unknown          -  38 current validators (18.07%),  69 delinquent validators ( 6.47%)
```