### PR TITLE
Improve explorer tx count animation

### DIFF
--- a/explorer/src/providers/stats/solanaBeach.tsx
+++ b/explorer/src/providers/stats/solanaBeach.tsx
@@ -74,7 +74,7 @@ const DashboardContext = React.createContext<DashboardState | undefined>(
   undefined
 );
 
-type PerformanceInfo = StructType<typeof PerformanceInfo>;
+export type PerformanceInfo = StructType<typeof PerformanceInfo>;
 type PerformanceState = { info: PerformanceInfo | undefined };
 const PerformanceContext = React.createContext<PerformanceState | undefined>(
   undefined


### PR DESCRIPTION
#### Problem
- Count up can get stalled if the latest performance info message is delayed

#### Summary of Changes
- Overshoot the latest tx count by 10s in the animation to avoid delay issues

Fixes #
