### PR TITLE
Fix rewards points

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -253,13 +253,16 @@ impl VoteState {
     ///
     ///  if commission calculation is 100% one way or other,
     ///   indicate with false for was_split
-    pub fn commission_split(&self, on: f64) -> (f64, f64, bool) {
+    pub fn commission_split(&self, on: u64) -> (u64, u64, bool) {
         match self.commission.min(100) {
-            0 => (0.0, on, false),
-            100 => (on, 0.0, false),
+            0 => (0, on, false),
+            100 => (on, 0, false),
             split => {
-                let mine = on * f64::from(split) / f64::from(100);
-                (mine, on - mine, true)
+                let on = u128::from(on);
+                let mine = on * u128::from(split) / 100u128;
+                let theirs = on * u128::from(100 - split) / 100u128;
+
+                (mine as u64, theirs as u64, true)
             }
         }
     }
@@ -1562,19 +1565,22 @@ mod tests {
     fn test_vote_state_commission_split() {
         let vote_state = VoteState::default();
 
-        assert_eq!(vote_state.commission_split(1.0), (0.0, 1.0, false));
+        assert_eq!(vote_state.commission_split(1), (0, 1, false));
 
         let mut vote_state = VoteState::default();
         vote_state.commission = std::u8::MAX;
-        assert_eq!(vote_state.commission_split(1.0), (1.0, 0.0, false));
+        assert_eq!(vote_state.commission_split(1), (1, 0, false));
+
+        vote_state.commission = 99;
+        assert_eq!(vote_state.commission_split(10), (9, 0, true));
+
+        vote_state.commission = 1;
+        assert_eq!(vote_state.commission_split(10), (0, 9, true));
 
         vote_state.commission = 50;
-        let (voter_portion, staker_portion, was_split) = vote_state.commission_split(10.0);
+        let (voter_portion, staker_portion, was_split) = vote_state.commission_split(10);
 
-        assert_eq!(
-            (voter_portion.round(), staker_portion.round(), was_split),
-            (5.0, 5.0, true)
-        );
+        assert_eq!((voter_portion, staker_portion, was_split), (5, 5, true));
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -921,30 +921,50 @@ impl Bank {
             .fetch_add(validator_rewards_paid, Ordering::Relaxed);
     }
 
+    /// map stake delegations into resolved (pubkey, account) pairs
+    ///  returns a vector (has to be copied) of loaded
+    ///   ( (staker info) (voter info) )
+    ///
+    fn stake_delegation_accounts(&self) -> Vec<((Pubkey, Account), (Pubkey, Account))> {
+        self.stakes
+            .read()
+            .unwrap()
+            .stake_delegations()
+            .iter()
+            .filter_map(|(stake_pubkey, delegation)| {
+                match (
+                    self.get_account(&stake_pubkey),
+                    self.get_account(&delegation.voter_pubkey),
+                ) {
+                    (Some(stake_account), Some(vote_account)) => Some((
+                        (*stake_pubkey, stake_account),
+                        (delegation.voter_pubkey, vote_account),
+                    )),
+                    (_, _) => None,
+                }
+            })
+            .collect()
+    }
+
     /// iterate over all stakes, redeem vote credits for each stake we can
     ///   successfully load and parse, return total payout
     fn pay_validator_rewards(&mut self, rewards: u64) -> f64 {
         let stake_history = self.stakes.read().unwrap().history().clone();
 
-        let stake_delegations = self.stake_delegations();
+        let mut stake_delegation_accounts = self.stake_delegation_accounts();
 
-        // first, count total points
-        let points: u128 = stake_delegations
+        let points: u128 = stake_delegation_accounts
             .iter()
-            .map(|(stake_pubkey, delegation)| {
-                match (
-                    self.get_account(&stake_pubkey),
-                    self.get_account(&delegation.voter_pubkey),
-                ) {
-                    (Some(stake_account), Some(vote_account)) => stake_state::calculate_points(
+            .map(
+                |((_stake_pubkey, stake_account), (_vote_pubkey, vote_account))| {
+                    stake_state::calculate_points(
                         &stake_account,
                         &vote_account,
                         Some(&stake_history),
                     )
-                    .unwrap_or(0),
-                    (_, _) => 0,
-                }
-            })
+                    .unwrap_or(0)
+                },
+            )
             .sum();
 
         if points == 0 {
@@ -956,43 +976,33 @@ impl Bank {
         let mut rewards = HashMap::new();
 
         // pay according to point value
-        stake_delegations
-            .iter()
-            .for_each(|(stake_pubkey, delegation)| {
-                match (
-                    self.get_account(&stake_pubkey),
-                    self.get_account(&delegation.voter_pubkey),
-                ) {
-                    (Some(mut stake_account), Some(mut vote_account)) => {
-                        let redeemed = stake_state::redeem_rewards(
-                            &mut stake_account,
-                            &mut vote_account,
-                            &point_value,
-                            Some(&stake_history),
-                        );
-                        if let Ok((stakers_reward, voters_reward)) = redeemed {
-                            self.store_account(&stake_pubkey, &stake_account);
-                            self.store_account(&delegation.voter_pubkey, &vote_account);
+        stake_delegation_accounts.iter_mut().for_each(
+            |((stake_pubkey, stake_account), (vote_pubkey, vote_account))| {
+                let redeemed = stake_state::redeem_rewards(
+                    stake_account,
+                    vote_account,
+                    &point_value,
+                    Some(&stake_history),
+                );
+                if let Ok((stakers_reward, voters_reward)) = redeemed {
+                    self.store_account(&stake_pubkey, &stake_account);
+                    self.store_account(&vote_pubkey, &vote_account);
 
-                            if voters_reward > 0 {
-                                *rewards.entry(delegation.voter_pubkey).or_insert(0i64) +=
-                                    voters_reward as i64;
-                            }
-
-                            if stakers_reward > 0 {
-                                *rewards.entry(*stake_pubkey).or_insert(0i64) +=
-                                    stakers_reward as i64;
-                            }
-                        } else {
-                            debug!(
-                                "stake_state::redeem_rewards() failed for {}: {:?}",
-                                stake_pubkey, redeemed
-                            );
-                        }
+                    if voters_reward > 0 {
+                        *rewards.entry(*vote_pubkey).or_insert(0i64) += voters_reward as i64;
                     }
-                    (_, _) => (),
+
+                    if stakers_reward > 0 {
+                        *rewards.entry(*stake_pubkey).or_insert(0i64) += stakers_reward as i64;
+                    }
+                } else {
+                    debug!(
+                        "stake_state::redeem_rewards() failed for {}: {:?}",
+                        stake_pubkey, redeemed
+                    );
                 }
-            });
+            },
+        );
 
         assert_eq!(self.rewards, None);
         self.rewards = Some(rewards.drain().collect());
@@ -4644,20 +4654,13 @@ mod tests {
         bank.store_account(&vote_id, &vote_account);
 
         let validator_points: u128 = bank
-            .stake_delegations()
+            .stake_delegation_accounts()
             .iter()
-            .map(|(stake_pubkey, delegation)| {
-                match (
-                    bank.get_account(&stake_pubkey),
-                    bank.get_account(&delegation.voter_pubkey),
-                ) {
-                    (Some(stake_account), Some(vote_account)) => {
-                        stake_state::calculate_points(&stake_account, &vote_account, None)
-                            .unwrap_or(0)
-                    }
-                    (_, _) => 0,
-                }
-            })
+            .map(
+                |((_stake_pubkey, stake_account), (_vote_pubkey, vote_account))| {
+                    stake_state::calculate_points(&stake_account, &vote_account, None).unwrap_or(0)
+                },
+            )
             .sum();
 
         // put a child bank in epoch 1, which calls update_rewards()...

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -54,7 +54,7 @@ use solana_sdk::{
     timing::years_as_slots,
     transaction::{Result, Transaction, TransactionError},
 };
-use solana_stake_program::stake_state::{self, Delegation};
+use solana_stake_program::stake_state::{self, Delegation, PointValue};
 use solana_vote_program::vote_state::VoteState;
 use std::{
     cell::RefCell,
@@ -899,8 +899,11 @@ impl Bank {
             (*inflation).validator(year) * self.capitalization() as f64 * period
         } as u64;
 
+        let vote_balance_and_staked = self.stakes.read().unwrap().vote_balance_and_staked();
+
         let validator_point_value = self.pay_validator_rewards(validator_rewards);
 
+        // this sysvar could be retired...
         self.update_sysvar_account(&sysvar::rewards::id(), |account| {
             sysvar::rewards::create_account(
                 self.inherit_sysvar_account_balance(account),
@@ -908,13 +911,19 @@ impl Bank {
             )
         });
 
+        let validator_rewards_paid =
+            self.stakes.read().unwrap().vote_balance_and_staked() - vote_balance_and_staked;
+
+        // verify that we didn't pay any more than we expected to
+        assert!(validator_rewards >= validator_rewards_paid);
+
         self.capitalization
-            .fetch_add(validator_rewards, Ordering::Relaxed);
+            .fetch_add(validator_rewards_paid, Ordering::Relaxed);
     }
 
     /// iterate over all stakes, redeem vote credits for each stake we can
     ///   successfully load and parse, return total payout
-    fn pay_validator_rewards(&mut self, validator_rewards: u64) -> f64 {
+    fn pay_validator_rewards(&mut self, rewards: u64) -> f64 {
         let stake_history = self.stakes.read().unwrap().history().clone();
 
         let stake_delegations = self.stake_delegations();
@@ -938,7 +947,11 @@ impl Bank {
             })
             .sum();
 
-        let point_value = self.check_point_value(validator_rewards as f64 / points as f64);
+        if points == 0 {
+            return 0.0;
+        }
+
+        let point_value = PointValue { rewards, points };
 
         let mut rewards = HashMap::new();
 
@@ -954,7 +967,7 @@ impl Bank {
                         let redeemed = stake_state::redeem_rewards(
                             &mut stake_account,
                             &mut vote_account,
-                            point_value,
+                            &point_value,
                             Some(&stake_history),
                         );
                         if let Ok((stakers_reward, voters_reward)) = redeemed {
@@ -983,7 +996,7 @@ impl Bank {
 
         assert_eq!(self.rewards, None);
         self.rewards = Some(rewards.drain().collect());
-        point_value
+        point_value.rewards as f64 / point_value.points as f64
     }
 
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {
@@ -999,21 +1012,6 @@ impl Bank {
     pub fn update_recent_blockhashes(&self) {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         self.update_recent_blockhashes_locked(&blockhash_queue);
-    }
-
-    // If the point values are not `normal`, bring them back into range and
-    // set them to the last value or 0.
-    fn check_point_value(&self, mut validator_point_value: f64) -> f64 {
-        let rewards = sysvar::rewards::Rewards::from_account(
-            &self
-                .get_account(&sysvar::rewards::id())
-                .unwrap_or_else(|| sysvar::rewards::create_account(1, 0.0)),
-        )
-        .unwrap_or_else(Default::default);
-        if !validator_point_value.is_normal() {
-            validator_point_value = rewards.validator_point_value;
-        }
-        validator_point_value
     }
 
     fn collect_fees(&self) {
@@ -6292,23 +6290,6 @@ mod tests {
         );
 
         assert!(bank.is_delta.load(Ordering::Relaxed));
-    }
-
-    #[test]
-    #[allow(clippy::float_cmp)]
-    fn test_check_point_value() {
-        let (genesis_config, _) = create_genesis_config(500);
-        let bank = Arc::new(Bank::new(&genesis_config));
-
-        // check that point values are 0 if no previous value was known and current values are not normal
-        assert_eq!(bank.check_point_value(std::f64::INFINITY), 0.0);
-
-        bank.store_account(
-            &sysvar::rewards::id(),
-            &sysvar::rewards::create_account(1, 1.0),
-        );
-        // check that point values are the previous value if current values are not normal
-        assert_eq!(bank.check_point_value(std::f64::INFINITY), 1.0);
     }
 
     #[test]

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -282,7 +282,7 @@ mod test_bank_serialize {
 
     // These some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "6MnT4MzuLHe4Uq96YaF3JF2gL1RvprzQHCaV9TaWgYLe")]
+    #[frozen_abi(digest = "FaZaic5p7bvdsKDxGJmaPVyp12AbAmURyYoGiUdx1Ksu")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperFuture {
         #[serde(serialize_with = "wrapper_future")]
@@ -305,7 +305,7 @@ mod test_bank_serialize {
         .serialize(s)
     }
 
-    #[frozen_abi(digest = "92KVEUQ8PwKe5DgZ6AyDQGAi9pvi7kfHdMBE4hcs5EQ4")]
+    #[frozen_abi(digest = "9g4bYykzsC86fULgu9iUh4kpvb1pxvAmipvyZPChLhws")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperLegacy {
         #[serde(serialize_with = "wrapper_legacy")]

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -173,9 +173,7 @@ pub mod tests {
     use super::*;
     use solana_sdk::{pubkey::Pubkey, rent::Rent};
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state::{
-        self, VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY,
-    };
+    use solana_vote_program::vote_state::{self, VoteState};
 
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
     pub fn create_staked_node_accounts(stake: u64) -> ((Pubkey, Account), (Pubkey, Account)) {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -87,6 +87,13 @@ impl Stakes {
             .sum()
     }
 
+    pub fn vote_balance_and_staked(&self) -> u64 {
+        self.vote_accounts
+            .iter()
+            .map(|(_pubkey, (staked, account))| staked + account.lamports)
+            .sum()
+    }
+
     pub fn is_stake(account: &Account) -> bool {
         solana_vote_program::check_id(&account.owner)
             || solana_stake_program::check_id(&account.owner)


### PR DESCRIPTION
 #### Problem
 Stakes.points overflows on a normal network, which leads to an inflated point_value, which leads to an overpayment of validators (excess inflation).

 #### Summary of Changes
 * promote "points" to u128
 * since Stakes.points is a u64 and expanding it to u128 would break bank deserialization from a snapshot, move calculation of points per epoch into pay_validator_rewards() instead of the incremental calculation previously performed by Stakes
 * remove tests for Stakes.points -> Stakes.unused
 * re-order the tuples that were `(voter_rewards, staker_rewards)` to `(staker_rewards, voter_rewards)` for a little bit more sanity

Fixes #10872
