### PR TITLE
Make test-checks.sh helpful and cargo-for-all-lock-files.sh useful

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -36,8 +36,9 @@ if [[ $CI_BASE_BRANCH = "$EDGE_CHANNEL" ]]; then
     true
   else
     check_status=$?
-    echo "Some Cargo.lock might be outdated; update them (or just be a compilation error?)"
-    echo "protip: you can use ./scripts/cargo-for-all-lock-files.sh [check|update] ..."
+    echo "$0: Some Cargo.lock might be outdated; sync them (or just be a compilation error?)" >&2
+    echo "$0: protip: $ ./scripts/cargo-for-all-lock-files.sh [--ignore-exit-code] ... \\" >&2
+    echo "$0:   [tree (for outdated Cargo.lock sync)|check (for compilation error)|update -p foo --precise x.y.z (for your Cargo.toml update)] ..." >&2
     exit "$check_status"
   fi
 else


### PR DESCRIPTION
#### Problem

test-check.sh isn't so helpful.

#### Summary of Changes

Improve the messaging and ensure `cargo-for-all-lock-files.sh` really supports intended use case with `--ignore-exit-code`.

Follow-up to recent discord discussions and #10790

I'll skip full CI run as this is tested here: https://buildkite.com/solana-labs/solana/builds/26995#09f70703-a12d-4464-971d-9a9fc6610543/139-145
