### PR TITLE
Temporalily disable inflation to fix it later

### DIFF
--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -17,41 +17,29 @@ use solana_runtime::bank::{Bank, EnteredEpochCallback};
 
 pub fn get_inflation(operating_mode: OperatingMode, epoch: Epoch) -> Option<Inflation> {
     match operating_mode {
-        OperatingMode::Development => {
-            if epoch == 0 {
-                Some(Inflation::default())
-            } else {
-                None
-            }
-        }
-        OperatingMode::Preview => {
-            if epoch == 0 {
-                // No inflation at epoch 0
-                Some(Inflation::new_disabled())
-            } else if epoch == 44 {
-                // testnet enabled inflation at epoch 44:
-                // https://github.com/solana-labs/solana/blob/d8e885f4259e6c7db420cce513cb34ebf961073d
-                Some(Inflation::default())
-            } else if epoch == 68 {
-                // Completely disable inflation prior to ship the inflation fix at epoch 68
-                Some(Inflation::new_disabled())
-            } else {
-                None
-            }
-        }
-        OperatingMode::Stable => {
-            if epoch == 0 {
-                // No inflation at epoch 0
-                Some(Inflation::new_disabled())
-            } else if epoch == std::u64::MAX {
-                // Inflation starts
-                // The epoch of std::u64::MAX is a placeholder and is expected to be reduced in
-                // a future hard fork.
-                Some(Inflation::default())
-            } else {
-                None
-            }
-        }
+        OperatingMode::Development => match epoch {
+            0 => Some(Inflation::default()),
+            _ => None,
+        },
+        OperatingMode::Preview => match epoch {
+            // No inflation at epoch 0
+            0 => Some(Inflation::new_disabled()),
+            // testnet enabled inflation at epoch 44:
+            // https://github.com/solana-labs/solana/blob/d8e885f4259e6c7db420cce513cb34ebf961073d
+            44 => Some(Inflation::default()),
+            // Completely disable inflation prior to ship the inflation fix at epoch 68
+            68 => Some(Inflation::new_disabled()),
+            _ => None,
+        },
+        OperatingMode::Stable => match epoch {
+            // No inflation at epoch 0
+            0 => Some(Inflation::new_disabled()),
+            // Inflation starts
+            // The epoch of Epoch::MAX is a placeholder and is expected to be reduced in
+            // a future hard fork.
+            Epoch::MAX => Some(Inflation::default()),
+            _ => None,
+        },
     }
 }
 

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -16,28 +16,25 @@ use log::*;
 use solana_runtime::bank::{Bank, EnteredEpochCallback};
 
 pub fn get_inflation(operating_mode: OperatingMode, epoch: Epoch) -> Option<Inflation> {
-    let past_epoch_inflation = get_inflation_for_epoch(operating_mode, epoch.saturating_sub(1));
-    let epoch_inflation = get_inflation_for_epoch(operating_mode, epoch);
-
-    if epoch_inflation != past_epoch_inflation || epoch == 0 {
-        Some(epoch_inflation)
-    } else {
-        None
-    }
-}
-
-pub fn get_inflation_for_epoch(operating_mode: OperatingMode, epoch: Epoch) -> Inflation {
     match operating_mode {
-        OperatingMode::Development => Inflation::default(),
+        OperatingMode::Development => {
+            if epoch == 0 {
+                Some(Inflation::default())
+            } else {
+                None
+            }
+        }
         OperatingMode::Stable | OperatingMode::Preview => {
-            if epoch == std::u64::MAX {
+            if epoch == 0 {
+                // No inflation at epoch 0
+                Some(Inflation::new_disabled())
+            } else if epoch == std::u64::MAX {
                 // Inflation starts
                 // The epoch of std::u64::MAX is a placeholder and is expected to be reduced in
                 // a future hard fork.
-                Inflation::default()
+                Some(Inflation::default())
             } else {
-                // No inflation from epoch 0
-                Inflation::new_disabled()
+                None
             }
         }
     }


### PR DESCRIPTION
#### Problem

Rewards calculation has a bug (#10914 ) and we want to fix it without downtime on tds.

#### Summary of Changes

Also, fix a minor footgun (commented as a on-code comment).

First, disable it (from the context):

>  mvines | I'll never DM you: @t-nelson  / @ryoqun - why don't we push an update to testnet ASAP that disables inflation in the next epoch.  Then we can easily ship https://github.com/solana-labs/solana/pull/10914 in the following update.
>  mvines | I'll never DM you:
> > Then the 3rd update re-enables inflation
> 
> I guess that 3rd update isn't necessary.  The 2nd update could re-enable inflation along with the rewards fix

Context: https://discord.com/channels/428295358100013066/560503042458517505/732738934794223667
