### PR TITLE
Add --print-account-stats argument to ledger-tool

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2692,6 +2692,10 @@ impl Bank {
         self.rc.accounts.accounts_db.shrink_all_slots();
     }
 
+    pub fn print_accounts_stats(&self) {
+        self.rc.accounts.accounts_db.print_accounts_stats("");
+    }
+
     pub fn process_stale_slot_with_budget(
         &self,
         mut consumed_budget: usize,


### PR DESCRIPTION
### Problem

No way to see information about the account stores in a snapshot.

#### Summary of Changes

Add --print-account-stats option to ledger tool to allow printing the stats after ledger verify to the desired slot.

Fixes #
