### PR TITLE
Gate nonce-overwrite change

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -650,6 +650,7 @@ impl Accounts {
         loaded: &mut [(Result<TransactionLoadResult>, Option<HashAgeKind>)],
         rent_collector: &RentCollector,
         last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
+        fix_recent_blockhashes_sysvar_delay: bool,
     ) {
         let accounts_to_store = self.collect_accounts_to_store(
             txs,
@@ -658,6 +659,7 @@ impl Accounts {
             loaded,
             rent_collector,
             last_blockhash_with_fee_calculator,
+            fix_recent_blockhashes_sysvar_delay,
         );
         self.accounts_db.store(slot, &accounts_to_store);
     }
@@ -684,6 +686,7 @@ impl Accounts {
         loaded: &'a mut [(Result<TransactionLoadResult>, Option<HashAgeKind>)],
         rent_collector: &RentCollector,
         last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
+        fix_recent_blockhashes_sysvar_delay: bool,
     ) -> Vec<(&'a Pubkey, &'a Account)> {
         let mut accounts = Vec::with_capacity(loaded.len());
         for (i, ((raccs, _hash_age_kind), tx)) in loaded
@@ -720,6 +723,7 @@ impl Accounts {
                     res,
                     maybe_nonce,
                     last_blockhash_with_fee_calculator,
+                    fix_recent_blockhashes_sysvar_delay,
                 );
                 if message.is_writable(i) {
                     if account.rent_epoch == 0 {
@@ -1675,6 +1679,7 @@ mod tests {
             &mut loaded,
             &rent_collector,
             &(Hash::default(), FeeCalculator::default()),
+            true,
         );
         assert_eq!(collected_accounts.len(), 2);
         assert!(collected_accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1776,6 +1776,7 @@ impl Bank {
             loaded_accounts,
             &self.rent_collector,
             &self.last_blockhash_with_fee_calculator(),
+            self.fix_recent_blockhashes_sysvar_delay(),
         );
         self.collect_rent(executed, loaded_accounts);
 


### PR DESCRIPTION
#### Problem
(From https://github.com/solana-labs/solana/pull/11032)
As of #10973 , a successful nonce transaction advances the nonce to the most recent blockhash from the RecentBlockhashes sysvar instead of re-overwriting that nonce with the most recent bank blockhash. We expect those hashes to be the same, but in fact that can be different in the final tick of the slot, due to this: https://github.com/solana-labs/solana/blob/1880621740f07740e9ac8b9ec817fac157aa9239/runtime/src/bank.rs#L1255
This caused a bank hash mismatch on our api nodes.

We fixed the discrepancy, but that fix needs gating due to changing the bank. Therefore the overwrite also needs gating to avoid breaking anything while nodes are upgrading.

#### Summary of Changes
- Pass fix_recent_blockhashes_sysvar_delay into `prepare_if_nonce_account()` to gate overwrite in tandem with recent_blockhashes_sysvar_delay fix