### PR TITLE
feat: add parsed account data APIs

### DIFF
--- a/web3.js/flow-typed/superstruct.js
+++ b/web3.js/flow-typed/superstruct.js
@@ -1,6 +1,7 @@
 declare module 'superstruct' {
   declare type StructFunc = {
       (any): any,
+      object(schema: any): any;
       union(schema: any): any;
       array(schema: any): any;
       literal(schema: any): any;

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -104,16 +104,16 @@ declare module '@solana/web3.js' {
     feeCalculator: FeeCalculator;
   };
 
-  export type PublicKeyAndAccount = {
+  export type PublicKeyAndAccount<T> = {
     pubkey: PublicKey;
-    account: AccountInfo;
+    account: AccountInfo<T>;
   };
 
-  export type AccountInfo = {
+  export type AccountInfo<T> = {
     executable: boolean;
     owner: PublicKey;
     lamports: number;
-    data: Buffer;
+    data: T;
     rentEpoch?: number;
   };
 
@@ -181,9 +181,14 @@ declare module '@solana/web3.js' {
     meta: ConfirmedTransactionMeta | null;
   };
 
+  export type ParsedAccountData = {
+    program: string;
+    parsed: any;
+  };
+
   export type KeyedAccountInfo = {
     accountId: PublicKey;
-    accountInfo: AccountInfo;
+    accountInfo: AccountInfo<Buffer>;
   };
 
   export type Version = {
@@ -210,7 +215,7 @@ declare module '@solana/web3.js' {
   };
 
   export type AccountChangeCallback = (
-    accountInfo: AccountInfo,
+    accountInfo: AccountInfo<Buffer>,
     context: Context,
   ) => void;
   export type ProgramAccountChangeCallback = (
@@ -280,15 +285,25 @@ declare module '@solana/web3.js' {
     getAccountInfoAndContext(
       publicKey: PublicKey,
       commitment?: Commitment,
-    ): Promise<RpcResponseAndContext<AccountInfo | null>>;
+    ): Promise<RpcResponseAndContext<AccountInfo<Buffer> | null>>;
     getAccountInfo(
       publicKey: PublicKey,
       commitment?: Commitment,
-    ): Promise<AccountInfo | null>;
+    ): Promise<AccountInfo<Buffer> | null>;
+    getParsedAccountInfo(
+      publicKey: PublicKey,
+      commitment?: Commitment,
+    ): Promise<
+      RpcResponseAndContext<AccountInfo<Buffer | ParsedAccountData> | null>
+    >;
     getProgramAccounts(
       programId: PublicKey,
       commitment?: Commitment,
-    ): Promise<Array<PublicKeyAndAccount>>;
+    ): Promise<Array<PublicKeyAndAccount<Buffer>>>;
+    getParsedProgramAccounts(
+      programId: PublicKey,
+      commitment?: Commitment,
+    ): Promise<Array<PublicKeyAndAccount<Buffer | ParsedAccountData>>>;
     getBalanceAndContext(
       publicKey: PublicKey,
       commitment?: Commitment,
@@ -311,7 +326,18 @@ declare module '@solana/web3.js' {
       filter: TokenAccountsFilter,
       commitment?: Commitment,
     ): Promise<
-      RpcResponseAndContext<Array<{pubkey: PublicKey; account: AccountInfo}>>
+      RpcResponseAndContext<
+        Array<{pubkey: PublicKey; account: AccountInfo<Buffer>}>
+      >
+    >;
+    getParsedTokenAccountsByOwner(
+      ownerAddress: PublicKey,
+      filter: TokenAccountsFilter,
+      commitment?: Commitment,
+    ): Promise<
+      RpcResponseAndContext<
+        Array<{pubkey: PublicKey; account: AccountInfo<ParsedAccountData>}>
+      >
     >;
     getLargestAccounts(
       config?: GetLargestAccountsConfig,

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -125,16 +125,16 @@ declare module '@solana/web3.js' {
     feeCalculator: FeeCalculator,
   };
 
-  declare export type PublicKeyAndAccount = {
+  declare export type PublicKeyAndAccount<T> = {
     pubkey: PublicKey,
-    account: AccountInfo,
+    account: AccountInfo<T>,
   };
 
-  declare export type AccountInfo = {
+  declare export type AccountInfo<T> = {
     executable: boolean,
     owner: PublicKey,
     lamports: number,
-    data: Buffer,
+    data: T,
     rentEpoch: number | null,
   };
 
@@ -167,6 +167,11 @@ declare module '@solana/web3.js' {
     slot: number,
     transaction: Transaction,
     meta: ConfirmedTransactionMeta | null,
+  };
+
+  declare export type ParsedAccountData = {
+    program: string,
+    parsed: any,
   };
 
   declare export type ParsedMessageAccount = {
@@ -204,7 +209,7 @@ declare module '@solana/web3.js' {
 
   declare export type KeyedAccountInfo = {
     accountId: PublicKey,
-    accountInfo: AccountInfo,
+    accountInfo: AccountInfo<Buffer>,
   };
 
   declare export type Version = {
@@ -231,7 +236,7 @@ declare module '@solana/web3.js' {
   };
 
   declare type AccountChangeCallback = (
-    accountInfo: AccountInfo,
+    accountInfo: AccountInfo<Buffer>,
     context: Context,
   ) => void;
   declare type ProgramAccountChangeCallback = (
@@ -301,15 +306,25 @@ declare module '@solana/web3.js' {
     getAccountInfoAndContext(
       publicKey: PublicKey,
       commitment: ?Commitment,
-    ): Promise<RpcResponseAndContext<AccountInfo | null>>;
+    ): Promise<RpcResponseAndContext<AccountInfo<Buffer> | null>>;
     getAccountInfo(
       publicKey: PublicKey,
       commitment: ?Commitment,
-    ): Promise<AccountInfo | null>;
+    ): Promise<AccountInfo<Buffer> | null>;
+    getParsedAccountInfo(
+      publicKey: PublicKey,
+      commitment: ?Commitment,
+    ): Promise<
+      RpcResponseAndContext<AccountInfo<Buffer | ParsedAccountData> | null>,
+    >;
     getProgramAccounts(
       programId: PublicKey,
       commitment: ?Commitment,
-    ): Promise<Array<PublicKeyAndAccount>>;
+    ): Promise<Array<PublicKeyAndAccount<Buffer>>>;
+    getParsedProgramAccounts(
+      programId: PublicKey,
+      commitment: ?Commitment,
+    ): Promise<Array<PublicKeyAndAccount<Buffer | ParsedAccountData>>>;
     getBalanceAndContext(
       publicKey: PublicKey,
       commitment: ?Commitment,
@@ -332,7 +347,9 @@ declare module '@solana/web3.js' {
       filter: TokenAccountsFilter,
       commitment: ?Commitment,
     ): Promise<
-      RpcResponseAndContext<Array<{pubkey: PublicKey, account: AccountInfo}>>,
+      RpcResponseAndContext<
+        Array<{pubkey: PublicKey, account: AccountInfo<Buffer>}>,
+      >,
     >;
     getLargestAccounts(
       config: ?GetLargestAccountsConfig,


### PR DESCRIPTION
#### Problem
Need API for getting parsed account data from RPC

#### Summary of Changes
- Added `getParsedAccountInfo`, `getParsedProgramAccounts`, and `getParsedTokenAccountsByOwner`

Fixes #
