### PR TITLE
Fall back to root if highest_confirmed_slot bank does not exist

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -121,7 +121,10 @@ impl JsonRpcRequestProcessor {
                     .unwrap()
                     .highest_confirmed_slot();
                 debug!("RPC using confirmed slot: {:?}", slot);
-                Ok(r_bank_forks.get(slot).cloned().unwrap())
+                Ok(r_bank_forks
+                    .get(slot)
+                    .cloned()
+                    .unwrap_or_else(|| r_bank_forks.root_bank().clone()))
             }
             CommitmentLevel::Max => {
                 let cluster_root = self


### PR DESCRIPTION
#### Problem
Node panics if Single commitment is requested but that bank does not exist in BankForks. 

#### Summary of Changes
- Fall back to root if highest_confirmed_slot bank does not exist CC @carllin 

Fixes #11389
