### PR TITLE
Speed up local cluster partitioning tests

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1145,9 +1145,7 @@ mod tests {
         // Create the set of relevant voters for the next epoch
         let new_epoch = last_known_epoch + 1;
         let first_slot_in_new_epoch = bank.epoch_schedule().get_first_slot_in_epoch(new_epoch);
-        let new_keypairs: Vec<_> = (0..10)
-            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
-            .collect();
+        let new_keypairs: Vec<_> = (0..10).map(|_| ValidatorVoteKeypairs::new_rand()).collect();
         let new_epoch_authorized_voters: HashMap<_, _> = new_keypairs
             .iter()
             .chain(validator_voting_keypairs[0..5].iter())
@@ -1186,15 +1184,14 @@ mod tests {
         let ref_count_per_vote = 2;
 
         // Create some voters at genesis
-        let validator_keypairs: Vec<_> = (0..2)
-            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
-            .collect();
+        let validator_keypairs: Vec<_> =
+            (0..2).map(|_| ValidatorVoteKeypairs::new_rand()).collect();
 
         let GenesisConfigInfo { genesis_config, .. } =
             genesis_utils::create_genesis_config_with_vote_accounts(
                 10_000,
                 &validator_keypairs,
-                100,
+                vec![100; validator_keypairs.len()],
             );
         let bank = Bank::new(&genesis_config);
         let exit = Arc::new(AtomicBool::new(false));
@@ -1331,14 +1328,13 @@ mod tests {
         Vec<ValidatorVoteKeypairs>,
         Arc<RpcSubscriptions>,
     ) {
-        let validator_voting_keypairs: Vec<_> = (0..10)
-            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
-            .collect();
+        let validator_voting_keypairs: Vec<_> =
+            (0..10).map(|_| ValidatorVoteKeypairs::new_rand()).collect();
         let GenesisConfigInfo { genesis_config, .. } =
             genesis_utils::create_genesis_config_with_vote_accounts(
                 10_000,
                 &validator_voting_keypairs,
-                100,
+                vec![100; validator_voting_keypairs.len()],
             );
         let bank = Bank::new(&genesis_config);
         let vote_tracker = VoteTracker::new(&bank);

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -705,6 +705,7 @@ impl ClusterInfoVoteListener {
 
         if let Some(stakes) = epoch_stakes {
             if let Some(vote_account) = stakes.stakes().vote_accounts().get(pubkey) {
+                info!("stake of pubkey: {}, {}", pubkey, vote_account.0);
                 if is_new {
                     *sum += vote_account.0;
                 }

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -705,7 +705,6 @@ impl ClusterInfoVoteListener {
 
         if let Some(stakes) = epoch_stakes {
             if let Some(vote_account) = stakes.stakes().vote_accounts().get(pubkey) {
-                info!("stake of pubkey: {}, {}", pubkey, vote_account.0);
                 if is_new {
                     *sum += vote_account.0;
                 }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -687,12 +687,7 @@ pub mod test {
             create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
         },
     };
-    use solana_sdk::{
-        clock::Slot,
-        hash::Hash,
-        pubkey::Pubkey,
-        signature::{Keypair, Signer},
-    };
+    use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signer};
     use solana_vote_program::{
         vote_state::{Vote, VoteStateVersions, MAX_LOCKOUT_HISTORY},
         vote_transaction,
@@ -947,14 +942,8 @@ pub mod test {
             HeaviestSubtreeForkChoice,
         ) {
             let keypairs: HashMap<_, _> = std::iter::repeat_with(|| {
-                let node_keypair = Keypair::new();
-                let vote_keypair = Keypair::new();
-                let stake_keypair = Keypair::new();
-                let node_pubkey = node_keypair.pubkey();
-                (
-                    node_pubkey,
-                    ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
-                )
+                let vote_keypairs = ValidatorVoteKeypairs::new_rand();
+                (vote_keypairs.node_keypair.pubkey(), vote_keypairs)
             })
             .take(num_keypairs)
             .collect();
@@ -990,7 +979,11 @@ pub mod test {
             genesis_config,
             mint_keypair,
             voting_keypair: _,
-        } = create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stake);
+        } = create_genesis_config_with_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![stake; validator_keypairs.len()],
+        );
 
         let bank0 = Bank::new(&genesis_config);
 

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -168,7 +168,7 @@ impl ForkProgress {
         num_dropped_blocks_on_fork: u64,
     ) -> Self {
         let validator_fork_info = {
-            if bank.collector_id() == my_pubkey {
+            if bank.collector_id() == my_pubkey && bank.slot() > 0 {
                 let stake = bank.epoch_vote_account_stake(voting_pubkey);
                 Some(ValidatorStakeInfo::new(
                     *voting_pubkey,

--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -1182,7 +1182,7 @@ mod test {
         } = genesis_utils::create_genesis_config_with_vote_accounts(
             1_000_000_000,
             &[&keypairs],
-            10000,
+            vec![10000],
         );
         let bank0 = Arc::new(Bank::new(&genesis_config));
         let bank9 = Bank::new_from_parent(&bank0, &Pubkey::default(), duplicate_slot);
@@ -1244,7 +1244,7 @@ mod test {
             genesis_utils::create_genesis_config_with_vote_accounts(
                 1_000_000_000,
                 &[keypairs],
-                100,
+                vec![100],
             );
         let bank0 = Bank::new(&genesis_config);
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1955,9 +1955,8 @@ pub(crate) mod tests {
                 Blockstore::open(&ledger_path)
                     .expect("Expected to be able to open database ledger"),
             );
-            let validator_authorized_voter_keypairs: Vec<_> = (0..20)
-                .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
-                .collect();
+            let validator_authorized_voter_keypairs: Vec<_> =
+                (0..20).map(|_| ValidatorVoteKeypairs::new_rand()).collect();
 
             let validator_voting_keys: HashMap<_, _> = validator_authorized_voter_keypairs
                 .iter()
@@ -1967,7 +1966,7 @@ pub(crate) mod tests {
                 genesis_utils::create_genesis_config_with_vote_accounts(
                     10_000,
                     &validator_authorized_voter_keypairs,
-                    100,
+                    vec![100; validator_authorized_voter_keypairs.len()],
                 );
             let bank0 = Bank::new(&genesis_config);
             let mut progress = ProgressMap::default();
@@ -2658,15 +2657,9 @@ pub(crate) mod tests {
 
     #[test]
     fn test_compute_bank_stats_confirmed() {
-        let node_keypair = Keypair::new();
-        let vote_keypair = Keypair::new();
-        let stake_keypair = Keypair::new();
-        let node_pubkey = node_keypair.pubkey();
-        let mut keypairs = HashMap::new();
-        keypairs.insert(
-            node_pubkey,
-            ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
-        );
+        let vote_keypairs = ValidatorVoteKeypairs::new_rand();
+        let node_pubkey = vote_keypairs.node_keypair.pubkey();
+        let keypairs: HashMap<_, _> = vec![(node_pubkey, vote_keypairs)].into_iter().collect();
 
         let (bank_forks, mut progress, mut heaviest_subtree_fork_choice) =
             initialize_state(&keypairs, 10_000);
@@ -2985,14 +2978,8 @@ pub(crate) mod tests {
     #[test]
     fn test_update_slot_propagated_threshold_from_votes() {
         let keypairs: HashMap<_, _> = iter::repeat_with(|| {
-            let node_keypair = Keypair::new();
-            let vote_keypair = Keypair::new();
-            let stake_keypair = Keypair::new();
-            let node_pubkey = node_keypair.pubkey();
-            (
-                node_pubkey,
-                ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
-            )
+            let vote_keypairs = ValidatorVoteKeypairs::new_rand();
+            (vote_keypairs.node_keypair.pubkey(), vote_keypairs)
         })
         .take(10)
         .collect();
@@ -3165,17 +3152,10 @@ pub(crate) mod tests {
     #[test]
     fn test_update_propagation_status() {
         // Create genesis stakers
-        let node_keypair = Keypair::new();
-        let vote_keypair = Keypair::new();
-        let stake_keypair = Keypair::new();
-        let vote_pubkey = Arc::new(vote_keypair.pubkey());
-        let mut keypairs = HashMap::new();
-
-        keypairs.insert(
-            node_keypair.pubkey(),
-            ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
-        );
-
+        let vote_keypairs = ValidatorVoteKeypairs::new_rand();
+        let node_pubkey = vote_keypairs.node_keypair.pubkey();
+        let vote_pubkey = Arc::new(vote_keypairs.vote_keypair.pubkey());
+        let keypairs: HashMap<_, _> = vec![(node_pubkey, vote_keypairs)].into_iter().collect();
         let stake = 10_000;
         let (mut bank_forks, mut progress_map, _) = initialize_state(&keypairs, stake);
 
@@ -3257,14 +3237,8 @@ pub(crate) mod tests {
     #[test]
     fn test_chain_update_propagation_status() {
         let keypairs: HashMap<_, _> = iter::repeat_with(|| {
-            let node_keypair = Keypair::new();
-            let vote_keypair = Keypair::new();
-            let stake_keypair = Keypair::new();
-            let node_pubkey = node_keypair.pubkey();
-            (
-                node_pubkey,
-                ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
-            )
+            let vote_keypairs = ValidatorVoteKeypairs::new_rand();
+            (vote_keypairs.node_keypair.pubkey(), vote_keypairs)
         })
         .take(10)
         .collect();
@@ -3340,14 +3314,8 @@ pub(crate) mod tests {
     fn test_chain_update_propagation_status2() {
         let num_validators = 6;
         let keypairs: HashMap<_, _> = iter::repeat_with(|| {
-            let node_keypair = Keypair::new();
-            let vote_keypair = Keypair::new();
-            let stake_keypair = Keypair::new();
-            let node_pubkey = node_keypair.pubkey();
-            (
-                node_pubkey,
-                ValidatorVoteKeypairs::new(node_keypair, vote_keypair, stake_keypair),
-            )
+            let vote_keypairs = ValidatorVoteKeypairs::new_rand();
+            (vote_keypairs.node_keypair.pubkey(), vote_keypairs)
         })
         .take(num_validators)
         .collect();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -917,8 +917,8 @@ impl ReplayStage {
             let root_slot = bank_forks.read().unwrap().root();
             datapoint_info!("replay_stage-my_leader_slot", ("slot", poh_slot, i64),);
             info!(
-                "new fork:{} parent:{} (leader) root:{}",
-                poh_slot, parent_slot, root_slot
+                "{} new fork:{} parent:{} (leader) root:{}",
+                my_pubkey, poh_slot, parent_slot, root_slot
             );
 
             let tpu_bank = Self::new_bank_from_parent_with_notify(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -917,8 +917,8 @@ impl ReplayStage {
             let root_slot = bank_forks.read().unwrap().root();
             datapoint_info!("replay_stage-my_leader_slot", ("slot", poh_slot, i64),);
             info!(
-                "{} new fork:{} parent:{} (leader) root:{}",
-                my_pubkey, poh_slot, parent_slot, root_slot
+                "new fork:{} parent:{} (leader) root:{}",
+                poh_slot, parent_slot, root_slot
             );
 
             let tpu_bank = Self::new_bank_from_parent_with_notify(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1769,7 +1769,7 @@ pub mod tests {
         blockhash: Hash,
         alice: Keypair,
         leader_pubkey: Pubkey,
-        leader_vote_keypair: Keypair,
+        leader_vote_keypair: Arc<Keypair>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         confirmed_block_signatures: Vec<Signature>,
     }
@@ -1830,7 +1830,7 @@ pub mod tests {
             vote,
         );
         let vote_msg = Message::new(&[vote_ix], Some(&leader_vote_keypair.pubkey()));
-        let vote_tx = Transaction::new(&[&leader_vote_keypair], vote_msg, Hash::default());
+        let vote_tx = Transaction::new(&[&*leader_vote_keypair], vote_msg, Hash::default());
         let shreds = entries_to_test_shreds(
             vec![next_entry_mut(&mut Hash::default(), 0, vec![vote_tx])],
             1,
@@ -3191,7 +3191,7 @@ pub mod tests {
         );
     }
 
-    fn new_bank_forks() -> (Arc<RwLock<BankForks>>, Keypair, Keypair) {
+    fn new_bank_forks() -> (Arc<RwLock<BankForks>>, Keypair, Arc<Keypair>) {
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -928,11 +928,13 @@ mod tests {
     fn test_vote_subscribe() {
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests()));
 
-        let validator_voting_keypairs: Vec<_> = (0..10)
-            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
-            .collect();
-        let GenesisConfigInfo { genesis_config, .. } =
-            create_genesis_config_with_vote_accounts(10_000, &validator_voting_keypairs, 100);
+        let validator_voting_keypairs: Vec<_> =
+            (0..10).map(|_| ValidatorVoteKeypairs::new_rand()).collect();
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config_with_vote_accounts(
+            10_000,
+            &validator_voting_keypairs,
+            vec![100; validator_voting_keypairs.len()],
+        );
         let exit = Arc::new(AtomicBool::new(false));
         let bank = Bank::new(&genesis_config);
         let bank_forks = BankForks::new(bank);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -849,6 +849,8 @@ impl TestValidator {
         } = create_genesis_config_with_leader_ex(
             mint_lamports,
             &contact_info.id,
+            Arc::new(Keypair::new()),
+            Arc::new(Keypair::new()),
             42,
             bootstrap_validator_lamports,
         );
@@ -865,7 +867,6 @@ impl TestValidator {
 
         let (ledger_path, blockhash) = create_new_tmp_ledger!(&genesis_config);
 
-        let leader_voting_keypair = Arc::new(voting_keypair);
         let config = ValidatorConfig {
             rpc_ports: Some((node.info.rpc.port(), node.info.rpc_pubsub.port())),
             ..ValidatorConfig::default()
@@ -874,8 +875,8 @@ impl TestValidator {
             node,
             &node_keypair,
             &ledger_path,
-            &leader_voting_keypair.pubkey(),
-            vec![leader_voting_keypair.clone()],
+            &voting_keypair.pubkey(),
+            vec![voting_keypair.clone()],
             None,
             true,
             &config,
@@ -887,7 +888,7 @@ impl TestValidator {
             alice: mint_keypair,
             ledger_path,
             genesis_hash: blockhash,
-            vote_pubkey: leader_voting_keypair.pubkey(),
+            vote_pubkey: voting_keypair.pubkey(),
         }
     }
 }

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -29,13 +29,12 @@ fn test_node(exit: &Arc<AtomicBool>) -> (Arc<ClusterInfo>, GossipService, UdpSoc
 }
 
 fn test_node_with_bank(
-    node_keypair: Keypair,
+    node_keypair: Arc<Keypair>,
     exit: &Arc<AtomicBool>,
     bank_forks: Arc<RwLock<BankForks>>,
 ) -> (Arc<ClusterInfo>, GossipService, UdpSocket) {
-    let keypair = Arc::new(node_keypair);
-    let mut test_node = Node::new_localhost_with_pubkey(&keypair.pubkey());
-    let cluster_info = Arc::new(ClusterInfo::new(test_node.info.clone(), keypair));
+    let mut test_node = Node::new_localhost_with_pubkey(&node_keypair.pubkey());
+    let cluster_info = Arc::new(ClusterInfo::new(test_node.info.clone(), node_keypair));
     let gossip_service = GossipService::new(
         &cluster_info,
         Some(bank_forks),
@@ -224,7 +223,11 @@ pub fn cluster_info_scale() {
     let vote_keypairs: Vec<_> = (0..num_nodes)
         .map(|_| ValidatorVoteKeypairs::new_rand())
         .collect();
-    let genesis_config_info = create_genesis_config_with_vote_accounts(10_000, &vote_keypairs, 100);
+    let genesis_config_info = create_genesis_config_with_vote_accounts(
+        10_000,
+        &vote_keypairs,
+        vec![100; vote_keypairs.len()],
+    );
     let bank0 = Bank::new(&genesis_config_info.genesis_config);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
 

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -16,11 +16,10 @@ use solana_ledger::{
 use solana_sdk::{
     client::SyncClient,
     clock::{
-        self, Slot, DEFAULT_MS_PER_SLOT, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT,
-        NUM_CONSECUTIVE_LEADER_SLOTS,
+        self, Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS,
     },
     commitment_config::CommitmentConfig,
-    epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
+    epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     hash::Hash,
     poh_config::PohConfig,
     pubkey::Pubkey,
@@ -170,11 +169,6 @@ pub fn verify_ledger_ticks(ledger_path: &Path, ticks_per_slot: usize) {
                 .map(|child_slot| (child_slot, slot, last_id)),
         );
     }
-}
-
-pub fn time_until_nth_epoch(epoch: u64, slots_per_epoch: u64, stakers_slot_offset: u64) -> u64 {
-    let epoch_schedule = EpochSchedule::custom(slots_per_epoch, stakers_slot_offset, true);
-    epoch_schedule.get_last_slot_in_epoch(epoch) * DEFAULT_MS_PER_SLOT
 }
 
 pub fn sleep_n_epochs(

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -318,17 +318,17 @@ impl LocalCluster {
             info!("listener {} ", validator_pubkey,);
         } else {
             // Give the validator some lamports to setup vote accounts
-            let validator_balance = Self::transfer_with_client(
-                &client,
-                &self.funding_keypair,
-                &validator_pubkey,
-                stake * 2 + 2,
-            );
-            info!(
-                "validator {} balance {}",
-                validator_pubkey, validator_balance
-            );
             if should_create_vote_pubkey {
+                let validator_balance = Self::transfer_with_client(
+                    &client,
+                    &self.funding_keypair,
+                    &validator_pubkey,
+                    stake * 2 + 2,
+                );
+                info!(
+                    "validator {} balance {}",
+                    validator_pubkey, validator_balance
+                );
                 Self::setup_vote_and_stake_accounts(
                     &client,
                     voting_keypair.as_ref().unwrap(),
@@ -461,6 +461,10 @@ impl LocalCluster {
     ) -> Result<()> {
         let vote_account_pubkey = vote_account.pubkey();
         let node_pubkey = from_account.pubkey();
+        info!(
+            "setup_vote_and_stake_accounts: {}, {}",
+            node_pubkey, vote_account_pubkey
+        );
         let stake_account_keypair = Keypair::new();
         let stake_account_pubkey = stake_account_keypair.pubkey();
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -62,6 +62,7 @@ pub struct ClusterConfig {
     pub ticks_per_slot: u64,
     pub slots_per_epoch: u64,
     pub stakers_slot_offset: u64,
+    pub skip_warmup_slots: bool,
     pub native_instruction_processors: Vec<(String, Pubkey)>,
     pub operating_mode: OperatingMode,
     pub poh_config: PohConfig,
@@ -81,6 +82,7 @@ impl Default for ClusterConfig {
             native_instruction_processors: vec![],
             operating_mode: OperatingMode::Development,
             poh_config: PohConfig::default(),
+            skip_warmup_slots: false,
         }
     }
 }
@@ -157,8 +159,11 @@ impl LocalCluster {
             stakes_in_genesis,
         );
         genesis_config.ticks_per_slot = config.ticks_per_slot;
-        genesis_config.epoch_schedule =
-            EpochSchedule::custom(config.slots_per_epoch, config.stakers_slot_offset, true);
+        genesis_config.epoch_schedule = EpochSchedule::custom(
+            config.slots_per_epoch,
+            config.stakers_slot_offset,
+            !config.skip_warmup_slots,
+        );
         genesis_config.operating_mode = config.operating_mode;
         genesis_config.poh_config = config.poh_config.clone();
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -476,7 +476,6 @@ fn run_kill_partition_switch_threshold<F>(
 }
 
 #[test]
-#[ignore]
 #[serial]
 fn test_kill_partition_switch_threshold_no_progress() {
     let max_switch_threshold_failure_pct = 1.0 - 2.0 * SWITCH_FORK_THRESHOLD;
@@ -505,7 +504,6 @@ fn test_kill_partition_switch_threshold_no_progress() {
 }
 
 #[test]
-#[ignore]
 #[serial]
 fn test_kill_partition_switch_threshold_progress() {
     let max_switch_threshold_failure_pct = 1.0 - 2.0 * SWITCH_FORK_THRESHOLD;

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -507,7 +507,7 @@ fn test_kill_partition_switch_threshold_no_progress() {
 #[test]
 #[ignore]
 #[serial]
-fn test_kill_partition_switch_threshold2() {
+fn test_kill_partition_switch_threshold_progress() {
     let max_switch_threshold_failure_pct = 1.0 - 2.0 * SWITCH_FORK_THRESHOLD;
     let total_stake = 10_000;
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -265,7 +265,12 @@ fn run_cluster_partition<E, F>(
         cluster_lamports,
         node_stakes,
         validator_configs: vec![validator_config; num_nodes],
-        validator_keys: Some(validator_keys),
+        validator_keys: Some(
+            validator_keys
+                .into_iter()
+                .zip(iter::repeat_with(|| true))
+                .collect(),
+        ),
         ..ClusterConfig::default()
     };
 
@@ -760,7 +765,7 @@ fn test_frozen_account_from_genesis() {
         Arc::new(solana_sdk::signature::keypair_from_seed(&[0u8; 32]).unwrap());
 
     let config = ClusterConfig {
-        validator_keys: Some(vec![validator_identity.clone()]),
+        validator_keys: Some(vec![(validator_identity.clone(), true)]),
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
         validator_configs: vec![
@@ -788,7 +793,7 @@ fn test_frozen_account_from_snapshot() {
     snapshot_test_config.validator_config.frozen_accounts = vec![validator_identity.pubkey()];
 
     let config = ClusterConfig {
-        validator_keys: Some(vec![validator_identity.clone()]),
+        validator_keys: Some(vec![(validator_identity.clone(), true)]),
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
         validator_configs: vec![snapshot_test_config.validator_config.clone()],
@@ -864,6 +869,7 @@ fn test_consistency_halt() {
         &validator_snapshot_test_config.validator_config,
         validator_stake as u64,
         Arc::new(Keypair::new()),
+        None,
     );
     let num_nodes = 2;
     assert_eq!(
@@ -958,6 +964,7 @@ fn test_snapshot_download() {
         &validator_snapshot_test_config.validator_config,
         stake,
         Arc::new(Keypair::new()),
+        None,
     );
 }
 
@@ -1095,6 +1102,7 @@ fn test_snapshots_blockstore_floor() {
         &validator_snapshot_test_config.validator_config,
         validator_stake,
         Arc::new(Keypair::new()),
+        None,
     );
     let all_pubkeys = cluster.get_node_pubkeys();
     let validator_id = all_pubkeys

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -2,15 +2,12 @@ use crate::{
     bank::Bank,
     genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs},
 };
-use solana_sdk::{
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-};
+use solana_sdk::{pubkey::Pubkey, signature::Signer};
 
 pub fn setup_bank_and_vote_pubkeys(num_vote_accounts: usize, stake: u64) -> (Bank, Vec<Pubkey>) {
     // Create some voters at genesis
     let validator_voting_keypairs: Vec<_> = (0..num_vote_accounts)
-        .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+        .map(|_| ValidatorVoteKeypairs::new_rand())
         .collect();
 
     let vote_pubkeys: Vec<_> = validator_voting_keypairs
@@ -21,7 +18,7 @@ pub fn setup_bank_and_vote_pubkeys(num_vote_accounts: usize, stake: u64) -> (Ban
         genesis_utils::create_genesis_config_with_vote_accounts(
             10_000,
             &validator_voting_keypairs,
-            stake,
+            vec![stake; validator_voting_keypairs.len()],
         );
     let bank = Bank::new(&genesis_config);
     (bank, vote_pubkeys)

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -45,7 +45,7 @@ impl ValidatorVoteKeypairs {
 pub struct GenesisConfigInfo {
     pub genesis_config: GenesisConfig,
     pub mint_keypair: Keypair,
-    pub voting_keypair: Keypair,
+    pub voting_keypair: Arc<Keypair>,
 }
 
 pub fn create_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {
@@ -58,13 +58,23 @@ pub fn create_genesis_config_with_vote_accounts(
     stakes: Vec<u64>,
 ) -> GenesisConfigInfo {
     assert_eq!(voting_keypairs.len(), stakes.len());
-    let mut genesis_config_info = create_genesis_config(mint_lamports);
+
+    let mut genesis_config_info = create_genesis_config_with_leader_ex(
+        mint_lamports,
+        &voting_keypairs[0].borrow().node_keypair.pubkey(),
+        voting_keypairs[0].borrow().vote_keypair.clone(),
+        voting_keypairs[0].borrow().stake_keypair.clone(),
+        stakes[0],
+        BOOTSTRAP_VALIDATOR_LAMPORTS,
+    );
+
     for (validator_voting_keypairs, stake) in voting_keypairs.iter().zip(stakes) {
         let node_pubkey = validator_voting_keypairs.borrow().node_keypair.pubkey();
         let vote_pubkey = validator_voting_keypairs.borrow().vote_keypair.pubkey();
         let stake_pubkey = validator_voting_keypairs.borrow().stake_keypair.pubkey();
 
         // Create accounts
+        let node_account = Account::new(BOOTSTRAP_VALIDATOR_LAMPORTS, 0, &system_program::id());
         let vote_account = vote_state::create_account(&vote_pubkey, &node_pubkey, 0, stake);
         let stake_account = stake_state::create_account(
             &stake_pubkey,
@@ -76,7 +86,8 @@ pub fn create_genesis_config_with_vote_accounts(
 
         // Put newly created accounts into genesis
         genesis_config_info.genesis_config.accounts.extend(vec![
-            (vote_pubkey, vote_account.clone()),
+            (node_pubkey, node_account),
+            (vote_pubkey, vote_account),
             (stake_pubkey, stake_account),
         ]);
     }
@@ -92,6 +103,8 @@ pub fn create_genesis_config_with_leader(
     create_genesis_config_with_leader_ex(
         mint_lamports,
         bootstrap_validator_pubkey,
+        Arc::new(Keypair::new()),
+        Arc::new(Keypair::new()),
         bootstrap_validator_stake_lamports,
         BOOTSTRAP_VALIDATOR_LAMPORTS,
     )
@@ -100,13 +113,12 @@ pub fn create_genesis_config_with_leader(
 pub fn create_genesis_config_with_leader_ex(
     mint_lamports: u64,
     bootstrap_validator_pubkey: &Pubkey,
+    bootstrap_validator_voting_keypair: Arc<Keypair>,
+    bootstrap_validator_staking_keypair: Arc<Keypair>,
     bootstrap_validator_stake_lamports: u64,
     bootstrap_validator_lamports: u64,
 ) -> GenesisConfigInfo {
     let mint_keypair = Keypair::new();
-    let bootstrap_validator_voting_keypair = Keypair::new();
-    let bootstrap_validator_staking_keypair = Keypair::new();
-
     let bootstrap_validator_vote_account = vote_state::create_account(
         &bootstrap_validator_voting_keypair.pubkey(),
         &bootstrap_validator_pubkey,


### PR DESCRIPTION
#### Problem
Local cluster partitioning tests are slow because they take  ~500 slots = 3 mins a while to warm up to 256 slots to make sure 

1) Validators stakes are warmed up
2) Epochs are sufficiently long before starting the partitioning tests

#### Summary of Changes
Add validators to genesis block, fix epochs to 2048 slots, so that warmup is not necessary.

Fixes #
