### PR TITLE
Rewrite on clean

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2692,6 +2692,10 @@ impl Bank {
         self.rc.accounts.accounts_db.shrink_all_slots();
     }
 
+    pub fn print_accounts_stats(&self) {
+        self.rc.accounts.accounts_db.print_accounts_stats("");
+    }
+
     pub fn process_stale_slot_with_budget(
         &self,
         mut consumed_budget: usize,


### PR DESCRIPTION
#### Problem

No path to rewrite storages to reduce number of append-vecs which contain significant zero lamport accounts.

#### Summary of Changes

Rewrite append vecs in clean to remove zero lamport accounts.

Fixes #
