### PR TITLE
Add block time placeholder to getConfirmedBlock

### DIFF
--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -314,6 +314,7 @@ The result field will be an object with the following fields:
   * `rewards: <array>` - an array of JSON objects containing:
     * `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
     * `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
+  * `blockTime: <i64 | null>` - estimated production time, as Unix timestamp (seconds since the Unix epoch). null if not available
 
 #### Example:
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1641,6 +1641,7 @@ impl Blockstore {
                         slot_transaction_iterator,
                     ),
                     rewards,
+                    block_time: None, // See https://github.com/solana-labs/solana/issues/10089
                 };
                 return Ok(block);
             }
@@ -5244,6 +5245,7 @@ pub mod tests {
             blockhash: blockhash.to_string(),
             previous_blockhash: Hash::default().to_string(),
             rewards: vec![],
+            block_time: None,
         };
         // The previous_blockhash of `expected_block` is default because its parent slot is a
         // root, but empty of entries. This is special handling for snapshot root slots.
@@ -5265,6 +5267,7 @@ pub mod tests {
             blockhash: blockhash.to_string(),
             previous_blockhash: blockhash.to_string(),
             rewards: vec![],
+            block_time: None,
         };
         assert_eq!(confirmed_block, expected_block);
 

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -9,7 +9,7 @@ pub mod parse_instruction;
 use crate::{parse_accounts::parse_accounts, parse_instruction::parse};
 use serde_json::Value;
 use solana_sdk::{
-    clock::Slot,
+    clock::{Slot, UnixTimestamp},
     commitment_config::CommitmentConfig,
     instruction::CompiledInstruction,
     message::MessageHeader,
@@ -118,6 +118,7 @@ pub struct ConfirmedBlock {
     pub parent_slot: Slot,
     pub transactions: Vec<TransactionWithStatusMeta>,
     pub rewards: Rewards,
+    pub block_time: Option<UnixTimestamp>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
It would be very convenient to return block time in `getConfirmedBlock` instead of having a separate `getBlockTime` endpoint (which could then potentially be deprecated).

`getBlockTime` exists because it's computed using stake-weighted time stamps from validator votes, thus requiring bank and account information, whereas `getConfirmedBlock` is populated from blocktree data.  Plus there's https://github.com/solana-labs/solana/issues/10089

As a babystep towards fixing https://github.com/solana-labs/solana/issues/10089, add a stub `blockTime` field to `getConfirmedBlock`.

This helps with #10900 (aka "6 months of transaction history") because the `ConfirmedBlock` struct will be stored in S3, so allocating space in this struct for the block time means that the rest of #10089 can be filled in later without blocking progress on #10900