### PR TITLE
Prevent stub inclusion when building shared objects

### DIFF
--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -53,7 +53,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -85,7 +85,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/programs/bpf/rust/dep_crate/src/lib.rs
+++ b/programs/bpf/rust/dep_crate/src/lib.rs
@@ -20,7 +20,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -201,4 +201,5 @@ fn process_instruction(
     Ok(())
 }
 
+// Pull in syscall stubs when building for non-BPF targets
 solana_sdk::program_stubs!();

--- a/programs/bpf/rust/invoked/src/lib.rs
+++ b/programs/bpf/rust/invoked/src/lib.rs
@@ -195,4 +195,5 @@ fn process_instruction(
     Ok(())
 }
 
+// Pull in syscall stubs when building for non-BPF targets
 solana_sdk::program_stubs!();

--- a/programs/bpf/rust/iter/src/lib.rs
+++ b/programs/bpf/rust/iter/src/lib.rs
@@ -21,7 +21,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/programs/bpf/rust/many_args/src/lib.rs
+++ b/programs/bpf/rust/many_args/src/lib.rs
@@ -29,7 +29,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -51,7 +51,7 @@ pub fn many_args_sret(
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/programs/bpf/rust/noop/src/lib.rs
+++ b/programs/bpf/rust/noop/src/lib.rs
@@ -67,7 +67,7 @@ fn process_instruction(
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/programs/bpf/rust/param_passing/src/lib.rs
+++ b/programs/bpf/rust/param_passing/src/lib.rs
@@ -26,7 +26,7 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/programs/bpf/rust/param_passing_dep/src/lib.rs
+++ b/programs/bpf/rust/param_passing_dep/src/lib.rs
@@ -27,7 +27,7 @@ impl<'a> TestDep {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pulls in the stubs required for `info!()`
+    // Pull in syscall stubs when building for non-BPF targets
     solana_sdk::program_stubs!();
 
     #[test]

--- a/sdk/src/program_stubs.rs
+++ b/sdk/src/program_stubs.rs
@@ -1,5 +1,6 @@
-//! @brief Stubs for syscalls when building tests for x86
+//! @brief Syscall stubs when building for non-BPF targets
 
+#[cfg(not(target_arch = "bpf"))]
 fn print_line_to_stdout(_message: &str) {
     #[cfg(not(feature = "program"))]
     {
@@ -11,6 +12,7 @@ fn print_line_to_stdout(_message: &str) {
     }
 }
 
+#[cfg(not(target_arch = "bpf"))]
 #[no_mangle]
 /// # Safety
 pub unsafe fn sol_log_(message: *const u8, length: u64) {
@@ -19,11 +21,13 @@ pub unsafe fn sol_log_(message: *const u8, length: u64) {
     print_line_to_stdout(string);
 }
 
+#[cfg(not(target_arch = "bpf"))]
 #[no_mangle]
 pub fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     print_line_to_stdout(&format!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5));
 }
 
+#[cfg(not(target_arch = "bpf"))]
 #[no_mangle]
 pub fn sol_invoke_signed_rust() {
     print_line_to_stdout("sol_invoke_signed_rust()");
@@ -32,6 +36,7 @@ pub fn sol_invoke_signed_rust() {
 #[macro_export]
 macro_rules! program_stubs {
     () => {
+        #[cfg(not(target_arch = "bpf"))]
         #[test]
         fn pull_in_externs() {
             use solana_sdk::program_stubs::{sol_invoke_signed_rust, sol_log_, sol_log_64_};


### PR DESCRIPTION
#### Problem

When building shared objects the included stubs might be picked up rather than leaving an unresolved symbol for the loader to fixup.

This issue seems to be dependent on linking order or something other magic because it only popped up on 1.2 and reliably recreating it required some weird stuff

#### Summary of Changes

Only include the stubs if not building a shared object.  These changes make it explicit and also clean up the program's since it moves the target ifdef out of the user's code.

Fixes #
