### PR TITLE
Move clean accounts to background service

### DIFF
--- a/core/src/accounts_background_service.rs
+++ b/core/src/accounts_background_service.rs
@@ -18,24 +18,31 @@ const INTERVAL_MS: u64 = 100;
 const SHRUNKEN_ACCOUNT_PER_SEC: usize = 250;
 const SHRUNKEN_ACCOUNT_PER_INTERVAL: usize =
     SHRUNKEN_ACCOUNT_PER_SEC / (1000 / INTERVAL_MS as usize);
+const CLEAN_INTERVAL_SLOTS: u64 = 100;
 
 impl AccountsBackgroundService {
     pub fn new(bank_forks: Arc<RwLock<BankForks>>, exit: &Arc<AtomicBool>) -> Self {
         info!("AccountsBackgroundService active");
         let exit = exit.clone();
         let mut consumed_budget = 0;
+        let mut last_cleaned_slot = 0;
         let t_background = Builder::new()
             .name("solana-accounts-background".to_string())
             .spawn(move || loop {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
-                let bank = bank_forks.read().unwrap().working_bank();
+                let bank = bank_forks.read().unwrap().root_bank().clone();
 
                 bank.process_dead_slots();
 
                 consumed_budget = bank
                     .process_stale_slot_with_budget(consumed_budget, SHRUNKEN_ACCOUNT_PER_INTERVAL);
+
+                if bank.block_height() - last_cleaned_slot > CLEAN_INTERVAL_SLOTS {
+                    bank.clean_accounts();
+                    last_cleaned_slot = bank.block_height();
+                }
 
                 sleep(Duration::from_millis(INTERVAL_MS));
             })

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -229,7 +229,6 @@ impl BankForks {
                 bank.squash();
                 is_root_bank_squashed = bank_slot == root;
 
-                bank.clean_accounts();
                 bank.update_accounts_hash();
 
                 if self.snapshot_config.is_some() && accounts_package_sender.is_some() {


### PR DESCRIPTION
#### Problem

Accounts dependency checks can take many seconds with a large number of accounts.

#### Summary of Changes

Move work to accounts background service and re-factor locks to avoid locking the index while the dependency checks are done.

Fixes #10889
