### PR TITLE
fix rewards points

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -982,6 +982,43 @@ pub fn create_account(
     rent: &Rent,
     lamports: u64,
 ) -> Account {
+    do_create_account(
+        authorized,
+        voter_pubkey,
+        vote_account,
+        rent,
+        lamports,
+        Epoch::MAX,
+    )
+}
+
+// utility function, used by tests
+pub fn create_account_with_activation_epoch(
+    authorized: &Pubkey,
+    voter_pubkey: &Pubkey,
+    vote_account: &Account,
+    rent: &Rent,
+    lamports: u64,
+    activation_epoch: Epoch,
+) -> Account {
+    do_create_account(
+        authorized,
+        voter_pubkey,
+        vote_account,
+        rent,
+        lamports,
+        activation_epoch,
+    )
+}
+
+fn do_create_account(
+    authorized: &Pubkey,
+    voter_pubkey: &Pubkey,
+    vote_account: &Account,
+    rent: &Rent,
+    lamports: u64,
+    activation_epoch: Epoch,
+) -> Account {
     let mut stake_account = Account::new(lamports, std::mem::size_of::<StakeState>(), &id());
 
     let vote_state = VoteState::from(vote_account).expect("vote_state");
@@ -999,7 +1036,7 @@ pub fn create_account(
                 lamports - rent_exempt_reserve, // underflow is an error, is basically: assert!(lamports > rent_exempt_reserve);
                 voter_pubkey,
                 &vote_state,
-                std::u64::MAX,
+                activation_epoch,
                 &Config::default(),
             ),
         ))

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -19,7 +19,7 @@ use solana_sdk::{
     stake_history::{StakeHistory, StakeHistoryEntry},
 };
 use solana_vote_program::vote_state::{VoteState, VoteStateVersions};
-use std::collections::HashSet;
+use std::{collections::HashSet, convert::TryFrom};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, AbiExample)]
 #[allow(clippy::large_enum_variant)]
@@ -462,8 +462,7 @@ impl Stake {
             .checked_div(point_value.points)
             .unwrap();
 
-        assert!(rewards <= u128::from(std::u64::MAX));
-        let rewards = rewards as u64;
+        let rewards = u64::try_from(rewards).unwrap();
 
         // don't bother trying to split if fractional lamports got truncated
         if rewards == 0 {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -259,6 +259,11 @@ impl VoteState {
             100 => (on, 0, false),
             split => {
                 let on = u128::from(on);
+                // Calculate mine and theirs independently and symmetrically instead of
+                // using the remainder of the other to treat them strictly equally.
+                // This is also to cancel the rewarding if either of the parties
+                // should receive only fractional lamports, resulting in not being rewarded at all.
+                // Thus, note that we intentionally discard any residual fractional lamports.
                 let mine = on * u128::from(split) / 100u128;
                 let theirs = on * u128::from(100 - split) / 100u128;
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -253,13 +253,16 @@ impl VoteState {
     ///
     ///  if commission calculation is 100% one way or other,
     ///   indicate with false for was_split
-    pub fn commission_split(&self, on: f64) -> (f64, f64, bool) {
+    pub fn commission_split(&self, on: u64) -> (u64, u64, bool) {
         match self.commission.min(100) {
-            0 => (0.0, on, false),
-            100 => (on, 0.0, false),
+            0 => (0, on, false),
+            100 => (on, 0, false),
             split => {
-                let mine = on * f64::from(split) / f64::from(100);
-                (mine, on - mine, true)
+                let on = u128::from(on);
+                let mine = on * u128::from(split) / 100u128;
+                let theirs = on * u128::from(100 - split) / 100u128;
+
+                (mine as u64, theirs as u64, true)
             }
         }
     }
@@ -1562,19 +1565,22 @@ mod tests {
     fn test_vote_state_commission_split() {
         let vote_state = VoteState::default();
 
-        assert_eq!(vote_state.commission_split(1.0), (0.0, 1.0, false));
+        assert_eq!(vote_state.commission_split(1), (0, 1, false));
 
         let mut vote_state = VoteState::default();
         vote_state.commission = std::u8::MAX;
-        assert_eq!(vote_state.commission_split(1.0), (1.0, 0.0, false));
+        assert_eq!(vote_state.commission_split(1), (1, 0, false));
+
+        vote_state.commission = 99;
+        assert_eq!(vote_state.commission_split(10), (9, 0, true));
+
+        vote_state.commission = 1;
+        assert_eq!(vote_state.commission_split(10), (0, 9, true));
 
         vote_state.commission = 50;
-        let (voter_portion, staker_portion, was_split) = vote_state.commission_split(10.0);
+        let (voter_portion, staker_portion, was_split) = vote_state.commission_split(10);
 
-        assert_eq!(
-            (voter_portion.round(), staker_portion.round(), was_split),
-            (5.0, 5.0, true)
-        );
+        assert_eq!((voter_portion, staker_portion, was_split), (5, 5, true));
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -898,9 +898,9 @@ impl Bank {
             let inflation = self.inflation.read().unwrap();
 
             (*inflation).validator(year) * self.capitalization() as f64 * period
-        };
+        } as u64;
 
-        let validator_point_value = self.pay_validator_rewards(validator_rewards as u64);
+        let validator_point_value = self.pay_validator_rewards(validator_rewards);
 
         self.update_sysvar_account(&sysvar::rewards::id(), |account| {
             sysvar::rewards::create_account(
@@ -910,7 +910,7 @@ impl Bank {
         });
 
         self.capitalization
-            .fetch_add(validator_rewards as u64, Ordering::Relaxed);
+            .fetch_add(validator_rewards, Ordering::Relaxed);
     }
 
     /// iterate over all stakes, redeem vote credits for each stake we can
@@ -4746,7 +4746,22 @@ mod tests {
         }
         bank.store_account(&vote_id, &vote_account);
 
-        let validator_points = bank.stakes.read().unwrap().points();
+        let validator_points: u128 = bank
+            .stake_delegations()
+            .iter()
+            .map(|(stake_pubkey, delegation)| {
+                match (
+                    bank.get_account(&stake_pubkey),
+                    bank.get_account(&delegation.voter_pubkey),
+                ) {
+                    (Some(stake_account), Some(vote_account)) => {
+                        stake_state::calculate_points(&stake_account, &vote_account, None)
+                            .unwrap_or(0)
+                    }
+                    (_, _) => 0,
+                }
+            })
+            .sum();
 
         // put a child bank in epoch 1, which calls update_rewards()...
         let bank1 = Bank::new_from_parent(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -935,11 +935,11 @@ impl Bank {
             .fetch_add(validator_rewards_paid, Ordering::Relaxed);
     }
 
-    /// map stake delegations into resolved (pubkey, account) pairs
+    /// map stake delegations into resolved pubkeys
     ///  returns a vector (has to be copied) of loaded
-    ///   ( (staker info) (voter info) )
+    ///   ( staker pubkey voter pubkey )
     ///
-    fn stake_delegation_accounts(&self) -> Vec<((Pubkey, Account), (Pubkey, Account))> {
+    fn stake_delegation_pubkeys(&self) -> Vec<(Pubkey, Pubkey)> {
         self.stakes
             .read()
             .unwrap()
@@ -950,14 +950,23 @@ impl Bank {
                     self.get_account(&stake_pubkey),
                     self.get_account(&delegation.voter_pubkey),
                 ) {
-                    (Some(stake_account), Some(vote_account)) => Some((
-                        (*stake_pubkey, stake_account),
-                        (delegation.voter_pubkey, vote_account),
-                    )),
+                    (Some(_stake_account), Some(_vote_account)) => {
+                        Some((*stake_pubkey, delegation.voter_pubkey))
+                    }
                     (_, _) => None,
                 }
             })
             .collect()
+    }
+
+    fn paired_accounts(
+        &self,
+        (stake_pubkey, vote_pubkey): (Pubkey, Pubkey),
+    ) -> ((Pubkey, Account), (Pubkey, Account)) {
+        (
+            (stake_pubkey, self.get_account(&stake_pubkey).unwrap()),
+            (vote_pubkey, self.get_account(&vote_pubkey).unwrap()),
+        )
     }
 
     /// iterate over all stakes, redeem vote credits for each stake we can
@@ -965,10 +974,11 @@ impl Bank {
     fn pay_validator_rewards(&mut self, rewards: u64) -> f64 {
         let stake_history = self.stakes.read().unwrap().history().clone();
 
-        let mut stake_delegation_accounts = self.stake_delegation_accounts();
+        let stake_delegation_pubkeys = self.stake_delegation_pubkeys();
 
-        let points: u128 = stake_delegation_accounts
+        let points: u128 = stake_delegation_pubkeys
             .iter()
+            .map(|pubkeys| self.paired_accounts(*pubkeys))
             .map(
                 |((_stake_pubkey, stake_account), (_vote_pubkey, vote_account))| {
                     stake_state::calculate_points(
@@ -990,33 +1000,36 @@ impl Bank {
         let mut rewards = HashMap::new();
 
         // pay according to point value
-        stake_delegation_accounts.iter_mut().for_each(
-            |((stake_pubkey, stake_account), (vote_pubkey, vote_account))| {
-                let redeemed = stake_state::redeem_rewards(
-                    stake_account,
-                    vote_account,
-                    &point_value,
-                    Some(&stake_history),
-                );
-                if let Ok((stakers_reward, voters_reward)) = redeemed {
-                    self.store_account(&stake_pubkey, &stake_account);
-                    self.store_account(&vote_pubkey, &vote_account);
-
-                    if voters_reward > 0 {
-                        *rewards.entry(*vote_pubkey).or_insert(0i64) += voters_reward as i64;
-                    }
-
-                    if stakers_reward > 0 {
-                        *rewards.entry(*stake_pubkey).or_insert(0i64) += stakers_reward as i64;
-                    }
-                } else {
-                    debug!(
-                        "stake_state::redeem_rewards() failed for {}: {:?}",
-                        stake_pubkey, redeemed
+        stake_delegation_pubkeys
+            .into_iter()
+            .map(|pubkeys| self.paired_accounts(pubkeys))
+            .for_each(
+                |((stake_pubkey, mut stake_account), (vote_pubkey, mut vote_account))| {
+                    let redeemed = stake_state::redeem_rewards(
+                        &mut stake_account,
+                        &mut vote_account,
+                        &point_value,
+                        Some(&stake_history),
                     );
-                }
-            },
-        );
+                    if let Ok((stakers_reward, voters_reward)) = redeemed {
+                        self.store_account(&stake_pubkey, &stake_account);
+                        self.store_account(&vote_pubkey, &vote_account);
+
+                        if voters_reward > 0 {
+                            *rewards.entry(vote_pubkey).or_insert(0i64) += voters_reward as i64;
+                        }
+
+                        if stakers_reward > 0 {
+                            *rewards.entry(stake_pubkey).or_insert(0i64) += stakers_reward as i64;
+                        }
+                    } else {
+                        debug!(
+                            "stake_state::redeem_rewards() failed for {}: {:?}",
+                            stake_pubkey, redeemed
+                        );
+                    }
+                },
+            );
 
         assert_eq!(self.rewards, None);
         self.rewards = Some(rewards.drain().collect());
@@ -4768,8 +4781,9 @@ mod tests {
         bank.store_account(&vote_id, &vote_account);
 
         let validator_points: u128 = bank
-            .stake_delegation_accounts()
+            .stake_delegation_pubkeys()
             .iter()
+            .map(|pubkeys| bank.paired_accounts(*pubkeys))
             .map(
                 |((_stake_pubkey, stake_account), (_vote_pubkey, vote_account))| {
                     stake_state::calculate_points(&stake_account, &vote_account, None).unwrap_or(0)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -915,18 +915,12 @@ impl Bank {
 
         let validator_rewards_paid =
             self.stakes.read().unwrap().vote_balance_and_staked() - vote_balance_and_staked;
-        assert_eq!(
-            validator_rewards_paid,
-            u64::try_from(
-                self.rewards
-                    .as_ref()
-                    .unwrap()
-                    .iter()
-                    .map(|(_pubkey, reward)| reward)
-                    .sum::<i64>()
-            )
-            .unwrap()
-        );
+        if let Some(rewards) = self.rewards.as_ref() {
+            assert_eq!(
+                validator_rewards_paid,
+                u64::try_from(rewards.iter().map(|(_pubkey, reward)| reward).sum::<i64>()).unwrap()
+            );
+        }
 
         // verify that we didn't pay any more than we expected to
         assert!(validator_rewards >= validator_rewards_paid);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -900,9 +900,8 @@ impl Bank {
             (*inflation).validator(year) * self.capitalization() as f64 * period
         };
 
-        let validator_points = self.stakes.write().unwrap().claim_points();
-        let validator_point_value =
-            self.check_point_value(validator_rewards / validator_points as f64);
+        let validator_point_value = self.pay_validator_rewards(validator_rewards as u64);
+
         self.update_sysvar_account(&sysvar::rewards::id(), |account| {
             sysvar::rewards::create_account(
                 self.inherit_sysvar_account_balance(account),
@@ -910,65 +909,82 @@ impl Bank {
             )
         });
 
-        let validator_rewards = self.pay_validator_rewards(validator_point_value);
-
         self.capitalization
             .fetch_add(validator_rewards as u64, Ordering::Relaxed);
     }
 
     /// iterate over all stakes, redeem vote credits for each stake we can
     ///   successfully load and parse, return total payout
-    fn pay_validator_rewards(&mut self, point_value: f64) -> u64 {
+    fn pay_validator_rewards(&mut self, validator_rewards: u64) -> f64 {
         let stake_history = self.stakes.read().unwrap().history().clone();
-        let mut validator_rewards = HashMap::new();
 
-        let total_validator_rewards = self
-            .stake_delegations()
+        let stake_delegations = self.stake_delegations();
+
+        // first, count total points
+        let points: u128 = stake_delegations
             .iter()
             .map(|(stake_pubkey, delegation)| {
                 match (
                     self.get_account(&stake_pubkey),
                     self.get_account(&delegation.voter_pubkey),
                 ) {
-                    (Some(mut stake_account), Some(mut vote_account)) => {
-                        let rewards = stake_state::redeem_rewards(
-                            &mut stake_account,
-                            &mut vote_account,
-                            point_value,
-                            Some(&stake_history),
-                        );
-                        if let Ok((stakers_reward, voters_reward)) = rewards {
-                            self.store_account(&stake_pubkey, &stake_account);
-                            self.store_account(&delegation.voter_pubkey, &vote_account);
-
-                            if voters_reward > 0 {
-                                *validator_rewards
-                                    .entry(delegation.voter_pubkey)
-                                    .or_insert(0i64) += voters_reward as i64;
-                            }
-
-                            if stakers_reward > 0 {
-                                *validator_rewards.entry(*stake_pubkey).or_insert(0i64) +=
-                                    stakers_reward as i64;
-                            }
-
-                            stakers_reward + voters_reward
-                        } else {
-                            debug!(
-                                "stake_state::redeem_rewards() failed for {}: {:?}",
-                                stake_pubkey, rewards
-                            );
-                            0
-                        }
-                    }
+                    (Some(stake_account), Some(vote_account)) => stake_state::calculate_points(
+                        &stake_account,
+                        &vote_account,
+                        Some(&stake_history),
+                    )
+                    .unwrap_or(0),
                     (_, _) => 0,
                 }
             })
             .sum();
 
+        let point_value = self.check_point_value(validator_rewards as f64 / points as f64);
+
+        let mut rewards = HashMap::new();
+
+        // pay according to point value
+        stake_delegations
+            .iter()
+            .for_each(|(stake_pubkey, delegation)| {
+                match (
+                    self.get_account(&stake_pubkey),
+                    self.get_account(&delegation.voter_pubkey),
+                ) {
+                    (Some(mut stake_account), Some(mut vote_account)) => {
+                        let redeemed = stake_state::redeem_rewards(
+                            &mut stake_account,
+                            &mut vote_account,
+                            point_value,
+                            Some(&stake_history),
+                        );
+                        if let Ok((stakers_reward, voters_reward)) = redeemed {
+                            self.store_account(&stake_pubkey, &stake_account);
+                            self.store_account(&delegation.voter_pubkey, &vote_account);
+
+                            if voters_reward > 0 {
+                                *rewards.entry(delegation.voter_pubkey).or_insert(0i64) +=
+                                    voters_reward as i64;
+                            }
+
+                            if stakers_reward > 0 {
+                                *rewards.entry(*stake_pubkey).or_insert(0i64) +=
+                                    stakers_reward as i64;
+                            }
+                        } else {
+                            debug!(
+                                "stake_state::redeem_rewards() failed for {}: {:?}",
+                                stake_pubkey, redeemed
+                            );
+                        }
+                    }
+                    (_, _) => (),
+                }
+            });
+
         assert_eq!(self.rewards, None);
-        self.rewards = Some(validator_rewards.drain().collect());
-        total_validator_rewards
+        self.rewards = Some(rewards.drain().collect());
+        point_value
     }
 
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -60,6 +60,7 @@ use solana_vote_program::{vote_instruction::VoteInstruction, vote_state::VoteSta
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
+    convert::TryFrom,
     mem,
     ops::RangeInclusive,
     path::PathBuf,
@@ -914,6 +915,18 @@ impl Bank {
 
         let validator_rewards_paid =
             self.stakes.read().unwrap().vote_balance_and_staked() - vote_balance_and_staked;
+        assert_eq!(
+            validator_rewards_paid,
+            u64::try_from(
+                self.rewards
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .map(|(_pubkey, reward)| reward)
+                    .sum::<i64>()
+            )
+            .unwrap()
+        );
 
         // verify that we didn't pay any more than we expected to
         assert!(validator_rewards >= validator_rewards_paid);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -282,7 +282,7 @@ mod test_bank_serialize {
 
     // These some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "6MnT4MzuLHe4Uq96YaF3JF2gL1RvprzQHCaV9TaWgYLe")]
+    #[frozen_abi(digest = "FaZaic5p7bvdsKDxGJmaPVyp12AbAmURyYoGiUdx1Ksu")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperFuture {
         #[serde(serialize_with = "wrapper_future")]
@@ -305,7 +305,7 @@ mod test_bank_serialize {
         .serialize(s)
     }
 
-    #[frozen_abi(digest = "92KVEUQ8PwKe5DgZ6AyDQGAi9pvi7kfHdMBE4hcs5EQ4")]
+    #[frozen_abi(digest = "9g4bYykzsC86fULgu9iUh4kpvb1pxvAmipvyZPChLhws")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperLegacy {
         #[serde(serialize_with = "wrapper_legacy")]

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -173,9 +173,7 @@ pub mod tests {
     use super::*;
     use solana_sdk::{pubkey::Pubkey, rent::Rent};
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state::{
-        self, VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY,
-    };
+    use solana_vote_program::vote_state::{self, VoteState};
 
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
     pub fn create_staked_node_accounts(stake: u64) -> ((Pubkey, Account), (Pubkey, Account)) {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -87,6 +87,13 @@ impl Stakes {
             .sum()
     }
 
+    pub fn vote_balance_and_staked(&self) -> u64 {
+        self.vote_accounts
+            .iter()
+            .map(|(_pubkey, (staked, account))| staked + account.lamports)
+            .sum()
+    }
+
     pub fn is_stake(account: &Account) -> bool {
         solana_vote_program::check_id(&account.owner)
             || solana_stake_program::check_id(&account.owner)

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -88,10 +88,15 @@ impl Stakes {
     }
 
     pub fn vote_balance_and_staked(&self) -> u64 {
-        self.vote_accounts
+        self.stake_delegations
             .iter()
-            .map(|(_pubkey, (staked, account))| staked + account.lamports)
-            .sum()
+            .map(|(_, stake_delegation)| stake_delegation.stake)
+            .sum::<u64>()
+            + self
+                .vote_accounts
+                .iter()
+                .map(|(_pubkey, (_staked, vote_account))| vote_account.lamports)
+                .sum::<u64>()
     }
 
     pub fn is_stake(account: &Account) -> bool {


### PR DESCRIPTION
 #### Problem
 Stakes.points overflows on a normal network, which leads to an inflated point_value, which leads to an overpayment of validators (excess inflation).

 #### Summary of Changes
 * promote "points" to u128
 * since Stakes.points is a u64 and expanding it to u128 would break bank deserialization from a snapshot, move calculation of points per epoch into pay_validator_rewards() instead of the incremental calculation previously performed by Stakes
 * remove tests for Stakes.points -> Stakes.unused
 * re-order the tuples that were `(voter_rewards, staker_rewards)` to `(staker_rewards, voter_rewards)` for a little bit more sanity


Fixes #10872
