### PR TITLE
[web3] fix: broken SlotInfo type def

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -145,9 +145,9 @@ declare module '@solana/web3.js' {
   };
 
   export type SlotInfo = {
-    parent: 'number';
-    slot: 'number';
-    root: 'number';
+    parent: number;
+    slot: number;
+    root: number;
   };
 
   export type AccountChangeCallback = (

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -162,9 +162,9 @@ declare module '@solana/web3.js' {
   };
 
   declare export type SlotInfo = {
-    parent: 'number',
-    slot: 'number',
-    root: 'number',
+    parent: number,
+    slot: number,
+    root: number,
   };
 
   declare type AccountChangeCallback = (


### PR DESCRIPTION
#### Problem
`SlotInfo` typedef was presumably copy pasted from the struct def and specifies `'number'` instead of `number`
