### PR TITLE
CLI: Fix vote blind indexing

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -391,6 +391,7 @@ pub enum CliCommand {
     VoteUpdateValidator {
         vote_account_pubkey: Pubkey,
         new_identity_account: SignerIndex,
+        withdraw_authority: SignerIndex,
     },
     VoteUpdateCommission {
         vote_account_pubkey: Pubkey,
@@ -2206,11 +2207,13 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::VoteUpdateValidator {
             vote_account_pubkey,
             new_identity_account,
+            withdraw_authority,
         } => process_vote_update_validator(
             &rpc_client,
             config,
             &vote_account_pubkey,
             *new_identity_account,
+            *withdraw_authority,
         ),
         CliCommand::VoteUpdateCommission {
             vote_account_pubkey,
@@ -3498,6 +3501,7 @@ mod tests {
         config.command = CliCommand::VoteUpdateValidator {
             vote_account_pubkey: bob_pubkey,
             new_identity_account: 2,
+            withdraw_authority: 1,
         };
         let result = process_command(&config);
         assert!(result.is_ok());
@@ -3729,6 +3733,7 @@ mod tests {
         config.command = CliCommand::VoteUpdateValidator {
             vote_account_pubkey: bob_pubkey,
             new_identity_account: 1,
+            withdraw_authority: 1,
         };
         assert!(process_command(&config).is_err());
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -367,6 +367,7 @@ pub enum CliCommand {
     },
     // Vote Commands
     CreateVoteAccount {
+        vote_account: SignerIndex,
         seed: Option<String>,
         identity_account: SignerIndex,
         authorized_voter: Option<Pubkey>,
@@ -2157,6 +2158,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
 
         // Create vote account
         CliCommand::CreateVoteAccount {
+            vote_account,
             seed,
             identity_account,
             authorized_voter,
@@ -2165,6 +2167,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         } => process_create_vote_account(
             &rpc_client,
             config,
+            *vote_account,
             seed,
             *identity_account,
             authorized_voter,
@@ -3476,6 +3479,7 @@ mod tests {
         let bob_pubkey = bob_keypair.pubkey();
         let identity_keypair = Keypair::new();
         config.command = CliCommand::CreateVoteAccount {
+            vote_account: 1,
             seed: None,
             identity_account: 2,
             authorized_voter: Some(bob_pubkey),
@@ -3714,6 +3718,7 @@ mod tests {
         let bob_keypair = Keypair::new();
         let identity_keypair = Keypair::new();
         config.command = CliCommand::CreateVoteAccount {
+            vote_account: 1,
             seed: None,
             identity_account: 2,
             authorized_voter: Some(bob_pubkey),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -395,6 +395,7 @@ pub enum CliCommand {
     VoteUpdateCommission {
         vote_account_pubkey: Pubkey,
         commission: u8,
+        withdraw_authority: SignerIndex,
     },
     // Wallet Commands
     Address,
@@ -2214,7 +2215,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::VoteUpdateCommission {
             vote_account_pubkey,
             commission,
-        } => process_vote_update_commission(&rpc_client, config, &vote_account_pubkey, *commission),
+            withdraw_authority,
+        } => process_vote_update_commission(
+            &rpc_client,
+            config,
+            &vote_account_pubkey,
+            *commission,
+            *withdraw_authority,
+        ),
 
         // Wallet Commands
 

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -249,7 +249,7 @@ pub fn parse_create_vote_account(
     default_signer_path: &str,
     wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
 ) -> Result<CliCommandInfo, CliError> {
-    let (vote_account, _) = signer_of(matches, "vote_account", wallet_manager)?;
+    let (vote_account, vote_account_pubkey) = signer_of(matches, "vote_account", wallet_manager)?;
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let (identity_account, identity_pubkey) =
         signer_of(matches, "identity_account", wallet_manager)?;
@@ -267,6 +267,7 @@ pub fn parse_create_vote_account(
 
     Ok(CliCommandInfo {
         command: CliCommand::CreateVoteAccount {
+            vote_account: signer_info.index_of(vote_account_pubkey).unwrap(),
             seed,
             identity_account: signer_info.index_of(identity_pubkey).unwrap(),
             authorized_voter,
@@ -418,13 +419,14 @@ pub fn parse_withdraw_from_vote_account(
 pub fn process_create_vote_account(
     rpc_client: &RpcClient,
     config: &CliConfig,
+    vote_account: SignerIndex,
     seed: &Option<String>,
     identity_account: SignerIndex,
     authorized_voter: &Option<Pubkey>,
     authorized_withdrawer: &Option<Pubkey>,
     commission: u8,
 ) -> ProcessResult {
-    let vote_account = config.signers[1];
+    let vote_account = config.signers[vote_account];
     let vote_account_pubkey = vote_account.pubkey();
     let vote_account_address = if let Some(seed) = seed {
         Pubkey::create_with_seed(&vote_account_pubkey, &seed, &solana_vote_program::id())?
@@ -857,6 +859,7 @@ mod tests {
             parse_command(&test_create_vote_account, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
+                    vote_account: 1,
                     seed: None,
                     identity_account: 2,
                     authorized_voter: None,
@@ -885,6 +888,7 @@ mod tests {
             parse_command(&test_create_vote_account2, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
+                    vote_account: 1,
                     seed: None,
                     identity_account: 2,
                     authorized_voter: None,
@@ -917,6 +921,7 @@ mod tests {
             parse_command(&test_create_vote_account3, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
+                    vote_account: 1,
                     seed: None,
                     identity_account: 2,
                     authorized_voter: Some(authed),
@@ -947,6 +952,7 @@ mod tests {
             parse_command(&test_create_vote_account4, &default_keypair_file, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::CreateVoteAccount {
+                    vote_account: 1,
                     seed: None,
                     identity_account: 2,
                     authorized_voter: None,

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -316,7 +316,8 @@ pub fn parse_vote_update_validator(
         pubkey_of_signer(matches, "vote_account_pubkey", wallet_manager)?.unwrap();
     let (new_identity_account, new_identity_pubkey) =
         signer_of(matches, "new_identity_account", wallet_manager)?;
-    let (authorized_withdrawer, _) = signer_of(matches, "authorized_withdrawer", wallet_manager)?;
+    let (authorized_withdrawer, authorized_withdrawer_pubkey) =
+        signer_of(matches, "authorized_withdrawer", wallet_manager)?;
 
     let payer_provided = None;
     let signer_info = generate_unique_signers(
@@ -330,6 +331,7 @@ pub fn parse_vote_update_validator(
         command: CliCommand::VoteUpdateValidator {
             vote_account_pubkey,
             new_identity_account: signer_info.index_of(new_identity_pubkey).unwrap(),
+            withdraw_authority: signer_info.index_of(authorized_withdrawer_pubkey).unwrap(),
         },
         signers: signer_info.signers,
     })
@@ -565,8 +567,9 @@ pub fn process_vote_update_validator(
     config: &CliConfig,
     vote_account_pubkey: &Pubkey,
     new_identity_account: SignerIndex,
+    withdraw_authority: SignerIndex,
 ) -> ProcessResult {
-    let authorized_withdrawer = config.signers[1];
+    let authorized_withdrawer = config.signers[withdraw_authority];
     let new_identity_account = config.signers[new_identity_account];
     let new_identity_pubkey = new_identity_account.pubkey();
     check_unique_pubkeys(
@@ -971,6 +974,7 @@ mod tests {
                 command: CliCommand::VoteUpdateValidator {
                     vote_account_pubkey: pubkey,
                     new_identity_account: 2,
+                    withdraw_authority: 1,
                 },
                 signers: vec![
                     read_keypair_file(&default_keypair_file).unwrap().into(),

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -58,6 +58,7 @@ fn test_stake_delegation_force() {
     let vote_keypair = Keypair::new();
     config.signers = vec![&default_signer, &vote_keypair];
     config.command = CliCommand::CreateVoteAccount {
+        vote_account: 1,
         seed: None,
         identity_account: 0,
         authorized_voter: None,

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -50,6 +50,7 @@ fn test_vote_authorize_and_withdraw() {
     let vote_account_pubkey = vote_account_keypair.pubkey();
     config.signers = vec![&default_signer, &vote_account_keypair];
     config.command = CliCommand::CreateVoteAccount {
+        vote_account: 1,
         seed: None,
         identity_account: 0,
         authorized_voter: None,

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -125,6 +125,7 @@ fn test_vote_authorize_and_withdraw() {
     config.command = CliCommand::VoteUpdateValidator {
         vote_account_pubkey,
         new_identity_account: 2,
+        withdraw_authority: 1,
     };
     process_command(&config).unwrap();
 


### PR DESCRIPTION
#### Problem

Several CLI `vote-*` subcommands can be constructed such that a blind index into the signers array is out of bounds

#### Summary of Changes

Plumb signer array indices through from parser

Fixes #11022
