### PR TITLE
Remove ::solana_sdk hack

### DIFF
--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -58,16 +58,12 @@ macro_rules! declare_name {
                 // `declare_name(foo)`
                 //
                 // See the `respan!` macro for more details.
-                // This should use `crate::respan!` once
-                // https://github.com/rust-lang/rust/pull/72121 is merged:
-                // see https://github.com/solana-labs/solana/issues/10933.
-                // For now, we need to use `::solana_sdk`
                 //
                 // `respan!` respans the path `$crate::id`, which we then call (hence the extra
                 // parens)
                 (
                     stringify!($filename).to_string(),
-                    ::solana_sdk::respan!($crate::$id, $name)(),
+                    $crate::respan!($crate::$id, $name)(),
                 )
             };
         }


### PR DESCRIPTION
Fixes #10933

Now that https://github.com/rust-lang/rust/pull/72121 has been merged,
using a `$crate` path from a nested `macro_rules!` will work properly
across multiple crates. This allows us to stop using `::solana_sdk`
to reference to the `respan!` macro.

