### PR TITLE
.gitignore: Keep .DS_Store out of the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ log-*/
 # fetch-spl.sh artifacts
 /spl-genesis-args.sh
 /spl_*.so
+
+.DS_Store


### PR DESCRIPTION
🚔 A .DS_Store snuck into https://github.com/solana-labs/solana/pull/11368