### PR TITLE
Remote Wallet: bubble up derivation-path parse errors

### DIFF
--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -281,12 +281,26 @@ impl RemoteWalletInfo {
                             key_path.pop();
                         }
                         let mut parts = key_path.split('/');
-                        derivation_path.account = parts
-                            .next()
-                            .and_then(|account| account.replace("'", "").parse::<u32>().ok());
-                        derivation_path.change = parts
-                            .next()
-                            .and_then(|change| change.replace("'", "").parse::<u32>().ok());
+                        derivation_path.account = if let Some(account) = parts.next() {
+                            Some(account.replace("'", "").parse::<u32>().map_err(|_| {
+                                RemoteWalletError::InvalidDerivationPath(format!(
+                                    "account `{}` invalid",
+                                    account
+                                ))
+                            })?)
+                        } else {
+                            None
+                        };
+                        derivation_path.change = if let Some(change) = parts.next() {
+                            Some(change.replace("'", "").parse::<u32>().map_err(|_| {
+                                RemoteWalletError::InvalidDerivationPath(format!(
+                                    "change `{}` invalid",
+                                    change
+                                ))
+                            })?)
+                        } else {
+                            None
+                        };
                         if parts.next().is_some() {
                             return Err(RemoteWalletError::InvalidDerivationPath(format!(
                                 "key path `{}` too deep, only <account>/<change> supported",


### PR DESCRIPTION
#### Problem
The Remote Wallet code silently drops unparseable `account` or `change` values from the derivation path, so `?key=A/1` returns the wallet key at `?key=<empty>` and `?key=1/A` returns the wallet key at derivation path `?key=1`.
This might result in signing with unintended keys.

#### Summary of Changes
Bubble up derivation path parse errors so that signing doesn't occur on malformed query strings

Fixes #10722 
