### PR TITLE
getInflationRate RPC endpoint now only supports the current epoch and works

### DIFF
--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -677,11 +677,11 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ### getInflationRate
 
-Returns the specific inflation values for a particular epoch
+Returns the specific inflation values for the current epoch
 
 #### Parameters:
 
-* `<u64>` - (optional) Epoch, default is the current epoch
+None
 
 #### Results:
 


### PR DESCRIPTION
`getInflationRate` is broken for testnet due to how it reaches into genesis-programs/ instead of simply asking the bank.

Bad:
```
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getInflationRate"}' http://testnet.solana.com
{"jsonrpc":"2.0","result":{"epoch":61,"foundation":0.0,"total":0.0,"validator":0.0},"id":1}
```

The correct inflation rate, as reported by a testnet node running with this PR:
```
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getInflationRate"}' http://localhost:8899
{"jsonrpc":"2.0","result":{"epoch":61,"foundation":0.007178616599014334,"total":0.14357233198028668,"validator":0.12203648218324367},"id":1}
```