### PR TITLE
Make accounts explicit in unrecognized jsonParsed instructions

### DIFF
--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use solana_sdk::message::Message;
 
 type AccountAttributes = Vec<AccountAttribute>;
@@ -11,7 +11,7 @@ enum AccountAttribute {
 }
 
 pub fn parse_accounts(message: &Message) -> Value {
-    let mut accounts: Vec<Value> = vec![];
+    let mut accounts: Map<String, Value> = Map::new();
     for (i, account_key) in message.account_keys.iter().enumerate() {
         let mut attributes: AccountAttributes = vec![];
         if message.is_writable(i) {
@@ -20,7 +20,7 @@ pub fn parse_accounts(message: &Message) -> Value {
         if message.is_signer(i) {
             attributes.push(AccountAttribute::Signer);
         }
-        accounts.push(json!({ account_key.to_string(): attributes }));
+        accounts.insert(account_key.to_string(), json!(attributes));
     }
     json!(accounts)
 }
@@ -44,12 +44,12 @@ mod test {
         };
         message.account_keys = vec![pubkey0, pubkey1, pubkey2, pubkey3];
 
-        let expected_json = json!([
-            {pubkey0.to_string(): ["writable", "signer"]},
-            {pubkey1.to_string(): ["signer"]},
-            {pubkey2.to_string(): ["writable"]},
-            {pubkey3.to_string(): []},
-        ]);
+        let expected_json = json!({
+            pubkey0.to_string(): ["writable", "signer"],
+            pubkey1.to_string(): ["signer"],
+            pubkey2.to_string(): ["writable"],
+            pubkey3.to_string(): [],
+        });
 
         assert_eq!(parse_accounts(&message), expected_json);
     }


### PR DESCRIPTION
#### Problem
In a `jsonParsed` message, the `message.accountKeys` list is forced to be an array or objects, so that the indexes in any instructions that cannot be decoded still make sense. But this makes `message.accountKeys` harder to work with downstream. 

#### Summary of Changes
Convert instruction indexes in unrecognized jsonParsed instructions to explicit keys, so that `message.accountKeys` can be a proper map

cc: @jstarry 
