### PR TITLE
Drop bank from BlockCommitmentCache

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -116,7 +116,7 @@ impl AggregateCommitmentService {
                 block_commitment,
                 highest_confirmed_root,
                 aggregation_data.total_stake,
-                aggregation_data.bank,
+                aggregation_data.bank.slot(),
                 aggregation_data.root,
                 aggregation_data.root,
             );

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -183,7 +183,7 @@ impl JsonRpcRequestProcessor {
                 HashMap::new(),
                 0,
                 0,
-                bank.clone(),
+                bank.slot(),
                 0,
                 0,
             ))),
@@ -1796,7 +1796,7 @@ pub mod tests {
             block_commitment,
             0,
             10,
-            bank.clone(),
+            bank.slot(),
             0,
             0,
         )));
@@ -3324,7 +3324,7 @@ pub mod tests {
             block_commitment,
             0,
             42,
-            bank_forks.read().unwrap().working_bank(),
+            bank_forks.read().unwrap().highest_slot(),
             0,
             0,
         )));
@@ -3828,7 +3828,7 @@ pub mod tests {
             block_commitment,
             highest_confirmed_root,
             50,
-            bank.clone(),
+            bank.slot(),
             0,
             0,
         );

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -525,9 +525,8 @@ mod tests {
             subscriptions: Arc::new(RpcSubscriptions::new(
                 &Arc::new(AtomicBool::new(false)),
                 bank_forks.clone(),
-                Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_bank(
-                    bank_forks.read().unwrap().get(1).unwrap().clone(),
-                    1,
+                Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_slots(
+                    1, 1,
                 ))),
             )),
             uid: Arc::new(atomic::AtomicUsize::default()),

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -961,9 +961,8 @@ pub(crate) mod tests {
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks.clone(),
-            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_bank(
-                bank_forks.read().unwrap().get(1).unwrap().clone(),
-                1,
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_slots(
+                1, 1,
             ))),
         );
         subscriptions.add_account_subscription(
@@ -1158,7 +1157,7 @@ pub(crate) mod tests {
         block_commitment.entry(0).or_insert(cache0);
         block_commitment.entry(1).or_insert(cache1);
         let block_commitment_cache =
-            BlockCommitmentCache::new(block_commitment, 0, 10, bank1, 0, 0);
+            BlockCommitmentCache::new(block_commitment, 0, 10, bank1.slot(), 0, 0);
 
         let exit = Arc::new(AtomicBool::new(false));
         let subscriptions = RpcSubscriptions::new(
@@ -1433,9 +1432,8 @@ pub(crate) mod tests {
         let subscriptions = RpcSubscriptions::new(
             &exit,
             bank_forks.clone(),
-            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_bank(
-                bank_forks.read().unwrap().get(1).unwrap().clone(),
-                1,
+            Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests_with_slots(
+                1, 1,
             ))),
         );
         let sub_id0 = SubscriptionId::Number(0 as u64);

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -41,7 +41,7 @@ pub struct BlockCommitmentCache {
     block_commitment: HashMap<Slot, BlockCommitment>,
     highest_confirmed_root: Slot,
     total_stake: u64,
-    bank: Arc<Bank>,
+    recent_slot: Slot,
     root: Slot,
     pub highest_confirmed_slot: Slot,
 }
@@ -53,7 +53,7 @@ impl std::fmt::Debug for BlockCommitmentCache {
             .field("total_stake", &self.total_stake)
             .field(
                 "bank",
-                &format_args!("Bank({{current_slot: {:?}}})", self.bank.slot()),
+                &format_args!("Bank({{current_slot: {:?}}})", self.recent_slot),
             )
             .field("root", &self.root)
             .finish()
@@ -73,7 +73,7 @@ impl BlockCommitmentCache {
             block_commitment,
             highest_confirmed_root,
             total_stake,
-            bank,
+            recent_slot: bank.slot(),
             root,
             highest_confirmed_slot,
         }
@@ -91,12 +91,8 @@ impl BlockCommitmentCache {
         self.total_stake
     }
 
-    pub fn bank(&self) -> Arc<Bank> {
-        self.bank.clone()
-    }
-
     pub fn slot(&self) -> Slot {
-        self.bank.slot()
+        self.recent_slot
     }
 
     pub fn root(&self) -> Slot {
@@ -160,7 +156,7 @@ impl BlockCommitmentCache {
             block_commitment,
             total_stake: 42,
             highest_confirmed_root: root,
-            bank,
+            recent_slot: bank.slot(),
             root,
             highest_confirmed_slot: root,
         }

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -40,7 +40,8 @@ pub struct BlockCommitmentCache {
     block_commitment: HashMap<Slot, BlockCommitment>,
     highest_confirmed_root: Slot,
     total_stake: u64,
-    recent_slot: Slot,
+    /// The slot of the bank from which all other slots were calculated.
+    slot: Slot,
     root: Slot,
     pub highest_confirmed_slot: Slot,
 }
@@ -52,7 +53,7 @@ impl std::fmt::Debug for BlockCommitmentCache {
             .field("total_stake", &self.total_stake)
             .field(
                 "bank",
-                &format_args!("Bank({{current_slot: {:?}}})", self.recent_slot),
+                &format_args!("Bank({{current_slot: {:?}}})", self.slot),
             )
             .field("root", &self.root)
             .finish()
@@ -64,7 +65,7 @@ impl BlockCommitmentCache {
         block_commitment: HashMap<Slot, BlockCommitment>,
         highest_confirmed_root: Slot,
         total_stake: u64,
-        recent_slot: Slot,
+        slot: Slot,
         root: Slot,
         highest_confirmed_slot: Slot,
     ) -> Self {
@@ -72,7 +73,7 @@ impl BlockCommitmentCache {
             block_commitment,
             highest_confirmed_root,
             total_stake,
-            recent_slot,
+            slot,
             root,
             highest_confirmed_slot,
         }
@@ -91,7 +92,7 @@ impl BlockCommitmentCache {
     }
 
     pub fn slot(&self) -> Slot {
-        self.recent_slot
+        self.slot
     }
 
     pub fn root(&self) -> Slot {
@@ -148,14 +149,14 @@ impl BlockCommitmentCache {
         }
     }
 
-    pub fn new_for_tests_with_slots(recent_slot: Slot, root: Slot) -> Self {
+    pub fn new_for_tests_with_slots(slot: Slot, root: Slot) -> Self {
         let mut block_commitment: HashMap<Slot, BlockCommitment> = HashMap::new();
         block_commitment.insert(0, BlockCommitment::default());
         Self {
             block_commitment,
             total_stake: 42,
             highest_confirmed_root: root,
-            recent_slot,
+            slot,
             root,
             highest_confirmed_slot: root,
         }


### PR DESCRIPTION
#### Problem

BlockCommitmentCache caches Bank slots, except that it also holds a reference to a Bank, only to return its slot.

#### Summary of Changes

Create BlockCommitmentCache with the Bank's slot instead of the Bank.
