### PR TITLE
Move SendTransactionService to solana_runtime

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,7 +54,6 @@ pub mod rpc_pubsub;
 pub mod rpc_pubsub_service;
 pub mod rpc_service;
 pub mod rpc_subscriptions;
-pub mod send_transaction_service;
 pub mod serve_repair;
 pub mod serve_repair_service;
 pub mod sigverify;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -3,7 +3,7 @@
 use crate::{
     cluster_info::ClusterInfo, contact_info::ContactInfo,
     non_circulating_supply::calculate_non_circulating_supply, rpc_error::RpcCustomError,
-    rpc_health::*, send_transaction_service::SendTransactionService, validator::ValidatorExit,
+    rpc_health::*, validator::ValidatorExit,
 };
 use bincode::{config::Options, serialize};
 use jsonrpc_core::{Error, Metadata, Result};
@@ -28,6 +28,7 @@ use solana_runtime::{
     bank_forks::BankForks,
     commitment::{BlockCommitmentArray, BlockCommitmentCache},
     log_collector::LogCollector,
+    send_transaction_service::SendTransactionService,
 };
 use solana_sdk::{
     account_utils::StateMut,

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -1,9 +1,6 @@
 //! The `rpc_service` module implements the Solana JSON RPC service.
 
-use crate::{
-    cluster_info::ClusterInfo, rpc::*, rpc_health::*,
-    send_transaction_service::SendTransactionService, validator::ValidatorExit,
-};
+use crate::{cluster_info::ClusterInfo, rpc::*, rpc_health::*, validator::ValidatorExit};
 use jsonrpc_core::MetaIoHandler;
 use jsonrpc_http_server::{
     hyper, AccessControlAllowOrigin, CloseHandle, DomainsValidation, RequestMiddleware,
@@ -14,6 +11,7 @@ use solana_ledger::blockstore::Blockstore;
 use solana_runtime::{
     bank_forks::{BankForks, SnapshotConfig},
     commitment::BlockCommitmentCache,
+    send_transaction_service::SendTransactionService,
     snapshot_utils,
 };
 use solana_sdk::{hash::Hash, native_token::lamports_to_sol, pubkey::Pubkey};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,6 +21,7 @@ pub mod message_processor;
 mod native_loader;
 pub mod nonce_utils;
 pub mod rent_collector;
+pub mod send_transaction_service;
 pub mod serde_snapshot;
 pub mod snapshot_package;
 pub mod snapshot_utils;

--- a/runtime/src/send_transaction_service.rs
+++ b/runtime/src/send_transaction_service.rs
@@ -1,5 +1,6 @@
+use crate::{bank::Bank, bank_forks::BankForks};
+use log::*;
 use solana_metrics::{datapoint_warn, inc_new_counter_info};
-use solana_runtime::{bank::Bank, bank_forks::BankForks};
 use solana_sdk::{clock::Slot, signature::Signature};
 use std::{
     collections::HashMap,


### PR DESCRIPTION
#### Problem

SendTransactionService isn't available to BanksClient, which is implemented in solana_runtime in a draft PR.

#### Summary of Changes

Move SendTransactionService to solana_runtime.
