### PR TITLE
Fix parsing

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1201,7 +1201,7 @@ fn main() {
                         if ancestors.contains(&slot) && !map.contains_key(&slot) {
                             map.insert(slot, line);
                         }
-                        if slot == starting_slot
+                        if slot == ending_slot
                             && frozen.contains_key(&slot)
                             && full.contains_key(&slot)
                         {


### PR DESCRIPTION
#### Problem
Parsing logs ends prematurely at starting slot rather than the ending slot

#### Summary of Changes
Use ending slot
Fixes #
