### PR TITLE
Consistently create temp dirs under ledger/farf

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1256,7 +1256,7 @@ fn main() {
                     bank.clean_accounts();
                     bank.update_accounts_hash();
 
-                    let temp_dir = tempfile::TempDir::new().unwrap_or_else(|err| {
+                    let temp_dir = tempfile::tempdir_in(ledger_path).unwrap_or_else(|err| {
                         eprintln!("Unable to create temporary directory: {}", err);
                         exit(1);
                     });

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2700,7 +2700,7 @@ pub fn create_new_ledger(
     // ensure the genesis archive can be unpacked and it is under
     // max_genesis_archive_unpacked_size, immediately after creating it above.
     {
-        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_dir = tempfile::tempdir_in(ledger_path).unwrap();
         // unpack into a temp dir, while completely discarding the unpacked files
         let unpack_check = unpack_genesis_archive(
             &archive_path,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -173,6 +173,7 @@ impl LocalCluster {
             leader_node.info.rpc.port(),
             leader_node.info.rpc_pubsub.port(),
         ));
+        leader_config.account_paths = vec![leader_ledger_path.join("accounts")];
         let leader_server = Validator::new(
             leader_node,
             &leader_keypair,
@@ -300,6 +301,7 @@ impl LocalCluster {
             validator_node.info.rpc_pubsub.port(),
         ));
         let voting_keypair = Arc::new(voting_keypair);
+        config.account_paths = vec![ledger_path.join("accounts")];
         let validator_server = Validator::new(
             validator_node,
             &validator_keypair,
@@ -558,7 +560,8 @@ impl Cluster for LocalCluster {
 
         // Restart the node
         let validator_info = &cluster_validator_info.info;
-
+        cluster_validator_info.config.account_paths =
+            vec![validator_info.ledger_path.join("accounts")];
         let restarted_node = Validator::new(
             node,
             &validator_info.keypair,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1182,9 +1182,15 @@ fn wait_for_next_snapshot(
     }
 }
 
+fn farf_dir() -> PathBuf {
+    std::env::var("FARF_DIR")
+        .unwrap_or_else(|_| "farf".to_string())
+        .into()
+}
+
 fn generate_account_paths(num_account_paths: usize) -> (Vec<TempDir>, Vec<PathBuf>) {
     let account_storage_dirs: Vec<TempDir> = (0..num_account_paths)
-        .map(|_| TempDir::new().unwrap())
+        .map(|_| tempfile::tempdir_in(farf_dir()).unwrap())
         .collect();
     let account_storage_paths: Vec<_> = account_storage_dirs
         .iter()
@@ -1205,8 +1211,8 @@ fn setup_snapshot_validator_config(
     num_account_paths: usize,
 ) -> SnapshotValidatorConfig {
     // Create the snapshot config
-    let snapshot_dir = TempDir::new().unwrap();
-    let snapshot_output_path = TempDir::new().unwrap();
+    let snapshot_dir = tempfile::tempdir_in(farf_dir()).unwrap();
+    let snapshot_output_path = tempfile::tempdir_in(farf_dir()).unwrap();
     let snapshot_config = SnapshotConfig {
         snapshot_interval_slots,
         snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -222,7 +222,7 @@ pub fn archive_snapshot_package(snapshot_package: &AccountsPackage) -> Result<()
     fs::create_dir_all(tar_dir)?;
 
     // Create the staging directories
-    let staging_dir = TempDir::new()?;
+    let staging_dir = tempfile::tempdir_in(tar_dir)?;
     let staging_accounts_dir = staging_dir.path().join(TAR_ACCOUNTS_DIR);
     let staging_snapshots_dir = staging_dir.path().join(TAR_SNAPSHOTS_DIR);
     let staging_version_file = staging_dir.path().join(TAR_VERSION_FILE);


### PR DESCRIPTION
#### Problem

Sometimes temp dirs are created under `/tmp` (the tempfile crate's default) or not. This is confusing:

```bash
$ git grep tempdir_in origin/master 
origin/master:core/src/snapshot_packager_service.rs:        let link_snapshots_dir = tempfile::tempdir_in(&temp_dir).unwrap();
origin/master:runtime/src/snapshot_utils.rs:    let snapshot_hard_links_dir = tempfile::tempdir_in(snapshot_path)?;
origin/master:runtime/src/snapshot_utils.rs:    let unpack_dir = tempfile::tempdir_in(snapshot_path)?;
$ git grep TempDir::new origin/master 
origin/master:core/src/accounts_hash_verifier.rs:            let snapshot_links = TempDir::new().unwrap();
origin/master:core/src/snapshot_packager_service.rs:        create_and_verify_snapshot(TempDir::new().unwrap().path())
origin/master:core/tests/bank_forks.rs:            let accounts_dir = TempDir::new().unwrap();
origin/master:core/tests/bank_forks.rs:            let snapshot_dir = TempDir::new().unwrap();
origin/master:core/tests/bank_forks.rs:            let snapshot_output_path = TempDir::new().unwrap();
origin/master:core/tests/bank_forks.rs:        let saved_snapshots_dir = TempDir::new().unwrap();
origin/master:core/tests/bank_forks.rs:        let saved_accounts_dir = TempDir::new().unwrap();
origin/master:install/src/command.rs:    let temp_dir = TempDir::new(clap::crate_name!())?;
origin/master:ledger-tool/src/main.rs:                    let temp_dir = tempfile::TempDir::new().unwrap_or_else(|err| {
origin/master:ledger/src/blockstore.rs:        let temp_dir = tempfile::TempDir::new().unwrap();
origin/master:local-cluster/tests/local_cluster.rs:        .map(|_| TempDir::new().unwrap())
origin/master:local-cluster/tests/local_cluster.rs:    let snapshot_dir = TempDir::new().unwrap();
origin/master:local-cluster/tests/local_cluster.rs:    let snapshot_output_path = TempDir::new().unwrap();
origin/master:runtime/src/accounts_db.rs:    let temp_dirs: IOResult<Vec<TempDir>> = (0..count).map(|_| TempDir::new()).collect();
origin/master:runtime/src/hardened_unpack.rs:        let temp_dir = tempfile::TempDir::new().unwrap();
origin/master:runtime/src/serde_snapshot/tests.rs:    let copied_accounts = TempDir::new().unwrap();
origin/master:runtime/src/serde_snapshot/tests.rs:    let copied_accounts = TempDir::new().unwrap();
origin/master:runtime/src/serde_snapshot/tests.rs:    let copied_accounts = TempDir::new().unwrap();
origin/master:runtime/src/snapshot_utils.rs:    let staging_dir = TempDir::new()?;
origin/master:runtime/src/snapshot_utils.rs:    let temp_dir = tempfile::TempDir::new().unwrap();
origin/master:runtime/src/snapshot_utils.rs:        let temp_dir = tempfile::TempDir::new().unwrap();
origin/master:runtime/src/snapshot_utils.rs:        let temp_dir = tempfile::TempDir::new().unwrap();
origin/master:runtime/src/snapshot_utils.rs:        let temp_dir = tempfile::TempDir::new().unwrap();
origin/master:runtime/src/snapshot_utils.rs:        let temp_dir = tempfile::TempDir::new().unwrap();
origin/master:runtime/src/snapshot_utils.rs:        let temp_dir = tempfile::TempDir::new().unwrap();
$ git rev-parse origin/master
4b93a7c1f6859d3771d5e6a5ec1a03f763eb12b1
```

It took some time to notice `mount`-ing `local-cluster/farf` isn't enough while debugging: https://github.com/solana-labs/solana/pull/10718#discussion_r446262397

Also, when I was testing on cloud instances in the distant past, I was crippled by the use of `/tmp` for snapshot-handling, because `/tmp` was on the system partition file system with little free space albeit plenty of capacity for the ledger dir.


Also, when creating snapshots, using same temp dir with the `accounts` dir may realize more cheaper file system move/copies.

Also, using the system-wide /tmp for testing and running validator as a background hampers the general system performance (i.e. my local computer) and `CTRL-C`-ing it pollutes `/tmp` for unneeded reason too often even if I provision a special dir `farf` on a different block device, ignoring system administrator's intention.....


#### Summary of Changes

Consistently, create them under the `farf` dir or the ledger dir. This PR doesn't fix all of uses in our codebase but still it should cover almost all relevant codepath.

Part of #10718 