### PR TITLE
[web3] feat: add getLeaderSchedule api

### DIFF
--- a/web3.js/flow-typed/superstruct.js
+++ b/web3.js/flow-typed/superstruct.js
@@ -6,6 +6,7 @@ declare module 'superstruct' {
       literal(schema: any): any;
       tuple(schema: any): any;
       pick(schema: any): any;
+      record(schema: any): any;
   };
 
   declare module.exports: {

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -193,6 +193,10 @@ declare module '@solana/web3.js' {
     firstNormalSlot: number;
   };
 
+  export type LeaderSchedule = {
+    [address: string]: number[];
+  };
+
   export type Supply = {
     total: number;
     circulating: number;
@@ -266,6 +270,7 @@ declare module '@solana/web3.js' {
     getTotalSupply(commitment?: Commitment): Promise<number>;
     getVersion(): Promise<Version>;
     getInflationGovernor(commitment?: Commitment): Promise<InflationGovernor>;
+    getLeaderSchedule(): Promise<LeaderSchedule>;
     getEpochSchedule(): Promise<EpochSchedule>;
     getEpochInfo(commitment?: Commitment): Promise<EpochInfo>;
     getRecentBlockhashAndContext(

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -210,6 +210,10 @@ declare module '@solana/web3.js' {
     absoluteSlot: number,
   };
 
+  declare export type LeaderSchedule = {
+    [address: string]: number[],
+  };
+
   declare export type Supply = {
     total: number,
     circulating: number,
@@ -283,6 +287,7 @@ declare module '@solana/web3.js' {
     getTotalSupply(commitment: ?Commitment): Promise<number>;
     getVersion(): Promise<Version>;
     getInflationGovernor(commitment: ?Commitment): Promise<InflationGovernor>;
+    getLeaderSchedule(): Promise<LeaderSchedule>;
     getEpochSchedule(): Promise<EpochSchedule>;
     getEpochInfo(commitment: ?Commitment): Promise<EpochInfo>;
     getRecentBlockhashAndContext(

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -289,6 +289,21 @@ const GetEpochScheduleResult = struct({
 });
 
 /**
+ * Leader schedule
+ * (see https://docs.solana.com/terminology#leader-schedule)
+ *
+ * @typedef {Object} LeaderSchedule
+ */
+type LeaderSchedule = {
+  [address: string]: number[],
+};
+
+const GetLeaderScheduleResult = struct.record([
+  'string',
+  struct.array(['number']),
+]);
+
+/**
  * Transaction error or null
  */
 const TransactionErrorResult = struct.union(['null', 'object']);
@@ -423,6 +438,13 @@ const GetEpochScheduleRpcResult = struct({
   error: 'any?',
   result: GetEpochScheduleResult,
 });
+
+/**
+ * Expected JSON RPC response for the "getLeaderSchedule" message
+ */
+const GetLeaderScheduleRpcResult = jsonRpcResult(
+  GetLeaderScheduleResult,
+);
 
 /**
  * Expected JSON RPC response for the "getBalance" message
@@ -1474,6 +1496,20 @@ export class Connection {
     }
     assert(typeof res.result !== 'undefined');
     return GetEpochScheduleResult(res.result);
+  }
+
+  /**
+   * Fetch the leader schedule for the current epoch
+   * @return {Promise<RpcResponseAndContext<LeaderSchedule>>}
+   */
+  async getLeaderSchedule(): Promise<LeaderSchedule> {
+    const unsafeRes = await this._rpcRequest('getLeaderSchedule', []);
+    const res = GetLeaderScheduleRpcResult(unsafeRes);
+    if (res.error) {
+      throw new Error('failed to get leader schedule: ' + res.error.message);
+    }
+    assert(typeof res.result !== 'undefined');
+    return res.result;
   }
 
   /**

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -443,6 +443,33 @@ test('get epoch schedule', async () => {
   }
 });
 
+test('get leader schedule', async () => {
+  const connection = new Connection(url);
+
+  mockRpc.push([
+    url,
+    {
+      method: 'getLeaderSchedule',
+      params: [],
+    },
+    {
+      error: null,
+      result: {
+        '123vij84ecQEKUvQ7gYMKxKwKF6PbYSzCzzURYA4xULY': [0, 1, 2, 3],
+        '8PTjAikKoAybKXcEPnDSoy8wSNNikUBJ1iKawJKQwXnB': [4, 5, 6, 7],
+      },
+    },
+  ]);
+
+  const leaderSchedule = await connection.getLeaderSchedule();
+  expect(Object.keys(leaderSchedule).length).toBeGreaterThanOrEqual(1);
+  for (const key in leaderSchedule) {
+    const slots = leaderSchedule[key];
+    expect(Array.isArray(slots)).toBe(true);
+    expect(slots.length).toBeGreaterThanOrEqual(4);
+  }
+});
+
 test('get slot', async () => {
   const connection = new Connection(url);
 


### PR DESCRIPTION
#### Problem
`getLeaderSchedule` method is not available in the web3 sdk

#### Summary of Changes
- Add `getLeaderSchedule`
- Update type defs
- Add test

Fixes #
