### PR TITLE
Add --warp-epoch and --force-inflation to ledger-tool cap.

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -22,8 +22,13 @@ use solana_runtime::{
     snapshot_utils::SnapshotVersion,
 };
 use solana_sdk::{
-    clock::Slot, genesis_config::GenesisConfig, hash::Hash, native_token::lamports_to_sol,
-    pubkey::Pubkey, shred_version::compute_shred_version,
+    clock::{Epoch, Slot},
+    genesis_config::GenesisConfig,
+    hash::Hash,
+    inflation::Inflation,
+    native_token::lamports_to_sol,
+    pubkey::Pubkey,
+    shred_version::compute_shred_version,
 };
 use solana_vote_program::vote_state::VoteState;
 use std::{
@@ -1016,6 +1021,22 @@ fn main() {
             .arg(&halt_at_slot_arg)
             .arg(&hard_forks_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
+            .arg(
+                Arg::with_name("warp_epoch")
+                    .required(false)
+                    .long("warp-epoch")
+                    .takes_value(true)
+                    .value_name("WARP_EPOCH")
+                    .help("After loading the snapshot epoch warp the ledger to EPOCH_SLOT, \
+                           which could be an epoch in a galaxy far far away"),
+            )
+            .arg(
+                Arg::with_name("force_inflation")
+                    .required(false)
+                    .long("force-inflation")
+                    .takes_value(false)
+                    .help("Force inflation"),
+            )
         ).subcommand(
             SubCommand::with_name("purge")
             .about("Delete a range of slots from the ledger.")
@@ -1573,37 +1594,65 @@ fn main() {
                         }
                     }
 
-                    let computed_capitalization: u64 = bank
-                        .get_program_accounts(None)
-                        .into_iter()
-                        .filter_map(|(_pubkey, account)| {
-                            if account.lamports == u64::max_value() {
-                                return None;
-                            }
+                    if arg_matches.is_present("warp_epoch") {
+                        let base_bank = bank;
 
-                            let is_specially_retained =
-                                solana_sdk::native_loader::check_id(&account.owner)
-                                    || solana_sdk::sysvar::check_id(&account.owner);
+                        let raw_warp_epoch = value_t!(arg_matches, "warp_epoch", String).unwrap();
+                        let warp_epoch = if raw_warp_epoch.starts_with('+') {
+                            base_bank.epoch() + value_t!(arg_matches, "warp_epoch", Epoch).unwrap()
+                        } else {
+                            value_t!(arg_matches, "warp_epoch", Epoch).unwrap()
+                        };
+                        if warp_epoch < base_bank.epoch() {
+                            eprintln!(
+                                "Error: can't warp epoch backwards: {} => {}",
+                                base_bank.epoch(),
+                                warp_epoch
+                            );
+                            exit(1);
+                        }
 
-                            if is_specially_retained {
-                                // specially retained accounts are ensured to exist by
-                                // alwaysing having a balance of 1 lamports, which is
-                                // outside the capitalization calculation.
-                                Some(account.lamports - 1)
-                            } else {
-                                Some(account.lamports)
-                            }
-                        })
-                        .sum();
+                        if arg_matches.is_present("force_inflation") {
+                            let inflation = Inflation::default();
+                            println!("Forcing inflation: {:?}", inflation);
+                            bank.set_inflation(inflation);
+                        }
 
-                    if bank.capitalization() != computed_capitalization {
-                        panic!(
-                            "Capitalization mismatch!?: {} != {}",
-                            bank.capitalization(),
-                            computed_capitalization
+                        let next_epoch = base_bank
+                            .epoch_schedule()
+                            .get_first_slot_in_epoch(warp_epoch);
+                        let warped_bank =
+                            Bank::new_from_parent(&base_bank, base_bank.collector_id(), next_epoch);
+                        base_bank.assert_capitalization();
+                        warped_bank.assert_capitalization();
+
+                        println!("Slot: {} => {}", base_bank.slot(), warped_bank.slot());
+                        println!("Epoch: {} => {}", base_bank.epoch(), warped_bank.epoch());
+                        println!(
+                            "Capitalization: {} => {}",
+                            Sol(base_bank.capitalization()),
+                            Sol(warped_bank.capitalization())
                         );
+
+                        for (pubkey, warped_account) in
+                            warped_bank.get_all_accounts_modified_since_parent()
+                        {
+                            if let Some(base_account) = base_bank.get_account(&pubkey) {
+                                if base_account.lamports != warped_account.lamports {
+                                    println!(
+                                        "{}({}): {} => {}",
+                                        pubkey,
+                                        base_account.owner,
+                                        Sol(base_account.lamports),
+                                        Sol(warped_account.lamports)
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        bank.assert_capitalization();
+                        println!("Capitalization: {}", Sol(bank.capitalization()));
                     }
-                    println!("Capitalization: {}", Sol(bank.capitalization()));
                 }
                 Err(err) => {
                     eprintln!("Failed to load ledger: {:?}", err);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1601,7 +1601,7 @@ fn main() {
                     });
 
                     if arg_matches.is_present("recaculate_capitalization") {
-                        println!("Resetting capitalization");
+                        println!("Recalculating capitalization");
                         let old_capitalization = bank.set_capitalization();
                         if old_capitalization == bank.capitalization() {
                             eprintln!("Capitalization was identical: {}", Sol(old_capitalization));

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1600,7 +1600,7 @@ fn main() {
                         exit(1);
                     });
 
-                    if arg_matches.is_present("recaculate_capitalization") {
+                    if arg_matches.is_present("recalculate_capitalization") {
                         println!("Recalculating capitalization");
                         let old_capitalization = bank.set_capitalization();
                         if old_capitalization == bank.capitalization() {
@@ -1679,10 +1679,10 @@ fn main() {
                             println!("Sum of lamports changes: {}", Sol(overall_delta));
                         }
                     } else {
-                        if arg_matches.is_present("recaculate_capitalization") {
-                            eprintln!("Capitalization isn't verified because it's reset");
+                        if arg_matches.is_present("recalculate_capitalization") {
+                            eprintln!("Capitalization isn't verified because it's recalculated");
                         }
-                        if arg_matches.is_present("force_inflation") {
+                        if arg_matches.is_present("enable_inflation") {
                             eprintln!(
                                 "Forcing inflation isn't meaningful because bank isn't warping"
                             );

--- a/sdk/src/native_token.rs
+++ b/sdk/src/native_token.rs
@@ -14,24 +14,25 @@ pub fn sol_to_lamports(sol: f64) -> u64 {
 use std::fmt::{Debug, Display, Formatter, Result};
 pub struct Sol(pub u64);
 
-impl Display for Sol {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+impl Sol {
+    fn write_in_sol(&self, f: &mut Formatter) -> Result {
         write!(
             f,
-            "{}.{:09} SOL",
+            "◎{}.{:09}",
             self.0 / LAMPORTS_PER_SOL,
             self.0 % LAMPORTS_PER_SOL
         )
     }
 }
 
+impl Display for Sol {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        self.write_in_sol(f)
+    }
+}
+
 impl Debug for Sol {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(
-            f,
-            "{}.{:09} SOL",
-            self.0 / LAMPORTS_PER_SOL,
-            self.0 % LAMPORTS_PER_SOL
-        )
+        self.write_in_sol(f)
     }
 }

--- a/sdk/src/native_token.rs
+++ b/sdk/src/native_token.rs
@@ -10,3 +10,28 @@ pub fn lamports_to_sol(lamports: u64) -> f64 {
 pub fn sol_to_lamports(sol: f64) -> u64 {
     (sol * LAMPORTS_PER_SOL as f64) as u64
 }
+
+use std::fmt::{Debug, Display, Formatter, Result};
+pub struct Sol(pub u64);
+
+impl Display for Sol {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(
+            f,
+            "{}.{:09} SOL",
+            self.0 / LAMPORTS_PER_SOL,
+            self.0 % LAMPORTS_PER_SOL
+        )
+    }
+}
+
+impl Debug for Sol {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(
+            f,
+            "{}.{:09} SOL",
+            self.0 / LAMPORTS_PER_SOL,
+            self.0 % LAMPORTS_PER_SOL
+        )
+    }
+}


### PR DESCRIPTION
#### Problem

It's hard/tedious to casually check what a realistic inflation on mainnet-beta will be as a proactive measure.

#### Summary of Changes

Introduce small toy functionality to do that practice run for inflation.

Complement with #10914.
