### PR TITLE
Reduce logging lines

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2084,7 +2084,7 @@ impl ClusterInfo {
     }
 
     fn print_reset_stats(&self, last_print: &mut Instant) {
-        if last_print.elapsed().as_millis() > 1000 {
+        if last_print.elapsed().as_millis() > 2000 {
             datapoint_info!(
                 "cluster_info_stats",
                 ("entrypoint", self.stats.entrypoint.clear(), i64),

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -217,11 +217,11 @@ impl RepairService {
                 });
             }
 
-            if last_stats.elapsed().as_secs() > 1 {
+            if last_stats.elapsed().as_secs() > 2 {
                 let repair_total = repair_stats.shred.count
                     + repair_stats.highest_shred.count
                     + repair_stats.orphan.count;
-                info!("repair_stats: {:#?}", repair_stats);
+                info!("repair_stats: {:?}", repair_stats);
                 if repair_total > 0 {
                     datapoint_info!(
                         "serve_repair-repair",

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -160,11 +160,11 @@ fn update_retransmit_stats(
             ),
         );
         let mut packets_by_slot = stats.packets_by_slot.lock().unwrap();
-        info!("retransmit: packets_by_slot: {:#?}", packets_by_slot);
+        info!("retransmit: packets_by_slot: {:?}", packets_by_slot);
         packets_by_slot.clear();
         drop(packets_by_slot);
         let mut packets_by_source = stats.packets_by_source.lock().unwrap();
-        info!("retransmit: packets_by_source: {:#?}", packets_by_source);
+        info!("retransmit: packets_by_source: {:?}", packets_by_source);
         packets_by_source.clear();
     }
 }


### PR DESCRIPTION
#### Problem

Too many logging lines caused by pretty-printing and logging too often.

#### Summary of Changes

Don't use pretty-print which can easily be restored in post-processing and reduce interval of some datapoints.

Fixes #
