### PR TITLE
Test off curve pubkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3849,6 +3849,7 @@ dependencies = [
  "bv",
  "byteorder",
  "chrono",
+ "curve25519-dalek",
  "ed25519-dalek",
  "generic-array 0.14.3",
  "hex",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -60,6 +60,7 @@ solana-sdk-macro-frozen-abi = { path = "macro-frozen-abi", version = "1.3.0" }
 rustversion = "1.0.3"
 
 [dev-dependencies]
+curve25519-dalek = "2.1.0"
 tiny-bip39 = "0.7.0"
 
 [package.metadata.docs.rs]

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -61,16 +61,18 @@ impl Signature {
         Self(GenericArray::clone_from_slice(&signature_slice))
     }
 
+    pub(self) fn verify_verbose(
+        &self,
+        pubkey_bytes: &[u8],
+        message_bytes: &[u8],
+    ) -> Result<(), ed25519_dalek::SignatureError> {
+        let publickey = ed25519_dalek::PublicKey::from_bytes(pubkey_bytes)?;
+        let signature = self.0.as_slice().try_into()?;
+        publickey.verify_strict(message_bytes, &signature)
+    }
+
     pub fn verify(&self, pubkey_bytes: &[u8], message_bytes: &[u8]) -> bool {
-        let pubkey = ed25519_dalek::PublicKey::from_bytes(pubkey_bytes);
-        let signature = self.0.as_slice().try_into();
-        if pubkey.is_err() || signature.is_err() {
-            return false;
-        }
-        pubkey
-            .unwrap()
-            .verify_strict(message_bytes, &signature.unwrap())
-            .is_ok()
+        self.verify_verbose(pubkey_bytes, message_bytes).is_ok()
     }
 }
 


### PR DESCRIPTION
#### Problem

No test that pubkeys which aren't on the ed25519 curve cause signature verification to fail.

#### Summary of Changes

Add one