### PR TITLE
Add ProgramInstruction derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4614,6 +4614,7 @@ name = "solana-sdk-macro"
 version = "1.3.0"
 dependencies = [
  "bs58 0.3.1",
+ "proc-macro-error",
  "proc-macro2 1.0.17",
  "quote 1.0.6",
  "syn 1.0.27",

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -466,7 +466,7 @@ impl ClusterInfoVoteListener {
                 {
                     let vote = {
                         match vote_instruction {
-                            VoteInstruction::Vote(vote) => vote,
+                            VoteInstruction::Vote { vote } => vote,
                             _ => {
                                 continue;
                             }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1867,7 +1867,7 @@ impl Blockstore {
                 for instruction in transaction.message.instructions {
                     let program_id = instruction.program_id(&transaction.message.account_keys);
                     if program_id == &solana_vote_program::id() {
-                        if let Ok(VoteInstruction::Vote(vote)) =
+                        if let Ok(VoteInstruction::Vote { vote }) =
                             limited_deserialize(&instruction.data)
                         {
                             if let Some(timestamp) = vote.timestamp {

--- a/sdk/macro/Cargo.toml
+++ b/sdk/macro/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 [dependencies]
 bs58 = "0.3.0"
 proc-macro2 = "1.0"
+proc-macro-error = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -42,6 +42,7 @@ pub mod stake_history;
 pub mod system_instruction;
 pub mod system_program;
 pub mod sysvar;
+pub mod test_enum;
 pub mod timing;
 
 /// Convenience macro to declare a static public key and functions to interact with it

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -68,6 +68,7 @@ pub mod timing;
 /// ```
 pub use solana_sdk_macro::declare_id;
 pub use solana_sdk_macro::pubkeys;
+pub use solana_sdk_macro::ProgramInstruction;
 
 // On-chain program specific modules
 pub mod account_info;

--- a/sdk/src/test_enum.rs
+++ b/sdk/src/test_enum.rs
@@ -58,3 +58,48 @@ pub enum TestInstructionVerbose {
         pubkey: Pubkey,
     },
 }
+
+mod tests {
+
+    #[test]
+    fn test_from() {
+        use super::*;
+        let transfer = TestInstruction::Transfer { lamports: 42 };
+        let verbose_transfer = TestInstructionVerbose::from_instruction(transfer, vec![2, 3]);
+        assert_eq!(
+            verbose_transfer,
+            TestInstructionVerbose::Transfer {
+                funding_account: 2,
+                recipient_account: 3,
+                lamports: 42
+            }
+        );
+
+        let advance = TestInstruction::AdvanceNonceAccount;
+        let verbose_advance = TestInstructionVerbose::from_instruction(advance, vec![2, 3, 4]);
+        assert_eq!(
+            verbose_advance,
+            TestInstructionVerbose::AdvanceNonceAccount {
+                nonce_account: 2,
+                recent_blockhashes_sysvar: 3,
+                nonce_authority: 4,
+            }
+        );
+
+        let nonce_address = Pubkey::new_rand();
+        let initialize = TestInstruction::InitializeNonceAccount {
+            pubkey: nonce_address,
+        };
+        let verbose_initialize =
+            TestInstructionVerbose::from_instruction(initialize, vec![2, 3, 4]);
+        assert_eq!(
+            verbose_initialize,
+            TestInstructionVerbose::InitializeNonceAccount {
+                nonce_account: 2,
+                recent_blockhashes_sysvar: 3,
+                rent_sysvar: 4,
+                pubkey: nonce_address,
+            }
+        );
+    }
+}

--- a/sdk/src/test_enum.rs
+++ b/sdk/src/test_enum.rs
@@ -1,0 +1,60 @@
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk_macro::ProgramInstruction;
+
+#[repr(C)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, ProgramInstruction)]
+#[instruction_derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum TestInstructionVerbose {
+    #[doc = "Consumes a stored nonce, replacing it with a successor"]
+    AdvanceNonceAccount {
+        #[account(signer, writable)]
+        #[desc = "Nonce account"]
+        #[index = 0]
+        nonce_account: u8,
+
+        #[account]
+        #[desc = "RecentBlockhashes sysvar"]
+        #[index = 1]
+        recent_blockhashes_sysvar: u8,
+
+        #[account(signer)]
+        #[desc = "Nonce authority"]
+        #[index = 2]
+        nonce_authority: u8,
+    },
+    #[doc = "Transfer lamports"]
+    Transfer {
+        #[account(signer, writable)]
+        #[desc = "Funding account"]
+        #[index = 0]
+        funding_account: u8,
+
+        #[account(writable)]
+        #[desc = "Recipient account"]
+        #[index = 1]
+        recipient_account: u8,
+
+        lamports: u64,
+    },
+    #[doc = "Drive state of Uninitalized nonce account to Initialized, setting the nonce value"]
+    #[doc = "No signatures are required to execute this instruction, enabling derived nonce account addresses"]
+    InitializeNonceAccount {
+        #[account(signer, writable)]
+        #[desc = "Nonce account"]
+        #[index = 0]
+        nonce_account: u8,
+
+        #[account]
+        #[desc = "RecentBlockhashes sysvar"]
+        #[index = 1]
+        recent_blockhashes_sysvar: u8,
+
+        #[account]
+        #[desc = "Rent sysvar"]
+        #[index = 2]
+        rent_sysvar: u8,
+
+        #[doc = "The `Pubkey` parameter specifies the entity authorized to execute nonce instruction on the account"]
+        pubkey: Pubkey,
+    },
+}

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -174,7 +174,7 @@ fn process_confirmed_block(notifier: &Notifier, slot: Slot, confirmed_block: Con
                     let program_pubkey =
                         transaction.message.account_keys[instruction.program_id_index as usize];
                     if program_pubkey == solana_vote_program::id() {
-                        if let Ok(VoteInstruction::Vote(_)) =
+                        if let Ok(VoteInstruction::Vote { .. }) =
                             limited_deserialize::<VoteInstruction>(&instruction.data)
                         {
                             vote_transactions += 1;


### PR DESCRIPTION
#### Problem
Currently, inspecting an on-chain transaction requires depending on a client-side, language-specific decoding library to parse the instruction. If rpc methods could return decoded instruction details, these custom solutions would be unnecessary.

We can deserialize each instruction using its Instruction enum, but decoding the account-key list into human-readable identifiers requires manual parsing. Our current Instruction enums have that account information, but only in variant docs.

A procedural macro could automate generating 2 enums: one that details account information programmatically and can be used for parsing instructions for rpc, and the other the current slim Instruction for transaction building.

An additional benefit of such a macro is that it could generate the variant docs for our current Instructions, keeping those docs consistent across instruction types.

#### Summary of Changes
- Add procedural macro that takes a InstructionVerbose enum as input and outputs the standard Instruction enum (with pretty, consistent docs), as well as a method to convert between them.
- Rewrite VoteInstruction to VoteInstructionVerbose to demonstrate the scope of changes

CC #10476 
