### PR TITLE
Fix race in ci/run-sanity.sh

### DIFF
--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -19,13 +19,16 @@ while [[ ! -f config/run/init-completed ]]; do
   fi
 done
 
-while [[ $($solana_cli --url http://localhost:8899 slot --commitment recent) -eq 0 ]]; do
+snapshot_slot=1
+
+# wait a bit longer than snapshot_slot
+while [[ $($solana_cli --url http://localhost:8899 slot --commitment recent) -le $((snapshot_slot + 1)) ]]; do
   sleep 1
 done
 curl -X POST -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' http://localhost:8899
 
 wait $pid
 
-$solana_ledger_tool create-snapshot --ledger config/ledger 1 config/snapshot-ledger
+$solana_ledger_tool create-snapshot --ledger config/ledger "$snapshot_slot" config/snapshot-ledger
 cp config/ledger/genesis.tar.bz2 config/snapshot-ledger
 $solana_ledger_tool verify --ledger config/snapshot-ledger


### PR DESCRIPTION
#### Problem

CI is a bit unstable on master:

https://buildkite.com/solana-labs/solana/builds/26540#3a9158a5-2de3-4b61-b25a-25e63f4400ac/2724-2898
Even if this

```bash
 while [[ $($solana_cli --url http://localhost:8899 slot --commitment recent) -eq 0 ]]; do
```

evaluates to:

```
+ [[ 1 -eq 0 ]]
```

, it seems that we can't create snapshot for the slot 1:

```
     Running `target/debug/solana-ledger-tool create-snapshot --ledger config/ledger 1 config/snapshot-ledger`
...
Error: Slot 1 is not available
```

#### Summary of Changes

Wait more.


#### context

frustrated while developing at #10718 