### PR TITLE
Return token amounts as floats

### DIFF
--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -7,9 +7,16 @@ use spl_token_v1_0::{
 };
 use std::{mem::size_of, str::FromStr};
 
-// A helper function to convert spl_token_v1_0::id() as spl_sdk::pubkey::Pubkey to solana_sdk::pubkey::Pubkey
+// A helper function to convert spl_token_v1_0::id() as spl_sdk::pubkey::Pubkey to
+// solana_sdk::pubkey::Pubkey
 pub fn spl_token_id_v1_0() -> Pubkey {
     Pubkey::from_str(&spl_token_v1_0::id().to_string()).unwrap()
+}
+
+// A helper function to convert spl_token_v1_0::native_mint::id() as spl_sdk::pubkey::Pubkey to
+// solana_sdk::pubkey::Pubkey
+pub fn spl_token_v1_0_native_mint() -> Pubkey {
+    Pubkey::from_str(&spl_token_v1_0::native_mint::id().to_string()).unwrap()
 }
 
 pub fn parse_token(data: &[u8]) -> Result<TokenAccountType, ParseAccountError> {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -734,7 +734,7 @@ impl RpcClient {
         })
     }
 
-    pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<f64> {
+    pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<RpcTokenAmount> {
         Ok(self
             .get_token_account_balance_with_commitment(pubkey, CommitmentConfig::default())?
             .value)
@@ -744,7 +744,7 @@ impl RpcClient {
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<f64> {
+    ) -> RpcResult<RpcTokenAmount> {
         self.send(
             RpcRequest::GetTokenAccountBalance,
             json!([pubkey.to_string(), commitment_config]),
@@ -841,7 +841,7 @@ impl RpcClient {
         })
     }
 
-    pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<f64> {
+    pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<RpcTokenAmount> {
         Ok(self
             .get_token_supply_with_commitment(mint, CommitmentConfig::default())?
             .value)
@@ -851,7 +851,7 @@ impl RpcClient {
         &self,
         mint: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<f64> {
+    ) -> RpcResult<RpcTokenAmount> {
         self.send(
             RpcRequest::GetTokenSupply,
             json!([mint.to_string(), commitment_config]),

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -734,7 +734,7 @@ impl RpcClient {
         })
     }
 
-    pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<u64> {
+    pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<f64> {
         Ok(self
             .get_token_account_balance_with_commitment(pubkey, CommitmentConfig::default())?
             .value)
@@ -744,7 +744,7 @@ impl RpcClient {
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<u64> {
+    ) -> RpcResult<f64> {
         self.send(
             RpcRequest::GetTokenAccountBalance,
             json!([pubkey.to_string(), commitment_config]),
@@ -841,7 +841,7 @@ impl RpcClient {
         })
     }
 
-    pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<u64> {
+    pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<f64> {
         Ok(self
             .get_token_supply_with_commitment(mint, CommitmentConfig::default())?
             .value)
@@ -851,7 +851,7 @@ impl RpcClient {
         &self,
         mint: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<u64> {
+    ) -> RpcResult<f64> {
         self.send(
             RpcRequest::GetTokenSupply,
             json!([mint.to_string(), commitment_config]),

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -226,7 +226,7 @@ pub struct RpcStakeActivation {
 pub struct RpcTokenAmount {
     pub ui_amount: f64,
     pub decimals: u8,
-    pub amount: RpcAmount, // "u64"
+    pub amount: RpcAmount,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -9,6 +9,7 @@ use solana_sdk::{
 use std::{collections::HashMap, net::SocketAddr};
 
 pub type RpcResult<T> = client_error::Result<Response<T>>;
+pub type RpcAmount = String;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RpcResponseContext {
@@ -222,7 +223,16 @@ pub struct RpcStakeActivation {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct RpcTokenAmount {
+    pub ui_amount: f64,
+    pub decimals: u8,
+    pub amount: RpcAmount, // "u64"
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct RpcTokenAccountBalance {
     pub address: String,
-    pub amount: f64,
+    #[serde(flatten)]
+    pub amount: RpcTokenAmount,
 }

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -224,5 +224,5 @@ pub struct RpcStakeActivation {
 #[serde(rename_all = "camelCase")]
 pub struct RpcTokenAccountBalance {
     pub address: String,
-    pub amount: u64,
+    pub amount: f64,
 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -4404,7 +4404,8 @@ pub mod tests {
         let result: Value = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
         let balance: f64 = serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert_eq!(balance, 4.2);
+        let error = f64::EPSILON;
+        assert!((balance - 4.2).abs() < error);
 
         // Test non-existent token account
         let req = format!(
@@ -4428,7 +4429,8 @@ pub mod tests {
         let result: Value = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
         let supply: f64 = serde_json::from_value(result["result"]["value"].clone()).unwrap();
-        assert_eq!(supply, 2.0 * 4.2);
+        let error = f64::EPSILON;
+        assert!((supply - 2.0 * 4.2).abs() < error);
 
         // Test non-existent mint address
         let req = format!(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1113,7 +1113,7 @@ fn get_token_program_id_and_mint(
 /// program_id) and decimals
 fn get_mint_owner_and_decimals(bank: &Arc<Bank>, mint: &Pubkey) -> Result<(Pubkey, u8)> {
     if mint == &spl_token_v1_0_native_mint() {
-        // Uncomment the following once spl_token is bumped to a version that includes ative_mint::DECIMALS
+        // Uncomment the following once spl_token is bumped to a version that includes native_mint::DECIMALS
         // Ok((spl_token_id_v1_0(), spl_token_v1_0::native_mint::DECIMALS))
         Ok((spl_token_id_v1_0(), 9))
     } else {

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1033,8 +1033,9 @@ Returns the token balance of an SPL Token account.
 
 The result will be an RpcResponse JSON object with `value` equal to a JSON object containing:
 
-- `amount: <f64>` - the balance, using mint-prescribed decimals
-- `rawAmount: <u64>` - the raw balance without decimals
+- `uiAmount: <f64>` - the balance, using mint-prescribed decimals
+- `amount: <string>` - the raw balance without decimals, a string representation of u64
+- `decimals: <u8>` - number of base 10 digits to the right of the decimal place
 
 #### Example:
 
@@ -1042,7 +1043,7 @@ The result will be an RpcResponse JSON object with `value` equal to a JSON objec
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getTokenAccountBalance", "params": ["7fUAJdStEuGbc3sM84cKRL6yYaaSstyLSU4ve5oovLS7"]}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":{"amount":98.64,"rawAmount":9864},"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":{"uiAmount":98.64,"amount":"9864","decimals":2},"id":1}
 ```
 
 ### getTokenAccountsByDelegate
@@ -1130,8 +1131,9 @@ Returns the total supply of an SPL Token type.
 
 The result will be an RpcResponse JSON object with `value` equal to a JSON object containing:
 
-- `amount: <f64>` - the total token supply, using mint-prescribed decimals
-- `rawAmount: <u64>` - the raw total token supply without decimals
+- `uiAmount: <f64>` - the total token supply, using mint-prescribed decimals
+- `amount: <string>` - the raw total token supply without decimals, a string representation of u64
+- `decimals: <u8>` - number of base 10 digits to the right of the decimal place
 
 #### Example:
 
@@ -1139,8 +1141,8 @@ The result will be an RpcResponse JSON object with `value` equal to a JSON objec
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getTokenSupply", "params": ["3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E"]}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":{"amount":1000.0,"rawAmount":100000},"id":1}
-```}
+{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":{"uiAmount":1000.0,"amount":"100000","decimals":2},"id":1}
+```
 
 ### getTransactionCount
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1031,7 +1031,10 @@ Returns the token balance of an SPL Token account.
 
 #### Results:
 
-- `RpcResponse<f64>` - RpcResponse JSON object with `value` field set to the balance, using mint-prescribed decimals
+The result will be an RpcResponse JSON object with `value` equal to a JSON object containing:
+
+- `amount: <f64>` - the balance, using mint-prescribed decimals
+- `rawAmount: <u64>` - the raw balance without decimals
 
 #### Example:
 
@@ -1039,7 +1042,7 @@ Returns the token balance of an SPL Token account.
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getTokenAccountBalance", "params": ["7fUAJdStEuGbc3sM84cKRL6yYaaSstyLSU4ve5oovLS7"]}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":98.64,"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":{"amount":98.64,"rawAmount":9864},"id":1}
 ```
 
 ### getTokenAccountsByDelegate
@@ -1125,7 +1128,10 @@ Returns the total supply of an SPL Token type.
 
 #### Results:
 
-- `RpcResponse<f64>` - RpcResponse JSON object with `value` field set to the total token supply, using mint-prescribed decimals
+The result will be an RpcResponse JSON object with `value` equal to a JSON object containing:
+
+- `amount: <f64>` - the total token supply, using mint-prescribed decimals
+- `rawAmount: <u64>` - the raw total token supply without decimals
 
 #### Example:
 
@@ -1133,8 +1139,8 @@ Returns the total supply of an SPL Token type.
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getTokenSupply", "params": ["3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E"]}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":1000.0,"id":1}
-```
+{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":{"amount":1000.0,"rawAmount":100000},"id":1}
+```}
 
 ### getTransactionCount
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1031,7 +1031,7 @@ Returns the token balance of an SPL Token account.
 
 #### Results:
 
-- `RpcResponse<u64>` - RpcResponse JSON object with `value` field set to the balance
+- `RpcResponse<f64>` - RpcResponse JSON object with `value` field set to the balance, using mint-prescribed decimals
 
 #### Example:
 
@@ -1039,7 +1039,7 @@ Returns the token balance of an SPL Token account.
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getTokenAccountBalance", "params": ["7fUAJdStEuGbc3sM84cKRL6yYaaSstyLSU4ve5oovLS7"]}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":9864,"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":98.64,"id":1}
 ```
 
 ### getTokenAccountsByDelegate
@@ -1125,7 +1125,7 @@ Returns the total supply of an SPL Token type.
 
 #### Results:
 
-- `RpcResponse<u64>` - RpcResponse JSON object with `value` field set to the total token supply
+- `RpcResponse<f64>` - RpcResponse JSON object with `value` field set to the total token supply, using mint-prescribed decimals
 
 #### Example:
 
@@ -1133,7 +1133,7 @@ Returns the total supply of an SPL Token type.
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getTokenSupply", "params": ["3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E"]}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":100000,"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":1000.0,"id":1}
 ```
 
 ### getTransactionCount


### PR DESCRIPTION
#### Problem
In order to correctly represent a spl-token balance to the user, it needs to be normalized with the mint's decimals value. But getTokenAccountBalance/getTokenSupply don't provide this information.

#### Summary of Changes
- Change return type of `getTokenAccountBalance` and `getTokenSupply` to struct containing ui_amount (f64), amount (string representation of u64), and decimals (u8).
- Change `getTokenLargestAccounts` amount field to same struct
- Fixup native-mint handling across all token rpcs

Fixes #11366 
