### PR TITLE
Simplify BlockCommitmentCache slot info

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -1,12 +1,9 @@
-use crate::{
-    consensus::Stake,
-    rpc_subscriptions::{CacheSlotInfo, RpcSubscriptions},
-};
+use crate::{consensus::Stake, rpc_subscriptions::RpcSubscriptions};
 use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
 use solana_runtime::{
     bank::Bank,
-    commitment::{BlockCommitment, BlockCommitmentCache, VOTE_THRESHOLD_SIZE},
+    commitment::{BlockCommitment, BlockCommitmentCache, CacheSlotInfo, VOTE_THRESHOLD_SIZE},
 };
 use solana_sdk::clock::Slot;
 use solana_vote_program::vote_state::VoteState;
@@ -114,14 +111,16 @@ impl AggregateCommitmentService {
 
             let mut new_block_commitment = BlockCommitmentCache::new(
                 block_commitment,
-                highest_confirmed_root,
                 aggregation_data.total_stake,
-                aggregation_data.bank.slot(),
-                aggregation_data.root,
-                aggregation_data.root,
+                CacheSlotInfo {
+                    slot: aggregation_data.bank.slot(),
+                    root: aggregation_data.root,
+                    highest_confirmed_slot: aggregation_data.root,
+                    highest_confirmed_root,
+                }
             );
-            new_block_commitment.highest_confirmed_slot =
-                new_block_commitment.calculate_highest_confirmed_slot();
+            let highest_confirmed_slot = new_block_commitment.calculate_highest_confirmed_slot();
+            new_block_commitment.set_highest_confirmed_slot(highest_confirmed_slot);
 
             let mut w_block_commitment_cache = block_commitment_cache.write().unwrap();
 
@@ -136,12 +135,10 @@ impl AggregateCommitmentService {
                 )
             );
 
-            subscriptions.notify_subscribers(CacheSlotInfo {
-                current_slot: w_block_commitment_cache.slot(),
-                node_root: w_block_commitment_cache.root(),
-                highest_confirmed_root: w_block_commitment_cache.highest_confirmed_root(),
-                highest_confirmed_slot: w_block_commitment_cache.highest_confirmed_slot(),
-            });
+            // Triggers rpc_subscription notifications as soon as new commitment data is available,
+            // sending just the commitment cache slot information that the notifications thread
+            // needs
+            subscriptions.notify_subscribers(w_block_commitment_cache.slot_info());
         }
     }
 

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -117,7 +117,7 @@ impl AggregateCommitmentService {
                     root: aggregation_data.root,
                     highest_confirmed_slot: aggregation_data.root,
                     highest_confirmed_root,
-                }
+                },
             );
             let highest_confirmed_slot = new_block_commitment.calculate_highest_confirmed_slot();
             new_block_commitment.set_highest_confirmed_slot(highest_confirmed_slot);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -27,7 +27,7 @@ use solana_runtime::{
     accounts::AccountAddressFilter,
     bank::Bank,
     bank_forks::BankForks,
-    commitment::{BlockCommitmentArray, BlockCommitmentCache},
+    commitment::{BlockCommitmentArray, BlockCommitmentCache, CacheSlotInfo},
     log_collector::LogCollector,
     send_transaction_service::{SendTransactionService, TransactionInfo},
 };
@@ -192,10 +192,12 @@ impl JsonRpcRequestProcessor {
             block_commitment_cache: Arc::new(RwLock::new(BlockCommitmentCache::new(
                 HashMap::new(),
                 0,
-                0,
-                bank.slot(),
-                0,
-                0,
+                CacheSlotInfo {
+                    slot: bank.slot(),
+                    root: 0,
+                    highest_confirmed_slot: 0,
+                    highest_confirmed_root: 0,
+                },
             ))),
             blockstore,
             validator_exit: create_validator_exit(&exit),
@@ -1816,11 +1818,13 @@ pub mod tests {
         block_commitment.entry(1).or_insert(commitment_slot1);
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::new(
             block_commitment,
-            0,
             10,
-            bank.slot(),
-            0,
-            0,
+            CacheSlotInfo {
+                slot: bank.slot(),
+                root: 0,
+                highest_confirmed_slot: 0,
+                highest_confirmed_root: 0,
+            },
         )));
 
         // Add timestamp vote to blockstore
@@ -3329,11 +3333,13 @@ pub mod tests {
             .or_insert_with(|| commitment_slot1.clone());
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::new(
             block_commitment,
-            0,
             42,
-            bank_forks.read().unwrap().highest_slot(),
-            0,
-            0,
+            CacheSlotInfo {
+                slot: bank_forks.read().unwrap().highest_slot(),
+                root: 0,
+                highest_confirmed_slot: 0,
+                highest_confirmed_root: 0,
+            },
         )));
 
         let mut config = JsonRpcConfig::default();
@@ -3856,11 +3862,13 @@ pub mod tests {
         let highest_confirmed_root = 1;
         let block_commitment_cache = BlockCommitmentCache::new(
             block_commitment,
-            highest_confirmed_root,
             50,
-            bank.slot(),
-            0,
-            0,
+            CacheSlotInfo {
+                slot: bank.slot(),
+                root: 0,
+                highest_confirmed_slot: 0,
+                highest_confirmed_root,
+            },
         );
 
         assert!(is_confirmed_rooted(

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -349,7 +349,7 @@ mod tests {
     use super::*;
     use crate::{
         cluster_info_vote_listener::{ClusterInfoVoteListener, VoteTracker},
-        rpc_subscriptions::{tests::robust_poll_or_panic, CacheSlotInfo},
+        rpc_subscriptions::tests::robust_poll_or_panic,
     };
     use crossbeam_channel::unbounded;
     use jsonrpc_core::{futures::sync::mpsc, Response};
@@ -359,7 +359,7 @@ mod tests {
     use solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
-        commitment::BlockCommitmentCache,
+        commitment::{BlockCommitmentCache, CacheSlotInfo},
         genesis_utils::{
             create_genesis_config, create_genesis_config_with_vote_accounts, GenesisConfigInfo,
             ValidatorVoteKeypairs,
@@ -393,7 +393,7 @@ mod tests {
             .unwrap()
             .process_transaction(tx)?;
         let mut cache_slot_info = CacheSlotInfo::default();
-        cache_slot_info.current_slot = current_slot;
+        cache_slot_info.slot = current_slot;
         subscriptions.notify_subscribers(cache_slot_info);
         Ok(())
     }
@@ -733,14 +733,14 @@ mod tests {
             .process_transaction(&tx)
             .unwrap();
         let mut cache_slot_info = CacheSlotInfo::default();
-        cache_slot_info.current_slot = 1;
+        cache_slot_info.slot = 1;
         rpc.subscriptions.notify_subscribers(cache_slot_info);
 
         let cache_slot_info = CacheSlotInfo {
-            current_slot: 2,
-            node_root: 1,
-            highest_confirmed_root: 1,
+            slot: 2,
+            root: 1,
             highest_confirmed_slot: 1,
+            highest_confirmed_root: 1,
         };
         rpc.subscriptions.notify_subscribers(cache_slot_info);
         let expected = json!({


### PR DESCRIPTION
#### Problem
BlockCommitmentCache and CacheSlotInfo store the same data, but in different ways. No functional reason for this, and it just obfuscates the code.

#### Summary of Changes
Reorganization only: Store a CacheSlotInfo in BlockCommitmentCache.

Closes #11104 
