### PR TITLE
validator: Add --snapshot-version stub to ease migration to 1.2.0

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -698,6 +698,15 @@ pub fn main() {
                       0 to disable snapshots"),
         )
         .arg(
+            Arg::with_name("snapshot_version")
+                .long("snapshot-version")
+                .value_name("SNAPSHOT_VERSION")
+                .validator(|s: String| if s == "1.1.0" { Ok(()) } else { Err(format!("Invalid snapshot version: {}", s)) })
+                .takes_value(true)
+                .default_value("1.1.0")
+                .help("Output snapshot version"),
+        )
+        .arg(
             Arg::with_name("limit_ledger_size")
                 .long("limit-ledger-size")
                 .value_name("SHRED_COUNT")


### PR DESCRIPTION
The v1.2 version of `solana-validator` outputs a snapshot version that's incompatible with v1.1 by default. 

To simplify the v1.1 to v1.2 upgrade of mainnet-beta, when the Solana trusted validators upgrade to v1.2 they should continue producing a v1.1-compatible snapshot so that other validators that have not yet upgraded don't get left behind, and to enable a v1.2 validator to downgrade to v1.1 if they encounter any difficulties.   The same is true for the Solana nodes, we should be able to upgrade to v1.2 and then back down to v1.1 if needed.   

Adding the `--snapshot-version` argument to v1.1 enables the same `solana-validator` command-line to work across v1.1 and v1.2, so we can upgrade/downgrade at will.