### PR TITLE
Token Accounts: return ui_amount, decimals with decoded account

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -12,6 +12,8 @@ use crate::parse_account_data::{parse_account_data, ParsedAccount};
 use solana_sdk::{account::Account, clock::Epoch, pubkey::Pubkey};
 use std::str::FromStr;
 
+pub type UiAmount = String;
+
 /// A duplicate representation of an Account for pretty JSON serialization
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -8,7 +8,7 @@ pub mod parse_nonce;
 pub mod parse_token;
 pub mod parse_vote;
 
-use crate::parse_account_data::{parse_account_data, ParsedAccount};
+use crate::parse_account_data::{parse_account_data, AccountAdditionalData, ParsedAccount};
 use solana_sdk::{account::Account, clock::Epoch, pubkey::Pubkey};
 use std::str::FromStr;
 
@@ -46,11 +46,17 @@ pub enum UiAccountEncoding {
 }
 
 impl UiAccount {
-    pub fn encode(account: Account, encoding: UiAccountEncoding) -> Self {
+    pub fn encode(
+        account: Account,
+        encoding: UiAccountEncoding,
+        additional_data: Option<AccountAdditionalData>,
+    ) -> Self {
         let data = match encoding {
             UiAccountEncoding::Binary => account.data.into(),
             UiAccountEncoding::JsonParsed => {
-                if let Ok(parsed_data) = parse_account_data(&account.owner, &account.data) {
+                if let Ok(parsed_data) =
+                    parse_account_data(&account.owner, &account.data, additional_data)
+                {
                     UiAccountData::Json(parsed_data)
                 } else {
                     account.data.into()

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -12,7 +12,7 @@ use crate::parse_account_data::{parse_account_data, AccountAdditionalData, Parse
 use solana_sdk::{account::Account, clock::Epoch, pubkey::Pubkey};
 use std::str::FromStr;
 
-pub type UiAmount = String;
+pub type StringAmount = String;
 
 /// A duplicate representation of an Account for pretty JSON serialization
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -30,6 +30,9 @@ pub enum ParseAccountError {
     #[error("Program not parsable")]
     ProgramNotParsable,
 
+    #[error("Additional data required to parse: {0}")]
+    AdditionalDataMissing(String),
+
     #[error("Instruction error")]
     InstructionError(#[from] InstructionError),
 

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -61,7 +61,7 @@ pub fn parse_account_data(
         .ok_or_else(|| ParseAccountError::ProgramNotParsable)?;
     let parsed_json = match program_name {
         ParsableAccount::Nonce => serde_json::to_value(parse_nonce(data)?)?,
-        ParsableAccount::SplToken => serde_json::to_value(parse_token(data)?)?,
+        ParsableAccount::SplToken => serde_json::to_value(parse_token(data, None)?)?,
         ParsableAccount::Vote => serde_json::to_value(parse_vote(data)?)?,
     };
     Ok(ParsedAccount {

--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -52,16 +52,25 @@ pub enum ParsableAccount {
     Vote,
 }
 
+#[derive(Default)]
+pub struct AccountAdditionalData {
+    pub spl_token_decimals: Option<u8>,
+}
+
 pub fn parse_account_data(
     program_id: &Pubkey,
     data: &[u8],
+    additional_data: Option<AccountAdditionalData>,
 ) -> Result<ParsedAccount, ParseAccountError> {
     let program_name = PARSABLE_PROGRAM_IDS
         .get(program_id)
         .ok_or_else(|| ParseAccountError::ProgramNotParsable)?;
+    let additional_data = additional_data.unwrap_or_default();
     let parsed_json = match program_name {
         ParsableAccount::Nonce => serde_json::to_value(parse_nonce(data)?)?,
-        ParsableAccount::SplToken => serde_json::to_value(parse_token(data, None)?)?,
+        ParsableAccount::SplToken => {
+            serde_json::to_value(parse_token(data, additional_data.spl_token_decimals)?)?
+        }
         ParsableAccount::Vote => serde_json::to_value(parse_vote(data)?)?,
     };
     Ok(ParsedAccount {
@@ -83,18 +92,19 @@ mod test {
     fn test_parse_account_data() {
         let other_program = Pubkey::new_rand();
         let data = vec![0; 4];
-        assert!(parse_account_data(&other_program, &data).is_err());
+        assert!(parse_account_data(&other_program, &data, None).is_err());
 
         let vote_state = VoteState::default();
         let mut vote_account_data: Vec<u8> = vec![0; VoteState::size_of()];
         let versioned = VoteStateVersions::Current(Box::new(vote_state));
         VoteState::serialize(&versioned, &mut vote_account_data).unwrap();
-        let parsed = parse_account_data(&solana_vote_program::id(), &vote_account_data).unwrap();
+        let parsed =
+            parse_account_data(&solana_vote_program::id(), &vote_account_data, None).unwrap();
         assert_eq!(parsed.program, "vote".to_string());
 
         let nonce_data = Versions::new_current(State::Initialized(Data::default()));
         let nonce_account_data = bincode::serialize(&nonce_data).unwrap();
-        let parsed = parse_account_data(&system_program::id(), &nonce_account_data).unwrap();
+        let parsed = parse_account_data(&system_program::id(), &nonce_account_data, None).unwrap();
         assert_eq!(parsed.program, "nonce".to_string());
     }
 }

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -1,6 +1,6 @@
 use crate::{
     parse_account_data::{ParsableAccount, ParseAccountError},
-    UiAmount,
+    StringAmount,
 };
 use solana_sdk::pubkey::Pubkey;
 use spl_token_v1_0::{
@@ -110,7 +110,7 @@ pub struct UiTokenAccount {
 pub struct UiTokenAmount {
     pub ui_amount: f64,
     pub decimals: u8,
-    pub amount: UiAmount,
+    pub amount: StringAmount,
 }
 
 pub fn token_amount_to_ui_amount(amount: u64, decimals: u8) -> UiTokenAmount {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1235,7 +1235,7 @@ fn process_show_account(
     let cli_account = CliAccount {
         keyed_account: RpcKeyedAccount {
             pubkey: account_pubkey.to_string(),
-            account: UiAccount::encode(account, UiAccountEncoding::Binary),
+            account: UiAccount::encode(account, UiAccountEncoding::Binary, None),
         },
         use_lamports_unit,
     };

--- a/cli/src/offline/blockhash_query.rs
+++ b/cli/src/offline/blockhash_query.rs
@@ -350,7 +350,7 @@ mod tests {
         )
         .unwrap();
         let nonce_pubkey = Pubkey::new(&[4u8; 32]);
-        let rpc_nonce_account = UiAccount::encode(nonce_account, UiAccountEncoding::Binary);
+        let rpc_nonce_account = UiAccount::encode(nonce_account, UiAccountEncoding::Binary, None);
         let get_account_response = json!(Response {
             context: RpcResponseContext { slot: 1 },
             value: json!(Some(rpc_nonce_account)),

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -15,7 +15,10 @@ use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
 use serde_json::{json, Value};
 use solana_account_decoder::{
-    parse_token::{parse_token, TokenAccountType, UiMint, UiMultisig, UiTokenAccount},
+    parse_token::{
+        get_token_account_mint, parse_token, TokenAccountType, UiMint, UiMultisig,
+        UiTokenAccountWithDecimals, UiTokenAmount,
+    },
     UiAccount,
 };
 use solana_sdk::{
@@ -38,6 +41,7 @@ use solana_transaction_status::{
 };
 use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::{
+    collections::HashMap,
     net::SocketAddr,
     thread::sleep,
     time::{Duration, Instant},
@@ -682,7 +686,10 @@ impl RpcClient {
         Ok(hash)
     }
 
-    pub fn get_token_account(&self, pubkey: &Pubkey) -> ClientResult<Option<UiTokenAccount>> {
+    pub fn get_token_account(
+        &self,
+        pubkey: &Pubkey,
+    ) -> ClientResult<Option<UiTokenAccountWithDecimals>> {
         Ok(self
             .get_token_account_with_commitment(pubkey, CommitmentConfig::default())?
             .value)
@@ -692,20 +699,38 @@ impl RpcClient {
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<Option<UiTokenAccount>> {
+    ) -> RpcResult<Option<UiTokenAccountWithDecimals>> {
         let Response {
             context,
             value: account,
         } = self.get_account_with_commitment(pubkey, commitment_config)?;
 
+        if account.is_none() {
+            return Err(RpcError::ForUser(format!("AccountNotFound: pubkey={}", pubkey)).into());
+        }
+        let account = account.unwrap();
+        let mint = get_token_account_mint(&account.data)
+            .and_then(|mint_pubkey| {
+                self.get_token_mint_with_commitment(&mint_pubkey, commitment_config)
+                    .ok()
+                    .map(|response| response.value)
+                    .flatten()
+            })
+            .ok_or_else(|| {
+                Into::<ClientError>::into(RpcError::ForUser(format!(
+                    "AccountNotFound: mint for token acccount pubkey={}",
+                    pubkey
+                )))
+            })?;
+
         Ok(Response {
             context,
-            value: account
-                .map(|account| match parse_token(&account.data) {
-                    Ok(TokenAccountType::Account(ui_token_account)) => Some(ui_token_account),
-                    _ => None,
-                })
-                .flatten(),
+            value: match parse_token(&account.data, Some(mint.decimals)) {
+                Ok(TokenAccountType::AccountWithDecimals(ui_token_account)) => {
+                    Some(ui_token_account)
+                }
+                _ => None,
+            },
         })
     }
 
@@ -728,7 +753,7 @@ impl RpcClient {
         Ok(Response {
             context,
             value: account
-                .map(|account| match parse_token(&account.data) {
+                .map(|account| match parse_token(&account.data, None) {
                     Ok(TokenAccountType::Mint(ui_token_mint)) => Some(ui_token_mint),
                     _ => None,
                 })
@@ -755,7 +780,7 @@ impl RpcClient {
         Ok(Response {
             context,
             value: account
-                .map(|account| match parse_token(&account.data) {
+                .map(|account| match parse_token(&account.data, None) {
                     Ok(TokenAccountType::Multisig(ui_token_multisig)) => Some(ui_token_multisig),
                     _ => None,
                 })
@@ -763,7 +788,7 @@ impl RpcClient {
         })
     }
 
-    pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<RpcTokenAmount> {
+    pub fn get_token_account_balance(&self, pubkey: &Pubkey) -> ClientResult<UiTokenAmount> {
         Ok(self
             .get_token_account_balance_with_commitment(pubkey, CommitmentConfig::default())?
             .value)
@@ -773,7 +798,7 @@ impl RpcClient {
         &self,
         pubkey: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<RpcTokenAmount> {
+    ) -> RpcResult<UiTokenAmount> {
         self.send(
             RpcRequest::GetTokenAccountBalance,
             json!([pubkey.to_string(), commitment_config]),
@@ -784,7 +809,7 @@ impl RpcClient {
         &self,
         delegate: &Pubkey,
         token_account_filter: TokenAccountsFilter,
-    ) -> ClientResult<Vec<(Pubkey, UiTokenAccount)>> {
+    ) -> ClientResult<Vec<(Pubkey, UiTokenAccountWithDecimals)>> {
         Ok(self
             .get_token_accounts_by_delegate_with_commitment(
                 delegate,
@@ -799,7 +824,7 @@ impl RpcClient {
         delegate: &Pubkey,
         token_account_filter: TokenAccountsFilter,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<Vec<(Pubkey, UiTokenAccount)>> {
+    ) -> RpcResult<Vec<(Pubkey, UiTokenAccountWithDecimals)>> {
         let token_account_filter = match token_account_filter {
             TokenAccountsFilter::Mint(mint) => RpcTokenAccountsFilter::Mint(mint.to_string()),
             TokenAccountsFilter::ProgramId(program_id) => {
@@ -817,10 +842,10 @@ impl RpcClient {
                 commitment_config
             ]),
         )?;
-        let pubkey_accounts = accounts_to_token_accounts(parse_keyed_accounts(
-            accounts,
-            RpcRequest::GetTokenAccountsByDelegate,
-        )?);
+        let pubkey_accounts = self.accounts_to_token_accounts(
+            commitment_config,
+            parse_keyed_accounts(accounts, RpcRequest::GetTokenAccountsByDelegate)?,
+        );
         Ok(Response {
             context,
             value: pubkey_accounts,
@@ -831,7 +856,7 @@ impl RpcClient {
         &self,
         owner: &Pubkey,
         token_account_filter: TokenAccountsFilter,
-    ) -> ClientResult<Vec<(Pubkey, UiTokenAccount)>> {
+    ) -> ClientResult<Vec<(Pubkey, UiTokenAccountWithDecimals)>> {
         Ok(self
             .get_token_accounts_by_owner_with_commitment(
                 owner,
@@ -846,7 +871,7 @@ impl RpcClient {
         owner: &Pubkey,
         token_account_filter: TokenAccountsFilter,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<Vec<(Pubkey, UiTokenAccount)>> {
+    ) -> RpcResult<Vec<(Pubkey, UiTokenAccountWithDecimals)>> {
         let token_account_filter = match token_account_filter {
             TokenAccountsFilter::Mint(mint) => RpcTokenAccountsFilter::Mint(mint.to_string()),
             TokenAccountsFilter::ProgramId(program_id) => {
@@ -860,17 +885,17 @@ impl RpcClient {
             RpcRequest::GetTokenAccountsByOwner,
             json!([owner.to_string(), token_account_filter, commitment_config]),
         )?;
-        let pubkey_accounts = accounts_to_token_accounts(parse_keyed_accounts(
-            accounts,
-            RpcRequest::GetTokenAccountsByDelegate,
-        )?);
+        let pubkey_accounts = self.accounts_to_token_accounts(
+            commitment_config,
+            parse_keyed_accounts(accounts, RpcRequest::GetTokenAccountsByDelegate)?,
+        );
         Ok(Response {
             context,
             value: pubkey_accounts,
         })
     }
 
-    pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<RpcTokenAmount> {
+    pub fn get_token_supply(&self, mint: &Pubkey) -> ClientResult<UiTokenAmount> {
         Ok(self
             .get_token_supply_with_commitment(mint, CommitmentConfig::default())?
             .value)
@@ -880,11 +905,40 @@ impl RpcClient {
         &self,
         mint: &Pubkey,
         commitment_config: CommitmentConfig,
-    ) -> RpcResult<RpcTokenAmount> {
+    ) -> RpcResult<UiTokenAmount> {
         self.send(
             RpcRequest::GetTokenSupply,
             json!([mint.to_string(), commitment_config]),
         )
+    }
+
+    fn accounts_to_token_accounts(
+        &self,
+        commitment_config: CommitmentConfig,
+        pubkey_accounts: Vec<(Pubkey, Account)>,
+    ) -> Vec<(Pubkey, UiTokenAccountWithDecimals)> {
+        let mut mint_decimals: HashMap<Pubkey, u8> = HashMap::new();
+        pubkey_accounts
+            .into_iter()
+            .filter_map(|(pubkey, account)| {
+                let mint_pubkey = get_token_account_mint(&account.data)?;
+                let decimals = mint_decimals.get(&mint_pubkey).cloned().or_else(|| {
+                    let mint = self
+                        .get_token_mint_with_commitment(&mint_pubkey, commitment_config)
+                        .ok()
+                        .map(|response| response.value)
+                        .flatten()?;
+                    mint_decimals.insert(mint_pubkey, mint.decimals);
+                    Some(mint.decimals)
+                })?;
+                match parse_token(&account.data, Some(decimals)) {
+                    Ok(TokenAccountType::AccountWithDecimals(ui_token_account)) => {
+                        Some((pubkey, ui_token_account))
+                    }
+                    _ => None,
+                }
+            })
+            .collect()
     }
 
     fn poll_balance_with_timeout_and_commitment(
@@ -1249,18 +1303,6 @@ fn parse_keyed_accounts(
         ));
     }
     Ok(pubkey_accounts)
-}
-
-fn accounts_to_token_accounts(
-    pubkey_accounts: Vec<(Pubkey, Account)>,
-) -> Vec<(Pubkey, UiTokenAccount)> {
-    pubkey_accounts
-        .into_iter()
-        .filter_map(|(pubkey, account)| match parse_token(&account.data) {
-            Ok(TokenAccountType::Account(ui_token_account)) => Some((pubkey, ui_token_account)),
-            _ => None,
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -1,5 +1,5 @@
 use crate::client_error;
-use solana_account_decoder::UiAccount;
+use solana_account_decoder::{parse_token::UiTokenAmount, UiAccount};
 use solana_sdk::{
     clock::{Epoch, Slot},
     fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -10,7 +10,6 @@ use solana_transaction_status::ConfirmedTransactionStatusWithSignature;
 use std::{collections::HashMap, net::SocketAddr};
 
 pub type RpcResult<T> = client_error::Result<Response<T>>;
-pub type RpcAmount = String;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RpcResponseContext {
@@ -224,18 +223,10 @@ pub struct RpcStakeActivation {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct RpcTokenAmount {
-    pub ui_amount: f64,
-    pub decimals: u8,
-    pub amount: RpcAmount,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
 pub struct RpcTokenAccountBalance {
     pub address: String,
     #[serde(flatten)]
-    pub amount: RpcTokenAmount,
+    pub amount: UiTokenAmount,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -676,7 +676,8 @@ mod tests {
             .get_account(&nonce_account.pubkey())
             .unwrap()
             .data;
-        let expected_data = parse_account_data(&system_program::id(), &expected_data).unwrap();
+        let expected_data =
+            parse_account_data(&system_program::id(), &expected_data, None).unwrap();
         let expected = json!({
            "jsonrpc": "2.0",
            "method": "accountNotification",

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -251,7 +251,7 @@ fn filter_account_result(
         if fork != last_notified_slot {
             let encoding = encoding.unwrap_or(UiAccountEncoding::Binary);
             return (
-                Box::new(iter::once(UiAccount::encode(account, encoding))),
+                Box::new(iter::once(UiAccount::encode(account, encoding, None))),
                 fork,
             );
         }
@@ -294,7 +294,7 @@ fn filter_program_results(
                 })
                 .map(move |(pubkey, account)| RpcKeyedAccount {
                     pubkey: pubkey.to_string(),
-                    account: UiAccount::encode(account, encoding.clone()),
+                    account: UiAccount::encode(account, encoding.clone(), None),
                 }),
         ),
         last_notified_slot,

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -1,5 +1,6 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
 
+use crate::rpc::{get_parsed_token_account, get_parsed_token_accounts};
 use core::hash::Hash;
 use jsonrpc_core::futures::Future;
 use jsonrpc_pubsub::{
@@ -7,7 +8,7 @@ use jsonrpc_pubsub::{
     SubscriptionId,
 };
 use serde::Serialize;
-use solana_account_decoder::{UiAccount, UiAccountEncoding};
+use solana_account_decoder::{parse_token::spl_token_id_v1_0, UiAccount, UiAccountEncoding};
 use solana_client::{
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     rpc_filter::RpcFilterType,
@@ -178,7 +179,7 @@ where
     K: Eq + Hash + Clone + Copy,
     S: Clone + Serialize,
     B: Fn(&Bank, &K) -> X,
-    F: Fn(X, Slot, Option<T>) -> (Box<dyn Iterator<Item = S>>, Slot),
+    F: Fn(X, Slot, Option<T>, Option<Arc<Bank>>) -> (Box<dyn Iterator<Item = S>>, Slot),
     X: Clone + Serialize + Default,
     T: Clone,
 {
@@ -202,16 +203,18 @@ where
                     commitment_slots.highest_confirmed_slot
                 }
             };
-            let results = {
-                let bank_forks = bank_forks.read().unwrap();
-                bank_forks
-                    .get(slot)
-                    .map(|desired_bank| bank_method(&desired_bank, hashmap_key))
-                    .unwrap_or_default()
-            };
+            let bank = bank_forks.read().unwrap().get(slot).cloned();
+            let results = bank
+                .clone()
+                .map(|desired_bank| bank_method(&desired_bank, hashmap_key))
+                .unwrap_or_default();
             let mut w_last_notified_slot = last_notified_slot.write().unwrap();
-            let (filter_results, result_slot) =
-                filter_results(results, *w_last_notified_slot, config.as_ref().cloned());
+            let (filter_results, result_slot) = filter_results(
+                results,
+                *w_last_notified_slot,
+                config.as_ref().cloned(),
+                bank,
+            );
             for result in filter_results {
                 notifier.notify(
                     Response {
@@ -244,16 +247,24 @@ fn filter_account_result(
     result: Option<(Account, Slot)>,
     last_notified_slot: Slot,
     encoding: Option<UiAccountEncoding>,
+    bank: Option<Arc<Bank>>,
 ) -> (Box<dyn Iterator<Item = UiAccount>>, Slot) {
     if let Some((account, fork)) = result {
         // If fork < last_notified_slot this means that we last notified for a fork
         // and should notify that the account state has been reverted.
         if fork != last_notified_slot {
             let encoding = encoding.unwrap_or(UiAccountEncoding::Binary);
-            return (
-                Box::new(iter::once(UiAccount::encode(account, encoding, None))),
-                fork,
-            );
+            if account.owner == spl_token_id_v1_0() && encoding == UiAccountEncoding::JsonParsed {
+                let bank = bank.unwrap(); // If result.is_some(), bank must also be Some
+                if let Some(ui_account) = get_parsed_token_account(bank, account) {
+                    return (Box::new(iter::once(ui_account)), fork);
+                }
+            } else {
+                return (
+                    Box::new(iter::once(UiAccount::encode(account, encoding, None))),
+                    fork,
+                );
+            }
         }
     }
     (Box::new(iter::empty()), last_notified_slot)
@@ -263,6 +274,7 @@ fn filter_signature_result(
     result: Option<transaction::Result<()>>,
     last_notified_slot: Slot,
     _config: Option<()>,
+    _bank: Option<Arc<Bank>>,
 ) -> (Box<dyn Iterator<Item = RpcSignatureResult>>, Slot) {
     (
         Box::new(
@@ -278,27 +290,30 @@ fn filter_program_results(
     accounts: Vec<(Pubkey, Account)>,
     last_notified_slot: Slot,
     config: Option<ProgramConfig>,
+    bank: Option<Arc<Bank>>,
 ) -> (Box<dyn Iterator<Item = RpcKeyedAccount>>, Slot) {
     let config = config.unwrap_or_default();
     let encoding = config.encoding.unwrap_or(UiAccountEncoding::Binary);
     let filters = config.filters;
-    (
-        Box::new(
-            accounts
-                .into_iter()
-                .filter(move |(_, account)| {
-                    filters.iter().all(|filter_type| match filter_type {
-                        RpcFilterType::DataSize(size) => account.data.len() as u64 == *size,
-                        RpcFilterType::Memcmp(compare) => compare.bytes_match(&account.data),
-                    })
-                })
-                .map(move |(pubkey, account)| RpcKeyedAccount {
+    let keyed_accounts = accounts.into_iter().filter(move |(_, account)| {
+        filters.iter().all(|filter_type| match filter_type {
+            RpcFilterType::DataSize(size) => account.data.len() as u64 == *size,
+            RpcFilterType::Memcmp(compare) => compare.bytes_match(&account.data),
+        })
+    });
+    let accounts: Box<dyn Iterator<Item = RpcKeyedAccount>> =
+        if encoding == UiAccountEncoding::JsonParsed {
+            let bank = bank.unwrap(); // If !accounts.is_empty(), bank must be Some
+            Box::new(get_parsed_token_accounts(bank, keyed_accounts))
+        } else {
+            Box::new(
+                keyed_accounts.map(move |(pubkey, account)| RpcKeyedAccount {
                     pubkey: pubkey.to_string(),
                     account: UiAccount::encode(account, encoding.clone(), None),
                 }),
-        ),
-        last_notified_slot,
-    )
+            )
+        };
+    (accounts, last_notified_slot)
 }
 
 #[derive(Clone)]
@@ -860,7 +875,7 @@ impl RpcSubscriptions {
             &subscriptions.gossip_account_subscriptions,
             &subscriptions.gossip_program_subscriptions,
             &subscriptions.gossip_signature_subscriptions,
-            &bank_forks,
+            bank_forks,
             &commitment_slots,
             &notifier,
         );
@@ -881,7 +896,7 @@ impl RpcSubscriptions {
         for pubkey in &pubkeys {
             Self::check_account(
                 pubkey,
-                &bank_forks,
+                bank_forks,
                 account_subscriptions.clone(),
                 &notifier,
                 &commitment_slots,
@@ -895,7 +910,7 @@ impl RpcSubscriptions {
         for program_id in &programs {
             Self::check_program(
                 program_id,
-                &bank_forks,
+                bank_forks,
                 program_subscriptions.clone(),
                 &notifier,
                 &commitment_slots,
@@ -909,7 +924,7 @@ impl RpcSubscriptions {
         for signature in &signatures {
             Self::check_signature(
                 signature,
-                &bank_forks,
+                bank_forks,
                 signature_subscriptions.clone(),
                 &notifier,
                 &commitment_slots,

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1118,7 +1118,7 @@ The result will be an RpcResponse JSON object with `value` equal to an array of 
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getTokenAccountsByDelegate", "params": ["4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T", {"programId": "TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"}, {"encoding": "jsonParsed"}]}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":[{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"amount":1,"delegate":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}}},"executable":false,"lamports":1726080,"owner":"TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o","rentEpoch":4},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}],"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":[{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","uiAmount":0.1,"decimals":1},"delegate":"4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T","delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}}},"executable":false,"lamports":1726080,"owner":"TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o","rentEpoch":4},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}],"id":1}
 ```
 
 ### getTokenAccountsByOwner
@@ -1154,7 +1154,7 @@ The result will be an RpcResponse JSON object with `value` equal to an array of 
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getTokenAccountsByOwner", "params": ["4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F", {"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E"}, {"encoding": "jsonParsed"}]}' http://localhost:8899
 // Result
-{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":[{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"amount":1,"delegate":null,"delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"}}},"executable":false,"lamports":1726080,"owner":"TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o","rentEpoch":4},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}],"id":1}
+{"jsonrpc":"2.0","result":{"context":{"slot":1114},"value":[{"data":{"program":"spl-token","parsed":{"accountType":"account","info":{"tokenAmount":{"amount":"1","uiAmount":0.1,"decimals":1},"delegate":null,"delegatedAmount":1,"isInitialized":true,"isNative":false,"mint":"3wyAj7Rt1TWVPZVteFJPLa26JmLvdb1CAKEFZm3NY75E","owner":"4Qkev8aNZcqFNSRhQzwyLMFSsi94jHqE8WNVTJzTP99F"}}},"executable":false,"lamports":1726080,"owner":"TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o","rentEpoch":4},"pubkey":"CnPoSPKXu7wJqxe59Fs72tkBeALovhsCxYeFwPCQH9TD"}],"id":1}
 ```
 
 ### getTokenSupply
@@ -1481,8 +1481,10 @@ Subscribe to an account to receive notifications when the lamports or data for a
       },
       "value": {
         "data": {
-           "nonce": {
-              "initialized": {
+           "program": "nonce"
+           "parsed": {
+              "type": "initialized",
+              "info": {
                  "authority": "Bbqg1M4YVVfbhEzwA9SpC9FhsaG83YMTYoR4a8oTDLX",
                  "blockhash": "LUaQTmM7WbMRiATdMMHaRGakPtCkc2GHtH57STKXs6k",
                  "feeCalculator": {
@@ -1597,8 +1599,10 @@ Subscribe to a program to receive notifications when the lamports or data for a 
         "pubkey": "H4vnBqifaSACnKa7acsxstsY1iV1bvJNxsCY7enrd1hq"
         "account": {
           "data": {
-             "nonce": {
-                "initialized": {
+             "program": "nonce"
+             "parsed": {
+                "type": "initialized",
+                "info": {
                    "authority": "Bbqg1M4YVVfbhEzwA9SpC9FhsaG83YMTYoR4a8oTDLX",
                    "blockhash": "LUaQTmM7WbMRiATdMMHaRGakPtCkc2GHtH57STKXs6k",
                    "feeCalculator": {


### PR DESCRIPTION
#### Problem
Parsed token accounts include an `amount`, but this raw number isn't useful to clients without the Mint decimal context.

#### Summary of Changes
- Return complete UiTokenAmount with decoded accounts. Prioritize rpc_client, but update RPC jsonParsed elements for consistency.

Fixes https://github.com/solana-labs/solana/pull/11370#discussion_r465459871
