### PR TITLE
Program feature-flag entrypoint

### DIFF
--- a/sdk/src/entrypoint.rs
+++ b/sdk/src/entrypoint.rs
@@ -35,6 +35,7 @@ pub const SUCCESS: u64 = 0;
 macro_rules! entrypoint {
     ($process_instruction:ident) => {
         /// # Safety
+        #[cfg(feature = "program")]
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
             let (program_id, accounts, instruction_data) =


### PR DESCRIPTION
#### Problem
SPL programs are locked to a particular version of solana-sdk. This means that if we pull an SPL program into this repo (as in #11136 ), we also need that version of solana-sdk to be able to use the program's sdk structs, like Pubkey.
However, this causes a build error in some environments due to duplicate definitions of entrypoint: https://buildkite.com/solana-labs/solana/builds/27729#3a54cd90-83d3-43cf-b5f6-d5cc31cec04a

#### Summary of Changes
Wrap entrypoint in the program feature flag to prevent multiple definitions when pulling in a duplicate version of solana-sdk

Toward unblocking #11136 
