### PR TITLE
[web3] remove instanceof checks

### DIFF
--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -19,7 +19,6 @@ declare module '@solana/web3.js' {
     constructor(
       value: number | string | Buffer | Uint8Array | Array<number>,
     ): PublicKey;
-    static isPublicKey(o: {}): boolean;
     static createWithSeed(
       fromPublicKey: PublicKey,
       seed: string,

--- a/web3.js/src/publickey.js
+++ b/web3.js/src/publickey.js
@@ -36,13 +36,6 @@ export class PublicKey {
   }
 
   /**
-   * Checks if the provided object is a PublicKey
-   */
-  static isPublicKey(o: Object): boolean {
-    return o instanceof PublicKey;
-  }
-
-  /**
    * Checks if two publicKeys are equal
    */
   equals(publicKey: PublicKey): boolean {

--- a/web3.js/test/account.test.js
+++ b/web3.js/test/account.test.js
@@ -1,10 +1,8 @@
 // @flow
 import {Account} from '../src/account';
-import {PublicKey} from '../src/publickey';
 
 test('generate new account', () => {
   const account = new Account();
-  expect(PublicKey.isPublicKey(account.publicKey)).toBeTruthy();
   expect(account.secretKey).toHaveLength(64);
 });
 

--- a/web3.js/test/publickey.test.js
+++ b/web3.js/test/publickey.test.js
@@ -103,14 +103,6 @@ test('equals', () => {
   expect(arrayKey.equals(base56Key)).toBe(true);
 });
 
-test('isPublicKey', () => {
-  const key = new PublicKey(
-    '0x100000000000000000000000000000000000000000000000000000000000000',
-  );
-  expect(PublicKey.isPublicKey(key)).toBe(true);
-  expect(PublicKey.isPublicKey({})).toBe(false);
-});
-
 test('toBase58', () => {
   const key = new PublicKey(
     '0x300000000000000000000000000000000000000000000000000000000000000',


### PR DESCRIPTION
#### Problem
Calls to `instanceof` will not work if two versions of web3 are present. After the introduction of `spl-token` library, it's
 more likely that devs will have multiple versions of web3. This is also an issue when using `spl-token` within web3 tests.

#### Summary of Changes
- Remove all references to `instanceof` and replace with more flexible checks
- Remove `isPublicKey` method

Fixes #
