### PR TITLE
Fix skipped slot detection for eager rent collect

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1850,9 +1850,32 @@ impl Bank {
         let (parent_epoch, mut parent_slot_index) =
             self.get_epoch_and_slot_index(self.parent_slot());
 
+        let should_enable = match self.operating_mode() {
+            OperatingMode::Development => true,
+            OperatingMode::Preview => current_epoch >= Epoch::max_value(),
+            OperatingMode::Stable => {
+                #[cfg(not(test))]
+                let should_enable = current_epoch >= Epoch::max_value();
+
+                // needed for test_rent_eager_across_epoch_with_gap_under_multi_epoch_cycle,
+                // which depends on OperatingMode::Stable
+                #[cfg(test)]
+                let should_enable = true;
+
+                should_enable
+            }
+        };
+
         let mut partitions = vec![];
         if parent_epoch < current_epoch {
-            if current_slot_index > 0 {
+            // this needs to be gated because this potentially can change the behavior
+            // (= bank hash) at each start of epochs
+            let slot_skipped = if should_enable {
+                (self.slot() - self.parent_slot()) > 1
+            } else {
+                current_slot_index > 0
+            };
+            if slot_skipped {
                 // Generate special partitions because there are skipped slots
                 // exactly at the epoch transition.
 
@@ -1865,24 +1888,9 @@ impl Bank {
                     parent_epoch,
                 ));
 
-                let should_enable = match self.operating_mode() {
-                    OperatingMode::Development => true,
-                    OperatingMode::Preview => current_epoch >= Epoch::max_value(),
-                    OperatingMode::Stable => {
-                        #[cfg(not(test))]
-                        let should_enable = current_epoch >= Epoch::max_value();
-
-                        // needed for test_rent_eager_across_epoch_with_gap_under_multi_epoch_cycle,
-                        // which depends on OperatingMode::Stable
-                        #[cfg(test)]
-                        let should_enable = true;
-
-                        should_enable
-                    }
-                };
                 // this needs to be gated because this potentially can change the behavior
                 // (= bank hash) at each start of epochs
-                if should_enable {
+                if should_enable && current_slot_index > 0 {
                     // ... for current epoch
                     partitions.push(self.partition_from_slot_indexes_with_gapped_epochs(
                         0,
@@ -3613,7 +3621,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rent_eager_across_epoch_with_gap() {
+    fn test_rent_eager_across_epoch_with_full_gap() {
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
 
         let mut bank = Arc::new(Bank::new(&genesis_config));
@@ -3630,6 +3638,30 @@ mod tests {
             bank.rent_collection_partitions(),
             vec![(14, 31, 32), (0, 0, 64), (0, 17, 64)]
         );
+        bank = Arc::new(new_from_parent(&bank));
+        assert_eq!(bank.rent_collection_partitions(), vec![(17, 18, 64)]);
+    }
+
+    #[test]
+    fn test_rent_eager_across_epoch_with_half_gap() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1);
+
+        let mut bank = Arc::new(Bank::new(&genesis_config));
+        assert_eq!(bank.rent_collection_partitions(), vec![(0, 0, 32)]);
+
+        bank = Arc::new(new_from_parent(&bank));
+        assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 32)]);
+        for _ in 2..15 {
+            bank = Arc::new(new_from_parent(&bank));
+        }
+        assert_eq!(bank.rent_collection_partitions(), vec![(13, 14, 32)]);
+        bank = Arc::new(Bank::new_from_parent(&bank, &Pubkey::default(), 32));
+        assert_eq!(
+            bank.rent_collection_partitions(),
+            vec![(14, 31, 32), (0, 0, 64)]
+        );
+        bank = Arc::new(new_from_parent(&bank));
+        assert_eq!(bank.rent_collection_partitions(), vec![(0, 1, 64)]);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Sorry, skipped slot detection was half-way for eager-rent collection... Found today with tds's epoch 61 -> epoch 62 transition:

Bad (curent behavior; missing last pubkey range for previous epoch):

```
  [2020-07-02T10:07:47.938607650Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431984-431985)/432000 [42700796466919]: fffdb97530eaf468000000000000000000000000000000000000000000000000-fffde04b3eb90b4fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:48.441329379Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431985-431986)/432000 [42700796466919]: fffde04b3eb90b50000000000000000000000000000000000000000000000000-fffe07214c872237ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:48.671771528Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431986-431987)/432000 [42700796466919]: fffe07214c872238000000000000000000000000000000000000000000000000-fffe2df75a55391fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:50.686829811Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431987-431992)/432000 [213503982334599]: fffe2df75a553920000000000000000000000000000000000000000000000000-fffef0259f5baba7ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:50.994492961Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431992-431993)/432000 [42700796466919]: fffef0259f5baba8000000000000000000000000000000000000000000000000-ffff16fbad29c28fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:51.218920166Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431993-431994)/432000 [42700796466919]: ffff16fbad29c290000000000000000000000000000000000000000000000000-ffff3dd1baf7d977ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:51.473983021Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431994-431995)/432000 [42700796466919]: ffff3dd1baf7d978000000000000000000000000000000000000000000000000-ffff64a7c8c5f05fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:52.706004672Z ERROR solana_runtime::bank] pubkey_range_from_partition: (0-0)/432000 [42700796466919]: 0000000000000000000000000000000000000000000000000000000000000000-000026d60dce16e7ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:53.339003499Z ERROR solana_runtime::bank] pubkey_range_from_partition: (0-1)/432000 [42700796466919]: 000026d60dce16e8000000000000000000000000000000000000000000000000-00004dac1b9c2dcfffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:53.512714362Z ERROR solana_runtime::bank] pubkey_range_from_partition: (1-2)/432000 [42700796466919]: 00004dac1b9c2dd0000000000000000000000000000000000000000000000000-00007482296a44b7ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:07:56.082589683Z ERROR solana_runtime::bank] pubkey_range_from_partition: (2-3)/432000 [42700796466919]: 00007482296a44b8000000000000000000000000000000000000000000000000-00009b5837385b9fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:08:03.608213480Z ERROR solana_runtime::bank] pubkey_range_from_partition: (3-4)/432000 [42700796466919]: 00009b5837385ba0000000000000000000000000000000000000000000000000-0000c22e45067287ffffffffffffffffffffffffffffffffffffffffffffffff
```

#### Summary of Changes

Correctly detect it.... Also adjust gating a bit. I think tweaking gated logic is safe because it's still not scheduled.

Good (future behavior; adding last pubkey range for previous epoch):

```
  [2020-07-02T10:33:05.549159029Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431984-431985)/432000 [42700796466919]: fffdb97530eaf468000000000000000000000000000000000000000000000000-fffde04b3eb90b4fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:05.696762691Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431985-431986)/432000 [42700796466919]: fffde04b3eb90b50000000000000000000000000000000000000000000000000-fffe07214c872237ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:05.842711290Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431986-431987)/432000 [42700796466919]: fffe07214c872238000000000000000000000000000000000000000000000000-fffe2df75a55391fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:06.538348390Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431987-431992)/432000 [213503982334599]: fffe2df75a553920000000000000000000000000000000000000000000000000-fffef0259f5baba7ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:06.686124680Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431992-431993)/432000 [42700796466919]: fffef0259f5baba8000000000000000000000000000000000000000000000000-ffff16fbad29c28fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:06.847646971Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431993-431994)/432000 [42700796466919]: ffff16fbad29c290000000000000000000000000000000000000000000000000-ffff3dd1baf7d977ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:07.020169944Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431994-431995)/432000 [42700796466919]: ffff3dd1baf7d978000000000000000000000000000000000000000000000000-ffff64a7c8c5f05fffffffffffffffffffffffffffffffffffffffffffffffff
!![2020-07-02T10:33:07.783721912Z ERROR solana_runtime::bank] pubkey_range_from_partition: (431995-431999)/432000 [170803185979295]: ffff64a7c8c5f060000000000000000000000000000000000000000000000000-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:07.783787254Z ERROR solana_runtime::bank] pubkey_range_from_partition: (0-0)/432000 [42700796466919]: 0000000000000000000000000000000000000000000000000000000000000000-000026d60dce16e7ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:07.783831748Z ERROR solana_runtime::bank] pubkey_range_from_partition: (0-0)/432000 [42700796466919]: 0000000000000000000000000000000000000000000000000000000000000000-000026d60dce16e7ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:07.981193413Z ERROR solana_runtime::bank] pubkey_range_from_partition: (0-1)/432000 [42700796466919]: 000026d60dce16e8000000000000000000000000000000000000000000000000-00004dac1b9c2dcfffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:08.158625999Z ERROR solana_runtime::bank] pubkey_range_from_partition: (1-2)/432000 [42700796466919]: 00004dac1b9c2dd0000000000000000000000000000000000000000000000000-00007482296a44b7ffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:08.331153600Z ERROR solana_runtime::bank] pubkey_range_from_partition: (2-3)/432000 [42700796466919]: 00007482296a44b8000000000000000000000000000000000000000000000000-00009b5837385b9fffffffffffffffffffffffffffffffffffffffffffffffff
  [2020-07-02T10:33:08.509018255Z ERROR solana_runtime::bank] pubkey_range_from_partition: (3-4)/432000 [42700796466919]: 00009b5837385ba0000000000000000000000000000000000000000000000000-0000c22e45067287ffffffffffffffffffffffffffffffffffffffffffffffff
```

follow-up to #10206.

CC: @t-nelson FYI: @mvines 