### PR TITLE
Rpc: add filter to getProgramAccounts

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -8,6 +8,7 @@ pub mod perf_utils;
 pub mod pubsub_client;
 pub mod rpc_client;
 pub mod rpc_config;
+pub mod rpc_filter;
 pub mod rpc_request;
 pub mod rpc_response;
 pub mod rpc_sender;

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -1,3 +1,4 @@
+use crate::rpc_filter::RpcFilterType;
 use solana_account_decoder::UiAccountEncoding;
 use solana_sdk::{clock::Epoch, commitment_config::CommitmentConfig};
 
@@ -48,4 +49,12 @@ pub struct RpcAccountInfoConfig {
     pub encoding: Option<UiAccountEncoding>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcProgramAccountsConfig {
+    pub filters: Option<Vec<RpcFilterType>>,
+    #[serde(flatten)]
+    pub account_config: RpcAccountInfoConfig,
 }

--- a/client/src/rpc_filter.rs
+++ b/client/src/rpc_filter.rs
@@ -1,0 +1,75 @@
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RpcFilterType {
+    CompareBytes(CompareBytes),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CompareBytes {
+    offset: usize,
+    bytes: Vec<u8>,
+}
+
+impl CompareBytes {
+    pub fn bytes_match(&self, data: &[u8]) -> bool {
+        if self.offset > data.len() {
+            return false;
+        }
+        if data[self.offset..].len() < self.bytes.len() {
+            return false;
+        }
+        data[self.offset..self.offset + self.bytes.len()] == self.bytes[..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bytes_match() {
+        let data = vec![1, 2, 3, 4, 5];
+
+        // Exact match of data succeeds
+        assert!(CompareBytes {
+            offset: 0,
+            bytes: vec![1, 2, 3, 4, 5],
+        }
+        .bytes_match(&data));
+
+        // Partial match of data succeeds
+        assert!(CompareBytes {
+            offset: 0,
+            bytes: vec![1, 2],
+        }
+        .bytes_match(&data));
+
+        // Offset partial match of data succeeds
+        assert!(CompareBytes {
+            offset: 2,
+            bytes: vec![3, 4],
+        }
+        .bytes_match(&data));
+
+        // Incorrect partial match of data fails
+        assert!(!CompareBytes {
+            offset: 0,
+            bytes: vec![2],
+        }
+        .bytes_match(&data));
+
+        // Bytes overrun data fails
+        assert!(!CompareBytes {
+            offset: 2,
+            bytes: vec![3, 4, 5, 6],
+        }
+        .bytes_match(&data));
+
+        // Offset outside data fails
+        assert!(!CompareBytes {
+            offset: 6,
+            bytes: vec![5],
+        }
+        .bytes_match(&data));
+    }
+}

--- a/client/src/rpc_filter.rs
+++ b/client/src/rpc_filter.rs
@@ -3,12 +3,14 @@ use thiserror::Error;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum RpcFilterType {
+    DataSize(u64),
     Memcmp(Memcmp),
 }
 
 impl RpcFilterType {
     pub fn verify(&self) -> Result<(), RpcFilterError> {
         match self {
+            RpcFilterType::DataSize(_) => Ok(()),
             RpcFilterType::Memcmp(compare) => {
                 let encoding = compare.encoding.as_ref().unwrap_or(&MemcmpEncoding::Binary);
                 match encoding {

--- a/client/src/rpc_filter.rs
+++ b/client/src/rpc_filter.rs
@@ -1,24 +1,50 @@
+use thiserror::Error;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum RpcFilterType {
     CompareBytes(CompareBytes),
 }
 
+impl RpcFilterType {
+    pub fn verify(&self) -> Result<(), RpcFilterError> {
+        match self {
+            RpcFilterType::CompareBytes(compare) => bs58::decode(&compare.bytes)
+                .into_vec()
+                .map(|_| ())
+                .map_err(|e| e.into()),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum RpcFilterError {
+    #[error("bs58 decode error")]
+    DecodeError(#[from] bs58::decode::Error),
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CompareBytes {
+    /// Data offset to begin match
     offset: usize,
-    bytes: Vec<u8>,
+    /// Base-58 encoded bytes
+    bytes: String,
 }
 
 impl CompareBytes {
     pub fn bytes_match(&self, data: &[u8]) -> bool {
+        let bytes = bs58::decode(&self.bytes).into_vec();
+        if bytes.is_err() {
+            return false;
+        }
+        let bytes = bytes.unwrap();
         if self.offset > data.len() {
             return false;
         }
-        if data[self.offset..].len() < self.bytes.len() {
+        if data[self.offset..].len() < bytes.len() {
             return false;
         }
-        data[self.offset..self.offset + self.bytes.len()] == self.bytes[..]
+        data[self.offset..self.offset + bytes.len()] == bytes[..]
     }
 }
 
@@ -33,42 +59,49 @@ mod tests {
         // Exact match of data succeeds
         assert!(CompareBytes {
             offset: 0,
-            bytes: vec![1, 2, 3, 4, 5],
+            bytes: bs58::encode(vec![1, 2, 3, 4, 5]).into_string(),
         }
         .bytes_match(&data));
 
         // Partial match of data succeeds
         assert!(CompareBytes {
             offset: 0,
-            bytes: vec![1, 2],
+            bytes: bs58::encode(vec![1, 2]).into_string(),
         }
         .bytes_match(&data));
 
         // Offset partial match of data succeeds
         assert!(CompareBytes {
             offset: 2,
-            bytes: vec![3, 4],
+            bytes: bs58::encode(vec![3, 4]).into_string(),
         }
         .bytes_match(&data));
 
         // Incorrect partial match of data fails
         assert!(!CompareBytes {
             offset: 0,
-            bytes: vec![2],
+            bytes: bs58::encode(vec![2]).into_string(),
         }
         .bytes_match(&data));
 
         // Bytes overrun data fails
         assert!(!CompareBytes {
             offset: 2,
-            bytes: vec![3, 4, 5, 6],
+            bytes: bs58::encode(vec![3, 4, 5, 6]).into_string(),
         }
         .bytes_match(&data));
 
         // Offset outside data fails
         assert!(!CompareBytes {
             offset: 6,
-            bytes: vec![5],
+            bytes: bs58::encode(vec![5]).into_string(),
+        }
+        .bytes_match(&data));
+
+        // Invalid base-58 fails
+        assert!(!CompareBytes {
+            offset: 0,
+            bytes: "III".to_string(),
         }
         .bytes_match(&data));
     }

--- a/client/src/rpc_filter.rs
+++ b/client/src/rpc_filter.rs
@@ -9,10 +9,18 @@ pub enum RpcFilterType {
 impl RpcFilterType {
     pub fn verify(&self) -> Result<(), RpcFilterError> {
         match self {
-            RpcFilterType::Memcmp(compare) => bs58::decode(&compare.bytes)
-                .into_vec()
-                .map(|_| ())
-                .map_err(|e| e.into()),
+            RpcFilterType::Memcmp(compare) => {
+                let encoding = compare.encoding.as_ref().unwrap_or(&MemcmpEncoding::Binary);
+                match encoding {
+                    MemcmpEncoding::Binary => {
+                        let MemcmpEncodedBytes::Binary(bytes) = &compare.bytes;
+                        bs58::decode(&bytes)
+                            .into_vec()
+                            .map(|_| ())
+                            .map_err(|e| e.into())
+                    }
+                }
+            }
         }
     }
 }
@@ -24,27 +32,45 @@ pub enum RpcFilterError {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum MemcmpEncoding {
+    Binary,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum MemcmpEncodedBytes {
+    Binary(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Memcmp {
     /// Data offset to begin match
-    offset: usize,
-    /// Base-58 encoded bytes
-    bytes: String,
+    pub offset: usize,
+    /// Bytes, encoded with specified encoding, or default Binary
+    pub bytes: MemcmpEncodedBytes,
+    /// Optional encoding specification
+    pub encoding: Option<MemcmpEncoding>,
 }
 
 impl Memcmp {
     pub fn bytes_match(&self, data: &[u8]) -> bool {
-        let bytes = bs58::decode(&self.bytes).into_vec();
-        if bytes.is_err() {
-            return false;
+        match &self.bytes {
+            MemcmpEncodedBytes::Binary(bytes) => {
+                let bytes = bs58::decode(bytes).into_vec();
+                if bytes.is_err() {
+                    return false;
+                }
+                let bytes = bytes.unwrap();
+                if self.offset > data.len() {
+                    return false;
+                }
+                if data[self.offset..].len() < bytes.len() {
+                    return false;
+                }
+                data[self.offset..self.offset + bytes.len()] == bytes[..]
+            }
         }
-        let bytes = bytes.unwrap();
-        if self.offset > data.len() {
-            return false;
-        }
-        if data[self.offset..].len() < bytes.len() {
-            return false;
-        }
-        data[self.offset..self.offset + bytes.len()] == bytes[..]
     }
 }
 
@@ -59,49 +85,56 @@ mod tests {
         // Exact match of data succeeds
         assert!(Memcmp {
             offset: 0,
-            bytes: bs58::encode(vec![1, 2, 3, 4, 5]).into_string(),
+            bytes: MemcmpEncodedBytes::Binary(bs58::encode(vec![1, 2, 3, 4, 5]).into_string()),
+            encoding: None,
         }
         .bytes_match(&data));
 
         // Partial match of data succeeds
         assert!(Memcmp {
             offset: 0,
-            bytes: bs58::encode(vec![1, 2]).into_string(),
+            bytes: MemcmpEncodedBytes::Binary(bs58::encode(vec![1, 2]).into_string()),
+            encoding: None,
         }
         .bytes_match(&data));
 
         // Offset partial match of data succeeds
         assert!(Memcmp {
             offset: 2,
-            bytes: bs58::encode(vec![3, 4]).into_string(),
+            bytes: MemcmpEncodedBytes::Binary(bs58::encode(vec![3, 4]).into_string()),
+            encoding: None,
         }
         .bytes_match(&data));
 
         // Incorrect partial match of data fails
         assert!(!Memcmp {
             offset: 0,
-            bytes: bs58::encode(vec![2]).into_string(),
+            bytes: MemcmpEncodedBytes::Binary(bs58::encode(vec![2]).into_string()),
+            encoding: None,
         }
         .bytes_match(&data));
 
         // Bytes overrun data fails
         assert!(!Memcmp {
             offset: 2,
-            bytes: bs58::encode(vec![3, 4, 5, 6]).into_string(),
+            bytes: MemcmpEncodedBytes::Binary(bs58::encode(vec![3, 4, 5, 6]).into_string()),
+            encoding: None,
         }
         .bytes_match(&data));
 
         // Offset outside data fails
         assert!(!Memcmp {
             offset: 6,
-            bytes: bs58::encode(vec![5]).into_string(),
+            bytes: MemcmpEncodedBytes::Binary(bs58::encode(vec![5]).into_string()),
+            encoding: None,
         }
         .bytes_match(&data));
 
         // Invalid base-58 fails
         assert!(!Memcmp {
             offset: 0,
-            bytes: "III".to_string(),
+            bytes: MemcmpEncodedBytes::Binary("III".to_string()),
+            encoding: None,
         }
         .bytes_match(&data));
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -243,7 +243,7 @@ impl JsonRpcRequestProcessor {
             .into_iter()
             .filter(|(_, account)| {
                 filters.iter().all(|filter_type| match filter_type {
-                    RpcFilterType::CompareBytes(compare) => compare.bytes_match(&account.data),
+                    RpcFilterType::Memcmp(compare) => compare.bytes_match(&account.data),
                 })
             })
             .map(|(pubkey, account)| RpcKeyedAccount {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2390,13 +2390,7 @@ pub mod tests {
             new_program_id
         );
         let res = io.handle_request_sync(&req, meta.clone());
-        let expected = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "result":[],
-                "id":1}}
-            "#,
-        );
+        let expected = "{\"jsonrpc\":\"2.0\",\"result\":[],\"id\":1}".to_string();
         let expected: Response =
             serde_json::from_str(&expected).expect("expected response deserialization");
         let result: Response = serde_json::from_str(&res.expect("actual response"))
@@ -2457,14 +2451,8 @@ pub mod tests {
             }}"#,
             new_program_id
         );
-        let res = io.handle_request_sync(&req, meta.clone());
-        let expected = format!(
-            r#"{{
-                "jsonrpc":"2.0",
-                "result":[],
-                "id":1}}
-            "#,
-        );
+        let res = io.handle_request_sync(&req, meta);
+        let expected = "{\"jsonrpc\":\"2.0\",\"result\":[],\"id\":1}".to_string();
         let expected: Response =
             serde_json::from_str(&expected).expect("expected response deserialization");
         let result: Response = serde_json::from_str(&res.expect("actual response"))
@@ -3058,7 +3046,7 @@ pub mod tests {
             ),
             encoding: None,
         });
-        assert_eq!(verify_filter(&filter).unwrap(), ());
+        assert_eq!(verify_filter(&filter), Ok(()));
         // Invalid base-58
         let filter = RpcFilterType::Memcmp(Memcmp {
             offset: 0,

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -121,14 +121,14 @@ fn test_rpc_invalid_requests() {
     let json = post_rpc(req, &leader_data);
 
     let the_error = json["error"]["message"].as_str().unwrap();
-    assert_eq!(the_error, "Invalid");
+    assert_eq!(the_error, "Invalid param: Invalid");
 
     // test invalid get_account_info request
     let req = json_req!("getAccountInfo", json!(["invalid9999"]));
     let json = post_rpc(req, &leader_data);
 
     let the_error = json["error"]["message"].as_str().unwrap();
-    assert_eq!(the_error, "Invalid");
+    assert_eq!(the_error, "Invalid param: Invalid");
 
     // test invalid get_account_info request
     let req = json_req!("getAccountInfo", json!([bob_pubkey.to_string()]));

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -790,6 +790,14 @@ Returns all accounts owned by the provided program Pubkey
   * (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
   * (optional) `encoding: <string>` - encoding for Account data, either "binary" or jsonParsed". If parameter not provided, the default encoding is binary.
     Parsed-JSON encoding attempts to use program-specific state parsers to return more human-readable and explicit account state data. If parsed-JSON is requested but a parser cannot be found, the field falls back to binary encoding, detectable when the `data` field is type `<string>`.
+  * (optional) `filters: <array>` - filter results using various [filter objects](jsonrpc-api.md#filters); account must meet all filter criteria to be included in results
+
+##### Filters:
+* `memcmp: <object>` - compares a provided series of bytes with program account data at a particular offset. Fields:
+  * `offset: <usize>` - offset into program account data to start comparison
+  * `bytes: <string>` - data to match, as base-58 encoded string
+
+* `dataSize: <u64>` - compares the program account data length with the provided data size
 
 #### Results:
 
@@ -808,6 +816,12 @@ The result field will be an array of JSON objects, which will contain:
 ```bash
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getProgramAccounts", "params":["4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T"]}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":[{"account":{"data":"2R9jLfiAQ9bgdcw6h8s44439","executable":false,"lamports":15298080,"owner":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","rentEpoch":28},"pubkey":"CxELquR1gPP8wHe33gZ4QxqGB3sZ9RSwsJ2KshVewkFY"}],"id":1}
+
+// Request with Filters
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getProgramAccounts", "params":["4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T", {"filters":[{"dataSize": 17},{"memcmp": {"offset": 4, "bytes": "3Mc6vR"}}]}]}' http://localhost:8899
 
 // Result
 {"jsonrpc":"2.0","result":[{"account":{"data":"2R9jLfiAQ9bgdcw6h8s44439","executable":false,"lamports":15298080,"owner":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","rentEpoch":28},"pubkey":"CxELquR1gPP8wHe33gZ4QxqGB3sZ9RSwsJ2KshVewkFY"}],"id":1}


### PR DESCRIPTION
#### Problem
Users will need a way to inspect and manage all the SPL Token accounts they own. This could be accomplished by calling `getProgramAccounts` for the token program-id and deserializing all the accounts to inspect the `owner` field. But spl-token::State is not yet ready/published to be pulled in as a dependency, and moreover that deserialization is a lot of overhead.
Instead, we can use a generic byte-comparison filter. This gives users flexibility as to what part of account data is matched, and gives us the opportunity to add different types of filters in the future.

#### Summary of Changes
- Add RpcFilterType and implement a byte-comparison filter for getProgramAccounts
  - Filters should be passed as part of the config struct; an array of filters is accepted, and all must pass in order for an account to be included in the response
  - The compare-bytes filter object looks like this: `{"compareBytes":{"offset":44,"bytes":"7kgfDmgbEfypBujqn4tyApjf8H7ZWuaL3F6Ah9vQHzgR"}}`, where offset is the offset into account.data that will be matched, and bytes are base-58 encoded string representation of bytes to compare

TODO:
- [x] update docs
- [x] update rpc tests
