### PR TITLE
Fix warnings

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -393,7 +393,8 @@ mod tests {
         );
 
         // Case: Write bytes to an offset
-        let keyed_accounts = vec![KeyedAccount::new(&program_key, true, &program_account)];
+        #[allow(unused_mut)]
+        let mut keyed_accounts = vec![KeyedAccount::new(&program_key, true, &program_account)];
         keyed_accounts[0].account.borrow_mut().data = vec![0; 6];
         assert_eq!(
             Ok(()),
@@ -410,7 +411,8 @@ mod tests {
         );
 
         // Case: Overflow
-        let keyed_accounts = vec![KeyedAccount::new(&program_key, true, &program_account)];
+        #[allow(unused_mut)]
+        let mut keyed_accounts = vec![KeyedAccount::new(&program_key, true, &program_account)];
         keyed_accounts[0].account.borrow_mut().data = vec![0; 5];
         assert_eq!(
             Err(InstructionError::AccountDataTooSmall),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -393,7 +393,7 @@ mod tests {
         );
 
         // Case: Write bytes to an offset
-        let mut keyed_accounts = vec![KeyedAccount::new(&program_key, true, &program_account)];
+        let keyed_accounts = vec![KeyedAccount::new(&program_key, true, &program_account)];
         keyed_accounts[0].account.borrow_mut().data = vec![0; 6];
         assert_eq!(
             Ok(()),
@@ -410,7 +410,7 @@ mod tests {
         );
 
         // Case: Overflow
-        let mut keyed_accounts = vec![KeyedAccount::new(&program_key, true, &program_account)];
+        let keyed_accounts = vec![KeyedAccount::new(&program_key, true, &program_account)];
         keyed_accounts[0].account.borrow_mut().data = vec![0; 5];
         assert_eq!(
             Err(InstructionError::AccountDataTooSmall),

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1354,7 +1354,7 @@ mod tests {
         let not_owned_account = Account::new(84, 1, &Pubkey::new_rand());
         let not_owned_preaccount = PreAccount::new(&not_owned_key, &not_owned_account, false, true);
 
-        let mut accounts = vec![
+        let accounts = vec![
             Rc::new(RefCell::new(owned_account)),
             Rc::new(RefCell::new(not_owned_account)),
         ];

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1354,7 +1354,8 @@ mod tests {
         let not_owned_account = Account::new(84, 1, &Pubkey::new_rand());
         let not_owned_preaccount = PreAccount::new(&not_owned_key, &not_owned_account, false, true);
 
-        let accounts = vec![
+        #[allow(unused_mut)]
+        let mut accounts = vec![
             Rc::new(RefCell::new(owned_account)),
             Rc::new(RefCell::new(not_owned_account)),
         ];


### PR DESCRIPTION
#### Problem

`borrow_mut()` requires the variable being borrowed to be but even if itself is not modified.  This is a bug in stable that has been fixed in nightly.  Latest nightly throws a warning that breaks CI

#### Summary of Changes

disable the warnings in the specific cases where the rust stable bug shows up

Fixes #
