### PR TITLE
Fix Travis PR detection environment

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -12,7 +12,7 @@ if [[ -n $CI ]]; then
     export CI_BUILD_ID=$TRAVIS_BUILD_ID
     export CI_COMMIT=$TRAVIS_COMMIT
     export CI_JOB_ID=$TRAVIS_JOB_ID
-    if [[ $TRAVIS_PULL_REQUEST =~ ^[0-9]+$ ]]; then
+    if [[ $TRAVIS_PULL_REQUEST != false ]]; then
       export CI_PULL_REQUEST=true
     else
       export CI_PULL_REQUEST=

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -12,7 +12,7 @@ if [[ -n $CI ]]; then
     export CI_BUILD_ID=$TRAVIS_BUILD_ID
     export CI_COMMIT=$TRAVIS_COMMIT
     export CI_JOB_ID=$TRAVIS_JOB_ID
-    if $TRAVIS_PULL_REQUEST; then
+    if [[ $TRAVIS_PULL_REQUEST =~ ^[0-9]+$ ]]; then
       export CI_PULL_REQUEST=true
     else
       export CI_PULL_REQUEST=


### PR DESCRIPTION
#### Problem
`ci/env.sh` does not correctly set environment variables for travis-CI to denote if a job is or is not a pull request.

From https://docs.travis-ci.com/user/environment-variables/
`TRAVIS_PULL_REQUEST`: The pull request number if the current job is a pull request, “false” if it’s not a pull request.

#### Summary of Changes
Set `CI_PULL_REQUEST=true` if `TRAVIS_PULL_REQUEST` is digits.