### PR TITLE
Fix race condition between shrinking and cleaning (for 1.1)

### DIFF
--- a/core/src/accounts_background_service.rs
+++ b/core/src/accounts_background_service.rs
@@ -31,7 +31,13 @@ impl AccountsBackgroundService {
                 bank.process_dead_slots();
 
                 // Currently, given INTERVAL_MS, we process 1 slot/100 ms
-                bank.process_stale_slot();
+                let shrunken_account_count = bank.process_stale_slot();
+                if shrunken_account_count > 0 {
+                    datapoint_info!(
+                        "stale_slot_shrink",
+                        ("accounts", shrunken_account_count, i64)
+                    );
+                }
 
                 sleep(Duration::from_millis(INTERVAL_MS));
             })

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4060,20 +4060,18 @@ pub mod tests {
                 accounts_for_shrink.process_stale_slot();
             });
 
-            let mut current_slot = 0;
             let mut alive_accounts = vec![];
             let owner = Pubkey::default();
 
             // populate the AccountsDB with plenty of food for slot shrinking
             // also this simulates realistic some heavy spike account updates in the wild
-            for _ in 0..1000 {
+            for current_slot in 0..1000 {
                 while alive_accounts.len() <= 10 {
                     alive_accounts.push((
                         Pubkey::new_rand(),
                         Account::new(thread_rng().gen_range(0, 50), 0, &owner),
                     ));
                 }
-                current_slot += 1;
 
                 alive_accounts.retain(|(_pubkey, account)| account.lamports >= 1);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2714,8 +2714,8 @@ impl Bank {
         self.rc.accounts.accounts_db.process_dead_slots();
     }
 
-    pub fn process_stale_slot(&self) {
-        self.rc.accounts.accounts_db.process_stale_slot();
+    pub fn process_stale_slot(&self) -> usize {
+        self.rc.accounts.accounts_db.process_stale_slot()
     }
 
     pub fn shrink_all_stale_slots(&self) {


### PR DESCRIPTION
#### Problem

Slot shrinking violates an assumption of account cleaning: stores of slots should generally be immutable once rooted, especially when doing the cleaning process.

So, `panic!` can be triggered intermittently if the background slot shrinking touches to-be-cleaned slots while the cleaning process is running and vice versa.

Note: this is a possible DOS attack vector.

#### Summary of Changes

Ensure not to run slot shrinking if account cleaning is in progress by holding shared lock (`shrink_candidate_slots`) from each processing with appropriate lifetime.

Also, as a really last-minute bonus for the v1.1, just back-port some measure thing from #10099 .

(Also, this is manually back-ported version of #11235 because v1.1 branch doesn't contain #10099).

Fixes #11232 
