### PR TITLE
Update struct prefixes to Ui

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -54,7 +54,7 @@ use solana_stake_program::{
     stake_instruction::LockupArgs,
     stake_state::{Lockup, StakeAuthorize},
 };
-use solana_transaction_status::{EncodedTransaction, TransactionEncoding};
+use solana_transaction_status::{EncodedTransaction, UiTransactionEncoding};
 use solana_vote_program::vote_state::VoteAuthorize;
 use std::{
     collections::HashMap,
@@ -1173,7 +1173,7 @@ fn process_confirm(
             if let Some(transaction_status) = status {
                 if config.verbose {
                     match rpc_client
-                        .get_confirmed_transaction(signature, TransactionEncoding::Binary)
+                        .get_confirmed_transaction(signature, UiTransactionEncoding::Binary)
                     {
                         Ok(confirmed_transaction) => {
                             println!(

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -5,7 +5,7 @@ use solana_sdk::{
     hash::Hash, native_token::lamports_to_sol, program_utils::limited_deserialize,
     transaction::Transaction,
 };
-use solana_transaction_status::RpcTransactionStatusMeta;
+use solana_transaction_status::UiTransactionStatusMeta;
 use std::{collections::HashMap, fmt, io};
 
 // Pretty print a "name value"
@@ -81,7 +81,7 @@ pub fn println_signers(
 pub fn write_transaction<W: io::Write>(
     w: &mut W,
     transaction: &Transaction,
-    transaction_status: &Option<RpcTransactionStatusMeta>,
+    transaction_status: &Option<UiTransactionStatusMeta>,
     prefix: &str,
 ) -> io::Result<()> {
     let message = &transaction.message;
@@ -204,7 +204,7 @@ pub fn write_transaction<W: io::Write>(
 
 pub fn println_transaction(
     transaction: &Transaction,
-    transaction_status: &Option<RpcTransactionStatusMeta>,
+    transaction_status: &Option<UiTransactionStatusMeta>,
     prefix: &str,
 ) {
     let mut w = Vec::new();

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -28,7 +28,7 @@ use solana_sdk::{
     transaction::{self, Transaction},
 };
 use solana_transaction_status::{
-    ConfirmedBlock, ConfirmedTransaction, TransactionEncoding, TransactionStatus,
+    ConfirmedBlock, ConfirmedTransaction, TransactionStatus, UiTransactionEncoding,
 };
 use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::{
@@ -238,13 +238,13 @@ impl RpcClient {
     }
 
     pub fn get_confirmed_block(&self, slot: Slot) -> ClientResult<ConfirmedBlock> {
-        self.get_confirmed_block_with_encoding(slot, TransactionEncoding::Json)
+        self.get_confirmed_block_with_encoding(slot, UiTransactionEncoding::Json)
     }
 
     pub fn get_confirmed_block_with_encoding(
         &self,
         slot: Slot,
-        encoding: TransactionEncoding,
+        encoding: UiTransactionEncoding,
     ) -> ClientResult<ConfirmedBlock> {
         self.send(RpcRequest::GetConfirmedBlock, json!([slot, encoding]))
     }
@@ -285,7 +285,7 @@ impl RpcClient {
     pub fn get_confirmed_transaction(
         &self,
         signature: &Signature,
-        encoding: TransactionEncoding,
+        encoding: UiTransactionEncoding,
     ) -> ClientResult<ConfirmedTransaction> {
         self.send(
             RpcRequest::GetConfirmedTransaction,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -40,7 +40,7 @@ use solana_sdk::{
     transaction::{self, Transaction},
 };
 use solana_transaction_status::{
-    ConfirmedBlock, ConfirmedTransaction, TransactionEncoding, TransactionStatus,
+    ConfirmedBlock, ConfirmedTransaction, TransactionStatus, UiTransactionEncoding,
 };
 use solana_vote_program::vote_state::{VoteState, MAX_LOCKOUT_HISTORY};
 use std::{
@@ -541,7 +541,7 @@ impl JsonRpcRequestProcessor {
     pub fn get_confirmed_block(
         &self,
         slot: Slot,
-        encoding: Option<TransactionEncoding>,
+        encoding: Option<UiTransactionEncoding>,
     ) -> Result<Option<ConfirmedBlock>> {
         if self.config.enable_rpc_transaction_history
             && slot
@@ -710,7 +710,7 @@ impl JsonRpcRequestProcessor {
     pub fn get_confirmed_transaction(
         &self,
         signature: Signature,
-        encoding: Option<TransactionEncoding>,
+        encoding: Option<UiTransactionEncoding>,
     ) -> Result<Option<ConfirmedTransaction>> {
         if self.config.enable_rpc_transaction_history {
             Ok(self
@@ -1031,7 +1031,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         slot: Slot,
-        encoding: Option<TransactionEncoding>,
+        encoding: Option<UiTransactionEncoding>,
     ) -> Result<Option<ConfirmedBlock>>;
 
     #[rpc(meta, name = "getBlockTime")]
@@ -1050,7 +1050,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         signature_str: String,
-        encoding: Option<TransactionEncoding>,
+        encoding: Option<UiTransactionEncoding>,
     ) -> Result<Option<ConfirmedTransaction>>;
 
     #[rpc(meta, name = "getConfirmedSignaturesForAddress")]
@@ -1525,7 +1525,7 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         slot: Slot,
-        encoding: Option<TransactionEncoding>,
+        encoding: Option<UiTransactionEncoding>,
     ) -> Result<Option<ConfirmedBlock>> {
         meta.get_confirmed_block(slot, encoding)
     }
@@ -1547,7 +1547,7 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         signature_str: String,
-        encoding: Option<TransactionEncoding>,
+        encoding: Option<UiTransactionEncoding>,
     ) -> Result<Option<ConfirmedTransaction>> {
         let signature = verify_signature(&signature_str)?;
         meta.get_confirmed_transaction(signature, encoding)
@@ -1647,7 +1647,7 @@ pub mod tests {
         system_transaction,
         transaction::{self, TransactionError},
     };
-    use solana_transaction_status::{EncodedTransaction, RpcMessage, TransactionWithStatusMeta};
+    use solana_transaction_status::{EncodedTransaction, TransactionWithStatusMeta, UiMessage};
     use solana_vote_program::{
         vote_instruction,
         vote_state::{Vote, VoteInit, MAX_LOCKOUT_HISTORY},
@@ -3213,8 +3213,8 @@ pub mod tests {
                 if transaction.signatures[0] == confirmed_block_signatures[0].to_string() {
                     let meta = meta.unwrap();
                     let transaction_recent_blockhash = match transaction.message {
-                        RpcMessage::Parsed(message) => message.recent_blockhash,
-                        RpcMessage::Raw(message) => message.recent_blockhash,
+                        UiMessage::Parsed(message) => message.recent_blockhash,
+                        UiMessage::Raw(message) => message.recent_blockhash,
                     };
                     assert_eq!(transaction_recent_blockhash, blockhash.to_string());
                     assert_eq!(meta.status, Ok(()));

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -37,8 +37,8 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_transaction_status::{
-    ConfirmedBlock, ConfirmedTransaction, EncodedTransaction, Rewards, RpcTransactionStatusMeta,
-    TransactionEncoding, TransactionStatusMeta, TransactionWithStatusMeta,
+    ConfirmedBlock, ConfirmedTransaction, EncodedTransaction, Rewards, TransactionStatusMeta,
+    TransactionWithStatusMeta, UiTransactionEncoding, UiTransactionStatusMeta,
 };
 use solana_vote_program::{vote_instruction::VoteInstruction, vote_state::TIMESTAMP_SLOT_INTERVAL};
 use std::{
@@ -1516,7 +1516,7 @@ impl Blockstore {
     pub fn get_confirmed_block(
         &self,
         slot: Slot,
-        encoding: Option<TransactionEncoding>,
+        encoding: Option<UiTransactionEncoding>,
     ) -> Result<ConfirmedBlock> {
         datapoint_info!(
             "blockstore-rpc-api",
@@ -1528,7 +1528,7 @@ impl Blockstore {
         if *lowest_cleanup_slot > 0 && *lowest_cleanup_slot >= slot {
             return Err(BlockstoreError::SlotCleanedUp);
         }
-        let encoding = encoding.unwrap_or(TransactionEncoding::Json);
+        let encoding = encoding.unwrap_or(UiTransactionEncoding::Json);
         if self.is_root(slot) {
             let slot_meta_cf = self.db.column::<cf::SlotMeta>();
             let slot_meta = match slot_meta_cf.get(slot)? {
@@ -1579,7 +1579,7 @@ impl Blockstore {
     fn map_transactions_to_statuses<'a>(
         &self,
         slot: Slot,
-        encoding: TransactionEncoding,
+        encoding: UiTransactionEncoding,
         iterator: impl Iterator<Item = Transaction> + 'a,
     ) -> Vec<TransactionWithStatusMeta> {
         iterator
@@ -1591,7 +1591,7 @@ impl Blockstore {
                     meta: self
                         .read_transaction_status((signature, slot))
                         .expect("Expect database get to succeed")
-                        .map(RpcTransactionStatusMeta::from),
+                        .map(UiTransactionStatusMeta::from),
                 }
             })
             .collect()
@@ -1761,7 +1761,7 @@ impl Blockstore {
     pub fn get_confirmed_transaction(
         &self,
         signature: Signature,
-        encoding: Option<TransactionEncoding>,
+        encoding: Option<UiTransactionEncoding>,
     ) -> Result<Option<ConfirmedTransaction>> {
         datapoint_info!(
             "blockstore-rpc-api",
@@ -1770,7 +1770,7 @@ impl Blockstore {
         if let Some((slot, status)) = self.get_transaction_status(signature)? {
             let transaction = self.find_transaction_in_slot(slot, signature)?
                 .expect("Transaction to exist in slot entries if it exists in statuses and hasn't been cleaned up");
-            let encoding = encoding.unwrap_or(TransactionEncoding::Json);
+            let encoding = encoding.unwrap_or(UiTransactionEncoding::Json);
             let encoded_transaction = EncodedTransaction::encode(transaction, encoding);
             Ok(Some(ConfirmedTransaction {
                 slot,
@@ -5100,7 +5100,7 @@ pub mod tests {
             .put_meta_bytes(slot - 1, &serialize(&parent_meta).unwrap())
             .unwrap();
 
-        let expected_transactions: Vec<(Transaction, Option<RpcTransactionStatusMeta>)> = entries
+        let expected_transactions: Vec<(Transaction, Option<UiTransactionStatusMeta>)> = entries
             .iter()
             .cloned()
             .filter(|entry| !entry.is_tick())
@@ -5164,7 +5164,7 @@ pub mod tests {
                 .iter()
                 .cloned()
                 .map(|(tx, meta)| TransactionWithStatusMeta {
-                    transaction: EncodedTransaction::encode(tx, TransactionEncoding::Json),
+                    transaction: EncodedTransaction::encode(tx, UiTransactionEncoding::Json),
                     meta,
                 })
                 .collect(),
@@ -5185,7 +5185,7 @@ pub mod tests {
                 .iter()
                 .cloned()
                 .map(|(tx, meta)| TransactionWithStatusMeta {
-                    transaction: EncodedTransaction::encode(tx, TransactionEncoding::Json),
+                    transaction: EncodedTransaction::encode(tx, UiTransactionEncoding::Json),
                     meta,
                 })
                 .collect(),
@@ -5802,7 +5802,7 @@ pub mod tests {
         blockstore.insert_shreds(shreds, None, false).unwrap();
         blockstore.set_roots(&[slot - 1, slot]).unwrap();
 
-        let expected_transactions: Vec<(Transaction, Option<RpcTransactionStatusMeta>)> = entries
+        let expected_transactions: Vec<(Transaction, Option<UiTransactionStatusMeta>)> = entries
             .iter()
             .cloned()
             .filter(|entry| !entry.is_tick())
@@ -5845,7 +5845,7 @@ pub mod tests {
         for (transaction, status) in expected_transactions.clone() {
             let signature = transaction.signatures[0];
             let encoded_transaction =
-                EncodedTransaction::encode(transaction, TransactionEncoding::Json);
+                EncodedTransaction::encode(transaction, UiTransactionEncoding::Json);
             let expected_transaction = ConfirmedTransaction {
                 slot,
                 transaction: TransactionWithStatusMeta {
@@ -6073,7 +6073,7 @@ pub mod tests {
 
             let map = blockstore.map_transactions_to_statuses(
                 slot,
-                TransactionEncoding::Json,
+                UiTransactionEncoding::Json,
                 transactions.into_iter(),
             );
             assert_eq!(map.len(), 5);

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -7,7 +7,7 @@ use solana_sdk::{
     pubkey::Pubkey, signature::Signature, transaction::Transaction,
 };
 use solana_stake_program::{stake_instruction::StakeInstruction, stake_state::Lockup};
-use solana_transaction_status::{ConfirmedBlock, RpcTransactionStatusMeta, TransactionEncoding};
+use solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding, UiTransactionStatusMeta};
 use std::{collections::HashMap, thread::sleep, time::Duration};
 
 pub type PubkeyString = String;
@@ -65,7 +65,7 @@ impl AccountsInfo {
 fn process_transaction(
     slot: Slot,
     transaction: &Transaction,
-    meta: &RpcTransactionStatusMeta,
+    meta: &UiTransactionStatusMeta,
     accounts: &mut HashMap<PubkeyString, AccountInfo>,
 ) {
     let mut last_instruction = true;
@@ -289,7 +289,7 @@ fn load_blocks(
     let mut blocks = vec![];
     for slot in slots.into_iter() {
         let block =
-            rpc_client.get_confirmed_block_with_encoding(slot, TransactionEncoding::Binary)?;
+            rpc_client.get_confirmed_block_with_encoding(slot, UiTransactionEncoding::Binary)?;
         blocks.push((slot, block));
     }
     Ok(blocks)

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -19,21 +19,21 @@ use solana_sdk::{
 /// A duplicate representation of an Instruction for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", untagged)]
-pub enum RpcInstruction {
-    Compiled(RpcCompiledInstruction),
+pub enum UiInstruction {
+    Compiled(UiCompiledInstruction),
     Parsed(Value),
 }
 
 /// A duplicate representation of a CompiledInstruction for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcCompiledInstruction {
+pub struct UiCompiledInstruction {
     pub program_id_index: u8,
     pub accounts: Vec<u8>,
     pub data: String,
 }
 
-impl From<&CompiledInstruction> for RpcCompiledInstruction {
+impl From<&CompiledInstruction> for UiCompiledInstruction {
     fn from(instruction: &CompiledInstruction) -> Self {
         Self {
             program_id_index: instruction.program_id_index,
@@ -66,7 +66,7 @@ impl Default for TransactionStatusMeta {
 /// A duplicate representation of TransactionStatusMeta with `err` field
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcTransactionStatusMeta {
+pub struct UiTransactionStatusMeta {
     pub err: Option<TransactionError>,
     pub status: Result<()>, // This field is deprecated.  See https://github.com/solana-labs/solana/issues/9302
     pub fee: u64,
@@ -74,7 +74,7 @@ pub struct RpcTransactionStatusMeta {
     pub post_balances: Vec<u64>,
 }
 
-impl From<TransactionStatusMeta> for RpcTransactionStatusMeta {
+impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
     fn from(meta: TransactionStatusMeta) -> Self {
         Self {
             err: meta.status.clone().err(),
@@ -131,47 +131,47 @@ pub struct ConfirmedTransaction {
 /// A duplicate representation of a Transaction for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcTransaction {
+pub struct UiTransaction {
     pub signatures: Vec<String>,
-    pub message: RpcMessage,
+    pub message: UiMessage,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", untagged)]
-pub enum RpcMessage {
-    Parsed(RpcParsedMessage),
-    Raw(RpcRawMessage),
+pub enum UiMessage {
+    Parsed(UiParsedMessage),
+    Raw(UiRawMessage),
 }
 
 /// A duplicate representation of a Message, in raw format, for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcRawMessage {
+pub struct UiRawMessage {
     pub header: MessageHeader,
     pub account_keys: Vec<String>,
     pub recent_blockhash: String,
-    pub instructions: Vec<RpcCompiledInstruction>,
+    pub instructions: Vec<UiCompiledInstruction>,
 }
 
 /// A duplicate representation of a Message, in parsed format, for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcParsedMessage {
+pub struct UiParsedMessage {
     pub account_keys: Value,
     pub recent_blockhash: String,
-    pub instructions: Vec<RpcInstruction>,
+    pub instructions: Vec<UiInstruction>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionWithStatusMeta {
     pub transaction: EncodedTransaction,
-    pub meta: Option<RpcTransactionStatusMeta>,
+    pub meta: Option<UiTransactionStatusMeta>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub enum TransactionEncoding {
+pub enum UiTransactionEncoding {
     Binary,
     Json,
     JsonParsed,
@@ -181,18 +181,18 @@ pub enum TransactionEncoding {
 #[serde(rename_all = "camelCase", untagged)]
 pub enum EncodedTransaction {
     Binary(String),
-    Json(RpcTransaction),
+    Json(UiTransaction),
 }
 
 impl EncodedTransaction {
-    pub fn encode(transaction: Transaction, encoding: TransactionEncoding) -> Self {
+    pub fn encode(transaction: Transaction, encoding: UiTransactionEncoding) -> Self {
         match encoding {
-            TransactionEncoding::Binary => EncodedTransaction::Binary(
+            UiTransactionEncoding::Binary => EncodedTransaction::Binary(
                 bs58::encode(bincode::serialize(&transaction).unwrap()).into_string(),
             ),
             _ => {
-                let message = if encoding == TransactionEncoding::Json {
-                    RpcMessage::Raw(RpcRawMessage {
+                let message = if encoding == UiTransactionEncoding::Json {
+                    UiMessage::Raw(UiRawMessage {
                         header: transaction.message.header,
                         account_keys: transaction
                             .message
@@ -209,7 +209,7 @@ impl EncodedTransaction {
                             .collect(),
                     })
                 } else {
-                    RpcMessage::Parsed(RpcParsedMessage {
+                    UiMessage::Parsed(UiParsedMessage {
                         account_keys: parse_accounts(&transaction.message),
                         recent_blockhash: transaction.message.recent_blockhash.to_string(),
                         instructions: transaction
@@ -220,15 +220,15 @@ impl EncodedTransaction {
                                 let program_id =
                                     instruction.program_id(&transaction.message.account_keys);
                                 if let Some(parsed_instruction) = parse(program_id, instruction) {
-                                    RpcInstruction::Parsed(parsed_instruction)
+                                    UiInstruction::Parsed(parsed_instruction)
                                 } else {
-                                    RpcInstruction::Compiled(instruction.into())
+                                    UiInstruction::Compiled(instruction.into())
                                 }
                             })
                             .collect(),
                     })
                 };
-                EncodedTransaction::Json(RpcTransaction {
+                EncodedTransaction::Json(UiTransaction {
                     signatures: transaction
                         .signatures
                         .iter()

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -16,6 +16,7 @@ use solana_sdk::{
     transaction::{Result, Transaction, TransactionError},
 };
 
+/// A duplicate representation of an Instruction for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum RpcInstruction {
@@ -62,6 +63,7 @@ impl Default for TransactionStatusMeta {
     }
 }
 
+/// A duplicate representation of TransactionStatusMeta with `err` field
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionStatusMeta {
@@ -141,7 +143,7 @@ pub enum RpcMessage {
     Raw(RpcRawMessage),
 }
 
-/// A duplicate representation of a Message for pretty JSON serialization
+/// A duplicate representation of a Message, in raw format, for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcRawMessage {
@@ -151,7 +153,7 @@ pub struct RpcRawMessage {
     pub instructions: Vec<RpcCompiledInstruction>,
 }
 
-/// A duplicate representation of a Message for pretty JSON serialization
+/// A duplicate representation of a Message, in parsed format, for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcParsedMessage {

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -16,7 +16,7 @@ use solana_sdk::{
     clock::Slot, hash::Hash, native_token::lamports_to_sol, program_utils::limited_deserialize,
     pubkey::Pubkey,
 };
-use solana_transaction_status::{ConfirmedBlock, TransactionEncoding};
+use solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding};
 use solana_vote_program::vote_instruction::VoteInstruction;
 use std::{
     collections::HashMap,
@@ -226,7 +226,7 @@ fn load_blocks(
     let mut blocks = vec![];
     for slot in slots.into_iter() {
         let block =
-            rpc_client.get_confirmed_block_with_encoding(slot, TransactionEncoding::Binary)?;
+            rpc_client.get_confirmed_block_with_encoding(slot, UiTransactionEncoding::Binary)?;
         blocks.push((slot, block));
     }
     Ok(blocks)


### PR DESCRIPTION
#### Problem
A lot of things are called `Rpc` when they don't necessarily have anything to do with rpc messaging. We recently came up with a new `Ui` prefix to replace Rpc in account-decoder crate.

#### Summary of Changes
- Use `Ui` prefix in transaction-status structs
