### PR TITLE
Skip and warn for hard-forks which are less than the start slot

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -323,16 +323,14 @@ pub fn process_blockstore_from_root(
         let hard_forks = bank.hard_forks();
 
         for hard_fork_slot in new_hard_forks.iter() {
-            // Ensure the user isn't trying to add new hard forks for a slot that's earlier than the current
-            // root slot.  Doing so won't cause any effect so emit an error
-            if *hard_fork_slot < start_slot {
-                error!(
-                    "Unable to add new hard fork at {}, it must be greater than slot {}",
-                    hard_fork_slot, start_slot
+            if *hard_fork_slot > start_slot {
+                hard_forks.write().unwrap().register(*hard_fork_slot);
+            } else {
+                warn!(
+                    "Hard fork at {} ignored, option can be removed.",
+                    hard_fork_slot
                 );
-                return Err(BlockstoreProcessorError::InvalidHardFork(*hard_fork_slot));
             }
-            hard_forks.write().unwrap().register(*hard_fork_slot);
         }
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -327,7 +327,7 @@ pub fn process_blockstore_from_root(
                 hard_forks.write().unwrap().register(*hard_fork_slot);
             } else {
                 warn!(
-                    "Hard fork at {} ignored, option can be removed.",
+                    "Hard fork at {} ignored, --hard-fork option can be removed.",
                     hard_fork_slot
                 );
             }


### PR DESCRIPTION
#### Problem

`--hard-fork` option is used during a restart, but then after the restart is complete, then the option is not needed if the starting slot is past the hard-fork since the hard-fork should already be in the snapshot it started from. This requires the validator to remove the option or risk their validator not starting after the network is started and they have advanced the root slot.

#### Summary of Changes

Ignore `--hard-fork` slots below the start slot, so that the validator can safely leave the hard-fork options in their config and remove it at their leisure or when the next --hard-fork is needed.

Fixes #
