### PR TITLE
Skip affected file check on tagged release

### DIFF
--- a/.travis/affects.sh
+++ b/.travis/affects.sh
@@ -3,6 +3,11 @@
 # Check if files in the commit range match one or more prefixes
 #
 
+# Always run the job if we are on a tagged release
+if [[ -n "$TRAVIS_TAG" ]]; then
+  exit 0
+fi
+
 (
   set -x
   git diff --name-only "$TRAVIS_COMMIT_RANGE"


### PR DESCRIPTION
#### Problem
Travis prematurely exits a release tag job due to the affected file check.

#### Summary of Changes
Skip the affected file check if a tag is set in the travis environment
