### PR TITLE
ledger-tool: Better slot printing

### DIFF
--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -43,7 +43,7 @@ fn nominal() {
     assert!(output.status.success());
 
     // Print everything
-    let output = run_ledger_tool(&["-l", &ledger_path, "print"]);
+    let output = run_ledger_tool(&["-l", &ledger_path, "print", "-vvv"]);
     assert!(output.status.success());
-    assert_eq!(count_newlines(&output.stdout), ticks + meta_lines + 1);
+    assert_eq!(count_newlines(&output.stdout), ticks + meta_lines);
 }


### PR DESCRIPTION
#### Problem

`ledger-tool print` command is limited in that cannot control how much output to print per slot or how many slots to print.

#### Summary of Changes

Add --num-slots argument to limit the number of slots to print and also add a verbosity level to allow for printing a smaller amount of slot data. Can use verbose multiple times like ssh, `-v` or `-vvv`.

Fixes #
