### PR TITLE
Switch to using weighted repair in RepairService

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -28,7 +28,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     transaction::Transaction,
 };
-use solana_vote_program::vote_instruction::VoteInstruction;
+use solana_vote_program::{vote_instruction::VoteInstruction, vote_state::Vote};
 use std::{
     collections::{HashMap, HashSet},
     sync::{
@@ -40,10 +40,12 @@ use std::{
 };
 
 // Map from a vote account to the authorized voter for an epoch
-pub type VerifiedVotePacketsSender = CrossbeamSender<Vec<(CrdsValueLabel, Packets)>>;
-pub type VerifiedVotePacketsReceiver = CrossbeamReceiver<Vec<(CrdsValueLabel, Packets)>>;
+pub type VerifiedLabelVotePacketsSender = CrossbeamSender<Vec<(CrdsValueLabel, Packets)>>;
+pub type VerifiedLabelVotePacketsReceiver = CrossbeamReceiver<Vec<(CrdsValueLabel, Packets)>>;
 pub type VerifiedVoteTransactionsSender = CrossbeamSender<Vec<Transaction>>;
 pub type VerifiedVoteTransactionsReceiver = CrossbeamReceiver<Vec<Transaction>>;
+pub type VerifiedVoteSender = CrossbeamSender<(Pubkey, Vote)>;
+pub type VerifiedVoteReceiver = CrossbeamReceiver<(Pubkey, Vote)>;
 
 #[derive(Default)]
 pub struct SlotVoteTracker {
@@ -202,15 +204,17 @@ impl ClusterInfoVoteListener {
     pub fn new(
         exit: &Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
-        sender: CrossbeamSender<Vec<Packets>>,
+        verified_packets_sender: CrossbeamSender<Vec<Packets>>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
         vote_tracker: Arc<VoteTracker>,
         bank_forks: Arc<RwLock<BankForks>>,
         subscriptions: Arc<RpcSubscriptions>,
+        verified_vote_sender: VerifiedVoteSender,
     ) -> Self {
         let exit_ = exit.clone();
 
-        let (verified_vote_packets_sender, verified_vote_packets_receiver) = unbounded();
+        let (verified_vote_label_packets_sender, verified_vote_label_packets_receiver) =
+            unbounded();
         let (verified_vote_transactions_sender, verified_vote_transactions_receiver) = unbounded();
         let listen_thread = Builder::new()
             .name("solana-cluster_info_vote_listener".to_string())
@@ -218,7 +222,7 @@ impl ClusterInfoVoteListener {
                 let _ = Self::recv_loop(
                     exit_,
                     &cluster_info,
-                    verified_vote_packets_sender,
+                    verified_vote_label_packets_sender,
                     verified_vote_transactions_sender,
                 );
             })
@@ -231,9 +235,9 @@ impl ClusterInfoVoteListener {
             .spawn(move || {
                 let _ = Self::bank_send_loop(
                     exit_,
-                    verified_vote_packets_receiver,
+                    verified_vote_label_packets_receiver,
                     poh_recorder,
-                    &sender,
+                    &verified_packets_sender,
                 );
             })
             .unwrap();
@@ -248,6 +252,7 @@ impl ClusterInfoVoteListener {
                     vote_tracker,
                     &bank_forks,
                     subscriptions,
+                    verified_vote_sender,
                 );
             })
             .unwrap();
@@ -267,7 +272,7 @@ impl ClusterInfoVoteListener {
     fn recv_loop(
         exit: Arc<AtomicBool>,
         cluster_info: &ClusterInfo,
-        verified_vote_packets_sender: VerifiedVotePacketsSender,
+        verified_vote_label_packets_sender: VerifiedLabelVotePacketsSender,
         verified_vote_transactions_sender: VerifiedVoteTransactionsSender,
     ) -> Result<()> {
         let mut last_ts = 0;
@@ -282,7 +287,7 @@ impl ClusterInfoVoteListener {
             if !votes.is_empty() {
                 let (vote_txs, packets) = Self::verify_votes(votes, labels);
                 verified_vote_transactions_sender.send(vote_txs)?;
-                verified_vote_packets_sender.send(packets)?;
+                verified_vote_label_packets_sender.send(packets)?;
             }
 
             sleep(Duration::from_millis(GOSSIP_SLEEP_MILLIS));
@@ -322,9 +327,9 @@ impl ClusterInfoVoteListener {
 
     fn bank_send_loop(
         exit: Arc<AtomicBool>,
-        verified_vote_packets_receiver: VerifiedVotePacketsReceiver,
+        verified_vote_label_packets_receiver: VerifiedLabelVotePacketsReceiver,
         poh_recorder: Arc<Mutex<PohRecorder>>,
-        packets_sender: &CrossbeamSender<Vec<Packets>>,
+        verified_packets_sender: &CrossbeamSender<Vec<Packets>>,
     ) -> Result<()> {
         let mut verified_vote_packets = VerifiedVotePackets::default();
         let mut time_since_lock = Instant::now();
@@ -334,9 +339,10 @@ impl ClusterInfoVoteListener {
                 return Ok(());
             }
 
-            if let Err(e) = verified_vote_packets
-                .get_and_process_vote_packets(&verified_vote_packets_receiver, &mut update_version)
-            {
+            if let Err(e) = verified_vote_packets.get_and_process_vote_packets(
+                &verified_vote_label_packets_receiver,
+                &mut update_version,
+            ) {
                 match e {
                     Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => {
                         return Ok(());
@@ -353,7 +359,7 @@ impl ClusterInfoVoteListener {
                 if let Some(bank) = bank {
                     let last_version = bank.last_vote_sync.load(Ordering::Relaxed);
                     let (new_version, msgs) = verified_vote_packets.get_latest_votes(last_version);
-                    packets_sender.send(msgs)?;
+                    verified_packets_sender.send(msgs)?;
                     bank.last_vote_sync.compare_and_swap(
                         last_version,
                         new_version,
@@ -371,6 +377,7 @@ impl ClusterInfoVoteListener {
         vote_tracker: Arc<VoteTracker>,
         bank_forks: &RwLock<BankForks>,
         subscriptions: Arc<RpcSubscriptions>,
+        verified_vote_sender: VerifiedVoteSender,
     ) -> Result<()> {
         loop {
             if exit.load(Ordering::Relaxed) {
@@ -387,6 +394,7 @@ impl ClusterInfoVoteListener {
                 root_bank.slot(),
                 &subscriptions,
                 epoch_stakes,
+                &verified_vote_sender,
             ) {
                 match e {
                     Error::CrossbeamRecvTimeoutError(RecvTimeoutError::Disconnected) => {
@@ -423,6 +431,7 @@ impl ClusterInfoVoteListener {
         last_root: Slot,
         subscriptions: &RpcSubscriptions,
         epoch_stakes: Option<&EpochStakes>,
+        verified_vote_sender: &VerifiedVoteSender,
     ) -> Result<()> {
         let timer = Duration::from_millis(200);
         let mut vote_txs = vote_txs_receiver.recv_timeout(timer)?;
@@ -435,6 +444,7 @@ impl ClusterInfoVoteListener {
             last_root,
             subscriptions,
             epoch_stakes,
+            verified_vote_sender,
         );
         Ok(())
     }
@@ -445,77 +455,84 @@ impl ClusterInfoVoteListener {
         root: Slot,
         subscriptions: &RpcSubscriptions,
         epoch_stakes: Option<&EpochStakes>,
+        verified_vote_sender: &VerifiedVoteSender,
     ) {
         let mut diff: HashMap<Slot, HashSet<Arc<Pubkey>>> = HashMap::new();
         {
-            let all_slot_trackers = &vote_tracker.slot_vote_trackers;
-            for tx in vote_txs {
-                if let (Some(vote_pubkey), Some(vote_instruction)) = tx
-                    .message
-                    .instructions
-                    .first()
-                    .and_then(|first_instruction| {
-                        first_instruction.accounts.first().map(|offset| {
-                            (
-                                tx.message.account_keys.get(*offset as usize),
-                                limited_deserialize(&first_instruction.data).ok(),
-                            )
+            let valid_votes: Vec<(Pubkey, Vote)> = vote_txs
+                .into_iter()
+                .filter_map(|tx| {
+                    if let (Some(vote_pubkey), Some(vote_instruction)) = tx
+                        .message
+                        .instructions
+                        .first()
+                        .and_then(|first_instruction| {
+                            first_instruction.accounts.first().map(|offset| {
+                                (
+                                    tx.message.account_keys.get(*offset as usize),
+                                    limited_deserialize(&first_instruction.data).ok(),
+                                )
+                            })
                         })
-                    })
-                    .unwrap_or((None, None))
-                {
-                    let vote = {
-                        match vote_instruction {
-                            VoteInstruction::Vote(vote) => vote,
-                            _ => {
-                                continue;
+                        .unwrap_or((None, None))
+                    {
+                        let vote = {
+                            match vote_instruction {
+                                VoteInstruction::Vote(vote) => vote,
+                                _ => {
+                                    return None;
+                                }
                             }
+                        };
+
+                        if vote.slots.is_empty() {
+                            return None;
                         }
-                    };
 
-                    if vote.slots.is_empty() {
+                        let last_vote_slot = vote.slots.last().unwrap();
+
+                        // Determine the authorized voter based on the last vote slot. This will
+                        // drop votes from authorized voters trying to make votes for slots
+                        // earlier than the epoch for which they are authorized
+                        let actual_authorized_voter =
+                            vote_tracker.get_authorized_voter(&vote_pubkey, *last_vote_slot);
+
+                        if actual_authorized_voter.is_none() {
+                            None
+                        } else if !VoteTracker::vote_contains_authorized_voter(
+                            &tx,
+                            &actual_authorized_voter.unwrap(),
+                        ) {
+                            // Voting without the correct authorized pubkey, dump the vote
+                            None
+                        } else {
+                            let _ = verified_vote_sender.send((*vote_pubkey, vote.clone()));
+                            subscriptions.notify_vote(&vote);
+                            Some((*vote_pubkey, vote))
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            for (vote_pubkey, vote) in valid_votes {
+                let all_slot_trackers = &vote_tracker.slot_vote_trackers;
+                for &slot in vote.slots.iter() {
+                    if slot <= root {
                         continue;
                     }
 
-                    let last_vote_slot = vote.slots.last().unwrap();
-
-                    // Determine the authorized voter based on the last vote slot. This will
-                    // drop votes from authorized voters trying to make votes for slots
-                    // earlier than the epoch for which they are authorized
-                    let actual_authorized_voter =
-                        vote_tracker.get_authorized_voter(&vote_pubkey, *last_vote_slot);
-
-                    if actual_authorized_voter.is_none() {
-                        continue;
-                    }
-
-                    // Voting without the correct authorized pubkey, dump the vote
-                    if !VoteTracker::vote_contains_authorized_voter(
-                        &tx,
-                        &actual_authorized_voter.unwrap(),
-                    ) {
-                        continue;
-                    }
-
-                    for &slot in vote.slots.iter() {
-                        if slot <= root {
+                    // Don't insert if we already have marked down this pubkey
+                    // voting for this slot
+                    let maybe_slot_tracker = all_slot_trackers.read().unwrap().get(&slot).cloned();
+                    if let Some(slot_tracker) = maybe_slot_tracker {
+                        if slot_tracker.read().unwrap().voted.contains(&vote_pubkey) {
                             continue;
                         }
-
-                        // Don't insert if we already have marked down this pubkey
-                        // voting for this slot
-                        let maybe_slot_tracker =
-                            all_slot_trackers.read().unwrap().get(&slot).cloned();
-                        if let Some(slot_tracker) = maybe_slot_tracker {
-                            if slot_tracker.read().unwrap().voted.contains(vote_pubkey) {
-                                continue;
-                            }
-                        }
-                        let unduplicated_pubkey = vote_tracker.keys.get_or_insert(vote_pubkey);
-                        diff.entry(slot).or_default().insert(unduplicated_pubkey);
                     }
-
-                    subscriptions.notify_vote(&vote);
+                    let unduplicated_pubkey = vote_tracker.keys.get_or_insert(&vote_pubkey);
+                    diff.entry(slot).or_default().insert(unduplicated_pubkey);
                 }
             }
         }
@@ -782,6 +799,7 @@ mod tests {
         // Create some voters at genesis
         let (vote_tracker, _, validator_voting_keypairs, subscriptions) = setup();
         let (votes_sender, votes_receiver) = unbounded();
+        let (verified_vote_sender, verified_vote_receiver) = unbounded();
 
         let vote_slots = vec![1, 2];
         validator_voting_keypairs.iter().for_each(|keypairs| {
@@ -805,8 +823,20 @@ mod tests {
             0,
             &subscriptions,
             None,
+            &verified_vote_sender,
         )
         .unwrap();
+
+        // Check that the received votes were pushed to other commponents
+        //  subscribing via a channel
+        let received_votes: Vec<_> = verified_vote_receiver.into_iter().collect();
+        assert_eq!(received_votes.len(), validator_voting_keypairs.len());
+        for (voting_keypair, (received_pubkey, received_vote)) in
+            validator_voting_keypairs.zip(received_votes)
+        {
+            assert_eq!(voting_keypair.pubkey(), received_pubkey);
+            assert_eq!(received_vote.slots, vote_slots);
+        }
         for vote_slot in vote_slots {
             let slot_vote_tracker = vote_tracker.get_slot_vote_tracker(vote_slot).unwrap();
             let r_slot_vote_tracker = slot_vote_tracker.read().unwrap();

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -51,7 +51,7 @@ pub type VerifiedVoteReceiver = CrossbeamReceiver<(Pubkey, Vote)>;
 pub struct SlotVoteTracker {
     voted: HashSet<Arc<Pubkey>>,
     updates: Option<Vec<Arc<Pubkey>>>,
-    pub total_stake: u64,
+    total_stake: u64,
 }
 
 impl SlotVoteTracker {
@@ -64,7 +64,7 @@ impl SlotVoteTracker {
 #[derive(Default)]
 pub struct VoteTracker {
     // Map from a slot to a set of validators who have voted for that slot
-    pub slot_vote_trackers: RwLock<HashMap<Slot, Arc<RwLock<SlotVoteTracker>>>>,
+    slot_vote_trackers: RwLock<HashMap<Slot, Arc<RwLock<SlotVoteTracker>>>>,
     // Don't track votes from people who are not staked, acts as a spam filter
     epoch_authorized_voters: RwLock<HashMap<Epoch, Arc<EpochAuthorizedVoters>>>,
     leader_schedule_epoch: RwLock<Epoch>,

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -3,6 +3,7 @@
 use crate::{
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::VoteTracker,
+    cluster_info_vote_listener::VerifiedVoteReceiver,
     cluster_slots::ClusterSlots,
     repair_weighted_traversal::Contains,
     result::Result,
@@ -144,6 +145,7 @@ impl RepairService {
         repair_info: RepairInfo,
         cluster_slots: Arc<ClusterSlots>,
         vote_tracker: Arc<VoteTracker>,
+        verified_vote_receiver: VerifiedVoteReceiver,
     ) -> Self {
         let t_repair = Builder::new()
             .name("solana-repair-service".to_string())
@@ -156,6 +158,7 @@ impl RepairService {
                     repair_info,
                     &cluster_slots,
                     vote_tracker,
+                    verified_vote_receiver,
                 )
             })
             .unwrap();
@@ -171,6 +174,7 @@ impl RepairService {
         repair_info: RepairInfo,
         cluster_slots: &ClusterSlots,
         vote_tracker: Arc<VoteTracker>,
+        verified_vote_receiver: VerifiedVoteReceiver,
     ) {
         let serve_repair = ServeRepair::new(cluster_info.clone());
         let id = cluster_info.id();

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -2,8 +2,8 @@
 //! regularly finds missing shreds in the ledger and sends repair requests for those shreds
 use crate::{
     cluster_info::ClusterInfo,
-    cluster_info_vote_listener::VoteTracker,
     cluster_info_vote_listener::VerifiedVoteReceiver,
+    cluster_info_vote_listener::VoteTracker,
     cluster_slots::ClusterSlots,
     repair_weighted_traversal::Contains,
     result::Result,
@@ -145,7 +145,7 @@ impl RepairService {
         repair_info: RepairInfo,
         cluster_slots: Arc<ClusterSlots>,
         vote_tracker: Arc<VoteTracker>,
-        verified_vote_receiver: VerifiedVoteReceiver,
+        _verified_vote_receiver: VerifiedVoteReceiver,
     ) -> Self {
         let t_repair = Builder::new()
             .name("solana-repair-service".to_string())
@@ -158,7 +158,7 @@ impl RepairService {
                     repair_info,
                     &cluster_slots,
                     vote_tracker,
-                    verified_vote_receiver,
+                    _verified_vote_receiver,
                 )
             })
             .unwrap();
@@ -174,7 +174,7 @@ impl RepairService {
         repair_info: RepairInfo,
         cluster_slots: &ClusterSlots,
         vote_tracker: Arc<VoteTracker>,
-        verified_vote_receiver: VerifiedVoteReceiver,
+        _verified_vote_receiver: VerifiedVoteReceiver,
     ) {
         let serve_repair = ServeRepair::new(cluster_info.clone());
         let id = cluster_info.id();

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -10,9 +10,6 @@ use crate::{
     serve_repair::{RepairType, ServeRepair, DEFAULT_NONCE},
 };
 use crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender};
-use rand::distributions::{Distribution, WeightedIndex};
-use rand::{thread_rng, Rng, SeedableRng};
-use rand_chacha::ChaChaRng;
 use solana_ledger::{
     blockstore::{Blockstore, CompletedSlotsReceiver, SlotMeta},
     shred::Nonce,
@@ -864,14 +861,8 @@ mod test {
 
             let vote_tracker = Arc::new(VoteTracker::default());
             assert_eq!(
-                RepairService::generate_repairs(
-                    &blockstore,
-                    0,
-                    std::usize::MAX,
-                    &HashMap::new(),
-                    &vote_tracker
-                )
-                .unwrap(),
+                RepairService::generate_repairs(&blockstore, 0, std::usize::MAX, &HashMap::new())
+                    .unwrap(),
                 expected
             );
 
@@ -886,55 +877,6 @@ mod test {
                 .unwrap()[..],
                 expected[0..expected.len() - 2]
             );
-        }
-        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
-    }
-
-    #[test]
-    pub fn test_repairs_distributed_across_slots() {
-        solana_logger::setup();
-        let blockstore_path = get_tmp_ledger_path!();
-        {
-            let blockstore = Blockstore::open(&blockstore_path).unwrap();
-
-            let num_entries_per_slot = 100;
-
-            // Create some shreds
-            for i in 1..10 {
-                let (shreds, _) = make_slot_entries(i, 0, num_entries_per_slot as u64);
-
-                // Only insert the first shred
-                blockstore
-                    .insert_shreds(shreds[..1].to_vec(), None, false)
-                    .unwrap();
-            }
-
-            let vote_tracker = Arc::new(VoteTracker::default());
-            let repairs = RepairService::generate_repairs(
-                &blockstore,
-                0,
-                num_entries_per_slot,
-                &HashMap::new(),
-                &vote_tracker,
-            )
-            .unwrap();
-            let mut repairs_slots = HashMap::new();
-            for repair in repairs {
-                match repair {
-                    RepairType::Shred(slot, _shred_index) => {
-                        *repairs_slots.entry(slot).or_insert(0) += 1;
-                    }
-                    RepairType::HighestShred(slot, _shred_index) => {
-                        *repairs_slots.entry(slot).or_insert(0) += 1;
-                    }
-                    RepairType::Orphan(slot) => {
-                        *repairs_slots.entry(slot).or_insert(0) += 1;
-                    }
-                }
-            }
-            for i in 1..10 {
-                assert!(repairs_slots.contains_key(&i));
-            }
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }
@@ -962,14 +904,8 @@ mod test {
 
             let vote_tracker = Arc::new(VoteTracker::default());
             assert_eq!(
-                RepairService::generate_repairs(
-                    &blockstore,
-                    0,
-                    std::usize::MAX,
-                    &HashMap::new(),
-                    &vote_tracker
-                )
-                .unwrap(),
+                RepairService::generate_repairs(&blockstore, 0, std::usize::MAX, &HashMap::new())
+                    .unwrap(),
                 expected
             );
         }

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -1,6 +1,6 @@
 use crate::{
     heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
-    repair_service::RepairStats,
+    repair_service::RepairTiming,
     repair_weighted_traversal::{self, Contains},
     serve_repair::RepairType,
 };
@@ -136,7 +136,7 @@ impl RepairWeight {
         max_new_orphans: usize,
         max_new_shreds: usize,
         ignore_slots: &dyn Contains<Slot>,
-        repair_stats: Option<&mut RepairStats>,
+        repair_timing: Option<&mut RepairTiming>,
     ) -> Vec<RepairType> {
         let mut repairs = vec![];
         let mut get_best_orphans_elapsed = Measure::start("get_best_orphans");
@@ -155,9 +155,9 @@ impl RepairWeight {
         self.get_best_shreds(blockstore, &mut repairs, max_new_shreds, ignore_slots);
         get_best_shreds_elapsed.stop();
 
-        if let Some(repair_stats) = repair_stats {
-            repair_stats.get_best_orphans_us += get_best_orphans_elapsed.as_us();
-            repair_stats.get_best_shreds_us += get_best_shreds_elapsed.as_us();
+        if let Some(repair_timing) = repair_timing {
+            repair_timing.get_best_orphans_elapsed += get_best_orphans_elapsed.as_us();
+            repair_timing.get_best_shreds_elapsed += get_best_shreds_elapsed.as_us();
         }
         repairs
     }

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -3,6 +3,7 @@
 use crate::cluster_info_vote_listener::VoteTracker;
 use crate::{
     cluster_info::{compute_retransmit_peers, ClusterInfo, DATA_PLANE_FANOUT},
+    cluster_info_vote_listener::VerifiedVoteReceiver,
     cluster_slots::ClusterSlots,
     contact_info::ContactInfo,
     repair_service::DuplicateSlotsResetSender,
@@ -415,6 +416,7 @@ impl RetransmitStage {
         cluster_slots: Arc<ClusterSlots>,
         duplicate_slots_reset_sender: DuplicateSlotsResetSender,
         vote_tracker: Arc<VoteTracker>,
+        verified_vote_receiver: VerifiedVoteReceiver,
     ) -> Self {
         let (retransmit_sender, retransmit_receiver) = channel();
 
@@ -460,6 +462,7 @@ impl RetransmitStage {
             },
             cluster_slots,
             vote_tracker,
+            verified_vote_receiver,
         );
 
         let thread_hdls = t_retransmit;

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -1,6 +1,5 @@
 //! The `retransmit_stage` retransmits shreds between validators
 
-use crate::cluster_info_vote_listener::VoteTracker;
 use crate::{
     cluster_info::{compute_retransmit_peers, ClusterInfo, DATA_PLANE_FANOUT},
     cluster_info_vote_listener::VerifiedVoteReceiver,
@@ -415,7 +414,6 @@ impl RetransmitStage {
         shred_version: u16,
         cluster_slots: Arc<ClusterSlots>,
         duplicate_slots_reset_sender: DuplicateSlotsResetSender,
-        vote_tracker: Arc<VoteTracker>,
         verified_vote_receiver: VerifiedVoteReceiver,
     ) -> Self {
         let (retransmit_sender, retransmit_receiver) = channel();
@@ -461,7 +459,6 @@ impl RetransmitStage {
                 rv && is_connected
             },
             cluster_slots,
-            vote_tracker,
             verified_vote_receiver,
         );
 

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -876,11 +876,13 @@ mod tests {
         });
 
         // Process votes and check they were notified.
+        let (r, s) = unbounded();
         ClusterInfoVoteListener::get_and_process_votes_for_tests(
             &votes_receiver,
             &vote_tracker,
             0,
             &rpc.subscriptions,
+            s,
         )
         .unwrap();
 

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -876,13 +876,13 @@ mod tests {
         });
 
         // Process votes and check they were notified.
-        let (r, s) = unbounded();
+        let (s, _r) = unbounded();
         ClusterInfoVoteListener::get_and_process_votes_for_tests(
             &votes_receiver,
             &vote_tracker,
             0,
             &rpc.subscriptions,
-            s,
+            &s,
         )
         .unwrap();
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -6,7 +6,7 @@ use crate::{
     accounts_hash_verifier::AccountsHashVerifier,
     broadcast_stage::RetransmitSlotsSender,
     cluster_info::ClusterInfo,
-    cluster_info_vote_listener::VoteTracker,
+    cluster_info_vote_listener::{VerifiedVoteReceiver, VoteTracker},
     cluster_slots::ClusterSlots,
     ledger_cleanup_service::LedgerCleanupService,
     poh_recorder::PohRecorder,
@@ -97,6 +97,7 @@ impl Tvu {
         snapshot_package_sender: Option<AccountsPackageSender>,
         vote_tracker: Arc<VoteTracker>,
         retransmit_slots_sender: RetransmitSlotsSender,
+        verified_vote_receiver: VerifiedVoteReceiver,
         tvu_config: TvuConfig,
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info.keypair.clone();
@@ -148,6 +149,7 @@ impl Tvu {
             cluster_slots.clone(),
             duplicate_slots_reset_sender,
             vote_tracker.clone(),
+            verified_vote_receiver,
         );
 
         let (ledger_cleanup_slot_sender, ledger_cleanup_slot_receiver) = channel();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -283,6 +283,7 @@ pub mod tests {
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let (retransmit_slots_sender, _retransmit_slots_receiver) = unbounded();
+        let (_verified_vote_sender, verified_vote_receiver) = unbounded();
         let bank_forks = Arc::new(RwLock::new(bank_forks));
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
@@ -315,6 +316,7 @@ pub mod tests {
             None,
             Arc::new(VoteTracker::new(&bank)),
             retransmit_slots_sender,
+            verified_vote_receiver,
             TvuConfig::default(),
         );
         exit.store(true, Ordering::Relaxed);

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -148,7 +148,6 @@ impl Tvu {
             tvu_config.shred_version,
             cluster_slots.clone(),
             duplicate_slots_reset_sender,
-            vote_tracker.clone(),
             verified_vote_receiver,
         );
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -415,6 +415,7 @@ impl Validator {
         let vote_tracker = Arc::new(VoteTracker::new(bank_forks.read().unwrap().root_bank()));
 
         let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
+        let (verified_vote_sender, verified_vote_receiver) = unbounded();
         let tvu = Tvu::new(
             vote_account,
             authorized_voter_keypairs,
@@ -459,6 +460,7 @@ impl Validator {
             snapshot_package_sender,
             vote_tracker.clone(),
             retransmit_slots_sender,
+            verified_vote_receiver,
             TvuConfig {
                 max_ledger_shreds: config.max_ledger_shreds,
                 halt_on_trusted_validators_accounts_hash_mismatch: config
@@ -485,6 +487,7 @@ impl Validator {
             node.info.shred_version,
             vote_tracker,
             bank_forks,
+            verified_vote_sender,
         );
 
         datapoint_info!("validator-new", ("id", id.to_string(), String));

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cluster_info_vote_listener::VerifiedVotePacketsReceiver, crds_value::CrdsValueLabel,
+    cluster_info_vote_listener::VerifiedLabelVotePacketsReceiver, crds_value::CrdsValueLabel,
     result::Result,
 };
 use solana_perf::packet::Packets;
@@ -18,7 +18,7 @@ impl Deref for VerifiedVotePackets {
 impl VerifiedVotePackets {
     pub fn get_and_process_vote_packets(
         &mut self,
-        vote_packets_receiver: &VerifiedVotePacketsReceiver,
+        vote_packets_receiver: &VerifiedLabelVotePacketsReceiver,
         last_update_version: &mut u64,
     ) -> Result<()> {
         let timer = Duration::from_millis(200);

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -3,8 +3,8 @@
 //!
 use crate::{
     cluster_info::ClusterInfo,
-    cluster_info_vote_listener::VoteTracker,
     cluster_info_vote_listener::VerifiedVoteReceiver,
+    cluster_info_vote_listener::VoteTracker,
     cluster_slots::ClusterSlots,
     repair_response,
     repair_service::{RepairInfo, RepairService},

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -4,6 +4,7 @@
 use crate::{
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::VoteTracker,
+    cluster_info_vote_listener::VerifiedVoteReceiver,
     cluster_slots::ClusterSlots,
     repair_response,
     repair_service::{RepairInfo, RepairService},
@@ -302,6 +303,7 @@ impl WindowService {
         shred_filter: F,
         cluster_slots: Arc<ClusterSlots>,
         vote_tracker: Arc<VoteTracker>,
+        verified_vote_receiver: VerifiedVoteReceiver,
     ) -> WindowService
     where
         F: 'static
@@ -319,6 +321,7 @@ impl WindowService {
             repair_info,
             cluster_slots,
             vote_tracker,
+            verified_vote_receiver,
         );
 
         let (insert_sender, insert_receiver) = unbounded();

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -4,7 +4,6 @@
 use crate::{
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::VerifiedVoteReceiver,
-    cluster_info_vote_listener::VoteTracker,
     cluster_slots::ClusterSlots,
     repair_response,
     repair_service::{RepairInfo, RepairService},
@@ -302,7 +301,6 @@ impl WindowService {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         shred_filter: F,
         cluster_slots: Arc<ClusterSlots>,
-        vote_tracker: Arc<VoteTracker>,
         verified_vote_receiver: VerifiedVoteReceiver,
     ) -> WindowService
     where
@@ -320,7 +318,6 @@ impl WindowService {
             cluster_info.clone(),
             repair_info,
             cluster_slots,
-            vote_tracker,
             verified_vote_receiver,
         );
 

--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -1,4 +1,31 @@
 {
+  "__inputs": [],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.2.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": "5.0.0"
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -15,8 +42,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1547,
-  "iteration": 1591834899194,
+  "id": null,
+  "iteration": 1593566799866,
   "links": [
     {
       "asDropdown": true,
@@ -53,7 +80,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 69,
+      "id": 1,
       "panels": [],
       "title": "Summary",
       "type": "row"
@@ -82,7 +109,7 @@
         "x": 0,
         "y": 1
       },
-      "id": 1,
+      "id": 2,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -195,7 +222,7 @@
         "x": 12,
         "y": 1
       },
-      "id": 2,
+      "id": 3,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -296,7 +323,7 @@
         "x": 14,
         "y": 1
       },
-      "id": 3,
+      "id": 4,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -424,7 +451,7 @@
         "x": 0,
         "y": 3
       },
-      "id": 4,
+      "id": 5,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -536,7 +563,7 @@
         "x": 4,
         "y": 3
       },
-      "id": 5,
+      "id": 6,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -648,7 +675,7 @@
         "x": 8,
         "y": 3
       },
-      "id": 6,
+      "id": 7,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -760,7 +787,7 @@
         "x": 11,
         "y": 3
       },
-      "id": 7,
+      "id": 8,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -872,7 +899,7 @@
         "x": 0,
         "y": 5
       },
-      "id": 8,
+      "id": 9,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -983,7 +1010,7 @@
         "x": 3,
         "y": 5
       },
-      "id": 9,
+      "id": 10,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -1094,7 +1121,7 @@
         "x": 6,
         "y": 5
       },
-      "id": 10,
+      "id": 11,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -1205,7 +1232,7 @@
         "x": 9,
         "y": 5
       },
-      "id": 11,
+      "id": 12,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -1316,7 +1343,7 @@
         "x": 11,
         "y": 5
       },
-      "id": 12,
+      "id": 13,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -1417,7 +1444,7 @@
         "x": 14,
         "y": 6
       },
-      "id": 13,
+      "id": 14,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -1573,7 +1600,7 @@
         "x": 0,
         "y": 7
       },
-      "id": 14,
+      "id": 15,
       "legend": {
         "avg": false,
         "current": false,
@@ -1839,7 +1866,7 @@
         "x": 14,
         "y": 11
       },
-      "id": 15,
+      "id": 16,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -1951,7 +1978,7 @@
         "x": 0,
         "y": 16
       },
-      "id": 16,
+      "id": 17,
       "panels": [],
       "title": "Stability",
       "type": "row"
@@ -1969,7 +1996,7 @@
         "x": 0,
         "y": 17
       },
-      "id": 17,
+      "id": 18,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -2125,7 +2152,7 @@
         "x": 8,
         "y": 17
       },
-      "id": 18,
+      "id": 19,
       "legend": {
         "avg": false,
         "current": false,
@@ -2361,7 +2388,7 @@
         "x": 15,
         "y": 17
       },
-      "id": 19,
+      "id": 20,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2472,7 +2499,7 @@
         "x": 19,
         "y": 17
       },
-      "id": 20,
+      "id": 21,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2583,7 +2610,7 @@
         "x": 22,
         "y": 17
       },
-      "id": 21,
+      "id": 22,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -2683,7 +2710,7 @@
         "x": 15,
         "y": 19
       },
-      "id": 22,
+      "id": 23,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -2801,7 +2828,7 @@
         "x": 20,
         "y": 19
       },
-      "id": 23,
+      "id": 24,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -2919,7 +2946,7 @@
         "x": 0,
         "y": 20
       },
-      "id": 24,
+      "id": 25,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -3072,7 +3099,7 @@
         "x": 0,
         "y": 23
       },
-      "id": 25,
+      "id": 26,
       "links": [],
       "pageSize": null,
       "scroll": true,
@@ -3160,7 +3187,7 @@
         "x": 15,
         "y": 23
       },
-      "id": 26,
+      "id": 27,
       "legend": {
         "avg": false,
         "current": false,
@@ -3641,7 +3668,7 @@
         "x": 0,
         "y": 29
       },
-      "id": 27,
+      "id": 28,
       "links": [],
       "pageSize": null,
       "scroll": true,
@@ -3726,7 +3753,7 @@
         "x": 8,
         "y": 29
       },
-      "id": 28,
+      "id": 29,
       "links": [],
       "pageSize": null,
       "scroll": true,
@@ -3811,7 +3838,7 @@
         "x": 16,
         "y": 29
       },
-      "id": 29,
+      "id": 30,
       "links": [],
       "pageSize": null,
       "scroll": true,
@@ -3894,7 +3921,7 @@
         "x": 0,
         "y": 35
       },
-      "id": 30,
+      "id": 31,
       "panels": [],
       "title": "Validator Streamer",
       "type": "row"
@@ -3912,7 +3939,7 @@
         "x": 0,
         "y": 36
       },
-      "id": 31,
+      "id": 32,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -4151,7 +4178,7 @@
         "x": 8,
         "y": 36
       },
-      "id": 32,
+      "id": 33,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -4433,7 +4460,7 @@
         "x": 16,
         "y": 36
       },
-      "id": 33,
+      "id": 34,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -4644,7 +4671,7 @@
         "x": 0,
         "y": 42
       },
-      "id": 34,
+      "id": 35,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -5050,7 +5077,7 @@
         "x": 8,
         "y": 42
       },
-      "id": 35,
+      "id": 36,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -5222,7 +5249,7 @@
         "x": 16,
         "y": 42
       },
-      "id": 36,
+      "id": 37,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -5543,7 +5570,7 @@
         "x": 0,
         "y": 48
       },
-      "id": 37,
+      "id": 38,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -5973,7 +6000,7 @@
         "x": 8,
         "y": 48
       },
-      "id": 38,
+      "id": 39,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -6206,7 +6233,7 @@
         "x": 16,
         "y": 48
       },
-      "id": 39,
+      "id": 73,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -6225,7 +6252,16 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "replay-slot-stats.total_shreds",
+          "yaxis": 2
+        },
+        {
+          "alias": "replay-slot-stats.total_entries",
+          "yaxis": 2
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -6249,7 +6285,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"bank-forks_set_root_ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"get-best-orphans-us\") AS \"get-best-orphans-us\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -6288,7 +6324,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"squash_accounts_ms\")  AS \"squash_account\" FROM \"$testnet\".\"autogen\".\"tower-observed\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"get-best-shreds-us\") AS \"get-best-shreds-us\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
@@ -6327,124 +6363,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"count\")  AS \"serialize_bank\" FROM \"$testnet\".\"autogen\".\"bank-serialize-ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
-          "rawQuery": true,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "count"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "cluster_info-vote-count",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "SELECT mean(\"count\")  AS \"add_snapshot_ms\" FROM \"$testnet\".\"autogen\".\"add-snapshot-ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
-          "rawQuery": true,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "count"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "cluster_info-vote-count",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "SELECT mean(\"duration\")  AS \"serialize_account_storage\" FROM \"$testnet\".\"autogen\".\"serialize_account_storage_ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
-          "rawQuery": true,
-          "refId": "C",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "count"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "sum"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "hide": false,
-          "measurement": "cluster_info-vote-count",
-          "orderByTime": "ASC",
-          "policy": "autogen",
-          "query": "SELECT mean(\"squash_cache_ms\")  AS \"squash_cache\" FROM \"$testnet\".\"autogen\".\"tower-observed\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"add-votes-us\") AS \"add-votes-us\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "C",
           "resultFormat": "time_series",
@@ -6468,7 +6387,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Time spent in squashing ($hostid)",
+      "title": "Repair Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -6484,7 +6403,7 @@
       },
       "yaxes": [
         {
-          "format": "ms",
+          "format": "µs",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -6492,7 +6411,7 @@
           "show": true
         },
         {
-          "format": "short",
+          "format": "µs",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -6532,7 +6451,7 @@
         "x": 0,
         "y": 54
       },
-      "id": 40,
+      "id": 41,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -6834,7 +6753,7 @@
         "x": 8,
         "y": 54
       },
-      "id": 41,
+      "id": 42,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -6975,26 +6894,32 @@
       }
     },
     {
-      "aliasColors": {},
+      "aliasColors": {
+        "cluster-info.repair": "#ba43a9",
+        "replay_stage-new_leader.last": "#00ffbb",
+        "tower-observed.squash_account": "#0a437c",
+        "tower-observed.squash_cache": "#ea6460",
+        "window-service.receive": "#b7dbab",
+        "window-stage.consumed": "#5195ce"
+      },
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
-        "h": 5,
+        "h": 6,
         "w": 8,
         "x": 16,
         "y": 54
       },
-      "id": 42,
+      "id": 40,
       "legend": {
         "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "rightSide": false,
         "show": true,
         "total": false,
         "values": false
@@ -7002,9 +6927,9 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
+      "nullPointMode": "connected",
       "percentage": false,
-      "pointradius": 5,
+      "pointradius": 2,
       "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
@@ -7027,10 +6952,50 @@
               "type": "fill"
             }
           ],
+          "hide": false,
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT sum(\"recovered\") AS \"recovered\" FROM \"$testnet\".\"autogen\".\"blockstore-erasure\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval) FILL(0)",
+          "query": "SELECT mean(\"count\") FROM \"$testnet\".\"autogen\".\"bank-forks_set_root_ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"squash_accounts_ms\")  AS \"squash_account\" FROM \"$testnet\".\"autogen\".\"tower-observed\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
@@ -7065,12 +7030,130 @@
               "type": "fill"
             }
           ],
+          "hide": false,
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT sum(\"num_recovered\") AS \"num_recovered\" FROM \"$testnet\".\"autogen\".\"recv-window-insert-shreds\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval) FILL(0)",
+          "query": "SELECT mean(\"count\")  AS \"serialize_bank\" FROM \"$testnet\".\"autogen\".\"bank-serialize-ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
-          "refId": "A",
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"count\")  AS \"add_snapshot_ms\" FROM \"$testnet\".\"autogen\".\"add-snapshot-ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"duration\")  AS \"serialize_account_storage\" FROM \"$testnet\".\"autogen\".\"serialize_account_storage_ms\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"squash_cache_ms\")  AS \"squash_cache\" FROM \"$testnet\".\"autogen\".\"tower-observed\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
           "resultFormat": "time_series",
           "select": [
             [
@@ -7092,7 +7175,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Erasure Recovery ($hostid)",
+      "title": "Time spent in squashing ($hostid)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -7108,7 +7191,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "ms",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -7142,7 +7225,7 @@
         "x": 0,
         "y": 59
       },
-      "id": 43,
+      "id": 44,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -7301,7 +7384,7 @@
         "x": 8,
         "y": 59
       },
-      "id": 44,
+      "id": 45,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -7412,18 +7495,19 @@
       "datasource": "$datasource",
       "fill": 1,
       "gridPos": {
-        "h": 6,
+        "h": 5,
         "w": 8,
         "x": 16,
-        "y": 59
+        "y": 60
       },
-      "id": 45,
+      "id": 43,
       "legend": {
         "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
+        "rightSide": false,
         "show": true,
         "total": false,
         "values": false
@@ -7459,7 +7543,45 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT count(\"slot\") AS \"num_skipped\" FROM \"$testnet\".\"autogen\".\"replay_stage-skip_leader_slot\"  WHERE host_id::tag =~ /$hostid/ AND  $timeFilter  GROUP BY time(1s) fill(null)\n",
+          "query": "SELECT sum(\"recovered\") AS \"recovered\" FROM \"$testnet\".\"autogen\".\"blockstore-erasure\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval) FILL(0)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT sum(\"num_recovered\") AS \"num_recovered\" FROM \"$testnet\".\"autogen\".\"recv-window-insert-shreds\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval) FILL(0)",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -7483,7 +7605,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Skipped Leader Slots ($hostid)",
+      "title": "Erasure Recovery ($hostid)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -7499,7 +7621,7 @@
       },
       "yaxes": [
         {
-          "format": "none",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -7507,7 +7629,7 @@
           "show": true
         },
         {
-          "format": "none",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -7535,7 +7657,7 @@
         "x": 0,
         "y": 65
       },
-      "id": 46,
+      "id": 47,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -7737,7 +7859,7 @@
         "x": 8,
         "y": 65
       },
-      "id": 47,
+      "id": 48,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8154,6 +8276,122 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 65
+      },
+      "id": 46,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT count(\"slot\") AS \"num_skipped\" FROM \"$testnet\".\"autogen\".\"replay_stage-skip_leader_slot\"  WHERE host_id::tag =~ /$hostid/ AND  $timeFilter  GROUP BY time(1s) fill(null)\n",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Skipped Leader Slots ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "aliasColors": {
         "poh-service.hashes": "#c15c17"
       },
@@ -8166,9 +8404,9 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 65
+        "y": 71
       },
-      "id": 72,
+      "id": 49,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8438,9 +8676,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 77
       },
-      "id": 48,
+      "id": 50,
       "panels": [],
       "title": "Tower Consensus",
       "type": "row"
@@ -8461,9 +8699,9 @@
         "h": 5,
         "w": 8,
         "x": 0,
-        "y": 72
+        "y": 78
       },
-      "id": 49,
+      "id": 51,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8621,9 +8859,9 @@
         "h": 5,
         "w": 8,
         "x": 8,
-        "y": 72
+        "y": 78
       },
-      "id": 50,
+      "id": 52,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8781,9 +9019,9 @@
         "h": 5,
         "w": 8,
         "x": 16,
-        "y": 72
+        "y": 78
       },
-      "id": 51,
+      "id": 53,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8966,9 +9204,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 77
+        "y": 83
       },
-      "id": 52,
+      "id": 54,
       "panels": [],
       "repeat": null,
       "title": "IP Network",
@@ -8985,9 +9223,9 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 78
+        "y": 84
       },
-      "id": 53,
+      "id": 55,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9218,9 +9456,9 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 78
+        "y": 84
       },
-      "id": 54,
+      "id": 56,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9371,9 +9609,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 83
+        "y": 89
       },
-      "id": 55,
+      "id": 57,
       "panels": [],
       "title": "Signature Verification",
       "type": "row"
@@ -9389,9 +9627,9 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 84
+        "y": 90
       },
-      "id": 56,
+      "id": 58,
       "legend": {
         "avg": false,
         "current": false,
@@ -9591,9 +9829,9 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 84
+        "y": 90
       },
-      "id": 57,
+      "id": 59,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9740,9 +9978,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 95
       },
-      "id": 58,
+      "id": 60,
       "panels": [],
       "title": "Snapshots",
       "type": "row"
@@ -9758,9 +9996,9 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 90
+        "y": 96
       },
-      "id": 59,
+      "id": 61,
       "legend": {
         "avg": false,
         "current": false,
@@ -9950,9 +10188,9 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 90
+        "y": 96
       },
-      "id": 60,
+      "id": 62,
       "legend": {
         "avg": false,
         "current": false,
@@ -10218,9 +10456,9 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 90
+        "y": 96
       },
-      "id": 61,
+      "id": 63,
       "legend": {
         "avg": false,
         "current": false,
@@ -10412,9 +10650,9 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 96
+        "y": 102
       },
-      "id": 62,
+      "id": 64,
       "legend": {
         "avg": false,
         "current": false,
@@ -10603,9 +10841,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 102
+        "y": 108
       },
-      "id": 71,
+      "id": 65,
       "panels": [],
       "title": "RPC Send Transaction Service",
       "type": "row"
@@ -10621,9 +10859,9 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 109
       },
-      "id": 72,
+      "id": 66,
       "legend": {
         "avg": false,
         "current": false,
@@ -10739,9 +10977,9 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 103
+        "y": 109
       },
-      "id": 73,
+      "id": 67,
       "legend": {
         "avg": false,
         "current": false,
@@ -11002,9 +11240,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 115
       },
-      "id": 63,
+      "id": 68,
       "panels": [],
       "title": "Bench TPS",
       "type": "row"
@@ -11020,9 +11258,9 @@
         "h": 5,
         "w": 7,
         "x": 0,
-        "y": 110
+        "y": 116
       },
-      "id": 64,
+      "id": 69,
       "legend": {
         "avg": false,
         "current": false,
@@ -11135,9 +11373,9 @@
         "h": 5,
         "w": 7,
         "x": 7,
-        "y": 110
+        "y": 116
       },
-      "id": 65,
+      "id": 70,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -11360,9 +11598,9 @@
         "h": 5,
         "w": 10,
         "x": 14,
-        "y": 110
+        "y": 116
       },
-      "id": 66,
+      "id": 71,
       "links": [],
       "pageSize": null,
       "scroll": true,
@@ -11448,9 +11686,9 @@
         "h": 4,
         "w": 10,
         "x": 0,
-        "y": 115
+        "y": 121
       },
-      "id": 67,
+      "id": 72,
       "legend": {
         "avg": false,
         "current": false,
@@ -11553,7 +11791,7 @@
       }
     }
   ],
-  "refresh": "1m",
+  "refresh": false,
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
@@ -11561,8 +11799,8 @@
     "list": [
       {
         "current": {
-          "text": "$datasource",
-          "value": "$datasource"
+          "text": "Solana Metrics (read-only)",
+          "value": "Solana Metrics (read-only)"
         },
         "hide": 1,
         "label": "Data Source",
@@ -11574,38 +11812,28 @@
         "type": "datasource"
       },
       {
-        "allValue": null,
-        "current": {
-          "text": "Mainnet Beta",
-          "value": "mainnet-beta"
-        },
+        "allValue": ".*",
+        "current": {},
+        "datasource": "$datasource",
         "hide": 1,
         "includeAll": false,
         "label": "Testnet",
         "multi": false,
         "name": "testnet",
-        "options": [
-          {
-            "selected": true,
-            "text": "Devnet",
-            "value": "devnet"
-          },
-          {
-            "selected": false,
-            "text": "Mainnet Beta",
-            "value": "mainnet-beta"
-          },
-          {
-            "selected": false,
-            "text": "Testnet",
-            "value": "tds"
-         }
-        ],
-        "query": "devnet,mainnet-beta,tds",
-        "type": "custom"
+        "options": [],
+        "query": "show databases",
+        "refresh": 1,
+        "regex": "(devnet|tds|mainnet-beta|testnet.*)",
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       },
       {
         "allValue": ".*",
+        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -11626,8 +11854,8 @@
     ]
   },
   "time": {
-    "from": "now-15m",
-    "to": "now"
+    "from": "2020-07-01T01:15:18.956Z",
+    "to": "2020-07-01T02:15:18.956Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -11650,7 +11878,7 @@
     ]
   },
   "timezone": "",
-  "title": "Cluster Telemetry",
-  "uid": "monitor",
-  "version": 1
+  "title": "Cluster Telemetry (edge)",
+  "uid": "monitor-edge",
+  "version": 6
 }

--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -1,31 +1,4 @@
 {
-  "__inputs": [],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.2.3"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": "5.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -42,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1593566799866,
+  "id": 1547,
+  "iteration": 1591834899194,
   "links": [
     {
       "asDropdown": true,
@@ -6285,7 +6258,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"get-best-orphans-us\") AS \"get-best-orphans-us\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"set-root-elapsed\") AS \"set-root-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -6324,7 +6297,7 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"get-best-shreds-us\") AS \"get-best-shreds-us\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"get-votes-elapsed\") AS \"get-votes-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "B",
           "resultFormat": "time_series",
@@ -6363,9 +6336,243 @@
           "measurement": "cluster_info-vote-count",
           "orderByTime": "ASC",
           "policy": "autogen",
-          "query": "SELECT mean(\"add-votes-us\") AS \"add-votes-us\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "query": "SELECT mean(\"add-votes-elapsed\") AS \"add-votes-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
           "rawQuery": true,
           "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"get-best-orphans-elapsed\") AS \"get-best-orphans-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"get-best-shreds-elapsed\") AS \"get-best-shreds-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"update-completed-slots-elapsed\") AS \"update-completed-slots-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"update-completed-slots-elapsed\") AS \"update-completed-slots-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "E",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"send-repairs-elapsed\") AS \"send-repairs-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "F",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"lowest-slot-elapsed\") AS \"lowest-slot-elapsed\" FROM \"$testnet\".\"autogen\".\"serve_repair-repair-timing\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "G",
           "resultFormat": "time_series",
           "select": [
             [
@@ -6387,7 +6594,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Repair Time",
+      "title": "Repair Timing",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -11791,7 +11998,7 @@
       }
     }
   ],
-  "refresh": false,
+  "refresh": "1m",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],
@@ -11799,8 +12006,8 @@
     "list": [
       {
         "current": {
-          "text": "Solana Metrics (read-only)",
-          "value": "Solana Metrics (read-only)"
+          "text": "$datasource",
+          "value": "$datasource"
         },
         "hide": 1,
         "label": "Data Source",
@@ -11812,28 +12019,38 @@
         "type": "datasource"
       },
       {
-        "allValue": ".*",
-        "current": {},
-        "datasource": "$datasource",
+        "allValue": null,
+        "current": {
+          "text": "Mainnet Beta",
+          "value": "mainnet-beta"
+        },
         "hide": 1,
         "includeAll": false,
         "label": "Testnet",
         "multi": false,
         "name": "testnet",
-        "options": [],
-        "query": "show databases",
-        "refresh": 1,
-        "regex": "(devnet|tds|mainnet-beta|testnet.*)",
-        "sort": 1,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "options": [
+          {
+            "selected": true,
+            "text": "Devnet",
+            "value": "devnet"
+          },
+          {
+            "selected": false,
+            "text": "Mainnet Beta",
+            "value": "mainnet-beta"
+          },
+          {
+            "selected": false,
+            "text": "Testnet",
+            "value": "tds"
+          }
+        ],
+        "query": "devnet,mainnet-beta,tds",
+        "type": "custom"
       },
       {
         "allValue": ".*",
-        "current": {},
         "datasource": "$datasource",
         "hide": 0,
         "includeAll": true,
@@ -11854,8 +12071,8 @@
     ]
   },
   "time": {
-    "from": "2020-07-01T01:15:18.956Z",
-    "to": "2020-07-01T02:15:18.956Z"
+    "from": "now-15m",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -11878,7 +12095,7 @@
     ]
   },
   "timezone": "",
-  "title": "Cluster Telemetry (edge)",
-  "uid": "monitor-edge",
-  "version": 6
+  "title": "Cluster Telemetry",
+  "uid": "monitor",
+  "version": 1
 }


### PR DESCRIPTION
#### Problem
1) Repair heuristic requires votes, which are unavailable to `repair_service`
2) `repair_service` does not use weighted repairs

#### Summary of Changes
1) Plumb channel for votes into repair_service
2) Switch repair_service to using `RepairWeight` for weighted repairs
3) Update repair timing metrics, add dashboard

Fixes #
