### PR TITLE
Move BankCommitmentCache to solana_runtime

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1,6 +1,5 @@
 use crate::{
     cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS},
-    commitment::VOTE_THRESHOLD_SIZE,
     crds_value::CrdsValueLabel,
     poh_recorder::PohRecorder,
     pubkey_references::LockedPubkeyReferences,
@@ -19,6 +18,7 @@ use solana_perf::packet::{self, Packets};
 use solana_runtime::{
     bank::Bank,
     bank_forks::BankForks,
+    commitment::VOTE_THRESHOLD_SIZE,
     epoch_stakes::{EpochAuthorizedVoters, EpochStakes},
 };
 use solana_sdk::{
@@ -600,10 +600,10 @@ impl ClusterInfoVoteListener {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commitment::BlockCommitmentCache;
     use solana_perf::packet;
     use solana_runtime::{
         bank::Bank,
+        commitment::BlockCommitmentCache,
         genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs},
     };
     use solana_sdk::hash::Hash;

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -601,7 +601,6 @@ impl ClusterInfoVoteListener {
 mod tests {
     use super::*;
     use crate::commitment::BlockCommitmentCache;
-    use solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path};
     use solana_perf::packet;
     use solana_runtime::{
         bank::Bank,
@@ -951,14 +950,10 @@ mod tests {
         let bank_forks = BankForks::new(bank);
         let bank = bank_forks.get(0).unwrap().clone();
         let vote_tracker = VoteTracker::new(&bank);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,
             Arc::new(RwLock::new(bank_forks)),
-            Arc::new(RwLock::new(BlockCommitmentCache::default_with_blockstore(
-                blockstore,
-            ))),
+            Arc::new(RwLock::new(BlockCommitmentCache::default())),
         ));
 
         // Send a vote to process, should add a reference to the pubkey for that voter
@@ -1060,14 +1055,10 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let bank_forks = BankForks::new(bank);
         let bank = bank_forks.get(0).unwrap().clone();
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,
             Arc::new(RwLock::new(bank_forks)),
-            Arc::new(RwLock::new(BlockCommitmentCache::default_with_blockstore(
-                blockstore,
-            ))),
+            Arc::new(RwLock::new(BlockCommitmentCache::default())),
         ));
 
         // Integrity Checks

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -115,7 +115,6 @@ impl AggregateCommitmentService {
                 largest_confirmed_root,
                 aggregation_data.total_stake,
                 aggregation_data.bank,
-                block_commitment_cache.read().unwrap().blockstore.clone(),
                 aggregation_data.root,
                 aggregation_data.root,
             );

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -1,11 +1,13 @@
 use crate::{
-    commitment::{BlockCommitment, BlockCommitmentCache, VOTE_THRESHOLD_SIZE},
     consensus::Stake,
     rpc_subscriptions::{CacheSlotInfo, RpcSubscriptions},
 };
 use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
-use solana_runtime::bank::Bank;
+use solana_runtime::{
+    bank::Bank,
+    commitment::{BlockCommitment, BlockCommitmentCache, VOTE_THRESHOLD_SIZE},
+};
 use solana_sdk::clock::Slot;
 use solana_vote_program::vote_state::VoteState;
 use std::{

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1,10 +1,9 @@
 use crate::{
-    commitment::VOTE_THRESHOLD_SIZE,
     progress_map::{LockoutIntervals, ProgressMap},
     pubkey_references::PubkeyReferences,
 };
 use chrono::prelude::*;
-use solana_runtime::{bank::Bank, bank_forks::BankForks};
+use solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE};
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,7 +10,6 @@ pub mod accounts_hash_verifier;
 pub mod banking_stage;
 pub mod broadcast_stage;
 pub mod cluster_info_vote_listener;
-pub mod commitment;
 pub mod commitment_service;
 mod deprecated;
 pub mod shred_fetch_stage;

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -4,7 +4,6 @@ use crate::{
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::VoteTracker,
     cluster_slots::ClusterSlots,
-    commitment::VOTE_THRESHOLD_SIZE,
     result::Result,
     serve_repair::{RepairType, ServeRepair, DEFAULT_NONCE},
 };
@@ -16,7 +15,7 @@ use solana_ledger::{
     blockstore::{Blockstore, CompletedSlotsReceiver, SlotMeta},
     shred::Nonce,
 };
-use solana_runtime::{bank::Bank, bank_forks::BankForks};
+use solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE};
 use solana_sdk::{clock::Slot, epoch_schedule::EpochSchedule, pubkey::Pubkey, timing::timestamp};
 use std::{
     collections::HashMap,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1879,9 +1879,7 @@ pub(crate) mod tests {
             let subscriptions = Arc::new(RpcSubscriptions::new(
                 &exit,
                 bank_forks.clone(),
-                Arc::new(RwLock::new(BlockCommitmentCache::default_with_blockstore(
-                    blockstore.clone(),
-                ))),
+                Arc::new(RwLock::new(BlockCommitmentCache::default())),
             ));
 
             // Insert shreds for slot NUM_CONSECUTIVE_LEADER_SLOTS,
@@ -2303,9 +2301,6 @@ pub(crate) mod tests {
             bank.store_account(&pubkey, &leader_vote_account);
         }
 
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-
         let leader_pubkey = Pubkey::new_rand();
         let leader_lamports = 3;
         let genesis_config_info =
@@ -2326,9 +2321,7 @@ pub(crate) mod tests {
         )));
 
         let exit = Arc::new(AtomicBool::new(false));
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,
             bank_forks.clone(),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -6,7 +6,6 @@ use crate::{
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::VoteTracker,
     cluster_slots::ClusterSlots,
-    commitment::BlockCommitmentCache,
     commitment_service::{AggregateCommitmentService, CommitmentAggregationData},
     consensus::{ComputedBankState, Stake, SwitchForkDecision, Tower, VotedStakes},
     fork_choice::{ForkChoice, SelectVoteAndResetForkResult},
@@ -28,7 +27,10 @@ use solana_ledger::{
 };
 use solana_measure::thread_mem_usage;
 use solana_metrics::inc_new_counter_info;
-use solana_runtime::{bank::Bank, bank_forks::BankForks, snapshot_package::AccountsPackageSender};
+use solana_runtime::{
+    bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache,
+    snapshot_package::AccountsPackageSender,
+};
 use solana_sdk::{
     clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
     genesis_config::OperatingMode,
@@ -1770,7 +1772,6 @@ impl ReplayStage {
 pub(crate) mod tests {
     use super::*;
     use crate::{
-        commitment::BlockCommitment,
         consensus::test::{initialize_state, VoteSimulator},
         consensus::Tower,
         progress_map::ValidatorStakeInfo,
@@ -1790,7 +1791,10 @@ pub(crate) mod tests {
             SIZE_OF_COMMON_SHRED_HEADER, SIZE_OF_DATA_SHRED_HEADER, SIZE_OF_DATA_SHRED_PAYLOAD,
         },
     };
-    use solana_runtime::genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs};
+    use solana_runtime::{
+        commitment::BlockCommitment,
+        genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs},
+    };
     use solana_sdk::{
         clock::NUM_CONSECUTIVE_LEADER_SLOTS,
         genesis_config,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -174,7 +174,6 @@ impl JsonRpcRequestProcessor {
                 0,
                 0,
                 bank.clone(),
-                blockstore.clone(),
                 0,
                 0,
             ))),
@@ -670,7 +669,7 @@ impl JsonRpcRequestProcessor {
         let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
         let confirmations = if r_block_commitment_cache.root() >= slot
-            && r_block_commitment_cache.is_confirmed_rooted(slot)
+            && r_block_commitment_cache.is_confirmed_rooted(&self.blockstore, slot)
         {
             None
         } else {
@@ -1688,7 +1687,6 @@ pub mod tests {
             0,
             10,
             bank.clone(),
-            blockstore.clone(),
             0,
             0,
         )));
@@ -2775,9 +2773,7 @@ pub mod tests {
         let validator_exit = create_validator_exit(&exit);
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
 
         let mut io = MetaIoHandler::default();
         let rpc = RpcSolImpl;
@@ -2813,9 +2809,7 @@ pub mod tests {
         let validator_exit = create_validator_exit(&exit);
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let bank_forks = new_bank_forks().0;
         let health = RpcHealth::stub();
 
@@ -2956,9 +2950,7 @@ pub mod tests {
         let validator_exit = create_validator_exit(&exit);
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let cluster_info = Arc::new(ClusterInfo::default());
         let bank_forks = new_bank_forks().0;
         let request_processor = JsonRpcRequestProcessor::new(
@@ -2986,9 +2978,7 @@ pub mod tests {
         let validator_exit = create_validator_exit(&exit);
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let mut config = JsonRpcConfig::default();
         config.enable_validator_exit = true;
         let bank_forks = new_bank_forks().0;
@@ -3076,7 +3066,6 @@ pub mod tests {
             0,
             42,
             bank_forks.read().unwrap().working_bank(),
-            blockstore.clone(),
             0,
             0,
         )));

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1,14 +1,9 @@
 //! The `rpc` module implements the Solana RPC interface.
 
 use crate::{
-    cluster_info::ClusterInfo,
-    commitment::{BlockCommitmentArray, BlockCommitmentCache},
-    contact_info::ContactInfo,
-    non_circulating_supply::calculate_non_circulating_supply,
-    rpc_error::RpcCustomError,
-    rpc_health::*,
-    send_transaction_service::SendTransactionService,
-    validator::ValidatorExit,
+    cluster_info::ClusterInfo, contact_info::ContactInfo,
+    non_circulating_supply::calculate_non_circulating_supply, rpc_error::RpcCustomError,
+    rpc_health::*, send_transaction_service::SendTransactionService, validator::ValidatorExit,
 };
 use bincode::serialize;
 use jsonrpc_core::{Error, Metadata, Result};
@@ -26,7 +21,11 @@ use solana_faucet::faucet::request_airdrop_transaction;
 use solana_ledger::{blockstore::Blockstore, blockstore_db::BlockstoreError, get_tmp_ledger_path};
 use solana_perf::packet::PACKET_DATA_SIZE;
 use solana_runtime::{
-    accounts::AccountAddressFilter, bank::Bank, bank_forks::BankForks, log_collector::LogCollector,
+    accounts::AccountAddressFilter,
+    bank::Bank,
+    bank_forks::BankForks,
+    commitment::{BlockCommitmentArray, BlockCommitmentCache},
+    log_collector::LogCollector,
 };
 use solana_sdk::{
     clock::{Epoch, Slot, UnixTimestamp},
@@ -1613,8 +1612,7 @@ pub(crate) fn create_validator_exit(exit: &Arc<AtomicBool>) -> Arc<RwLock<Option
 pub mod tests {
     use super::*;
     use crate::{
-        commitment::BlockCommitment, contact_info::ContactInfo,
-        non_circulating_supply::non_circulating_accounts,
+        contact_info::ContactInfo, non_circulating_supply::non_circulating_accounts,
         replay_stage::tests::create_test_transactions_and_populate_blockstore,
     };
     use bincode::deserialize;
@@ -1628,6 +1626,7 @@ pub mod tests {
         entry::next_entry_mut,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
     };
+    use solana_runtime::commitment::BlockCommitment;
     use solana_sdk::{
         clock::MAX_RECENT_BLOCKHASHES,
         fee_calculator::DEFAULT_BURN_PERCENT,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -350,7 +350,6 @@ mod tests {
     use super::*;
     use crate::{
         cluster_info_vote_listener::{ClusterInfoVoteListener, VoteTracker},
-        commitment::BlockCommitmentCache,
         rpc_subscriptions::{tests::robust_poll_or_panic, CacheSlotInfo},
     };
     use crossbeam_channel::unbounded;
@@ -361,6 +360,7 @@ mod tests {
     use solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
+        commitment::BlockCommitmentCache,
         genesis_utils::{
             create_genesis_config, create_genesis_config_with_vote_accounts, GenesisConfigInfo,
             ValidatorVoteKeypairs,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -8,8 +8,6 @@ use solana_client::rpc_response::{
     Response as RpcResponse, RpcAccount, RpcKeyedAccount, RpcSignatureResult,
 };
 #[cfg(test)]
-use solana_ledger::blockstore::Blockstore;
-#[cfg(test)]
 use solana_runtime::bank_forks::BankForks;
 use solana_sdk::{
     clock::Slot, commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Signature,
@@ -153,14 +151,9 @@ impl RpcSolPubSubImpl {
     }
 
     #[cfg(test)]
-    fn default_with_blockstore_bank_forks(
-        blockstore: Arc<Blockstore>,
-        bank_forks: Arc<RwLock<BankForks>>,
-    ) -> Self {
+    fn default_with_bank_forks(bank_forks: Arc<RwLock<BankForks>>) -> Self {
         let uid = Arc::new(atomic::AtomicUsize::default());
-        let subscriptions = Arc::new(RpcSubscriptions::default_with_blockstore_bank_forks(
-            blockstore, bank_forks,
-        ));
+        let subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(bank_forks));
         Self { uid, subscriptions }
     }
 }
@@ -365,14 +358,13 @@ mod tests {
     use jsonrpc_pubsub::{PubSubHandler, Session};
     use serial_test_derive::serial;
     use solana_budget_program::{self, budget_instruction};
-    use solana_ledger::{
-        genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        get_tmp_ledger_path,
-    };
     use solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
-        genesis_utils::{create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs},
+        genesis_utils::{
+            create_genesis_config, create_genesis_config_with_vote_accounts, GenesisConfigInfo,
+            ValidatorVoteKeypairs,
+        },
     };
     use solana_sdk::{
         hash::Hash,
@@ -424,15 +416,11 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let rpc = RpcSolPubSubImpl {
             subscriptions: Arc::new(RpcSubscriptions::new(
                 &Arc::new(AtomicBool::new(false)),
                 bank_forks.clone(),
-                Arc::new(RwLock::new(
-                    BlockCommitmentCache::new_for_tests_with_blockstore(blockstore),
-                )),
+                Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
             )),
             uid: Arc::new(atomic::AtomicUsize::default()),
         };
@@ -475,13 +463,11 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
 
         let session = create_session();
 
         let mut io = PubSubHandler::default();
-        let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
+        let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
         io.extend_with(rpc.to_delegate());
 
         let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash);
@@ -535,20 +521,15 @@ mod tests {
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
 
         let rpc = RpcSolPubSubImpl {
             subscriptions: Arc::new(RpcSubscriptions::new(
                 &Arc::new(AtomicBool::new(false)),
                 bank_forks.clone(),
-                Arc::new(RwLock::new(
-                    BlockCommitmentCache::new_for_tests_with_blockstore_bank(
-                        blockstore,
-                        bank_forks.read().unwrap().get(1).unwrap().clone(),
-                        1,
-                    ),
-                )),
+                Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_bank(
+                    bank_forks.read().unwrap().get(1).unwrap().clone(),
+                    1,
+                ))),
             )),
             uid: Arc::new(atomic::AtomicUsize::default()),
         };
@@ -636,13 +617,11 @@ mod tests {
     fn test_account_unsubscribe() {
         let bob_pubkey = Pubkey::new_rand();
         let session = create_session();
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::new(&genesis_config))));
 
         let mut io = PubSubHandler::default();
-        let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
+        let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
 
         io.extend_with(rpc.to_delegate());
 
@@ -682,21 +661,14 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bob = Keypair::new();
 
-        let mut rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(
-            blockstore.clone(),
-            bank_forks.clone(),
-        );
+        let mut rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks.clone());
         let exit = Arc::new(AtomicBool::new(false));
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks.clone(),
-            Arc::new(RwLock::new(
-                BlockCommitmentCache::new_for_tests_with_blockstore(blockstore),
-            )),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
         );
         rpc.subscriptions = Arc::new(subscriptions);
         let session = create_session();
@@ -736,18 +708,11 @@ mod tests {
         let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bob = Keypair::new();
 
-        let mut rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(
-            blockstore.clone(),
-            bank_forks.clone(),
-        );
+        let mut rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks.clone());
         let exit = Arc::new(AtomicBool::new(false));
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::new_for_tests_with_blockstore(blockstore),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests()));
 
         let subscriptions =
             RpcSubscriptions::new(&exit, bank_forks.clone(), block_commitment_cache);
@@ -804,12 +769,10 @@ mod tests {
     #[test]
     #[serial]
     fn test_slot_subscribe() {
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
+        let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
         let session = create_session();
         let (subscriber, _id_receiver, receiver) = Subscriber::new_test("slotNotification");
         rpc.slot_subscribe(session, subscriber);
@@ -834,12 +797,10 @@ mod tests {
     #[test]
     #[serial]
     fn test_slot_unsubscribe() {
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
+        let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
         let session = create_session();
         let (subscriber, _id_receiver, receiver) = Subscriber::new_test("slotNotification");
         rpc.slot_subscribe(session, subscriber);
@@ -872,11 +833,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_vote_subscribe() {
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::new_for_tests_with_blockstore(blockstore.clone()),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests()));
 
         let validator_voting_keypairs: Vec<_> = (0..10)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
@@ -890,8 +847,7 @@ mod tests {
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
         // Setup RPC
-        let mut rpc =
-            RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks.clone());
+        let mut rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks.clone());
         let session = create_session();
         let (subscriber, _id_receiver, receiver) = Subscriber::new_test("voteNotification");
 
@@ -940,12 +896,10 @@ mod tests {
     #[test]
     #[serial]
     fn test_vote_unsubscribe() {
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
-        let rpc = RpcSolPubSubImpl::default_with_blockstore_bank_forks(blockstore, bank_forks);
+        let rpc = RpcSolPubSubImpl::default_with_bank_forks(bank_forks);
         let session = create_session();
         let (subscriber, _id_receiver, _) = Subscriber::new_test("voteNotification");
         rpc.vote_subscribe(session, subscriber);

--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -73,12 +73,11 @@ impl PubSubService {
 mod tests {
     use super::*;
     use crate::commitment::BlockCommitmentCache;
-    use solana_ledger::{
-        blockstore::Blockstore,
+    use solana_runtime::{
+        bank::Bank,
+        bank_forks::BankForks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        get_tmp_ledger_path,
     };
-    use solana_runtime::{bank::Bank, bank_forks::BankForks};
     use std::{
         net::{IpAddr, Ipv4Addr},
         sync::RwLock,
@@ -88,17 +87,13 @@ mod tests {
     fn test_pubsub_new() {
         let pubsub_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
         let exit = Arc::new(AtomicBool::new(false));
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,
             bank_forks,
-            Arc::new(RwLock::new(
-                BlockCommitmentCache::new_for_tests_with_blockstore(blockstore),
-            )),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
         ));
         let pubsub_service = PubSubService::new(&subscriptions, pubsub_addr, &exit);
         let thread = pubsub_service.thread_hdl.thread();

--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -72,10 +72,10 @@ impl PubSubService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commitment::BlockCommitmentCache;
     use solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
+        commitment::BlockCommitmentCache,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
     };
     use std::{

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -378,9 +378,7 @@ mod tests {
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let mut rpc_service = JsonRpcService::new(
             rpc_addr,
             JsonRpcConfig::default(),

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -1,7 +1,7 @@
 //! The `rpc_service` module implements the Solana JSON RPC service.
 
 use crate::{
-    cluster_info::ClusterInfo, commitment::BlockCommitmentCache, rpc::*, rpc_health::*,
+    cluster_info::ClusterInfo, rpc::*, rpc_health::*,
     send_transaction_service::SendTransactionService, validator::ValidatorExit,
 };
 use jsonrpc_core::MetaIoHandler;
@@ -13,6 +13,7 @@ use regex::Regex;
 use solana_ledger::blockstore::Blockstore;
 use solana_runtime::{
     bank_forks::{BankForks, SnapshotConfig},
+    commitment::BlockCommitmentCache,
     snapshot_utils,
 };
 use solana_sdk::{hash::Hash, native_token::lamports_to_sol, pubkey::Pubkey};

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -1,6 +1,5 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
 
-use crate::commitment::BlockCommitmentCache;
 use core::hash::Hash;
 use jsonrpc_core::futures::Future;
 use jsonrpc_pubsub::{
@@ -11,7 +10,7 @@ use serde::Serialize;
 use solana_client::rpc_response::{
     Response, RpcAccount, RpcKeyedAccount, RpcResponseContext, RpcSignatureResult,
 };
-use solana_runtime::{bank::Bank, bank_forks::BankForks};
+use solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache};
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp},
@@ -893,11 +892,13 @@ impl RpcSubscriptions {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::commitment::BlockCommitment;
     use jsonrpc_core::futures::{self, stream::Stream};
     use jsonrpc_pubsub::typed::Subscriber;
     use serial_test_derive::serial;
-    use solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo};
+    use solana_runtime::{
+        commitment::BlockCommitment,
+        genesis_utils::{create_genesis_config, GenesisConfigInfo},
+    };
     use solana_sdk::{
         signature::{Keypair, Signer},
         system_transaction,

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -11,7 +11,6 @@ use serde::Serialize;
 use solana_client::rpc_response::{
     Response, RpcAccount, RpcKeyedAccount, RpcResponseContext, RpcSignatureResult,
 };
-use solana_ledger::blockstore::Blockstore;
 use solana_runtime::{bank::Bank, bank_forks::BankForks};
 use solana_sdk::{
     account::Account,
@@ -375,16 +374,11 @@ impl RpcSubscriptions {
         }
     }
 
-    pub fn default_with_blockstore_bank_forks(
-        blockstore: Arc<Blockstore>,
-        bank_forks: Arc<RwLock<BankForks>>,
-    ) -> Self {
+    pub fn default_with_bank_forks(bank_forks: Arc<RwLock<BankForks>>) -> Self {
         Self::new(
             &Arc::new(AtomicBool::new(false)),
             bank_forks,
-            Arc::new(RwLock::new(BlockCommitmentCache::default_with_blockstore(
-                blockstore,
-            ))),
+            Arc::new(RwLock::new(BlockCommitmentCache::default())),
         )
     }
 
@@ -903,11 +897,7 @@ pub(crate) mod tests {
     use jsonrpc_core::futures::{self, stream::Stream};
     use jsonrpc_pubsub::typed::Subscriber;
     use serial_test_derive::serial;
-    use solana_ledger::{
-        blockstore::Blockstore,
-        genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        get_tmp_ledger_path,
-    };
+    use solana_runtime::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_sdk::{
         signature::{Keypair, Signer},
         system_transaction,
@@ -948,8 +938,6 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
@@ -965,13 +953,10 @@ pub(crate) mod tests {
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks.clone(),
-            Arc::new(RwLock::new(
-                BlockCommitmentCache::new_for_tests_with_blockstore_bank(
-                    blockstore,
-                    bank_forks.read().unwrap().get(1).unwrap().clone(),
-                    1,
-                ),
-            )),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_bank(
+                bank_forks.read().unwrap().get(1).unwrap().clone(),
+                1,
+            ))),
         );
         subscriptions.add_account_subscription(
             alice.pubkey(),
@@ -1042,8 +1027,6 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
@@ -1071,9 +1054,7 @@ pub(crate) mod tests {
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks,
-            Arc::new(RwLock::new(
-                BlockCommitmentCache::new_for_tests_with_blockstore(blockstore),
-            )),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
         );
         subscriptions.add_program_subscription(
             solana_budget_program::id(),
@@ -1130,8 +1111,6 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let mut bank_forks = BankForks::new(bank);
@@ -1171,7 +1150,7 @@ pub(crate) mod tests {
         block_commitment.entry(0).or_insert(cache0);
         block_commitment.entry(1).or_insert(cache1);
         let block_commitment_cache =
-            BlockCommitmentCache::new(block_commitment, 0, 10, bank1, blockstore, 0, 0);
+            BlockCommitmentCache::new(block_commitment, 0, 10, bank1, 0, 0);
 
         let exit = Arc::new(AtomicBool::new(false));
         let subscriptions = RpcSubscriptions::new(
@@ -1286,17 +1265,13 @@ pub(crate) mod tests {
             Subscriber::new_test("slotNotification");
         let sub_id = SubscriptionId::Number(0 as u64);
         let exit = Arc::new(AtomicBool::new(false));
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks,
-            Arc::new(RwLock::new(
-                BlockCommitmentCache::new_for_tests_with_blockstore(blockstore),
-            )),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
         );
         subscriptions.add_slot_subscription(sub_id.clone(), subscriber);
 
@@ -1338,17 +1313,13 @@ pub(crate) mod tests {
             Subscriber::new_test("rootNotification");
         let sub_id = SubscriptionId::Number(0 as u64);
         let exit = Arc::new(AtomicBool::new(false));
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks,
-            Arc::new(RwLock::new(
-                BlockCommitmentCache::new_for_tests_with_blockstore(blockstore),
-            )),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
         );
         subscriptions.add_root_subscription(sub_id.clone(), subscriber);
 
@@ -1436,8 +1407,6 @@ pub(crate) mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(100);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
@@ -1456,13 +1425,10 @@ pub(crate) mod tests {
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks.clone(),
-            Arc::new(RwLock::new(
-                BlockCommitmentCache::new_for_tests_with_blockstore_bank(
-                    blockstore,
-                    bank_forks.read().unwrap().get(1).unwrap().clone(),
-                    1,
-                ),
-            )),
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_bank(
+                bank_forks.read().unwrap().get(1).unwrap().clone(),
+                1,
+            ))),
         );
         let sub_id0 = SubscriptionId::Number(0 as u64);
         subscriptions.add_account_subscription(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -277,9 +277,7 @@ pub mod tests {
             create_test_recorder(&bank, &blockstore, None);
         let vote_keypair = Keypair::new();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let (retransmit_slots_sender, _retransmit_slots_receiver) = unbounded();
         let bank_forks = Arc::new(RwLock::new(bank_forks));
         let tvu = Tvu::new(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -8,7 +8,6 @@ use crate::{
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::VoteTracker,
     cluster_slots::ClusterSlots,
-    commitment::BlockCommitmentCache,
     ledger_cleanup_service::LedgerCleanupService,
     poh_recorder::PohRecorder,
     replay_stage::{ReplayStage, ReplayStageConfig},
@@ -25,7 +24,10 @@ use solana_ledger::{
     blockstore_processor::TransactionStatusSender,
     leader_schedule_cache::LeaderScheduleCache,
 };
-use solana_runtime::{bank_forks::BankForks, snapshot_package::AccountsPackageSender};
+use solana_runtime::{
+    bank_forks::BankForks, commitment::BlockCommitmentCache,
+    snapshot_package::AccountsPackageSender,
+};
 use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, Signer},

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -4,7 +4,6 @@ use crate::{
     broadcast_stage::BroadcastStageType,
     cluster_info::{ClusterInfo, Node},
     cluster_info_vote_listener::VoteTracker,
-    commitment::BlockCommitmentCache,
     contact_info::ContactInfo,
     gossip_service::{discover_cluster, GossipService},
     poh_recorder::{PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
@@ -35,6 +34,7 @@ use solana_metrics::datapoint_info;
 use solana_runtime::{
     bank::Bank,
     bank_forks::{BankForks, SnapshotConfig},
+    commitment::BlockCommitmentCache,
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
 };
 use solana_sdk::{

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -242,9 +242,7 @@ impl Validator {
 
         let cluster_info = Arc::new(ClusterInfo::new(node.info.clone(), keypair.clone()));
         let blockstore = Arc::new(blockstore);
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::default_with_blockstore(blockstore.clone()),
-        ));
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
 
         let subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -3,12 +3,13 @@ use solana_client::{
     rpc_client::RpcClient,
 };
 use solana_core::{
-    commitment::BlockCommitmentCache, rpc_pubsub_service::PubSubService,
-    rpc_subscriptions::RpcSubscriptions, validator::TestValidator,
+    rpc_pubsub_service::PubSubService, rpc_subscriptions::RpcSubscriptions,
+    validator::TestValidator,
 };
 use solana_runtime::{
     bank::Bank,
     bank_forks::BankForks,
+    commitment::BlockCommitmentCache,
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
 };
 use solana_sdk::{

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -6,12 +6,11 @@ use solana_core::{
     commitment::BlockCommitmentCache, rpc_pubsub_service::PubSubService,
     rpc_subscriptions::RpcSubscriptions, validator::TestValidator,
 };
-use solana_ledger::{
-    blockstore::Blockstore,
+use solana_runtime::{
+    bank::Bank,
+    bank_forks::BankForks,
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
-    get_tmp_ledger_path,
 };
-use solana_runtime::{bank::Bank, bank_forks::BankForks};
 use solana_sdk::{
     commitment_config::CommitmentConfig, pubkey::Pubkey, rpc_port, signature::Signer,
     system_transaction,
@@ -91,17 +90,13 @@ fn test_slot_subscription() {
         rpc_port::DEFAULT_RPC_PUBSUB_PORT,
     );
     let exit = Arc::new(AtomicBool::new(false));
-    let ledger_path = get_tmp_ledger_path!();
-    let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new(&genesis_config);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
     let subscriptions = Arc::new(RpcSubscriptions::new(
         &exit,
         bank_forks,
-        Arc::new(RwLock::new(BlockCommitmentCache::default_with_blockstore(
-            blockstore,
-        ))),
+        Arc::new(RwLock::new(BlockCommitmentCache::default())),
     ));
     let pubsub_service = PubSubService::new(&subscriptions, pubsub_addr, &exit);
     std::thread::sleep(Duration::from_millis(400));

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -1,4 +1,4 @@
-use solana_runtime::bank::Bank;
+use crate::bank::Bank;
 use solana_sdk::clock::Slot;
 use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::{collections::HashMap, sync::Arc};
@@ -31,8 +31,7 @@ impl BlockCommitment {
         self.commitment[MAX_LOCKOUT_HISTORY]
     }
 
-    #[cfg(test)]
-    pub(crate) fn new(commitment: BlockCommitmentArray) -> Self {
+    pub fn new(commitment: BlockCommitmentArray) -> Self {
         Self { commitment }
     }
 }
@@ -144,7 +143,6 @@ impl BlockCommitmentCache {
         })
     }
 
-    #[cfg(test)]
     pub fn new_for_tests() -> Self {
         let mut block_commitment: HashMap<Slot, BlockCommitment> = HashMap::new();
         block_commitment.insert(0, BlockCommitment::default());
@@ -155,7 +153,6 @@ impl BlockCommitmentCache {
         }
     }
 
-    #[cfg(test)]
     pub fn new_for_tests_with_bank(bank: Arc<Bank>, root: Slot) -> Self {
         let mut block_commitment: HashMap<Slot, BlockCommitment> = HashMap::new();
         block_commitment.insert(0, BlockCommitment::default());
@@ -169,7 +166,7 @@ impl BlockCommitmentCache {
         }
     }
 
-    pub(crate) fn set_largest_confirmed_root(&mut self, root: Slot) {
+    pub fn set_largest_confirmed_root(&mut self, root: Slot) {
         self.largest_confirmed_root = root;
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -8,6 +8,7 @@ pub mod bank_forks;
 mod blockhash_queue;
 pub mod bloom;
 pub mod builtin_programs;
+pub mod commitment;
 pub mod epoch_stakes;
 pub mod genesis_utils;
 pub mod hardened_unpack;


### PR DESCRIPTION
#### Problem

The JSON RPC library uses BlockCommitmentCache to select a bank, but that's up in the `solana_core`. I'd like to use that logic in a lower-level RPC crate that depends only on BankForks.

#### Summary of Changes

* Drop the Blockstore dependency from BlockCommitmentCache
* Move the `commitment.rs` module to `solana_runtime`