### PR TITLE
accounts_clean: Convert stack dependency calculation with iterative

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1703,4 +1703,26 @@ mod tests {
         assert!(!Accounts::has_duplicates(&[1, 2]));
         assert!(Accounts::has_duplicates(&[1, 2, 1]));
     }
+
+    #[test]
+    fn huge_clean() {
+        solana_logger::setup();
+        let accounts = Accounts::new(Vec::new());
+        let mut old_pubkey = Pubkey::default();
+        let zero_account = Account::new(0, 0, &Account::default().owner);
+        info!("storing..");
+        for i in 0..2_000 {
+            let pubkey = Pubkey::new_rand();
+            let account = Account::new((i + 1) as u64, 0, &Account::default().owner);
+            accounts.store_slow(i, &pubkey, &account);
+            accounts.store_slow(i, &old_pubkey, &zero_account);
+            old_pubkey = pubkey;
+            accounts.add_root(i);
+            if i % 1_000 == 0 {
+                info!("  store {}", i);
+            }
+        }
+        info!("done..cleaning..");
+        accounts.accounts_db.clean_accounts();
+    }
 }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -565,38 +565,6 @@ impl AccountsDB {
             .extend(previous_roots);
     }
 
-    fn inc_store_counts(
-        no_delete_id: AppendVecId,
-        purges: &HashMap<Pubkey, (SlotList<AccountInfo>, u64)>,
-        store_counts: &mut HashMap<AppendVecId, usize>,
-        already_counted: &mut HashSet<AppendVecId>,
-    ) {
-        if already_counted.contains(&no_delete_id) {
-            return;
-        }
-        *store_counts.get_mut(&no_delete_id).unwrap() += 1;
-        already_counted.insert(no_delete_id);
-        let mut affected_pubkeys = HashSet::new();
-        for (key, (account_infos, _ref_count)) in purges {
-            for (_slot, account_info) in account_infos {
-                if account_info.store_id == no_delete_id {
-                    affected_pubkeys.insert(key);
-                    break;
-                }
-            }
-        }
-        for key in affected_pubkeys {
-            for (_slot, account_info) in &purges.get(&key).unwrap().0 {
-                Self::inc_store_counts(
-                    account_info.store_id,
-                    purges,
-                    store_counts,
-                    already_counted,
-                );
-            }
-        }
-    }
-
     fn calc_delete_dependencies(
         purges: &HashMap<Pubkey, (SlotList<AccountInfo>, u64)>,
         store_counts: &mut HashMap<AppendVecId, usize>,
@@ -619,13 +587,37 @@ impl AccountsDB {
                 no_delete
             };
             if no_delete {
+                let mut pending_store_ids: HashSet<usize> = HashSet::new();
                 for (_slot_id, account_info) in account_infos {
-                    Self::inc_store_counts(
-                        account_info.store_id,
-                        &purges,
-                        store_counts,
-                        &mut already_counted,
-                    );
+                    if !already_counted.contains(&account_info.store_id) {
+                        pending_store_ids.insert(account_info.store_id);
+                    }
+                }
+                while !pending_store_ids.is_empty() {
+                    let id = pending_store_ids.iter().next().cloned().unwrap();
+                    pending_store_ids.remove(&id);
+                    if already_counted.contains(&id) {
+                        continue;
+                    }
+                    *store_counts.get_mut(&id).unwrap() += 1;
+                    already_counted.insert(id);
+
+                    let mut affected_pubkeys = HashSet::new();
+                    for (key, (account_infos, _ref_count)) in purges {
+                        for (_slot, account_info) in account_infos {
+                            if account_info.store_id == id {
+                                affected_pubkeys.insert(key);
+                                break;
+                            }
+                        }
+                    }
+                    for key in affected_pubkeys {
+                        for (_slot, account_info) in &purges.get(&key).unwrap().0 {
+                            if !already_counted.contains(&account_info.store_id) {
+                                pending_store_ids.insert(account_info.store_id);
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Problem

Stack overflow with large number of store dependencies.

#### Summary of Changes

Convert to clean dependency checking to iterative algorithm.

This also improves performance from ~400ms for a 10,000 account dependency chain to ~10ms from the `store_id => hashset<pubkey>` reverse lookup it creates instead of re-creating the affected key set for each store id.

Fixes #11066
