### PR TITLE
Use &[u8] for program address seeds rather then &str

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -96,12 +96,13 @@ extern uint64_t entrypoint(const uint8_t *input) {
       const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                           arguments, SOL_ARRAY_SIZE(arguments),
                                           data, SOL_ARRAY_SIZE(data)};
-      char seed1[] = "You pass butter";
-      char seed2[] = "Lil'";
-      char seed3[] = "Bits";
-      const SolSignerSeed seeds1[] = {{seed1, sol_strlen(seed1)}};
-      const SolSignerSeed seeds2[] = {{seed2, sol_strlen(seed2)},
-                                      {seed3, sol_strlen(seed3)}};
+      uint8_t seed1[] = {'Y', 'o', 'u', ' ', 'p', 'a', 's', 's',
+                         ' ', 'b', 'u', 't', 't', 'e', 'r'};
+      uint8_t seed2[] = {'L', 'i', 'l', '\''};
+      uint8_t seed3[] = {'B', 'i', 't', 's'};
+      const SolSignerSeed seeds1[] = {{seed1, SOL_ARRAY_SIZE(seed1)}};
+      const SolSignerSeed seeds2[] = {{seed2, SOL_ARRAY_SIZE(seed2)},
+                                      {seed3, SOL_ARRAY_SIZE(seed3)}};
       const SolSignerSeeds signers_seeds[] = {{seeds1, SOL_ARRAY_SIZE(seeds1)},
                                               {seeds2, SOL_ARRAY_SIZE(seeds2)}};
       sol_assert(SUCCESS == sol_invoke_signed(&instruction, accounts,

--- a/programs/bpf/c/src/invoked/invoked.c
+++ b/programs/bpf/c/src/invoked/invoked.c
@@ -77,7 +77,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
     break;
   }
   case TEST_RETURN_ERROR: {
-    sol_log("reutrn error");
+    sol_log("return error");
     return 42;
   }
   case TEST_DERIVED_SIGNERS: {
@@ -100,12 +100,12 @@ extern uint64_t entrypoint(const uint8_t *input) {
     const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                         arguments, SOL_ARRAY_SIZE(arguments),
                                         data, SOL_ARRAY_SIZE(data)};
-    char seed1[] = "Lil'";
-    char seed2[] = "Bits";
-    char seed3[] = "Gar Ma Nar Nar";
-    const SolSignerSeed seeds1[] = {{seed1, sol_strlen(seed1)},
-                                    {seed2, sol_strlen(seed2)}};
-    const SolSignerSeed seeds2[] = {{seed3, sol_strlen(seed3)}};
+    uint8_t seed1[] = {'L', 'i', 'l', '\''};
+    uint8_t seed2[] = {'B', 'i', 't', 's'};
+    const SolSignerSeed seeds1[] = {{seed1, SOL_ARRAY_SIZE(seed1)},
+                                    {seed2, SOL_ARRAY_SIZE(seed2)}};
+    const SolSignerSeed seeds2[] = {
+        {(uint8_t *)accounts[DERIVED_KEY2_INDEX].key, SIZE_PUBKEY}};
     const SolSignerSeeds signers_seeds[] = {{seeds1, SOL_ARRAY_SIZE(seeds1)},
                                             {seeds2, SOL_ARRAY_SIZE(seeds2)}};
 

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -110,7 +110,7 @@ fn process_instruction(
                 invoke_signed(
                     &invoked_instruction,
                     accounts,
-                    &[&["You pass butter"], &["Lil'", "Bits"]],
+                    &[&[b"You pass butter"], &[b"Lil'", b"Bits"]],
                 )?;
             }
 

--- a/programs/bpf/rust/invoked/src/lib.rs
+++ b/programs/bpf/rust/invoked/src/lib.rs
@@ -132,7 +132,10 @@ fn process_instruction(
             invoke_signed(
                 &invoked_instruction,
                 accounts,
-                &[&["Lil'", "Bits"], &["Gar Ma Nar Nar"]],
+                &[
+                    &[b"Lil'", b"Bits"],
+                    &[accounts[DERIVED_KEY2_INDEX].key.as_ref()],
+                ],
             )?;
         }
         TEST_VERIFY_NESTED_SIGNERS => {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -39,7 +39,6 @@ mod bpf {
 
     fn load_bpf_program(bank_client: &BankClient, payer_keypair: &Keypair, name: &str) -> Pubkey {
         let path = create_bpf_path(name);
-        println!("path {:?}", path);
         let mut file = File::open(path).unwrap();
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
@@ -353,11 +352,11 @@ mod bpf {
             bank.store_account(&from_keypair.pubkey(), &account);
 
             let derived_key1 =
-                Pubkey::create_program_address(&["You pass butter"], &invoke_program_id).unwrap();
+                Pubkey::create_program_address(&[b"You pass butter"], &invoke_program_id).unwrap();
             let derived_key2 =
-                Pubkey::create_program_address(&["Lil'", "Bits"], &invoked_program_id).unwrap();
+                Pubkey::create_program_address(&[b"Lil'", b"Bits"], &invoked_program_id).unwrap();
             let derived_key3 =
-                Pubkey::create_program_address(&["Gar Ma Nar Nar"], &invoked_program_id).unwrap();
+                Pubkey::create_program_address(&[derived_key2.as_ref()], &invoked_program_id).unwrap();
 
             let account_metas = vec![
                 AccountMeta::new(mint_keypair.pubkey(), true),

--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -377,7 +377,7 @@ typedef struct {
  * Seed used to create a program address
  */
 typedef struct {
-  const char *addr; /** Seed string */
+  const uint8_t *addr; /** Seed string */
   uint64_t len; /** Length of the seed string */
 } SolSignerSeed;
 

--- a/sdk/src/program.rs
+++ b/sdk/src/program.rs
@@ -14,7 +14,7 @@ pub fn invoke(instruction: &Instruction, account_infos: &[AccountInfo]) -> Progr
 pub fn invoke_signed(
     instruction: &Instruction,
     account_infos: &[AccountInfo],
-    signers_seeds: &[&[&str]],
+    signers_seeds: &[&[&[u8]]],
 ) -> ProgramResult {
     let result = unsafe {
         sol_invoke_signed_rust(

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -93,7 +93,7 @@ impl Pubkey {
             if seed.len() > MAX_SEED_LEN {
                 return Err(PubkeyError::MaxSeedLengthExceeded);
             }
-            hasher.hash(seed.as_ref());
+            hasher.hash(seed);
         }
         hasher.hashv(&[program_id.as_ref(), "ProgramDerivedAddress".as_ref()]);
 
@@ -243,19 +243,20 @@ mod tests {
 
     #[test]
     fn test_create_program_address() {
-        let exceeded_seed = from_utf8(&[127; MAX_SEED_LEN + 1]).unwrap();
-        let max_seed = from_utf8(&[0; MAX_SEED_LEN]).unwrap();
+        let exceeded_seed = &[127; MAX_SEED_LEN + 1];
+        let max_seed = &[0; MAX_SEED_LEN];
         let program_id = Pubkey::from_str("BPFLoader1111111111111111111111111111111111").unwrap();
+        let public_key = Pubkey::from_str("SeedPubey1111111111111111111111111111111111").unwrap();
 
         assert_eq!(
-            Pubkey::create_program_address(&[exceeded_seed.as_ref()], &program_id),
+            Pubkey::create_program_address(&[exceeded_seed], &program_id),
             Err(PubkeyError::MaxSeedLengthExceeded)
         );
         assert_eq!(
-            Pubkey::create_program_address(&[b"short_seed", exceeded_seed.as_ref()], &program_id),
+            Pubkey::create_program_address(&[b"short_seed", exceeded_seed], &program_id),
             Err(PubkeyError::MaxSeedLengthExceeded)
         );
-        assert!(Pubkey::create_program_address(&[max_seed.as_ref()], &Pubkey::new_rand(),).is_ok());
+        assert!(Pubkey::create_program_address(&[max_seed], &Pubkey::new_rand()).is_ok());
         assert_eq!(
             Pubkey::create_program_address(&[b""], &program_id),
             Ok("CsdSsqp6Upkh2qajhZMBM8xT4GAyDNSmcV37g4pN8rsc"
@@ -271,6 +272,12 @@ mod tests {
         assert_eq!(
             Pubkey::create_program_address(&[b"Talking", b"Squirrels"], &program_id),
             Ok("CawYq8Rmj4JRR992wVnGEFUjMEkmtmcFgEL4iS1qPczu"
+                .parse()
+                .unwrap())
+        );
+        assert_eq!(
+            Pubkey::create_program_address(&[public_key.as_ref()], &program_id),
+            Ok("4ak7qJacCKMAGP8xJtDkg2VYZh5QKExa71ijMDjZGQyb"
                 .parse()
                 .unwrap())
         );

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -85,7 +85,7 @@ impl Pubkey {
     }
 
     pub fn create_program_address(
-        seeds: &[&str],
+        seeds: &[&[u8]],
         program_id: &Pubkey,
     ) -> Result<Pubkey, PubkeyError> {
         let mut hasher = Hasher::default();
@@ -248,35 +248,35 @@ mod tests {
         let program_id = Pubkey::from_str("BPFLoader1111111111111111111111111111111111").unwrap();
 
         assert_eq!(
-            Pubkey::create_program_address(&[exceeded_seed], &program_id),
+            Pubkey::create_program_address(&[exceeded_seed.as_ref()], &program_id),
             Err(PubkeyError::MaxSeedLengthExceeded)
         );
         assert_eq!(
-            Pubkey::create_program_address(&["short_seed", exceeded_seed], &program_id),
+            Pubkey::create_program_address(&[b"short_seed", exceeded_seed.as_ref()], &program_id),
             Err(PubkeyError::MaxSeedLengthExceeded)
         );
-        assert!(Pubkey::create_program_address(&[max_seed], &Pubkey::new_rand(),).is_ok());
+        assert!(Pubkey::create_program_address(&[max_seed.as_ref()], &Pubkey::new_rand(),).is_ok());
         assert_eq!(
-            Pubkey::create_program_address(&[""], &program_id),
+            Pubkey::create_program_address(&[b""], &program_id),
             Ok("CsdSsqp6Upkh2qajhZMBM8xT4GAyDNSmcV37g4pN8rsc"
                 .parse()
                 .unwrap())
         );
         assert_eq!(
-            Pubkey::create_program_address(&["☉"], &program_id),
+            Pubkey::create_program_address(&["☉".as_ref()], &program_id),
             Ok("A8mYnN8Pfx7Nn6f8RoQgsPNtAGAWmmKSBCDfyDvE6sXF"
                 .parse()
                 .unwrap())
         );
         assert_eq!(
-            Pubkey::create_program_address(&["Talking", "Squirrels"], &program_id),
+            Pubkey::create_program_address(&[b"Talking", b"Squirrels"], &program_id),
             Ok("CawYq8Rmj4JRR992wVnGEFUjMEkmtmcFgEL4iS1qPczu"
                 .parse()
                 .unwrap())
         );
         assert_ne!(
-            Pubkey::create_program_address(&["Talking", "Squirrels"], &program_id),
-            Pubkey::create_program_address(&["Talking"], &program_id),
+            Pubkey::create_program_address(&[b"Talking", b"Squirrels"], &program_id),
+            Pubkey::create_program_address(&[b"Talking"], &program_id),
         );
     }
 


### PR DESCRIPTION
#### Problem

The function `create_program_address` takes `&str`, which is hard to generate from `Pubkey` inside a program.

#### Summary of Changes

Use `&[u8]` instread

Fixes #
