### PR TITLE
Add ability to parse logs for frozen/full slot information in ledger-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4212,6 +4212,7 @@ dependencies = [
  "clap",
  "histogram",
  "log 0.4.8",
+ "regex",
  "serde_json",
  "serde_yaml",
  "signal-hook",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -27,6 +27,7 @@ solana-transaction-status = { path = "../transaction-status", version = "1.3.0" 
 solana-version = { path = "../version", version = "1.3.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
 tempfile = "3.1.0"
+regex = "1"
 
 [dev-dependencies]
 assert_cmd = "1.0"


### PR DESCRIPTION
#### Problem
Hard to parse slot information (frozen/full) useful for debugging from large log files
#### Summary of Changes
Add `parse_full_frozen` command to ledger tool which given a ledger + starting slot + ending_slot + log file, will find all the ancestors of the given `ending_slot` and extract frozen/full logs for those slots.

Fixes #
