### PR TITLE
Rerere-enable RecentBlockhashes fix on testnet (epoch 76)

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2832,7 +2832,7 @@ impl Bank {
     fn fix_recent_blockhashes_sysvar_delay(&self) -> bool {
         let activation_slot = match self.operating_mode() {
             OperatingMode::Development => 0,
-            OperatingMode::Preview => Slot::MAX / 2,
+            OperatingMode::Preview => 27_740_256, // Epoch 76
             OperatingMode::Stable => Slot::MAX / 2,
         };
 


### PR DESCRIPTION
Backport of #11258