### PR TITLE
Add ancestor iterator

### DIFF
--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -25,7 +25,7 @@ impl<'a> Iterator for AncestorIterator<'a> {
     type Item = Slot;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let current = self.current.clone();
+        let current = self.current;
         current.map(|slot| {
             if slot != 0 {
                 self.current = self.blockstore.meta(slot).unwrap().and_then(|slot_meta| {
@@ -101,9 +101,7 @@ mod tests {
             fill_blockstore_slot_with_ticks(&blockstore, ticks_per_slot, 4, fork_point, fork_hash);
 
         // Test correctness
-        assert!(AncestorIterator::new(0, &blockstore)
-            .collect::<Vec<Slot>>()
-            .is_empty());
+        assert!(AncestorIterator::new(0, &blockstore).next().is_none());
         assert_eq!(
             AncestorIterator::new(4, &blockstore).collect::<Vec<Slot>>(),
             vec![1, 0]

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bank_forks_utils;
 pub mod block_error;
 #[macro_use]
 pub mod blockstore;
+pub mod ancestor_iterator;
 pub mod blockstore_db;
 pub mod blockstore_meta;
 pub mod blockstore_processor;


### PR DESCRIPTION
#### Problem
Bad merge, removed ancestor iterator from `lib.rs`

#### Summary of Changes
Add the module to `lib.rs`
Fixes #
