### PR TITLE
Add correct erasure metrics to dashboard

### DIFF
--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -7049,6 +7049,44 @@
             ]
           ],
           "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT sum(\"num_recovered\") AS \"num_recovered\" FROM \"$testnet\".\"autogen\".\"recv-window-insert-shreds\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval) FILL(0)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
         }
       ],
       "thresholds": [],


### PR DESCRIPTION
#### Problem

The erasure metrics on the dashboard are disabled by default.

#### Summary of Changes

Add the counter which is enabled to the dashboard.

Fixes #
