### PR TITLE
Rename CacheSlotInfo to CommitmentSlots

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -3,7 +3,7 @@ use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
 use solana_runtime::{
     bank::Bank,
-    commitment::{BlockCommitment, BlockCommitmentCache, CacheSlotInfo, VOTE_THRESHOLD_SIZE},
+    commitment::{BlockCommitment, BlockCommitmentCache, CommitmentSlots, VOTE_THRESHOLD_SIZE},
 };
 use solana_sdk::clock::Slot;
 use solana_vote_program::vote_state::VoteState;
@@ -112,7 +112,7 @@ impl AggregateCommitmentService {
             let mut new_block_commitment = BlockCommitmentCache::new(
                 block_commitment,
                 aggregation_data.total_stake,
-                CacheSlotInfo {
+                CommitmentSlots {
                     slot: aggregation_data.bank.slot(),
                     root: aggregation_data.root,
                     highest_confirmed_slot: aggregation_data.root,
@@ -138,7 +138,7 @@ impl AggregateCommitmentService {
             // Triggers rpc_subscription notifications as soon as new commitment data is available,
             // sending just the commitment cache slot information that the notifications thread
             // needs
-            subscriptions.notify_subscribers(w_block_commitment_cache.slot_info());
+            subscriptions.notify_subscribers(w_block_commitment_cache.commitment_slots());
         }
     }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -27,7 +27,7 @@ use solana_runtime::{
     accounts::AccountAddressFilter,
     bank::Bank,
     bank_forks::BankForks,
-    commitment::{BlockCommitmentArray, BlockCommitmentCache, CacheSlotInfo},
+    commitment::{BlockCommitmentArray, BlockCommitmentCache, CommitmentSlots},
     log_collector::LogCollector,
     send_transaction_service::{SendTransactionService, TransactionInfo},
 };
@@ -192,7 +192,7 @@ impl JsonRpcRequestProcessor {
             block_commitment_cache: Arc::new(RwLock::new(BlockCommitmentCache::new(
                 HashMap::new(),
                 0,
-                CacheSlotInfo {
+                CommitmentSlots {
                     slot: bank.slot(),
                     root: 0,
                     highest_confirmed_slot: 0,
@@ -1819,7 +1819,7 @@ pub mod tests {
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::new(
             block_commitment,
             10,
-            CacheSlotInfo {
+            CommitmentSlots {
                 slot: bank.slot(),
                 root: 0,
                 highest_confirmed_slot: 0,
@@ -3334,7 +3334,7 @@ pub mod tests {
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::new(
             block_commitment,
             42,
-            CacheSlotInfo {
+            CommitmentSlots {
                 slot: bank_forks.read().unwrap().highest_slot(),
                 root: 0,
                 highest_confirmed_slot: 0,
@@ -3863,7 +3863,7 @@ pub mod tests {
         let block_commitment_cache = BlockCommitmentCache::new(
             block_commitment,
             50,
-            CacheSlotInfo {
+            CommitmentSlots {
                 slot: bank.slot(),
                 root: 0,
                 highest_confirmed_slot: 0,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -359,7 +359,7 @@ mod tests {
     use solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
-        commitment::{BlockCommitmentCache, CacheSlotInfo},
+        commitment::{BlockCommitmentCache, CommitmentSlots},
         genesis_utils::{
             create_genesis_config, create_genesis_config_with_vote_accounts, GenesisConfigInfo,
             ValidatorVoteKeypairs,
@@ -392,9 +392,9 @@ mod tests {
             .get(current_slot)
             .unwrap()
             .process_transaction(tx)?;
-        let mut cache_slot_info = CacheSlotInfo::default();
-        cache_slot_info.slot = current_slot;
-        subscriptions.notify_subscribers(cache_slot_info);
+        let mut commitment_slots = CommitmentSlots::default();
+        commitment_slots.slot = current_slot;
+        subscriptions.notify_subscribers(commitment_slots);
         Ok(())
     }
 
@@ -687,7 +687,7 @@ mod tests {
             .process_transaction(&tx)
             .unwrap();
         rpc.subscriptions
-            .notify_subscribers(CacheSlotInfo::default());
+            .notify_subscribers(CommitmentSlots::default());
         // allow 200ms for notification thread to wake
         std::thread::sleep(Duration::from_millis(200));
         let _panic = robust_poll_or_panic(receiver);
@@ -732,17 +732,17 @@ mod tests {
             .unwrap()
             .process_transaction(&tx)
             .unwrap();
-        let mut cache_slot_info = CacheSlotInfo::default();
-        cache_slot_info.slot = 1;
-        rpc.subscriptions.notify_subscribers(cache_slot_info);
+        let mut commitment_slots = CommitmentSlots::default();
+        commitment_slots.slot = 1;
+        rpc.subscriptions.notify_subscribers(commitment_slots);
 
-        let cache_slot_info = CacheSlotInfo {
+        let commitment_slots = CommitmentSlots {
             slot: 2,
             root: 1,
             highest_confirmed_slot: 1,
             highest_confirmed_root: 1,
         };
-        rpc.subscriptions.notify_subscribers(cache_slot_info);
+        rpc.subscriptions.notify_subscribers(commitment_slots);
         let expected = json!({
            "jsonrpc": "2.0",
            "method": "accountNotification",

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -43,7 +43,7 @@ pub struct BlockCommitmentCache {
     block_commitment: HashMap<Slot, BlockCommitment>,
     /// Cache slot details. Cluster data is calculated from the block_commitment map, and cached in
     /// the struct to avoid the expense of recalculating on every call.
-    slot_info: CacheSlotInfo,
+    commitment_slots: CommitmentSlots,
     /// Total stake active during the bank's epoch
     total_stake: u64,
 }
@@ -55,9 +55,9 @@ impl std::fmt::Debug for BlockCommitmentCache {
             .field("total_stake", &self.total_stake)
             .field(
                 "bank",
-                &format_args!("Bank({{current_slot: {:?}}})", self.slot_info.slot),
+                &format_args!("Bank({{current_slot: {:?}}})", self.commitment_slots.slot),
             )
-            .field("root", &self.slot_info.root)
+            .field("root", &self.commitment_slots.root)
             .finish()
     }
 }
@@ -66,12 +66,12 @@ impl BlockCommitmentCache {
     pub fn new(
         block_commitment: HashMap<Slot, BlockCommitment>,
         total_stake: u64,
-        slot_info: CacheSlotInfo,
+        commitment_slots: CommitmentSlots,
     ) -> Self {
         Self {
             block_commitment,
             total_stake,
-            slot_info,
+            commitment_slots,
         }
     }
 
@@ -84,23 +84,23 @@ impl BlockCommitmentCache {
     }
 
     pub fn slot(&self) -> Slot {
-        self.slot_info.slot
+        self.commitment_slots.slot
     }
 
     pub fn root(&self) -> Slot {
-        self.slot_info.root
+        self.commitment_slots.root
     }
 
     pub fn highest_confirmed_slot(&self) -> Slot {
-        self.slot_info.highest_confirmed_slot
+        self.commitment_slots.highest_confirmed_slot
     }
 
     pub fn highest_confirmed_root(&self) -> Slot {
-        self.slot_info.highest_confirmed_root
+        self.commitment_slots.highest_confirmed_root
     }
 
-    pub fn slot_info(&self) -> CacheSlotInfo {
-        self.slot_info
+    pub fn commitment_slots(&self) -> CommitmentSlots {
+        self.commitment_slots
     }
 
     fn highest_slot_with_confirmation_count(&self, confirmation_count: usize) -> Slot {
@@ -112,7 +112,7 @@ impl BlockCommitmentCache {
                 }
             }
         }
-        self.slot_info.root
+        self.commitment_slots.root
     }
 
     pub fn calculate_highest_confirmed_slot(&self) -> Slot {
@@ -155,7 +155,7 @@ impl BlockCommitmentCache {
         Self {
             block_commitment,
             total_stake: 42,
-            slot_info: CacheSlotInfo {
+            commitment_slots: CommitmentSlots {
                 slot,
                 root,
                 highest_confirmed_slot: root,
@@ -165,16 +165,16 @@ impl BlockCommitmentCache {
     }
 
     pub fn set_highest_confirmed_slot(&mut self, slot: Slot) {
-        self.slot_info.highest_confirmed_slot = slot;
+        self.commitment_slots.highest_confirmed_slot = slot;
     }
 
     pub fn set_highest_confirmed_root(&mut self, root: Slot) {
-        self.slot_info.highest_confirmed_root = root;
+        self.commitment_slots.highest_confirmed_root = root;
     }
 }
 
 #[derive(Default, Clone, Copy)]
-pub struct CacheSlotInfo {
+pub struct CommitmentSlots {
     /// The slot of the bank from which all other slots were calculated.
     pub slot: Slot,
     /// The current node root
@@ -257,7 +257,7 @@ mod tests {
         let block_commitment_cache = BlockCommitmentCache::new(
             block_commitment,
             total_stake,
-            CacheSlotInfo {
+            CommitmentSlots {
                 slot: bank_slot_5,
                 root: 0,
                 highest_confirmed_slot: 0,
@@ -275,7 +275,7 @@ mod tests {
         let block_commitment_cache = BlockCommitmentCache::new(
             block_commitment,
             total_stake,
-            CacheSlotInfo {
+            CommitmentSlots {
                 slot: bank_slot_5,
                 root: 0,
                 highest_confirmed_slot: 0,
@@ -293,7 +293,7 @@ mod tests {
         let block_commitment_cache = BlockCommitmentCache::new(
             block_commitment,
             total_stake,
-            CacheSlotInfo {
+            CommitmentSlots {
                 slot: bank_slot_5,
                 root: 0,
                 highest_confirmed_slot: 0,
@@ -311,7 +311,7 @@ mod tests {
         let block_commitment_cache = BlockCommitmentCache::new(
             block_commitment,
             total_stake,
-            CacheSlotInfo {
+            CommitmentSlots {
                 slot: bank_slot_5,
                 root: 0,
                 highest_confirmed_slot: 0,
@@ -329,7 +329,7 @@ mod tests {
         let block_commitment_cache = BlockCommitmentCache::new(
             block_commitment,
             total_stake,
-            CacheSlotInfo {
+            CommitmentSlots {
                 slot: bank_slot_5,
                 root: 0,
                 highest_confirmed_slot: 0,


### PR DESCRIPTION
#### Problem
`CacheSlotInfo` seems like a strange name when it's no longer referring back to the BlockCommitmentCache, but actually in it.

#### Summary of Changes
Rename CacheSlotInfo to CommitmentSlots