### PR TITLE
Withdraw authority no longer implies a custodian

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -32,7 +32,7 @@ use solana_stake_program::{
     stake_state::{Authorized, Lockup, Meta, StakeAuthorize, StakeState},
 };
 use solana_vote_program::vote_state::VoteState;
-use std::{collections::HashSet, ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc};
 
 pub const STAKE_AUTHORITY_ARG: ArgConstant<'static> = ArgConstant {
     name: "stake_authority",
@@ -1485,7 +1485,7 @@ pub fn build_stake_state(
             let (active_stake, activating_stake, deactivating_stake) = stake
                 .delegation
                 .stake_activating_and_deactivating(current_epoch, Some(stake_history));
-            let lockup = if lockup.is_in_force(clock, &HashSet::new()) {
+            let lockup = if lockup.is_in_force(clock, None) {
                 Some(lockup.into())
             } else {
                 None
@@ -1535,7 +1535,7 @@ pub fn build_stake_state(
             authorized,
             lockup,
         }) => {
-            let lockup = if lockup.is_in_force(clock, &HashSet::new()) {
+            let lockup = if lockup.is_in_force(clock, None) {
                 Some(lockup.into())
             } else {
                 None

--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -23,14 +23,14 @@ pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> NonCirculatingSuppl
         let stake_account = StakeState::from(&account).unwrap_or_default();
         match stake_account {
             StakeState::Initialized(meta) => {
-                if meta.lockup.is_in_force(&clock, &HashSet::default())
+                if meta.lockup.is_in_force(&clock, None)
                     || withdraw_authority_list.contains(&meta.authorized.withdrawer)
                 {
                     non_circulating_accounts_set.insert(*pubkey);
                 }
             }
             StakeState::Stake(meta, _stake) => {
-                if meta.lockup.is_in_force(&clock, &HashSet::default())
+                if meta.lockup.is_in_force(&clock, None)
                     || withdraw_authority_list.contains(&meta.authorized.withdrawer)
                 {
                     non_circulating_accounts_set.insert(*pubkey);

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -454,7 +454,8 @@ pub fn process_instruction(
                 to,
                 &Clock::from_keyed_account(next_keyed_account(keyed_accounts)?)?,
                 &StakeHistory::from_keyed_account(next_keyed_account(keyed_accounts)?)?,
-                &signers,
+                next_keyed_account(keyed_accounts)?,
+                keyed_accounts.next(),
             )
         }
         StakeInstruction::Deactivate => me.deactivate(

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -452,7 +452,7 @@ mod test {
         let instructions = stake_instruction::create_account(
             &payer.pubkey(),
             &stake3_keypair.pubkey(),
-            &Authorized::auto(&payer.pubkey()),
+            &Authorized::auto(&stake3_keypair.pubkey()),
             &Lockup::default(),
             one_sol,
         );


### PR DESCRIPTION
#### Problem

If the stake account uses the same public key for both custodian and withdraw authority, a withdraw authority signature would imply a custodian signature, permitting a withdraw of the locked up account.

#### Summary of Changes

* Require the custodian argument to override lockup. Currently, any signer that matches the configured custodian will suffice.
* Require the withdraw authority argument to match the configured withdraw authority. Currently, any signer that matches the configured withdraw authority will suffice.