### PR TITLE
Set explicit spl-memo version

### DIFF
--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -15,7 +15,7 @@ Inflector = "0.11.4"
 lazy_static = "1.4.0"
 solana-sdk = { path = "../sdk", version = "1.3.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
-spl-memo = "1.0.0"
+spl-memo = "1.0.1"
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.54"

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -16,7 +16,7 @@ lazy_static = "1.4.0"
 solana-sdk = { path = "../sdk", version = "1.3.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.3.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
-spl-memo = "1.0.0"
+spl-memo = "1.0.1"
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.54"


### PR DESCRIPTION
#### Problem
spl-memo v1.0.0 doesn't carry necessary program_stubs.

#### Summary of Changes
Bump version. Cargo.lock is already updated.
