### PR TITLE
fix: add support for getConfirmedSignaturesForAddress2 RPC method

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -50,6 +50,11 @@ declare module '@solana/web3.js' {
     skipPreflight?: boolean;
   };
 
+  export type ConfirmedSignaturesForAddress2Options = {
+    before?: TransactionSignature;
+    limit?: number;
+  };
+
   export type TokenAccountsFilter =
     | {
         mint: PublicKey;
@@ -85,6 +90,13 @@ declare module '@solana/web3.js' {
     slot: number;
     err: TransactionError | null;
     confirmations: number | null;
+  };
+
+  export type ConfirmedSignatureInfo = {
+    signature: string;
+    slot: number;
+    err: TransactionError | null;
+    memo: string | null;
   };
 
   export type BlockhashAndFeeCalculator = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -66,6 +66,11 @@ declare module '@solana/web3.js' {
     skipPreflight: ?boolean,
   };
 
+  declare export type ConfirmedSignaturesForAddress2Options = {
+    before?: TransactionSignature,
+    limit?: number,
+  };
+
   declare export type TokenAccountsFilter =
     | {
         mint: PublicKey,
@@ -101,6 +106,13 @@ declare module '@solana/web3.js' {
     slot: number,
     err: TransactionError | null,
     confirmations: number | null,
+  };
+
+  declare export type ConfirmedSignatureInfo = {
+    signature: string,
+    slot: number,
+    err: TransactionError | null,
+    memo: string | null,
   };
 
   declare export type BlockhashAndFeeCalculator = {

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -756,6 +756,7 @@ test('get confirmed signatures for address', async () => {
     }
   }
 
+  // getConfirmedSignaturesForAddress tests...
   mockRpc.push([
     url,
     {
@@ -794,6 +795,38 @@ test('get confirmed signatures for address', async () => {
     badSlot + 1,
   );
   expect(emptySignatures.length).toBe(0);
+
+  // getConfirmedSignaturesForAddress2 tests...
+  mockRpc.push([
+    url,
+    {
+      method: 'getConfirmedSignaturesForAddress2',
+      params: [address.toBase58(), {limit: 1}],
+    },
+    {
+      error: null,
+      result: [
+        {
+          signature: expectedSignature,
+          slot,
+          err: null,
+          memo: null,
+        },
+      ],
+    },
+  ]);
+
+  const confirmedSignatures2 = await connection.getConfirmedSignaturesForAddress2(
+    address,
+    {limit: 1},
+  );
+  expect(confirmedSignatures2.length).toBe(1);
+  if (mockRpcEnabled) {
+    expect(confirmedSignatures2[0].signature).toBe(expectedSignature);
+    expect(confirmedSignatures2[0].slot).toBe(slot);
+    expect(confirmedSignatures2[0].err).toBeNull();
+    expect(confirmedSignatures2[0].memo).toBeNull();
+  }
 });
 
 test('get confirmed transaction', async () => {


### PR DESCRIPTION
web3.js bindings for https://github.com/solana-labs/solana/pull/11259

Blocked until https://github.com/solana-labs/solana/pull/11259 lands and the edge docker image is rebuilt