### PR TITLE
Remove ledger purge batching

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -684,7 +684,7 @@ fn backup_and_clear_blockstore(ledger_path: &Path, start_slot: Slot, shred_versi
 
         let end_slot = last_slot.unwrap();
         info!("Purging slots {} to {}", start_slot, end_slot);
-        blockstore.purge_slots_with_delay(start_slot, end_slot, None, PurgeType::Exact);
+        blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact);
         blockstore.purge_from_next_slots(start_slot, end_slot);
         info!("Purging done, compacting db..");
         if let Err(e) = blockstore.compact_storage(start_slot, end_slot) {

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -382,7 +382,6 @@ mod tests {
             max_ledger_shreds,
             &mut last_purge_slot,
             10,
-            None,
             &mut last_compaction_slot,
             10,
         )

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1432,7 +1432,7 @@ fn main() {
             let start_slot = value_t_or_exit!(arg_matches, "start_slot", Slot);
             let end_slot = value_t_or_exit!(arg_matches, "end_slot", Slot);
             let blockstore = open_blockstore(&ledger_path, AccessType::PrimaryOnly);
-            blockstore.purge_slots(start_slot, end_slot);
+            blockstore.purge_and_compact_slots(start_slot, end_slot);
             blockstore.purge_from_next_slots(start_slot, end_slot);
         }
         ("list-roots", Some(arg_matches)) => {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6155,14 +6155,14 @@ pub mod tests {
                 .insert_shreds(all_shreds, Some(&leader_schedule_cache), false)
                 .unwrap();
             verify_index_integrity(&blockstore, slot);
-            blockstore.purge_slots(0, slot);
+            blockstore.purge_and_compact_slots(0, slot);
 
             // Test inserting just the codes, enough for recovery
             blockstore
                 .insert_shreds(coding_shreds.clone(), Some(&leader_schedule_cache), false)
                 .unwrap();
             verify_index_integrity(&blockstore, slot);
-            blockstore.purge_slots(0, slot);
+            blockstore.purge_and_compact_slots(0, slot);
 
             // Test inserting some codes, but not enough for recovery
             blockstore
@@ -6173,7 +6173,7 @@ pub mod tests {
                 )
                 .unwrap();
             verify_index_integrity(&blockstore, slot);
-            blockstore.purge_slots(0, slot);
+            blockstore.purge_and_compact_slots(0, slot);
 
             // Test inserting just the codes, and some data, enough for recovery
             let shreds: Vec<_> = data_shreds[..data_shreds.len() - 1]
@@ -6185,7 +6185,7 @@ pub mod tests {
                 .insert_shreds(shreds, Some(&leader_schedule_cache), false)
                 .unwrap();
             verify_index_integrity(&blockstore, slot);
-            blockstore.purge_slots(0, slot);
+            blockstore.purge_and_compact_slots(0, slot);
 
             // Test inserting some codes, and some data, but enough for recovery
             let shreds: Vec<_> = data_shreds[..data_shreds.len() / 2 - 1]
@@ -6197,7 +6197,7 @@ pub mod tests {
                 .insert_shreds(shreds, Some(&leader_schedule_cache), false)
                 .unwrap();
             verify_index_integrity(&blockstore, slot);
-            blockstore.purge_slots(0, slot);
+            blockstore.purge_and_compact_slots(0, slot);
 
             // Test inserting all shreds in 2 rounds, make sure nothing is lost
             let shreds1: Vec<_> = data_shreds[..data_shreds.len() / 2 - 1]
@@ -6217,7 +6217,7 @@ pub mod tests {
                 .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
                 .unwrap();
             verify_index_integrity(&blockstore, slot);
-            blockstore.purge_slots(0, slot);
+            blockstore.purge_and_compact_slots(0, slot);
 
             // Test not all, but enough data and coding shreds in 2 rounds to trigger recovery,
             // make sure nothing is lost
@@ -6242,7 +6242,7 @@ pub mod tests {
                 .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
                 .unwrap();
             verify_index_integrity(&blockstore, slot);
-            blockstore.purge_slots(0, slot);
+            blockstore.purge_and_compact_slots(0, slot);
 
             // Test insert shreds in 2 rounds, but not enough to trigger
             // recovery, make sure nothing is lost
@@ -6267,7 +6267,7 @@ pub mod tests {
                 .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
                 .unwrap();
             verify_index_integrity(&blockstore, slot);
-            blockstore.purge_slots(0, slot);
+            blockstore.purge_and_compact_slots(0, slot);
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }

--- a/ledger/tests/blockstore.rs
+++ b/ledger/tests/blockstore.rs
@@ -42,7 +42,7 @@ fn test_multiple_threads_insert_shred() {
         assert_eq!(meta0.next_slots, expected_next_slots);
 
         // Delete slots for next iteration
-        blockstore.purge_slots(0, num_threads + 1);
+        blockstore.purge_and_compact_slots(0, num_threads + 1);
     }
 
     // Cleanup


### PR DESCRIPTION
#### Problem

Batching purges seems to lower performance overall since each delete_range seems to be constant time. Nodes can get into a situation of deleting a huge range of slots and they will issue many delete_ranges which each cause writes to the db and slowing down insert.

Some example of the node in tds that died https://github.com/solana-labs/solana/issues/10821:
```
[2020-06-26T06:58:10.443246600Z INFO  solana_core::ledger_cleanup_service] first_slot=0 total_slots=386755 total_shreds=50039179 max_ledger_shreds=50000000, iterate_time took 323ms
[2020-06-26T06:58:10.443759936Z INFO  solana_core::ledger_cleanup_service] purging data from slots 0 to 20606000
```
It had 50m shreds in 386k slots. It probably only had data back to slot: 20,606,000 - 386,755 = 20,219,245. But it walked from slot 0 all the way up.

#### Summary of Changes

Don't purge in batches, just do one delete_range.

Fixes #
