### PR TITLE
Avoid spl-sdk dependency, which inhibits crate publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2928,7 +2928,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "solana-sdk 1.2.13",
  "solana-sdk 1.3.0",
  "solana-vote-program",
  "spl-token",
@@ -3236,7 +3235,6 @@ dependencies = [
  "solana-perf",
  "solana-rayon-threadlimit",
  "solana-runtime",
- "solana-sdk 1.2.13",
  "solana-sdk 1.3.0",
  "solana-sdk-macro-frozen-abi",
  "solana-stake-program",
@@ -4220,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21aa023866f97c2644f932c2562d3c20e23a817e8abb0702625e0601cf9af80"
+checksum = "e1088b10ccb61c5f4f770dd46f643e8e2e7c70aeeda4e298a10ccf2090841328"
 dependencies = [
  "cbindgen",
  "num-derive 0.2.5",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -15,8 +15,7 @@ Inflector = "0.11.4"
 lazy_static = "1.4.0"
 solana-sdk = { path = "../sdk", version = "1.3.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
-spl-sdk = { package = "solana-sdk", version = "=1.2.13", default-features = false }
-spl-token-v1-0 = { package = "spl-token", version = "1.0.2", features = ["skip-no-mangle"] }
+spl-token-v1-0 = { package = "spl-token", version = "1.0.3", features = ["skip-no-mangle"] }
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.56"

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -1,8 +1,8 @@
 use crate::parse_account_data::{ParsableAccount, ParseAccountError};
 use solana_sdk::pubkey::Pubkey;
-use spl_sdk::pubkey::Pubkey as SplPubkey;
 use spl_token_v1_0::{
     option::COption,
+    solana_sdk::pubkey::Pubkey as SplTokenPubkey,
     state::{Account, Mint, Multisig, State},
 };
 use std::{mem::size_of, str::FromStr};
@@ -51,7 +51,7 @@ pub fn parse_token(data: &[u8]) -> Result<TokenAccountType, ParseAccountError> {
                 .signers
                 .iter()
                 .filter_map(|pubkey| {
-                    if pubkey != &SplPubkey::default() {
+                    if pubkey != &SplTokenPubkey::default() {
                         Some(pubkey.to_string())
                     } else {
                         None
@@ -109,8 +109,8 @@ mod test {
 
     #[test]
     fn test_parse_token() {
-        let mint_pubkey = SplPubkey::new(&[2; 32]);
-        let owner_pubkey = SplPubkey::new(&[3; 32]);
+        let mint_pubkey = SplTokenPubkey::new(&[2; 32]);
+        let owner_pubkey = SplTokenPubkey::new(&[3; 32]);
         let mut account_data = [0; size_of::<Account>()];
         let mut account: &mut Account = State::unpack_unchecked(&mut account_data).unwrap();
         account.mint = mint_pubkey;
@@ -144,12 +144,12 @@ mod test {
             }),
         );
 
-        let signer1 = SplPubkey::new(&[1; 32]);
-        let signer2 = SplPubkey::new(&[2; 32]);
-        let signer3 = SplPubkey::new(&[3; 32]);
+        let signer1 = SplTokenPubkey::new(&[1; 32]);
+        let signer2 = SplTokenPubkey::new(&[2; 32]);
+        let signer3 = SplTokenPubkey::new(&[3; 32]);
         let mut multisig_data = [0; size_of::<Multisig>()];
         let mut multisig: &mut Multisig = State::unpack_unchecked(&mut multisig_data).unwrap();
-        let mut signers = [SplPubkey::default(); 11];
+        let mut signers = [SplTokenPubkey::default(); 11];
         signers[0] = signer1;
         signers[1] = signer2;
         signers[2] = signer3;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,8 +67,7 @@ solana-transaction-status = { path = "../transaction-status", version = "1.3.0" 
 solana-version = { path = "../version", version = "1.3.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.3.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.3.0" }
-spl-sdk = { package = "solana-sdk", version = "=1.2.13", default-features = false }
-spl-token-v1-0 = { package = "spl-token", version = "1.0.2", features = ["skip-no-mangle"] }
+spl-token-v1-0 = { package = "spl-token", version = "1.0.3", features = ["skip-no-mangle"] }
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = "0.1"

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2087,8 +2087,9 @@ pub mod tests {
         vote_instruction,
         vote_state::{Vote, VoteInit, MAX_LOCKOUT_HISTORY},
     };
-    use spl_sdk::pubkey::Pubkey as SplPubkey;
-    use spl_token_v1_0::{option::COption, state::Mint};
+    use spl_token_v1_0::{
+        option::COption, solana_sdk::pubkey::Pubkey as SplTokenPubkey, state::Mint,
+    };
     use std::collections::HashMap;
 
     const TEST_MINT_LAMPORTS: u64 = 1_000_000;
@@ -4267,9 +4268,9 @@ pub mod tests {
 
         let mut account_data = [0; size_of::<TokenAccount>()];
         let account: &mut TokenAccount = TokenState::unpack_unchecked(&mut account_data).unwrap();
-        let mint = SplPubkey::new(&[2; 32]);
-        let owner = SplPubkey::new(&[3; 32]);
-        let delegate = SplPubkey::new(&[4; 32]);
+        let mint = SplTokenPubkey::new(&[2; 32]);
+        let owner = SplTokenPubkey::new(&[3; 32]);
+        let delegate = SplTokenPubkey::new(&[4; 32]);
         *account = TokenAccount {
             mint,
             owner,
@@ -4349,7 +4350,7 @@ pub mod tests {
         // Add another token account with the same owner and delegate but different mint
         let mut account_data = [0; size_of::<TokenAccount>()];
         let account: &mut TokenAccount = TokenState::unpack_unchecked(&mut account_data).unwrap();
-        let new_mint = SplPubkey::new(&[5; 32]);
+        let new_mint = SplTokenPubkey::new(&[5; 32]);
         *account = TokenAccount {
             mint: new_mint,
             owner,


### PR DESCRIPTION
cargo publish is broken, because it won't publish a crate that specifies different versions of the same dependency.   With https://github.com/solana-labs/solana-program-library/pull/170, the "spl-sdk" dependency can be avoided entirely.

This PR is blocked until spl-token v1.0.3 is published
