### PR TITLE
Use OrderedIterator in TransactionStatusService

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -549,6 +549,7 @@ impl BankingStage {
                 send_transaction_status_batch(
                     bank.clone(),
                     batch.transactions(),
+                    batch.iteration_order_vec(),
                     transaction_statuses,
                     TransactionBalancesSet::new(pre_balances, post_balances),
                     sender,

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -41,6 +41,11 @@ impl<'a, 'b> TransactionBatch<'a, 'b> {
     pub fn iteration_order(&self) -> Option<&[usize]> {
         self.iteration_order.as_deref()
     }
+
+    pub fn iteration_order_vec(&self) -> Option<Vec<usize>> {
+        self.iteration_order.clone()
+    }
+
     pub fn bank(&self) -> &Bank {
         self.bank
     }


### PR DESCRIPTION
#### Problem
The solana runtime randomizes the order that transactions within an entry are processed (#4978). However, `execute_batch` in `blockstore_processor` uses a straight Iterator instead of the OrderedIterator to zip transactions and statuses, meaning that if a batch does contain multiple transactions, results and transactions could be mismatched.

This only affects error logging and datapoints in `execute_batch`. However, this logic is copied in the TransactionStatusService, where it is much more problematic. For instance, if a DurableNonce transaction is batched with an Extant transaction but the order is flopped, TransactionStatusService will attempt to get a recent-blockhash fee calculator using the (expired) nonce and cause a panic (as seen in #10958 ).
This could also lead to transactions and statuses being mismatched in blockstore. We are not sure how extensive these effects might be on mainnet-beta. It's a fairly rare occurrence, dependent on multiple transactions in a batch, the iteration order, and the statuses being different. When hunting for the FeeCalculator panic, we found it to occur within 10k-25k slots when peppering a 5-node cluster with DurableNonce transactions.

#### Summary of Changes
- Use OrderedIterator in `blockstore_processor::execute_batch` and `write_transaction_status_batch`

Fixes #10958

Big thanks to @t-nelson for many hours of testnet work to help track this one down!


