### PR TITLE
Enable new fork choice on mainnet, 400,000 slots into epoch 61

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1860,7 +1860,8 @@ impl ReplayStage {
     pub fn get_unlock_switch_vote_slot(operating_mode: OperatingMode) -> Slot {
         match operating_mode {
             OperatingMode::Development => 0,
-            OperatingMode::Stable => std::u64::MAX / 2,
+            // 400_000 slots into epoch 61
+            OperatingMode::Stable => 26_752_000,
             // Epoch 63
             OperatingMode::Preview => 21_692_256,
         }
@@ -1869,7 +1870,8 @@ impl ReplayStage {
     pub fn get_unlock_heaviest_subtree_fork_choice(operating_mode: OperatingMode) -> Slot {
         match operating_mode {
             OperatingMode::Development => 0,
-            OperatingMode::Stable => std::u64::MAX / 2,
+            // 400_000 slots into epoch 61
+            OperatingMode::Stable => 26_752_000,
             // Epoch 63
             OperatingMode::Preview => 21_692_256,
         }


### PR DESCRIPTION
#### Problem
New fork choice rule not enabled on 1.2 for mainnet

#### Summary of Changes
Based on upgrade schedule, enable the new fork choice rule on mainnet for 400,000 slots into epoch 61, roughly 22 hours after everyone has upgraded.

Fixes #
