### PR TITLE
Don't bother `api.github.com` on pull requests to avoid getting rate limited

### DIFF
--- a/docs/set-solana-release-tag.sh
+++ b/docs/set-solana-release-tag.sh
@@ -5,12 +5,16 @@ cd "$(dirname "$0")"
 
 if [[ -n $CI_TAG ]]; then
   LATEST_SOLANA_RELEASE_VERSION=$CI_TAG
-else
+elif [[ -z $CI_PULL_REQUEST ]]; then
   LATEST_SOLANA_RELEASE_VERSION=$(\
     curl -sSfL https://api.github.com/repos/solana-labs/solana/releases/latest \
     | grep -m 1 tag_name \
     | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p' \
   )
+else
+  # Don't bother the `api.github.com` on pull requests to avoid getting rate
+  # limited
+  LATEST_SOLANA_RELEASE_VERSION=unknown-version
 fi
 
 if [[ -z "$LATEST_SOLANA_RELEASE_VERSION" ]]; then


### PR DESCRIPTION
`set-solana-release-tag.sh` fails a lot with:
  | curl: (22) The requested URL returned error: 403 rate limit exceeded
but we really don't care about getting the exact release version on a PR build so reduce the github API load

