### PR TITLE
Gate advance-nonce change

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1683,8 +1683,8 @@ mod tests {
             &mut loaded,
             &rent_collector,
             &(Hash::default(), FeeCalculator::default()),
-            std::u64::MAX,
-            OperatingMode::Stable,
+            1,
+            OperatingMode::Development,
         );
         assert_eq!(collected_accounts.len(), 2);
         assert!(collected_accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6486,6 +6486,21 @@ mod tests {
     }
 
     #[test]
+    fn test_blockhash_queue_sysvar_consistency() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        let mut bank = Arc::new(Bank::new(&genesis_config));
+        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+
+        let bhq_account = bank.get_account(&sysvar::recent_blockhashes::id()).unwrap();
+        let recent_blockhashes =
+            sysvar::recent_blockhashes::RecentBlockhashes::from_account(&bhq_account).unwrap();
+
+        let sysvar_recent_blockhash = recent_blockhashes[0].blockhash;
+        let bank_last_blockhash = bank.last_blockhash();
+        assert_eq!(sysvar_recent_blockhash, bank_last_blockhash);
+    }
+
+    #[test]
     fn test_bank_inherit_last_vote_sync() {
         let (genesis_config, _) = create_genesis_config(500);
         let bank0 = Arc::new(Bank::new(&genesis_config));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6917,11 +6917,11 @@ mod tests {
         );
     }
 
-    #[ignore] // This test fails due to operating_mode/slot gating
     #[test]
     fn test_nonce_fee_calculator_updates() {
         let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000);
         genesis_config.rent.lamports_per_byte_year = 0;
+        genesis_config.operating_mode = OperatingMode::Development;
         let mut bank = Arc::new(Bank::new(&genesis_config));
 
         // Deliberately use bank 0 to initialize nonce account, so that nonce account fee_calculator indicates 0 fees

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6487,6 +6487,7 @@ mod tests {
 
     #[test]
     fn test_blockhash_queue_sysvar_consistency() {
+        // Demonstrates need for feature gating on change to nonce update on success case
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
         let mut bank = Arc::new(Bank::new(&genesis_config));
         goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
@@ -6497,7 +6498,7 @@ mod tests {
 
         let sysvar_recent_blockhash = recent_blockhashes[0].blockhash;
         let bank_last_blockhash = bank.last_blockhash();
-        assert_eq!(sysvar_recent_blockhash, bank_last_blockhash);
+        assert_ne!(sysvar_recent_blockhash, bank_last_blockhash);
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1767,6 +1767,7 @@ impl Bank {
             loaded_accounts,
             &self.rent_collector,
             &self.last_blockhash_with_fee_calculator(),
+            self.operating_mode(),
         );
         self.collect_rent(executed, loaded_accounts);
 
@@ -6916,6 +6917,7 @@ mod tests {
         );
     }
 
+    #[ignore] // This test fails due to operating_mode/slot gating
     #[test]
     fn test_nonce_fee_calculator_updates() {
         let (mut genesis_config, mint_keypair) = create_genesis_config(1_000_000);

--- a/runtime/src/nonce_utils.rs
+++ b/runtime/src/nonce_utils.rs
@@ -111,7 +111,7 @@ pub fn fee_calculator_of(account: &Account) -> Option<FeeCalculator> {
 
 fn get_fix_nonce_overwrite_slot(operating_mode: OperatingMode) -> Slot {
     match operating_mode {
-        OperatingMode::Development => std::u64::MAX / 2,
+        OperatingMode::Development => 0,
         OperatingMode::Stable => std::u64::MAX / 2,
         OperatingMode::Preview => std::u64::MAX / 2,
     }
@@ -325,8 +325,8 @@ mod tests {
             tx_result,
             maybe_nonce,
             last_blockhash_with_fee_calculator,
-            std::u64::MAX,
-            OperatingMode::Stable,
+            1,
+            OperatingMode::Development,
         );
         expect_account == account
     }


### PR DESCRIPTION
#### Problem
As of #10973 , a successful nonce transaction advances the nonce to the most recent blockhash from the RecentBlockhashes sysvar instead of re-overwriting that nonce with the most recent bank blockhash. We expect those hashes to be the same, but in fact that can be different in the final tick of the slot, due to this: https://github.com/solana-labs/solana/blob/1880621740f07740e9ac8b9ec817fac157aa9239/runtime/src/bank.rs#L1255

This caused a bank hash mismatch on our api nodes.

#### Summary of Changes
- Gate the change by operating mode/slot

Fixes #11020 
