### PR TITLE
Make accounts file clean faster

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -31,6 +31,7 @@ use solana_ledger::{
     leader_schedule::FixedSchedule,
     leader_schedule_cache::LeaderScheduleCache,
 };
+use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
 use solana_runtime::{
     bank::Bank,
@@ -199,9 +200,13 @@ impl Validator {
             }
         }
 
+        info!("Cleaning accounts paths..");
+        let mut start = Measure::start("clean_accounts_paths");
         for accounts_path in &config.account_paths {
             cleanup_accounts_path(accounts_path);
         }
+        start.stop();
+        info!("done. {}", start);
 
         let (
             genesis_config,
@@ -966,30 +971,13 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
     online_stake * 100 / total_activated_stake
 }
 
-fn cleanup_accounts_dir_entry(path: std::fs::DirEntry, accounts_file_regex: &regex::Regex) {
-    if let Ok(file_type) = path.file_type() {
-        if file_type.is_file() {
-            if let Ok(file_name) = path.file_name().into_string() {
-                if accounts_file_regex.is_match(&file_name) {
-                    if let Err(e) = std::fs::remove_file(path.path()) {
-                        info!("Couldn't delete file: {:?} error: {:?}", path, e);
-                    }
-                }
-            }
-        }
-    }
-}
-
 // Cleanup anything that looks like an accounts append-vec
 fn cleanup_accounts_path(account_path: &std::path::Path) {
-    use regex::Regex;
-    let accounts_file_regex = Regex::new(r"(\d+).(\d+)").unwrap();
-    if let Ok(dir_entries) = std::fs::read_dir(&account_path) {
-        for entry in dir_entries {
-            if let Ok(path) = entry {
-                cleanup_accounts_dir_entry(path, &accounts_file_regex);
-            }
-        }
+    if std::fs::remove_dir_all(account_path).is_err() {
+        warn!(
+            "encountered error removing accounts path: {:?}",
+            account_path
+        );
     }
 }
 
@@ -1170,21 +1158,5 @@ mod tests {
             &cluster_info,
             rpc_override_health_check
         ));
-    }
-
-    #[test]
-    fn accounts_clean() {
-        use std::fs::File;
-        let temp_dir = tempfile::tempdir_in("farf").unwrap();
-        let temp_path = temp_dir.path();
-        {
-            let _file1 = File::create(temp_path.join("foo.txt")).unwrap();
-            let _file2 = File::create(temp_path.join("123.2222")).unwrap();
-        }
-        std::fs::create_dir(temp_path.join("12.088")).unwrap();
-        cleanup_accounts_path(temp_dir.path());
-        assert!(File::open(temp_path.join("foo.txt")).is_ok());
-        assert!(File::open(temp_path.join("123.2222")).is_err());
-        assert!(std::fs::read_dir(temp_path.join("12.088")).is_ok());
     }
 }


### PR DESCRIPTION
#### Problem

Accounts clean tries to be careful and delete files that only look like append vecs in accounts paths. This is really slow and causes long startup times for validators.

#### Summary of Changes

`remove_dir_all` which will remove the whole path and be much faster.

Fixes #
