### PR TITLE
Remove unused ComputedBankState::lockout_intervals

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1,7 +1,5 @@
 use crate::{
-    commitment::VOTE_THRESHOLD_SIZE,
-    progress_map::{LockoutIntervals, ProgressMap},
-    pubkey_references::PubkeyReferences,
+    commitment::VOTE_THRESHOLD_SIZE, progress_map::ProgressMap, pubkey_references::PubkeyReferences,
 };
 use chrono::prelude::*;
 use solana_runtime::{bank::Bank, bank_forks::BankForks};
@@ -82,7 +80,6 @@ pub(crate) struct ComputedBankState {
     pub stake_lockouts: HashMap<Slot, StakeLockout>,
     pub total_staked: u64,
     pub bank_weight: u128,
-    pub lockout_intervals: LockoutIntervals,
     pub pubkey_votes: Vec<(Pubkey, Slot)>,
 }
 
@@ -256,7 +253,6 @@ impl Tower {
             stake_lockouts,
             total_staked,
             bank_weight,
-            lockout_intervals,
             pubkey_votes,
         }
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1235,7 +1235,6 @@ impl ReplayStage {
                     let ComputedBankState {
                         stake_lockouts,
                         total_staked,
-                        lockout_intervals,
                         ..
                     } = computed_bank_state;
                     let stats = progress
@@ -1243,7 +1242,6 @@ impl ReplayStage {
                         .expect("All frozen banks must exist in the Progress map");
                     stats.total_staked = total_staked;
                     stats.stake_lockouts = stake_lockouts;
-                    stats.lockout_intervals = lockout_intervals;
                     stats.block_height = bank.block_height();
                     stats.computed = true;
                     new_stats.push(bank_slot);


### PR DESCRIPTION
#### Problem

`ComputedBankState::lockout_intervals` isn't used at all and causes confusion to readers and does unneeded `.clone()` of `BTreeMap` (=LockoutIntervals).

#### Summary of Changes

Just remove it.

This should contain no functional change.

Part of #10718
