### PR TITLE
Update instruction encoding format

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -250,7 +250,9 @@ impl EncodedTransaction {
                                     instruction,
                                     &transaction.message.account_keys,
                                 ) {
-                                    UiInstruction::Parsed(parsed_instruction)
+                                    UiInstruction::Parsed(
+                                        serde_json::to_value(parsed_instruction).unwrap(),
+                                    )
                                 } else {
                                     UiInstruction::Parsed(json!(
                                         UiPartiallyDecodedInstruction::from(

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -7,8 +7,10 @@ pub mod parse_accounts;
 pub mod parse_instruction;
 pub mod parse_token;
 
-use crate::{parse_accounts::parse_accounts, parse_instruction::parse};
-use serde_json::{json, Value};
+use crate::{
+    parse_accounts::{parse_accounts, ParsedAccount},
+    parse_instruction::{parse, ParsedInstruction},
+};
 use solana_sdk::{
     clock::{Slot, UnixTimestamp},
     commitment_config::CommitmentConfig,
@@ -23,7 +25,14 @@ use solana_sdk::{
 #[serde(rename_all = "camelCase", untagged)]
 pub enum UiInstruction {
     Compiled(UiCompiledInstruction),
-    Parsed(Value),
+    Parsed(UiParsedInstruction),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum UiParsedInstruction {
+    Parsed(ParsedInstruction),
+    PartiallyDecoded(UiPartiallyDecodedInstruction),
 }
 
 /// A duplicate representation of a CompiledInstruction for pretty JSON serialization
@@ -183,7 +192,7 @@ pub struct UiRawMessage {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UiParsedMessage {
-    pub account_keys: Value,
+    pub account_keys: Vec<ParsedAccount>,
     pub recent_blockhash: String,
     pub instructions: Vec<UiInstruction>,
 }
@@ -236,7 +245,7 @@ impl EncodedTransaction {
                     })
                 } else {
                     UiMessage::Parsed(UiParsedMessage {
-                        account_keys: json!(parse_accounts(&transaction.message)),
+                        account_keys: parse_accounts(&transaction.message),
                         recent_blockhash: transaction.message.recent_blockhash.to_string(),
                         instructions: transaction
                             .message
@@ -250,13 +259,15 @@ impl EncodedTransaction {
                                     instruction,
                                     &transaction.message.account_keys,
                                 ) {
-                                    UiInstruction::Parsed(json!(parsed_instruction))
+                                    UiInstruction::Parsed(UiParsedInstruction::Parsed(
+                                        parsed_instruction,
+                                    ))
                                 } else {
-                                    UiInstruction::Parsed(json!(
+                                    UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(
                                         UiPartiallyDecodedInstruction::from(
                                             instruction,
-                                            &transaction.message.account_keys
-                                        )
+                                            &transaction.message.account_keys,
+                                        ),
                                     ))
                                 }
                             })

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -236,7 +236,7 @@ impl EncodedTransaction {
                     })
                 } else {
                     UiMessage::Parsed(UiParsedMessage {
-                        account_keys: parse_accounts(&transaction.message),
+                        account_keys: json!(parse_accounts(&transaction.message)),
                         recent_blockhash: transaction.message.recent_blockhash.to_string(),
                         instructions: transaction
                             .message
@@ -250,9 +250,7 @@ impl EncodedTransaction {
                                     instruction,
                                     &transaction.message.account_keys,
                                 ) {
-                                    UiInstruction::Parsed(
-                                        serde_json::to_value(parsed_instruction).unwrap(),
-                                    )
+                                    UiInstruction::Parsed(json!(parsed_instruction))
                                 } else {
                                     UiInstruction::Parsed(json!(
                                         UiPartiallyDecodedInstruction::from(

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -1,28 +1,23 @@
-use serde_json::{json, Map, Value};
 use solana_sdk::message::Message;
 
-type AccountAttributes = Vec<AccountAttribute>;
-
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-enum AccountAttribute {
-    Signer,
-    Writable,
+pub struct ParsedAccount {
+    pub pubkey: String,
+    pub writable: bool,
+    pub signer: bool,
 }
 
-pub fn parse_accounts(message: &Message) -> Value {
-    let mut accounts: Map<String, Value> = Map::new();
+pub fn parse_accounts(message: &Message) -> Vec<ParsedAccount> {
+    let mut accounts: Vec<ParsedAccount> = vec![];
     for (i, account_key) in message.account_keys.iter().enumerate() {
-        let mut attributes: AccountAttributes = vec![];
-        if message.is_writable(i) {
-            attributes.push(AccountAttribute::Writable);
-        }
-        if message.is_signer(i) {
-            attributes.push(AccountAttribute::Signer);
-        }
-        accounts.insert(account_key.to_string(), json!(attributes));
+        accounts.push(ParsedAccount {
+            pubkey: account_key.to_string(),
+            writable: message.is_writable(i),
+            signer: message.is_signer(i),
+        });
     }
-    json!(accounts)
+    accounts
 }
 
 #[cfg(test)]
@@ -44,13 +39,30 @@ mod test {
         };
         message.account_keys = vec![pubkey0, pubkey1, pubkey2, pubkey3];
 
-        let expected_json = json!({
-            pubkey0.to_string(): ["writable", "signer"],
-            pubkey1.to_string(): ["signer"],
-            pubkey2.to_string(): ["writable"],
-            pubkey3.to_string(): [],
-        });
-
-        assert_eq!(parse_accounts(&message), expected_json);
+        assert_eq!(
+            parse_accounts(&message),
+            vec![
+                ParsedAccount {
+                    pubkey: pubkey0.to_string(),
+                    writable: true,
+                    signer: true,
+                },
+                ParsedAccount {
+                    pubkey: pubkey1.to_string(),
+                    writable: false,
+                    signer: true,
+                },
+                ParsedAccount {
+                    pubkey: pubkey2.to_string(),
+                    writable: true,
+                    signer: false,
+                },
+                ParsedAccount {
+                    pubkey: pubkey3.to_string(),
+                    writable: false,
+                    signer: false,
+                },
+            ]
+        );
     }
 }

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -1,6 +1,6 @@
 use solana_sdk::message::Message;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ParsedAccount {
     pub pubkey: String,

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -1,6 +1,6 @@
 use crate::parse_token::parse_token;
 use inflector::Inflector;
-use serde_json::{json, Value};
+use serde_json::Value;
 use solana_account_decoder::parse_token::spl_token_id_v1_0;
 use solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey};
 use std::{
@@ -21,7 +21,7 @@ lazy_static! {
     };
 }
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum ParseInstructionError {
     #[error("{0:?} instruction not parsable")]
     InstructionNotParsable(ParsableProgram),
@@ -31,6 +31,24 @@ pub enum ParseInstructionError {
 
     #[error("Program not parsable")]
     ProgramNotParsable,
+
+    #[error("Serde json error")]
+    SerdeJsonError(#[from] serde_json::error::Error),
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ParsedInstruction {
+    pub program: String,
+    pub program_id: String,
+    pub parsed: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ParsedInstructionEnum {
+    pub instruction_type: String,
+    pub info: Value,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -44,17 +62,19 @@ pub fn parse(
     program_id: &Pubkey,
     instruction: &CompiledInstruction,
     account_keys: &[Pubkey],
-) -> Result<Value, ParseInstructionError> {
+) -> Result<ParsedInstruction, ParseInstructionError> {
     let program_name = PARSABLE_PROGRAM_IDS
         .get(program_id)
         .ok_or_else(|| ParseInstructionError::ProgramNotParsable)?;
     let parsed_json = match program_name {
         ParsableProgram::SplMemo => parse_memo(instruction),
-        ParsableProgram::SplToken => parse_token(instruction, account_keys)?,
+        ParsableProgram::SplToken => serde_json::to_value(parse_token(instruction, account_keys)?)?,
     };
-    Ok(json!({
-        format!("{:?}", program_name).to_kebab_case(): parsed_json
-    }))
+    Ok(ParsedInstruction {
+        program: format!("{:?}", program_name).to_kebab_case(),
+        program_id: program_id.to_string(),
+        parsed: parsed_json,
+    })
 }
 
 fn parse_memo(instruction: &CompiledInstruction) -> Value {
@@ -64,6 +84,7 @@ fn parse_memo(instruction: &CompiledInstruction) -> Value {
 #[cfg(test)]
 mod test {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_parse() {
@@ -72,18 +93,16 @@ mod test {
             accounts: vec![],
             data: vec![240, 159, 166, 150],
         };
-        let expected_json = json!({
-            "spl-memo": "🦖"
-        });
         assert_eq!(
             parse(&MEMO_PROGRAM_ID, &memo_instruction, &[]).unwrap(),
-            expected_json
+            ParsedInstruction {
+                program: "spl-memo".to_string(),
+                program_id: MEMO_PROGRAM_ID.to_string(),
+                parsed: json!("🦖"),
+            }
         );
 
         let non_parsable_program_id = Pubkey::new(&[1; 32]);
-        assert_eq!(
-            parse(&non_parsable_program_id, &memo_instruction, &[]).unwrap_err(),
-            ParseInstructionError::ProgramNotParsable
-        );
+        assert!(parse(&non_parsable_program_id, &memo_instruction, &[]).is_err());
     }
 }

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -32,11 +32,11 @@ pub enum ParseInstructionError {
     #[error("Program not parsable")]
     ProgramNotParsable,
 
-    #[error("Serde json error")]
+    #[error("Internal error, please report")]
     SerdeJsonError(#[from] serde_json::error::Error),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ParsedInstruction {
     pub program: String,
@@ -47,6 +47,7 @@ pub struct ParsedInstruction {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ParsedInstructionEnum {
+    #[serde(rename = "type")]
     pub instruction_type: String,
     pub info: Value,
 }


### PR DESCRIPTION
#### Problem
RPC parsed responses are not very client friendly.

#### Summary of Changes
- Update Transaction-related encoding formats: message account keys and instruction

New account-key formatting:
```json
"accountKeys": [
  {
    "pubkey": "4frSc8sFGfUsTMWeFmE2dg9NqgLXk63jTwwc1yGyR3dr",
    "signer": true,
    "writable": true
  },
  {
    "pubkey": "8z1JZ5K2b5LyovkCckdXJGNoyGCtXXCpmehKvbNxYgeB",
    "signer": true,
    "writable": true
  },
  {
    "pubkey": "TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o",
    "signer": false,
    "writable": false
  }
]
```

New instruction formatting:
```json
{
  "parsed": {
    "info": {
      "account": "8z1JZ5K2b5LyovkCckdXJGNoyGCtXXCpmehKvbNxYgeB",
      "mint": "6dQhs6hK9LFxKdRn1yQaw5TBhHVw4hzq4vbAcuaYYuaq",
      "owner": "8q3Md4QBT6Ucm1AorRfTXCAbVe6m57XspTGHdNJPvDK8"
    },
    "type": "initializeAccount"
  },
  "program": "spl-token",
  "programId": "TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
}
```

Toward #11357 
