### PR TITLE
Skip no-mangle feature flag

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2018"
 [features]
 # On-chain program specific dependencies
 program = []
+# No-mangle objects cannot be declared multiple times by certain linkers; use
+# this feature to skip these object when they are already declared, eg. in
+# another version of solana-sdk
+skip-no-mangle = []
 # Dependencies that are not compatible or needed for on-chain programs
 default = [
     "assert_matches",

--- a/sdk/src/entrypoint.rs
+++ b/sdk/src/entrypoint.rs
@@ -35,6 +35,7 @@ pub const SUCCESS: u64 = 0;
 macro_rules! entrypoint {
     ($process_instruction:ident) => {
         /// # Safety
+        #[cfg(not(feature = "skip-no-mangle"))]
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
             let (program_id, accounts, instruction_data) =

--- a/sdk/src/program_stubs.rs
+++ b/sdk/src/program_stubs.rs
@@ -2,7 +2,7 @@
 
 #![cfg(feature = "program")]
 
-#[cfg(not(target_arch = "bpf"))]
+#[cfg(all(not(target_arch = "bpf"), not(feature = "skip-no-mangle")))]
 fn print_line_to_stdout(_message: &str) {
     #[cfg(not(feature = "program"))]
     {
@@ -14,7 +14,7 @@ fn print_line_to_stdout(_message: &str) {
     }
 }
 
-#[cfg(not(target_arch = "bpf"))]
+#[cfg(all(not(target_arch = "bpf"), not(feature = "skip-no-mangle")))]
 #[no_mangle]
 /// # Safety
 pub unsafe fn sol_log_(message: *const u8, length: u64) {
@@ -23,13 +23,13 @@ pub unsafe fn sol_log_(message: *const u8, length: u64) {
     print_line_to_stdout(string);
 }
 
-#[cfg(not(target_arch = "bpf"))]
+#[cfg(all(not(target_arch = "bpf"), not(feature = "skip-no-mangle")))]
 #[no_mangle]
 pub fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
     print_line_to_stdout(&format!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5));
 }
 
-#[cfg(not(target_arch = "bpf"))]
+#[cfg(all(not(target_arch = "bpf"), not(feature = "skip-no-mangle")))]
 #[no_mangle]
 pub fn sol_invoke_signed_rust() {
     print_line_to_stdout("sol_invoke_signed_rust()");
@@ -38,7 +38,7 @@ pub fn sol_invoke_signed_rust() {
 #[macro_export]
 macro_rules! program_stubs {
     () => {
-        #[cfg(not(target_arch = "bpf"))]
+        #[cfg(all(not(target_arch = "bpf"), not(feature = "skip-no-mangle")))]
         #[test]
         fn pull_in_externs() {
             use solana_sdk::program_stubs::{sol_invoke_signed_rust, sol_log_, sol_log_64_};


### PR DESCRIPTION
#### Problem
SPL programs are locked to a particular version of solana-sdk. This means that if we pull an SPL program into this repo (as in #11136 ), we also need that version of solana-sdk to be able to use the program's sdk structs, like Pubkey.
However, this causes a build error in some environments due to duplicate definitions of various no-mangle objects: https://buildkite.com/solana-labs/solana/builds/27729#3a54cd90-83d3-43cf-b5f6-d5cc31cec04a

#### Summary of Changes
Add a feature flag to be able to skip these no-mangle objects when pulling in a duplicate version of solana-sdk

Toward unblocking #11136 
