### PR TITLE
Add hook for getting vote transactions on replay

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -287,7 +287,7 @@ fn simulate_process_entries(
         hash: next_hash(&bank.last_blockhash(), 1, &tx_vector),
         transactions: tx_vector,
     };
-    process_entries(&bank, &[entry], randomize_txs, None).unwrap();
+    process_entries(&bank, &[entry], randomize_txs, None, None).unwrap();
 }
 
 fn bench_process_entries(randomize_txs: bool, bencher: &mut Bencher) {

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -37,7 +37,7 @@ use solana_sdk::{
 };
 use solana_vote_program::{self, vote_state::Vote, vote_transaction};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::{
         atomic::{AtomicBool, Ordering},
         {Arc, Mutex, RwLock},
@@ -546,7 +546,6 @@ impl ClusterInfoVoteListener {
         subscriptions: &RpcSubscriptions,
         verified_vote_sender: &VerifiedVoteSender,
         diff: &mut HashMap<Slot, HashMap<Arc<Pubkey>, bool>>,
-        optimistic_confirmation_counted: &mut HashSet<(Slot, Pubkey)>,
         new_optimistic_confirmed_slots: &mut Vec<(Slot, Hash)>,
         is_gossip_vote: bool,
     ) {
@@ -558,7 +557,8 @@ impl ClusterInfoVoteListener {
 
         let root = root_bank.slot();
         let last_vote_hash = vote.hash;
-        for slot in &vote.slots {
+        let mut is_new_vote = false;
+        for slot in vote.slots.iter().rev() {
             // If slot is before the root, or so far ahead we don't have
             // stake information, then ignore it
             let epoch = root_bank.epoch_schedule().get_epoch(*slot);
@@ -571,7 +571,7 @@ impl ClusterInfoVoteListener {
             let total_epoch_stake = epoch_stakes.total_stake();
             let unduplicated_pubkey = vote_tracker.keys.get_or_insert(&vote_pubkey);
 
-            // The last vote slot , which is the greatest slot in the stack
+            // The last vote slot, which is the greatest slot in the stack
             // of votes in a vote transaction, qualifies for optimistic confirmation.
             let update_optimistic_confirmation_info = if slot == last_vote_slot {
                 let stake = epoch_vote_accounts
@@ -588,29 +588,49 @@ impl ClusterInfoVoteListener {
                 // Fast track processing of the last slot in a vote transactions
                 // so that notifications for optimistic confirmation can be sent
                 // as soon as possible.
-                if !optimistic_confirmation_counted.contains(&(*slot, *unduplicated_pubkey))
-                    && Self::add_optimistic_confirmation_vote(
-                        vote_tracker,
-                        *slot,
-                        hash,
-                        unduplicated_pubkey.clone(),
-                        stake,
-                        total_epoch_stake,
-                    )
-                {
-                    optimistic_confirmation_counted.insert((*slot, *unduplicated_pubkey));
+                let (is_confirmed, is_new) = Self::add_optimistic_confirmation_vote(
+                    vote_tracker,
+                    *slot,
+                    hash,
+                    unduplicated_pubkey.clone(),
+                    stake,
+                    total_epoch_stake,
+                );
+
+                if is_confirmed {
                     new_optimistic_confirmed_slots.push((*slot, last_vote_hash));
                     // TODO: Notify subscribers about new optimistic confirmation
                 }
+
+                if !is_new && !is_gossip_vote {
+                    // By now:
+                    // 1) The vote must have come from ReplayStage,
+                    // 2) We've seen this vote from replay for this hash before
+                    // (`add_optimistic_confirmation_vote()` will not set `is_new == true`
+                    // for same slot different hash), so short circuit because this vote
+                    // has no new information
+
+                    // Note gossip votes will always be processed because those should be unique
+                    // and we need to update the gossip-only stake in the `VoteTracker`.
+                    return;
+                }
+
+                is_new_vote = is_new;
             }
 
             diff.entry(*slot)
                 .or_default()
-                .insert(unduplicated_pubkey, is_gossip_vote);
+                .entry(unduplicated_pubkey)
+                .and_modify(|seen_in_gossip_previously| {
+                    *seen_in_gossip_previously = *seen_in_gossip_previously || is_gossip_vote
+                })
+                .or_insert(is_gossip_vote);
         }
 
-        subscriptions.notify_vote(&vote);
-        let _ = verified_vote_sender.send((*vote_pubkey, vote.slots));
+        if is_new_vote {
+            subscriptions.notify_vote(&vote);
+            let _ = verified_vote_sender.send((*vote_pubkey, vote.slots));
+        }
     }
 
     fn process_votes(
@@ -621,7 +641,6 @@ impl ClusterInfoVoteListener {
         subscriptions: &RpcSubscriptions,
         verified_vote_sender: &VerifiedVoteSender,
     ) -> Vec<(Slot, Hash)> {
-        let mut optimistic_confirmation_counted: HashSet<(Slot, Pubkey)> = HashSet::new();
         let mut diff: HashMap<Slot, HashMap<Arc<Pubkey>, bool>> = HashMap::new();
         let mut new_optimistic_confirmed_slots = vec![];
 
@@ -670,7 +689,6 @@ impl ClusterInfoVoteListener {
                 subscriptions,
                 verified_vote_sender,
                 &mut diff,
-                &mut optimistic_confirmation_counted,
                 &mut new_optimistic_confirmed_slots,
                 i < gossip_vote_txs.len(),
             );
@@ -685,13 +703,6 @@ impl ClusterInfoVoteListener {
                 slot_diff.retain(|pubkey, seen_in_gossip_above| {
                     let seen_in_gossip_previously = r_slot_tracker.voted.get(pubkey);
                     let is_new = seen_in_gossip_previously.is_none();
-                    if is_new && !*seen_in_gossip_above {
-                        // If this vote wasn't seen in gossip, then it must be a
-                        // replay vote, and we haven't sent a notification for
-                        // those yet
-                        let _ = verified_vote_sender.send((**pubkey, vec![slot]));
-                    }
-
                     // `is_new_from_gossip` means we observed a vote for this slot
                     // for the first time in gossip
                     let is_new_from_gossip = !seen_in_gossip_previously.cloned().unwrap_or(false)
@@ -745,7 +756,8 @@ impl ClusterInfoVoteListener {
         new_optimistic_confirmed_slots
     }
 
-    // Returns if the slot was optimistically confirmed
+    // Returns if the slot was optimistically confirmed, and whether
+    // the slot was new
     fn add_optimistic_confirmation_vote(
         vote_tracker: &VoteTracker,
         slot: Slot,
@@ -753,7 +765,7 @@ impl ClusterInfoVoteListener {
         pubkey: Arc<Pubkey>,
         stake: u64,
         total_epoch_stake: u64,
-    ) -> bool {
+    ) -> (bool, bool) {
         let slot_tracker = vote_tracker.get_or_insert_slot_tracker(slot);
         // Insert vote and check for optimistic confirmation
         let mut w_slot_tracker = slot_tracker.write().unwrap();
@@ -808,16 +820,18 @@ impl ClusterInfoVoteListener {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::replay_stage::ReplayVotesSender;
+    use solana_ledger::blockstore_processor::ReplayVotesSender;
     use solana_perf::packet;
     use solana_runtime::{
         bank::Bank,
         commitment::BlockCommitmentCache,
         genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs},
     };
-    use solana_sdk::hash::Hash;
-    use solana_sdk::signature::Signature;
-    use solana_sdk::signature::{Keypair, Signer};
+    use solana_sdk::{
+        hash::Hash,
+        signature::{Keypair, Signature, Signer},
+    };
+    use solana_vote_program::vote_state::Vote;
     use std::collections::BTreeSet;
 
     #[test]
@@ -1072,7 +1086,7 @@ mod tests {
         gossip_vote_slots: Vec<Slot>,
         replay_vote_slots: Vec<Slot>,
         validator_voting_keypairs: &[ValidatorVoteKeypairs],
-        hash: Option<Hash>,
+        switch_proof_hash: Option<Hash>,
         votes_sender: &VerifiedVoteTransactionsSender,
         replay_votes_sender: &ReplayVotesSender,
     ) {
@@ -1086,16 +1100,18 @@ mod tests {
                 node_keypair,
                 vote_keypair,
                 vote_keypair,
-                hash,
+                switch_proof_hash,
             );
             votes_sender.send(vec![vote_tx]).unwrap();
-            for vote_slot in &replay_vote_slots {
-                // Send twice, should only expect to be notified once later
+            let replay_vote = Vote::new(replay_vote_slots.clone(), Hash::default());
+            // Send same vote twice, but should only notify once
+            for _ in 0..2 {
                 replay_votes_sender
-                    .send(Arc::new(vec![(vote_keypair.pubkey(), *vote_slot)]))
-                    .unwrap();
-                replay_votes_sender
-                    .send(Arc::new(vec![(vote_keypair.pubkey(), *vote_slot)]))
+                    .send((
+                        vote_keypair.pubkey(),
+                        replay_vote.clone(),
+                        switch_proof_hash,
+                    ))
                     .unwrap();
             }
         });
@@ -1179,7 +1195,7 @@ mod tests {
                 // the `optimistic` vote set.
                 let optimistic_votes_tracker =
                     r_slot_vote_tracker.optimistic_votes_tracker(&Hash::default());
-                if vote_slot == 2 {
+                if vote_slot == 2 || vote_slot == 4 {
                     let optimistic_votes_tracker = optimistic_votes_tracker.unwrap();
                     assert!(optimistic_votes_tracker.voted().contains(&pubkey));
                     assert_eq!(
@@ -1293,7 +1309,7 @@ mod tests {
         }
     }
 
-    fn run_test_process_votes3(hash: Option<Hash>) {
+    fn run_test_process_votes3(switch_proof_hash: Option<Hash>) {
         let (votes_sender, votes_receiver) = unbounded();
         let (verified_vote_sender, _verified_vote_receiver) = unbounded();
         let (replay_votes_sender, replay_votes_receiver) = unbounded();
@@ -1312,6 +1328,7 @@ mod tests {
             vec![2],
             vec![0, 1, 2],
             vec![1, 0, 2],
+            vec![0, 1, 2, 0, 1, 2],
         ];
         for events in ordered_events {
             let (vote_tracker, bank, validator_voting_keypairs, subscriptions) = setup();
@@ -1327,13 +1344,17 @@ mod tests {
                         node_keypair,
                         vote_keypair,
                         vote_keypair,
-                        hash,
+                        switch_proof_hash,
                     );
                     votes_sender.send(vec![vote_tx.clone()]).unwrap();
                 }
                 if e == 1 || e == 2 {
                     replay_votes_sender
-                        .send(Arc::new(vec![(vote_keypair.pubkey(), vote_slot)]))
+                        .send((
+                            vote_keypair.pubkey(),
+                            Vote::new(vec![vote_slot], Hash::default()),
+                            switch_proof_hash,
+                        ))
                         .unwrap();
                 }
                 let _ = ClusterInfoVoteListener::get_and_process_votes(
@@ -1427,9 +1448,6 @@ mod tests {
         // SlotVoteTracker.voted, one in SlotVoteTracker.updates, one in
         // SlotVoteTracker.optimistic_votes_tracker
         let ref_count_per_vote = 3;
-        // Replay votes don't get added to `SlotVoteTracker.optimistic_votes_tracker`,
-        // so there's one less
-        let ref_count_per_replay_vote = ref_count_per_vote - 1;
         let ref_count_per_new_key = 1;
 
         // Create some voters at genesis
@@ -1472,14 +1490,15 @@ mod tests {
         ClusterInfoVoteListener::process_votes(
             &vote_tracker,
             vote_tx,
+            // Add gossip vote for same slot, should not affect outcome
+            vec![(
+                validator0_keypairs.vote_keypair.pubkey(),
+                Vote::new(vec![voted_slot], Hash::default()),
+                None,
+            )],
             &bank,
             &subscriptions,
             &verified_vote_sender,
-            // Add vote for same slot, should not affect outcome
-            &[Arc::new(vec![(
-                validator0_keypairs.vote_keypair.pubkey(),
-                voted_slot,
-            )])],
         );
         let ref_count = Arc::strong_count(
             &vote_tracker
@@ -1541,13 +1560,14 @@ mod tests {
         ClusterInfoVoteListener::process_votes(
             &vote_tracker,
             vote_txs,
+            vec![(
+                validator_keypairs[1].vote_keypair.pubkey(),
+                Vote::new(vec![first_slot_in_new_epoch], Hash::default()),
+                None,
+            )],
             &new_root_bank,
             &subscriptions,
             &verified_vote_sender,
-            &[Arc::new(vec![(
-                validator_keypairs[1].vote_keypair.pubkey(),
-                first_slot_in_new_epoch,
-            )])],
         );
 
         // Check new replay vote pubkey first
@@ -1564,7 +1584,7 @@ mod tests {
         // `ref_count_per_optimistic_vote + ref_count_per_new_key`.
         // +ref_count_per_new_key for the new pubkey  in `vote_tracker.keys` and
         // +ref_count_per_optimistic_vote for the one new vote
-        assert_eq!(ref_count, ref_count_per_replay_vote + ref_count_per_new_key);
+        assert_eq!(ref_count, ref_count_per_vote + ref_count_per_new_key);
 
         // Check the existing pubkey
         let ref_count = Arc::strong_count(

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -679,7 +679,6 @@ pub mod test {
         progress_map::ForkProgress,
         replay_stage::{HeaviestForkFailures, ReplayStage},
     };
-    use crossbeam_channel::unbounded;
     use solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
@@ -795,7 +794,6 @@ pub mod test {
                 .cloned()
                 .collect();
 
-            let (replay_slot_sender, _replay_slot_receiver) = unbounded();
             let _ = ReplayStage::compute_bank_stats(
                 &my_pubkey,
                 &ancestors,
@@ -808,7 +806,6 @@ pub mod test {
                 &mut PubkeyReferences::default(),
                 &mut self.heaviest_subtree_fork_choice,
                 &mut BankWeightForkChoice::default(),
-                &replay_slot_sender,
             );
 
             let vote_bank = self

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -8,13 +8,15 @@ use crate::{
     cluster_info_vote_listener::{ClusterInfoVoteListener, VerifiedVoteSender, VoteTracker},
     fetch_stage::FetchStage,
     poh_recorder::{PohRecorder, WorkingBankEntry},
-    replay_stage::ReplayVotesReceiver,
     rpc_subscriptions::RpcSubscriptions,
     sigverify::TransactionSigVerifier,
     sigverify_stage::SigVerifyStage,
 };
 use crossbeam_channel::unbounded;
-use solana_ledger::{blockstore::Blockstore, blockstore_processor::TransactionStatusSender};
+use solana_ledger::{
+    blockstore::Blockstore,
+    blockstore_processor::{ReplayVotesReceiver, TransactionStatusSender},
+};
 use solana_runtime::bank_forks::BankForks;
 use std::{
     net::UdpSocket,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -10,7 +10,7 @@ use crate::{
     cluster_slots::ClusterSlots,
     ledger_cleanup_service::LedgerCleanupService,
     poh_recorder::PohRecorder,
-    replay_stage::{ReplayStage, ReplayStageConfig, ReplayVotesSender},
+    replay_stage::{ReplayStage, ReplayStageConfig},
     retransmit_stage::RetransmitStage,
     rewards_recorder_service::RewardsRecorderSender,
     rpc_subscriptions::RpcSubscriptions,
@@ -21,7 +21,7 @@ use crate::{
 use crossbeam_channel::unbounded;
 use solana_ledger::{
     blockstore::{Blockstore, CompletedSlotsReceiver},
-    blockstore_processor::TransactionStatusSender,
+    blockstore_processor::{ReplayVotesSender, TransactionStatusSender},
     leader_schedule_cache::LeaderScheduleCache,
 };
 use solana_runtime::{

--- a/core/src/vote_stake_tracker.rs
+++ b/core/src/vote_stake_tracker.rs
@@ -9,23 +9,29 @@ pub struct VoteStakeTracker {
 }
 
 impl VoteStakeTracker {
-    // Returns true if the stake that has voted has just crosssed the supermajority
+    // Returns tuple (is_confirmed, is_new) where
+    // `is_confirmed` is true if the stake that has voted has just crosssed the supermajority
     // of stake
+    // `is_new` is true if the vote has not been seen before
     pub fn add_vote_pubkey(
         &mut self,
         vote_pubkey: Arc<Pubkey>,
         stake: u64,
         total_epoch_stake: u64,
-    ) -> bool {
-        if !self.voted.contains(&vote_pubkey) {
+    ) -> (bool, bool) {
+        let is_new = !self.voted.contains(&vote_pubkey);
+        if is_new {
             self.voted.insert(vote_pubkey);
             let ratio_before = self.stake as f64 / total_epoch_stake as f64;
             self.stake += stake;
             let ratio_now = self.stake as f64 / total_epoch_stake as f64;
 
-            ratio_before <= VOTE_THRESHOLD_SIZE && ratio_now > VOTE_THRESHOLD_SIZE
+            (
+                ratio_before <= VOTE_THRESHOLD_SIZE && ratio_now > VOTE_THRESHOLD_SIZE,
+                is_new,
+            )
         } else {
-            false
+            (false, is_new)
         }
     }
 
@@ -48,21 +54,26 @@ mod test {
         let mut vote_stake_tracker = VoteStakeTracker::default();
         for i in 0..10 {
             let pubkey = Arc::new(Pubkey::new_rand());
-            let res = vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
+            let (is_confirmed, is_new) =
+                vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
             let stake = vote_stake_tracker.stake();
-            vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
+            let (is_confirmed2, is_new2) =
+                vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
             let stake2 = vote_stake_tracker.stake();
 
             // Stake should not change from adding same pubkey twice
             assert_eq!(stake, stake2);
+            assert!(!is_confirmed2);
+            assert!(!is_new2);
 
             // at i == 7, the voted stake is 70%, which is the first time crossing
             // the supermajority threshold
             if i == 6 {
-                assert!(res);
+                assert!(is_confirmed);
             } else {
-                assert!(!res);
+                assert!(!is_confirmed);
             }
+            assert!(is_new);
         }
     }
 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -686,6 +686,7 @@ fn load_bank_forks(
         snapshot_config.as_ref(),
         process_options,
         None,
+        None,
     )
 }
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -2,7 +2,7 @@ use crate::{
     blockstore::Blockstore,
     blockstore_processor::{
         self, BlockstoreProcessorError, BlockstoreProcessorResult, ProcessOptions,
-        TransactionStatusSender,
+        ReplayVotesSender, TransactionStatusSender,
     },
     entry::VerifyRecyclers,
     leader_schedule_cache::LeaderScheduleCache,
@@ -36,6 +36,7 @@ pub fn load(
     snapshot_config: Option<&SnapshotConfig>,
     process_options: ProcessOptions,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> LoadResult {
     if let Some(snapshot_config) = snapshot_config.as_ref() {
         info!(
@@ -89,6 +90,7 @@ pub fn load(
                         &process_options,
                         &VerifyRecyclers::default(),
                         transaction_status_sender,
+                        replay_votes_sender,
                     ),
                     Some(deserialized_snapshot_hash),
                 );

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -6,7 +6,7 @@ use crate::{
     entry::{create_ticks, Entry, EntrySlice, EntryVerificationStatus, VerifyRecyclers},
     leader_schedule_cache::LeaderScheduleCache,
 };
-use crossbeam_channel::Sender;
+use crossbeam_channel::{Receiver, Sender};
 use itertools::Itertools;
 use log::*;
 use rand::{seq::SliceRandom, thread_rng};
@@ -29,6 +29,7 @@ use solana_sdk::{
     timing::duration_as_ms,
     transaction::{Result, Transaction, TransactionError},
 };
+use solana_vote_program::{vote_state::Vote, vote_transaction};
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -41,6 +42,10 @@ use thiserror::Error;
 
 pub type BlockstoreProcessorResult =
     result::Result<(BankForks, LeaderScheduleCache), BlockstoreProcessorError>;
+
+pub type ReplayedVote = (Pubkey, Vote, Option<Hash>);
+pub type ReplayVotesSender = Sender<ReplayedVote>;
+pub type ReplayVotesReceiver = Receiver<ReplayedVote>;
 
 thread_local!(static PAR_THREAD_POOL: RefCell<ThreadPool> = RefCell::new(rayon::ThreadPoolBuilder::new()
                     .num_threads(get_thread_count())
@@ -93,6 +98,7 @@ fn execute_batch(
     batch: &TransactionBatch,
     bank: &Arc<Bank>,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> Result<()> {
     let (
         TransactionResults {
@@ -105,6 +111,19 @@ fn execute_batch(
         MAX_PROCESSING_AGE,
         transaction_status_sender.is_some(),
     );
+
+    if let Some(replay_votes_sender) = replay_votes_sender {
+        for (transaction, (processing_result, _)) in
+            OrderedIterator::new(batch.transactions(), batch.iteration_order())
+                .zip(&processing_results)
+        {
+            if Bank::can_commit(processing_result) && !transaction.signatures.is_empty() {
+                if let Some(parsed_vote) = vote_transaction::parse_vote_transaction(transaction) {
+                    let _ = replay_votes_sender.send(parsed_vote);
+                }
+            }
+        }
+    }
 
     if let Some(sender) = transaction_status_sender {
         send_transaction_status_batch(
@@ -126,6 +145,7 @@ fn execute_batches(
     batches: &[TransactionBatch],
     entry_callback: Option<&ProcessCallback>,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> Result<()> {
     inc_new_counter_debug!("bank-par_execute_entries-count", batches.len());
     let results: Vec<Result<()>> = PAR_THREAD_POOL.with(|thread_pool| {
@@ -133,7 +153,7 @@ fn execute_batches(
             batches
                 .into_par_iter()
                 .map_with(transaction_status_sender, |sender, batch| {
-                    let result = execute_batch(batch, bank, sender.clone());
+                    let result = execute_batch(batch, bank, sender.clone(), replay_votes_sender);
                     if let Some(entry_callback) = entry_callback {
                         entry_callback(bank);
                     }
@@ -156,8 +176,16 @@ pub fn process_entries(
     entries: &[Entry],
     randomize: bool,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> Result<()> {
-    process_entries_with_callback(bank, entries, randomize, None, transaction_status_sender)
+    process_entries_with_callback(
+        bank,
+        entries,
+        randomize,
+        None,
+        transaction_status_sender,
+        replay_votes_sender,
+    )
 }
 
 fn process_entries_with_callback(
@@ -166,6 +194,7 @@ fn process_entries_with_callback(
     randomize: bool,
     entry_callback: Option<&ProcessCallback>,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> Result<()> {
     // accumulator for entries that can be processed in parallel
     let mut batches = vec![];
@@ -182,6 +211,7 @@ fn process_entries_with_callback(
                     &batches,
                     entry_callback,
                     transaction_status_sender.clone(),
+                    replay_votes_sender,
                 )?;
                 batches.clear();
                 for hash in &tick_hashes {
@@ -237,12 +267,19 @@ fn process_entries_with_callback(
                     &batches,
                     entry_callback,
                     transaction_status_sender.clone(),
+                    replay_votes_sender,
                 )?;
                 batches.clear();
             }
         }
     }
-    execute_batches(bank, &batches, entry_callback, transaction_status_sender)?;
+    execute_batches(
+        bank,
+        &batches,
+        entry_callback,
+        transaction_status_sender,
+        replay_votes_sender,
+    )?;
     for hash in tick_hashes {
         bank.register_tick(&hash);
     }
@@ -308,7 +345,15 @@ pub fn process_blockstore(
     info!("processing ledger for slot 0...");
     let recyclers = VerifyRecyclers::default();
     process_bank_0(&bank0, blockstore, &opts, &recyclers)?;
-    process_blockstore_from_root(genesis_config, blockstore, bank0, &opts, &recyclers, None)
+    process_blockstore_from_root(
+        genesis_config,
+        blockstore,
+        bank0,
+        &opts,
+        &recyclers,
+        None,
+        None,
+    )
 }
 
 // Process blockstore from a known root bank
@@ -319,6 +364,7 @@ pub fn process_blockstore_from_root(
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> BlockstoreProcessorResult {
     info!("processing ledger from slot {}...", bank.slot());
     let allocated = thread_mem_usage::Allocatedp::default();
@@ -384,6 +430,7 @@ pub fn process_blockstore_from_root(
                 opts,
                 recyclers,
                 transaction_status_sender,
+                replay_votes_sender,
             )?;
             (initial_forks, leader_schedule_cache)
         } else {
@@ -473,6 +520,7 @@ fn confirm_full_slot(
     recyclers: &VerifyRecyclers,
     progress: &mut ConfirmationProgress,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> result::Result<(), BlockstoreProcessorError> {
     let mut timing = ConfirmationTiming::default();
     let skip_verification = !opts.poh_verify;
@@ -483,6 +531,7 @@ fn confirm_full_slot(
         progress,
         skip_verification,
         transaction_status_sender,
+        replay_votes_sender,
         opts.entry_callback.as_ref(),
         recyclers,
     )?;
@@ -543,6 +592,7 @@ pub fn confirm_slot(
     progress: &mut ConfirmationProgress,
     skip_verification: bool,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
     entry_callback: Option<&ProcessCallback>,
     recyclers: &VerifyRecyclers,
 ) -> result::Result<(), BlockstoreProcessorError> {
@@ -610,6 +660,7 @@ pub fn confirm_slot(
         true,
         entry_callback,
         transaction_status_sender,
+        replay_votes_sender,
     )
     .map_err(BlockstoreProcessorError::from);
     replay_elapsed.stop();
@@ -646,8 +697,16 @@ fn process_bank_0(
 ) -> result::Result<(), BlockstoreProcessorError> {
     assert_eq!(bank0.slot(), 0);
     let mut progress = ConfirmationProgress::new(bank0.last_blockhash());
-    confirm_full_slot(blockstore, bank0, opts, recyclers, &mut progress, None)
-        .expect("processing for bank 0 must succeed");
+    confirm_full_slot(
+        blockstore,
+        bank0,
+        opts,
+        recyclers,
+        &mut progress,
+        None,
+        None,
+    )
+    .expect("processing for bank 0 must succeed");
     bank0.freeze();
     Ok(())
 }
@@ -720,6 +779,7 @@ fn load_frozen_forks(
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> result::Result<Vec<Arc<Bank>>, BlockstoreProcessorError> {
     let mut initial_forks = HashMap::new();
     let mut last_status_report = Instant::now();
@@ -766,6 +826,7 @@ fn load_frozen_forks(
             recyclers,
             &mut progress,
             transaction_status_sender.clone(),
+            replay_votes_sender,
         )
         .is_err()
         {
@@ -816,10 +877,11 @@ fn process_single_slot(
     recyclers: &VerifyRecyclers,
     progress: &mut ConfirmationProgress,
     transaction_status_sender: Option<TransactionStatusSender>,
+    replay_votes_sender: Option<&ReplayVotesSender>,
 ) -> result::Result<(), BlockstoreProcessorError> {
     // Mark corrupt slots as dead so validators don't replay this slot and
     // see DuplicateSignature errors later in ReplayStage
-    confirm_full_slot(blockstore, bank, opts, recyclers, progress, transaction_status_sender).map_err(|err| {
+    confirm_full_slot(blockstore, bank, opts, recyclers, progress, transaction_status_sender, replay_votes_sender).map_err(|err| {
         let slot = bank.slot();
         warn!("slot {} failed to verify: {}", slot, err);
         if blockstore.is_primary_access() {
@@ -1593,7 +1655,7 @@ pub mod tests {
         );
 
         // Now ensure the TX is accepted despite pointing to the ID of an empty entry.
-        process_entries(&bank, &slot_entries, true, None).unwrap();
+        process_entries(&bank, &slot_entries, true, None, None).unwrap();
         assert_eq!(bank.process_transaction(&tx), Ok(()));
     }
 
@@ -1798,7 +1860,7 @@ pub mod tests {
         // ensure bank can process a tick
         assert_eq!(bank.tick_height(), 0);
         let tick = next_entry(&genesis_config.hash(), 1, vec![]);
-        assert_eq!(process_entries(&bank, &[tick], true, None), Ok(()));
+        assert_eq!(process_entries(&bank, &[tick], true, None, None), Ok(()));
         assert_eq!(bank.tick_height(), 1);
     }
 
@@ -1831,7 +1893,7 @@ pub mod tests {
         );
         let entry_2 = next_entry(&entry_1.hash, 1, vec![tx]);
         assert_eq!(
-            process_entries(&bank, &[entry_1, entry_2], true, None),
+            process_entries(&bank, &[entry_1, entry_2], true, None, None),
             Ok(())
         );
         assert_eq!(bank.get_balance(&keypair1.pubkey()), 2);
@@ -1891,7 +1953,8 @@ pub mod tests {
                 &bank,
                 &[entry_1_to_mint, entry_2_to_3_mint_to_1],
                 false,
-                None
+                None,
+                None,
             ),
             Ok(())
         );
@@ -1962,6 +2025,7 @@ pub mod tests {
             &bank,
             &[entry_1_to_mint.clone(), entry_2_to_3_mint_to_1.clone()],
             false,
+            None,
             None,
         )
         .is_err());
@@ -2074,6 +2138,7 @@ pub mod tests {
             ],
             false,
             None,
+            None,
         )
         .is_err());
 
@@ -2121,7 +2186,7 @@ pub mod tests {
             system_transaction::transfer(&keypair2, &keypair4.pubkey(), 1, bank.last_blockhash());
         let entry_2 = next_entry(&entry_1.hash, 1, vec![tx]);
         assert_eq!(
-            process_entries(&bank, &[entry_1, entry_2], true, None),
+            process_entries(&bank, &[entry_1, entry_2], true, None, None),
             Ok(())
         );
         assert_eq!(bank.get_balance(&keypair3.pubkey()), 1);
@@ -2181,7 +2246,7 @@ pub mod tests {
                 next_entry_mut(&mut hash, 0, transactions)
             })
             .collect();
-        assert_eq!(process_entries(&bank, &entries, true, None), Ok(()));
+        assert_eq!(process_entries(&bank, &entries, true, None, None), Ok(()));
     }
 
     #[test]
@@ -2241,7 +2306,7 @@ pub mod tests {
 
         // Transfer lamports to each other
         let entry = next_entry(&bank.last_blockhash(), 1, tx_vector);
-        assert_eq!(process_entries(&bank, &[entry], true, None), Ok(()));
+        assert_eq!(process_entries(&bank, &[entry], true, None, None), Ok(()));
         bank.squash();
 
         // Even number keypair should have balance of 2 * initial_lamports and
@@ -2299,7 +2364,7 @@ pub mod tests {
             system_transaction::transfer(&keypair1, &keypair4.pubkey(), 1, bank.last_blockhash());
         let entry_2 = next_entry(&tick.hash, 1, vec![tx]);
         assert_eq!(
-            process_entries(&bank, &[entry_1, tick, entry_2.clone()], true, None),
+            process_entries(&bank, &[entry_1, tick, entry_2.clone()], true, None, None),
             Ok(())
         );
         assert_eq!(bank.get_balance(&keypair3.pubkey()), 1);
@@ -2310,7 +2375,7 @@ pub mod tests {
             system_transaction::transfer(&keypair2, &keypair3.pubkey(), 1, bank.last_blockhash());
         let entry_3 = next_entry(&entry_2.hash, 1, vec![tx]);
         assert_eq!(
-            process_entries(&bank, &[entry_3], true, None),
+            process_entries(&bank, &[entry_3], true, None, None),
             Err(TransactionError::AccountNotFound)
         );
     }
@@ -2390,7 +2455,7 @@ pub mod tests {
         );
 
         assert_eq!(
-            process_entries(&bank, &[entry_1_to_mint], false, None),
+            process_entries(&bank, &[entry_1_to_mint], false, None, None),
             Err(TransactionError::AccountInUse)
         );
 
@@ -2449,7 +2514,6 @@ pub mod tests {
             &opts,
             &recyclers,
             &mut ConfirmationProgress::new(bank0.last_blockhash()),
-            None,
         )
         .unwrap();
         bank1.squash();
@@ -2543,7 +2607,7 @@ pub mod tests {
                 })
                 .collect();
             info!("paying iteration {}", i);
-            process_entries(&bank, &entries, true, None).expect("paying failed");
+            process_entries(&bank, &entries, true, None, None).expect("paying failed");
 
             let entries: Vec<_> = (0..NUM_TRANSFERS)
                 .step_by(NUM_TRANSFERS_PER_ENTRY)
@@ -2566,7 +2630,7 @@ pub mod tests {
                 .collect();
 
             info!("refunding iteration {}", i);
-            process_entries(&bank, &entries, true, None).expect("refunding failed");
+            process_entries(&bank, &entries, true, None, None).expect("refunding failed");
 
             // advance to next block
             process_entries(
@@ -2575,6 +2639,7 @@ pub mod tests {
                     .map(|_| next_entry_mut(&mut hash, 1, vec![]))
                     .collect::<Vec<_>>(),
                 true,
+                None,
                 None,
             )
             .expect("process ticks failed");
@@ -2618,7 +2683,7 @@ pub mod tests {
         let entry = next_entry(&new_blockhash, 1, vec![tx]);
         entries.push(entry);
 
-        process_entries_with_callback(&bank0, &entries, true, None, None).unwrap();
+        process_entries_with_callback(&bank0, &entries, true, None, None, None).unwrap();
         assert_eq!(bank0.get_balance(&keypair.pubkey()), 1)
     }
 


### PR DESCRIPTION
#### Problem
No current way of extracting vote transactions from replay pipeline for building switching proofs and accelerating detection of optimistic confirmation in `cluster_info_vote_listener.rs`

#### Summary of Changes
1) Add detection of votes from entry verification in `blockstore_processor.rs`
2) Add fast tracking of votes over a channel from replay to optimistic confirmation detection in `cluster_info_vote_listener.rs`.

Fixes #
