### PR TITLE
Rename largest_confirmed_root to highest_confirmed_root

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -35,7 +35,7 @@ impl CommitmentAggregationData {
     }
 }
 
-fn get_largest_confirmed_root(mut rooted_stake: Vec<(Slot, u64)>, total_stake: u64) -> Slot {
+fn get_highest_confirmed_root(mut rooted_stake: Vec<(Slot, u64)>, total_stake: u64) -> Slot {
     rooted_stake.sort_by(|a, b| a.0.cmp(&b.0).reverse());
     let mut stake_sum = 0;
     for (root, stake) in rooted_stake {
@@ -109,12 +109,12 @@ impl AggregateCommitmentService {
             let (block_commitment, rooted_stake) =
                 Self::aggregate_commitment(&ancestors, &aggregation_data.bank);
 
-            let largest_confirmed_root =
-                get_largest_confirmed_root(rooted_stake, aggregation_data.total_stake);
+            let highest_confirmed_root =
+                get_highest_confirmed_root(rooted_stake, aggregation_data.total_stake);
 
             let mut new_block_commitment = BlockCommitmentCache::new(
                 block_commitment,
-                largest_confirmed_root,
+                highest_confirmed_root,
                 aggregation_data.total_stake,
                 aggregation_data.bank,
                 aggregation_data.root,
@@ -139,7 +139,7 @@ impl AggregateCommitmentService {
             subscriptions.notify_subscribers(CacheSlotInfo {
                 current_slot: w_block_commitment_cache.slot(),
                 node_root: w_block_commitment_cache.root(),
-                largest_confirmed_root: w_block_commitment_cache.largest_confirmed_root(),
+                highest_confirmed_root: w_block_commitment_cache.highest_confirmed_root(),
                 highest_confirmed_slot: w_block_commitment_cache.highest_confirmed_slot(),
             });
         }
@@ -233,18 +233,18 @@ mod tests {
     use solana_vote_program::vote_state::{self, VoteStateVersions};
 
     #[test]
-    fn test_get_largest_confirmed_root() {
-        assert_eq!(get_largest_confirmed_root(vec![], 10), 0);
+    fn test_get_highest_confirmed_root() {
+        assert_eq!(get_highest_confirmed_root(vec![], 10), 0);
         let mut rooted_stake = vec![];
         rooted_stake.push((0, 5));
         rooted_stake.push((1, 5));
-        assert_eq!(get_largest_confirmed_root(rooted_stake, 10), 0);
+        assert_eq!(get_highest_confirmed_root(rooted_stake, 10), 0);
         let mut rooted_stake = vec![];
         rooted_stake.push((1, 5));
         rooted_stake.push((0, 10));
         rooted_stake.push((2, 5));
         rooted_stake.push((1, 4));
-        assert_eq!(get_largest_confirmed_root(rooted_stake, 10), 1);
+        assert_eq!(get_highest_confirmed_root(rooted_stake, 10), 1);
     }
 
     #[test]
@@ -451,6 +451,6 @@ mod tests {
             }
         }
         assert_eq!(rooted_stake.len(), 2);
-        assert_eq!(get_largest_confirmed_root(rooted_stake, 100), 1)
+        assert_eq!(get_highest_confirmed_root(rooted_stake, 100), 1)
     }
 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1025,11 +1025,11 @@ impl ReplayStage {
             blockstore
                 .set_roots(&rooted_slots)
                 .expect("Ledger set roots failed");
-            let largest_confirmed_root = Some(
+            let highest_confirmed_root = Some(
                 block_commitment_cache
                     .read()
                     .unwrap()
-                    .largest_confirmed_root(),
+                    .highest_confirmed_root(),
             );
             Self::handle_new_root(
                 new_root,
@@ -1037,7 +1037,7 @@ impl ReplayStage {
                 progress,
                 accounts_hash_sender,
                 all_pubkeys,
-                largest_confirmed_root,
+                highest_confirmed_root,
                 heaviest_subtree_fork_choice,
             );
             subscriptions.notify_roots(rooted_slots);
@@ -1729,14 +1729,14 @@ impl ReplayStage {
         progress: &mut ProgressMap,
         accounts_hash_sender: &Option<AccountsPackageSender>,
         all_pubkeys: &mut PubkeyReferences,
-        largest_confirmed_root: Option<Slot>,
+        highest_confirmed_root: Option<Slot>,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
     ) {
         let old_epoch = bank_forks.read().unwrap().root_bank().epoch();
         bank_forks.write().unwrap().set_root(
             new_root,
             accounts_hash_sender,
-            largest_confirmed_root,
+            highest_confirmed_root,
         );
         let r_bank_forks = bank_forks.read().unwrap();
         let new_epoch = bank_forks.read().unwrap().root_bank().epoch();
@@ -2109,7 +2109,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_handle_new_root_ahead_of_largest_confirmed_root() {
+    fn test_handle_new_root_ahead_of_highest_confirmed_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -70,7 +70,7 @@ pub fn is_confirmed_rooted(
     blockstore: &Blockstore,
     slot: Slot,
 ) -> bool {
-    slot <= block_commitment_cache.largest_confirmed_root()
+    slot <= block_commitment_cache.highest_confirmed_root()
         && (blockstore.is_root(slot)
             || block_commitment_cache
                 .bank()
@@ -137,7 +137,7 @@ impl JsonRpcRequestProcessor {
                     .block_commitment_cache
                     .read()
                     .unwrap()
-                    .largest_confirmed_root();
+                    .highest_confirmed_root();
                 debug!("RPC using block: {:?}", slot);
                 slot
             }
@@ -552,7 +552,7 @@ impl JsonRpcRequestProcessor {
                     .block_commitment_cache
                     .read()
                     .unwrap()
-                    .largest_confirmed_root()
+                    .highest_confirmed_root()
         {
             let result = self.blockstore.get_confirmed_block(slot, encoding);
             self.check_slot_cleaned_up(&result, slot)?;
@@ -572,7 +572,7 @@ impl JsonRpcRequestProcessor {
             self.block_commitment_cache
                 .read()
                 .unwrap()
-                .largest_confirmed_root(),
+                .highest_confirmed_root(),
         );
         if end_slot < start_slot {
             return Ok(vec![]);
@@ -591,7 +591,7 @@ impl JsonRpcRequestProcessor {
                 .block_commitment_cache
                 .read()
                 .unwrap()
-                .largest_confirmed_root()
+                .highest_confirmed_root()
         {
             // This calculation currently assumes that bank.slots_per_year will remain unchanged after
             // genesis (ie. that this bank's slot_per_year will be applicable to any rooted slot being
@@ -662,7 +662,7 @@ impl JsonRpcRequestProcessor {
                             .block_commitment_cache
                             .read()
                             .unwrap()
-                            .largest_confirmed_root()
+                            .highest_confirmed_root()
                     })
                     .map(|(slot, status_meta)| {
                         let err = status_meta.status.clone().err();
@@ -725,7 +725,7 @@ impl JsonRpcRequestProcessor {
                             .block_commitment_cache
                             .read()
                             .unwrap()
-                            .largest_confirmed_root()
+                            .highest_confirmed_root()
                 })
         } else {
             None
@@ -744,7 +744,7 @@ impl JsonRpcRequestProcessor {
                 self.block_commitment_cache
                     .read()
                     .unwrap()
-                    .largest_confirmed_root(),
+                    .highest_confirmed_root(),
             );
             self.blockstore
                 .get_confirmed_signatures_for_address(pubkey, start_slot, end_slot)
@@ -3538,7 +3538,7 @@ pub mod tests {
         block_commitment_cache
             .write()
             .unwrap()
-            .set_largest_confirmed_root(8);
+            .set_highest_confirmed_root(8);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getConfirmedBlocks","params":[0]}"#;
         let res = io.handle_request_sync(&req, meta.clone());
@@ -3594,7 +3594,7 @@ pub mod tests {
         block_commitment_cache
             .write()
             .unwrap()
-            .set_largest_confirmed_root(7);
+            .set_highest_confirmed_root(7);
 
         let slot_duration = slot_duration_from_slots_per_year(bank.slots_per_year());
 
@@ -3826,9 +3826,9 @@ pub mod tests {
         block_commitment.entry(1).or_insert(cache0);
         block_commitment.entry(2).or_insert(cache1);
         block_commitment.entry(3).or_insert(cache2);
-        let largest_confirmed_root = 1;
+        let highest_confirmed_root = 1;
         let block_commitment_cache =
-            BlockCommitmentCache::new(block_commitment, largest_confirmed_root, 50, bank, 0, 0);
+            BlockCommitmentCache::new(block_commitment, highest_confirmed_root, 50, bank, 0, 0);
 
         assert!(is_confirmed_rooted(&block_commitment_cache, &blockstore, 0));
         assert!(is_confirmed_rooted(&block_commitment_cache, &blockstore, 1));

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -740,7 +740,7 @@ mod tests {
         let cache_slot_info = CacheSlotInfo {
             current_slot: 2,
             node_root: 1,
-            largest_confirmed_root: 1,
+            highest_confirmed_root: 1,
             highest_confirmed_slot: 1,
         };
         rpc.subscriptions.notify_subscribers(cache_slot_info);

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -47,7 +47,7 @@ pub struct SlotInfo {
 pub struct CacheSlotInfo {
     pub current_slot: Slot,
     pub node_root: Slot,
-    pub largest_confirmed_root: Slot,
+    pub highest_confirmed_root: Slot,
     pub highest_confirmed_slot: Slot,
 }
 
@@ -179,7 +179,7 @@ where
         ) in hashmap.iter()
         {
             let slot = match commitment.commitment {
-                CommitmentLevel::Max => cache_slot_info.largest_confirmed_root,
+                CommitmentLevel::Max => cache_slot_info.highest_confirmed_root,
                 CommitmentLevel::Recent => cache_slot_info.current_slot,
                 CommitmentLevel::Root => cache_slot_info.node_root,
                 CommitmentLevel::Single | CommitmentLevel::SingleGossip => {
@@ -466,7 +466,7 @@ impl RpcSubscriptions {
                 .block_commitment_cache
                 .read()
                 .unwrap()
-                .largest_confirmed_root(),
+                .highest_confirmed_root(),
             CommitmentLevel::Recent => self.block_commitment_cache.read().unwrap().slot(),
             CommitmentLevel::Root => self.block_commitment_cache.read().unwrap().root(),
             CommitmentLevel::Single => self

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -336,7 +336,7 @@ impl Validator {
             block_commitment_cache
                 .write()
                 .unwrap()
-                .set_largest_confirmed_root(bank_forks.read().unwrap().root());
+                .set_highest_confirmed_root(bank_forks.read().unwrap().root());
 
             // Park with the RPC service running, ready for inspection!
             warn!("Validator halted");

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -184,7 +184,7 @@ impl BankForks {
         &mut self,
         root: Slot,
         accounts_package_sender: &Option<AccountsPackageSender>,
-        largest_confirmed_root: Option<Slot>,
+        highest_confirmed_root: Option<Slot>,
     ) {
         let old_epoch = self.root_bank().epoch();
         self.root = root;
@@ -261,7 +261,7 @@ impl BankForks {
         }
         let new_tx_count = root_bank.transaction_count();
 
-        self.prune_non_root(root, largest_confirmed_root);
+        self.prune_non_root(root, highest_confirmed_root);
 
         inc_new_counter_info!(
             "bank-forks_set_root_ms",
@@ -338,13 +338,13 @@ impl BankForks {
         Ok(())
     }
 
-    fn prune_non_root(&mut self, root: Slot, largest_confirmed_root: Option<Slot>) {
+    fn prune_non_root(&mut self, root: Slot, highest_confirmed_root: Option<Slot>) {
         let descendants = self.descendants();
         self.banks.retain(|slot, _| {
             *slot == root
                 || descendants[&root].contains(slot)
                 || (*slot < root
-                    && *slot >= largest_confirmed_root.unwrap_or(root)
+                    && *slot >= highest_confirmed_root.unwrap_or(root)
                     && descendants[slot].contains(&root))
         });
         datapoint_debug!(

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -39,7 +39,7 @@ impl BlockCommitment {
 #[derive(Default)]
 pub struct BlockCommitmentCache {
     block_commitment: HashMap<Slot, BlockCommitment>,
-    largest_confirmed_root: Slot,
+    highest_confirmed_root: Slot,
     total_stake: u64,
     bank: Arc<Bank>,
     root: Slot,
@@ -63,7 +63,7 @@ impl std::fmt::Debug for BlockCommitmentCache {
 impl BlockCommitmentCache {
     pub fn new(
         block_commitment: HashMap<Slot, BlockCommitment>,
-        largest_confirmed_root: Slot,
+        highest_confirmed_root: Slot,
         total_stake: u64,
         bank: Arc<Bank>,
         root: Slot,
@@ -71,7 +71,7 @@ impl BlockCommitmentCache {
     ) -> Self {
         Self {
             block_commitment,
-            largest_confirmed_root,
+            highest_confirmed_root,
             total_stake,
             bank,
             root,
@@ -83,8 +83,8 @@ impl BlockCommitmentCache {
         self.block_commitment.get(&slot)
     }
 
-    pub fn largest_confirmed_root(&self) -> Slot {
-        self.largest_confirmed_root
+    pub fn highest_confirmed_root(&self) -> Slot {
+        self.highest_confirmed_root
     }
 
     pub fn total_stake(&self) -> u64 {
@@ -159,15 +159,15 @@ impl BlockCommitmentCache {
         Self {
             block_commitment,
             total_stake: 42,
-            largest_confirmed_root: root,
+            highest_confirmed_root: root,
             bank,
             root,
             highest_confirmed_slot: root,
         }
     }
 
-    pub fn set_largest_confirmed_root(&mut self, root: Slot) {
-        self.largest_confirmed_root = root;
+    pub fn set_highest_confirmed_root(&mut self, root: Slot) {
+        self.highest_confirmed_root = root;
     }
 }
 


### PR DESCRIPTION
#### Problem

Confusing use of the term "largest".  We use "highest" everywhere else.

#### Summary of Changes

Per @CriesofCarrots, we can safely rename "largest_confirmed_root" to "highest_confirmed_root"
