### PR TITLE
Cleanup rpc

### DIFF
--- a/core/src/rpc_error.rs
+++ b/core/src/rpc_error.rs
@@ -1,15 +1,10 @@
 use jsonrpc_core::{Error, ErrorCode};
 use solana_sdk::clock::Slot;
 
-const JSON_RPC_SERVER_ERROR_0: i64 = -32000;
 const JSON_RPC_SERVER_ERROR_1: i64 = -32001;
 const JSON_RPC_SERVER_ERROR_2: i64 = -32002;
 
 pub enum RpcCustomError {
-    NonexistentClusterRoot {
-        cluster_root: Slot,
-        node_root: Slot,
-    },
     BlockCleanedUp {
         slot: Slot,
         first_available_block: Slot,
@@ -22,17 +17,6 @@ pub enum RpcCustomError {
 impl From<RpcCustomError> for Error {
     fn from(e: RpcCustomError) -> Self {
         match e {
-            RpcCustomError::NonexistentClusterRoot {
-                cluster_root,
-                node_root,
-            } => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_0),
-                message: format!(
-                    "Cluster largest_confirmed_root {} does not exist on node. Node root: {}",
-                    cluster_root, node_root,
-                ),
-                data: None,
-            },
             RpcCustomError::BlockCleanedUp {
                 slot,
                 first_available_block,

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -402,7 +402,6 @@ mod tests {
             rpc_service
                 .request_processor
                 .get_balance(&mint_keypair.pubkey(), None)
-                .unwrap()
                 .value
         );
         rpc_service.exit();


### PR DESCRIPTION
#### Problem

Can't share code between jsonrpc_core and tarpc services. Most JsonRpcRequestProcessor methods return a jsonrpc_core-specific Result even though their only error cases are unreachable.

#### Summary of Changes

Assume the genesis block is the default largest confirmed root. Remove all the Result wrappers. There were no tests for those unreachable branches, so no test changes.

Still not sharing code between jsonrpc_core and tarpc services, but one step closer.
