### PR TITLE
Remove accidental MB activation for RecentBlockhashes consistency fix

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3065,8 +3065,8 @@ impl Bank {
     fn fix_recent_blockhashes_sysvar_delay(&self) -> bool {
         let activation_slot = match self.operating_mode() {
             OperatingMode::Development => 0,
-            OperatingMode::Stable => 26_444_256, // Epoch 74
             OperatingMode::Preview => Slot::MAX / 2,
+            OperatingMode::Stable => Slot::MAX / 2,
         };
 
         self.slot() >= activation_slot


### PR DESCRIPTION
#### Problem

MB activation was unintentionally set instead of testnet

#### Summary of Changes

Disable it again.
Re-order Operating mode match arms to follow feature progression