### PR TITLE
Add TreeDiff trait to reuse tree diff functions

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -62,6 +62,7 @@ pub mod sigverify_stage;
 pub mod snapshot_packager_service;
 pub mod tpu;
 pub mod transaction_status_service;
+pub mod tree_diff;
 pub mod tvu;
 pub mod validator;
 pub mod verified_vote_packets;

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -3,6 +3,7 @@ use crate::{
     repair_service::RepairTiming,
     repair_weighted_traversal::{self, Contains},
     serve_repair::RepairType,
+    tree_diff::TreeDiff,
 };
 use solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore};
 use solana_measure::measure::Measure;

--- a/core/src/repair_weighted_traversal.rs
+++ b/core/src/repair_weighted_traversal.rs
@@ -1,6 +1,6 @@
 use crate::{
     heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, repair_service::RepairService,
-    serve_repair::RepairType,
+    serve_repair::RepairType, tree_diff::TreeDiff,
 };
 use solana_ledger::blockstore::Blockstore;
 use solana_sdk::clock::Slot;

--- a/core/src/tree_diff.rs
+++ b/core/src/tree_diff.rs
@@ -1,0 +1,32 @@
+use solana_sdk::clock::Slot;
+use std::collections::HashSet;
+
+pub trait TreeDiff {
+    fn children(&self, slot: Slot) -> Option<&[Slot]>;
+
+    fn contains_slot(&self, slot: Slot) -> bool;
+
+    // Find all nodes reachable from `root1`, excluding subtree at `root2`
+    fn subtree_diff(&self, root1: Slot, root2: Slot) -> HashSet<Slot> {
+        if !self.contains_slot(root1) {
+            return HashSet::new();
+        }
+        let mut pending_slots = vec![root1];
+        let mut reachable_set = HashSet::new();
+        while !pending_slots.is_empty() {
+            let current_slot = pending_slots.pop().unwrap();
+            if current_slot == root2 {
+                continue;
+            }
+            reachable_set.insert(current_slot);
+            for child in self
+                .children(current_slot)
+                .expect("slot was discovered earlier, must exist")
+            {
+                pending_slots.push(*child);
+            }
+        }
+
+        reachable_set
+    }
+}


### PR DESCRIPTION
#### Problem
`subtree_diff()` is a useful function for other tree structures, so should be reusable

#### Summary of Changes
Introduce trait for tree structures that includes default utility functions like ``subtree_diff()`

Fixes #
