### PR TITLE
Remove unused StakeLockout::lockout

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -19,15 +19,15 @@ use std::{
 pub struct CommitmentAggregationData {
     bank: Arc<Bank>,
     root: Slot,
-    total_staked: u64,
+    total_stake: u64,
 }
 
 impl CommitmentAggregationData {
-    pub fn new(bank: Arc<Bank>, root: Slot, total_staked: u64) -> Self {
+    pub fn new(bank: Arc<Bank>, root: Slot, total_stake: u64) -> Self {
         Self {
             bank,
             root,
-            total_staked,
+            total_stake,
         }
     }
 }
@@ -107,12 +107,12 @@ impl AggregateCommitmentService {
                 Self::aggregate_commitment(&ancestors, &aggregation_data.bank);
 
             let largest_confirmed_root =
-                get_largest_confirmed_root(rooted_stake, aggregation_data.total_staked);
+                get_largest_confirmed_root(rooted_stake, aggregation_data.total_stake);
 
             let mut new_block_commitment = BlockCommitmentCache::new(
                 block_commitment,
                 largest_confirmed_root,
-                aggregation_data.total_staked,
+                aggregation_data.total_stake,
                 aggregation_data.bank,
                 block_commitment_cache.read().unwrap().blockstore.clone(),
                 aggregation_data.root,

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -1,5 +1,6 @@
 use crate::{
     commitment::{BlockCommitment, BlockCommitmentCache, VOTE_THRESHOLD_SIZE},
+    consensus::Stake,
     rpc_subscriptions::{CacheSlotInfo, RpcSubscriptions},
 };
 use solana_measure::measure::Measure;
@@ -19,7 +20,7 @@ use std::{
 pub struct CommitmentAggregationData {
     bank: Arc<Bank>,
     root: Slot,
-    total_stake: u64,
+    total_stake: Stake,
 }
 
 impl CommitmentAggregationData {

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -24,7 +24,7 @@ pub struct CommitmentAggregationData {
 }
 
 impl CommitmentAggregationData {
-    pub fn new(bank: Arc<Bank>, root: Slot, total_stake: u64) -> Self {
+    pub fn new(bank: Arc<Bank>, root: Slot, total_stake: Stake) -> Self {
         Self {
             bank,
             root,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -544,7 +544,7 @@ impl Tower {
         let mut slot_with_ancestors = vec![vote.slot];
         slot_with_ancestors.extend(vote_slot_ancestors.unwrap());
         for slot in slot_with_ancestors {
-            stake_lockouts.insert(slot, StakeLockout::default());
+            stake_lockouts.entry(slot).or_default();
         }
     }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -492,7 +492,7 @@ impl Tower {
         &self,
         slot: Slot,
         voted_stakes: &VotedStakes,
-        total_stake: u64,
+        total_stake: Stake,
     ) -> bool {
         let mut lockouts = self.lockouts.clone();
         lockouts.process_slot_vote_unchecked(slot);

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -1,6 +1,9 @@
 use crate::{
-    cluster_info_vote_listener::SlotVoteTracker, cluster_slots::SlotPubkeys, consensus::Stake,
-    pubkey_references::PubkeyReferences, replay_stage::SUPERMINORITY_THRESHOLD,
+    cluster_info_vote_listener::SlotVoteTracker,
+    cluster_slots::SlotPubkeys,
+    pubkey_references::PubkeyReferences,
+    replay_stage::SUPERMINORITY_THRESHOLD,
+    {consensus::Stake, consensus::VotedStakes},
 };
 use solana_ledger::blockstore_processor::{ConfirmationProgress, ConfirmationTiming};
 use solana_runtime::{bank::Bank, bank_forks::BankForks};
@@ -196,7 +199,7 @@ pub(crate) struct ForkStats {
     pub(crate) is_empty: bool,
     pub(crate) vote_threshold: bool,
     pub(crate) is_locked_out: bool,
-    pub(crate) voted_stakes: HashMap<Slot, Stake>,
+    pub(crate) voted_stakes: VotedStakes,
     pub(crate) confirmation_reported: bool,
     pub(crate) computed: bool,
     pub(crate) lockout_intervals: LockoutIntervals,

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -1,7 +1,6 @@
 use crate::{
-    cluster_info_vote_listener::SlotVoteTracker, cluster_slots::SlotPubkeys,
-    consensus::StakeLockout, pubkey_references::PubkeyReferences,
-    replay_stage::SUPERMINORITY_THRESHOLD,
+    cluster_info_vote_listener::SlotVoteTracker, cluster_slots::SlotPubkeys, consensus::Stake,
+    pubkey_references::PubkeyReferences, replay_stage::SUPERMINORITY_THRESHOLD,
 };
 use solana_ledger::blockstore_processor::{ConfirmationProgress, ConfirmationTiming};
 use solana_runtime::{bank::Bank, bank_forks::BankForks};
@@ -190,14 +189,14 @@ impl ForkProgress {
 pub(crate) struct ForkStats {
     pub(crate) weight: u128,
     pub(crate) fork_weight: u128,
-    pub(crate) total_staked: u64,
+    pub(crate) total_stake: Stake,
     pub(crate) block_height: u64,
     pub(crate) has_voted: bool,
     pub(crate) is_recent: bool,
     pub(crate) is_empty: bool,
     pub(crate) vote_threshold: bool,
     pub(crate) is_locked_out: bool,
-    pub(crate) stake_lockouts: HashMap<u64, StakeLockout>,
+    pub(crate) voted_stakes: HashMap<Slot, Stake>,
     pub(crate) confirmation_reported: bool,
     pub(crate) computed: bool,
     pub(crate) lockout_intervals: LockoutIntervals,

--- a/docs/src/implemented-proposals/commitment.md
+++ b/docs/src/implemented-proposals/commitment.md
@@ -23,13 +23,12 @@ this array, representing all the possible number of confirmations from 1 to
 Building this `BlockCommitment` struct leverages the computations already being
 performed for building consensus. The `collect_vote_lockouts` function in
 `consensus.rs` builds a HashMap, where each entry is of the form `(b, s)`
-where `s` is a `StakeLockout` struct representing the amount of stake and
-lockout on a bank `b`.
+where `s` is the amount of stake on a bank `b`.
 
 This computation is performed on a votable candidate bank `b` as follows.
 
 ```text
-   let output: HashMap<b, StakeLockout> = HashMap::new();
+   let output: HashMap<b, Stake> = HashMap::new();
    for vote_account in b.vote_accounts {
        for v in vote_account.vote_stack {
            for a in ancestors(v) {
@@ -39,7 +38,7 @@ This computation is performed on a votable candidate bank `b` as follows.
    }
 ```
 
-where `f` is some accumulation function that modifies the `StakeLockout` entry
+where `f` is some accumulation function that modifies the `Stake` entry
 for slot `a` with some data derivable from vote `v` and `vote_account`
 (stake, lockout, etc.). Note here that the `ancestors` here only includes
 slots that are present in the current status cache. Signatures for banks earlier
@@ -63,7 +62,7 @@ votes > v as the number of confirmations will be lower).
 Now more specifically, we augment the above computation to:
 
 ```text
-   let output: HashMap<b, StakeLockout> = HashMap::new();
+   let output: HashMap<b, Stake> = HashMap::new();
    let fork_commitment_cache = ForkCommitmentCache::default();
    for vote_account in b.vote_accounts {
        // vote stack is sorted from oldest vote to newest vote
@@ -78,12 +77,12 @@ Now more specifically, we augment the above computation to:
 where `f'` is defined as:
 ```text
     fn f`(
-        stake_lockout: &mut StakeLockout,
+        stake: &mut Stake,
         some_ancestor: &mut BlockCommitment,
         vote_account: VoteAccount,
         v: Vote, total_stake: u64
     ){
-        f(stake_lockout, vote_account, v);
+        f(stake, vote_account, v);
         *some_ancestor.commitment[v.num_confirmations] += vote_account.stake;
     }
 ```


### PR DESCRIPTION
#### Problem

StakeLockout::lockout isn't used anymore and it does unnecessary computation to mange the field and uses extra memory.

Also, the naming is outdated as a result.

#### Summary of Changes

Remove the field and tidy up the namings of types and fields.

This PR should contain no functional change.

Part of #10718 
