### PR TITLE
v1.1: validator: Add --expected-bank-hash stub for v1.2 command-line compatibility

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -737,6 +737,14 @@ pub fn main() {
                 .help("Require the genesis have this hash"),
         )
         .arg(
+            Arg::with_name("expected_bank_hash")
+                .long("expected-bank-hash")
+                .value_name("HASH")
+                .takes_value(true)
+                .validator(hash_validator)
+                .hidden(true) // This is a stub implementation for v1.2 command-line compatibility
+        )
+        .arg(
             Arg::with_name("expected_shred_version")
                 .long("expected-shred-version")
                 .value_name("VERSION")


### PR DESCRIPTION
Add a stub ` --expected-bank-hash` solana-validator argument to avoid a footgun when the mainnet-beta nodes are upgraded to v1.2