### PR TITLE
Add account-decoder utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,6 +3630,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-account-decoder"
+version = "1.3.0"
+dependencies = [
+ "Inflector",
+ "bincode",
+ "bs58 0.3.1",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-sdk 1.3.0",
+ "solana-vote-program",
+ "spl-memo",
+ "thiserror",
+]
+
+[[package]]
 name = "solana-accounts-bench"
 version = "1.3.0"
 dependencies = [
@@ -3816,6 +3833,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "solana-account-decoder",
  "solana-budget-program",
  "solana-clap-utils",
  "solana-cli-config",
@@ -3866,6 +3884,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "solana-account-decoder",
  "solana-logger",
  "solana-net-utils",
  "solana-sdk 1.3.0",
@@ -3925,6 +3944,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "serial_test_derive",
+ "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-budget-program",
  "solana-clap-utils",
@@ -4792,6 +4812,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-sdk 1.3.0",
+ "solana-stake-program",
+ "solana-vote-program",
  "spl-memo",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "sys-tuner",
     "tokens",
     "transaction-status",
+    "account-decoder",
     "upload-perf",
     "net-utils",
     "version",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "solana-account-decoder"
+version = "1.3.0"
+description = "Solana account decoder"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+homepage = "https://solana.com/"
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+bincode = "1.2.1"
+bs58 = "0.3.1"
+Inflector = "0.11.4"
+lazy_static = "1.4.0"
+solana-sdk = { path = "../sdk", version = "1.3.0" }
+solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
+spl-memo = "1.0.0"
+serde = "1.0.112"
+serde_derive = "1.0.103"
+serde_json = "1.0.54"
+thiserror = "1.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use solana_sdk::{account::Account, clock::Epoch, pubkey::Pubkey};
 use std::str::FromStr;
 
-/// A duplicate representation of a Message for pretty JSON serialization
+/// A duplicate representation of an Account for pretty JSON serialization
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct UiAccount {

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -15,9 +15,9 @@ use std::str::FromStr;
 /// A duplicate representation of a Message for pretty JSON serialization
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct EncodedAccount {
+pub struct UiAccount {
     pub lamports: u64,
-    pub data: EncodedAccountData,
+    pub data: UiAccountData,
     pub owner: String,
     pub executable: bool,
     pub rent_epoch: Epoch,
@@ -25,12 +25,12 @@ pub struct EncodedAccount {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", untagged)]
-pub enum EncodedAccountData {
+pub enum UiAccountData {
     Binary(String),
     Json(Value),
 }
 
-impl From<Vec<u8>> for EncodedAccountData {
+impl From<Vec<u8>> for UiAccountData {
     fn from(data: Vec<u8>) -> Self {
         Self::Binary(bs58::encode(data).into_string())
     }
@@ -38,24 +38,24 @@ impl From<Vec<u8>> for EncodedAccountData {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub enum AccountEncoding {
+pub enum UiAccountEncoding {
     Binary,
     JsonParsed,
 }
 
-impl EncodedAccount {
-    pub fn encode(account: Account, encoding: AccountEncoding) -> Self {
+impl UiAccount {
+    pub fn encode(account: Account, encoding: UiAccountEncoding) -> Self {
         let data = match encoding {
-            AccountEncoding::Binary => account.data.into(),
-            AccountEncoding::JsonParsed => {
+            UiAccountEncoding::Binary => account.data.into(),
+            UiAccountEncoding::JsonParsed => {
                 if let Ok(parsed_data) = parse_account_data(&account.owner, &account.data) {
-                    EncodedAccountData::Json(parsed_data)
+                    UiAccountData::Json(parsed_data)
                 } else {
                     account.data.into()
                 }
             }
         };
-        EncodedAccount {
+        UiAccount {
             lamports: account.lamports,
             data,
             owner: account.owner.to_string(),
@@ -66,8 +66,8 @@ impl EncodedAccount {
 
     pub fn decode(&self) -> Option<Account> {
         let data = match &self.data {
-            EncodedAccountData::Json(_) => None,
-            EncodedAccountData::Binary(blob) => bs58::decode(blob).into_vec().ok(),
+            UiAccountData::Json(_) => None,
+            UiAccountData::Binary(blob) => bs58::decode(blob).into_vec().ok(),
         }?;
         Some(Account {
             lamports: self.lamports,

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -1,0 +1,80 @@
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate serde_derive;
+
+pub mod parse_account_data;
+pub mod parse_nonce;
+pub mod parse_vote;
+
+use crate::parse_account_data::parse_account_data;
+use serde_json::Value;
+use solana_sdk::{account::Account, clock::Epoch, pubkey::Pubkey};
+use std::str::FromStr;
+
+/// A duplicate representation of a Message for pretty JSON serialization
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcAccount {
+    pub lamports: u64,
+    pub data: EncodedAccount,
+    pub owner: String,
+    pub executable: bool,
+    pub rent_epoch: Epoch,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum EncodedAccount {
+    Binary(String),
+    Json(Value),
+}
+
+impl From<Vec<u8>> for EncodedAccount {
+    fn from(data: Vec<u8>) -> Self {
+        Self::Binary(bs58::encode(data).into_string())
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum AccountEncoding {
+    Binary,
+    Json,
+}
+
+impl RpcAccount {
+    pub fn encode(account: Account, encoding: AccountEncoding) -> Self {
+        let data = match encoding {
+            AccountEncoding::Binary => account.data.into(),
+            AccountEncoding::Json => {
+                if let Ok(parsed_data) = parse_account_data(&account.owner, &account.data) {
+                    EncodedAccount::Json(parsed_data)
+                } else {
+                    account.data.into()
+                }
+            }
+        };
+        RpcAccount {
+            lamports: account.lamports,
+            data,
+            owner: account.owner.to_string(),
+            executable: account.executable,
+            rent_epoch: account.rent_epoch,
+        }
+    }
+
+    pub fn decode(&self) -> Option<Account> {
+        let data = match &self.data {
+            EncodedAccount::Json(_) => None,
+            EncodedAccount::Binary(blob) => bs58::decode(blob).into_vec().ok(),
+        }?;
+        Some(Account {
+            lamports: self.lamports,
+            data,
+            owner: Pubkey::from_str(&self.owner).ok()?,
+            executable: self.executable,
+            rent_epoch: self.rent_epoch,
+        })
+    }
+}

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -40,14 +40,14 @@ impl From<Vec<u8>> for EncodedAccountData {
 #[serde(rename_all = "camelCase")]
 pub enum AccountEncoding {
     Binary,
-    Json,
+    JsonParsed,
 }
 
 impl EncodedAccount {
     pub fn encode(account: Account, encoding: AccountEncoding) -> Self {
         let data = match encoding {
             AccountEncoding::Binary => account.data.into(),
-            AccountEncoding::Json => {
+            AccountEncoding::JsonParsed => {
                 if let Ok(parsed_data) = parse_account_data(&account.owner, &account.data) {
                     EncodedAccountData::Json(parsed_data)
                 } else {

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -1,0 +1,51 @@
+use crate::{parse_nonce::parse_nonce, parse_vote::parse_vote};
+use inflector::Inflector;
+use serde_json::{json, Value};
+use solana_sdk::{instruction::InstructionError, pubkey::Pubkey, system_program};
+use std::{collections::HashMap, str::FromStr};
+use thiserror::Error;
+
+lazy_static! {
+    static ref SYSTEM_PROGRAM_ID: Pubkey =
+        Pubkey::from_str(&system_program::id().to_string()).unwrap();
+    static ref VOTE_PROGRAM_ID: Pubkey =
+        Pubkey::from_str(&solana_vote_program::id().to_string()).unwrap();
+    pub static ref PARSABLE_PROGRAM_IDS: HashMap<Pubkey, ParsableAccount> = {
+        let mut m = HashMap::new();
+        m.insert(*SYSTEM_PROGRAM_ID, ParsableAccount::Nonce);
+        m.insert(*VOTE_PROGRAM_ID, ParsableAccount::Vote);
+        m
+    };
+}
+
+#[derive(Error, Debug)]
+pub enum ParseAccountError {
+    #[error("Program not parsable")]
+    ProgramNotParsable,
+
+    #[error("Instruction error")]
+    InstructionError(#[from] InstructionError),
+
+    #[error("Serde json error")]
+    SerdeJsonError(#[from] serde_json::error::Error),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ParsableAccount {
+    Nonce,
+    Vote,
+}
+
+pub fn parse_account_data(program_id: &Pubkey, data: &[u8]) -> Result<Value, ParseAccountError> {
+    let program_name = PARSABLE_PROGRAM_IDS
+        .get(program_id)
+        .ok_or_else(|| ParseAccountError::ProgramNotParsable)?;
+    let parsed_json = match program_name {
+        ParsableAccount::Nonce => serde_json::to_value(parse_nonce(data)?)?,
+        ParsableAccount::Vote => serde_json::to_value(parse_vote(data)?)?,
+    };
+    Ok(json!({
+        format!("{:?}", program_name).to_kebab_case(): parsed_json
+    }))
+}

--- a/account-decoder/src/parse_nonce.rs
+++ b/account-decoder/src/parse_nonce.rs
@@ -1,0 +1,35 @@
+use crate::parse_account_data::ParseAccountError;
+use solana_sdk::{
+    fee_calculator::FeeCalculator,
+    instruction::InstructionError,
+    nonce::{state::Versions, State},
+};
+
+pub fn parse_nonce(data: &[u8]) -> Result<RpcNonceState, ParseAccountError> {
+    let nonce_state: Versions = bincode::deserialize(data)
+        .map_err(|_| ParseAccountError::from(InstructionError::InvalidAccountData))?;
+    let nonce_state = nonce_state.convert_to_current();
+    match nonce_state {
+        State::Uninitialized => Ok(RpcNonceState::Uninitialized),
+        State::Initialized(data) => Ok(RpcNonceState::Initialized(RpcNonceData {
+            authority: data.authority.to_string(),
+            blockhash: data.blockhash.to_string(),
+            fee_calculator: data.fee_calculator,
+        })),
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RpcNonceState {
+    Uninitialized,
+    Initialized(RpcNonceData),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcNonceData {
+    pub authority: String,
+    pub blockhash: String,
+    pub fee_calculator: FeeCalculator,
+}

--- a/account-decoder/src/parse_nonce.rs
+++ b/account-decoder/src/parse_nonce.rs
@@ -19,6 +19,7 @@ pub fn parse_nonce(data: &[u8]) -> Result<UiNonceState, ParseAccountError> {
     }
 }
 
+/// A duplicate representation of NonceState for pretty JSON serialization
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum UiNonceState {

--- a/account-decoder/src/parse_nonce.rs
+++ b/account-decoder/src/parse_nonce.rs
@@ -5,13 +5,13 @@ use solana_sdk::{
     nonce::{state::Versions, State},
 };
 
-pub fn parse_nonce(data: &[u8]) -> Result<RpcNonceState, ParseAccountError> {
+pub fn parse_nonce(data: &[u8]) -> Result<UiNonceState, ParseAccountError> {
     let nonce_state: Versions = bincode::deserialize(data)
         .map_err(|_| ParseAccountError::from(InstructionError::InvalidAccountData))?;
     let nonce_state = nonce_state.convert_to_current();
     match nonce_state {
-        State::Uninitialized => Ok(RpcNonceState::Uninitialized),
-        State::Initialized(data) => Ok(RpcNonceState::Initialized(RpcNonceData {
+        State::Uninitialized => Ok(UiNonceState::Uninitialized),
+        State::Initialized(data) => Ok(UiNonceState::Initialized(UiNonceData {
             authority: data.authority.to_string(),
             blockhash: data.blockhash.to_string(),
             fee_calculator: data.fee_calculator,
@@ -21,14 +21,14 @@ pub fn parse_nonce(data: &[u8]) -> Result<RpcNonceState, ParseAccountError> {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum RpcNonceState {
+pub enum UiNonceState {
     Uninitialized,
-    Initialized(RpcNonceData),
+    Initialized(UiNonceData),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcNonceData {
+pub struct UiNonceData {
     pub authority: String,
     pub blockhash: String,
     pub fee_calculator: FeeCalculator,

--- a/account-decoder/src/parse_nonce.rs
+++ b/account-decoder/src/parse_nonce.rs
@@ -19,17 +19,47 @@ pub fn parse_nonce(data: &[u8]) -> Result<UiNonceState, ParseAccountError> {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum UiNonceState {
     Uninitialized,
     Initialized(UiNonceData),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UiNonceData {
     pub authority: String,
     pub blockhash: String,
     pub fee_calculator: FeeCalculator,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use solana_sdk::{
+        hash::Hash,
+        nonce::{
+            state::{Data, Versions},
+            State,
+        },
+        pubkey::Pubkey,
+    };
+
+    #[test]
+    fn test_parse_nonce() {
+        let nonce_data = Versions::new_current(State::Initialized(Data::default()));
+        let nonce_account_data = bincode::serialize(&nonce_data).unwrap();
+        assert_eq!(
+            parse_nonce(&nonce_account_data).unwrap(),
+            UiNonceState::Initialized(UiNonceData {
+                authority: Pubkey::default().to_string(),
+                blockhash: Hash::default().to_string(),
+                fee_calculator: FeeCalculator::default(),
+            }),
+        );
+
+        let bad_data = vec![0; 4];
+        assert!(parse_nonce(&bad_data).is_err());
+    }
 }

--- a/account-decoder/src/parse_nonce.rs
+++ b/account-decoder/src/parse_nonce.rs
@@ -5,13 +5,13 @@ use solana_sdk::{
     nonce::{state::Versions, State},
 };
 
-pub fn parse_nonce(data: &[u8]) -> Result<RpcNonceState, ParseAccountError> {
+pub fn parse_nonce(data: &[u8]) -> Result<DisplayNonceState, ParseAccountError> {
     let nonce_state: Versions = bincode::deserialize(data)
         .map_err(|_| ParseAccountError::from(InstructionError::InvalidAccountData))?;
     let nonce_state = nonce_state.convert_to_current();
     match nonce_state {
-        State::Uninitialized => Ok(RpcNonceState::Uninitialized),
-        State::Initialized(data) => Ok(RpcNonceState::Initialized(RpcNonceData {
+        State::Uninitialized => Ok(DisplayNonceState::Uninitialized),
+        State::Initialized(data) => Ok(DisplayNonceState::Initialized(DisplayNonceData {
             authority: data.authority.to_string(),
             blockhash: data.blockhash.to_string(),
             fee_calculator: data.fee_calculator,
@@ -21,14 +21,14 @@ pub fn parse_nonce(data: &[u8]) -> Result<RpcNonceState, ParseAccountError> {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum RpcNonceState {
+pub enum DisplayNonceState {
     Uninitialized,
-    Initialized(RpcNonceData),
+    Initialized(DisplayNonceData),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcNonceData {
+pub struct DisplayNonceData {
     pub authority: String,
     pub blockhash: String,
     pub fee_calculator: FeeCalculator,

--- a/account-decoder/src/parse_nonce.rs
+++ b/account-decoder/src/parse_nonce.rs
@@ -5,13 +5,13 @@ use solana_sdk::{
     nonce::{state::Versions, State},
 };
 
-pub fn parse_nonce(data: &[u8]) -> Result<DisplayNonceState, ParseAccountError> {
+pub fn parse_nonce(data: &[u8]) -> Result<RpcNonceState, ParseAccountError> {
     let nonce_state: Versions = bincode::deserialize(data)
         .map_err(|_| ParseAccountError::from(InstructionError::InvalidAccountData))?;
     let nonce_state = nonce_state.convert_to_current();
     match nonce_state {
-        State::Uninitialized => Ok(DisplayNonceState::Uninitialized),
-        State::Initialized(data) => Ok(DisplayNonceState::Initialized(DisplayNonceData {
+        State::Uninitialized => Ok(RpcNonceState::Uninitialized),
+        State::Initialized(data) => Ok(RpcNonceState::Initialized(RpcNonceData {
             authority: data.authority.to_string(),
             blockhash: data.blockhash.to_string(),
             fee_calculator: data.fee_calculator,
@@ -21,14 +21,14 @@ pub fn parse_nonce(data: &[u8]) -> Result<DisplayNonceState, ParseAccountError> 
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum DisplayNonceState {
+pub enum RpcNonceState {
     Uninitialized,
-    Initialized(DisplayNonceData),
+    Initialized(RpcNonceData),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DisplayNonceData {
+pub struct RpcNonceData {
     pub authority: String,
     pub blockhash: String,
     pub fee_calculator: FeeCalculator,

--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -5,12 +5,12 @@ use solana_sdk::{
 };
 use solana_vote_program::vote_state::{BlockTimestamp, Lockout, VoteState};
 
-pub fn parse_vote(data: &[u8]) -> Result<DisplayVoteState, ParseAccountError> {
+pub fn parse_vote(data: &[u8]) -> Result<RpcVoteState, ParseAccountError> {
     let mut vote_state = VoteState::deserialize(data).map_err(ParseAccountError::from)?;
     let epoch_credits = vote_state
         .epoch_credits()
         .iter()
-        .map(|(epoch, credits, previous_credits)| DisplayEpochCredits {
+        .map(|(epoch, credits, previous_credits)| RpcEpochCredits {
             epoch: *epoch,
             credits: *credits,
             previous_credits: *previous_credits,
@@ -19,7 +19,7 @@ pub fn parse_vote(data: &[u8]) -> Result<DisplayVoteState, ParseAccountError> {
     let votes = vote_state
         .votes
         .iter()
-        .map(|lockout| DisplayLockout {
+        .map(|lockout| RpcLockout {
             slot: lockout.slot,
             confirmation_count: lockout.confirmation_count,
         })
@@ -27,7 +27,7 @@ pub fn parse_vote(data: &[u8]) -> Result<DisplayVoteState, ParseAccountError> {
     let authorized_voters = vote_state
         .authorized_voters()
         .iter()
-        .map(|(epoch, authorized_voter)| DisplayAuthorizedVoters {
+        .map(|(epoch, authorized_voter)| RpcAuthorizedVoters {
             epoch: *epoch,
             authorized_voter: authorized_voter.to_string(),
         })
@@ -38,16 +38,14 @@ pub fn parse_vote(data: &[u8]) -> Result<DisplayVoteState, ParseAccountError> {
         .iter()
         .filter(|(pubkey, _, _)| pubkey != &Pubkey::default())
         .map(
-            |(authorized_pubkey, epoch_of_last_authorized_switch, target_epoch)| {
-                DisplayPriorVoters {
-                    authorized_pubkey: authorized_pubkey.to_string(),
-                    epoch_of_last_authorized_switch: *epoch_of_last_authorized_switch,
-                    target_epoch: *target_epoch,
-                }
+            |(authorized_pubkey, epoch_of_last_authorized_switch, target_epoch)| RpcPriorVoters {
+                authorized_pubkey: authorized_pubkey.to_string(),
+                epoch_of_last_authorized_switch: *epoch_of_last_authorized_switch,
+                target_epoch: *target_epoch,
             },
         )
         .collect();
-    Ok(DisplayVoteState {
+    Ok(RpcVoteState {
         node_pubkey: vote_state.node_pubkey.to_string(),
         authorized_withdrawer: vote_state.authorized_withdrawer.to_string(),
         commission: vote_state.commission,
@@ -63,26 +61,26 @@ pub fn parse_vote(data: &[u8]) -> Result<DisplayVoteState, ParseAccountError> {
 /// A duplicate representation of VoteState for pretty JSON serialization
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DisplayVoteState {
+pub struct RpcVoteState {
     node_pubkey: String,
     authorized_withdrawer: String,
     commission: u8,
-    votes: Vec<DisplayLockout>,
+    votes: Vec<RpcLockout>,
     root_slot: Option<Slot>,
-    authorized_voters: Vec<DisplayAuthorizedVoters>,
-    prior_voters: Vec<DisplayPriorVoters>,
-    epoch_credits: Vec<DisplayEpochCredits>,
+    authorized_voters: Vec<RpcAuthorizedVoters>,
+    prior_voters: Vec<RpcPriorVoters>,
+    epoch_credits: Vec<RpcEpochCredits>,
     last_timestamp: BlockTimestamp,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct DisplayLockout {
+struct RpcLockout {
     slot: Slot,
     confirmation_count: u32,
 }
 
-impl From<&Lockout> for DisplayLockout {
+impl From<&Lockout> for RpcLockout {
     fn from(lockout: &Lockout) -> Self {
         Self {
             slot: lockout.slot,
@@ -93,14 +91,14 @@ impl From<&Lockout> for DisplayLockout {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct DisplayAuthorizedVoters {
+struct RpcAuthorizedVoters {
     epoch: Epoch,
     authorized_voter: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct DisplayPriorVoters {
+struct RpcPriorVoters {
     authorized_pubkey: String,
     epoch_of_last_authorized_switch: Epoch,
     target_epoch: Epoch,
@@ -108,7 +106,7 @@ struct DisplayPriorVoters {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct DisplayEpochCredits {
+struct RpcEpochCredits {
     epoch: Epoch,
     credits: u64,
     previous_credits: u64,

--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -1,0 +1,113 @@
+use crate::parse_account_data::ParseAccountError;
+use solana_sdk::{
+    clock::{Epoch, Slot},
+    pubkey::Pubkey,
+};
+use solana_vote_program::vote_state::{BlockTimestamp, Lockout, VoteState};
+
+pub fn parse_vote(data: &[u8]) -> Result<RpcVoteState, ParseAccountError> {
+    let mut vote_state = VoteState::deserialize(data).map_err(ParseAccountError::from)?;
+    let epoch_credits = vote_state
+        .epoch_credits()
+        .iter()
+        .map(|(epoch, credits, previous_credits)| RpcEpochCredits {
+            epoch: *epoch,
+            credits: *credits,
+            previous_credits: *previous_credits,
+        })
+        .collect();
+    let votes = vote_state
+        .votes
+        .iter()
+        .map(|lockout| RpcLockout {
+            slot: lockout.slot,
+            confirmation_count: lockout.confirmation_count,
+        })
+        .collect();
+    let authorized_voters = vote_state
+        .authorized_voters()
+        .iter()
+        .map(|(epoch, authorized_voter)| RpcAuthorizedVoters {
+            epoch: *epoch,
+            authorized_voter: authorized_voter.to_string(),
+        })
+        .collect();
+    let prior_voters = vote_state
+        .prior_voters()
+        .buf()
+        .iter()
+        .filter(|(pubkey, _, _)| pubkey != &Pubkey::default())
+        .map(
+            |(authorized_pubkey, epoch_of_last_authorized_switch, target_epoch)| RpcPriorVoters {
+                authorized_pubkey: authorized_pubkey.to_string(),
+                epoch_of_last_authorized_switch: *epoch_of_last_authorized_switch,
+                target_epoch: *target_epoch,
+            },
+        )
+        .collect();
+    Ok(RpcVoteState {
+        node_pubkey: vote_state.node_pubkey.to_string(),
+        authorized_withdrawer: vote_state.authorized_withdrawer.to_string(),
+        commission: vote_state.commission,
+        votes,
+        root_slot: vote_state.root_slot,
+        authorized_voters,
+        prior_voters,
+        epoch_credits,
+        last_timestamp: vote_state.last_timestamp,
+    })
+}
+
+/// A duplicate representation of VoteState for pretty JSON serialization
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcVoteState {
+    node_pubkey: String,
+    authorized_withdrawer: String,
+    commission: u8,
+    votes: Vec<RpcLockout>,
+    root_slot: Option<Slot>,
+    authorized_voters: Vec<RpcAuthorizedVoters>,
+    prior_voters: Vec<RpcPriorVoters>,
+    epoch_credits: Vec<RpcEpochCredits>,
+    last_timestamp: BlockTimestamp,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RpcLockout {
+    slot: Slot,
+    confirmation_count: u32,
+}
+
+impl From<&Lockout> for RpcLockout {
+    fn from(lockout: &Lockout) -> Self {
+        Self {
+            slot: lockout.slot,
+            confirmation_count: lockout.confirmation_count,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RpcAuthorizedVoters {
+    epoch: Epoch,
+    authorized_voter: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RpcPriorVoters {
+    authorized_pubkey: String,
+    epoch_of_last_authorized_switch: Epoch,
+    target_epoch: Epoch,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RpcEpochCredits {
+    epoch: Epoch,
+    credits: u64,
+    previous_credits: u64,
+}

--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -5,12 +5,12 @@ use solana_sdk::{
 };
 use solana_vote_program::vote_state::{BlockTimestamp, Lockout, VoteState};
 
-pub fn parse_vote(data: &[u8]) -> Result<RpcVoteState, ParseAccountError> {
+pub fn parse_vote(data: &[u8]) -> Result<UiVoteState, ParseAccountError> {
     let mut vote_state = VoteState::deserialize(data).map_err(ParseAccountError::from)?;
     let epoch_credits = vote_state
         .epoch_credits()
         .iter()
-        .map(|(epoch, credits, previous_credits)| RpcEpochCredits {
+        .map(|(epoch, credits, previous_credits)| UiEpochCredits {
             epoch: *epoch,
             credits: *credits,
             previous_credits: *previous_credits,
@@ -19,7 +19,7 @@ pub fn parse_vote(data: &[u8]) -> Result<RpcVoteState, ParseAccountError> {
     let votes = vote_state
         .votes
         .iter()
-        .map(|lockout| RpcLockout {
+        .map(|lockout| UiLockout {
             slot: lockout.slot,
             confirmation_count: lockout.confirmation_count,
         })
@@ -27,7 +27,7 @@ pub fn parse_vote(data: &[u8]) -> Result<RpcVoteState, ParseAccountError> {
     let authorized_voters = vote_state
         .authorized_voters()
         .iter()
-        .map(|(epoch, authorized_voter)| RpcAuthorizedVoters {
+        .map(|(epoch, authorized_voter)| UiAuthorizedVoters {
             epoch: *epoch,
             authorized_voter: authorized_voter.to_string(),
         })
@@ -38,14 +38,14 @@ pub fn parse_vote(data: &[u8]) -> Result<RpcVoteState, ParseAccountError> {
         .iter()
         .filter(|(pubkey, _, _)| pubkey != &Pubkey::default())
         .map(
-            |(authorized_pubkey, epoch_of_last_authorized_switch, target_epoch)| RpcPriorVoters {
+            |(authorized_pubkey, epoch_of_last_authorized_switch, target_epoch)| UiPriorVoters {
                 authorized_pubkey: authorized_pubkey.to_string(),
                 epoch_of_last_authorized_switch: *epoch_of_last_authorized_switch,
                 target_epoch: *target_epoch,
             },
         )
         .collect();
-    Ok(RpcVoteState {
+    Ok(UiVoteState {
         node_pubkey: vote_state.node_pubkey.to_string(),
         authorized_withdrawer: vote_state.authorized_withdrawer.to_string(),
         commission: vote_state.commission,
@@ -61,26 +61,26 @@ pub fn parse_vote(data: &[u8]) -> Result<RpcVoteState, ParseAccountError> {
 /// A duplicate representation of VoteState for pretty JSON serialization
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcVoteState {
+pub struct UiVoteState {
     node_pubkey: String,
     authorized_withdrawer: String,
     commission: u8,
-    votes: Vec<RpcLockout>,
+    votes: Vec<UiLockout>,
     root_slot: Option<Slot>,
-    authorized_voters: Vec<RpcAuthorizedVoters>,
-    prior_voters: Vec<RpcPriorVoters>,
-    epoch_credits: Vec<RpcEpochCredits>,
+    authorized_voters: Vec<UiAuthorizedVoters>,
+    prior_voters: Vec<UiPriorVoters>,
+    epoch_credits: Vec<UiEpochCredits>,
     last_timestamp: BlockTimestamp,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct RpcLockout {
+struct UiLockout {
     slot: Slot,
     confirmation_count: u32,
 }
 
-impl From<&Lockout> for RpcLockout {
+impl From<&Lockout> for UiLockout {
     fn from(lockout: &Lockout) -> Self {
         Self {
             slot: lockout.slot,
@@ -91,14 +91,14 @@ impl From<&Lockout> for RpcLockout {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct RpcAuthorizedVoters {
+struct UiAuthorizedVoters {
     epoch: Epoch,
     authorized_voter: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct RpcPriorVoters {
+struct UiPriorVoters {
     authorized_pubkey: String,
     epoch_of_last_authorized_switch: Epoch,
     target_epoch: Epoch,
@@ -106,7 +106,7 @@ struct RpcPriorVoters {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct RpcEpochCredits {
+struct UiEpochCredits {
     epoch: Epoch,
     credits: u64,
     previous_credits: u64,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "0.10.6", default-features = false, features = ["blocking"
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.54"
+solana-account-decoder = { path = "../account-decoder", version = "1.3.0" }
 solana-budget-program = { path = "../programs/budget", version = "1.3.0" }
 solana-clap-utils = { path = "../clap-utils", version = "1.3.0" }
 solana-cli-config = { path = "../cli-config", version = "1.3.0" }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -15,7 +15,7 @@ use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use log::*;
 use num_traits::FromPrimitive;
 use serde_json::{self, json, Value};
-use solana_account_decoder::{AccountEncoding, EncodedAccount};
+use solana_account_decoder::{UiAccount, UiAccountEncoding};
 use solana_budget_program::budget_instruction::{self, BudgetError};
 use solana_clap_utils::{
     commitment::commitment_arg_with_default, input_parsers::*, input_validators::*,
@@ -1226,7 +1226,7 @@ fn process_show_account(
     let cli_account = CliAccount {
         keyed_account: RpcKeyedAccount {
             pubkey: account_pubkey.to_string(),
-            account: EncodedAccount::encode(account, AccountEncoding::Binary),
+            account: UiAccount::encode(account, UiAccountEncoding::Binary),
         },
         use_lamports_unit,
     };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -15,6 +15,7 @@ use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use log::*;
 use num_traits::FromPrimitive;
 use serde_json::{self, json, Value};
+use solana_account_decoder::{AccountEncoding, RpcAccount};
 use solana_budget_program::budget_instruction::{self, BudgetError};
 use solana_clap_utils::{
     commitment::commitment_arg_with_default, input_parsers::*, input_validators::*,
@@ -24,7 +25,7 @@ use solana_client::{
     client_error::{ClientError, ClientErrorKind, Result as ClientResult},
     rpc_client::RpcClient,
     rpc_config::{RpcLargestAccountsFilter, RpcSendTransactionConfig},
-    rpc_response::{RpcAccount, RpcKeyedAccount},
+    rpc_response::RpcKeyedAccount,
 };
 #[cfg(not(test))]
 use solana_faucet::faucet::request_airdrop_transaction;
@@ -1225,7 +1226,7 @@ fn process_show_account(
     let cli_account = CliAccount {
         keyed_account: RpcKeyedAccount {
             pubkey: account_pubkey.to_string(),
-            account: RpcAccount::encode(account),
+            account: RpcAccount::encode(account, AccountEncoding::Binary),
         },
         use_lamports_unit,
     };

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -15,7 +15,7 @@ use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use log::*;
 use num_traits::FromPrimitive;
 use serde_json::{self, json, Value};
-use solana_account_decoder::{AccountEncoding, RpcAccount};
+use solana_account_decoder::{AccountEncoding, EncodedAccount};
 use solana_budget_program::budget_instruction::{self, BudgetError};
 use solana_clap_utils::{
     commitment::commitment_arg_with_default, input_parsers::*, input_validators::*,
@@ -1226,7 +1226,7 @@ fn process_show_account(
     let cli_account = CliAccount {
         keyed_account: RpcKeyedAccount {
             pubkey: account_pubkey.to_string(),
-            account: RpcAccount::encode(account, AccountEncoding::Binary),
+            account: EncodedAccount::encode(account, AccountEncoding::Binary),
         },
         use_lamports_unit,
     };

--- a/cli/src/offline/blockhash_query.rs
+++ b/cli/src/offline/blockhash_query.rs
@@ -111,9 +111,10 @@ mod tests {
     use crate::{nonce::nonce_arg, offline::blockhash_query::BlockhashQuery};
     use clap::App;
     use serde_json::{self, json, Value};
+    use solana_account_decoder::{AccountEncoding, RpcAccount};
     use solana_client::{
         rpc_request::RpcRequest,
-        rpc_response::{Response, RpcAccount, RpcFeeCalculator, RpcResponseContext},
+        rpc_response::{Response, RpcFeeCalculator, RpcResponseContext},
     };
     use solana_sdk::{
         account::Account, fee_calculator::FeeCalculator, hash::hash, nonce, system_program,
@@ -349,7 +350,7 @@ mod tests {
         )
         .unwrap();
         let nonce_pubkey = Pubkey::new(&[4u8; 32]);
-        let rpc_nonce_account = RpcAccount::encode(nonce_account);
+        let rpc_nonce_account = RpcAccount::encode(nonce_account, AccountEncoding::Binary);
         let get_account_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
             value: json!(Some(rpc_nonce_account)),

--- a/cli/src/offline/blockhash_query.rs
+++ b/cli/src/offline/blockhash_query.rs
@@ -111,7 +111,7 @@ mod tests {
     use crate::{nonce::nonce_arg, offline::blockhash_query::BlockhashQuery};
     use clap::App;
     use serde_json::{self, json, Value};
-    use solana_account_decoder::{AccountEncoding, EncodedAccount};
+    use solana_account_decoder::{UiAccount, UiAccountEncoding};
     use solana_client::{
         rpc_request::RpcRequest,
         rpc_response::{Response, RpcFeeCalculator, RpcResponseContext},
@@ -350,7 +350,7 @@ mod tests {
         )
         .unwrap();
         let nonce_pubkey = Pubkey::new(&[4u8; 32]);
-        let rpc_nonce_account = EncodedAccount::encode(nonce_account, AccountEncoding::Binary);
+        let rpc_nonce_account = UiAccount::encode(nonce_account, UiAccountEncoding::Binary);
         let get_account_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
             value: json!(Some(rpc_nonce_account)),

--- a/cli/src/offline/blockhash_query.rs
+++ b/cli/src/offline/blockhash_query.rs
@@ -111,7 +111,7 @@ mod tests {
     use crate::{nonce::nonce_arg, offline::blockhash_query::BlockhashQuery};
     use clap::App;
     use serde_json::{self, json, Value};
-    use solana_account_decoder::{AccountEncoding, RpcAccount};
+    use solana_account_decoder::{AccountEncoding, EncodedAccount};
     use solana_client::{
         rpc_request::RpcRequest,
         rpc_response::{Response, RpcFeeCalculator, RpcResponseContext},
@@ -350,7 +350,7 @@ mod tests {
         )
         .unwrap();
         let nonce_pubkey = Pubkey::new(&[4u8; 32]);
-        let rpc_nonce_account = RpcAccount::encode(nonce_account, AccountEncoding::Binary);
+        let rpc_nonce_account = EncodedAccount::encode(nonce_account, AccountEncoding::Binary);
         let get_account_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
             value: json!(Some(rpc_nonce_account)),

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,9 +19,10 @@ reqwest = { version = "0.10.6", default-features = false, features = ["blocking"
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.54"
-solana-transaction-status = { path = "../transaction-status", version = "1.3.0" }
+solana-account-decoder = { path = "../account-decoder", version = "1.3.0" }
 solana-net-utils = { path = "../net-utils", version = "1.3.0" }
 solana-sdk = { path = "../sdk", version = "1.3.0" }
+solana-transaction-status = { path = "../transaction-status", version = "1.3.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
 thiserror = "1.0"
 tungstenite = "0.10.1"

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -11,7 +11,7 @@ use bincode::serialize;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
 use serde_json::{json, Value};
-use solana_account_decoder::RpcAccount;
+use solana_account_decoder::EncodedAccount;
 use solana_sdk::{
     account::Account,
     clock::{
@@ -441,7 +441,7 @@ impl RpcClient {
                 let Response {
                     context,
                     value: rpc_account,
-                } = serde_json::from_value::<Response<Option<RpcAccount>>>(result_json)?;
+                } = serde_json::from_value::<Response<Option<EncodedAccount>>>(result_json)?;
                 trace!("Response account {:?} {:?}", pubkey, rpc_account);
                 let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
                 Ok(Response {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -11,6 +11,7 @@ use bincode::serialize;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
 use serde_json::{json, Value};
+use solana_account_decoder::RpcAccount;
 use solana_sdk::{
     account::Account,
     clock::{
@@ -442,7 +443,7 @@ impl RpcClient {
                     value: rpc_account,
                 } = serde_json::from_value::<Response<Option<RpcAccount>>>(result_json)?;
                 trace!("Response account {:?} {:?}", pubkey, rpc_account);
-                let account = rpc_account.and_then(|rpc_account| rpc_account.decode().ok());
+                let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
                 Ok(Response {
                     context,
                     value: account,

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -11,7 +11,7 @@ use bincode::serialize;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
 use serde_json::{json, Value};
-use solana_account_decoder::EncodedAccount;
+use solana_account_decoder::UiAccount;
 use solana_sdk::{
     account::Account,
     clock::{
@@ -441,7 +441,7 @@ impl RpcClient {
                 let Response {
                     context,
                     value: rpc_account,
-                } = serde_json::from_value::<Response<Option<EncodedAccount>>>(result_json)?;
+                } = serde_json::from_value::<Response<Option<UiAccount>>>(result_json)?;
                 trace!("Response account {:?} {:?}", pubkey, rpc_account);
                 let account = rpc_account.and_then(|rpc_account| rpc_account.decode());
                 Ok(Response {

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -1,4 +1,4 @@
-use solana_account_decoder::AccountEncoding;
+use solana_account_decoder::UiAccountEncoding;
 use solana_sdk::{clock::Epoch, commitment_config::CommitmentConfig};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -45,7 +45,7 @@ pub struct RpcInflationConfig {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcAccountInfoConfig {
-    pub encoding: Option<AccountEncoding>,
+    pub encoding: Option<UiAccountEncoding>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
 }

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -1,3 +1,4 @@
+use solana_account_decoder::AccountEncoding;
 use solana_sdk::{clock::Epoch, commitment_config::CommitmentConfig};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -37,6 +38,14 @@ pub struct RpcLargestAccountsConfig {
 #[serde(rename_all = "camelCase")]
 pub struct RpcInflationConfig {
     pub epoch: Option<Epoch>,
+    #[serde(flatten)]
+    pub commitment: Option<CommitmentConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcAccountInfoConfig {
+    pub encoding: Option<AccountEncoding>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
 }

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -1,13 +1,12 @@
-use crate::{client_error, rpc_request::RpcError};
+use crate::client_error;
+use solana_account_decoder::RpcAccount;
 use solana_sdk::{
-    account::Account,
     clock::{Epoch, Slot},
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     inflation::Inflation,
-    pubkey::Pubkey,
     transaction::{Result, TransactionError},
 };
-use std::{collections::HashMap, net::SocketAddr, str::FromStr};
+use std::{collections::HashMap, net::SocketAddr};
 
 pub type RpcResult<T> = client_error::Result<Response<T>>;
 
@@ -98,43 +97,6 @@ pub struct RpcKeyedAccount {
 #[serde(rename_all = "camelCase")]
 pub struct RpcSignatureResult {
     pub err: Option<TransactionError>,
-}
-
-/// A duplicate representation of a Message for pretty JSON serialization
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcAccount {
-    pub lamports: u64,
-    pub data: String,
-    pub owner: String,
-    pub executable: bool,
-    pub rent_epoch: Epoch,
-}
-
-impl RpcAccount {
-    pub fn encode(account: Account) -> Self {
-        RpcAccount {
-            lamports: account.lamports,
-            data: bs58::encode(account.data.clone()).into_string(),
-            owner: account.owner.to_string(),
-            executable: account.executable,
-            rent_epoch: account.rent_epoch,
-        }
-    }
-
-    pub fn decode(&self) -> std::result::Result<Account, RpcError> {
-        Ok(Account {
-            lamports: self.lamports,
-            data: bs58::decode(self.data.clone()).into_vec().map_err(|_| {
-                RpcError::RpcRequestError("Could not parse encoded account data".to_string())
-            })?,
-            owner: Pubkey::from_str(&self.owner).map_err(|_| {
-                RpcError::RpcRequestError("Could not parse encoded account owner".to_string())
-            })?,
-            executable: self.executable,
-            rent_epoch: self.rent_epoch,
-        })
-    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -1,5 +1,5 @@
 use crate::client_error;
-use solana_account_decoder::EncodedAccount;
+use solana_account_decoder::UiAccount;
 use solana_sdk::{
     clock::{Epoch, Slot},
     fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -90,7 +90,7 @@ pub struct RpcInflationRate {
 #[serde(rename_all = "camelCase")]
 pub struct RpcKeyedAccount {
     pub pubkey: String,
-    pub account: EncodedAccount,
+    pub account: UiAccount,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -1,5 +1,5 @@
 use crate::client_error;
-use solana_account_decoder::RpcAccount;
+use solana_account_decoder::EncodedAccount;
 use solana_sdk::{
     clock::{Epoch, Slot},
     fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -90,7 +90,7 @@ pub struct RpcInflationRate {
 #[serde(rename_all = "camelCase")]
 pub struct RpcKeyedAccount {
     pub pubkey: String,
-    pub account: RpcAccount,
+    pub account: EncodedAccount,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,11 +42,11 @@ regex = "1.3.9"
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.54"
+solana-account-decoder = { path = "../account-decoder", version = "1.3.0" }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "1.3.0" }
 solana-budget-program = { path = "../programs/budget", version = "1.3.0" }
 solana-clap-utils = { path = "../clap-utils", version = "1.3.0" }
 solana-client = { path = "../client", version = "1.3.0" }
-solana-transaction-status = { path = "../transaction-status", version = "1.3.0" }
 solana-faucet = { path = "../faucet", version = "1.3.0" }
 solana-genesis-programs = { path = "../genesis-programs", version = "1.3.0" }
 solana-ledger = { path = "../ledger", version = "1.3.0" }
@@ -60,10 +60,11 @@ solana-runtime = { path = "../runtime", version = "1.3.0" }
 solana-sdk = { path = "../sdk", version = "1.3.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.3.0" }
 solana-streamer = { path = "../streamer", version = "1.3.0" }
+solana-sys-tuner = { path = "../sys-tuner", version = "1.3.0" }
+solana-transaction-status = { path = "../transaction-status", version = "1.3.0" }
 solana-version = { path = "../version", version = "1.3.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.3.0" }
-solana-sys-tuner = { path = "../sys-tuner", version = "1.3.0" }
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = "0.1"

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -8,7 +8,7 @@ use crate::{
 use bincode::serialize;
 use jsonrpc_core::{Error, Metadata, Result};
 use jsonrpc_derive::rpc;
-use solana_account_decoder::{AccountEncoding, RpcAccount};
+use solana_account_decoder::{AccountEncoding, EncodedAccount};
 use solana_client::{
     rpc_config::*,
     rpc_request::{
@@ -207,14 +207,14 @@ impl JsonRpcRequestProcessor {
         &self,
         pubkey: &Pubkey,
         config: Option<RpcAccountInfoConfig>,
-    ) -> Result<RpcResponse<Option<RpcAccount>>> {
+    ) -> Result<RpcResponse<Option<EncodedAccount>>> {
         let config = config.unwrap_or_default();
         let bank = self.bank(config.commitment)?;
         let encoding = config.encoding.unwrap_or(AccountEncoding::Binary);
         new_response(
             &bank,
             bank.get_account(pubkey)
-                .map(|account| RpcAccount::encode(account, encoding)),
+                .map(|account| EncodedAccount::encode(account, encoding)),
         )
     }
 
@@ -241,7 +241,7 @@ impl JsonRpcRequestProcessor {
             .into_iter()
             .map(|(pubkey, account)| RpcKeyedAccount {
                 pubkey: pubkey.to_string(),
-                account: RpcAccount::encode(account, encoding.clone()),
+                account: EncodedAccount::encode(account, encoding.clone()),
             })
             .collect())
     }
@@ -833,7 +833,7 @@ pub trait RpcSol {
         meta: Self::Metadata,
         pubkey_str: String,
         config: Option<RpcAccountInfoConfig>,
-    ) -> Result<RpcResponse<Option<RpcAccount>>>;
+    ) -> Result<RpcResponse<Option<EncodedAccount>>>;
 
     #[rpc(meta, name = "getProgramAccounts")]
     fn get_program_accounts(
@@ -1086,7 +1086,7 @@ impl RpcSol for RpcSolImpl {
         meta: Self::Metadata,
         pubkey_str: String,
         config: Option<RpcAccountInfoConfig>,
-    ) -> Result<RpcResponse<Option<RpcAccount>>> {
+    ) -> Result<RpcResponse<Option<EncodedAccount>>> {
         debug!("get_account_info rpc request received: {:?}", pubkey_str);
         let pubkey = verify_pubkey(pubkey_str)?;
         meta.get_account_info(&pubkey, config)

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -8,7 +8,7 @@ use crate::{
 use bincode::serialize;
 use jsonrpc_core::{Error, Metadata, Result};
 use jsonrpc_derive::rpc;
-use solana_account_decoder::{AccountEncoding, EncodedAccount};
+use solana_account_decoder::{UiAccount, UiAccountEncoding};
 use solana_client::{
     rpc_config::*,
     rpc_request::{
@@ -207,14 +207,14 @@ impl JsonRpcRequestProcessor {
         &self,
         pubkey: &Pubkey,
         config: Option<RpcAccountInfoConfig>,
-    ) -> Result<RpcResponse<Option<EncodedAccount>>> {
+    ) -> Result<RpcResponse<Option<UiAccount>>> {
         let config = config.unwrap_or_default();
         let bank = self.bank(config.commitment)?;
-        let encoding = config.encoding.unwrap_or(AccountEncoding::Binary);
+        let encoding = config.encoding.unwrap_or(UiAccountEncoding::Binary);
         new_response(
             &bank,
             bank.get_account(pubkey)
-                .map(|account| EncodedAccount::encode(account, encoding)),
+                .map(|account| UiAccount::encode(account, encoding)),
         )
     }
 
@@ -235,13 +235,13 @@ impl JsonRpcRequestProcessor {
     ) -> Result<Vec<RpcKeyedAccount>> {
         let config = config.unwrap_or_default();
         let bank = self.bank(config.commitment)?;
-        let encoding = config.encoding.unwrap_or(AccountEncoding::Binary);
+        let encoding = config.encoding.unwrap_or(UiAccountEncoding::Binary);
         Ok(bank
             .get_program_accounts(Some(&program_id))
             .into_iter()
             .map(|(pubkey, account)| RpcKeyedAccount {
                 pubkey: pubkey.to_string(),
-                account: EncodedAccount::encode(account, encoding.clone()),
+                account: UiAccount::encode(account, encoding.clone()),
             })
             .collect())
     }
@@ -833,7 +833,7 @@ pub trait RpcSol {
         meta: Self::Metadata,
         pubkey_str: String,
         config: Option<RpcAccountInfoConfig>,
-    ) -> Result<RpcResponse<Option<EncodedAccount>>>;
+    ) -> Result<RpcResponse<Option<UiAccount>>>;
 
     #[rpc(meta, name = "getProgramAccounts")]
     fn get_program_accounts(
@@ -1086,7 +1086,7 @@ impl RpcSol for RpcSolImpl {
         meta: Self::Metadata,
         pubkey_str: String,
         config: Option<RpcAccountInfoConfig>,
-    ) -> Result<RpcResponse<Option<EncodedAccount>>> {
+    ) -> Result<RpcResponse<Option<UiAccount>>> {
         debug!("get_account_info rpc request received: {:?}", pubkey_str);
         let pubkey = verify_pubkey(pubkey_str)?;
         meta.get_account_info(&pubkey, config)

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -4,7 +4,7 @@ use crate::rpc_subscriptions::{RpcSubscriptions, RpcVote, SlotInfo};
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::{typed::Subscriber, Session, SubscriptionId};
-use solana_account_decoder::EncodedAccount;
+use solana_account_decoder::UiAccount;
 use solana_client::rpc_response::{Response as RpcResponse, RpcKeyedAccount, RpcSignatureResult};
 #[cfg(test)]
 use solana_runtime::bank_forks::BankForks;
@@ -36,7 +36,7 @@ pub trait RpcSolPubSub {
     fn account_subscribe(
         &self,
         meta: Self::Metadata,
-        subscriber: Subscriber<RpcResponse<EncodedAccount>>,
+        subscriber: Subscriber<RpcResponse<UiAccount>>,
         pubkey_str: String,
         commitment: Option<CommitmentConfig>,
     );
@@ -171,7 +171,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
     fn account_subscribe(
         &self,
         _meta: Self::Metadata,
-        subscriber: Subscriber<RpcResponse<EncodedAccount>>,
+        subscriber: Subscriber<RpcResponse<UiAccount>>,
         pubkey_str: String,
         commitment: Option<CommitmentConfig>,
     ) {

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -4,7 +4,7 @@ use crate::rpc_subscriptions::{RpcSubscriptions, RpcVote, SlotInfo};
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::{typed::Subscriber, Session, SubscriptionId};
-use solana_account_decoder::RpcAccount;
+use solana_account_decoder::EncodedAccount;
 use solana_client::rpc_response::{Response as RpcResponse, RpcKeyedAccount, RpcSignatureResult};
 #[cfg(test)]
 use solana_runtime::bank_forks::BankForks;
@@ -36,7 +36,7 @@ pub trait RpcSolPubSub {
     fn account_subscribe(
         &self,
         meta: Self::Metadata,
-        subscriber: Subscriber<RpcResponse<RpcAccount>>,
+        subscriber: Subscriber<RpcResponse<EncodedAccount>>,
         pubkey_str: String,
         commitment: Option<CommitmentConfig>,
     );
@@ -171,7 +171,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
     fn account_subscribe(
         &self,
         _meta: Self::Metadata,
-        subscriber: Subscriber<RpcResponse<RpcAccount>>,
+        subscriber: Subscriber<RpcResponse<EncodedAccount>>,
         pubkey_str: String,
         commitment: Option<CommitmentConfig>,
     ) {

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -4,9 +4,8 @@ use crate::rpc_subscriptions::{RpcSubscriptions, RpcVote, SlotInfo};
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use jsonrpc_pubsub::{typed::Subscriber, Session, SubscriptionId};
-use solana_client::rpc_response::{
-    Response as RpcResponse, RpcAccount, RpcKeyedAccount, RpcSignatureResult,
-};
+use solana_account_decoder::RpcAccount;
+use solana_client::rpc_response::{Response as RpcResponse, RpcKeyedAccount, RpcSignatureResult};
 #[cfg(test)]
 use solana_runtime::bank_forks::BankForks;
 use solana_sdk::{

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -7,8 +7,9 @@ use jsonrpc_pubsub::{
     SubscriptionId,
 };
 use serde::Serialize;
+use solana_account_decoder::{AccountEncoding, RpcAccount};
 use solana_client::rpc_response::{
-    Response, RpcAccount, RpcKeyedAccount, RpcResponseContext, RpcSignatureResult,
+    Response, RpcKeyedAccount, RpcResponseContext, RpcSignatureResult,
 };
 use solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache};
 use solana_sdk::{
@@ -230,7 +231,13 @@ fn filter_account_result(
         // If fork < last_notified_slot this means that we last notified for a fork
         // and should notify that the account state has been reverted.
         if fork != last_notified_slot {
-            return (Box::new(iter::once(RpcAccount::encode(account))), fork);
+            return (
+                Box::new(iter::once(RpcAccount::encode(
+                    account,
+                    AccountEncoding::Binary,
+                ))),
+                fork,
+            );
         }
     }
     (Box::new(iter::empty()), last_notified_slot)
@@ -260,7 +267,7 @@ fn filter_program_results(
                 .into_iter()
                 .map(|(pubkey, account)| RpcKeyedAccount {
                     pubkey: pubkey.to_string(),
-                    account: RpcAccount::encode(account),
+                    account: RpcAccount::encode(account, AccountEncoding::Binary),
                 }),
         ),
         last_notified_slot,

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -7,9 +7,10 @@ use jsonrpc_core_client::transports::ws;
 use log::*;
 use reqwest::{self, header::CONTENT_TYPE};
 use serde_json::{json, Value};
+use solana_account_decoder::RpcAccount;
 use solana_client::{
     rpc_client::{get_rpc_request_str, RpcClient},
-    rpc_response::{Response, RpcAccount, RpcSignatureResult},
+    rpc_response::{Response, RpcSignatureResult},
 };
 use solana_core::contact_info::ContactInfo;
 use solana_core::{rpc_pubsub::gen_client::Client as PubsubClient, validator::TestValidator};

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -7,7 +7,7 @@ use jsonrpc_core_client::transports::ws;
 use log::*;
 use reqwest::{self, header::CONTENT_TYPE};
 use serde_json::{json, Value};
-use solana_account_decoder::EncodedAccount;
+use solana_account_decoder::UiAccount;
 use solana_client::{
     rpc_client::{get_rpc_request_str, RpcClient},
     rpc_response::{Response, RpcSignatureResult},
@@ -173,7 +173,7 @@ fn test_rpc_subscriptions() {
     // Track when subscriptions are ready
     let (ready_sender, ready_receiver) = channel::<()>();
     // Track account notifications are received
-    let (account_sender, account_receiver) = channel::<Response<EncodedAccount>>();
+    let (account_sender, account_receiver) = channel::<Response<UiAccount>>();
     // Track when status notifications are received
     let (status_sender, status_receiver) = channel::<(String, Response<RpcSignatureResult>)>();
 

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -7,7 +7,7 @@ use jsonrpc_core_client::transports::ws;
 use log::*;
 use reqwest::{self, header::CONTENT_TYPE};
 use serde_json::{json, Value};
-use solana_account_decoder::RpcAccount;
+use solana_account_decoder::EncodedAccount;
 use solana_client::{
     rpc_client::{get_rpc_request_str, RpcClient},
     rpc_response::{Response, RpcSignatureResult},
@@ -173,7 +173,7 @@ fn test_rpc_subscriptions() {
     // Track when subscriptions are ready
     let (ready_sender, ready_receiver) = channel::<()>();
     // Track account notifications are received
-    let (account_sender, account_receiver) = channel::<Response<RpcAccount>>();
+    let (account_sender, account_receiver) = channel::<Response<EncodedAccount>>();
     // Track when status notifications are received
     let (status_sender, status_receiver) = channel::<(String, Response<RpcSignatureResult>)>();
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -137,7 +137,11 @@ Returns all information associated with the account of provided Pubkey
 #### Parameters:
 
 * `<string>` - Pubkey of account to query, as base-58 encoded string
-* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+* `<object>` - (optional) Configuration object containing the following optional fields:
+  * (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  * (optional) `encoding: <string>` - encoding for Account data, either "binary" or json".
+    JSON encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
+    If parameter not provided, the default encoding is binary.
 
 #### Results:
 
@@ -147,7 +151,7 @@ The result will be an RpcResponse JSON object with `value` equal to:
 * `<object>` - otherwise, a JSON object containing:
   * `lamports: <u64>`, number of lamports assigned to this account, as a u64
   * `owner: <string>`, base-58 encoded Pubkey of the program this account has been assigned to
-  * `data: <string>`, base-58 encoded data associated with the account
+  * `data: <string|object>`, data associated with the account, either as base-58 encoded binary data or JSON format `{<program>: <state>}`, depending on encoding parameter
   * `executable: <bool>`, boolean indicating if the account contains a program \(and is strictly read-only\)
   * `rentEpoch`: <u64>, the epoch at which this account will next owe rent, as u64
 
@@ -155,10 +159,16 @@ The result will be an RpcResponse JSON object with `value` equal to:
 
 ```bash
 // Request
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getAccountInfo", "params":["2gVkYWexTHR5Hb2aLeQN3tnngvWzisFKXDUPrgMHpdST"]}' http://localhost:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getAccountInfo", "params":["4fYNw3dojWmQ4dXtSGE9epjRGy9pFSx62YypT7avPYvA"]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"executable":false,"owner":"4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM","lamports":1,"data":"Joig2k8Ax4JPMpWhXRyc2jMa7Wejz4X1xqVi3i7QRkmVj1ChUgNc4VNpGUQePJGBAui3c6886peU9GEbjsyeANN8JGStprwLbLwcw5wpPjuQQb9mwrjVmoDQBjj3MzZKgeHn6wmnQ5k8DBFuoCYKWWsJfH2gv9FvCzrN6K1CRcQZzF","rentEpoch":2}},"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"data":"11116bv5nS2h3y12kD1yUKeMZvGcKLSjQgX6BeV7u1FrjeJcKfsHRTPuR3oZ1EioKtYGiYxpxMG5vpbZLsbcBYBEmZZcMKaSoGx9JZeAuWf","executable":false,"lamports":1000000000,"owner":"11111111111111111111111111111111","rentEpoch":2}},"id":1}
+
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getAccountInfo", "params":["4fYNw3dojWmQ4dXtSGE9epjRGy9pFSx62YypT7avPYvA",{"encoding":"json"}]}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":{"data":{"nonce":{"initialized":{"authority":"Bbqg1M4YVVfbhEzwA9SpC9FhsaG83YMTYoR4a8oTDLX","blockhash":"3xLP3jK6dVJwpeGeTDYTwdDK3TKchUf1gYYGHa4sF3XJ","feeCalculator":{"lamportsPerSignature":5000}}}},"executable":false,"lamports":1000000000,"owner":"11111111111111111111111111111111","rentEpoch":2}},"id":1}
 ```
 
 ### getBalance
@@ -779,7 +789,11 @@ Returns all accounts owned by the provided program Pubkey
 #### Parameters:
 
 * `<string>` - Pubkey of program, as base-58 encoded string
-* `<object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+* `<object>` - (optional) Configuration object containing the following optional fields:
+  * (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  * (optional) `encoding: <string>` - encoding for Account data, either "binary" or json".
+    JSON encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
+    If parameter not provided, the default encoding is binary.
 
 #### Results:
 
@@ -789,7 +803,7 @@ The result field will be an array of JSON objects, which will contain:
 * `account: <object>` - a JSON object, with the following sub fields:
    * `lamports: <u64>`, number of lamports assigned to this account, as a u64
    * `owner: <string>`, base-58 encoded Pubkey of the program this account has been assigned to
-   * `data: <string>`, base-58 encoded data associated with the account
+   `data: <string|object>`, data associated with the account, either as base-58 encoded binary data or JSON format `{<program>: <state>}`, depending on encoding parameter
    * `executable: <bool>`, boolean indicating if the account contains a program \(and is strictly read-only\)
    * `rentEpoch`: <u64>, the epoch at which this account will next owe rent, as u64
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -139,9 +139,8 @@ Returns all information associated with the account of provided Pubkey
 * `<string>` - Pubkey of account to query, as base-58 encoded string
 * `<object>` - (optional) Configuration object containing the following optional fields:
   * (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
-  * (optional) `encoding: <string>` - encoding for Account data, either "binary" or json".
-    JSON encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
-    If parameter not provided, the default encoding is binary.
+  * (optional) `encoding: <string>` - encoding for Account data, either "binary" or jsonParsed". If parameter not provided, the default encoding is binary.
+    Parsed-JSON encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data. If parsed-JSON is requested but a parser cannot be found, the field falls back to binary encoding, detectable when the `data` field is type `<string>`.
 
 #### Results:
 
@@ -289,9 +288,8 @@ Returns identity and transaction information about a confirmed block in the ledg
 #### Parameters:
 
 * `<u64>` - slot, as u64 integer
-* `<string>` - (optional) encoding for each returned Transaction, either "json", "jsonParsed", or "binary".
-  Parsed-JSON encoding attempts to use program-specific instruction parsers to return more human-readable and explicit program data.
-  If parameter not provided, the default encoding is JSON.
+* `<string>` - (optional) encoding for each returned Transaction, either "json", "jsonParsed", or "binary". If parameter not provided, the default encoding is JSON.
+  Parsed-JSON encoding attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If parsed-JSON is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
 
 #### Results:
 
@@ -410,9 +408,8 @@ Returns transaction details for a confirmed transaction
 #### Parameters:
 
 * `<string>` - transaction signature as base-58 encoded string
-* `<string>` - (optional) encoding for the returned Transaction, either "json", "jsonParsed", or "binary".
-  Parsed-JSON encoding attempts to use program-specific instruction parsers to return more human-readable and explicit program data.
-  If parameter not provided, the default encoding is JSON.
+* `<string>` - (optional) encoding for the returned Transaction, either "json", "jsonParsed", or "binary". If parameter not provided, the default encoding is JSON.
+  Parsed-JSON encoding attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If parsed-JSON is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
 
 #### Results:
 
@@ -791,9 +788,8 @@ Returns all accounts owned by the provided program Pubkey
 * `<string>` - Pubkey of program, as base-58 encoded string
 * `<object>` - (optional) Configuration object containing the following optional fields:
   * (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
-  * (optional) `encoding: <string>` - encoding for Account data, either "binary" or json".
-    JSON encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data.
-    If parameter not provided, the default encoding is binary.
+  * (optional) `encoding: <string>` - encoding for Account data, either "binary" or jsonParsed". If parameter not provided, the default encoding is binary.
+    Parsed-JSON encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data. If parsed-JSON is requested but a parser cannot be found, the field falls back to binary encoding, detectable when the `data` field is type `<string>`.
 
 #### Results:
 

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -14,6 +14,8 @@ bs58 = "0.3.1"
 Inflector = "0.11.4"
 lazy_static = "1.4.0"
 solana-sdk = { path = "../sdk", version = "1.3.0" }
+solana-stake-program = { path = "../programs/stake", version = "1.3.0" }
+solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
 spl-memo = "1.0.0"
 serde = "1.0.112"
 serde_derive = "1.0.103"

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -23,7 +23,7 @@ pub enum RpcInstruction {
     Parsed(Value),
 }
 
-/// A duplicate representation of a Message for pretty JSON serialization
+/// A duplicate representation of a CompiledInstruction for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcCompiledInstruction {

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -8,7 +8,7 @@ use std::{
 
 lazy_static! {
     static ref MEMO_PROGRAM_ID: Pubkey = Pubkey::from_str(&spl_memo::id().to_string()).unwrap();
-    pub static ref PARSABLE_PROGRAM_IDS: HashMap<Pubkey, ParsableProgram> = {
+    static ref PARSABLE_PROGRAM_IDS: HashMap<Pubkey, ParsableProgram> = {
         let mut m = HashMap::new();
         m.insert(*MEMO_PROGRAM_ID, ParsableProgram::SplMemo);
         m
@@ -17,7 +17,7 @@ lazy_static! {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum ParsableProgram {
+enum ParsableProgram {
     SplMemo,
 }
 


### PR DESCRIPTION
#### Problem
Currently, inspecting an on-chain account requires depending on a client-side, language-specific decoding library to parse the account data. If rpc methods could return decoded account data, these custom solutions would be unnecessary.

#### Summary of Changes
- Add account-decoder crate to handle parsing and beautifying accounts owned by a select set of programs.
  There are a lot of similarities between what this crate does and what `solana-transaction-status`. Combining and renaming should be considered in the future.
- Implement account decoding for vote and system (nonce) accounts and return via `getAccountInfo` and `getProgramAccounts` rpcs.
  Currently, client behavior remains the same; deduplication in rpc_client/cli/web3.js = follow-up work.

Toward #10475 
Remaining work on that issue is parsing SPL Token accounts, which is blocked on publishing spl-token to crates.io.
