### PR TITLE
Disable specialization-warnings

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -27,7 +27,7 @@ echo --- build environment
 )
 
 export RUST_BACKTRACE=1
-export RUSTFLAGS="-D warnings"
+export RUSTFLAGS="-D warnings -A incomplete_features"
 
 # Only force up-to-date lock files on edge
 if [[ $CI_BASE_BRANCH = "$EDGE_CHANNEL" ]]; then

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -16,7 +16,7 @@ testName=$(basename "$0" .sh)
 source ci/rust-version.sh stable
 
 export RUST_BACKTRACE=1
-export RUSTFLAGS="-D warnings -A incomplete_features"
+export RUSTFLAGS="-D warnings"
 source scripts/ulimit-n.sh
 
 # Clear cached json keypair files

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -16,7 +16,7 @@ testName=$(basename "$0" .sh)
 source ci/rust-version.sh stable
 
 export RUST_BACKTRACE=1
-export RUSTFLAGS="-D warnings"
+export RUSTFLAGS="-D warnings -A incomplete_features"
 source scripts/ulimit-n.sh
 
 # Clear cached json keypair files


### PR DESCRIPTION
#### Problem

Per the following rust issue, specialization is incomplete and unstable:
https://github.com/rust-lang/rust/issues/31844

Bumping the rust nightly to the latest version results in warnings the CI blocks on.

#### Summary of Changes

Disable the warnings for now, tracking issue: #10980

Fixes #
