### PR TITLE
Realloc not supported

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -846,6 +846,12 @@ fn call<'a>(
         let account = account.borrow();
         if message.is_writable(i) && !account.executable {
             *lamport_ref = account.lamports;
+            if data.len() != account.data.len() {
+                return Err(SyscallError::InstructionError(
+                    InstructionError::AccountDataSizeChanged,
+                )
+                .into());
+            }
             data.clone_from_slice(&account.data);
         }
     }


### PR DESCRIPTION
#### Problem

`SystemInstruction::CreateAccount` not supported via cross-program invocations because account data reallocation not supported yet

#### Summary of Changes

Return an error if the account data size changed during a cross-program invocation

Fixes #
