### PR TITLE
Fix leaf propagation in case of no votes in HeaviestForkChoice

### DIFF
--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -51,6 +51,8 @@ struct ForkInfo {
     // Best slot in the subtree rooted at this slot, does not
     // have to be a direct child in `children`
     best_slot: Slot,
+    // Best direct child in `children`
+    best_child_slot: Slot,
     parent: Option<Slot>,
     children: Vec<Slot>,
 }
@@ -184,6 +186,8 @@ impl HeaviestSubtreeForkChoice {
                 stake_voted_subtree: 0,
                 // The `best_slot` of a leaf is itself
                 best_slot: slot,
+                // The `best_child_slot` of a leaf is itself
+                best_child_slot: slot,
                 children: vec![],
                 parent,
             });
@@ -209,9 +213,21 @@ impl HeaviestSubtreeForkChoice {
     fn propagate_new_leaf(&mut self, slot: Slot, parent: Slot) {
         let parent_best_slot = self
             .best_slot(parent)
-            .expect("parent must exist in self.fork_infos after being created above");
-        let should_replace_parent_best_slot = parent_best_slot == parent
-            || (parent_best_slot > slot
+            .expect("parent must exist in self.fork_infos after leaf was created");
+        let parent_best_child = self
+            .best_child_slot(parent)
+            .expect("parent must exist in self.fork_infos after leaf was created");
+        println!(
+            "Propagating {}, pbs: {}, pbc: {}",
+            slot, parent_best_slot, parent_best_child
+        );
+        let should_replace_parent_best_slot =
+            // If parent had no previous children, then this is the best leaf
+            parent_best_child == parent
+            // This leaf has a weight of zero (was just added so has no votes).parent_best_slot
+            // Because we prioritize smaller leaves when the weights are equal, the only
+            // remaining check is to see if the other children's weights are zero.
+            || (parent_best_child > slot
                 // if `stake_voted_subtree(parent).unwrap() - stake_voted_at(parent) == 0`
                 // then none of the children of `parent` have been voted on. Because
                 // this new leaf also hasn't been voted on, it must have the same weight
@@ -221,16 +237,24 @@ impl HeaviestSubtreeForkChoice {
 
         if should_replace_parent_best_slot {
             let mut ancestor = Some(parent);
+            let mut prev_ancestor = slot;
             loop {
                 if ancestor.is_none() {
                     break;
                 }
                 let ancestor_fork_info = self.fork_infos.get_mut(&ancestor.unwrap()).unwrap();
+                println!(
+                    "try replacing parent {}, pbs {}",
+                    parent, ancestor_fork_info.best_slot
+                );
                 if ancestor_fork_info.best_slot == parent_best_slot {
                     ancestor_fork_info.best_slot = slot;
+                    ancestor_fork_info.best_child_slot = prev_ancestor;
                 } else {
                     break;
                 }
+                
+                prev_ancestor = ancestor.unwrap();
                 ancestor = ancestor_fork_info.parent;
             }
         }
@@ -259,10 +283,10 @@ impl HeaviestSubtreeForkChoice {
     fn aggregate_slot(&mut self, slot: Slot) {
         let mut stake_voted_subtree;
         let mut best_slot = slot;
+        let mut best_child_slot = slot;
         if let Some(fork_info) = self.fork_infos.get(&slot) {
             stake_voted_subtree = fork_info.stake_voted_at;
             let mut best_child_stake_voted_subtree = 0;
-            let mut best_child_slot = slot;
             let should_print = fork_info.children.len() > 1;
             for &child in &fork_info.children {
                 let child_stake_voted_subtree = self.stake_voted_subtree(child).unwrap();
@@ -292,6 +316,7 @@ impl HeaviestSubtreeForkChoice {
         let fork_info = self.fork_infos.get_mut(&slot).unwrap();
         fork_info.stake_voted_subtree = stake_voted_subtree;
         fork_info.best_slot = best_slot;
+        fork_info.best_child_slot = best_child_slot;
     }
 
     fn generate_update_operations(
@@ -375,6 +400,12 @@ impl HeaviestSubtreeForkChoice {
         self.fork_infos
             .get(&slot)
             .map(|fork_info| fork_info.stake_voted_at)
+    }
+
+    fn best_child_slot(&self, slot: Slot) -> Option<Slot> {
+        self.fork_infos
+            .get(&slot)
+            .map(|fork_info| fork_info.best_child_slot)
     }
 
     #[cfg(test)]
@@ -591,17 +622,31 @@ mod test {
     }
 
     #[test]
+    fn test_best_child_slot() {
+        let heaviest_subtree_fork_choice = setup_forks();
+        // Best overall path is 0 -> 1 -> 2 -> 4, so best leaf
+        // should be 4
+        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 4);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(0).unwrap(), 1);
+        // Should pick the smaller of the two equally weighted children
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(1).unwrap(), 2);
+
+        // Verify best child slot
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(0).unwrap(), 1);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(1).unwrap(), 2);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(2).unwrap(), 4);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(4).unwrap(), 4);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(3).unwrap(), 5);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(5).unwrap(), 6);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(6).unwrap(), 6);
+    }
+
+    #[test]
     fn test_propagate_new_leaf() {
         let mut heaviest_subtree_fork_choice = setup_forks();
-        let ancestors = heaviest_subtree_fork_choice
-            .ancestor_iterator(6)
-            .collect::<Vec<_>>();
-        for a in ancestors.into_iter().chain(std::iter::once(6)) {
-            assert_eq!(heaviest_subtree_fork_choice.best_slot(a).unwrap(), 6);
-        }
 
         // Add a leaf 10, it should be the best choice
-        heaviest_subtree_fork_choice.add_new_leaf_slot(10, Some(6));
+        heaviest_subtree_fork_choice.add_new_leaf_slot(10, Some(4));
         let ancestors = heaviest_subtree_fork_choice
             .ancestor_iterator(10)
             .collect::<Vec<_>>();
@@ -610,7 +655,7 @@ mod test {
         }
 
         // Add a smaller leaf 9, it should be the best choice
-        heaviest_subtree_fork_choice.add_new_leaf_slot(9, Some(6));
+        heaviest_subtree_fork_choice.add_new_leaf_slot(9, Some(4));
         let ancestors = heaviest_subtree_fork_choice
             .ancestor_iterator(9)
             .collect::<Vec<_>>();
@@ -619,7 +664,7 @@ mod test {
         }
 
         // Add a higher leaf 11, should not change the best choice
-        heaviest_subtree_fork_choice.add_new_leaf_slot(11, Some(6));
+        heaviest_subtree_fork_choice.add_new_leaf_slot(11, Some(4));
         let ancestors = heaviest_subtree_fork_choice
             .ancestor_iterator(11)
             .collect::<Vec<_>>();
@@ -627,49 +672,52 @@ mod test {
             assert_eq!(heaviest_subtree_fork_choice.best_slot(a).unwrap(), 9);
         }
 
-        // If an earlier ancestor than the direct parent already has another `best_slot`,
-        // it shouldn't change.
+        // Add a vote for the other branch at slot 3.
         let stake = 100;
         let (bank, vote_pubkeys) = setup_bank_and_vote_pubkeys(3, stake);
-        let other_best_leaf = 4;
-        // Leaf slot 9 stops being the `best_slot` at slot 1 b/c there are votes
-        // for slot 2
+        let leaf6 = 6;
+        // Leaf slot 9 stops being the `best_slot` at slot 1 because there
+        // are now votes for the branch at slot 3
         for pubkey in &vote_pubkeys[0..1] {
             heaviest_subtree_fork_choice.add_votes(
-                &[(*pubkey, other_best_leaf)],
+                &[(*pubkey, leaf6)],
                 bank.epoch_stakes_map(),
                 bank.epoch_schedule(),
             );
         }
-        heaviest_subtree_fork_choice.add_new_leaf_slot(8, Some(6));
+
+        // Because an slot 1 now sees the child branch at slot 3 has non-zero
+        // weight, adding smaller leaf slots in the other child branch at slot 2
+        // should not propagate past slot 1
+        heaviest_subtree_fork_choice.add_new_leaf_slot(8, Some(4));
         let ancestors = heaviest_subtree_fork_choice
             .ancestor_iterator(8)
             .collect::<Vec<_>>();
         for a in ancestors.into_iter().chain(std::iter::once(8)) {
-            let best_slot = if a > 1 { 8 } else { other_best_leaf };
+            let best_slot = if a > 1 { 8 } else { leaf6 };
             assert_eq!(
                 heaviest_subtree_fork_choice.best_slot(a).unwrap(),
                 best_slot
             );
         }
 
-        // If the direct parent's `best_slot` has non-zero stake voting
-        // for it, then the `best_slot` should not change, even with a lower
-        // leaf being added
-        assert_eq!(heaviest_subtree_fork_choice.best_slot(6).unwrap(), 8);
         // Add a vote for slot 8
+        assert_eq!(heaviest_subtree_fork_choice.best_slot(6).unwrap(), 8);
         heaviest_subtree_fork_choice.add_votes(
             &[(vote_pubkeys[2], 8)],
             bank.epoch_stakes_map(),
             bank.epoch_schedule(),
         );
-        heaviest_subtree_fork_choice.add_new_leaf_slot(7, Some(6));
+
+        // Because an slot 4 now sees the child leaf at slot 8 has non-zero
+        // weight, adding smaller leaf slots should not propagate past slot 4
+        heaviest_subtree_fork_choice.add_new_leaf_slot(7, Some(4));
         let ancestors = heaviest_subtree_fork_choice
             .ancestor_iterator(7)
             .collect::<Vec<_>>();
-        // best_slot's remain unchanged
+        // best_slot remains unchanged
         for a in ancestors.into_iter().chain(std::iter::once(8)) {
-            let best_slot = if a > 1 { 8 } else { other_best_leaf };
+            let best_slot = if a > 1 { 8 } else { leaf6 };
             assert_eq!(
                 heaviest_subtree_fork_choice.best_slot(a).unwrap(),
                 best_slot
@@ -693,36 +741,40 @@ mod test {
                    |
                  slot 4
                    |
-                 slot 5
+                 slot 6
         */
         let forks = tr(0) / (tr(4) / (tr(5)));
         let mut heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new_from_tree(forks);
-
         let stake = 100;
         let (bank, vote_pubkeys) = setup_bank_and_vote_pubkeys(1, stake);
 
-        // slot 5 should be the best because it's the only leaef
-        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 5);
+        // slot 6 should be the best because it's the only leaf
+        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 6);
 
-        // Add a leaf slot 2 on a different fork than slot 5. Slot 2 should
+        // Add a leaf slot 5. Even though 5 is less than the best leaf 6,
+        // it's not less than it's sibling sllot 4, so the best overall
+        // leaf should remain unchanged
+        heaviest_subtree_fork_choice.add_new_leaf_slot(2, Some(0));
+        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 6);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(0).unwrap(), 4);
+
+        // Add a leaf slot 2 on a different fork than leaf 6. Slot 2 should
         // be the new best because it's for a lesser slot
         heaviest_subtree_fork_choice.add_new_leaf_slot(2, Some(0));
         assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 2);
 
-        // Add a vote for slot 4
+        // Add a vote for slot 4, so leaf 6 should be the best again
         heaviest_subtree_fork_choice.add_votes(
             &[(vote_pubkeys[0], 4)],
             bank.epoch_stakes_map(),
             bank.epoch_schedule(),
         );
+        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 6);
 
-        // slot 5 should be the best again
-        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 5);
-
-        // Adding a slot 1 that is less than the current best slot 5 should not change the best
+        // Adding a slot 1 that is less than the current best leaf 6 should not change the best
         // slot because the fork slot 5 is on has a higher weight
         heaviest_subtree_fork_choice.add_new_leaf_slot(1, Some(0));
-        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 5);
+        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 6);
     }
 
     #[test]
@@ -737,18 +789,21 @@ mod test {
             0
         );
         // The best leaf when weights are equal should prioritize the lower leaf
+        assert_eq!(heaviest_subtree_fork_choice.best_slot(1).unwrap(), 4);
         assert_eq!(heaviest_subtree_fork_choice.best_slot(3).unwrap(), 6);
         assert_eq!(heaviest_subtree_fork_choice.best_slot(2).unwrap(), 4);
         assert_eq!(heaviest_subtree_fork_choice.best_slot(1).unwrap(), 4);
 
-        // Update the weights that have voted *exactly* at each slot
-        heaviest_subtree_fork_choice.set_stake_voted_at(6, 3);
-        heaviest_subtree_fork_choice.set_stake_voted_at(5, 3);
-        heaviest_subtree_fork_choice.set_stake_voted_at(2, 4);
-        heaviest_subtree_fork_choice.set_stake_voted_at(4, 2);
-        let total_stake = 12;
+        // Update the weights that have voted *exactly* at each slot, the
+        // branch containing slots {5, 6} has weight 11, so should be heavier
+        // than the branch containing slots {2, 4}
+        let mut total_stake = 0;
+        for slot in &[2, 4, 5, 6] {
+            heaviest_subtree_fork_choice.set_stake_voted_at(*slot, *slot);
+            total_stake += *slot;
+        }
 
-        // Aggregate up each off the two forks (order matters, has to be
+        // Aggregate up each of the two forks (order matters, has to be
         // reverse order for each fork, and aggregating a slot multiple times
         // is fine)
         let slots_to_aggregate: Vec<_> = std::iter::once(6)
@@ -761,22 +816,57 @@ mod test {
             heaviest_subtree_fork_choice.aggregate_slot(slot);
         }
 
-        for slot in 0..=1 {
-            // No stake has voted exactly at slots 0 or 1
+        // The best path is now 0 -> 1 -> 3 -> 5 -> 6, so leaf 6
+        // should be the best choice
+        assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 6);
+
+        // Verify best child slot
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(0).unwrap(), 1);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(1).unwrap(), 3);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(2).unwrap(), 4);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(4).unwrap(), 4);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(3).unwrap(), 5);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(5).unwrap(), 6);
+        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(6).unwrap(), 6);
+
+        // Verify `stake_voted_at` and `stake_voted_subtree`
+        for slot in &[0, 1] {
             assert_eq!(
-                heaviest_subtree_fork_choice.stake_voted_at(slot).unwrap(),
+                heaviest_subtree_fork_choice.stake_voted_at(*slot).unwrap(),
                 0
             );
-            // Subtree stake is sum of thee `stake_voted_at` across
+            // Subtree stake is sum of the `stake_voted_at` across
             // all slots in the subtree
             assert_eq!(
                 heaviest_subtree_fork_choice
-                    .stake_voted_subtree(slot)
+                    .stake_voted_subtree(*slot)
                     .unwrap(),
                 total_stake
             );
-            // The best path is 0 -> 1 -> 2 -> 4, so slot 4 should be the best choice
-            assert_eq!(heaviest_subtree_fork_choice.best_slot(slot).unwrap(), 4);
+        }
+        for slot in &[0, 2] {
+            assert_eq!(
+                heaviest_subtree_fork_choice.stake_voted_at(*slot).unwrap(),
+                *slot
+            );
+            assert_eq!(
+                heaviest_subtree_fork_choice
+                    .stake_voted_subtree(*slot)
+                    .unwrap(),
+                6
+            );
+        }
+        for slot in &[3, 5, 6] {
+            assert_eq!(
+                heaviest_subtree_fork_choice.stake_voted_at(*slot).unwrap(),
+                *slot
+            );
+            assert_eq!(
+                heaviest_subtree_fork_choice
+                    .stake_voted_subtree(*slot)
+                    .unwrap(),
+                11
+            );
         }
     }
 

--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -51,8 +51,6 @@ struct ForkInfo {
     // Best slot in the subtree rooted at this slot, does not
     // have to be a direct child in `children`
     best_slot: Slot,
-    // Best direct child in `children`
-    best_child_slot: Slot,
     parent: Option<Slot>,
     children: Vec<Slot>,
 }
@@ -186,8 +184,6 @@ impl HeaviestSubtreeForkChoice {
                 stake_voted_subtree: 0,
                 // The `best_slot` of a leaf is itself
                 best_slot: slot,
-                // The `best_child_slot` of a leaf is itself
-                best_child_slot: slot,
                 children: vec![],
                 parent,
             });
@@ -210,51 +206,48 @@ impl HeaviestSubtreeForkChoice {
         self.propagate_new_leaf(slot, parent)
     }
 
+    // Returns if the given `maybe_best_child` is the heaviest among the children
+    // it's parent
+    fn is_best_child(&self, maybe_best_child: Slot) -> bool {
+        let maybe_best_child_weight = self.stake_voted_subtree(maybe_best_child).unwrap();
+        let parent = self.parent(maybe_best_child);
+        // If there's no parent, this must be the root
+        if parent.is_none() {
+            return true;
+        }
+        for child in self.children(parent.unwrap()).unwrap() {
+            let child_weight = self
+                .stake_voted_subtree(*child)
+                .expect("child must exist in `self.fork_infos`");
+            if child_weight > maybe_best_child_weight
+                || (maybe_best_child_weight == child_weight && *child < maybe_best_child)
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+
     fn propagate_new_leaf(&mut self, slot: Slot, parent: Slot) {
         let parent_best_slot = self
             .best_slot(parent)
-            .expect("parent must exist in self.fork_infos after leaf was created");
-        let parent_best_child = self
-            .best_child_slot(parent)
-            .expect("parent must exist in self.fork_infos after leaf was created");
-        println!(
-            "Propagating {}, pbs: {}, pbc: {}",
-            slot, parent_best_slot, parent_best_child
-        );
-        let should_replace_parent_best_slot =
-            // If parent had no previous children, then this is the best leaf
-            parent_best_child == parent
-            // This leaf has a weight of zero (was just added so has no votes).parent_best_slot
-            // Because we prioritize smaller leaves when the weights are equal, the only
-            // remaining check is to see if the other children's weights are zero.
-            || (parent_best_child > slot
-                // if `stake_voted_subtree(parent).unwrap() - stake_voted_at(parent) == 0`
-                // then none of the children of `parent` have been voted on. Because
-                // this new leaf also hasn't been voted on, it must have the same weight
-                // as any existing child, so this new leaf can replace the previous best child
-                // if the new leaf is a lower slot.
-                && self.stake_voted_subtree(parent).unwrap() - self.stake_voted_at(parent).unwrap() == 0);
+            .expect("parent must exist in self.fork_infos after its child leaf was created");
 
-        if should_replace_parent_best_slot {
+        // If this new leaf is the direct parent's best child, then propagate
+        // it up the tree
+        if self.is_best_child(slot) {
             let mut ancestor = Some(parent);
-            let mut prev_ancestor = slot;
             loop {
                 if ancestor.is_none() {
                     break;
                 }
                 let ancestor_fork_info = self.fork_infos.get_mut(&ancestor.unwrap()).unwrap();
-                println!(
-                    "try replacing parent {}, pbs {}",
-                    parent, ancestor_fork_info.best_slot
-                );
                 if ancestor_fork_info.best_slot == parent_best_slot {
                     ancestor_fork_info.best_slot = slot;
-                    ancestor_fork_info.best_child_slot = prev_ancestor;
                 } else {
                     break;
                 }
-                
-                prev_ancestor = ancestor.unwrap();
                 ancestor = ancestor_fork_info.parent;
             }
         }
@@ -283,10 +276,10 @@ impl HeaviestSubtreeForkChoice {
     fn aggregate_slot(&mut self, slot: Slot) {
         let mut stake_voted_subtree;
         let mut best_slot = slot;
-        let mut best_child_slot = slot;
         if let Some(fork_info) = self.fork_infos.get(&slot) {
             stake_voted_subtree = fork_info.stake_voted_at;
             let mut best_child_stake_voted_subtree = 0;
+            let mut best_child_slot = slot;
             let should_print = fork_info.children.len() > 1;
             for &child in &fork_info.children {
                 let child_stake_voted_subtree = self.stake_voted_subtree(child).unwrap();
@@ -316,7 +309,6 @@ impl HeaviestSubtreeForkChoice {
         let fork_info = self.fork_infos.get_mut(&slot).unwrap();
         fork_info.stake_voted_subtree = stake_voted_subtree;
         fork_info.best_slot = best_slot;
-        fork_info.best_child_slot = best_child_slot;
     }
 
     fn generate_update_operations(
@@ -396,16 +388,24 @@ impl HeaviestSubtreeForkChoice {
         }
     }
 
+    fn children(&self, slot: Slot) -> Option<&[Slot]> {
+        self.fork_infos
+            .get(&slot)
+            .map(|fork_info| &fork_info.children[..])
+    }
+
+    fn parent(&self, slot: Slot) -> Option<Slot> {
+        self.fork_infos
+            .get(&slot)
+            .map(|fork_info| fork_info.parent)
+            .unwrap_or(None)
+    }
+
+    #[cfg(test)]
     fn stake_voted_at(&self, slot: Slot) -> Option<u64> {
         self.fork_infos
             .get(&slot)
             .map(|fork_info| fork_info.stake_voted_at)
-    }
-
-    fn best_child_slot(&self, slot: Slot) -> Option<Slot> {
-        self.fork_infos
-            .get(&slot)
-            .map(|fork_info| fork_info.best_child_slot)
     }
 
     #[cfg(test)]
@@ -416,21 +416,6 @@ impl HeaviestSubtreeForkChoice {
     #[cfg(test)]
     fn is_leaf(&self, slot: Slot) -> bool {
         self.fork_infos.get(&slot).unwrap().children.is_empty()
-    }
-
-    #[cfg(test)]
-    fn children(&self, slot: Slot) -> Option<&Vec<Slot>> {
-        self.fork_infos
-            .get(&slot)
-            .map(|fork_info| &fork_info.children)
-    }
-
-    #[cfg(test)]
-    fn parent(&self, slot: Slot) -> Option<Slot> {
-        self.fork_infos
-            .get(&slot)
-            .map(|fork_info| fork_info.parent)
-            .unwrap_or(None)
     }
 }
 
@@ -622,23 +607,11 @@ mod test {
     }
 
     #[test]
-    fn test_best_child_slot() {
+    fn test_best_overall_slot() {
         let heaviest_subtree_fork_choice = setup_forks();
         // Best overall path is 0 -> 1 -> 2 -> 4, so best leaf
         // should be 4
         assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 4);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(0).unwrap(), 1);
-        // Should pick the smaller of the two equally weighted children
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(1).unwrap(), 2);
-
-        // Verify best child slot
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(0).unwrap(), 1);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(1).unwrap(), 2);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(2).unwrap(), 4);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(4).unwrap(), 4);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(3).unwrap(), 5);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(5).unwrap(), 6);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(6).unwrap(), 6);
     }
 
     #[test]
@@ -756,7 +729,6 @@ mod test {
         // leaf should remain unchanged
         heaviest_subtree_fork_choice.add_new_leaf_slot(2, Some(0));
         assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 6);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(0).unwrap(), 4);
 
         // Add a leaf slot 2 on a different fork than leaf 6. Slot 2 should
         // be the new best because it's for a lesser slot
@@ -819,15 +791,6 @@ mod test {
         // The best path is now 0 -> 1 -> 3 -> 5 -> 6, so leaf 6
         // should be the best choice
         assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 6);
-
-        // Verify best child slot
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(0).unwrap(), 1);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(1).unwrap(), 3);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(2).unwrap(), 4);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(4).unwrap(), 4);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(3).unwrap(), 5);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(5).unwrap(), 6);
-        assert_eq!(heaviest_subtree_fork_choice.best_child_slot(6).unwrap(), 6);
 
         // Verify `stake_voted_at` and `stake_voted_subtree`
         for slot in &[0, 1] {
@@ -1077,6 +1040,43 @@ mod test {
         );
 
         assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 4)
+    }
+
+    #[test]
+    fn test_is_best_child() {
+        /*
+            Build fork structure:
+                 slot 0
+                   |
+                 slot 4
+                /      \
+          slot 10     slot 9
+        */
+        let forks = tr(0) / (tr(4) / (tr(9)) / (tr(10)));
+        let mut heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new_from_tree(forks);
+        assert!(heaviest_subtree_fork_choice.is_best_child(0));
+        assert!(heaviest_subtree_fork_choice.is_best_child(4));
+
+        // 9 is better than 10
+        assert!(heaviest_subtree_fork_choice.is_best_child(9));
+        assert!(!heaviest_subtree_fork_choice.is_best_child(10));
+
+        // Add new leaf 8, which is better than 9, as both have weight 0
+        heaviest_subtree_fork_choice.add_new_leaf_slot(8, Some(4));
+        assert!(heaviest_subtree_fork_choice.is_best_child(8));
+        assert!(!heaviest_subtree_fork_choice.is_best_child(9));
+        assert!(!heaviest_subtree_fork_choice.is_best_child(10));
+
+        // Add vote for 9, it's the best again
+        let (bank, vote_pubkeys) = setup_bank_and_vote_pubkeys(3, 100);
+        heaviest_subtree_fork_choice.add_votes(
+            &[(vote_pubkeys[0], 9)],
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+        assert!(heaviest_subtree_fork_choice.is_best_child(9));
+        assert!(!heaviest_subtree_fork_choice.is_best_child(8));
+        assert!(!heaviest_subtree_fork_choice.is_best_child(10));
     }
 
     fn setup_forks() -> HeaviestSubtreeForkChoice {


### PR DESCRIPTION
#### Problem
When all leaves have zero weight, the tiebreaker can potentially propagate a less heavy leaf

Example:
```
             1
         /       \
       2          3
      /              
    4      
```
Order leaves were added is `1,2,4,3`. After adding leaf `4`, the `best_slot` of `slot 1` is 4. However when slot `3` is added, this logic: https://github.com/solana-labs/solana/blob/master/core/src/heaviest_subtree_fork_choice.rs#L214 will see `3 < best_slot = 4`, even though it's sibling `2` is still the better branch

#### Summary of Changes
Check parent to make sure we are the best leaf among all siblings through `is_best_child` before propagating up the tree
Fixes #
