### PR TITLE
Build Rust programs with `--no-default-features --features program` to match solana-sdk

### DIFF
--- a/sdk/bpf/rust/build.sh
+++ b/sdk/bpf/rust/build.sh
@@ -40,6 +40,6 @@ export XARGO_RUST_SRC="$bpf_sdk/dependencies/rust-bpf-sysroot/src"
 export RUST_COMPILER_RT_ROOT="$bpf_sdk/dependencies/rust-bpf-sysroot/src/compiler-rt"
 
 cd "$1"
-xargo build --target bpfel-unknown-unknown --release
+xargo build --target bpfel-unknown-unknown --release --no-default-features --features program
 
 { { set +x; } 2>/dev/null; echo Success; }


### PR DESCRIPTION
### Problem
spl-token crate on crates.io isn't usable by Rust clients

#### Summary of Changes
If programs are built with the same feature set as solana-sdk, https://github.com/solana-labs/solana-program-library/pull/169 becomes unblocked