### PR TITLE
Designate mainnet-beta epoch 61 as an upgrade epoch

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1510,7 +1510,7 @@ impl Bank {
             #[cfg(not(test))]
             OperatingMode::Development => false,
             OperatingMode::Preview => false,
-            OperatingMode::Stable => self.epoch == Epoch::max_value(),
+            OperatingMode::Stable => self.epoch == 61,
         }
     }
 


### PR DESCRIPTION
To support the upcoming mainnet-beta upgrade from 1.1 to 1.2, 61 will be an epoch where all user transactions are disabled so the validator nodes can safely upgrade without the risk of disturbing user transactions should something go wrong and a cluster restart becomes necessary.