### PR TITLE
Fix net-utils test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,6 +4385,7 @@ dependencies = [
  "solana-version",
  "tokio 0.1.22",
  "tokio-codec",
+ "url 2.1.1",
 ]
 
 [[package]]

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -23,6 +23,7 @@ solana-logger = { path = "../logger", version = "1.3.0" }
 solana-version = { path = "../version", version = "1.3.0" }
 tokio = "0.1"
 tokio-codec = "0.1"
+url = "2.1.1"
 
 [lib]
 name = "solana_net_utils"


### PR DESCRIPTION
#### Problem

`test_parse_host` fails on my home network. It resolves `localhost:1234` to an IPv4 address (and `localhost` to an IPv6 address). That test expects the URL with a port to fail.

#### Summary of Changes

First parse the input and reject any input that contains an explicit port. Instead of checking for `:<port>`, use a URL parser, since it'll fail faster and give better error messages than attempting to resolve some garbage input.