### PR TITLE
Rpc: Add getStakeActivation endpoint

### DIFF
--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -37,7 +37,7 @@ pub struct RpcLargestAccountsConfig {
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcInflationConfig {
+pub struct RpcStakeConfig {
     pub epoch: Option<Epoch>,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -205,8 +205,17 @@ pub struct RpcSupply {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
+pub enum StakeActivationState {
+    Activating,
+    Active,
+    Deactivating,
+    Inactive,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcStakeActivation {
+    pub state: StakeActivationState,
     pub active: u64,
-    pub activating: u64,
-    pub deactivating: u64,
+    pub inactive: u64,
 }

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -202,3 +202,11 @@ pub struct RpcSupply {
     pub non_circulating: u64,
     pub non_circulating_accounts: Vec<String>,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcStakeActivation {
+    pub active: u64,
+    pub activating: u64,
+    pub deactivating: u64,
+}

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -30,6 +30,7 @@ use solana_runtime::{
     log_collector::LogCollector,
 };
 use solana_sdk::{
+    account_utils::StateMut,
     clock::{Slot, UnixTimestamp},
     commitment_config::{CommitmentConfig, CommitmentLevel},
     epoch_info::EpochInfo,
@@ -37,9 +38,12 @@ use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
     signature::Signature,
+    stake_history::StakeHistory,
+    sysvar::{stake_history, Sysvar},
     timing::slot_duration_from_slots_per_year,
     transaction::{self, Transaction},
 };
+use solana_stake_program::stake_state::StakeState;
 use solana_transaction_status::{
     ConfirmedBlock, ConfirmedTransaction, TransactionStatus, UiTransactionEncoding,
 };
@@ -755,6 +759,46 @@ impl JsonRpcRequestProcessor {
             .get_first_available_block()
             .unwrap_or_default()
     }
+
+    pub fn get_stake_activation(
+        &self,
+        pubkey: &Pubkey,
+        config: Option<RpcStakeConfig>,
+    ) -> Result<RpcStakeActivation> {
+        let config = config.unwrap_or_default();
+        let bank = self.bank(config.commitment)?;
+        let epoch = config.epoch.unwrap_or_else(|| bank.epoch());
+        if bank.epoch().saturating_sub(epoch) > solana_sdk::stake_history::MAX_ENTRIES as u64 {
+            return Err(Error::invalid_params(format!(
+                "Invalid param: epoch {:?} is too far in the past",
+                epoch
+            )));
+        }
+
+        let stake_account = bank
+            .get_account(pubkey)
+            .ok_or_else(|| Error::invalid_params("Invalid param: account not found".to_string()))?;
+        let stake_state: StakeState = stake_account
+            .state()
+            .map_err(|_| Error::invalid_params("Invalid param: not a stake account".to_string()))?;
+        let delegation = stake_state.delegation().ok_or_else(|| {
+            Error::invalid_params("Invalid param: stake account has not been delegated".to_string())
+        })?;
+
+        let stake_history_account = bank
+            .get_account(&stake_history::id())
+            .ok_or_else(Error::internal_error)?;
+        let stake_history =
+            StakeHistory::from_account(&stake_history_account).ok_or_else(Error::internal_error)?;
+
+        let (active, activating, deactivating) =
+            delegation.stake_activating_and_deactivating(epoch, Some(&stake_history));
+        Ok(RpcStakeActivation {
+            active,
+            activating,
+            deactivating,
+        })
+    }
 }
 
 fn verify_filter(input: &RpcFilterType) -> Result<()> {
@@ -1062,6 +1106,14 @@ pub trait RpcSol {
 
     #[rpc(meta, name = "getFirstAvailableBlock")]
     fn get_first_available_block(&self, meta: Self::Metadata) -> Result<Slot>;
+
+    #[rpc(meta, name = "getStakeActivation")]
+    fn get_stake_activation(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        config: Option<RpcStakeConfig>,
+    ) -> Result<RpcStakeActivation>;
 }
 
 pub struct RpcSolImpl;
@@ -1588,6 +1640,20 @@ impl RpcSol for RpcSolImpl {
 
     fn get_first_available_block(&self, meta: Self::Metadata) -> Result<Slot> {
         Ok(meta.get_first_available_block())
+    }
+
+    fn get_stake_activation(
+        &self,
+        meta: Self::Metadata,
+        pubkey_str: String,
+        config: Option<RpcStakeConfig>,
+    ) -> Result<RpcStakeActivation> {
+        debug!(
+            "get_stake_activation rpc request received: {:?}",
+            pubkey_str
+        );
+        let pubkey = verify_pubkey(pubkey_str)?;
+        meta.get_stake_activation(&pubkey, config)
     }
 }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -766,7 +766,7 @@ impl JsonRpcRequestProcessor {
         config: Option<RpcStakeConfig>,
     ) -> Result<RpcStakeActivation> {
         let config = config.unwrap_or_default();
-        let bank = self.bank(config.commitment)?;
+        let bank = self.bank(config.commitment);
         let epoch = config.epoch.unwrap_or_else(|| bank.epoch());
         if bank.epoch().saturating_sub(epoch) > solana_sdk::stake_history::MAX_ENTRIES as u64 {
             return Err(Error::invalid_params(format!(

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -960,8 +960,8 @@ Returns epoch activation information for a stake account
 The result will be a JSON object with the following fields:
 
 * `active: <u64>` - stake active during the epoch
-* `activating: <u64>` - stake activating during the epoch; will be added to active stake the following epoch
-* `deactivating: <u64>` - stake deactivating during the epoch; will be subtracted from active stake the following epoch
+* `activating: <u64>` - stake scheduled for activation; will be added to the active stake in one or more epochs
+* `deactivating: <u64>` - stake scheduled for deactivation; will be subtracted from active stake in one or more epochs
 
 #### Example:
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -41,6 +41,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 * [getSignatureStatuses](jsonrpc-api.md#getsignaturestatuses)
 * [getSlot](jsonrpc-api.md#getslot)
 * [getSlotLeader](jsonrpc-api.md#getslotleader)
+* [getStakeActivation](jsonrpc-api.md#getstakeactivation)
 * [getSupply](jsonrpc-api.md#getsupply)
 * [getTransactionCount](jsonrpc-api.md#gettransactioncount)
 * [getVersion](jsonrpc-api.md#getversion)
@@ -941,6 +942,41 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 // Result
 {"jsonrpc":"2.0","result":"ENvAW7JScgYq6o4zKZwewtkzzJgDzuJAFxYasvmEQdpS","id":1}
+```
+
+### getStakeActivation
+
+Returns epoch activation information for a stake account
+
+#### Parameters:
+
+* `<string>` - Pubkey of stake account to query, as base-58 encoded string
+* `<object>` - (optional) Configuration object containing the following optional fields:
+  * (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  * (optional) `epoch: <u64>` - epoch for which to calculate activation details. If parameter not provided, defaults to current epoch.
+
+#### Results:
+
+The result will be a JSON object with the following fields:
+
+* `active: <u64>` - stake active during the epoch
+* `activating: <u64>` - stake activating during the epoch; will be added to active stake the following epoch
+* `deactivating: <u64>` - stake deactivating during the epoch; will be subtracted from active stake the following epoch
+
+#### Example:
+
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getStakeActivation", "params": ["CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT"]}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":{"activating":99873287840,"active":124429280,"deactivating":0},"id":1}
+
+// Request with Epoch
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getStakeActivation", "params": ["CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT", {"epoch": 4}]}' http://localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":{"activating":99997717120,"active":0,"deactivating":0},"id":1}
 ```
 
 ### getSupply

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -959,9 +959,9 @@ Returns epoch activation information for a stake account
 
 The result will be a JSON object with the following fields:
 
+* `state: <string` - the stake account's activation state, one of: `active`, `inactive`, `activating`, `deactivating`
 * `active: <u64>` - stake active during the epoch
-* `activating: <u64>` - stake scheduled for activation; will be added to the active stake in one or more epochs
-* `deactivating: <u64>` - stake scheduled for deactivation; will be subtracted from active stake in one or more epochs
+* `inactive: <u64>` - stake inactive during the epoch
 
 #### Example:
 
@@ -970,13 +970,13 @@ The result will be a JSON object with the following fields:
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getStakeActivation", "params": ["CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT"]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"activating":99873287840,"active":124429280,"deactivating":0},"id":1}
+{"jsonrpc":"2.0","result":{"active":197717120,"inactive":0,"state":"active"},"id":1}
 
 // Request with Epoch
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getStakeActivation", "params": ["CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT", {"epoch": 4}]}' http://localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"activating":99997717120,"active":0,"deactivating":0},"id":1}
+{"jsonrpc":"2.0","result":{"active":124429280,"inactive":73287840,"state":"activating"},"id":1}
 ```
 
 ### getSupply


### PR DESCRIPTION
#### Problem
`solana stake-account` returns lots of useful information about stake activation/deactivation for the current epoch. But it's pretty hard to calculate this information if you're not using the solana cli.

#### Summary of Changes
- Add `getStakeActivation` endpoint; it takes a stake account address (and optional past epoch and optional commitment) as input parameters and returns effective, activating, and deactivating stake amounts

Fixes #10885 
