### PR TITLE
Remove fee-payer guesswork from Message and Transaction

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -137,11 +137,11 @@ mod tests {
         let pubkey0 = Pubkey::new(&[0; 32]);
         let pubkey1 = Pubkey::new(&[1; 32]);
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
-        let message0 = Message::new(&[ix0]);
+        let message0 = Message::new(&[ix0], Some(&pubkey0));
 
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
         let ix1 = system_instruction::transfer(&pubkey1, &pubkey0, 1);
-        let message1 = Message::new(&[ix0, ix1]);
+        let message1 = Message::new(&[ix0, ix1], Some(&pubkey0));
 
         let mut mocks = HashMap::new();
         mocks.insert(RpcRequest::GetBalance, account_balance_response.clone());
@@ -225,13 +225,13 @@ mod tests {
         let pubkey0 = Pubkey::new(&[0; 32]);
         let pubkey1 = Pubkey::new(&[1; 32]);
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
-        let message0 = Message::new(&[ix0]);
+        let message0 = Message::new(&[ix0], Some(&pubkey0));
         assert_eq!(calculate_fee(&fee_calculator, &[&message0]), 1);
 
         // Two messages, additive fees.
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
         let ix1 = system_instruction::transfer(&pubkey1, &pubkey0, 1);
-        let message1 = Message::new(&[ix0, ix1]);
+        let message1 = Message::new(&[ix0, ix1], Some(&pubkey0));
         assert_eq!(calculate_fee(&fee_calculator, &[&message0, &message1]), 3);
     }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1377,7 +1377,7 @@ fn process_deploy(
         program_data.len() as u64,
         &bpf_loader::id(),
     );
-    let message = Message::new(&[ix]);
+    let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut create_account_tx = Transaction::new_unsigned(message);
     let signers = [config.signers[0], program_id];
     create_account_tx.try_sign(&signers, blockhash)?;
@@ -1390,7 +1390,7 @@ fn process_deploy(
             (i * DATA_CHUNK_SIZE) as u32,
             chunk.to_vec(),
         );
-        let message = Message::new_with_payer(&[instruction], Some(&signers[0].pubkey()));
+        let message = Message::new(&[instruction], Some(&signers[0].pubkey()));
         let mut tx = Transaction::new_unsigned(message);
         tx.try_sign(&signers, blockhash)?;
         write_transactions.push(tx);
@@ -1400,7 +1400,7 @@ fn process_deploy(
     }
 
     let instruction = loader_instruction::finalize(&program_id.pubkey(), &bpf_loader::id());
-    let message = Message::new_with_payer(&[instruction], Some(&signers[0].pubkey()));
+    let message = Message::new(&[instruction], Some(&signers[0].pubkey()));
     let mut finalize_tx = Transaction::new_unsigned(message);
     finalize_tx.try_sign(&signers, blockhash)?;
     messages.push(&finalize_tx.message);
@@ -1483,7 +1483,7 @@ fn process_pay(
             if let Some(nonce_account) = &nonce_account {
                 Message::new_with_nonce(vec![ix], None, nonce_account, &nonce_authority.pubkey())
             } else {
-                Message::new(&[ix])
+                Message::new(&[ix], Some(&config.signers[0].pubkey()))
             }
         };
 
@@ -1539,7 +1539,7 @@ fn process_pay(
                 cancelable,
                 lamports,
             );
-            Message::new(&ixs)
+            Message::new(&ixs, Some(&config.signers[0].pubkey()))
         };
         let (message, _) = resolve_spend_tx_and_check_account_balance(
             rpc_client,
@@ -1590,7 +1590,7 @@ fn process_pay(
                 cancelable,
                 lamports,
             );
-            Message::new(&ixs)
+            Message::new(&ixs, Some(&config.signers[0].pubkey()))
         };
         let (message, _) = resolve_spend_tx_and_check_account_balance(
             rpc_client,
@@ -1633,7 +1633,7 @@ fn process_cancel(rpc_client: &RpcClient, config: &CliConfig, pubkey: &Pubkey) -
         pubkey,
         &config.signers[0].pubkey(),
     );
-    let message = Message::new(&[ix]);
+    let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee_with_commitment(
@@ -1663,7 +1663,7 @@ fn process_time_elapsed(
         .value;
 
     let ix = budget_instruction::apply_timestamp(&config.signers[0].pubkey(), pubkey, to, dt);
-    let message = Message::new(&[ix]);
+    let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee_with_commitment(
@@ -1714,7 +1714,7 @@ fn process_transfer(
                 &nonce_authority.pubkey(),
             )
         } else {
-            Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+            Message::new(&ixs, Some(&fee_payer.pubkey()))
         }
     };
 
@@ -1765,7 +1765,7 @@ fn process_witness(
         .value;
 
     let ix = budget_instruction::apply_signature(&config.signers[0].pubkey(), pubkey, to);
-    let message = Message::new(&[ix]);
+    let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, blockhash)?;
     check_account_for_fee_with_commitment(

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -892,7 +892,7 @@ pub fn process_ping(
 
         let build_message = |lamports| {
             let ix = system_instruction::transfer(&config.signers[0].pubkey(), &to, lamports);
-            Message::new(&[ix])
+            Message::new(&[ix], Some(&config.signers[0].pubkey()))
         };
         let (message, _) = resolve_spend_tx_and_check_account_balance(
             rpc_client,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -453,7 +453,7 @@ pub fn process_authorize_nonce_account(
 
     let nonce_authority = config.signers[nonce_authority];
     let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
-    let message = Message::new_with_payer(&[ix], Some(&config.signers[0].pubkey()));
+    let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
 
@@ -512,7 +512,7 @@ pub fn process_create_nonce_account(
                 lamports,
             )
         };
-        Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()))
+        Message::new(&ixs, Some(&config.signers[0].pubkey()))
     };
 
     let (recent_blockhash, fee_calculator, _) = rpc_client
@@ -600,7 +600,7 @@ pub fn process_new_nonce(
     let (recent_blockhash, fee_calculator, _) = rpc_client
         .get_recent_blockhash_with_commitment(config.commitment)?
         .value;
-    let message = Message::new_with_payer(&[ix], Some(&config.signers[0].pubkey()));
+    let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -667,7 +667,7 @@ pub fn process_withdraw_from_nonce_account(
         destination_account_pubkey,
         lamports,
     );
-    let message = Message::new_with_payer(&[ix], Some(&config.signers[0].pubkey()));
+    let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee_with_commitment(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -891,7 +891,7 @@ pub fn process_create_stake_account(
                 &nonce_authority.pubkey(),
             )
         } else {
-            Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+            Message::new(&ixs, Some(&fee_payer.pubkey()))
         }
     };
 
@@ -996,7 +996,7 @@ pub fn process_stake_authorize(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+        Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
 
@@ -1056,7 +1056,7 @@ pub fn process_deactivate_stake_account(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+        Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
 
@@ -1125,7 +1125,7 @@ pub fn process_withdraw_stake(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+        Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
 
@@ -1265,7 +1265,7 @@ pub fn process_split_stake(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+        Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
 
@@ -1364,7 +1364,7 @@ pub fn process_merge_stake(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+        Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
 
@@ -1427,7 +1427,7 @@ pub fn process_stake_set_lockup(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+        Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
 
@@ -1712,7 +1712,7 @@ pub fn process_delegate_stake(
             &nonce_authority.pubkey(),
         )
     } else {
-        Message::new_with_payer(&ixs, Some(&fee_payer.pubkey()))
+        Message::new(&ixs, Some(&fee_payer.pubkey()))
     };
     let mut tx = Transaction::new_unsigned(message);
 

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -346,7 +346,7 @@ pub fn process_set_validator_info(
                 keys,
                 &validator_info,
             )]);
-            Message::new(&instructions)
+            Message::new(&instructions, Some(&config.signers[0].pubkey()))
         } else {
             println!(
                 "Updating Validator {:?} info at: {:?}",
@@ -359,7 +359,7 @@ pub fn process_set_validator_info(
                 keys,
                 &validator_info,
             )];
-            Message::new_with_payer(&instructions, Some(&config.signers[0].pubkey()))
+            Message::new(&instructions, Some(&config.signers[0].pubkey()))
         }
     };
 

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -469,7 +469,7 @@ pub fn process_create_vote_account(
                 lamports,
             )
         };
-        Message::new(&ixs)
+        Message::new(&ixs, Some(&config.signers[0].pubkey()))
     };
 
     if let Ok(response) =
@@ -540,7 +540,7 @@ pub fn process_vote_authorize(
         vote_authorize,        // vote or withdraw
     )];
 
-    let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
+    let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -580,7 +580,7 @@ pub fn process_vote_update_validator(
         &new_identity_pubkey,
     )];
 
-    let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
+    let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -614,7 +614,7 @@ pub fn process_vote_update_commission(
         commission,
     )];
 
-    let message = Message::new_with_payer(&ixs, Some(&config.signers[0].pubkey()));
+    let message = Message::new(&ixs, Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee_with_commitment(
@@ -743,7 +743,7 @@ pub fn process_withdraw_from_vote_account(
         destination_account_pubkey,
     );
 
-    let message = Message::new_with_payer(&[ix], Some(&config.signers[0].pubkey()));
+    let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut transaction = Transaction::new_unsigned(message);
     transaction.try_sign(&config.signers, recent_blockhash)?;
     check_account_for_fee_with_commitment(

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -336,7 +336,7 @@ impl SyncClient for ThinClient {
         keypair: &Keypair,
         instruction: Instruction,
     ) -> TransportResult<Signature> {
-        let message = Message::new(&[instruction]);
+        let message = Message::new(&[instruction], Some(&keypair.pubkey()));
         self.send_message(&[keypair], message)
     }
 
@@ -574,7 +574,7 @@ impl AsyncClient for ThinClient {
         instruction: Instruction,
         recent_blockhash: Hash,
     ) -> TransportResult<Signature> {
-        let message = Message::new(&[instruction]);
+        let message = Message::new(&[instruction], Some(&keypair.pubkey()));
         self.async_send_message(&[keypair], message, recent_blockhash)
     }
     fn async_transfer(

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -19,6 +19,7 @@ use solana_perf::test_tx::test_tx;
 use solana_runtime::bank::Bank;
 use solana_sdk::genesis_config::GenesisConfig;
 use solana_sdk::hash::Hash;
+use solana_sdk::message::Message;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signature::Signature;
@@ -116,9 +117,8 @@ fn make_programs_txs(txes: usize, hash: Hash) -> Vec<Transaction> {
                 let to_key = Pubkey::new_rand();
                 instructions.push(system_instruction::transfer(&from_key.pubkey(), &to_key, 1));
             }
-            let mut new = Transaction::new_unsigned_instructions(&instructions);
-            new.sign(&[&from_key], hash);
-            new
+            let message = Message::new(&instructions, Some(&from_key.pubkey()));
+            Transaction::new(&[&from_key], message, hash)
         })
         .collect()
 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1711,7 +1711,7 @@ pub mod tests {
             &leader_vote_keypair.pubkey(),
             vote,
         );
-        let vote_msg = Message::new_with_payer(&[vote_ix], Some(&leader_vote_keypair.pubkey()));
+        let vote_msg = Message::new(&[vote_ix], Some(&leader_vote_keypair.pubkey()));
         let vote_tx = Transaction::new(&[&leader_vote_keypair], vote_msg, Hash::default());
         let shreds = entries_to_test_shreds(
             vec![next_entry_mut(&mut Hash::default(), 0, vec![vote_tx])],
@@ -3425,7 +3425,7 @@ pub mod tests {
             bank.get_minimum_balance_for_rent_exemption(VoteState::size_of()),
         );
 
-        let message = Message::new_with_payer(&instructions, Some(&alice.pubkey()));
+        let message = Message::new(&instructions, Some(&alice.pubkey()));
         let transaction = Transaction::new(
             &[&alice, &alice_vote_keypair],
             message,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -376,6 +376,7 @@ mod tests {
     };
     use solana_sdk::{
         hash::Hash,
+        message::Message,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
         system_program, system_transaction,
@@ -571,11 +572,8 @@ mod tests {
             None,
             51,
         );
-        let tx = Transaction::new_signed_instructions(
-            &[&contract_funds, &contract_state],
-            &ixs,
-            blockhash,
-        );
+        let message = Message::new(&ixs, Some(&contract_funds.pubkey()));
+        let tx = Transaction::new(&[&contract_funds, &contract_state], message, blockhash);
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions, 1).unwrap();
         sleep(Duration::from_millis(200));
 
@@ -617,7 +615,8 @@ mod tests {
             &contract_state.pubkey(),
             &bob_pubkey,
         );
-        let tx = Transaction::new_signed_instructions(&[&witness], &[ix], blockhash);
+        let message = Message::new(&[ix], Some(&witness.pubkey()));
+        let tx = Transaction::new(&[&witness], message, blockhash);
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions, 1).unwrap();
         sleep(Duration::from_millis(200));
 

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -125,9 +125,10 @@ impl Faucet {
                     );
                     info!("Requesting airdrop of {} to {:?}", lamports, to);
 
+                    let mint_pubkey = self.mint_keypair.pubkey();
                     let create_instruction =
-                        system_instruction::transfer(&self.mint_keypair.pubkey(), &to, lamports);
-                    let message = Message::new(&[create_instruction]);
+                        system_instruction::transfer(&mint_pubkey, &to, lamports);
+                    let message = Message::new(&[create_instruction], Some(&mint_pubkey));
                     Ok(Transaction::new(&[&self.mint_keypair], message, blockhash))
                 } else {
                     Err(Error::new(
@@ -413,7 +414,7 @@ mod tests {
 
         let keypair = Keypair::new();
         let expected_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);
-        let message = Message::new(&[expected_instruction]);
+        let message = Message::new(&[expected_instruction], Some(&keypair.pubkey()));
         let expected_tx = Transaction::new(&[&keypair], message, blockhash);
         let expected_bytes = serialize(&expected_tx).unwrap();
         let mut expected_vec_with_length = vec![0; 2];

--- a/faucet/tests/local-faucet.rs
+++ b/faucet/tests/local-faucet.rs
@@ -16,7 +16,7 @@ fn test_local_faucet() {
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
     let create_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);
-    let message = Message::new(&[create_instruction]);
+    let message = Message::new(&[create_instruction], Some(&keypair.pubkey()));
     let expected_tx = Transaction::new(&[&keypair], message, blockhash);
 
     let (sender, receiver) = channel();

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -218,9 +218,9 @@ fn new_update_manifest(
             lamports,
             vec![], // additional keys
         );
-        let mut transaction = Transaction::new_unsigned_instructions(&instructions);
+        let message = Message::new(&instructions, Some(&from_keypair.pubkey()));
         let signers = [from_keypair, update_manifest_keypair];
-        transaction.sign(&signers, recent_blockhash);
+        let transaction = Transaction::new(&signers, message, recent_blockhash);
         rpc_client.send_and_confirm_transaction(&transaction)?;
     }
     Ok(())

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -243,7 +243,7 @@ fn store_update_manifest(
         update_manifest,
     );
 
-    let message = Message::new_with_payer(&[instruction], Some(&from_keypair.pubkey()));
+    let message = Message::new(&[instruction], Some(&from_keypair.pubkey()));
     let transaction = Transaction::new(&signers, message, recent_blockhash);
     rpc_client.send_and_confirm_transaction(&transaction)?;
     Ok(())

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -592,11 +592,14 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
         }
         ("verify", Some(matches)) => {
             let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
-            let simple_message = Message::new(&[Instruction::new(
-                Pubkey::default(),
-                &0,
-                vec![AccountMeta::new(keypair.pubkey(), true)],
-            )])
+            let simple_message = Message::new(
+                &[Instruction::new(
+                    Pubkey::default(),
+                    &0,
+                    vec![AccountMeta::new(keypair.pubkey(), true)],
+                )],
+                Some(&keypair.pubkey()),
+            )
             .serialize();
             let signature = keypair.try_sign_message(&simple_message)?;
             let pubkey_bs58 = matches.value_of("pubkey").unwrap();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5225,7 +5225,7 @@ pub mod tests {
                 timestamp,
             };
             let vote_ix = vote_instruction::vote(&keypair.pubkey(), &keypair.pubkey(), vote);
-            let vote_msg = Message::new_with_payer(&[vote_ix], Some(&keypair.pubkey()));
+            let vote_msg = Message::new(&[vote_ix], Some(&keypair.pubkey()));
             let vote_tx = Transaction::new(&[keypair], vote_msg, Hash::default());
 
             vote_entries.push(next_entry_mut(&mut Hash::default(), 0, vec![vote_tx]));

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -677,6 +677,7 @@ mod tests {
     use solana_budget_program::budget_instruction;
     use solana_sdk::{
         hash::{hash, Hash},
+        message::Message,
         signature::{Keypair, Signer},
         system_transaction,
         transaction::Transaction,
@@ -687,19 +688,22 @@ mod tests {
         let budget_contract = Keypair::new();
         let budget_pubkey = budget_contract.pubkey();
         let ixs = budget_instruction::payment(&pubkey, &pubkey, &budget_pubkey, 1);
-        Transaction::new_signed_instructions(&[keypair, &budget_contract], &ixs, hash)
+        let message = Message::new(&ixs, Some(&pubkey));
+        Transaction::new(&[keypair, &budget_contract], message, hash)
     }
 
     fn create_sample_timestamp(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ix = budget_instruction::apply_timestamp(&pubkey, &pubkey, &pubkey, Utc::now());
-        Transaction::new_signed_instructions(&[keypair], &[ix], hash)
+        let message = Message::new(&[ix], Some(&pubkey));
+        Transaction::new(&[keypair], message, hash)
     }
 
     fn create_sample_apply_signature(keypair: &Keypair, hash: Hash) -> Transaction {
         let pubkey = keypair.pubkey();
         let ix = budget_instruction::apply_signature(&pubkey, &pubkey, &pubkey);
-        Transaction::new_signed_instructions(&[keypair], &[ix], hash)
+        let message = Message::new(&[ix], Some(&pubkey));
+        Transaction::new(&[keypair], message, hash)
     }
 
     #[test]

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -308,7 +308,6 @@ mod bpf {
                 result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(0, InstructionError::MaxSeedLengthExceeded)
             );
-
         }
     }
 
@@ -364,10 +363,12 @@ mod bpf {
             let derived_key2 =
                 Pubkey::create_program_address(&[b"Lil'", b"Bits"], &invoked_program_id).unwrap();
             let derived_key3 =
-                Pubkey::create_program_address(&[derived_key2.as_ref()], &invoked_program_id).unwrap();
+                Pubkey::create_program_address(&[derived_key2.as_ref()], &invoked_program_id)
+                    .unwrap();
 
+            let mint_pubkey = mint_keypair.pubkey();
             let account_metas = vec![
-                AccountMeta::new(mint_keypair.pubkey(), true),
+                AccountMeta::new(mint_pubkey, true),
                 AccountMeta::new(argument_keypair.pubkey(), true),
                 AccountMeta::new_readonly(invoked_program_id, false),
                 AccountMeta::new(invoked_argument_keypair.pubkey(), true),
@@ -384,7 +385,7 @@ mod bpf {
 
             let instruction =
                 Instruction::new(invoke_program_id, &TEST_SUCCESS, account_metas.clone());
-            let message = Message::new(&[instruction]);
+            let message = Message::new(&[instruction], Some(&mint_pubkey));
             assert!(bank_client
                 .send_message(
                     &[
@@ -404,7 +405,7 @@ mod bpf {
                 &TEST_PRIVILEGE_ESCALATION_SIGNER,
                 account_metas.clone(),
             );
-            let message = Message::new(&[instruction]);
+            let message = Message::new(&[instruction], Some(&mint_pubkey));
             assert_eq!(
                 bank_client
                     .send_message(
@@ -426,7 +427,7 @@ mod bpf {
                 &TEST_PRIVILEGE_ESCALATION_WRITABLE,
                 account_metas.clone(),
             );
-            let message = Message::new(&[instruction]);
+            let message = Message::new(&[instruction], Some(&mint_pubkey));
             assert_eq!(
                 bank_client
                     .send_message(

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -774,7 +774,7 @@ fn call<'a>(
         ro_regions,
     )?;
     verify_instruction(syscall, &instruction, &signers)?;
-    let message = Message::new_with_payer(&[instruction], None);
+    let message = Message::new(&[instruction], None);
     let callee_program_id_index = message.instructions[0].program_id_index as usize;
     let callee_program_id = message.account_keys[callee_program_id_index];
     let (accounts, refs) = syscall.translate_accounts(

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -256,7 +256,7 @@ mod tests {
             budget_instruction::payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 1);
         instructions[1].accounts = vec![]; // <!-- Attack! Prevent accounts from being passed into processor.
 
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&alice_pubkey));
         assert_eq!(
             bank_client
                 .send_message(&[&alice_keypair, &budget_keypair], message)
@@ -276,7 +276,7 @@ mod tests {
         let budget_pubkey = budget_keypair.pubkey();
         let instructions =
             budget_instruction::payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 100);
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&alice_pubkey));
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -302,7 +302,7 @@ mod tests {
             None,
             1,
         );
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&alice_pubkey));
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -315,7 +315,7 @@ mod tests {
             .unwrap();
         let instruction =
             budget_instruction::apply_signature(&mallory_pubkey, &budget_pubkey, &bob_pubkey);
-        let mut message = Message::new(&[instruction]);
+        let mut message = Message::new(&[instruction], Some(&mallory_pubkey));
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         message.account_keys.insert(3, alice_pubkey);
@@ -352,7 +352,7 @@ mod tests {
             None,
             1,
         );
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&alice_pubkey));
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -365,7 +365,7 @@ mod tests {
             .unwrap();
         let instruction =
             budget_instruction::apply_timestamp(&mallory_pubkey, &budget_pubkey, &bob_pubkey, dt);
-        let mut message = Message::new(&[instruction]);
+        let mut message = Message::new(&[instruction], Some(&mallory_pubkey));
 
         // Attack! Part 2: Point the instruction to the expected, but unsigned, key.
         message.account_keys.insert(3, alice_pubkey);
@@ -402,7 +402,7 @@ mod tests {
             None,
             1,
         );
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&alice_pubkey));
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -472,7 +472,7 @@ mod tests {
             Some(alice_pubkey),
             1,
         );
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&alice_pubkey));
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -550,7 +550,7 @@ mod tests {
             game_hash,
             41,
         );
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&alice_pubkey));
         bank_client
             .send_message(&[&alice_keypair, &budget_keypair], message)
             .unwrap();
@@ -570,7 +570,7 @@ mod tests {
 
         // Anyone can sign the message, but presumably it's Bob, since he's the
         // one claiming the payout.
-        let message = Message::new_with_payer(&[instruction], Some(&bob_pubkey));
+        let message = Message::new(&[instruction], Some(&bob_pubkey));
         bank_client.send_message(&[&bob_keypair], message).unwrap();
 
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 0);

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -604,7 +604,10 @@ mod test {
         );
 
         client
-            .send_message(&[owner, &new], Message::new(&[instruction]))
+            .send_message(
+                &[owner, &new],
+                Message::new(&[instruction], Some(&owner.pubkey())),
+            )
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
         new.pubkey()
     }

--- a/programs/librapay/src/lib.rs
+++ b/programs/librapay/src/lib.rs
@@ -30,11 +30,11 @@ pub fn create_genesis<T: Client>(from: &Keypair, client: &T, amount: u64) -> Key
     );
 
     client
-        .send_message(&[&from, &genesis], Message::new(&[instruction]))
+        .send_message(&[&from, &genesis], Message::new(&[instruction], Some(&from.pubkey())))
         .unwrap();
 
     let instruction = librapay_instruction::genesis(&genesis.pubkey(), amount);
-    let message = Message::new_with_payer(&[instruction], Some(&from.pubkey()));
+    let message = Message::new(&[instruction], Some(&from.pubkey()));
     client.send_message(&[from, &genesis], message).unwrap();
 
     genesis

--- a/programs/librapay/src/lib.rs
+++ b/programs/librapay/src/lib.rs
@@ -30,7 +30,10 @@ pub fn create_genesis<T: Client>(from: &Keypair, client: &T, amount: u64) -> Key
     );
 
     client
-        .send_message(&[&from, &genesis], Message::new(&[instruction], Some(&from.pubkey())))
+        .send_message(
+            &[&from, &genesis],
+            Message::new(&[instruction], Some(&from.pubkey())),
+        )
         .unwrap();
 
     let instruction = librapay_instruction::genesis(&genesis.pubkey(), amount);

--- a/programs/librapay/src/librapay_transaction.rs
+++ b/programs/librapay/src/librapay_transaction.rs
@@ -8,6 +8,7 @@ use solana_sdk::{
     client::Client,
     commitment_config::CommitmentConfig,
     hash::Hash,
+    message::Message,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
     system_instruction,
@@ -87,7 +88,8 @@ pub fn create_accounts(
 
     let mut from_signers = vec![from_keypair];
     from_signers.extend_from_slice(to_keypair);
-    Transaction::new_signed_instructions(&from_signers, &instructions, recent_blockhash)
+    let message = Message::new(&instructions, Some(&from_keypair.pubkey()));
+    Transaction::new(&from_signers, message, recent_blockhash)
 }
 
 pub fn create_account(

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -93,7 +93,7 @@ mod tests {
             owner_pubkey,
             lamports,
         );
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair, account_keypair], message)
     }
 
@@ -109,7 +109,7 @@ mod tests {
             &old_owner_keypair.pubkey(),
             new_owner_pubkey,
         );
-        let message = Message::new_with_payer(&[instruction], Some(&payer_keypair.pubkey()));
+        let message = Message::new(&[instruction], Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair, old_owner_keypair], message)
     }
 

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -183,7 +183,7 @@ mod tests {
             date_instruction::create_account(&payer_keypair.pubkey(), &date_pubkey, 1);
         instructions.push(date_instruction::store(&date_pubkey, date));
 
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair, date_keypair], message)
     }
 
@@ -195,7 +195,7 @@ mod tests {
     ) -> Result<Signature> {
         let date_pubkey = date_keypair.pubkey();
         let instruction = date_instruction::store(&date_pubkey, date);
-        let message = Message::new_with_payer(&[instruction], Some(&payer_keypair.pubkey()));
+        let message = Message::new(&[instruction], Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair, date_keypair], message)
     }
 
@@ -218,7 +218,7 @@ mod tests {
             &date_pubkey,
             lamports,
         );
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair, contract_keypair], message)
     }
 
@@ -253,7 +253,7 @@ mod tests {
     ) -> Result<Signature> {
         let instruction =
             vest_instruction::redeem_tokens(&contract_pubkey, &date_pubkey, &payee_pubkey);
-        let message = Message::new_with_payer(&[instruction], Some(&payer_keypair.pubkey()));
+        let message = Message::new(&[instruction], Some(&payer_keypair.pubkey()));
         bank_client.send_message(&[payer_keypair], message)
     }
 
@@ -349,7 +349,7 @@ mod tests {
         );
         instructions[1].accounts = vec![]; // <!-- Attack! Prevent accounts from being passed into processor.
 
-        let message = Message::new(&instructions);
+        let message = Message::new(&instructions, Some(&alice_keypair.pubkey()));
         assert_eq!(
             bank_client
                 .send_message(&[&alice_keypair, &contract_keypair], message)

--- a/ramp-tps/src/voters.rs
+++ b/ramp-tps/src/voters.rs
@@ -5,6 +5,7 @@ use solana_notifier::Notifier;
 use solana_sdk::{
     clock::Slot,
     epoch_schedule::EpochSchedule,
+    message::Message,
     native_token::sol_to_lamports,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
@@ -138,16 +139,18 @@ fn delegate_stake(
             }
         };
 
-        let transaction = Transaction::new_signed_instructions(
+        let instructions = stake_instruction::create_account_and_delegate_stake(
+            &faucet_keypair.pubkey(),
+            &stake_account_keypair.pubkey(),
+            &vote_account_pubkey,
+            &StakeAuthorized::auto(&faucet_keypair.pubkey()),
+            &Lockup::default(),
+            sol_to_lamports(sol_gift as f64),
+        );
+        let message = Message::new(&instructions, Some(&faucet_keypair.pubkey()));
+        let transaction = Transaction::new(
             &[faucet_keypair, &stake_account_keypair],
-            &stake_instruction::create_account_and_delegate_stake(
-                &faucet_keypair.pubkey(),
-                &stake_account_keypair.pubkey(),
-                &vote_account_pubkey,
-                &StakeAuthorized::auto(&faucet_keypair.pubkey()),
-                &Lockup::default(),
-                sol_to_lamports(sol_gift as f64),
-            ),
+            message,
             recent_blockhash,
         );
 

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -11,6 +11,7 @@ use solana_sdk::{
     clock::MAX_RECENT_BLOCKHASHES,
     genesis_config::create_genesis_config,
     instruction::InstructionError,
+    message::Message,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
@@ -52,7 +53,8 @@ pub fn create_builtin_transactions(
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
             let (blockhash, _fee_calculator) = bank_client.get_recent_blockhash().unwrap();
-            Transaction::new_signed_instructions(&[&rando0], &[instruction], blockhash)
+            let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
+            Transaction::new(&[&rando0], message, blockhash)
         })
         .collect()
 }
@@ -73,7 +75,8 @@ pub fn create_native_loader_transactions(
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
             let (blockhash, _fee_calculator) = bank_client.get_recent_blockhash().unwrap();
-            Transaction::new_signed_instructions(&[&rando0], &[instruction], blockhash)
+            let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
+            Transaction::new(&[&rando0], message, blockhash)
         })
         .collect()
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4273,11 +4273,8 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let instructions =
             system_instruction::transfer_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
-        let tx = Transaction::new_signed_instructions(
-            &[&mint_keypair],
-            &instructions,
-            genesis_config.hash(),
-        );
+        let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
+        let tx = Transaction::new(&[&mint_keypair], message, genesis_config.hash());
         assert_eq!(
             bank.process_transaction(&tx).unwrap_err(),
             TransactionError::InstructionError(
@@ -4298,11 +4295,8 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let instructions =
             system_instruction::transfer_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
-        let tx = Transaction::new_signed_instructions(
-            &[&mint_keypair],
-            &instructions,
-            genesis_config.hash(),
-        );
+        let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
+        let tx = Transaction::new(&[&mint_keypair], message, genesis_config.hash());
         bank.process_transaction(&tx).unwrap();
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 0);
         assert_eq!(bank.get_balance(&key1), 1);
@@ -5633,9 +5627,10 @@ mod tests {
             10,
         );
 
-        let transaction = Transaction::new_signed_instructions(
+        let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
+        let transaction = Transaction::new(
             &[&mint_keypair, &vote_keypair],
-            &instructions,
+            message,
             bank.last_blockhash(),
         );
 
@@ -5690,9 +5685,10 @@ mod tests {
             10,
         ));
 
-        let transaction = Transaction::new_signed_instructions(
+        let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
+        let transaction = Transaction::new(
             &[&mint_keypair, &vote_keypair, &stake_keypair],
-            &instructions,
+            message,
             bank.last_blockhash(),
         );
 
@@ -5889,9 +5885,10 @@ mod tests {
         );
         instructions[1].program_id = mock_vote_program_id();
 
-        let transaction = Transaction::new_signed_instructions(
+        let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
+        let transaction = Transaction::new(
             &[&mint_keypair, &mock_account, &mock_validator_identity],
-            &instructions,
+            message,
             bank.last_blockhash(),
         );
 
@@ -5933,9 +5930,10 @@ mod tests {
             1,
         );
 
-        let transaction = Transaction::new_signed_instructions(
+        let message = Message::new(&instructions, Some(&mint_keypair.pubkey()));
+        let transaction = Transaction::new(
             &[&mint_keypair, &mock_account, &mock_validator_identity],
-            &instructions,
+            message,
             bank.last_blockhash(),
         );
 
@@ -6123,9 +6121,10 @@ mod tests {
             &nonce_authority,
             nonce_lamports,
         ));
-        let setup_tx = Transaction::new_signed_instructions(
+        let message = Message::new(&setup_ixs, Some(&mint_keypair.pubkey()));
+        let setup_tx = Transaction::new(
             &[mint_keypair, &custodian_keypair, &nonce_keypair],
-            &setup_ixs,
+            message,
             bank.last_blockhash(),
         );
         bank.process_transaction(&setup_tx)?;
@@ -6286,14 +6285,9 @@ mod tests {
         let blockhash = bank.last_blockhash();
         bank.store_account(&nonce.pubkey(), &nonce_account);
 
-        let tx = Transaction::new_signed_instructions(
-            &[&nonce],
-            &[system_instruction::assign(
-                &nonce.pubkey(),
-                &Pubkey::new(&[9u8; 32]),
-            )],
-            blockhash,
-        );
+        let ix = system_instruction::assign(&nonce.pubkey(), &Pubkey::new(&[9u8; 32]));
+        let message = Message::new(&[ix], Some(&nonce.pubkey()));
+        let tx = Transaction::new(&[&nonce], message, blockhash);
 
         let expect = Err(TransactionError::InstructionError(
             0,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5452,7 +5452,7 @@ mod tests {
         let mut transfer_instruction =
             system_instruction::transfer(&mint_keypair.pubkey(), &key.pubkey(), 0);
         transfer_instruction.accounts[0].is_signer = false;
-        let message = Message::new_with_payer(&[transfer_instruction], None);
+        let message = Message::new(&[transfer_instruction], None);
         let tx = Transaction::new(&[&Keypair::new(); 0], message, bank.last_blockhash());
 
         assert_eq!(

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -60,7 +60,7 @@ impl AsyncClient for BankClient {
         instruction: Instruction,
         recent_blockhash: Hash,
     ) -> Result<Signature> {
-        let message = Message::new(&[instruction]);
+        let message = Message::new(&[instruction], Some(&keypair.pubkey()));
         self.async_send_message(&[keypair], message, recent_blockhash)
     }
 
@@ -88,7 +88,7 @@ impl SyncClient for BankClient {
 
     /// Create and process a transaction from a single instruction.
     fn send_instruction(&self, keypair: &Keypair, instruction: Instruction) -> Result<Signature> {
-        let message = Message::new(&[instruction]);
+        let message = Message::new(&[instruction], Some(&keypair.pubkey()));
         self.send_message(&[keypair], message)
     }
 
@@ -306,7 +306,7 @@ mod tests {
             .accounts
             .push(AccountMeta::new(jane_pubkey, true));
 
-        let message = Message::new(&[transfer_instruction]);
+        let message = Message::new(&[transfer_instruction], Some(&john_pubkey));
         bank_client.send_message(&doe_keypairs, message).unwrap();
         assert_eq!(bank_client.get_balance(&bob_pubkey).unwrap(), 42);
     }

--- a/runtime/src/legacy_system_instruction_processor0.rs
+++ b/runtime/src/legacy_system_instruction_processor0.rs
@@ -906,7 +906,7 @@ mod tests {
             .transfer(50, &mint_keypair, &alice_pubkey)
             .unwrap();
 
-        let allocate_with_seed = Message::new_with_payer(
+        let allocate_with_seed = Message::new(
             &[system_instruction::allocate_with_seed(
                 &alice_with_seed,
                 &alice_pubkey,
@@ -959,7 +959,7 @@ mod tests {
         let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
         let bank_client = BankClient::new_shared(&bank);
         let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 0, len1, &program);
-        let message = Message::new(&[ix]);
+        let message = Message::new(&[ix], Some(&alice_pubkey));
         let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
         assert!(r.is_ok());
 
@@ -977,7 +977,7 @@ mod tests {
         let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
         let bank_client = BankClient::new_shared(&bank);
         let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 1, len2, &program);
-        let message = Message::new(&[ix]);
+        let message = Message::new(&[ix], Some(&alice_pubkey));
         let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
         assert!(r.is_ok());
     }
@@ -1016,7 +1016,7 @@ mod tests {
             .transfer(50, &mint_keypair, &alice_pubkey)
             .unwrap();
 
-        let assign_with_seed = Message::new_with_payer(
+        let assign_with_seed = Message::new(
             &[system_instruction::assign_with_seed(
                 &alice_with_seed,
                 &alice_pubkey,

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -28,7 +28,7 @@ pub fn load_program<T: Client>(
     bank_client
         .send_message(
             &[from_keypair, &program_keypair],
-            Message::new(&[instruction]),
+            Message::new(&[instruction], Some(&from_keypair.pubkey())),
         )
         .unwrap();
 
@@ -37,7 +37,7 @@ pub fn load_program<T: Client>(
     for chunk in program.chunks(chunk_size) {
         let instruction =
             loader_instruction::write(&program_pubkey, loader_pubkey, offset, chunk.to_vec());
-        let message = Message::new_with_payer(&[instruction], Some(&from_keypair.pubkey()));
+        let message = Message::new(&[instruction], Some(&from_keypair.pubkey()));
         bank_client
             .send_message(&[from_keypair, &program_keypair], message)
             .unwrap();
@@ -45,7 +45,7 @@ pub fn load_program<T: Client>(
     }
 
     let instruction = loader_instruction::finalize(&program_pubkey, loader_pubkey);
-    let message = Message::new_with_payer(&[instruction], Some(&from_keypair.pubkey()));
+    let message = Message::new(&[instruction], Some(&from_keypair.pubkey()));
     bank_client
         .send_message(&[from_keypair, &program_keypair], message)
         .unwrap();

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -909,7 +909,7 @@ mod tests {
             .transfer(50, &mint_keypair, &alice_pubkey)
             .unwrap();
 
-        let allocate_with_seed = Message::new_with_payer(
+        let allocate_with_seed = Message::new(
             &[system_instruction::allocate_with_seed(
                 &alice_with_seed,
                 &alice_pubkey,
@@ -962,7 +962,7 @@ mod tests {
         let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
         let bank_client = BankClient::new_shared(&bank);
         let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 0, len1, &program);
-        let message = Message::new(&[ix]);
+        let message = Message::new(&[ix], Some(&alice_keypair.pubkey()));
         let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
         assert!(r.is_ok());
 
@@ -980,7 +980,7 @@ mod tests {
         let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
         let bank_client = BankClient::new_shared(&bank);
         let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 1, len2, &program);
-        let message = Message::new(&[ix]);
+        let message = Message::new(&[ix], Some(&alice_pubkey));
         let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
         assert!(r.is_ok());
     }
@@ -1019,7 +1019,7 @@ mod tests {
             .transfer(50, &mint_keypair, &alice_pubkey)
             .unwrap();
 
-        let assign_with_seed = Message::new_with_payer(
+        let assign_with_seed = Message::new(
             &[system_instruction::assign_with_seed(
                 &alice_with_seed,
                 &alice_pubkey,

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -193,13 +193,13 @@ mod tests {
         let pubkey0 = Pubkey::new(&[0; 32]);
         let pubkey1 = Pubkey::new(&[1; 32]);
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
-        let message = Message::new(&[ix0]);
+        let message = Message::new(&[ix0], Some(&pubkey0));
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 2);
 
         // Two signatures, double the fee.
         let ix0 = system_instruction::transfer(&pubkey0, &pubkey1, 1);
         let ix1 = system_instruction::transfer(&pubkey1, &pubkey0, 1);
-        let message = Message::new(&[ix0, ix1]);
+        let message = Message::new(&[ix0, ix1], Some(&pubkey0));
         assert_eq!(FeeCalculator::new(2).calculate_fee(&message), 4);
     }
 

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -51,7 +51,7 @@ pub(crate) fn new_stake_account(
         &lockup,
         lamports,
     );
-    Message::new_with_payer(&instructions, Some(fee_payer_pubkey))
+    Message::new(&instructions, Some(fee_payer_pubkey))
 }
 
 fn authorize_stake_accounts_instructions(
@@ -96,7 +96,7 @@ fn rebase_stake_account(
         new_base_pubkey,
         &i.to_string(),
     );
-    let message = Message::new_with_payer(&instructions, Some(&fee_payer_pubkey));
+    let message = Message::new(&instructions, Some(&fee_payer_pubkey));
     Some(message)
 }
 
@@ -133,7 +133,7 @@ fn move_stake_account(
     );
 
     instructions.extend(authorize_instructions.into_iter());
-    let message = Message::new_with_payer(&instructions, Some(&fee_payer_pubkey));
+    let message = Message::new(&instructions, Some(&fee_payer_pubkey));
     Some(message)
 }
 
@@ -157,7 +157,7 @@ pub(crate) fn authorize_stake_accounts(
                 new_stake_authority_pubkey,
                 new_withdraw_authority_pubkey,
             );
-            Message::new_with_payer(&instructions, Some(&fee_payer_pubkey))
+            Message::new(&instructions, Some(&fee_payer_pubkey))
         })
         .collect::<Vec<_>>()
 }
@@ -217,7 +217,7 @@ pub(crate) fn lockup_stake_accounts(
                 return None;
             }
             let instruction = stake_instruction::set_lockup(address, &lockup, custodian_pubkey);
-            let message = Message::new_with_payer(&[instruction], Some(&fee_payer_pubkey));
+            let message = Message::new(&[instruction], Some(&fee_payer_pubkey));
             Some(message)
         })
         .collect()

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -396,16 +396,18 @@ mod test {
 
         // Configure stake1
         let stake1_keypair = Keypair::new();
+        let instructions = stake_instruction::create_account(
+            &payer.pubkey(),
+            &stake1_keypair.pubkey(),
+            &Authorized::auto(&payer.pubkey()),
+            &Lockup::default(),
+            one_sol,
+        );
+        let message = Message::new(&instructions, Some(&payer.pubkey()));
         let stake1_signature = rpc_client
-            .send_transaction(&Transaction::new_signed_instructions(
+            .send_transaction(&Transaction::new(
                 &[&payer, &stake1_keypair],
-                &stake_instruction::create_account(
-                    &payer.pubkey(),
-                    &stake1_keypair.pubkey(),
-                    &Authorized::auto(&payer.pubkey()),
-                    &Lockup::default(),
-                    one_sol,
-                ),
+                message,
                 blockhash,
             ))
             .unwrap();
@@ -426,35 +428,39 @@ mod test {
 
         // Configure stake2 with non-compliant lockup
         let stake2_keypair = Keypair::new();
+        let instructions = stake_instruction::create_account(
+            &payer.pubkey(),
+            &stake2_keypair.pubkey(),
+            &Authorized::auto(&payer.pubkey()),
+            &Lockup {
+                custodian: payer.pubkey(),
+                ..Lockup::default()
+            },
+            one_sol,
+        );
+        let message = Message::new(&instructions, Some(&payer.pubkey()));
         let stake2_signature = rpc_client
-            .send_transaction(&Transaction::new_signed_instructions(
+            .send_transaction(&Transaction::new(
                 &[&payer, &stake2_keypair],
-                &stake_instruction::create_account(
-                    &payer.pubkey(),
-                    &stake2_keypair.pubkey(),
-                    &Authorized::auto(&payer.pubkey()),
-                    &Lockup {
-                        custodian: payer.pubkey(),
-                        ..Lockup::default()
-                    },
-                    one_sol,
-                ),
+                message,
                 blockhash,
             ))
             .unwrap();
 
         // Configure stake3
         let stake3_keypair = Keypair::new();
+        let instructions = stake_instruction::create_account(
+            &payer.pubkey(),
+            &stake3_keypair.pubkey(),
+            &Authorized::auto(&payer.pubkey()),
+            &Lockup::default(),
+            one_sol,
+        );
+        let message = Message::new(&instructions, Some(&payer.pubkey()));
         let stake3_initialize_signature = rpc_client
-            .send_transaction(&Transaction::new_signed_instructions(
+            .send_transaction(&Transaction::new(
                 &[&payer, &stake3_keypair],
-                &stake_instruction::create_account(
-                    &payer.pubkey(),
-                    &stake3_keypair.pubkey(),
-                    &Authorized::auto(&payer.pubkey()),
-                    &Lockup::default(),
-                    one_sol,
-                ),
+                message,
                 blockhash,
             ))
             .unwrap();
@@ -498,16 +504,18 @@ mod test {
 
         // Configure stake4
         let stake4_keypair = Keypair::new();
+        let instructions = stake_instruction::create_account(
+            &payer.pubkey(),
+            &stake4_keypair.pubkey(),
+            &Authorized::auto(&payer.pubkey()),
+            &Lockup::default(),
+            2 * one_sol,
+        );
+        let message = Message::new(&instructions, Some(&payer.pubkey()));
         let stake4_initialize_signature = rpc_client
-            .send_transaction(&Transaction::new_signed_instructions(
+            .send_transaction(&Transaction::new(
                 &[&payer, &stake4_keypair],
-                &stake_instruction::create_account(
-                    &payer.pubkey(),
-                    &stake4_keypair.pubkey(),
-                    &Authorized::auto(&payer.pubkey()),
-                    &Lockup::default(),
-                    2 * one_sol,
-                ),
+                message,
                 blockhash,
             ))
             .unwrap();

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -471,7 +471,7 @@ mod test {
             .send_transaction_with_config(
                 &Transaction::new(
                     &[&payer, &stake3_keypair],
-                    Message::new_with_payer(
+                    Message::new(
                         &[stake_instruction::withdraw(
                             &stake3_keypair.pubkey(),
                             &stake3_keypair.pubkey(),
@@ -525,7 +525,7 @@ mod test {
             .send_transaction_with_config(
                 &Transaction::new(
                     &[&payer, &stake5_keypair],
-                    Message::new_with_payer(
+                    Message::new(
                         &stake_instruction::split(
                             &stake4_keypair.pubkey(),
                             &payer.pubkey(),

--- a/stake-o-matic/src/main.rs
+++ b/stake-o-matic/src/main.rs
@@ -642,7 +642,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             );
             source_stake_lamports_required += config.baseline_stake_amount;
             create_stake_transactions.push((
-                Transaction::new_unsigned(Message::new_with_payer(
+                Transaction::new_unsigned(Message::new(
                     &stake_instruction::split_with_seed(
                         &config.source_stake_address,
                         &config.authorized_staker.pubkey(),
@@ -680,7 +680,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             );
             source_stake_lamports_required += config.bonus_stake_amount;
             create_stake_transactions.push((
-                Transaction::new_unsigned(Message::new_with_payer(
+                Transaction::new_unsigned(Message::new(
                     &stake_instruction::split_with_seed(
                         &config.source_stake_address,
                         &config.authorized_staker.pubkey(),
@@ -712,7 +712,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             // Delegate baseline stake
             if !stake_activated_in_current_epoch.contains(&baseline_stake_address) {
                 delegate_stake_transactions.push((
-                    Transaction::new_unsigned(Message::new_with_payer(
+                    Transaction::new_unsigned(Message::new(
                         &[stake_instruction::delegate_stake(
                             &baseline_stake_address,
                             &config.authorized_staker.pubkey(),
@@ -734,7 +734,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     if !stake_activated_in_current_epoch.contains(&bonus_stake_address) {
                         delegate_stake_transactions.push((
                         Transaction::new_unsigned(
-                        Message::new_with_payer(
+                        Message::new(
                             &[stake_instruction::delegate_stake(
                                 &bonus_stake_address,
                                 &config.authorized_staker.pubkey(),
@@ -754,7 +754,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     // Deactivate bonus stake
                     delegate_stake_transactions.push((
                     Transaction::new_unsigned(
-                    Message::new_with_payer(
+                    Message::new(
                         &[stake_instruction::deactivate_stake(
                             &bonus_stake_address,
                             &config.authorized_staker.pubkey(),
@@ -779,7 +779,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             {
                 // Deactivate baseline stake
                 delegate_stake_transactions.push((
-                    Transaction::new_unsigned(Message::new_with_payer(
+                    Transaction::new_unsigned(Message::new(
                         &[stake_instruction::deactivate_stake(
                             &baseline_stake_address,
                             &config.authorized_staker.pubkey(),
@@ -795,7 +795,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
                 // Deactivate bonus stake
                 delegate_stake_transactions.push((
-                    Transaction::new_unsigned(Message::new_with_payer(
+                    Transaction::new_unsigned(Message::new(
                         &[stake_instruction::deactivate_stake(
                             &bonus_stake_address,
                             &config.authorized_staker.pubkey(),

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -158,7 +158,7 @@ fn distribute_tokens(
         };
 
         let fee_payer_pubkey = args.fee_payer.pubkey();
-        let message = Message::new_with_payer(&instructions, Some(&fee_payer_pubkey));
+        let message = Message::new(&instructions, Some(&fee_payer_pubkey));
         match client.send_message(message, &signers) {
             Ok((transaction, last_valid_slot)) => {
                 db::set_transaction_info(
@@ -508,7 +508,7 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
         &lockup,
         sol_to_lamports(3000.0),
     );
-    let message = Message::new(&instructions);
+    let message = Message::new(&instructions, Some(&sender_keypair.pubkey()));
     let signers = [&sender_keypair, &stake_account_keypair];
     thin_client.send_message(message, &signers).unwrap();
 

--- a/tokens/src/thin_client.rs
+++ b/tokens/src/thin_client.rs
@@ -171,7 +171,7 @@ impl<'a> ThinClient<'a> {
     ) -> Result<(Transaction, u64)> {
         let create_instruction =
             system_instruction::transfer(&sender_keypair.pubkey(), &to_pubkey, lamports);
-        let message = Message::new(&[create_instruction]);
+        let message = Message::new(&[create_instruction], Some(&sender_keypair.pubkey()));
         self.send_message(message, &[sender_keypair])
     }
 


### PR DESCRIPTION
#### Problem

`Message::new` guesses what keypair to use for paying the transaction fee and panics if it can't find a suitable one. `Message::new_with_payer` makes the fee-payer explicit. `Message::new_with_payer` is always the better choice, but devs tend to use the default constructor first, sending them towards that panic for no good reason.

#### Summary of Changes

* Remove `Message::new` and make `Message::new_with_payer` the default constructor.
* Remove `Transaction::new_signed_instructions` and `Transaction::new_unsigned_instructions`.