### PR TITLE
Limited Deserialize isn't limiting anything

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1693,7 +1693,7 @@ fn deserialize_bs58_transaction(bs58_transaction: String) -> Result<(Vec<u8>, Tr
     }
     bincode::config()
         .limit(PACKET_DATA_SIZE as u64)
-        .deserialize(&wire_transaction)
+        .deserialize_from(&wire_transaction[..])
         .map_err(|err| {
             info!("transaction deserialize error: {:?}", err);
             Error::invalid_params(&err.to_string())

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -102,7 +102,7 @@ where
 {
     bincode::config()
         .limit(PACKET_DATA_SIZE as u64)
-        .deserialize(data)
+        .deserialize_from(data)
 }
 
 #[cfg(test)]

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -9,7 +9,7 @@ where
     let limit = crate::packet::PACKET_DATA_SIZE as u64;
     bincode::config()
         .limit(limit)
-        .deserialize(instruction_data)
+        .deserialize_from(instruction_data)
         .map_err(|_| InstructionError::InvalidInstructionData)
 }
 

--- a/sdk/src/program_utils.rs
+++ b/sdk/src/program_utils.rs
@@ -12,3 +12,24 @@ where
         .deserialize(instruction_data)
         .map_err(|_| InstructionError::InvalidInstructionData)
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_limited_deserialize() {
+        #[derive(Deserialize, Serialize)]
+        enum Foo {
+            Bar(Vec<u8>),
+        }
+
+        let item = Foo::Bar([1; crate::packet::PACKET_DATA_SIZE - 12].to_vec()); // crate::packet::PACKET_DATA_SIZE - 12: size limit, minus enum variant and vec len() serialized sizes
+        let serialized = bincode::serialize(&item).unwrap();
+        assert!(limited_deserialize::<Foo>(&serialized).is_ok());
+
+        let item = Foo::Bar([1; crate::packet::PACKET_DATA_SIZE - 11].to_vec()); // Extra byte should bump serialized size over the size limit
+        let serialized = bincode::serialize(&item).unwrap();
+        assert!(limited_deserialize::<Foo>(&serialized).is_err());
+    }
+}


### PR DESCRIPTION
#### Problem
We use this pattern several places.
```
bincode::config()
        .limit(u64)
        .deserialize()
```
However, it doesn't actually limit anything. See bincode issue: https://github.com/servo/bincode/issues/299
Also see failing test below; the 2nd assert fails because limited_deserialize does not return an error.

#### Summary of Changes
Use `deserialize_from` instead

Shred uses this same pattern, but using `deserialize_from` would require switching the trait bound to DeserializeOwned  https://github.com/solana-labs/solana/blob/2fdbb97244c20531f46214b71d7224aa034717a0/ledger/src/shred.rs#L138
Doing this seemed to build fine, but I am not sure what deeper implications the change might have.
