### PR TITLE
Expose TransactionStatusService to the other blockstore_processor path

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -8,7 +8,7 @@ use crate::{
     gossip_service::{discover_cluster, GossipService},
     poh_recorder::{PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
     poh_service::PohService,
-    rewards_recorder_service::RewardsRecorderService,
+    rewards_recorder_service::{RewardsRecorderSender, RewardsRecorderService},
     rpc::JsonRpcConfig,
     rpc_pubsub_service::PubSubService,
     rpc_service::JsonRpcService,
@@ -27,7 +27,8 @@ use solana_ledger::{
     bank_forks_utils,
     blockstore::{Blockstore, CompletedSlotsReceiver, PurgeType},
     blockstore_db::BlockstoreRecoveryMode,
-    blockstore_processor, create_new_tmp_ledger,
+    blockstore_processor::{self, TransactionStatusSender},
+    create_new_tmp_ledger,
     leader_schedule::FixedSchedule,
     leader_schedule_cache::LeaderScheduleCache,
 };
@@ -135,6 +136,14 @@ impl ValidatorExit {
     }
 }
 
+#[derive(Default)]
+struct TransactionHistoryServices {
+    transaction_status_sender: Option<TransactionStatusSender>,
+    transaction_status_service: Option<TransactionStatusService>,
+    rewards_recorder_sender: Option<RewardsRecorderSender>,
+    rewards_recorder_service: Option<RewardsRecorderService>,
+}
+
 pub struct Validator {
     pub id: Pubkey,
     validator_exit: Arc<RwLock<Option<ValidatorExit>>>,
@@ -203,6 +212,12 @@ impl Validator {
             cleanup_accounts_path(accounts_path);
         }
 
+        let mut validator_exit = ValidatorExit::default();
+        let exit = Arc::new(AtomicBool::new(false));
+        let exit_ = exit.clone();
+        validator_exit.register_exit(Box::new(move || exit_.store(true, Ordering::Relaxed)));
+        let validator_exit = Arc::new(RwLock::new(Some(validator_exit)));
+
         let (
             genesis_config,
             bank_forks,
@@ -211,7 +226,13 @@ impl Validator {
             completed_slots_receiver,
             leader_schedule_cache,
             snapshot_hash,
-        ) = new_banks_from_ledger(config, ledger_path, poh_verify);
+            TransactionHistoryServices {
+                transaction_status_sender,
+                transaction_status_service,
+                rewards_recorder_sender,
+                rewards_recorder_service,
+            },
+        ) = new_banks_from_ledger(config, ledger_path, poh_verify, &exit);
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let bank = bank_forks.working_bank();
@@ -243,14 +264,7 @@ impl Validator {
             }
         }
 
-        let mut validator_exit = ValidatorExit::default();
-        let exit = Arc::new(AtomicBool::new(false));
-        let exit_ = exit.clone();
-        validator_exit.register_exit(Box::new(move || exit_.store(true, Ordering::Relaxed)));
-        let validator_exit = Arc::new(RwLock::new(Some(validator_exit)));
-
         let cluster_info = Arc::new(ClusterInfo::new(node.info.clone(), keypair.clone()));
-        let blockstore = Arc::new(blockstore);
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
 
         let subscriptions = Arc::new(RpcSubscriptions::new(
@@ -290,36 +304,6 @@ impl Validator {
                 ),
             )
         });
-
-        let (transaction_status_sender, transaction_status_service) =
-            if rpc_service.is_some() && config.rpc_config.enable_rpc_transaction_history {
-                let (transaction_status_sender, transaction_status_receiver) = unbounded();
-                (
-                    Some(transaction_status_sender),
-                    Some(TransactionStatusService::new(
-                        transaction_status_receiver,
-                        blockstore.clone(),
-                        &exit,
-                    )),
-                )
-            } else {
-                (None, None)
-            };
-
-        let (rewards_recorder_sender, rewards_recorder_service) =
-            if rpc_service.is_some() && config.rpc_config.enable_rpc_transaction_history {
-                let (rewards_recorder_sender, rewards_receiver) = unbounded();
-                (
-                    Some(rewards_recorder_sender),
-                    Some(RewardsRecorderService::new(
-                        rewards_receiver,
-                        blockstore.clone(),
-                        &exit,
-                    )),
-                )
-            } else {
-                (None, None)
-            };
 
         info!(
             "Starting PoH: epoch={} slot={} tick_height={} blockhash={} leader={:?}",
@@ -579,14 +563,16 @@ fn new_banks_from_ledger(
     config: &ValidatorConfig,
     ledger_path: &Path,
     poh_verify: bool,
+    exit: &Arc<AtomicBool>,
 ) -> (
     GenesisConfig,
     BankForks,
-    Blockstore,
+    Arc<Blockstore>,
     Receiver<bool>,
     CompletedSlotsReceiver,
     LeaderScheduleCache,
     Option<(Slot, Hash)>,
+    TransactionHistoryServices,
 ) {
     info!("loading ledger from {:?}...", ledger_path);
     let genesis_config = open_genesis_config(ledger_path, config.max_genesis_archive_unpacked_size);
@@ -622,12 +608,23 @@ fn new_banks_from_ledger(
         ..blockstore_processor::ProcessOptions::default()
     };
 
+    let blockstore = Arc::new(blockstore);
+    let transaction_history_services =
+        if config.rpc_ports.is_some() && config.rpc_config.enable_rpc_transaction_history {
+            initialize_rpc_transaction_history_services(blockstore.clone(), exit)
+        } else {
+            TransactionHistoryServices::default()
+        };
+
     let (mut bank_forks, mut leader_schedule_cache, snapshot_hash) = bank_forks_utils::load(
         &genesis_config,
         &blockstore,
         config.account_paths.clone(),
         config.snapshot_config.as_ref(),
         process_options,
+        transaction_history_services
+            .transaction_status_sender
+            .clone(),
     )
     .unwrap_or_else(|err| {
         error!("Failed to load ledger: {:?}", err);
@@ -647,6 +644,7 @@ fn new_banks_from_ledger(
         completed_slots_receiver,
         leader_schedule_cache,
         snapshot_hash,
+        transaction_history_services,
     )
 }
 
@@ -708,6 +706,33 @@ fn backup_and_clear_blockstore(ledger_path: &Path, start_slot: Slot, shred_versi
         info!("done");
     }
     drop(blockstore);
+}
+
+fn initialize_rpc_transaction_history_services(
+    blockstore: Arc<Blockstore>,
+    exit: &Arc<AtomicBool>,
+) -> TransactionHistoryServices {
+    let (transaction_status_sender, transaction_status_receiver) = unbounded();
+    let transaction_status_sender = Some(transaction_status_sender);
+    let transaction_status_service = Some(TransactionStatusService::new(
+        transaction_status_receiver,
+        blockstore.clone(),
+        exit,
+    ));
+
+    let (rewards_recorder_sender, rewards_receiver) = unbounded();
+    let rewards_recorder_sender = Some(rewards_recorder_sender);
+    let rewards_recorder_service = Some(RewardsRecorderService::new(
+        rewards_receiver,
+        blockstore,
+        exit,
+    ));
+    TransactionHistoryServices {
+        transaction_status_sender,
+        transaction_status_service,
+        rewards_recorder_sender,
+        rewards_recorder_service,
+    }
 }
 
 // Return true on error, indicating the validator should exit.

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -680,6 +680,7 @@ fn load_bank_forks(
         account_paths,
         snapshot_config.as_ref(),
         process_options,
+        None,
     )
 }
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -2,6 +2,7 @@ use crate::{
     blockstore::Blockstore,
     blockstore_processor::{
         self, BlockstoreProcessorError, BlockstoreProcessorResult, ProcessOptions,
+        TransactionStatusSender,
     },
     entry::VerifyRecyclers,
     leader_schedule_cache::LeaderScheduleCache,
@@ -34,6 +35,7 @@ pub fn load(
     account_paths: Vec<PathBuf>,
     snapshot_config: Option<&SnapshotConfig>,
     process_options: ProcessOptions,
+    transaction_status_sender: Option<TransactionStatusSender>,
 ) -> LoadResult {
     if let Some(snapshot_config) = snapshot_config.as_ref() {
         info!(
@@ -86,6 +88,7 @@ pub fn load(
                         Arc::new(deserialized_bank),
                         &process_options,
                         &VerifyRecyclers::default(),
+                        transaction_status_sender,
                     ),
                     Some(deserialized_snapshot_hash),
                 );


### PR DESCRIPTION
#### Problem
Recently, an api-node issue resulted in a gap in rpc transaction history. We have ledger data, so it should be possible to fill in the gap when the node rebooted. However, the TransactionStatusService is not initialized prior to processing of existing ledger, and the processing functions do not have access to the TransactionStatusSender.

#### Summary of Changes
- Reorder `Validator::new_banks_from_ledger()` to make the TransactionStatusService available to `bank_forks_utils::load`
- Plumb TransactionStatusSender through blockstore_processor to the other caller of `confirm_full_slot()`

As @sakridge has pointed out, a better approach would be to unify the replay and blockstore-processor paths. This is a band-aid to improve api-node functionality until such a refactor. 
