### PR TITLE
Rename Client methods to match proposed BanksClient

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -970,7 +970,7 @@ fn fund_move_keys<T: Client>(
     let libra_funding_key = Keypair::new();
     let tx = librapay_transaction::create_account(funding_key, &libra_funding_key, 1, blockhash);
     client
-        .send_message(&[funding_key, &libra_funding_key], tx.message)
+        .send_and_confirm_message(&[funding_key, &libra_funding_key], tx.message)
         .unwrap();
 
     info!("minting to funding keypair");
@@ -983,7 +983,7 @@ fn fund_move_keys<T: Client>(
         blockhash,
     );
     client
-        .send_message(&[funding_key, libra_genesis_key], tx.message)
+        .send_and_confirm_message(&[funding_key, libra_genesis_key], tx.message)
         .unwrap();
 
     info!("creating {} move accounts...", keypairs.len());
@@ -1005,7 +1005,7 @@ fn fund_move_keys<T: Client>(
         let ser_size = bincode::serialized_size(&tx).unwrap();
         let mut keys = vec![funding_key];
         keys.extend(&keypairs);
-        client.send_message(&keys, tx.message).unwrap();
+        client.send_and_confirm_message(&keys, tx.message).unwrap();
 
         if i % 10 == 0 {
             info!(
@@ -1026,7 +1026,9 @@ fn fund_move_keys<T: Client>(
     let instructions = system_instruction::transfer_many(&funding_key.pubkey(), &pubkey_amounts);
     let message = Message::new(&instructions, Some(&funding_key.pubkey()));
     let tx = Transaction::new(&[funding_key], message, blockhash);
-    client.send_message(&[funding_key], tx.message).unwrap();
+    client
+        .send_and_confirm_message(&[funding_key], tx.message)
+        .unwrap();
     let mut balance = 0;
     for _ in 0..20 {
         if let Ok(balance_) = client
@@ -1049,7 +1051,7 @@ fn fund_move_keys<T: Client>(
     for (i, key) in libra_funding_keys.iter().enumerate() {
         let tx = librapay_transaction::create_account(&funding_keys[i], &key, 1, blockhash);
         client
-            .send_message(&[&funding_keys[i], &key], tx.message)
+            .send_and_confirm_message(&[&funding_keys[i], &key], tx.message)
             .unwrap();
 
         let tx = librapay_transaction::transfer(
@@ -1062,7 +1064,7 @@ fn fund_move_keys<T: Client>(
             blockhash,
         );
         client
-            .send_message(&[&funding_keys[i], &libra_funding_key], tx.message)
+            .send_and_confirm_message(&[&funding_keys[i], &libra_funding_key], tx.message)
             .unwrap();
 
         info!("funded libra funding key {}", i);

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -320,7 +320,7 @@ impl Client for ThinClient {
 }
 
 impl SyncClient for ThinClient {
-    fn send_message<T: Signers>(
+    fn send_and_confirm_message<T: Signers>(
         &self,
         keypairs: &T,
         message: Message,
@@ -331,16 +331,16 @@ impl SyncClient for ThinClient {
         Ok(signature)
     }
 
-    fn send_instruction(
+    fn send_and_confirm_instruction(
         &self,
         keypair: &Keypair,
         instruction: Instruction,
     ) -> TransportResult<Signature> {
         let message = Message::new(&[instruction], Some(&keypair.pubkey()));
-        self.send_message(&[keypair], message)
+        self.send_and_confirm_message(&[keypair], message)
     }
 
-    fn transfer(
+    fn transfer_and_confirm(
         &self,
         lamports: u64,
         keypair: &Keypair,
@@ -348,7 +348,7 @@ impl SyncClient for ThinClient {
     ) -> TransportResult<Signature> {
         let transfer_instruction =
             system_instruction::transfer(&keypair.pubkey(), pubkey, lamports);
-        self.send_instruction(keypair, transfer_instruction)
+        self.send_and_confirm_instruction(keypair, transfer_instruction)
     }
 
     fn get_account_data(&self, pubkey: &Pubkey) -> TransportResult<Option<Vec<u8>>> {

--- a/docs/src/implemented-proposals/cross-program-invocation.md
+++ b/docs/src/implemented-proposals/cross-program-invocation.md
@@ -9,7 +9,7 @@ let message = Message::new(vec![
     token_instruction::pay(&alice_pubkey),
     acme_instruction::launch_missiles(&bob_pubkey),
 ]);
-client.send_message(&[&alice_keypair, &bob_keypair], &message);
+client.send_and_confirm_message(&[&alice_keypair, &bob_keypair], &message);
 ```
 
 However, the current implementation does not allow the `acme` program to conveniently invoke `token` instructions on the client's behalf:
@@ -18,7 +18,7 @@ However, the current implementation does not allow the `acme` program to conveni
 let message = Message::new(vec![
     acme_instruction::pay_and_launch_missiles(&alice_pubkey, &bob_pubkey),
 ]);
-client.send_message(&[&alice_keypair, &bob_keypair], &message);
+client.send_and_confirm_message(&[&alice_keypair, &bob_keypair], &message);
 ```
 
 Currently, there is no way to create instruction `pay_and_launch_missiles` that executes `token_instruction::pay` from the `acme` program. A possible workaround is to extend the `acme` program with the implementation of the `token` program and create `token` accounts with `ACME_PROGRAM_ID`, which the `acme` program is permitted to modify. With that workaround, `acme` can modify token-like accounts created by the `acme` program, but not token accounts created by the `token` program.

--- a/docs/src/implemented-proposals/program-derived-addresses.md
+++ b/docs/src/implemented-proposals/program-derived-addresses.md
@@ -113,7 +113,7 @@ let message = Message::new(vec![
     token_instruction::transfer(&alice_pubkey, &escrow_pubkey, 1),
 ]);
 //transfer 1 token to escrow
-client.send_message(&[&alice_keypair], &message);
+client.send_and_confirm_message(&[&alice_keypair], &message);
 ```
 
 Programs can use the same function to generate the same address.

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -110,7 +110,7 @@ mod bpf {
                 AccountMeta::new(rent::id(), false),
             ];
             let instruction = Instruction::new(program_id, &1u8, account_metas);
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             if program.1 {
                 assert!(result.is_ok());
             } else {
@@ -162,42 +162,42 @@ mod bpf {
 
             bank.store_account(&pubkey, &account);
             let instruction = Instruction::new(program_id, &1u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
             assert!(result.is_ok());
             assert_eq!(data[0], 1);
 
             bank.store_account(&pubkey, &account);
             let instruction = Instruction::new(program_id, &2u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
             assert!(result.is_ok());
             assert_eq!(data[0], 2);
 
             bank.store_account(&pubkey, &account);
             let instruction = Instruction::new(program_id, &3u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
             assert!(result.is_ok());
             assert_eq!(data[0], 3);
 
             bank.store_account(&pubkey, &account);
             let instruction = Instruction::new(program_id, &4u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let lamports = bank_client.get_balance(&pubkey).unwrap();
             assert!(result.is_ok());
             assert_eq!(lamports, 11);
 
             bank.store_account(&pubkey, &account);
             let instruction = Instruction::new(program_id, &5u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let lamports = bank_client.get_balance(&pubkey).unwrap();
             assert!(result.is_ok());
             assert_eq!(lamports, 12);
 
             bank.store_account(&pubkey, &account);
             let instruction = Instruction::new(program_id, &6u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let lamports = bank_client.get_balance(&pubkey).unwrap();
             assert!(result.is_ok());
             assert_eq!(lamports, 13);
@@ -235,32 +235,32 @@ mod bpf {
             let account_metas = vec![AccountMeta::new(mint_keypair.pubkey(), true)];
 
             let instruction = Instruction::new(program_id, &1u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             assert!(result.is_ok());
 
             let instruction = Instruction::new(program_id, &2u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             assert_eq!(
                 result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
             );
 
             let instruction = Instruction::new(program_id, &3u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             assert_eq!(
                 result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(0, InstructionError::Custom(0))
             );
 
             let instruction = Instruction::new(program_id, &4u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             assert_eq!(
                 result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(0, InstructionError::Custom(42))
             );
 
             let instruction = Instruction::new(program_id, &5u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let result = result.unwrap_err().unwrap();
             if TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
                 != result
@@ -272,7 +272,7 @@ mod bpf {
             }
 
             let instruction = Instruction::new(program_id, &6u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let result = result.unwrap_err().unwrap();
             if TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
                 != result
@@ -284,7 +284,7 @@ mod bpf {
             }
 
             let instruction = Instruction::new(program_id, &7u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             let result = result.unwrap_err().unwrap();
             if TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
                 != result
@@ -296,14 +296,14 @@ mod bpf {
             }
 
             let instruction = Instruction::new(program_id, &8u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             assert_eq!(
                 result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
             );
 
             let instruction = Instruction::new(program_id, &9u8, account_metas.clone());
-            let result = bank_client.send_instruction(&mint_keypair, instruction);
+            let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
             assert_eq!(
                 result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(0, InstructionError::MaxSeedLengthExceeded)
@@ -387,7 +387,7 @@ mod bpf {
                 Instruction::new(invoke_program_id, &TEST_SUCCESS, account_metas.clone());
             let message = Message::new(&[instruction], Some(&mint_pubkey));
             assert!(bank_client
-                .send_message(
+                .send_and_confirm_message(
                     &[
                         &mint_keypair,
                         &argument_keypair,
@@ -408,7 +408,7 @@ mod bpf {
             let message = Message::new(&[instruction], Some(&mint_pubkey));
             assert_eq!(
                 bank_client
-                    .send_message(
+                    .send_and_confirm_message(
                         &[
                             &mint_keypair,
                             &argument_keypair,
@@ -430,7 +430,7 @@ mod bpf {
             let message = Message::new(&[instruction], Some(&mint_pubkey));
             assert_eq!(
                 bank_client
-                    .send_message(
+                    .send_and_confirm_message(
                         &[
                             &mint_keypair,
                             &argument_keypair,

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -586,7 +586,7 @@ mod test {
         let owner = Keypair::new();
         let bank_client = BankClient::new(bank);
         bank_client
-            .transfer(42, &mint_keypair, &owner.pubkey())
+            .transfer_and_confirm(42, &mint_keypair, &owner.pubkey())
             .unwrap();
 
         (bank_client, owner)
@@ -604,7 +604,7 @@ mod test {
         );
 
         client
-            .send_message(
+            .send_and_confirm_message(
                 &[owner, &new],
                 Message::new(&[instruction], Some(&owner.pubkey())),
             )
@@ -616,7 +616,7 @@ mod test {
         let new = create_account(&client, &owner);
         let instruction = exchange_instruction::account_request(&owner.pubkey(), &new);
         client
-            .send_instruction(owner, instruction)
+            .send_and_confirm_instruction(owner, instruction)
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
         new
     }
@@ -630,7 +630,7 @@ mod test {
             tokens,
         );
         client
-            .send_instruction(owner, instruction)
+            .send_and_confirm_instruction(owner, instruction)
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
     }
 
@@ -658,7 +658,7 @@ mod test {
             &src,
         );
         client
-            .send_instruction(owner, instruction)
+            .send_and_confirm_instruction(owner, instruction)
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
         (trade, src)
     }
@@ -691,7 +691,7 @@ mod test {
         let new = create_token_account(&client, &owner);
         let instruction = exchange_instruction::account_request(&owner.pubkey(), &new);
         client
-            .send_instruction(&owner, instruction)
+            .send_and_confirm_instruction(&owner, instruction)
             .expect_err(&format!("{}:{}", line!(), file!()));
     }
 
@@ -711,7 +711,7 @@ mod test {
             42,
         );
         client
-            .send_instruction(&owner, instruction)
+            .send_and_confirm_instruction(&owner, instruction)
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
 
         let new_account_data = client.get_account_data(&new).unwrap().unwrap();
@@ -798,7 +798,7 @@ mod test {
         let instruction =
             exchange_instruction::swap_request(&owner.pubkey(), &to_trade, &from_trade, &profit);
         client
-            .send_instruction(&owner, instruction)
+            .send_and_confirm_instruction(&owner, instruction)
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
 
         let to_trade_account_data = client.get_account_data(&to_trade).unwrap().unwrap();
@@ -865,7 +865,7 @@ mod test {
         let instruction =
             exchange_instruction::swap_request(&owner.pubkey(), &to_trade, &from_trade, &profit);
         client
-            .send_instruction(&owner, instruction)
+            .send_and_confirm_instruction(&owner, instruction)
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
 
         let new = create_token_account(&client, &owner);
@@ -873,13 +873,13 @@ mod test {
         let instruction =
             exchange_instruction::transfer_request(&owner.pubkey(), &new, &to_trade, Token::B, 1);
         client
-            .send_instruction(&owner, instruction)
+            .send_and_confirm_instruction(&owner, instruction)
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
 
         let instruction =
             exchange_instruction::transfer_request(&owner.pubkey(), &new, &from_trade, Token::A, 1);
         client
-            .send_instruction(&owner, instruction)
+            .send_and_confirm_instruction(&owner, instruction)
             .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
 
         let new_account_data = client.get_account_data(&new).unwrap().unwrap();

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -20,7 +20,7 @@ fn test_program_native_failure() {
     let bank_client = BankClient::new(bank);
     assert_eq!(
         bank_client
-            .send_instruction(&alice_keypair, instruction)
+            .send_and_confirm_instruction(&alice_keypair, instruction)
             .unwrap_err()
             .unwrap(),
         TransactionError::InstructionError(0, InstructionError::Custom(0))

--- a/programs/librapay/src/lib.rs
+++ b/programs/librapay/src/lib.rs
@@ -30,7 +30,7 @@ pub fn create_genesis<T: Client>(from: &Keypair, client: &T, amount: u64) -> Key
     );
 
     client
-        .send_message(
+        .send_and_confirm_message(
             &[&from, &genesis],
             Message::new(&[instruction], Some(&from.pubkey())),
         )
@@ -38,7 +38,7 @@ pub fn create_genesis<T: Client>(from: &Keypair, client: &T, amount: u64) -> Key
 
     let instruction = librapay_instruction::genesis(&genesis.pubkey(), amount);
     let message = Message::new(&[instruction], Some(&from.pubkey()));
-    client.send_message(&[from, &genesis], message).unwrap();
+    client.send_and_confirm_message(&[from, &genesis], message).unwrap();
 
     genesis
 }

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -94,7 +94,7 @@ mod tests {
             lamports,
         );
         let message = Message::new(&instructions, Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[payer_keypair, account_keypair], message)
+        bank_client.send_and_confirm_message(&[payer_keypair, account_keypair], message)
     }
 
     fn send_set_owner(
@@ -110,7 +110,7 @@ mod tests {
             new_owner_pubkey,
         );
         let message = Message::new(&[instruction], Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[payer_keypair, old_owner_keypair], message)
+        bank_client.send_and_confirm_message(&[payer_keypair, old_owner_keypair], message)
     }
 
     #[test]

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -184,7 +184,7 @@ mod tests {
         instructions.push(date_instruction::store(&date_pubkey, date));
 
         let message = Message::new(&instructions, Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[payer_keypair, date_keypair], message)
+        bank_client.send_and_confirm_message(&[payer_keypair, date_keypair], message)
     }
 
     fn store_date(
@@ -196,7 +196,7 @@ mod tests {
         let date_pubkey = date_keypair.pubkey();
         let instruction = date_instruction::store(&date_pubkey, date);
         let message = Message::new(&[instruction], Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[payer_keypair, date_keypair], message)
+        bank_client.send_and_confirm_message(&[payer_keypair, date_keypair], message)
     }
 
     fn create_vest_account(
@@ -219,7 +219,7 @@ mod tests {
             lamports,
         );
         let message = Message::new(&instructions, Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[payer_keypair, contract_keypair], message)
+        bank_client.send_and_confirm_message(&[payer_keypair, contract_keypair], message)
     }
 
     fn send_set_terminator(
@@ -230,7 +230,7 @@ mod tests {
     ) -> Result<Signature> {
         let instruction =
             vest_instruction::set_terminator(&contract_pubkey, &old_keypair.pubkey(), &new_pubkey);
-        bank_client.send_instruction(&old_keypair, instruction)
+        bank_client.send_and_confirm_instruction(&old_keypair, instruction)
     }
 
     fn send_set_payee(
@@ -241,7 +241,7 @@ mod tests {
     ) -> Result<Signature> {
         let instruction =
             vest_instruction::set_payee(&contract_pubkey, &old_keypair.pubkey(), &new_pubkey);
-        bank_client.send_instruction(&old_keypair, instruction)
+        bank_client.send_and_confirm_instruction(&old_keypair, instruction)
     }
 
     fn send_redeem_tokens(
@@ -254,7 +254,7 @@ mod tests {
         let instruction =
             vest_instruction::redeem_tokens(&contract_pubkey, &date_pubkey, &payee_pubkey);
         let message = Message::new(&[instruction], Some(&payer_keypair.pubkey()));
-        bank_client.send_message(&[payer_keypair], message)
+        bank_client.send_and_confirm_message(&[payer_keypair], message)
     }
 
     #[test]
@@ -352,7 +352,7 @@ mod tests {
         let message = Message::new(&instructions, Some(&alice_keypair.pubkey()));
         assert_eq!(
             bank_client
-                .send_message(&[&alice_keypair, &contract_keypair], message)
+                .send_and_confirm_message(&[&alice_keypair, &contract_keypair], message)
                 .unwrap_err()
                 .unwrap(),
             TransactionError::InstructionError(1, InstructionError::NotEnoughAccountKeys)
@@ -387,7 +387,7 @@ mod tests {
         // Transfer bob a token to pay the transaction fee.
         let mallory_keypair = Keypair::new();
         bank_client
-            .transfer(1, &alice_keypair, &mallory_keypair.pubkey())
+            .transfer_and_confirm(1, &alice_keypair, &mallory_keypair.pubkey())
             .unwrap();
         send_set_payee(
             &bank_client,
@@ -397,9 +397,9 @@ mod tests {
         )
         .unwrap_err();
 
-        // Ensure bob can update which account he wants vested funds transfered to.
+        // Ensure bob can update which account he wants vested funds transferred to.
         bank_client
-            .transfer(1, &alice_keypair, &bob_pubkey)
+            .transfer_and_confirm(1, &alice_keypair, &bob_pubkey)
             .unwrap();
         send_set_payee(
             &bank_client,
@@ -458,7 +458,7 @@ mod tests {
         // Transfer bob a token to pay the transaction fee.
         let mallory_keypair = Keypair::new();
         bank_client
-            .transfer(1, &alice_keypair, &mallory_keypair.pubkey())
+            .transfer_and_confirm(1, &alice_keypair, &mallory_keypair.pubkey())
             .unwrap();
         send_set_payee(
             &bank_client,
@@ -470,7 +470,7 @@ mod tests {
 
         // Ensure bob can update which account he wants vested funds transferred to.
         bank_client
-            .transfer(1, &alice_keypair, &bob_pubkey)
+            .transfer_and_confirm(1, &alice_keypair, &bob_pubkey)
             .unwrap();
         send_set_payee(
             &bank_client,
@@ -586,7 +586,7 @@ mod tests {
         let instruction =
             vest_instruction::terminate(&contract_pubkey, &alice_pubkey, &alice_pubkey);
         bank_client
-            .send_instruction(&alice_keypair, instruction)
+            .send_and_confirm_instruction(&alice_keypair, instruction)
             .unwrap();
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 2);
         assert_eq!(
@@ -630,7 +630,7 @@ mod tests {
         let instruction =
             vest_instruction::terminate(&contract_pubkey, &alice_pubkey, &carol_pubkey);
         bank_client
-            .send_instruction(&alice_keypair, instruction)
+            .send_and_confirm_instruction(&alice_keypair, instruction)
             .unwrap();
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 1);
         assert_eq!(bank_client.get_balance(&carol_pubkey).unwrap(), 1);
@@ -675,7 +675,7 @@ mod tests {
         let instruction =
             vest_instruction::renege(&contract_pubkey, &alice_pubkey, &carol_pubkey, 1);
         bank_client
-            .send_instruction(&alice_keypair, instruction)
+            .send_and_confirm_instruction(&alice_keypair, instruction)
             .unwrap();
         assert_eq!(bank_client.get_balance(&alice_pubkey).unwrap(), 1);
         assert_eq!(bank_client.get_balance(&carol_pubkey).unwrap(), 1);

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -48,7 +48,7 @@ pub fn create_builtin_transactions(
             // Seed the signer account
             let rando0 = Keypair::new();
             bank_client
-                .transfer(10_000, &mint_keypair, &rando0.pubkey())
+                .transfer_and_confirm(10_000, &mint_keypair, &rando0.pubkey())
                 .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);
@@ -70,7 +70,7 @@ pub fn create_native_loader_transactions(
             // Seed the signer account©41
             let rando0 = Keypair::new();
             bank_client
-                .transfer(10_000, &mint_keypair, &rando0.pubkey())
+                .transfer_and_confirm(10_000, &mint_keypair, &rando0.pubkey())
                 .unwrap_or_else(|_| panic!("{}:{}", line!(), file!()));
 
             let instruction = create_invoke_instruction(rando0.pubkey(), program_id, &1u8);

--- a/runtime/src/legacy_system_instruction_processor0.rs
+++ b/runtime/src/legacy_system_instruction_processor0.rs
@@ -903,7 +903,7 @@ mod tests {
         let alice_with_seed = Pubkey::create_with_seed(&alice_pubkey, seed, &owner).unwrap();
 
         bank_client
-            .transfer(50, &mint_keypair, &alice_pubkey)
+            .transfer_and_confirm(50, &mint_keypair, &alice_pubkey)
             .unwrap();
 
         let allocate_with_seed = Message::new(
@@ -918,13 +918,13 @@ mod tests {
         );
 
         assert!(bank_client
-            .send_message(&[&alice_keypair], allocate_with_seed)
+            .send_and_confirm_message(&[&alice_keypair], allocate_with_seed)
             .is_ok());
 
         let allocate = system_instruction::allocate(&alice_pubkey, 2);
 
         assert!(bank_client
-            .send_instruction(&alice_keypair, allocate)
+            .send_and_confirm_instruction(&alice_keypair, allocate)
             .is_ok());
     }
 
@@ -952,7 +952,7 @@ mod tests {
         let bank = Arc::new(Bank::new(&genesis_config));
         let bank_client = BankClient::new_shared(&bank);
         bank_client
-            .transfer(mint_lamports, &mint_keypair, &alice_pubkey)
+            .transfer_and_confirm(mint_lamports, &mint_keypair, &alice_pubkey)
             .unwrap();
 
         // create zero-lamports account to be cleaned
@@ -960,14 +960,14 @@ mod tests {
         let bank_client = BankClient::new_shared(&bank);
         let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 0, len1, &program);
         let message = Message::new(&[ix], Some(&alice_pubkey));
-        let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
+        let r = bank_client.send_and_confirm_message(&[&alice_keypair, &bob_keypair], message);
         assert!(r.is_ok());
 
         // transfer some to bogus pubkey just to make previous bank (=slot) really cleanable
         let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
         let bank_client = BankClient::new_shared(&bank);
         bank_client
-            .transfer(50, &alice_keypair, &Pubkey::new_rand())
+            .transfer_and_confirm(50, &alice_keypair, &Pubkey::new_rand())
             .unwrap();
 
         // super fun time; callback chooses to .clean_accounts() or not
@@ -978,7 +978,7 @@ mod tests {
         let bank_client = BankClient::new_shared(&bank);
         let ix = system_instruction::create_account(&alice_pubkey, &bob_pubkey, 1, len2, &program);
         let message = Message::new(&[ix], Some(&alice_pubkey));
-        let r = bank_client.send_message(&[&alice_keypair, &bob_keypair], message);
+        let r = bank_client.send_and_confirm_message(&[&alice_keypair, &bob_keypair], message);
         assert!(r.is_ok());
     }
 
@@ -1013,7 +1013,7 @@ mod tests {
         let alice_with_seed = Pubkey::create_with_seed(&alice_pubkey, seed, &owner).unwrap();
 
         bank_client
-            .transfer(50, &mint_keypair, &alice_pubkey)
+            .transfer_and_confirm(50, &mint_keypair, &alice_pubkey)
             .unwrap();
 
         let assign_with_seed = Message::new(
@@ -1027,7 +1027,7 @@ mod tests {
         );
 
         assert!(bank_client
-            .send_message(&[&alice_keypair], assign_with_seed)
+            .send_and_confirm_message(&[&alice_keypair], assign_with_seed)
             .is_ok());
     }
 
@@ -1042,7 +1042,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let bank_client = BankClient::new(bank);
         bank_client
-            .transfer(50, &alice_keypair, &mallory_pubkey)
+            .transfer_and_confirm(50, &alice_keypair, &mallory_pubkey)
             .unwrap();
 
         // Erroneously sign transaction with recipient account key
@@ -1058,7 +1058,7 @@ mod tests {
         );
         assert_eq!(
             bank_client
-                .send_instruction(&mallory_keypair, malicious_instruction)
+                .send_and_confirm_instruction(&mallory_keypair, malicious_instruction)
                 .unwrap_err()
                 .unwrap(),
             TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -26,7 +26,7 @@ pub fn load_program<T: Client>(
         loader_pubkey,
     );
     bank_client
-        .send_message(
+        .send_and_confirm_message(
             &[from_keypair, &program_keypair],
             Message::new(&[instruction], Some(&from_keypair.pubkey())),
         )
@@ -39,7 +39,7 @@ pub fn load_program<T: Client>(
             loader_instruction::write(&program_pubkey, loader_pubkey, offset, chunk.to_vec());
         let message = Message::new(&[instruction], Some(&from_keypair.pubkey()));
         bank_client
-            .send_message(&[from_keypair, &program_keypair], message)
+            .send_and_confirm_message(&[from_keypair, &program_keypair], message)
             .unwrap();
         offset += chunk_size as u32;
     }
@@ -47,7 +47,7 @@ pub fn load_program<T: Client>(
     let instruction = loader_instruction::finalize(&program_pubkey, loader_pubkey);
     let message = Message::new(&[instruction], Some(&from_keypair.pubkey()));
     bank_client
-        .send_message(&[from_keypair, &program_keypair], message)
+        .send_and_confirm_message(&[from_keypair, &program_keypair], message)
         .unwrap();
 
     program_pubkey

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -18,6 +18,6 @@ fn test_program_native_noop() {
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);
     let bank_client = BankClient::new(bank);
     bank_client
-        .send_instruction(&alice_keypair, instruction)
+        .send_and_confirm_instruction(&alice_keypair, instruction)
         .unwrap();
 }

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -62,7 +62,7 @@ fn fill_epoch_with_votes(
             Some(&mint_pubkey),
         );
         assert!(bank_client
-            .send_message(&[mint_keypair, vote_keypair], message)
+            .send_and_confirm_message(&[mint_keypair, vote_keypair], message)
             .is_ok());
     }
     bank
@@ -134,7 +134,7 @@ fn test_stake_create_and_split_single_signature() {
 
     // only one signature required
     bank_client
-        .send_message(&[&staker_keypair], message)
+        .send_and_confirm_message(&[&staker_keypair], message)
         .expect("failed to create and delegate stake account");
 
     // split the stake
@@ -155,7 +155,7 @@ fn test_stake_create_and_split_single_signature() {
     );
 
     assert!(bank_client
-        .send_message(&[&staker_keypair], message)
+        .send_and_confirm_message(&[&staker_keypair], message)
         .is_ok());
 
     // w00t!
@@ -200,7 +200,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
     );
 
     bank_client
-        .send_message(&[&staker_keypair], message)
+        .send_and_confirm_message(&[&staker_keypair], message)
         .expect("failed to create and delegate stake account");
 
     let split_stake_address =
@@ -210,7 +210,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
     // First, put a system account where we want the new stake account
     let existing_lamports = 42;
     bank_client
-        .transfer(existing_lamports, &staker_keypair, &split_stake_address)
+        .transfer_and_confirm(existing_lamports, &staker_keypair, &split_stake_address)
         .unwrap();
     assert_eq!(
         bank_client.get_balance(&split_stake_address).unwrap(),
@@ -231,7 +231,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
     );
     assert_eq!(
         bank_client
-            .send_message(&[&staker_keypair], message)
+            .send_and_confirm_message(&[&staker_keypair], message)
             .unwrap_err()
             .unwrap(),
         TransactionError::InstructionError(0, SystemError::AccountAlreadyInUse.into())
@@ -277,7 +277,7 @@ fn test_stake_account_lifetime() {
         Some(&mint_pubkey),
     );
     bank_client
-        .send_message(&[&mint_keypair, &vote_keypair, &identity_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &vote_keypair, &identity_keypair], message)
         .expect("failed to create vote account");
 
     let authorized = stake_state::Authorized::auto(&stake_pubkey);
@@ -294,7 +294,7 @@ fn test_stake_account_lifetime() {
         Some(&mint_pubkey),
     );
     bank_client
-        .send_message(&[&mint_keypair, &stake_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &stake_keypair], message)
         .expect("failed to create and delegate stake account");
 
     // Test that correct lamports are staked
@@ -318,7 +318,7 @@ fn test_stake_account_lifetime() {
         Some(&mint_pubkey),
     );
     assert!(bank_client
-        .send_message(&[&mint_keypair, &stake_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &stake_keypair], message)
         .is_err());
 
     // Test that lamports are still staked
@@ -381,7 +381,7 @@ fn test_stake_account_lifetime() {
         Some(&mint_pubkey),
     );
     assert!(bank_client
-        .send_message(
+        .send_and_confirm_message(
             &[&mint_keypair, &stake_keypair, &split_stake_keypair],
             message
         )
@@ -396,7 +396,7 @@ fn test_stake_account_lifetime() {
         Some(&mint_pubkey),
     );
     assert!(bank_client
-        .send_message(&[&mint_keypair, &stake_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &stake_keypair], message)
         .is_ok());
 
     let split_staked = get_staked(&bank, &split_stake_pubkey);
@@ -413,7 +413,7 @@ fn test_stake_account_lifetime() {
         Some(&mint_pubkey),
     );
     assert!(bank_client
-        .send_message(&[&mint_keypair, &stake_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &stake_keypair], message)
         .is_err());
 
     let mut bank = next_epoch(&bank);
@@ -436,7 +436,7 @@ fn test_stake_account_lifetime() {
     );
 
     assert!(bank_client
-        .send_message(&[&mint_keypair, &stake_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &stake_keypair], message)
         .is_err());
 
     // but we can withdraw unstaked
@@ -452,7 +452,7 @@ fn test_stake_account_lifetime() {
     );
     // assert we can withdraw unstaked tokens
     assert!(bank_client
-        .send_message(&[&mint_keypair, &stake_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &stake_keypair], message)
         .is_ok());
 
     // finish cooldown
@@ -476,7 +476,7 @@ fn test_stake_account_lifetime() {
         Some(&mint_pubkey),
     );
     assert!(bank_client
-        .send_message(&[&mint_keypair, &stake_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &stake_keypair], message)
         .is_ok());
 
     // verify all the math sums to zero
@@ -521,7 +521,7 @@ fn test_create_stake_account_from_seed() {
         Some(&mint_pubkey),
     );
     bank_client
-        .send_message(&[&mint_keypair, &vote_keypair, &identity_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair, &vote_keypair, &identity_keypair], message)
         .expect("failed to create vote account");
 
     let authorized = stake_state::Authorized::auto(&mint_pubkey);
@@ -540,7 +540,7 @@ fn test_create_stake_account_from_seed() {
         Some(&mint_pubkey),
     );
     bank_client
-        .send_message(&[&mint_keypair], message)
+        .send_and_confirm_message(&[&mint_keypair], message)
         .expect("failed to create and delegate stake account");
 
     // Test that correct lamports are staked

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -30,15 +30,28 @@ pub trait Client: SyncClient + AsyncClient {
 pub trait SyncClient {
     /// Create a transaction from the given message, and send it to the
     /// server, retrying as-needed.
-    fn send_message<T: Signers>(&self, keypairs: &T, message: Message) -> Result<Signature>;
+    fn send_and_confirm_message<T: Signers>(
+        &self,
+        keypairs: &T,
+        message: Message,
+    ) -> Result<Signature>;
 
     /// Create a transaction from a single instruction that only requires
     /// a single signer. Then send it to the server, retrying as-needed.
-    fn send_instruction(&self, keypair: &Keypair, instruction: Instruction) -> Result<Signature>;
+    fn send_and_confirm_instruction(
+        &self,
+        keypair: &Keypair,
+        instruction: Instruction,
+    ) -> Result<Signature>;
 
     /// Transfer lamports from `keypair` to `pubkey`, retrying until the
     /// transfer completes or produces and error.
-    fn transfer(&self, lamports: u64, keypair: &Keypair, pubkey: &Pubkey) -> Result<Signature>;
+    fn transfer_and_confirm(
+        &self,
+        lamports: u64,
+        keypair: &Keypair,
+        pubkey: &Pubkey,
+    ) -> Result<Signature>;
 
     /// Get an account or None if not found.
     fn get_account_data(&self, pubkey: &Pubkey) -> Result<Option<Vec<u8>>>;

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -83,7 +83,7 @@ fn process_new_stake_account(
         &*args.funding_keypair,
         &*args.base_keypair,
     ]);
-    let signature = send_message(client, message, &signers, false)?;
+    let signature = send_and_confirm_message(client, message, &signers, false)?;
     Ok(signature)
 }
 
@@ -105,7 +105,7 @@ fn process_authorize_stake_accounts(
         &*args.stake_authority,
         &*args.withdraw_authority,
     ]);
-    send_messages(client, messages, &signers, false)?;
+    send_and_confirm_messages(client, messages, &signers, false)?;
     Ok(())
 }
 
@@ -134,7 +134,7 @@ fn process_lockup_stake_accounts(
         return Ok(());
     }
     let signers = unique_signers(vec![&*args.fee_payer, &*args.custodian]);
-    send_messages(client, messages, &signers, args.no_wait)?;
+    send_and_confirm_messages(client, messages, &signers, args.no_wait)?;
     Ok(())
 }
 
@@ -161,7 +161,7 @@ fn process_rebase_stake_accounts(
         &*args.new_base_keypair,
         &*args.stake_authority,
     ]);
-    send_messages(client, messages, &signers, false)?;
+    send_and_confirm_messages(client, messages, &signers, false)?;
     Ok(())
 }
 
@@ -194,11 +194,11 @@ fn process_move_stake_accounts(
         &*args.stake_authority,
         &*authorize_args.withdraw_authority,
     ]);
-    send_messages(client, messages, &signers, false)?;
+    send_and_confirm_messages(client, messages, &signers, false)?;
     Ok(())
 }
 
-fn send_message<S: Signers>(
+fn send_and_confirm_message<S: Signers>(
     client: &RpcClient,
     message: Message,
     signers: &S,
@@ -217,7 +217,7 @@ fn send_message<S: Signers>(
     }
 }
 
-fn send_messages<S: Signers>(
+fn send_and_confirm_messages<S: Signers>(
     client: &RpcClient,
     messages: Vec<Message>,
     signers: &S,
@@ -225,7 +225,7 @@ fn send_messages<S: Signers>(
 ) -> Result<Vec<Signature>, ClientError> {
     let mut signatures = vec![];
     for message in messages {
-        let signature = send_message(client, message, signers, no_wait)?;
+        let signature = send_and_confirm_message(client, message, signers, no_wait)?;
         signatures.push(signature);
         println!("{}", signature);
     }

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -299,7 +299,7 @@ mod tests {
     ) -> Keypair {
         let fee_payer_keypair = Keypair::new();
         client
-            .transfer(lamports, &funding_keypair, &fee_payer_keypair.pubkey())
+            .transfer_and_confirm(lamports, &funding_keypair, &fee_payer_keypair.pubkey())
             .unwrap();
         fee_payer_keypair
     }
@@ -362,7 +362,9 @@ mod tests {
         );
 
         let signers = [&funding_keypair, &fee_payer_keypair, &base_keypair];
-        bank_client.send_message(&signers, message).unwrap();
+        bank_client
+            .send_and_confirm_message(&signers, message)
+            .unwrap();
 
         let account = get_account_at(&bank_client, &base_pubkey, 0);
         assert_eq!(account.lamports, lamports);
@@ -400,7 +402,9 @@ mod tests {
         );
 
         let signers = [&funding_keypair, &fee_payer_keypair, &base_keypair];
-        bank_client.send_message(&signers, message).unwrap();
+        bank_client
+            .send_and_confirm_message(&signers, message)
+            .unwrap();
 
         let new_stake_authority_pubkey = Pubkey::new_rand();
         let new_withdraw_authority_pubkey = Pubkey::new_rand();
@@ -420,7 +424,9 @@ mod tests {
             &withdraw_authority_keypair,
         ];
         for message in messages {
-            bank_client.send_message(&signers, message).unwrap();
+            bank_client
+                .send_and_confirm_message(&signers, message)
+                .unwrap();
         }
 
         let account = get_account_at(&bank_client, &base_pubkey, 0);
@@ -456,7 +462,9 @@ mod tests {
         );
 
         let signers = [&funding_keypair, &fee_payer_keypair, &base_keypair];
-        bank_client.send_message(&signers, message).unwrap();
+        bank_client
+            .send_and_confirm_message(&signers, message)
+            .unwrap();
 
         let lockups = get_lockups(&bank_client, &base_pubkey, 1);
         let messages = lockup_stake_accounts(
@@ -472,7 +480,9 @@ mod tests {
 
         let signers = [&fee_payer_keypair, &custodian_keypair];
         for message in messages {
-            bank_client.send_message(&signers, message).unwrap();
+            bank_client
+                .send_and_confirm_message(&signers, message)
+                .unwrap();
         }
 
         let account = get_account_at(&bank_client, &base_pubkey, 0);
@@ -541,7 +551,9 @@ mod tests {
         );
 
         let signers = [&funding_keypair, &fee_payer_keypair, &base_keypair];
-        bank_client.send_message(&signers, message).unwrap();
+        bank_client
+            .send_and_confirm_message(&signers, message)
+            .unwrap();
 
         let new_base_keypair = Keypair::new();
         let new_base_pubkey = new_base_keypair.pubkey();
@@ -560,7 +572,9 @@ mod tests {
             &stake_authority_keypair,
         ];
         for message in messages {
-            bank_client.send_message(&signers, message).unwrap();
+            bank_client
+                .send_and_confirm_message(&signers, message)
+                .unwrap();
         }
 
         // Ensure the new accounts are duplicates of the previous ones.
@@ -600,7 +614,9 @@ mod tests {
         );
 
         let signers = [&funding_keypair, &fee_payer_keypair, &base_keypair];
-        bank_client.send_message(&signers, message).unwrap();
+        bank_client
+            .send_and_confirm_message(&signers, message)
+            .unwrap();
 
         let new_base_keypair = Keypair::new();
         let new_base_pubkey = new_base_keypair.pubkey();
@@ -625,7 +641,9 @@ mod tests {
             &withdraw_authority_keypair,
         ];
         for message in messages {
-            bank_client.send_message(&signers, message).unwrap();
+            bank_client
+                .send_and_confirm_message(&signers, message)
+                .unwrap();
         }
 
         // Ensure the new accounts have the new authorities.

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -159,7 +159,7 @@ fn distribute_tokens(
 
         let fee_payer_pubkey = args.fee_payer.pubkey();
         let message = Message::new(&instructions, Some(&fee_payer_pubkey));
-        match client.send_message(message, &signers) {
+        match client.send_and_confirm_message(message, &signers) {
             Ok((transaction, last_valid_slot)) => {
                 db::set_transaction_info(
                     db,
@@ -510,7 +510,9 @@ pub fn test_process_distribute_stake_with_client<C: Client>(client: C, sender_ke
     );
     let message = Message::new(&instructions, Some(&sender_keypair.pubkey()));
     let signers = [&sender_keypair, &stake_account_keypair];
-    thin_client.send_message(message, &signers).unwrap();
+    thin_client
+        .send_and_confirm_message(message, &signers)
+        .unwrap();
 
     let alice_pubkey = Pubkey::new_rand();
     let allocation = Allocation {

--- a/tokens/src/thin_client.rs
+++ b/tokens/src/thin_client.rs
@@ -148,7 +148,7 @@ impl<'a> ThinClient<'a> {
         self.client.get_signature_statuses1(signatures)
     }
 
-    pub fn send_message<S: Signers>(
+    pub fn send_and_confirm_message<S: Signers>(
         &self,
         message: Message,
         signers: &S,
@@ -172,7 +172,7 @@ impl<'a> ThinClient<'a> {
         let create_instruction =
             system_instruction::transfer(&sender_keypair.pubkey(), &to_pubkey, lamports);
         let message = Message::new(&[create_instruction], Some(&sender_keypair.pubkey()));
-        self.send_message(message, &[sender_keypair])
+        self.send_and_confirm_message(message, &[sender_keypair])
     }
 
     pub fn get_fees(&self) -> Result<(Hash, FeeCalculator, Slot)> {


### PR DESCRIPTION
#### Problem

The Client trait, RpcClient, and proposed BanksClient have slightly different method names for the same functionality.

#### Summary of Changes

* Rename `Client::send_message` to `Client::send_and_confirm_message` to match proposed BanksClient.
* Rename `Client::send_instruction` to `Client::send_and_confirm_instruction` to allow `async_send_instruction` to take that name. 
* Rename `Client::transfer` to `Client::transfer_and_confirm` for consistency. 
