### PR TITLE
feat: add getParsedConfirmedTransaction API

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -148,6 +148,39 @@ declare module '@solana/web3.js' {
     meta: ConfirmedTransactionMeta | null;
   };
 
+  export type ParsedMessageAccount = {
+    pubkey: PublicKey;
+    signer: boolean;
+    writable: boolean;
+  };
+
+  export type ParsedInstruction = {
+    programId: PublicKey;
+    program: string;
+    parsed: string;
+  };
+
+  export type PartiallyDecodedInstruction = {
+    programId: PublicKey;
+    accounts: Array<PublicKey>;
+    data: string;
+  };
+
+  export type ParsedTransaction = {
+    signatures: Array<string>;
+    message: {
+      accountKeys: ParsedMessageAccount[];
+      instructions: (ParsedInstruction | PartiallyDecodedInstruction)[];
+      recentBlockhash: string;
+    };
+  };
+
+  export type ParsedConfirmedTransaction = {
+    slot: number;
+    transaction: ParsedTransaction;
+    meta: ConfirmedTransactionMeta | null;
+  };
+
   export type KeyedAccountInfo = {
     accountId: PublicKey;
     accountInfo: AccountInfo;
@@ -288,6 +321,9 @@ declare module '@solana/web3.js' {
     getConfirmedTransaction(
       signature: TransactionSignature,
     ): Promise<ConfirmedTransaction | null>;
+    getParsedConfirmedTransaction(
+      signature: TransactionSignature,
+    ): Promise<ParsedConfirmedTransaction | null>;
     getConfirmedSignaturesForAddress(
       address: PublicKey,
       startSlot: number,

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -164,6 +164,39 @@ declare module '@solana/web3.js' {
     meta: ConfirmedTransactionMeta | null,
   };
 
+  declare export type ParsedMessageAccount = {
+    pubkey: PublicKey,
+    signer: boolean,
+    writable: boolean,
+  };
+
+  declare export type ParsedInstruction = {|
+    programId: PublicKey,
+    program: string,
+    parsed: string,
+  |};
+
+  declare export type PartiallyDecodedInstruction = {|
+    programId: PublicKey,
+    accounts: Array<PublicKey>,
+    data: string,
+  |};
+
+  declare export type ParsedTransaction = {
+    signatures: Array<string>,
+    message: {
+      accountKeys: ParsedMessageAccount[],
+      instructions: (ParsedInstruction | PartiallyDecodedInstruction)[],
+      recentBlockhash: string,
+    },
+  };
+
+  declare export type ParsedConfirmedTransaction = {
+    slot: number,
+    transaction: ParsedTransaction,
+    meta: ConfirmedTransactionMeta | null,
+  };
+
   declare export type KeyedAccountInfo = {
     accountId: PublicKey,
     accountInfo: AccountInfo,
@@ -304,6 +337,9 @@ declare module '@solana/web3.js' {
     getConfirmedTransaction(
       signature: TransactionSignature,
     ): Promise<ConfirmedTransaction | null>;
+    getParsedConfirmedTransaction(
+      signature: TransactionSignature,
+    ): Promise<ParsedConfirmedTransaction | null>;
     getConfirmedSignaturesForAddress(
       address: PublicKey,
       startSlot: number,

--- a/web3.js/package-lock.json
+++ b/web3.js/package-lock.json
@@ -4743,24 +4743,23 @@
       }
     },
     "@solana/spl-token": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.0.4.tgz",
-      "integrity": "sha512-zYoZ6iYMKxGYbouunEkWdf6vWRJyEPOkAjvlNVjww9oPKMkIeM9VzgGtjZ/kKMelao1QEohH4JN9qXO4+LwfRA==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.0.5.tgz",
+      "integrity": "sha512-OXW/zHzMQqVGcSNrNt8sRaHlKT5vjdcUcmUHi8d4ssG8ChbZVA2lkJK10XDXlcnMIiSTindpEjiFmooYc9K3uQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.5",
-        "@solana/web3.js": "^0.63.2",
+        "@solana/web3.js": "^0.64.0",
         "bn.js": "^5.0.0",
         "buffer-layout": "^1.2.0",
         "dotenv": "8.2.0",
-        "json-to-pretty-yaml": "^1.2.2",
         "mkdirp-promise": "^5.0.1"
       }
     },
     "@solana/web3.js": {
-      "version": "0.63.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.63.2.tgz",
-      "integrity": "sha512-4jd8U1U/eFTEemr+jCzQCDepKnkttV4dxWsjMloifb82x1d6KgCzP+Jd6D9kr8f1MFj2i/AnG++97tlHAGTOkA==",
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.64.2.tgz",
+      "integrity": "sha512-aGRG1rn8fLerE4NscRL6rq0nSyYAK9K+TGRZxb6ue7Ontufa6wO1kxum4zJs17+xT0zVf8wABUtCMgP4W7FxpA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
@@ -14214,16 +14213,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "json-to-pretty-yaml": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
-      "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
-      "dev": true,
-      "requires": {
-        "remedial": "^1.0.7",
-        "remove-trailing-spaces": "^1.0.6"
-      }
-    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -20159,22 +20148,10 @@
         }
       }
     },
-    "remedial": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
-      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
-      "dev": true
-    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "remove-trailing-spaces": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.7.tgz",
-      "integrity": "sha512-wjM17CJ2kk0SgoGyJ7ZMzRRCuTq+V8YhMwpZ5XEWX0uaked2OUq6utvHXGNBQrfkUzUUABFMyxlKn+85hMv4dg==",
       "dev": true
     },
     "repeat-element": {

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -97,7 +97,7 @@
     "@babel/preset-flow": "^7.0.0",
     "@commitlint/config-conventional": "^9.0.1",
     "@commitlint/travis-cli": "^9.0.1",
-    "@solana/spl-token": "^0.0.4",
+    "@solana/spl-token": "^0.0.5",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
     "acorn": "^7.0.0",


### PR DESCRIPTION
#### Problem
- Need API for getting parsed confirmed transactions from RPC

#### Summary of Changes
- Add `getParsedConfirmedTransaction` method to `Connection`

--- 

Halfway through typing up all of the token instructions, I decided to add them directly to the explorer..
- Typing is super time intensive given our Flow / old superstruct / type def files setup
- It probably makes more sense for these types to live in `@solana/spl-token`
- I don't know of any immediate need for them inside web3

Fixes #
