### PR TITLE
Add getConfirmedSignaturesForAddress2 RPC method

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -231,7 +231,7 @@ pub enum CliCommand {
     TotalSupply,
     TransactionHistory {
         address: Pubkey,
-        start_after: Option<Signature>,
+        before: Option<Signature>,
         limit: usize,
     },
     // Nonce commands
@@ -1871,9 +1871,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::TotalSupply => process_total_supply(&rpc_client, config),
         CliCommand::TransactionHistory {
             address,
-            start_after,
+            before,
             limit,
-        } => process_transaction_history(&rpc_client, config, address, *start_after, *limit),
+        } => process_transaction_history(&rpc_client, config, address, *before, *limit),
 
         // Nonce Commands
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -231,8 +231,8 @@ pub enum CliCommand {
     TotalSupply,
     TransactionHistory {
         address: Pubkey,
-        end_slot: Option<Slot>,  // None == latest slot
-        slot_limit: Option<u64>, // None == search full history
+        start_after: Option<Signature>,
+        limit: usize,
     },
     // Nonce commands
     AuthorizeNonceAccount {
@@ -1871,9 +1871,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::TotalSupply => process_total_supply(&rpc_client, config),
         CliCommand::TransactionHistory {
             address,
-            end_slot,
-            slot_limit,
-        } => process_transaction_history(&rpc_client, address, *end_slot, *slot_limit),
+            start_after,
+            limit,
+        } => process_transaction_history(&rpc_client, config, address, *start_after, *limit),
 
         // Nonce Commands
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -277,8 +277,8 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .help("Maximum number of transaction signatures to return"),
                 )
                 .arg(
-                    Arg::with_name("after")
-                        .long("after")
+                    Arg::with_name("before")
+                        .long("before")
                         .value_name("TRANSACTION_SIGNATURE")
                         .takes_value(true)
                         .help("Start with the first signature older than this one"),
@@ -437,7 +437,7 @@ pub fn parse_transaction_history(
 ) -> Result<CliCommandInfo, CliError> {
     let address = pubkey_of_signer(matches, "address", wallet_manager)?.unwrap();
 
-    let start_after = match matches.value_of("after") {
+    let before = match matches.value_of("before") {
         Some(signature) => Some(
             signature
                 .parse()
@@ -450,7 +450,7 @@ pub fn parse_transaction_history(
     Ok(CliCommandInfo {
         command: CliCommand::TransactionHistory {
             address,
-            start_after,
+            before,
             limit,
         },
         signers: vec![],
@@ -1311,12 +1311,12 @@ pub fn process_transaction_history(
     rpc_client: &RpcClient,
     config: &CliConfig,
     address: &Pubkey,
-    start_after: Option<Signature>,
+    before: Option<Signature>,
     limit: usize,
 ) -> ProcessResult {
     let results = rpc_client.get_confirmed_signatures_for_address2_with_config(
         address,
-        start_after,
+        before,
         Some(limit),
     )?;
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -2,7 +2,10 @@ use crate::{
     client_error::{ClientError, ClientErrorKind, Result as ClientResult},
     http_sender::HttpSender,
     mock_sender::{MockSender, Mocks},
-    rpc_config::{RpcLargestAccountsConfig, RpcSendTransactionConfig, RpcTokenAccountsFilter},
+    rpc_config::{
+        RpcGetConfirmedSignaturesForAddress2Config, RpcLargestAccountsConfig,
+        RpcSendTransactionConfig, RpcTokenAccountsFilter,
+    },
     rpc_request::{RpcError, RpcRequest, TokenAccountsFilter},
     rpc_response::*,
     rpc_sender::RpcSender,
@@ -287,6 +290,32 @@ impl RpcClient {
             );
         }
         Ok(signatures)
+    }
+
+    pub fn get_confirmed_signatures_for_address2(
+        &self,
+        address: &Pubkey,
+    ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        self.get_confirmed_signatures_for_address2_with_config(address, None, None)
+    }
+
+    pub fn get_confirmed_signatures_for_address2_with_config(
+        &self,
+        address: &Pubkey,
+        start_after: Option<Signature>,
+        limit: Option<usize>,
+    ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        let config = RpcGetConfirmedSignaturesForAddress2Config {
+            start_after: start_after.map(|signature| signature.to_string()),
+            limit,
+        };
+
+        let result: Vec<RpcConfirmedTransactionStatusWithSignature> = self.send(
+            RpcRequest::GetConfirmedSignaturesForAddress2,
+            json!([address.to_string(), config]),
+        )?;
+
+        Ok(result)
     }
 
     pub fn get_confirmed_transaction(

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -302,11 +302,11 @@ impl RpcClient {
     pub fn get_confirmed_signatures_for_address2_with_config(
         &self,
         address: &Pubkey,
-        start_after: Option<Signature>,
+        before: Option<Signature>,
         limit: Option<usize>,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         let config = RpcGetConfirmedSignaturesForAddress2Config {
-            start_after: start_after.map(|signature| signature.to_string()),
+            before: before.map(|signature| signature.to_string()),
             limit,
         };
 

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -65,3 +65,10 @@ pub enum RpcTokenAccountsFilter {
     Mint(String),
     ProgramId(String),
 }
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcGetConfirmedSignaturesForAddress2Config {
+    pub start_after: Option<String>, // Signature as base-58 string
+    pub limit: Option<usize>,
+}

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -69,6 +69,6 @@ pub enum RpcTokenAccountsFilter {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcGetConfirmedSignaturesForAddress2Config {
-    pub start_after: Option<String>, // Signature as base-58 string
+    pub before: Option<String>, // Signature as base-58 string
     pub limit: Option<usize>,
 }

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -14,6 +14,7 @@ pub enum RpcRequest {
     GetConfirmedBlock,
     GetConfirmedBlocks,
     GetConfirmedSignaturesForAddress,
+    GetConfirmedSignaturesForAddress2,
     GetConfirmedTransaction,
     GetEpochInfo,
     GetEpochSchedule,
@@ -65,6 +66,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetConfirmedBlock => "getConfirmedBlock",
             RpcRequest::GetConfirmedBlocks => "getConfirmedBlocks",
             RpcRequest::GetConfirmedSignaturesForAddress => "getConfirmedSignaturesForAddress",
+            RpcRequest::GetConfirmedSignaturesForAddress2 => "getConfirmedSignaturesForAddress2",
             RpcRequest::GetConfirmedTransaction => "getConfirmedTransaction",
             RpcRequest::GetEpochInfo => "getEpochInfo",
             RpcRequest::GetEpochSchedule => "getEpochSchedule",
@@ -112,6 +114,7 @@ pub const NUM_LARGEST_ACCOUNTS: usize = 20;
 pub const MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS: usize = 256;
 pub const MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE: u64 = 10_000;
 pub const MAX_GET_CONFIRMED_BLOCKS_RANGE: u64 = 500_000;
+pub const MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT: usize = 1_000;
 
 // Validators that are this number of slots behind are considered delinquent
 pub const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 128;

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -6,6 +6,7 @@ use solana_sdk::{
     inflation::Inflation,
     transaction::{Result, TransactionError},
 };
+use solana_transaction_status::ConfirmedTransactionStatusWithSignature;
 use std::{collections::HashMap, net::SocketAddr};
 
 pub type RpcResult<T> = client_error::Result<Response<T>>;
@@ -235,4 +236,30 @@ pub struct RpcTokenAccountBalance {
     pub address: String,
     #[serde(flatten)]
     pub amount: RpcTokenAmount,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcConfirmedTransactionStatusWithSignature {
+    pub signature: String,
+    pub slot: Slot,
+    pub err: Option<TransactionError>,
+    pub memo: Option<String>,
+}
+
+impl From<ConfirmedTransactionStatusWithSignature> for RpcConfirmedTransactionStatusWithSignature {
+    fn from(value: ConfirmedTransactionStatusWithSignature) -> Self {
+        let ConfirmedTransactionStatusWithSignature {
+            signature,
+            slot,
+            err,
+            memo,
+        } = value;
+        Self {
+            signature: signature.to_string(),
+            slot,
+            err,
+            memo,
+        }
+    }
 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -17,6 +17,7 @@ use solana_client::{
     rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
     rpc_request::{
         TokenAccountsFilter, DELINQUENT_VALIDATOR_SLOT_DISTANCE, MAX_GET_CONFIRMED_BLOCKS_RANGE,
+        MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT,
         MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE,
         MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS, NUM_LARGEST_ACCOUNTS,
     },
@@ -770,6 +771,35 @@ impl JsonRpcRequestProcessor {
         }
     }
 
+    pub fn get_confirmed_signatures_for_address2(
+        &self,
+        address: Pubkey,
+        start_after: Option<Signature>,
+        limit: usize,
+    ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        if self.config.enable_rpc_transaction_history {
+            let highest_confirmed_root = self
+                .block_commitment_cache
+                .read()
+                .unwrap()
+                .highest_confirmed_root();
+
+            let results = self
+                .blockstore
+                .get_confirmed_signatures_for_address2(
+                    address,
+                    highest_confirmed_root,
+                    start_after,
+                    limit,
+                )
+                .map_err(|err| Error::invalid_params(format!("{}", err)))?;
+
+            Ok(results.into_iter().map(|x| x.into()).collect())
+        } else {
+            Ok(vec![])
+        }
+    }
+
     pub fn get_first_available_block(&self) -> Slot {
         self.blockstore
             .get_first_available_block()
@@ -1406,6 +1436,14 @@ pub trait RpcSol {
         end_slot: Slot,
     ) -> Result<Vec<String>>;
 
+    #[rpc(meta, name = "getConfirmedSignaturesForAddress2")]
+    fn get_confirmed_signatures_for_address2(
+        &self,
+        meta: Self::Metadata,
+        address: String,
+        config: Option<RpcGetConfirmedSignaturesForAddress2Config>,
+    ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>>;
+
     #[rpc(meta, name = "getFirstAvailableBlock")]
     fn get_first_available_block(&self, meta: Self::Metadata) -> Result<Slot>;
 
@@ -2034,6 +2072,39 @@ impl RpcSol for RpcSolImpl {
             .iter()
             .map(|signature| signature.to_string())
             .collect())
+    }
+
+    fn get_confirmed_signatures_for_address2(
+        &self,
+        meta: Self::Metadata,
+        address: String,
+        config: Option<RpcGetConfirmedSignaturesForAddress2Config>,
+    ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
+        let address = verify_pubkey(address)?;
+
+        let (start_after, limit) =
+            if let Some(RpcGetConfirmedSignaturesForAddress2Config { start_after, limit }) = config
+            {
+                (
+                    if let Some(start_after) = start_after {
+                        Some(verify_signature(&start_after)?)
+                    } else {
+                        None
+                    },
+                    limit.unwrap_or(MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT),
+                )
+            } else {
+                (None, MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT)
+            };
+
+        if limit == 0 || limit > MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT {
+            return Err(Error::invalid_params(format!(
+                "Invalid limit; max {}",
+                MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT
+            )));
+        }
+
+        meta.get_confirmed_signatures_for_address2(address, start_after, limit)
     }
 
     fn get_first_available_block(&self, meta: Self::Metadata) -> Result<Slot> {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -774,7 +774,7 @@ impl JsonRpcRequestProcessor {
     pub fn get_confirmed_signatures_for_address2(
         &self,
         address: Pubkey,
-        start_after: Option<Signature>,
+        before: Option<Signature>,
         limit: usize,
     ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         if self.config.enable_rpc_transaction_history {
@@ -789,7 +789,7 @@ impl JsonRpcRequestProcessor {
                 .get_confirmed_signatures_for_address2(
                     address,
                     highest_confirmed_root,
-                    start_after,
+                    before,
                     limit,
                 )
                 .map_err(|err| Error::invalid_params(format!("{}", err)))?;
@@ -2083,8 +2083,8 @@ impl RpcSol for RpcSolImpl {
         let address = verify_pubkey(address)?;
 
         let config = config.unwrap_or_default();
-        let start_after = if let Some(start_after) = config.start_after {
-            Some(verify_signature(&start_after)?)
+        let before = if let Some(before) = config.before {
+            Some(verify_signature(&before)?)
         } else {
             None
         };
@@ -2099,7 +2099,7 @@ impl RpcSol for RpcSolImpl {
             )));
         }
 
-        meta.get_confirmed_signatures_for_address2(address, start_after, limit)
+        meta.get_confirmed_signatures_for_address2(address, before, limit)
     }
 
     fn get_first_available_block(&self, meta: Self::Metadata) -> Result<Slot> {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2082,20 +2082,15 @@ impl RpcSol for RpcSolImpl {
     ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         let address = verify_pubkey(address)?;
 
-        let (start_after, limit) =
-            if let Some(RpcGetConfirmedSignaturesForAddress2Config { start_after, limit }) = config
-            {
-                (
-                    if let Some(start_after) = start_after {
-                        Some(verify_signature(&start_after)?)
-                    } else {
-                        None
-                    },
-                    limit.unwrap_or(MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT),
-                )
-            } else {
-                (None, MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT)
-            };
+        let config = config.unwrap_or_default();
+        let start_after = if let Some(start_after) = config.start_after {
+            Some(verify_signature(&start_after)?)
+        } else {
+            None
+        };
+        let limit = config
+            .limit
+            .unwrap_or(MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT);
 
         if limit == 0 || limit > MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT {
             return Err(Error::invalid_params(format!(

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -428,10 +428,8 @@ address backwards in time from the provided signature or most recent confirmed b
 #### Parameters:
 * `<string>` - account address as base-58 encoded string
 * `<object>` - (optional) Configuration object containing the following fields:
-  * `startAfter: <string>` - (optional) start searching backwards from this transaction signature,
-                             which must be a confirmed signature for the account
-                             address.  If not provided the search starts from
-                             the highest max confirmed block.
+  * `before: <string>` - (optional) start searching backwards from this transaction signature.
+                         If not provided the search starts from the top of the highest max confirmed block.
   * `limit: <number>` - (optional) maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
 
 #### Results:

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -24,6 +24,7 @@ To interact with a Solana node inside a JavaScript application, use the [solana-
 - [getConfirmedBlock](jsonrpc-api.md#getconfirmedblock)
 - [getConfirmedBlocks](jsonrpc-api.md#getconfirmedblocks)
 - [getConfirmedSignaturesForAddress](jsonrpc-api.md#getconfirmedsignaturesforaddress)
+- [getConfirmedSignaturesForAddress2](jsonrpc-api.md#getconfirmedsignaturesforaddress2)
 - [getConfirmedTransaction](jsonrpc-api.md#getconfirmedtransaction)
 - [getEpochInfo](jsonrpc-api.md#getepochinfo)
 - [getEpochSchedule](jsonrpc-api.md#getepochschedule)
@@ -389,6 +390,8 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"m
 
 ### getConfirmedSignaturesForAddress
 
+**DEPRECATED: Please use getConfirmedSignaturesForAddress2 instead**
+
 Returns a list of all the confirmed signatures for transactions involving an
 address, within a specified Slot range. Max range allowed is 10,000 Slots
 
@@ -414,6 +417,39 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"m
 
 // Result
 {"jsonrpc":"2.0","result":{["35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby","4bJdGN8Tt2kLWZ3Fa1dpwPSEkXWWTSszPSf1rRVsCwNjxbbUdwTeiWtmi8soA26YmwnKD4aAxNp8ci1Gjpdv4gsr","4LQ14a7BYY27578Uj8LPCaVhSdJGLn9DJqnUJHpy95FMqdKf9acAhUhecPQNjNUy6VoNFUbvwYkPociFSf87cWbG"]},"id":1}
+```
+
+
+### getConfirmedSignaturesForAddress2
+
+Returns confirmed signatures for transactions involving an
+address backwards in time from the provided signature or most recent confirmed block
+
+#### Parameters:
+* `<string>` - account address as base-58 encoded string
+* `<object>` - (optional) Configuration object containing the following fields:
+  * `startAfter: <string>` - (optional) start searching backwards from this transaction signature,
+                             which must be a confirmed signature for the account
+                             address.  If not provided the search starts from
+                             the highest max confirmed block.
+  * `limit: <number>` - (optional) maximum transaction signatures to return (between 1 and 1,000, default: 1,000).
+
+#### Results:
+The result field will be an array of transaction signature information, ordered
+from newest to oldest transaction:
+* `<object>`
+  * `signature: <string>` - transaction signature as base-58 encoded string
+  * `slot: <u64>` - The slot that contains the block with the transaction
+  * `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L14)
+  * `memo: <string |null>` - Memo associated with the transaction, null if no memo is present
+
+#### Example:
+```bash
+// Request
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedSignaturesForAddress2","params":["Vote111111111111111111111111111111111111111", {"limit": 1}]}' localhost:8899
+
+// Result
+{"jsonrpc":"2.0","result":[{"err":null,"memo":null,"signature":"5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv","slot":114}],"id":1}
 ```
 
 ### getConfirmedTransaction

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1927,7 +1927,7 @@ impl Blockstore {
         &self,
         address: Pubkey,
         highest_confirmed_root: Slot,
-        start_after: Option<Signature>,
+        before: Option<Signature>,
         limit: usize,
     ) -> Result<Vec<ConfirmedTransactionStatusWithSignature>> {
         datapoint_info!(
@@ -1940,12 +1940,12 @@ impl Blockstore {
         );
 
         // Figure the `slot` to start listing signatures at, based on the ledger location of the
-        // `start_after` signature if present.  Also generate a HashSet of signatures that should
+        // `before` signature if present.  Also generate a HashSet of signatures that should
         // be excluded from the results.
-        let (mut slot, mut excluded_signatures) = match start_after {
+        let (mut slot, mut excluded_signatures) = match before {
             None => (highest_confirmed_root, None),
-            Some(start_after) => {
-                let transaction_status = self.get_transaction_status(start_after)?;
+            Some(before) => {
+                let transaction_status = self.get_transaction_status(before)?;
                 match transaction_status {
                     None => return Ok(vec![]),
                     Some((slot, _)) => {
@@ -1978,7 +1978,7 @@ impl Blockstore {
                         // not by block ordering
                         slot_signatures.sort();
 
-                        if let Some(pos) = slot_signatures.iter().position(|&x| x == start_after) {
+                        if let Some(pos) = slot_signatures.iter().position(|&x| x == before) {
                             slot_signatures.truncate(pos + 1);
                         }
 
@@ -6345,7 +6345,7 @@ pub mod tests {
                 assert_eq!(results[1], all1[i + 1]);
             }
 
-            // A search for address 0 with a `start_after` signature from address1 should also work
+            // A search for address 0 with a `before` signature from address1 should also work
             let results = blockstore
                 .get_confirmed_signatures_for_address2(
                     address0,

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -17,6 +17,7 @@ use solana_sdk::{
     instruction::CompiledInstruction,
     message::MessageHeader,
     pubkey::Pubkey,
+    signature::Signature,
     transaction::{Result, Transaction, TransactionError},
 };
 
@@ -125,7 +126,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
 pub struct TransactionStatus {
     pub slot: Slot,
     pub confirmations: Option<usize>, // None = rooted
-    pub status: Result<()>,
+    pub status: Result<()>,           // legacy field
     pub err: Option<TransactionError>,
 }
 
@@ -134,6 +135,15 @@ impl TransactionStatus {
         (commitment_config == CommitmentConfig::default() && self.confirmations.is_none())
             || commitment_config == CommitmentConfig::recent()
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmedTransactionStatusWithSignature {
+    pub signature: Signature,
+    pub slot: Slot,
+    pub err: Option<TransactionError>,
+    pub memo: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Add `getConfirmedSignaturesForAddress2`, which doesn't require pagination through slots to find the latest transactions that affect and address.  Also allow for starting the search from a given signature.

The blockstore implementation, in this PR, is inefficient.  Adding different transaction-status CFs to improve this situation could be done in a follow-up PR.  However plugging this into BigTable (#11222) will be trivial as I already designed the BigTable schema around this method -- that work will occur in #11222 once that PR is rebased on this PR

This PR also reimplements the `solana transaction-history` command to use the new RPC method.

Fixes #10884
