### PR TITLE
Remove core dependencies from SendTransactionService

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -3026,7 +3026,7 @@ pub mod tests {
             blockstore,
             validator_exit,
             RpcHealth::stub(),
-            cluster_info.clone(),
+            cluster_info,
             Hash::default(),
             Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
@@ -3065,7 +3065,7 @@ pub mod tests {
             blockstore,
             validator_exit,
             health.clone(),
-            cluster_info.clone(),
+            cluster_info,
             Hash::default(),
             Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
@@ -3212,7 +3212,7 @@ pub mod tests {
             blockstore,
             validator_exit,
             RpcHealth::stub(),
-            cluster_info.clone(),
+            cluster_info,
             Hash::default(),
             Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
@@ -3239,7 +3239,7 @@ pub mod tests {
             blockstore,
             validator_exit,
             RpcHealth::stub(),
-            cluster_info.clone(),
+            cluster_info,
             Hash::default(),
             Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
@@ -3326,7 +3326,7 @@ pub mod tests {
             blockstore,
             validator_exit,
             RpcHealth::stub(),
-            cluster_info.clone(),
+            cluster_info,
             Hash::default(),
             Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -176,6 +176,7 @@ impl JsonRpcRequestProcessor {
         let blockstore = Arc::new(Blockstore::open(&get_tmp_ledger_path!()).unwrap());
         let exit = Arc::new(AtomicBool::new(false));
         let cluster_info = Arc::new(ClusterInfo::default());
+        let tpu_address = cluster_info.my_contact_info().tpu;
         Self {
             config: JsonRpcConfig::default(),
             bank_forks: bank_forks.clone(),
@@ -190,10 +191,10 @@ impl JsonRpcRequestProcessor {
             blockstore,
             validator_exit: create_validator_exit(&exit),
             health: Arc::new(RpcHealth::new(cluster_info.clone(), None, 0, exit.clone())),
-            cluster_info: cluster_info.clone(),
+            cluster_info,
             genesis_hash,
             send_transaction_service: Arc::new(SendTransactionService::new(
-                &cluster_info,
+                tpu_address,
                 &bank_forks,
                 &exit,
             )),
@@ -1865,6 +1866,7 @@ pub mod tests {
         let _ = bank.process_transaction(&tx);
 
         let cluster_info = Arc::new(ClusterInfo::default());
+        let tpu_address = cluster_info.my_contact_info().tpu;
 
         cluster_info.insert_info(ContactInfo::new_with_pubkey_socketaddr(
             &leader_pubkey,
@@ -1884,11 +1886,7 @@ pub mod tests {
             RpcHealth::stub(),
             cluster_info.clone(),
             Hash::default(),
-            Arc::new(SendTransactionService::new(
-                &cluster_info,
-                &bank_forks,
-                &exit,
-            )),
+            Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
 
         cluster_info.insert_info(ContactInfo::new_with_pubkey_socketaddr(
@@ -3019,6 +3017,7 @@ pub mod tests {
         let rpc = RpcSolImpl;
         io.extend_with(rpc.to_delegate());
         let cluster_info = Arc::new(ClusterInfo::default());
+        let tpu_address = cluster_info.my_contact_info().tpu;
         let bank_forks = new_bank_forks().0;
         let meta = JsonRpcRequestProcessor::new(
             JsonRpcConfig::default(),
@@ -3029,11 +3028,7 @@ pub mod tests {
             RpcHealth::stub(),
             cluster_info.clone(),
             Hash::default(),
-            Arc::new(SendTransactionService::new(
-                &cluster_info,
-                &bank_forks,
-                &exit,
-            )),
+            Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["37u9WtQpcm6ULa3Vmu7ySnANv"]}"#;
@@ -3062,6 +3057,7 @@ pub mod tests {
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(
             ContactInfo::new_with_socketaddr(&socketaddr!("127.0.0.1:1234")),
         ));
+        let tpu_address = cluster_info.my_contact_info().tpu;
         let meta = JsonRpcRequestProcessor::new(
             JsonRpcConfig::default(),
             bank_forks.clone(),
@@ -3071,11 +3067,7 @@ pub mod tests {
             health.clone(),
             cluster_info.clone(),
             Hash::default(),
-            Arc::new(SendTransactionService::new(
-                &cluster_info,
-                &bank_forks,
-                &exit,
-            )),
+            Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
 
         let mut bad_transaction =
@@ -3183,7 +3175,7 @@ pub mod tests {
         );
     }
 
-    pub(crate) fn new_bank_forks() -> (Arc<RwLock<BankForks>>, Keypair, Keypair) {
+    fn new_bank_forks() -> (Arc<RwLock<BankForks>>, Keypair, Keypair) {
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,
@@ -3211,6 +3203,7 @@ pub mod tests {
         let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let cluster_info = Arc::new(ClusterInfo::default());
+        let tpu_address = cluster_info.my_contact_info().tpu;
         let bank_forks = new_bank_forks().0;
         let request_processor = JsonRpcRequestProcessor::new(
             JsonRpcConfig::default(),
@@ -3221,11 +3214,7 @@ pub mod tests {
             RpcHealth::stub(),
             cluster_info.clone(),
             Hash::default(),
-            Arc::new(SendTransactionService::new(
-                &cluster_info,
-                &bank_forks,
-                &exit,
-            )),
+            Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
         assert_eq!(request_processor.validator_exit(), false);
         assert_eq!(exit.load(Ordering::Relaxed), false);
@@ -3242,6 +3231,7 @@ pub mod tests {
         config.enable_validator_exit = true;
         let bank_forks = new_bank_forks().0;
         let cluster_info = Arc::new(ClusterInfo::default());
+        let tpu_address = cluster_info.my_contact_info().tpu;
         let request_processor = JsonRpcRequestProcessor::new(
             config,
             bank_forks.clone(),
@@ -3251,11 +3241,7 @@ pub mod tests {
             RpcHealth::stub(),
             cluster_info.clone(),
             Hash::default(),
-            Arc::new(SendTransactionService::new(
-                &cluster_info,
-                &bank_forks,
-                &exit,
-            )),
+            Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
         assert_eq!(request_processor.validator_exit(), true);
         assert_eq!(exit.load(Ordering::Relaxed), true);
@@ -3332,6 +3318,7 @@ pub mod tests {
         let mut config = JsonRpcConfig::default();
         config.enable_validator_exit = true;
         let cluster_info = Arc::new(ClusterInfo::default());
+        let tpu_address = cluster_info.my_contact_info().tpu;
         let request_processor = JsonRpcRequestProcessor::new(
             config,
             bank_forks.clone(),
@@ -3341,11 +3328,7 @@ pub mod tests {
             RpcHealth::stub(),
             cluster_info.clone(),
             Hash::default(),
-            Arc::new(SendTransactionService::new(
-                &cluster_info,
-                &bank_forks,
-                &exit,
-            )),
+            Arc::new(SendTransactionService::new(tpu_address, &bank_forks, &exit)),
         );
         assert_eq!(
             request_processor.get_block_commitment(0),

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -250,9 +250,10 @@ impl JsonRpcService {
             override_health_check,
         ));
 
+        let tpu_address = cluster_info.my_contact_info().tpu;
         let exit_send_transaction_service = Arc::new(AtomicBool::new(false));
         let send_transaction_service = Arc::new(SendTransactionService::new(
-            &cluster_info,
+            tpu_address,
             &bank_forks,
             &exit_send_transaction_service,
         ));


### PR DESCRIPTION
#### Problem

Can't use SendTransactionService without depending on solana_core, which would be useful to a client that only needs to send transactions and inspect the resulting bank state.

#### Summary of Changes

* Remove dependency on ClusterInfo
* Remove dependency on RPC-specific BankForks constructor

The module could be moved into solana_runtime, but this PR doesn't do that for easy reviewing. Also, because we might choose to put the client into a separate crate.  I'll move the module within the BanksClient PR and see how it shakes out.
