### PR TITLE
Return FeeCalculator with TransactionResults to use in transaction_status_service

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -533,23 +533,21 @@ impl BankingStage {
         let num_to_commit = num_to_commit.unwrap();
 
         if num_to_commit != 0 {
-            let transaction_statuses = bank
-                .commit_transactions(
-                    txs,
-                    None,
-                    &mut loaded_accounts,
-                    &results,
-                    tx_count,
-                    signature_count,
-                )
-                .processing_results;
+            let results = bank.commit_transactions(
+                txs,
+                None,
+                &mut loaded_accounts,
+                &results,
+                tx_count,
+                signature_count,
+            );
 
             if let Some(sender) = transaction_status_sender {
                 let post_balances = bank.collect_balances(txs);
                 send_transaction_status_batch(
-                    bank.clone(),
+                    bank.slot(),
                     batch.transactions(),
-                    transaction_statuses,
+                    results,
                     TransactionBalancesSet::new(pre_balances, post_balances),
                     sender,
                 );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4925,8 +4925,8 @@ mod tests {
                     .burn(bank.fee_calculator.lamports_per_signature * 2)
                     .0
         );
-        assert_eq!(results[0], Ok(()));
-        assert_eq!(results[1], Ok(()));
+        assert_eq!(results[0], Ok(bank.fee_calculator.clone()));
+        assert_eq!(results[1], Ok(bank.fee_calculator.clone()));
     }
 
     #[test]
@@ -5036,6 +5036,7 @@ mod tests {
         let bank = Bank::new(&genesis_config);
         let alice = Keypair::new();
         let bob = Keypair::new();
+        let fee_calculator = bank.fee_calculator.clone();
 
         let tx1 =
             system_transaction::transfer(&mint_keypair, &alice.pubkey(), 1, genesis_config.hash());
@@ -5046,7 +5047,7 @@ mod tests {
             .load_execute_and_commit_transactions(&lock_result, MAX_PROCESSING_AGE, false)
             .0
             .fee_collection_results;
-        assert_eq!(results_alice[0], Ok(()));
+        assert_eq!(results_alice[0], Ok(fee_calculator));
 
         // try executing an interleaved transfer twice
         assert_eq!(


### PR DESCRIPTION
#### Problem
This `.expect()` is reachable by a mainnet-beta validator:
https://github.com/solana-labs/solana/blob/6429042b6e8621e340365752050ae1934bc5aa7e/core/src/transaction_status_service.rs#L65-L71

#### Summary of Changes
Return FeeCalculators used in processing transactions with TransactionResults, ensuring that if the transaction assessed fees successfully, the FeeCalculator is available for the TransactionStatusService.

Caveat: So far I haven't been able to write a test that fails on that `expect`.
A recent_blockhash transaction doesn't hit this exception, even if the blockhash is relatively old, because the bank uses the stricter MAX_PROCESSING_AGE to pass/fail transactions, so the recent_blockhash can be at worst in the middle of the bank's blockhash_queue.

Nonce transactions seem more suspicious, but I didn't come up with a failure case. I tried to remove a nonce account immediately after using it, before pulling the fee calculator from that bank, and the removal was caught by this error: https://github.com/solana-labs/solana/blob/17a8cc862ba4182dd01f5d61dceb1ab470e13a71/sdk/src/nonce/account.rs#L90 I didn't think of any other legitimate way to make the nonce account fee calculator unavailable, short of data corruption; advancing the nonce account doesn't hit the exception, since `fee_calculator_of` actually doesn't care if it's returning the right fee calculator (I think this could lead to incorrect nonced-tx fees being cached in Blockstore).

I still think this pr makes this area more robust, and if nothing else it resolves the potential issue with nonce transactions caching incorrect fee data in TSS.

Fixes #10958 
