### PR TITLE
Decouple genesis fetch and snapshot fetch

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -369,12 +369,29 @@ fn check_genesis_hash(
     Ok(())
 }
 
+fn load_local_genesis(
+    ledger_path: &std::path::Path,
+    expected_genesis_hash: Option<Hash>,
+) -> Result<GenesisConfig, String> {
+    let existing_genesis = GenesisConfig::load(&ledger_path)
+        .map_err(|err| format!("Failed to load genesis config: {}", err))?;
+    check_genesis_hash(&existing_genesis, expected_genesis_hash)?;
+
+    Ok(existing_genesis)
+}
+
 fn download_then_check_genesis_hash(
     rpc_addr: &SocketAddr,
     ledger_path: &std::path::Path,
     expected_genesis_hash: Option<Hash>,
     max_genesis_archive_unpacked_size: u64,
+    no_genesis_fetch: bool,
 ) -> Result<Hash, String> {
+    if no_genesis_fetch {
+        let genesis_config = load_local_genesis(ledger_path, expected_genesis_hash)?;
+        return Ok(genesis_config.hash());
+    }
+
     let genesis_package = ledger_path.join("genesis.tar.bz2");
     let genesis_config =
         if let Ok(tmp_genesis_package) = download_genesis_if_missing(rpc_addr, &genesis_package) {
@@ -394,11 +411,7 @@ fn download_then_check_genesis_hash(
 
             downloaded_genesis
         } else {
-            let existing_genesis = GenesisConfig::load(&ledger_path)
-                .map_err(|err| format!("Failed to load genesis config: {}", err))?;
-            check_genesis_hash(&existing_genesis, expected_genesis_hash)?;
-
-            existing_genesis
+            load_local_genesis(ledger_path, expected_genesis_hash)?
         };
 
     Ok(genesis_config.hash())
@@ -548,7 +561,6 @@ pub fn main() {
             Arg::with_name("no_snapshot_fetch")
                 .long("no-snapshot-fetch")
                 .takes_value(false)
-                .requires("entrypoint")
                 .help("Do not attempt to fetch a snapshot from the cluster, \
                       start from a local snapshot if present"),
         )
@@ -556,7 +568,6 @@ pub fn main() {
             Arg::with_name("no_genesis_fetch")
                 .long("no-genesis-fetch")
                 .takes_value(false)
-                .requires("entrypoint")
                 .help("Do not fetch genesis from the cluster"),
         )
         .arg(
@@ -1185,7 +1196,7 @@ pub fn main() {
         ) {
             exit(1);
         }
-        if !no_genesis_fetch {
+        if !no_genesis_fetch || !no_snapshot_fetch {
             let (cluster_info, gossip_exit_flag, gossip_service) = start_gossip_node(
                 &identity_keypair,
                 &cluster_entrypoint.gossip,
@@ -1222,6 +1233,7 @@ pub fn main() {
                         &ledger_path,
                         validator_config.expected_genesis_hash,
                         max_genesis_archive_unpacked_size,
+                        no_genesis_fetch,
                     );
 
                     if let Ok(genesis_hash) = genesis_hash {


### PR DESCRIPTION
#### Problem

If I give --no-genesis-fetch without --no-snapshot-fetch, then a snapshot would not be downloaded. Also, --entrypoint is marked as required if --no-snapshot-fetch and --no-genesis-fetch is given, but those options don't require an entrypoint and if they are given, the user is less likely to need an entrypoint since it is just using local data.

#### Summary of Changes

Remove --entrypoint required for --no-snapshot-fetch/--no-genesis-fetch and consider the options independently.

Fixes #
