### PR TITLE
v1.2: Skip entrypoint in programs

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,6 +11,8 @@ edition = "2018"
 [features]
 # On-chain program specific dependencies
 program = []
+# Program elements to optionally skip
+skip-no-mangle = []
 # Dependencies that are not compatible or needed for on-chain programs
 default = [
     "assert_matches",

--- a/sdk/src/entrypoint.rs
+++ b/sdk/src/entrypoint.rs
@@ -35,7 +35,7 @@ pub const SUCCESS: u64 = 0;
 macro_rules! entrypoint {
     ($process_instruction:ident) => {
         /// # Safety
-        #[cfg(feature = "program")]
+        #[cfg(not(feature = "skip-no-mangle"))]
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
             let (program_id, accounts, instruction_data) =


### PR DESCRIPTION
#### Problem
Gating entrypoint with the "program" feature doesn't work, as it gets pulled in via the program.

#### Summary of Changes
Add feature to skip elements instead of include

cc @t-nelson 
