### PR TITLE
Use raw bytes for create_program_address

### DIFF
--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -85,7 +85,7 @@ impl Pubkey {
     }
 
     pub fn create_program_address(
-        seeds: &[&str],
+        seeds: &[&[u8]],
         program_id: &Pubkey,
     ) -> Result<Pubkey, PubkeyError> {
         let mut hasher = Hasher::default();
@@ -248,35 +248,35 @@ mod tests {
         let program_id = Pubkey::from_str("BPFLoader1111111111111111111111111111111111").unwrap();
 
         assert_eq!(
-            Pubkey::create_program_address(&[exceeded_seed], &program_id),
+            Pubkey::create_program_address(&[exceeded_seed.as_ref()], &program_id),
             Err(PubkeyError::MaxSeedLengthExceeded)
         );
         assert_eq!(
-            Pubkey::create_program_address(&["short_seed", exceeded_seed], &program_id),
+            Pubkey::create_program_address(&[b"short_seed", exceeded_seed.as_ref()], &program_id),
             Err(PubkeyError::MaxSeedLengthExceeded)
         );
-        assert!(Pubkey::create_program_address(&[max_seed], &Pubkey::new_rand(),).is_ok());
+        assert!(Pubkey::create_program_address(&[max_seed.as_ref()], &Pubkey::new_rand(),).is_ok());
         assert_eq!(
-            Pubkey::create_program_address(&[""], &program_id),
+            Pubkey::create_program_address(&[b""], &program_id),
             Ok("CsdSsqp6Upkh2qajhZMBM8xT4GAyDNSmcV37g4pN8rsc"
                 .parse()
                 .unwrap())
         );
         assert_eq!(
-            Pubkey::create_program_address(&["☉"], &program_id),
+            Pubkey::create_program_address(&["☉".as_ref()], &program_id),
             Ok("A8mYnN8Pfx7Nn6f8RoQgsPNtAGAWmmKSBCDfyDvE6sXF"
                 .parse()
                 .unwrap())
         );
         assert_eq!(
-            Pubkey::create_program_address(&["Talking", "Squirrels"], &program_id),
+            Pubkey::create_program_address(&[b"Talking", b"Squirrels"], &program_id),
             Ok("CawYq8Rmj4JRR992wVnGEFUjMEkmtmcFgEL4iS1qPczu"
                 .parse()
                 .unwrap())
         );
         assert_ne!(
-            Pubkey::create_program_address(&["Talking", "Squirrels"], &program_id),
-            Pubkey::create_program_address(&["Talking"], &program_id),
+            Pubkey::create_program_address(&[b"Talking", b"Squirrels"], &program_id),
+            Pubkey::create_program_address(&[b"Talking"], &program_id),
         );
     }
 


### PR DESCRIPTION
#### Problem

`create_program_address` takes an `str`, which is hard to generate from Pubkey inside a program.

#### Summary of Changes

Use `&[u8]` instead.

Fixes #
