### PR TITLE
Add RepairWeight to track votes seen in gossip for weighted repair

### DIFF
--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -348,6 +348,12 @@ impl HeaviestSubtreeForkChoice {
         self.add_votes(&new_votes, epoch_stakes, epoch_schedule);
     }
 
+    pub fn stake_voted_at(&self, slot: Slot) -> Option<u64> {
+        self.fork_infos
+            .get(&slot)
+            .map(|fork_info| fork_info.stake_voted_at)
+    }
+
     fn propagate_new_leaf(&mut self, slot: Slot, parent: Slot) {
         let parent_best_slot = self
             .best_slot(parent)
@@ -523,13 +529,6 @@ impl HeaviestSubtreeForkChoice {
             self.latest_votes,
             best_path.iter().rev().collect::<Vec<&Slot>>()
         );
-    }
-
-    #[cfg(test)]
-    fn stake_voted_at(&self, slot: Slot) -> Option<u64> {
-        self.fork_infos
-            .get(&slot)
-            .map(|fork_info| fork_info.stake_voted_at)
     }
 
     #[cfg(test)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod progress_map;
 pub mod pubkey_references;
 pub mod repair_response;
 pub mod repair_service;
+pub mod repair_weight;
 pub mod repair_weighted_traversal;
 pub mod replay_stage;
 mod result;

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -71,6 +71,8 @@ pub struct RepairStats {
     pub shred: RepairStatsGroup,
     pub highest_shred: RepairStatsGroup,
     pub orphan: RepairStatsGroup,
+    pub get_best_orphans_us: u64,
+    pub get_best_shreds_us: u64,
 }
 
 #[derive(Default, Debug)]

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -177,6 +177,7 @@ impl RepairService {
         let mut repair_timing = RepairTiming::default();
         let mut last_stats = Instant::now();
         let duplicate_slot_repair_statuses = HashMap::new();
+
         Self::initialize_epoch_slots(
             blockstore,
             &cluster_info,

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -1,0 +1,834 @@
+use crate::{
+    heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
+    repair_weighted_traversal::{self, Contains},
+    serve_repair::RepairType,
+};
+use solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore};
+use solana_runtime::epoch_stakes::EpochStakes;
+use solana_sdk::{
+    clock::Slot,
+    epoch_schedule::{Epoch, EpochSchedule},
+    pubkey::Pubkey,
+};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+pub struct RepairWeight {
+    // Map from root -> a subtree rooted at that `root`
+    trees: HashMap<Slot, HeaviestSubtreeForkChoice>,
+    // Maps each slot to the root of the tree that contains it
+    slot_to_tree: HashMap<Slot, Slot>,
+    root: Slot,
+}
+
+impl RepairWeight {
+    pub fn new(root: Slot) -> Self {
+        let root_tree = HeaviestSubtreeForkChoice::new(root);
+        let slot_to_tree: HashMap<Slot, Slot> = vec![(root, root)].into_iter().collect();
+        let trees: HashMap<Slot, HeaviestSubtreeForkChoice> =
+            vec![(root, root_tree)].into_iter().collect();
+        Self {
+            trees,
+            slot_to_tree,
+            root,
+        }
+    }
+
+    pub fn add_votes<I>(
+        &mut self,
+        blockstore: &Blockstore,
+        votes: I,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_schedule: &EpochSchedule,
+    ) where
+        I: Iterator<Item = (Slot, Vec<Pubkey>)>,
+    {
+        let mut all_subtree_updates: HashMap<Slot, HashMap<Pubkey, Slot>> = HashMap::new();
+        for (slot, pubkey_votes) in votes {
+            if slot < self.root {
+                continue;
+            }
+            let mut tree_root = self.slot_to_tree.get(&slot).cloned();
+            let mut ancestors = VecDeque::new();
+            // If we don't know know  how this slot chains to any existing trees
+            // in `self.trees`, then use `blockstore` to see if this chains
+            // any existing trees in `self.trees`
+            if tree_root.is_none() {
+                let (discovered_ancestors, existing_subtree) =
+                    self.find_ancestor_subtree_of_slot(blockstore, slot);
+                ancestors = discovered_ancestors;
+                tree_root = existing_subtree;
+            }
+
+            let tree_root = tree_root.unwrap_or_else(|| {
+                // If `tree_root` is still None, then there is no known
+                // subtree that contains `slot`. Thus, create a new
+                // subtree rooted at the earliest known ancestor of `slot`
+                let earliest_ancestor = *ancestors.front().unwrap_or(&slot);
+                self.insert_new_tree(earliest_ancestor);
+                earliest_ancestor
+            });
+
+            let tree = self
+                .trees
+                .get_mut(&tree_root)
+                .expect("If tree root was found, it must exist in `self.trees`");
+
+            // First element in `ancestors` must be either:
+            // 1) Leaf of some existing subtree
+            // 2) Root of new subtree that was just created above through `self.insert_new_tree`
+            ancestors.push_back(slot);
+            if ancestors.len() > 1 {
+                for i in 0..ancestors.len() - 1 {
+                    tree.add_new_leaf_slot(ancestors[i + 1], Some(ancestors[i]));
+                    self.slot_to_tree.insert(ancestors[i + 1], tree_root);
+                }
+            }
+
+            // Now we know which subtree this slot chains to,
+            // add the votes to the list of updates
+            let subtree_updates = all_subtree_updates.entry(tree_root).or_default();
+            for pubkey in pubkey_votes {
+                let cur_max = subtree_updates.entry(pubkey).or_default();
+                *cur_max = std::cmp::max(*cur_max, slot);
+            }
+        }
+
+        for (tree_root, updates) in all_subtree_updates {
+            let tree = self
+                .trees
+                .get_mut(&tree_root)
+                .expect("`slot_to_tree` and `self.trees` must be in sync");
+            let updates: Vec<_> = updates.into_iter().collect();
+            tree.add_votes(&updates, epoch_stakes, epoch_schedule);
+        }
+    }
+
+    pub fn get_best_weighted_repairs(
+        &mut self,
+        blockstore: &Blockstore,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_schedule: &EpochSchedule,
+        max_new_orphans: usize,
+        max_new_shreds: usize,
+        ignore_slots: &dyn Contains<Slot>,
+    ) -> Vec<RepairType> {
+        let mut repairs = vec![];
+
+        // Update the orphans in order from heaviest to least heavy
+        self.get_best_orphans(
+            blockstore,
+            &mut repairs,
+            epoch_stakes,
+            epoch_schedule,
+            max_new_orphans,
+        );
+
+        // Find the best incomplete slots in rooted subtree
+        self.get_best_shreds(blockstore, &mut repairs, max_new_shreds, ignore_slots);
+
+        repairs
+    }
+
+    pub fn set_root(&mut self, new_root: Slot) {
+        // Roots should be monotonically increasing
+        assert!(self.root <= new_root);
+
+        if new_root == self.root {
+            return;
+        }
+        // Purge outdated trees from `self.trees`
+        let mut subtree_to_purge = self
+            .trees
+            .remove(&self.root)
+            .unwrap_or_else(|| panic!("Tree rooted at slot {} must exist", self.root));
+        subtree_to_purge.set_root(new_root);
+        self.trees.insert(new_root, subtree_to_purge);
+
+        // Purge outdated trees from `self.trees`
+        // TODO: account for slots > root not on the same fork
+        self.trees.retain(|slot, _| *slot >= new_root);
+
+        self.root = new_root;
+    }
+
+    // Generate shred repairs for main subtree rooted at `self.slot`
+    fn get_best_shreds(
+        &mut self,
+        blockstore: &Blockstore,
+        repairs: &mut Vec<RepairType>,
+        max_new_shreds: usize,
+        ignore_slots: &dyn Contains<Slot>,
+    ) {
+        let root_tree = self.trees.get(&self.root).expect("Root tree must exist");
+        repair_weighted_traversal::get_best_repair_shreds(
+            root_tree,
+            blockstore,
+            repairs,
+            max_new_shreds,
+            ignore_slots,
+        );
+    }
+
+    fn get_best_orphans(
+        &mut self,
+        blockstore: &Blockstore,
+        repairs: &mut Vec<RepairType>,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_schedule: &EpochSchedule,
+        max_new_orphans: usize,
+    ) {
+        // Sort each tree in `self.trees`, by the amount of stake that has voted on each,
+        // tiebreaker going to earlier slots, thus prioritizing earlier slots on the same fork
+        // to ensure replay can continue as soon as possible.
+        let mut stake_weighted_trees: Vec<(Slot, u64)> = self
+            .trees
+            .iter()
+            .map(|(slot, tree)| {
+                (
+                    *slot,
+                    tree.stake_voted_subtree(*slot)
+                        .expect("Tree must have weight at its own root"),
+                )
+            })
+            .collect();
+
+        // Heavier, smaller slots come first
+        Self::sort_by_stake_weight_slot(&mut stake_weighted_trees);
+        let mut best_orphans: HashSet<Slot> = HashSet::new();
+        for (heaviest_tree_root, _) in stake_weighted_trees {
+            if best_orphans.len() >= max_new_orphans {
+                break;
+            }
+            if heaviest_tree_root == self.root {
+                continue;
+            }
+            // Ignore trees that were merged in a previous iteration
+            if self.trees.contains_key(&heaviest_tree_root) {
+                let orphan_slot = self.update_orphan_ancestors(
+                    blockstore,
+                    heaviest_tree_root,
+                    epoch_stakes,
+                    epoch_schedule,
+                );
+                if orphan_slot != self.root && !best_orphans.contains(&orphan_slot) {
+                    best_orphans.insert(orphan_slot);
+                    repairs.push(RepairType::Orphan(orphan_slot));
+                }
+            }
+        }
+
+        // If there are fewer than `max_new_orphans`, just grab the next
+        // available ones
+        if best_orphans.len() < max_new_orphans {
+            for new_orphan in blockstore.orphans_iterator(self.root + 1).unwrap() {
+                if !best_orphans.contains(&new_orphan) {
+                    repairs.push(RepairType::Orphan(new_orphan));
+                    best_orphans.insert(new_orphan);
+                }
+
+                if best_orphans.len() == max_new_orphans {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Attempts to chain the orphan subtree rooted at `orphan_tree_root`
+    // to any earlier subtree with new any ancestry information in `blockstore`.
+    // Returns the earliest known ancestor of `heavest_tree_root`.
+    fn update_orphan_ancestors(
+        &mut self,
+        blockstore: &Blockstore,
+        mut orphan_tree_root: Slot,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_schedule: &EpochSchedule,
+    ) -> Slot {
+        // Must only be called on existing orphan trees
+        assert!(self.trees.contains_key(&orphan_tree_root));
+
+        // Check blockstore for any new parents of the heaviest orphan tree. Attempt
+        // to chain the orphan back to the main fork rooted at `self.root`.
+        while orphan_tree_root != self.root {
+            let (new_ancestors, parent_tree_root) =
+                self.find_ancestor_subtree_of_slot(blockstore, orphan_tree_root);
+            {
+                let heaviest_tree = self
+                    .trees
+                    .get_mut(&orphan_tree_root)
+                    .expect("Orphan must exist");
+
+                let num_skip = if parent_tree_root.is_some() {
+                    // Skip the leaf of the parent tree that the
+                    // orphan would merge with later in a call
+                    // to `merge_trees`
+                    1
+                } else {
+                    0
+                };
+
+                for ancestor in new_ancestors.iter().skip(num_skip).rev() {
+                    self.slot_to_tree.insert(*ancestor, orphan_tree_root);
+                    heaviest_tree.add_root_parent(*ancestor);
+                }
+            }
+            if let Some(parent_tree_root) = parent_tree_root {
+                // If another subtree is discovered to be the parent
+                // of this subtree, merge the two.
+                self.merge_trees(
+                    orphan_tree_root,
+                    parent_tree_root,
+                    *new_ancestors
+                        .front()
+                        .expect("Must exist leaf to merge to if `tree_to_merge`.is_some()"),
+                    epoch_stakes,
+                    epoch_schedule,
+                );
+                orphan_tree_root = parent_tree_root;
+            } else {
+                // If there's no other subtree to merge with, then return
+                // the current known earliest ancestor of this branch
+                if let Some(earliest_ancestor) = new_ancestors.front() {
+                    let tree = self.update_and_remove_subtree(orphan_tree_root, *earliest_ancestor);
+                    assert!(self.trees.insert(*earliest_ancestor, tree).is_none());
+                    orphan_tree_root = *earliest_ancestor;
+                }
+                break;
+            }
+        }
+
+        // Return the (potentially new in the case of some merges)
+        // root of this orphan subtree
+        orphan_tree_root
+    }
+
+    fn insert_new_tree(&mut self, new_tree_root: Slot) {
+        assert!(!self.trees.contains_key(&new_tree_root));
+
+        // Update `self.slot_to_tree`
+        self.slot_to_tree.insert(new_tree_root, new_tree_root);
+        self.trees
+            .insert(new_tree_root, HeaviestSubtreeForkChoice::new(new_tree_root));
+    }
+
+    fn find_ancestor_subtree_of_slot(
+        &self,
+        blockstore: &Blockstore,
+        slot: Slot,
+    ) -> (VecDeque<Slot>, Option<Slot>) {
+        let ancestors = AncestorIterator::new(slot, blockstore);
+        let mut ancestors_to_add = VecDeque::new();
+        let mut tree_to_merge = None;
+
+        // This means `heaviest_tree_root` has not been
+        // chained back to slots currently being replayed
+        // in BankForks. Try to see if blockstore has sufficient
+        // information to link this slot back
+        for a in ancestors {
+            ancestors_to_add.push_front(a);
+            // TODO: If chains to before `root`, without incurring a merge,
+            // purge this branch
+
+            // If an ancestor chains back to another subtree, then return
+            let other_tree_root = self.slot_to_tree.get(&a).cloned();
+            tree_to_merge = other_tree_root;
+            if tree_to_merge.is_some() {
+                break;
+            }
+        }
+
+        (ancestors_to_add, tree_to_merge)
+    }
+
+    // Attaches `tree1` rooted at `root1` to `tree2` rooted at `root2`
+    // at the leaf in `tree2` given by `merge_leaf`
+    fn merge_trees(
+        &mut self,
+        root1: Slot,
+        root2: Slot,
+        merge_leaf: Slot,
+        epoch_stakes: &HashMap<Epoch, EpochStakes>,
+        epoch_schedule: &EpochSchedule,
+    ) {
+        // Update self.slot_to_tree to reflect the merge
+        let tree1 = self.update_and_remove_subtree(root1, root2);
+
+        // Merge trees
+        let tree2 = self
+            .trees
+            .get_mut(&root2)
+            .expect("tree to be merged must exist");
+
+        tree2.merge(tree1, merge_leaf, epoch_stakes, epoch_schedule);
+    }
+
+    // Update all nodes in tree rooted at `root1` to point to `root2`,
+    // and remove old subtree at `slot1`
+    fn update_and_remove_subtree(&mut self, root1: Slot, root2: Slot) -> HeaviestSubtreeForkChoice {
+        let tree1 = self
+            .trees
+            .remove(&root1)
+            .expect("tree to remove must exist");
+        let all_slots = tree1.all_slots_stake_voted_subtree();
+        for (slot, _) in all_slots {
+            *self
+                .slot_to_tree
+                .get_mut(&slot)
+                .expect("Nodes in tree must exist in `self.slot_to_tree`") = root2;
+        }
+        tree1
+    }
+
+    // Heavier, smaller slots come first
+    fn sort_by_stake_weight_slot(slot_stake_voted: &mut Vec<(Slot, u64)>) {
+        slot_stake_voted.sort_by(|(slot, stake_voted), (slot_, stake_voted_)| {
+            if stake_voted == stake_voted_ {
+                slot.cmp(&slot_)
+            } else {
+                stake_voted.cmp(&stake_voted_).reverse()
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path};
+    use solana_runtime::bank_utils;
+    use trees::tr;
+
+    #[test]
+    fn test_sort_by_stake_weight_slot() {
+        let mut slots = vec![(3, 30), (2, 30), (5, 31)];
+        RepairWeight::sort_by_stake_weight_slot(&mut slots);
+        assert_eq!(slots, vec![(5, 31), (2, 30), (3, 30)]);
+    }
+
+    #[test]
+    fn test_add_votes() {
+        let blockstore = setup_forks();
+        let stake = 100;
+        let (bank, vote_pubkeys) = bank_utils::setup_bank_and_vote_pubkeys(3, stake);
+        let votes = vec![(1, vote_pubkeys.clone())];
+
+        let mut repair_weight = RepairWeight::new(0);
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        // repair_weight should contain one subtree 0->1
+        assert_eq!(repair_weight.trees.len(), 1);
+        assert_eq!(repair_weight.trees.get(&0).unwrap().ancestors(1), vec![0]);
+        for i in &[0, 1] {
+            assert_eq!(*repair_weight.slot_to_tree.get(i).unwrap(), 0);
+        }
+
+        // Add slots 6 and 4 with the same set of pubkeys,
+        // should discover the rest of the tree and the weights,
+        // and should only count the latest votes
+        let votes = vec![(4, vote_pubkeys.clone()), (6, vote_pubkeys)];
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+        assert_eq!(repair_weight.trees.len(), 1);
+        assert_eq!(
+            repair_weight.trees.get(&0).unwrap().ancestors(4),
+            vec![2, 1, 0]
+        );
+        assert_eq!(
+            repair_weight.trees.get(&0).unwrap().ancestors(6),
+            vec![5, 3, 1, 0]
+        );
+        for slot in 0..=6 {
+            assert_eq!(*repair_weight.slot_to_tree.get(&slot).unwrap(), 0);
+            let stake_voted_at = repair_weight
+                .trees
+                .get(&0)
+                .unwrap()
+                .stake_voted_at(slot)
+                .unwrap();
+            if slot == 6 {
+                assert_eq!(stake_voted_at, 3 * stake);
+            } else {
+                assert_eq!(stake_voted_at, 0);
+            }
+        }
+
+        for slot in &[6, 5, 3, 1, 0] {
+            let stake_voted_subtree = repair_weight
+                .trees
+                .get(&0)
+                .unwrap()
+                .stake_voted_subtree(*slot)
+                .unwrap();
+            assert_eq!(stake_voted_subtree, 3 * stake);
+        }
+        for slot in &[4, 2] {
+            let stake_voted_subtree = repair_weight
+                .trees
+                .get(&0)
+                .unwrap()
+                .stake_voted_subtree(*slot)
+                .unwrap();
+            assert_eq!(stake_voted_subtree, 0);
+        }
+    }
+
+    #[test]
+    fn test_add_votes_orphans() {
+        let blockstore = setup_orphans();
+        let stake = 100;
+        let (bank, vote_pubkeys) = bank_utils::setup_bank_and_vote_pubkeys(3, stake);
+        let votes = vec![(1, vote_pubkeys.clone()), (8, vote_pubkeys.clone())];
+
+        let mut repair_weight = RepairWeight::new(0);
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        // Should contain two trees, one for main fork, one for the orphan
+        // branch
+        assert_eq!(repair_weight.trees.len(), 2);
+        assert_eq!(repair_weight.trees.get(&0).unwrap().ancestors(1), vec![0]);
+        assert!(repair_weight.trees.get(&8).unwrap().ancestors(8).is_empty());
+
+        let votes = vec![(1, vote_pubkeys.clone()), (10, vote_pubkeys.clone())];
+        let mut repair_weight = RepairWeight::new(0);
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        // Should contain two trees, one for main fork, one for the orphan
+        // branch
+        assert_eq!(repair_weight.trees.len(), 2);
+        assert_eq!(repair_weight.trees.get(&0).unwrap().ancestors(1), vec![0]);
+        assert_eq!(repair_weight.trees.get(&8).unwrap().ancestors(10), vec![8]);
+
+        // Connect orphan back to main fork
+        blockstore.add_tree(tr(6) / (tr(8)), true, true);
+        assert_eq!(
+            AncestorIterator::new(8, &blockstore).collect::<Vec<_>>(),
+            vec![6, 5, 3, 1, 0]
+        );
+        let votes = vec![(11, vote_pubkeys)];
+
+        // Should not resolve orphans because `update_orphan_ancestors` has
+        // not been called, but should addd to the orphan branch
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+        assert_eq!(
+            repair_weight.trees.get(&8).unwrap().ancestors(11),
+            vec![10, 8]
+        );
+
+        for slot in &[8, 10, 11] {
+            assert_eq!(*repair_weight.slot_to_tree.get(&slot).unwrap(), 8);
+        }
+        for slot in 0..=1 {
+            assert_eq!(*repair_weight.slot_to_tree.get(&slot).unwrap(), 0);
+        }
+
+        // Call `update_orphan_ancestors` to resolve orphan
+        repair_weight.update_orphan_ancestors(
+            &blockstore,
+            8,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        for slot in &[8, 10, 11] {
+            assert_eq!(*repair_weight.slot_to_tree.get(&slot).unwrap(), 0);
+        }
+        assert_eq!(repair_weight.trees.len(), 1);
+        assert!(repair_weight.trees.get(&0).is_some());
+    }
+
+    #[test]
+    fn test_update_orphan_ancestors() {
+        let blockstore = setup_orphans();
+        let stake = 100;
+        let (bank, vote_pubkeys) = bank_utils::setup_bank_and_vote_pubkeys(3, stake);
+        // Create votes for both orphan branches
+        let votes = vec![
+            (10, vote_pubkeys[0..1].to_vec()),
+            (22, vote_pubkeys[1..3].to_vec()),
+        ];
+
+        let mut repair_weight = RepairWeight::new(0);
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        assert_eq!(repair_weight.trees.len(), 3);
+        // Roots of the orphan branches should exist
+        assert!(repair_weight.trees.get(&0).is_some());
+        assert!(repair_weight.trees.get(&8).is_some());
+        assert!(repair_weight.trees.get(&20).is_some());
+
+        // Call `update_orphan_ancestors` to resolve orphan
+        repair_weight.update_orphan_ancestors(
+            &blockstore,
+            8,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        // Nothing has changed because no orphans were
+        // resolved
+        assert_eq!(repair_weight.trees.len(), 3);
+        // Roots of the orphan branches should exist
+        assert!(repair_weight.trees.get(&0).is_some());
+        assert!(repair_weight.trees.get(&8).is_some());
+        assert!(repair_weight.trees.get(&20).is_some());
+
+        // Resolve orphans in blockstore
+        blockstore.add_tree(tr(6) / (tr(8)), true, true);
+        blockstore.add_tree(tr(11) / (tr(20)), true, true);
+        // Call `update_orphan_ancestors` to resolve orphan
+        repair_weight.update_orphan_ancestors(
+            &blockstore,
+            20,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        // Only the main fork should exist now
+        assert_eq!(repair_weight.trees.len(), 1);
+        assert!(repair_weight.trees.get(&0).is_some());
+    }
+
+    #[test]
+    fn test_get_best_orphans() {
+        let blockstore = setup_orphans();
+        let stake = 100;
+        let (bank, vote_pubkeys) = bank_utils::setup_bank_and_vote_pubkeys(2, stake);
+        let votes = vec![(8, vec![vote_pubkeys[0]]), (20, vec![vote_pubkeys[1]])];
+        let mut repair_weight = RepairWeight::new(0);
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        // Ask for only 1 orphan. Because the orphans have the same weight,
+        // should prioritize smaller orphan first
+        let mut repairs = vec![];
+        repair_weight.get_best_orphans(
+            &blockstore,
+            &mut repairs,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+            1,
+        );
+        assert_eq!(
+            repair_weight
+                .trees
+                .get(&8)
+                .unwrap()
+                .stake_voted_subtree(8)
+                .unwrap(),
+            repair_weight
+                .trees
+                .get(&20)
+                .unwrap()
+                .stake_voted_subtree(20)
+                .unwrap()
+        );
+        assert_eq!(repairs.len(), 1);
+        assert_eq!(repairs[0].slot(), 8);
+
+        // New vote on same orphan branch, without any new slot chaining
+        // information blockstore should not resolve the orphan
+        repairs = vec![];
+        let votes = vec![(10, vec![vote_pubkeys[0]])];
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+        repair_weight.get_best_orphans(
+            &blockstore,
+            &mut repairs,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+            1,
+        );
+        assert_eq!(repairs.len(), 1);
+        assert_eq!(repairs[0].slot(), 8);
+
+        // Ask for 2 orphans, should return all the orphans
+        repairs = vec![];
+        repair_weight.get_best_orphans(
+            &blockstore,
+            &mut repairs,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+            2,
+        );
+        assert_eq!(repairs.len(), 2);
+        assert_eq!(repairs[0].slot(), 8);
+        assert_eq!(repairs[1].slot(), 20);
+
+        // If one orphan gets heavier, should pick that one
+        repairs = vec![];
+        let votes = vec![(20, vec![vote_pubkeys[0]])];
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+        repair_weight.get_best_orphans(
+            &blockstore,
+            &mut repairs,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+            1,
+        );
+        assert_eq!(repairs.len(), 1);
+        assert_eq!(repairs[0].slot(), 20);
+
+        // Resolve the orphans, should now return no
+        // orphans
+        repairs = vec![];
+        blockstore.add_tree(tr(6) / (tr(8)), true, true);
+        blockstore.add_tree(tr(11) / (tr(20)), true, true);
+        repair_weight.get_best_orphans(
+            &blockstore,
+            &mut repairs,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+            1,
+        );
+        assert!(repairs.is_empty());
+    }
+
+    #[test]
+    fn test_get_extra_orphans() {
+        let blockstore = setup_orphans();
+        let stake = 100;
+        let (bank, vote_pubkeys) = bank_utils::setup_bank_and_vote_pubkeys(2, stake);
+        let votes = vec![(8, vec![vote_pubkeys[0]])];
+        let mut repair_weight = RepairWeight::new(0);
+        repair_weight.add_votes(
+            &blockstore,
+            votes.into_iter(),
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+        );
+
+        // Should only be one orphan in the `trees` map
+        assert_eq!(repair_weight.trees.len(), 2);
+        // Roots of the orphan branches should exist
+        assert!(repair_weight.trees.get(&0).is_some());
+        assert!(repair_weight.trees.get(&8).is_some());
+
+        // Ask for 2 orphans. Even though there's only one
+        // orphan in the `trees` map, we should search for
+        // exactly one more of the remaining two
+        let mut repairs = vec![];
+        blockstore.add_tree(tr(100) / (tr(101)), true, true);
+        repair_weight.get_best_orphans(
+            &blockstore,
+            &mut repairs,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+            2,
+        );
+        assert_eq!(repairs.len(), 2);
+        assert_eq!(repairs[0].slot(), 8);
+        assert_eq!(repairs[1].slot(), 20);
+
+        // If we ask for 3 orphans, we should get all of them
+        let mut repairs = vec![];
+        repair_weight.get_best_orphans(
+            &blockstore,
+            &mut repairs,
+            bank.epoch_stakes_map(),
+            bank.epoch_schedule(),
+            3,
+        );
+        assert_eq!(repairs.len(), 3);
+        assert_eq!(repairs[0].slot(), 8);
+        assert_eq!(repairs[1].slot(), 20);
+        assert_eq!(repairs[2].slot(), 100);
+    }
+
+    fn setup_orphans() -> Blockstore {
+        /*
+            Build fork structure:
+                 slot 0
+                   |
+                 slot 1
+                 /    \
+            slot 2    |
+               |    slot 3
+            slot 4    |
+                    slot 5
+                      |
+                    slot 6
+
+            Orphans:
+               slot 8
+                  |
+               slot 10
+                  |
+               slot 11
+
+            Orphans:
+              slot 20
+                 |
+              slot 22
+                 |
+              slot 23
+        */
+
+        let blockstore = setup_forks();
+        blockstore.add_tree(tr(8) / (tr(10) / (tr(11))), true, true);
+        blockstore.add_tree(tr(20) / (tr(22) / (tr(23))), true, true);
+        assert!(blockstore.orphan(8).unwrap().is_some());
+        blockstore
+    }
+
+    fn setup_forks() -> Blockstore {
+        /*
+            Build fork structure:
+                 slot 0
+                   |
+                 slot 1
+                 /    \
+            slot 2    |
+               |    slot 3
+            slot 4    |
+                    slot 5
+                      |
+                    slot 6
+        */
+        let forks = tr(0) / (tr(1) / (tr(2) / (tr(4))) / (tr(3) / (tr(5) / (tr(6)))));
+        let ledger_path = get_tmp_ledger_path!();
+        let blockstore = Blockstore::open(&ledger_path).unwrap();
+        blockstore.add_tree(forks, false, true);
+        blockstore
+    }
+}

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -33,7 +33,7 @@ use std::{
 pub const MAX_ORPHAN_REPAIR_RESPONSES: usize = 10;
 pub const DEFAULT_NONCE: u32 = 42;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum RepairType {
     Orphan(Slot),
     HighestShred(Slot, u64),

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -353,7 +353,8 @@ impl Blockstore {
         let mut walk = TreeWalk::from(forks);
         while let Some(visit) = walk.get() {
             let slot = visit.node().data;
-            if self.meta(slot).unwrap().is_some() {
+            if self.meta(slot).unwrap().is_some() && self.orphan(slot).unwrap().is_none() {
+                // If slot exists and is not an orphan, then skip it
                 walk.forward();
                 continue;
             }


### PR DESCRIPTION
#### Problem
Lacking a data structure to track all the repairs observed on gossip and aggregating them to pick the best repairs

#### Summary of Changes
1) Add `RepairWeight` which tracks all disjoint votes as disjoint trees (each tree represented by `HeaviestSubtreeForkChoice`). Votes are added through `add_votes`
2) Exposes functionality to link orphans back to the main tree through calls to `update_orphan_ancestors`, which looks at updates in blockstore and tries to chain orphans back to the main fork.
3) Introduces `get_best_weighted_repairs` which leverages `RepairWeightTraversal`: https://github.com/solana-labs/solana/pull/10877 to find the best repairs.
Fixes #
4) Lots of tests for `RepairWeight`