### PR TITLE
ledger-tool: Ignore SIGUSR1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,6 +4213,7 @@ dependencies = [
  "log 0.4.8",
  "serde_json",
  "serde_yaml",
+ "signal-hook",
  "solana-clap-utils",
  "solana-cli",
  "solana-ledger",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -31,5 +31,8 @@ tempfile = "3.1.0"
 [dev-dependencies]
 assert_cmd = "1.0"
 
+[target."cfg(unix)".dependencies]
+signal-hook = "0.1.15"
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -614,6 +614,16 @@ fn open_genesis_config_by(ledger_path: &Path, matches: &ArgMatches<'_>) -> Genes
 
 #[allow(clippy::cognitive_complexity)]
 fn main() {
+    // Ignore SIGUSR1 to prevent long-running calls being killed by logrotate
+    // in warehouse deployments
+    #[cfg(unix)]
+    {
+        // `register()` is unsafe because the action is called in a signal handler
+        // with the usual caveats. So long as this action body stays empty, we'll
+        // be fine
+        unsafe { signal_hook::register(signal_hook::SIGUSR1, || {}) }.unwrap();
+    }
+
     const DEFAULT_ROOT_COUNT: &str = "1";
     solana_logger::setup_with_default("solana=info");
 


### PR DESCRIPTION
#### Problem

`ledger-tool` doesn't ignore `SIGUSR1` which can lead to warehouse nodes being killed by `logrotate` should it be triggered during the archive step

#### Summary of Changes

Ignore it