### PR TITLE
Add UiTransactionEncoding::Raw

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -173,9 +173,10 @@ pub struct TransactionWithStatusMeta {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum UiTransactionEncoding {
-    Binary,
+    Binary, // base58 encoded raw transaction
     Json,
     JsonParsed,
+    Raw,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -183,6 +184,7 @@ pub enum UiTransactionEncoding {
 pub enum EncodedTransaction {
     Binary(String),
     Json(UiTransaction),
+    Raw(Transaction),
 }
 
 impl EncodedTransaction {
@@ -191,6 +193,7 @@ impl EncodedTransaction {
             UiTransactionEncoding::Binary => EncodedTransaction::Binary(
                 bs58::encode(bincode::serialize(&transaction).unwrap()).into_string(),
             ),
+            UiTransactionEncoding::Raw => EncodedTransaction::Raw(transaction),
             _ => {
                 let message = if encoding == UiTransactionEncoding::Json {
                     UiMessage::Raw(UiRawMessage {
@@ -247,6 +250,7 @@ impl EncodedTransaction {
                 .into_vec()
                 .ok()
                 .and_then(|bytes| bincode::deserialize(&bytes).ok()),
+            EncodedTransaction::Raw(transaction) => Some(transaction.clone()),
         }
     }
 }


### PR DESCRIPTION
There's no `EncodedTransaction` variant that just stores the raw transaction.   This is convenient for some users, like S3, that want to store transactions in the most compact format possible