### PR TITLE
Expose block height in the command-line

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -198,6 +198,7 @@ pub enum CliCommand {
     GetEpochInfo,
     GetGenesisHash,
     GetSlot,
+    GetBlockHeight,
     GetTransactionCount,
     LargestAccounts {
         filter: Option<RpcLargestAccountsFilter>,
@@ -638,6 +639,7 @@ pub fn parse_command(
         }),
         ("epoch", Some(matches)) => parse_get_epoch(matches),
         ("slot", Some(matches)) => parse_get_slot(matches),
+        ("block-height", Some(matches)) => parse_get_block_height(matches),
         ("largest-accounts", Some(matches)) => parse_largest_accounts(matches),
         ("supply", Some(matches)) => parse_supply(matches),
         ("total-supply", Some(matches)) => parse_total_supply(matches),
@@ -1829,6 +1831,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::GetEpochInfo => process_get_epoch_info(&rpc_client, config),
         CliCommand::GetGenesisHash => process_get_genesis_hash(&rpc_client),
         CliCommand::GetSlot => process_get_slot(&rpc_client, config),
+        CliCommand::GetBlockHeight => process_get_block_height(&rpc_client, config),
         CliCommand::LargestAccounts { filter } => {
             process_largest_accounts(&rpc_client, config, filter.clone())
         }

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -206,6 +206,7 @@ impl From<EpochInfo> for CliEpochInfo {
 impl fmt::Display for CliEpochInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f)?;
+        writeln_name_value(f, "Block height:", &self.epoch_info.block_height.to_string())?;
         writeln_name_value(f, "Slot:", &self.epoch_info.absolute_slot.to_string())?;
         writeln_name_value(f, "Epoch:", &self.epoch_info.epoch.to_string())?;
         let start_slot = self.epoch_info.absolute_slot - self.epoch_info.slot_index;

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -206,7 +206,11 @@ impl From<EpochInfo> for CliEpochInfo {
 impl fmt::Display for CliEpochInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f)?;
-        writeln_name_value(f, "Block height:", &self.epoch_info.block_height.to_string())?;
+        writeln_name_value(
+            f,
+            "Block height:",
+            &self.epoch_info.block_height.to_string(),
+        )?;
         writeln_name_value(f, "Slot:", &self.epoch_info.absolute_slot.to_string())?;
         writeln_name_value(f, "Epoch:", &self.epoch_info.epoch.to_string())?;
         let start_slot = self.epoch_info.absolute_slot - self.epoch_info.slot_index;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -116,6 +116,10 @@ impl ClusterQuerySubCommands for App<'_, '_> {
             .arg(commitment_arg()),
         )
         .subcommand(
+            SubCommand::with_name("block-height").about("Get current block height")
+            .arg(commitment_arg()),
+        )
+        .subcommand(
             SubCommand::with_name("epoch").about("Get current epoch")
             .arg(commitment_arg()),
         )
@@ -358,6 +362,13 @@ pub fn parse_get_epoch_info(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo,
 pub fn parse_get_slot(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     Ok(CliCommandInfo {
         command: CliCommand::GetSlot,
+        signers: vec![],
+    })
+}
+
+pub fn parse_get_block_height(_matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
+    Ok(CliCommandInfo {
+        command: CliCommand::GetBlockHeight,
         signers: vec![],
     })
 }
@@ -649,6 +660,13 @@ pub fn process_get_genesis_hash(rpc_client: &RpcClient) -> ProcessResult {
 pub fn process_get_slot(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
     let slot = rpc_client.get_slot_with_commitment(config.commitment)?;
     Ok(slot.to_string())
+}
+
+pub fn process_get_block_height(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
+    let epoch_info: CliEpochInfo = rpc_client
+        .get_epoch_info_with_commitment(config.commitment)?
+        .into();
+    Ok(epoch_info.epoch_info.block_height.to_string())
 }
 
 pub fn parse_show_block_production(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {


### PR DESCRIPTION
CLI follow-up for https://github.com/solana-labs/solana/pull/11153

```
$ solana block-height
23026037
```
and
```
$ solana epoch-info
Block height: 23026075          <---- NEW
Slot: 24048749
Epoch: 55
Epoch Slot Range: [23760000..24192000)
Epoch Completed Percent: 66.840%
Epoch Completed Slots: 288749/432000 (143251 remaining)
Epoch Completed Time: 1day 8h 4m 59s/2days (15h 55m remaining)
```