### PR TITLE
Simplify use of SendTransactionService

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -188,7 +188,7 @@ impl JsonRpcRequestProcessor {
 
         Self {
             config: JsonRpcConfig::default(),
-            bank_forks: bank_forks.clone(),
+            bank_forks,
             block_commitment_cache: Arc::new(RwLock::new(BlockCommitmentCache::new(
                 HashMap::new(),
                 0,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -184,8 +184,7 @@ impl JsonRpcRequestProcessor {
         let cluster_info = Arc::new(ClusterInfo::default());
         let tpu_address = cluster_info.my_contact_info().tpu;
         let (sender, receiver) = channel();
-        let _send_transaction_service =
-            SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
 
         Self {
             config: JsonRpcConfig::default(),
@@ -1909,9 +1908,7 @@ pub mod tests {
             cluster_info.clone(),
             Hash::default(),
         );
-
-        let _send_transaction_service =
-            SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
 
         cluster_info.insert_info(ContactInfo::new_with_pubkey_socketaddr(
             &leader_pubkey,
@@ -3053,8 +3050,7 @@ pub mod tests {
             cluster_info,
             Hash::default(),
         );
-        let _send_transaction_service =
-            SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["37u9WtQpcm6ULa3Vmu7ySnANv"]}"#;
         let res = io.handle_request_sync(req, meta);
@@ -3093,8 +3089,7 @@ pub mod tests {
             cluster_info,
             Hash::default(),
         );
-        let _send_transaction_service =
-            SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
 
         let mut bad_transaction =
             system_transaction::transfer(&Keypair::new(), &Pubkey::default(), 42, Hash::default());
@@ -3241,8 +3236,7 @@ pub mod tests {
             cluster_info,
             Hash::default(),
         );
-        let _send_transaction_service =
-            SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
         assert_eq!(request_processor.validator_exit(), false);
         assert_eq!(exit.load(Ordering::Relaxed), false);
     }
@@ -3269,8 +3263,7 @@ pub mod tests {
             cluster_info,
             Hash::default(),
         );
-        let _send_transaction_service =
-            SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
         assert_eq!(request_processor.validator_exit(), true);
         assert_eq!(exit.load(Ordering::Relaxed), true);
     }
@@ -3357,8 +3350,7 @@ pub mod tests {
             cluster_info,
             Hash::default(),
         );
-        let _send_transaction_service =
-            SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
         assert_eq!(
             request_processor.get_block_commitment(0),
             RpcBlockCommitment {

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -250,10 +250,12 @@ impl JsonRpcService {
 
         let tpu_address = cluster_info.my_contact_info().tpu;
         let exit_send_transaction_service = Arc::new(AtomicBool::new(false));
-        let send_transaction_service = Arc::new(SendTransactionService::new(
+        let (sender, receiver) = channel();
+        let _send_transaction_service = Arc::new(SendTransactionService::new(
             tpu_address,
             &bank_forks,
             &exit_send_transaction_service,
+            receiver,
         ));
 
         let request_processor = JsonRpcRequestProcessor::new(
@@ -265,7 +267,7 @@ impl JsonRpcService {
             health.clone(),
             cluster_info,
             genesis_hash,
-            send_transaction_service,
+            sender,
         );
 
         #[cfg(test)]

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -249,16 +249,7 @@ impl JsonRpcService {
         ));
 
         let tpu_address = cluster_info.my_contact_info().tpu;
-        let exit_send_transaction_service = Arc::new(AtomicBool::new(false));
-        let (sender, receiver) = channel();
-        let _send_transaction_service = Arc::new(SendTransactionService::new(
-            tpu_address,
-            &bank_forks,
-            &exit_send_transaction_service,
-            receiver,
-        ));
-
-        let request_processor = JsonRpcRequestProcessor::new(
+        let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             config,
             bank_forks.clone(),
             block_commitment_cache,
@@ -267,8 +258,15 @@ impl JsonRpcService {
             health.clone(),
             cluster_info,
             genesis_hash,
-            sender,
         );
+
+        let exit_send_transaction_service = Arc::new(AtomicBool::new(false));
+        let _send_transaction_service = Arc::new(SendTransactionService::new(
+            tpu_address,
+            &bank_forks,
+            &exit_send_transaction_service,
+            receiver,
+        ));
 
         #[cfg(test)]
         let test_request_processor = request_processor.clone();

--- a/runtime/src/send_transaction_service.rs
+++ b/runtime/src/send_transaction_service.rs
@@ -7,8 +7,8 @@ use std::{
     net::{SocketAddr, UdpSocket},
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc::{channel, Receiver, Sender},
-        Arc, Mutex, RwLock,
+        mpsc::Receiver,
+        Arc, RwLock,
     },
     thread::{self, Builder, JoinHandle},
     time::{Duration, Instant},
@@ -19,13 +19,22 @@ const MAX_TRANSACTION_QUEUE_SIZE: usize = 10_000; // This seems like a lot but m
 
 pub struct SendTransactionService {
     thread: JoinHandle<()>,
-    sender: Mutex<Sender<TransactionInfo>>,
 }
 
-struct TransactionInfo {
+pub struct TransactionInfo {
     signature: Signature,
     wire_transaction: Vec<u8>,
     last_valid_slot: Slot,
+}
+
+impl TransactionInfo {
+    pub fn new(signature: Signature, wire_transaction: Vec<u8>, last_valid_slot: Slot) -> Self {
+        Self {
+            signature,
+            wire_transaction,
+            last_valid_slot,
+        }
+    }
 }
 
 #[derive(Default, Debug, PartialEq)]
@@ -42,14 +51,10 @@ impl SendTransactionService {
         tpu_address: SocketAddr,
         bank_forks: &Arc<RwLock<BankForks>>,
         exit: &Arc<AtomicBool>,
+        receiver: Receiver<TransactionInfo>,
     ) -> Self {
-        let (sender, receiver) = channel::<TransactionInfo>();
-
         let thread = Self::retry_thread(receiver, bank_forks.clone(), tpu_address, exit.clone());
-        Self {
-            thread,
-            sender: Mutex::new(sender),
-        }
+        Self { thread }
     }
 
     fn retry_thread(
@@ -70,7 +75,11 @@ impl SendTransactionService {
                 }
 
                 if let Ok(transaction_info) = receiver.recv_timeout(Duration::from_secs(1)) {
-                    Self::send_transaction(&send_socket, &tpu_address, &transaction_info.wire_transaction);
+                    Self::send_transaction(
+                        &send_socket,
+                        &tpu_address,
+                        &transaction_info.wire_transaction,
+                    );
                     if transactions.len() < MAX_TRANSACTION_QUEUE_SIZE {
                         transactions.insert(transaction_info.signature, transaction_info);
                     } else {
@@ -165,19 +174,6 @@ impl SendTransactionService {
         }
     }
 
-    pub fn send(&self, signature: Signature, wire_transaction: Vec<u8>, last_valid_slot: Slot) {
-        inc_new_counter_info!("send_transaction_service-enqueue", 1, 1);
-        self.sender
-            .lock()
-            .unwrap()
-            .send(TransactionInfo {
-                signature,
-                wire_transaction,
-                last_valid_slot,
-            })
-            .unwrap_or_else(|err| warn!("Failed to enqueue transaction: {}", err));
-    }
-
     pub fn join(self) -> thread::Result<()> {
         self.thread.join()
     }
@@ -190,6 +186,7 @@ mod test {
         genesis_config::create_genesis_config, pubkey::Pubkey, signature::Signer,
         system_transaction,
     };
+    use std::sync::mpsc::channel;
 
     #[test]
     fn service_exit() {
@@ -197,8 +194,10 @@ mod test {
         let bank = Bank::default();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let exit = Arc::new(AtomicBool::new(false));
+        let (_sender, receiver) = channel();
 
-        let send_tranaction_service = SendTransactionService::new(tpu_address, &bank_forks, &exit);
+        let send_tranaction_service =
+            SendTransactionService::new(tpu_address, &bank_forks, &exit, receiver);
 
         exit.store(true, Ordering::Relaxed);
         send_tranaction_service.join().unwrap();
@@ -243,11 +242,7 @@ mod test {
         info!("Expired transactions are dropped..");
         transactions.insert(
             Signature::default(),
-            TransactionInfo {
-                signature: Signature::default(),
-                wire_transaction: vec![],
-                last_valid_slot: root_bank.slot() - 1,
-            },
+            TransactionInfo::new(Signature::default(), vec![], root_bank.slot() - 1),
         );
         let result = SendTransactionService::process_transactions(
             &working_bank,
@@ -268,11 +263,7 @@ mod test {
         info!("Rooted transactions are dropped...");
         transactions.insert(
             rooted_signature,
-            TransactionInfo {
-                signature: rooted_signature,
-                wire_transaction: vec![],
-                last_valid_slot: working_bank.slot(),
-            },
+            TransactionInfo::new(rooted_signature, vec![], working_bank.slot()),
         );
         let result = SendTransactionService::process_transactions(
             &working_bank,
@@ -293,11 +284,7 @@ mod test {
         info!("Failed transactions are dropped...");
         transactions.insert(
             failed_signature,
-            TransactionInfo {
-                signature: failed_signature,
-                wire_transaction: vec![],
-                last_valid_slot: working_bank.slot(),
-            },
+            TransactionInfo::new(failed_signature, vec![], working_bank.slot()),
         );
         let result = SendTransactionService::process_transactions(
             &working_bank,
@@ -318,11 +305,7 @@ mod test {
         info!("Non-rooted transactions are kept...");
         transactions.insert(
             non_rooted_signature,
-            TransactionInfo {
-                signature: non_rooted_signature,
-                wire_transaction: vec![],
-                last_valid_slot: working_bank.slot(),
-            },
+            TransactionInfo::new(non_rooted_signature, vec![], working_bank.slot()),
         );
         let result = SendTransactionService::process_transactions(
             &working_bank,
@@ -344,11 +327,7 @@ mod test {
         info!("Unknown transactions are retried...");
         transactions.insert(
             Signature::default(),
-            TransactionInfo {
-                signature: Signature::default(),
-                wire_transaction: vec![],
-                last_valid_slot: working_bank.slot(),
-            },
+            TransactionInfo::new(Signature::default(), vec![], working_bank.slot()),
         );
         let result = SendTransactionService::process_transactions(
             &working_bank,


### PR DESCRIPTION
#### Problem

Our services typically communicate with channels. By using channels, we can easily swap out what's on the other end.  In the case of something upstream from SendTransactionService, it's sometimes useful to swap out SendTransactionService for something that doesn't require a UDP socket.

#### Summary of Changes

Refactor SendTransactionService to send transactions after receiving them instead of just before sending. This allows us to remove the `send()` method and expose the `Receiver<TransactionInfo>` directly.  Upstream users of the service then no longer need to hold the object unless they intend to call `join()` on it. Instead, pass the upstream a `Sender<TransactionInfo>`, which may or may not have a SendTransactionService on the other end.
