### PR TITLE
Mergify backports: add v1.4, drop v1.1

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -50,14 +50,6 @@ pull_request_rules:
       label:
         add:
           - automerge
-  - name: v1.1 backport
-    conditions:
-      - label=v1.1
-    actions:
-      backport:
-        ignore_conflicts: true
-        branches:
-          - v1.1
   - name: v1.2 backport
     conditions:
       - label=v1.2
@@ -74,3 +66,11 @@ pull_request_rules:
         ignore_conflicts: true
         branches:
           - v1.3
+  - name: v1.4 backport
+    conditions:
+      - label=v1.4
+    actions:
+      backport:
+        ignore_conflicts: true
+        branches:
+          - v1.4


### PR DESCRIPTION
#### Problem

v1.1 branch is EOL

#### Summary of Changes

Drop mergify backports for v1.1
Add v1.4
