### PR TITLE
Gate automerge on Travis

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
   - name: automatic merge (squash) on CI success
     conditions:
       - status-success=buildkite/solana
-      #- status-success=Travis CI - Pull Request
+      - status-success=Travis CI - Pull Request
       - status-success=ci-gate
       - label=automerge
       - author≠@dont-squash-my-commits
@@ -18,7 +18,7 @@ pull_request_rules:
   - name: automatic merge (rebase) on CI success
     conditions:
       - status-success=buildkite/solana
-      #- status-success=Travis CI - Pull Request
+      - status-success=Travis CI - Pull Request
       - status-success=ci-gate
       - label=automerge
       - author=@dont-squash-my-commits

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -207,7 +207,7 @@ pull_or_push_steps() {
 
   # Run the full test suite by default, skipping only if modifications are local
   # to some particular areas of the tree
-  if affects_other_than ^.buildkite ^.travis .md$ ^docs/ ^web3.js/ ^explorer/ ^.gitbook; then
+  if affects_other_than ^.buildkite ^.mergify .md$ ^docs/ ^web3.js/ ^explorer/ ^.gitbook; then
     all_test_steps
   fi
 


### PR DESCRIPTION
With Travis PR builds more stable now, we can start gating the automerge label on Travis to unlock automerging JS dependabot PRs