### PR TITLE
Add top level link to Clusters page

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
       links: [
         {
           to: "introduction",
-          label: "Docs",
+          label: "Introduction",
           position: "left",
         },
         {
@@ -28,6 +28,11 @@ module.exports = {
         {
           to: "running-validator",
           label: "Validators",
+          position: "left",
+        },
+        {
+          to: "clusters",
+          label: "Clusters",
           position: "left",
         },
         {


### PR DESCRIPTION
#### Problem
Too many clicks to get to Clusters page, a good top level entry point.

#### Summary of Changes
One click