### PR TITLE
Add Google Analytics to all Explorer pages

### DIFF
--- a/explorer/public/index.html
+++ b/explorer/public/index.html
@@ -15,6 +15,15 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112467444-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-112467444-2');
+    </script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
### Problem

We can't understand how users interact with the Explorer. 

#### Summary of Changes

Add the Google Analytics tracking code to the Explorer index page.
