### PR TITLE
Use more accurate epoch duration calculation in explorer

### DIFF
--- a/explorer/src/components/StatsCard.tsx
+++ b/explorer/src/components/StatsCard.tsx
@@ -62,12 +62,16 @@ function StatsCardBody() {
   }
 
   const currentBlock = rootSlot.toLocaleString("en-US");
-  const { avgBlockTime_1min, epochInfo } = dashboardInfo;
+  const { avgBlockTime_1h, avgBlockTime_1min, epochInfo } = dashboardInfo;
+  const hourlyBlockTime = Math.round(1000 * avgBlockTime_1h);
   const averageBlockTime = Math.round(1000 * avgBlockTime_1min) + "ms";
   const { slotIndex, slotsInEpoch } = epochInfo;
   const currentEpoch = epochInfo.epoch.toString();
   const epochProgress = ((100 * slotIndex) / slotsInEpoch).toFixed(1) + "%";
-  const epochTimeRemaining = slotsToHumanString(slotsInEpoch - slotIndex);
+  const epochTimeRemaining = slotsToHumanString(
+    slotsInEpoch - slotIndex,
+    hourlyBlockTime
+  );
   const averageTps = Math.round(performanceInfo.avgTPS);
   const transactionCount = <AnimatedTransactionCount info={performanceInfo} />;
 

--- a/explorer/src/utils/index.tsx
+++ b/explorer/src/utils/index.tsx
@@ -52,6 +52,9 @@ HUMANIZER.addLanguage("short", {
   decimal: ".",
 });
 
-export function slotsToHumanString(slots: number): string {
-  return HUMANIZER.humanize(slots * MS_PER_SLOT);
+export function slotsToHumanString(
+  slots: number,
+  slotTime = MS_PER_SLOT
+): string {
+  return HUMANIZER.humanize(slots * slotTime);
 }


### PR DESCRIPTION
#### Problem
Explorer is currently estimating epoch duration using 400ms block times. In practice, slot times average around 480ms right now on mainnet. 

#### Summary of Changes
- Use hourly average block time to estimate epoch time remaining

Fixes #
