### PR TITLE
Fix recent blockhashes delay

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -968,15 +968,19 @@ impl Bank {
         total_validator_rewards
     }
 
-    pub fn update_recent_blockhashes(&self) {
+    fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {
         self.update_sysvar_account(&sysvar::recent_blockhashes::id(), |account| {
-            let blockhash_queue = self.blockhash_queue.read().unwrap();
-            let recent_blockhash_iter = blockhash_queue.get_recent_blockhashes();
+            let recent_blockhash_iter = locked_blockhash_queue.get_recent_blockhashes();
             sysvar::recent_blockhashes::create_account_with_data(
                 self.inherit_sysvar_account_balance(account),
                 recent_blockhash_iter,
             )
         });
+    }
+
+    pub fn update_recent_blockhashes(&self) {
+        let blockhash_queue = self.blockhash_queue.read().unwrap();
+        self.update_recent_blockhashes_locked(&blockhash_queue);
     }
 
     // If the point values are not `normal`, bring them back into range and

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1258,6 +1258,7 @@ impl Bank {
         let current_tick_height = self.tick_height.fetch_add(1, Ordering::Relaxed) as u64;
         if self.is_block_boundary(current_tick_height + 1) {
             w_blockhash_queue.register_hash(hash, &self.fee_calculator);
+            self.update_recent_blockhashes_locked(&w_blockhash_queue);
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7674,7 +7674,7 @@ mod tests {
         let pubkey1 = Pubkey::new_rand();
         let pubkey2 = Pubkey::new_rand();
 
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let mut bank = Arc::new(Bank::new(&genesis_config));
         bank.lazy_rent_collection.store(true, Ordering::Relaxed);
         assert_eq!(bank.process_stale_slot_with_budget(0, 0), 0);
         assert_eq!(bank.process_stale_slot_with_budget(133, 0), 133);
@@ -7683,15 +7683,22 @@ mod tests {
         assert_eq!(bank.process_stale_slot_with_budget(33, 100), 0);
         assert_eq!(bank.process_stale_slot_with_budget(133, 100), 33);
 
+        goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank).unwrap());
+
         bank.squash();
 
         let some_lamports = 123;
-        let bank = Arc::new(new_from_parent(&bank));
+        let mut bank = Arc::new(new_from_parent(&bank));
         bank.deposit(&pubkey1, some_lamports);
         bank.deposit(&pubkey2, some_lamports);
 
-        let bank = Arc::new(new_from_parent(&bank));
+        goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank).unwrap());
+
+        let mut bank = Arc::new(new_from_parent(&bank));
         bank.deposit(&pubkey1, some_lamports);
+
+        goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank).unwrap());
+
         bank.squash();
         bank.clean_accounts();
         let force_to_return_alive_account = 0;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6486,6 +6486,21 @@ mod tests {
     }
 
     #[test]
+    fn test_blockhash_queue_sysvar_consistency() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        let mut bank = Arc::new(Bank::new(&genesis_config));
+        goto_end_of_slot(Arc::get_mut(&mut bank).unwrap());
+
+        let bhq_account = bank.get_account(&sysvar::recent_blockhashes::id()).unwrap();
+        let recent_blockhashes =
+            sysvar::recent_blockhashes::RecentBlockhashes::from_account(&bhq_account).unwrap();
+
+        let sysvar_recent_blockhash = recent_blockhashes[0].blockhash;
+        let bank_last_blockhash = bank.last_blockhash();
+        assert_eq!(sysvar_recent_blockhash, bank_last_blockhash);
+    }
+
+    #[test]
     fn test_bank_inherit_last_vote_sync() {
         let (genesis_config, _) = create_genesis_config(500);
         let bank0 = Arc::new(Bank::new(&genesis_config));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7602,25 +7602,25 @@ mod tests {
             if bank.slot == 0 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "DX3Jk7ae6VdogRb73iC1zdyrYN5UzinLcSFES2FQx8dY"
+                    "DJ5664svVgjZ8sRLZSrdYAjaAzJe3aEGVBDpZEeoZJ5u"
                 );
             }
             if bank.slot == 32 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "FqLpq1gmTdzEmdEPa2JttEFDqRtuKwkKFKuLuqNSiYwH"
+                    "5yZDar5HaXypoeNnE9mEfVwJEEyDCP5W1pLwhuouPjqN"
                 );
             }
             if bank.slot == 64 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "rBbDCyHuCBWQrLY37zjj2zwsEnzNERWHwoH3W2NpRYe"
+                    "FmPBRC6AAZgXu1QiqZ445FhLYZXun9KTtjMMKqCim9Hd"
                 );
             }
             if bank.slot == 128 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "E9DThiAPbheGeLWBDsts8uzuwF3bJQzDWh5uo8ovtYiy"
+                    "Aqi2QcSoxaYu2QJHKaMHi9G8J2vNEtjpuKzjj5rHP9wr"
                 );
                 break;
             }


### PR DESCRIPTION
#### Problem

`Bank::blockhash_queue` advances on the last tick of a slot, while the `RecentBlockhashes` sysvar updates every `Bank::new_from_parent()`.  This leaves a one tick window where the two are out of sync, breaking the durable nonce program's assumption that the `RecentBlockhashes` sysvar us consistent for the duration of a block.

#### Summary of Changes

- Move `RecentBlockhashes` sysvar update from `Bank::new_from_parent()` to `Bank::register_tick()` (where `Bank::blockhash_queue()` is advanced.
- Mode gate the above change
- Fix up tests

Fixes #11020
Closes #11032 
