### PR TITLE
Use BlockCommitmentCache for RPC slots

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -121,9 +121,11 @@ impl JsonRpcRequestProcessor {
         match commitment_level {
             CommitmentLevel::Recent => {
                 if let Some(descendant_slot) = r_bank_forks.highest_descendant(slot) {
+                    debug!("RPC using highest descendant of the last-voted-on slot: {:?}, {:?}", descendant_slot, slot);
                     slot = descendant_slot;
+                } else {
+                    debug!("RPC using the last-voted-on slot: {:?}", slot);
                 }
-                debug!("RPC using working_bank: {:?}", slot);
             }
             CommitmentLevel::Root => {
                 debug!("RPC using node root: {:?}", slot);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -112,7 +112,7 @@ impl JsonRpcRequestProcessor {
             Some(config) => config.commitment,
         };
 
-        let mut slot = self
+        let slot = self
             .block_commitment_cache
             .read()
             .unwrap()
@@ -120,15 +120,7 @@ impl JsonRpcRequestProcessor {
 
         match commitment_level {
             CommitmentLevel::Recent => {
-                if let Some(descendant_slot) = r_bank_forks.highest_descendant(slot) {
-                    debug!(
-                        "RPC using highest descendant of the last-voted-on slot ({:?}): {:?}",
-                        slot, descendant_slot
-                    );
-                    slot = descendant_slot;
-                } else {
-                    debug!("RPC using the last-voted-on slot: {:?}", slot);
-                }
+                debug!("RPC using the heaviest slot: {:?}", slot);
             }
             CommitmentLevel::Root => {
                 debug!("RPC using node root: {:?}", slot);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -121,7 +121,7 @@ impl JsonRpcRequestProcessor {
         match commitment_level {
             CommitmentLevel::Recent => {
                 if let Some(descendant_slot) = r_bank_forks.highest_descendant(slot) {
-                    debug!("RPC using highest descendant of the last-voted-on slot: {:?}, {:?}", descendant_slot, slot);
+                    debug!("RPC using highest descendant of the last-voted-on slot ({:?}): {:?}", slot, descendant_slot);
                     slot = descendant_slot;
                 } else {
                     debug!("RPC using the last-voted-on slot: {:?}", slot);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -121,7 +121,10 @@ impl JsonRpcRequestProcessor {
         match commitment_level {
             CommitmentLevel::Recent => {
                 if let Some(descendant_slot) = r_bank_forks.highest_descendant(slot) {
-                    debug!("RPC using highest descendant of the last-voted-on slot ({:?}): {:?}", slot, descendant_slot);
+                    debug!(
+                        "RPC using highest descendant of the last-voted-on slot ({:?}): {:?}",
+                        slot, descendant_slot
+                    );
                     slot = descendant_slot;
                 } else {
                     debug!("RPC using the last-voted-on slot: {:?}", slot);

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -176,6 +176,20 @@ impl BankForks {
         self.banks.values().map(|bank| bank.slot()).max().unwrap()
     }
 
+    /// Return the slot of the highest descendant of the bank with the given slot.
+    pub fn highest_descendant(&self, slot: Slot) -> Option<Slot> {
+        self.banks
+            .values()
+            .filter_map(|bank| {
+                if bank.slot() != slot && bank.ancestors.contains_key(&slot) {
+                    Some(bank.slot())
+                } else {
+                    None
+                }
+            })
+            .max()
+    }
+
     pub fn working_bank(&self) -> Arc<Bank> {
         self[self.highest_slot()].clone()
     }
@@ -415,6 +429,9 @@ mod tests {
         assert_eq!(children, *descendants.get(&0).unwrap());
         assert!(descendants[&1].is_empty());
         assert!(descendants[&2].is_empty());
+        assert_eq!(bank_forks.highest_descendant(0), Some(2));
+        assert_eq!(bank_forks.highest_descendant(1), None);
+        assert_eq!(bank_forks.highest_descendant(2), None);
     }
 
     #[test]

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -176,20 +176,6 @@ impl BankForks {
         self.banks.values().map(|bank| bank.slot()).max().unwrap()
     }
 
-    /// Return the slot of the highest descendant of the bank with the given slot.
-    pub fn highest_descendant(&self, slot: Slot) -> Option<Slot> {
-        self.banks
-            .values()
-            .filter_map(|bank| {
-                if bank.slot() != slot && bank.ancestors.contains_key(&slot) {
-                    Some(bank.slot())
-                } else {
-                    None
-                }
-            })
-            .max()
-    }
-
     pub fn working_bank(&self) -> Arc<Bank> {
         self[self.highest_slot()].clone()
     }
@@ -429,9 +415,6 @@ mod tests {
         assert_eq!(children, *descendants.get(&0).unwrap());
         assert!(descendants[&1].is_empty());
         assert!(descendants[&2].is_empty());
-        assert_eq!(bank_forks.highest_descendant(0), Some(2));
-        assert_eq!(bank_forks.highest_descendant(1), None);
-        assert_eq!(bank_forks.highest_descendant(2), None);
     }
 
     #[test]

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -1,4 +1,4 @@
-use solana_sdk::clock::Slot;
+use solana_sdk::{clock::Slot, commitment_config::CommitmentLevel};
 use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::collections::HashMap;
 
@@ -101,6 +101,22 @@ impl BlockCommitmentCache {
 
     pub fn highest_confirmed_slot(&self) -> Slot {
         self.highest_confirmed_slot
+    }
+
+    pub fn highest_gossip_confirmed_slot(&self) -> Slot {
+        // TODO: see solana_core::RpcSubscriptions:
+        //self.last_checked_slots.get(&CommitmentLevel::SingleGossip).unwrap_or(&0)
+        self.highest_confirmed_slot
+    }
+
+    pub fn slot_with_commitment(&self, commitment_level: CommitmentLevel) -> Slot {
+        match commitment_level {
+            CommitmentLevel::Recent => self.slot(),
+            CommitmentLevel::Root => self.root(),
+            CommitmentLevel::Single => self.highest_confirmed_slot(),
+            CommitmentLevel::SingleGossip => self.highest_gossip_confirmed_slot(),
+            CommitmentLevel::Max => self.highest_confirmed_root(),
+        }
     }
 
     fn highest_slot_with_confirmation_count(&self, confirmation_count: usize) -> Slot {


### PR DESCRIPTION
#### Problems

RPC returns state from the highest slot, regardless of what fork it's in. This can give the impression of rollback even though the validator is far more committed to a particular fork.

#### Summary of Changes

Return the state from the slot that the validator finds most suitable for voting on.

* Add `BlockCommitmentCache::slot_with_commitment(CommitmentLevel)`

Note: this moves the code from Rpc, not RpcSubscriptions, so `SingleGossip` is not yet implemented and would require `last_checked_slots` move from RpcSubscriptions to BankCommitmentCache. That work is out of the scope of this PR but the natural next step.