### PR TITLE
Fix blockstore empty panic

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1804,9 +1804,9 @@ impl Blockstore {
                 (transaction_status_cf_primary_index, signature, 0),
                 IteratorDirection::Forward,
             ))?;
-            for ((_, sig, slot), data) in index_iterator {
+            for ((i, sig, slot), data) in index_iterator {
                 counter += 1;
-                if sig != signature {
+                if i != transaction_status_cf_primary_index || sig != signature {
                     break;
                 }
                 if self.is_root(slot) {
@@ -1842,8 +1842,9 @@ impl Blockstore {
             ("method", "get_confirmed_transaction".to_string(), String)
         );
         if let Some((slot, status)) = self.get_transaction_status(signature)? {
-            let transaction = self.find_transaction_in_slot(slot, signature)?
-                .expect("Transaction to exist in slot entries if it exists in statuses and hasn't been cleaned up");
+            let transaction = self
+                .find_transaction_in_slot(slot, signature)?
+                .ok_or(BlockstoreError::TransactionStatusSlotMismatch)?; // Should not happen
             let encoding = encoding.unwrap_or(UiTransactionEncoding::Json);
             let encoded_transaction = EncodedTransaction::encode(transaction, encoding);
             Ok(Some(ConfirmedTransaction {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6060,6 +6060,19 @@ pub mod tests {
     }
 
     #[test]
+    fn test_empty_transaction_status() {
+        let blockstore_path = get_tmp_ledger_path!();
+        let blockstore = Blockstore::open(&blockstore_path).unwrap();
+        blockstore.set_roots(&[0]).unwrap();
+        assert_eq!(
+            blockstore
+                .get_confirmed_transaction(Signature::default(), None)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn test_get_confirmed_signatures_for_address() {
         let blockstore_path = get_tmp_ledger_path!();
         {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6073,6 +6073,23 @@ pub mod tests {
     }
 
     #[test]
+    fn test_empty_transaction_status_contains_no_roots() {
+        let blockstore_path = get_tmp_ledger_path!();
+        let blockstore = Blockstore::open(&blockstore_path).unwrap();
+        blockstore.set_roots(&[0]).unwrap();
+        let index_iterator = blockstore
+            .transaction_status_cf
+            .iter(IteratorMode::From(
+                cf::TransactionStatus::as_index(0),
+                IteratorDirection::Forward,
+            ))
+            .unwrap();
+        for ((_, _, slot), _) in index_iterator {
+            assert!(!blockstore.is_root(slot));
+        }
+    }
+
+    #[test]
     fn test_get_confirmed_signatures_for_address() {
         let blockstore_path = get_tmp_ledger_path!();
         {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1678,11 +1678,11 @@ impl Blockstore {
             .put(1, &TransactionStatusIndexMeta::default())?;
         // This dummy status improves compaction performance
         self.transaction_status_cf.put(
-            cf::TransactionStatus::as_index(2),
+            (2, Signature::default(), Slot::MAX),
             &TransactionStatusMeta::default(),
         )?;
         self.address_signatures_cf.put(
-            cf::AddressSignatures::as_index(2),
+            (2, Pubkey::default(), Slot::MAX, Signature::default()),
             &AddressSignatureMeta::default(),
         )
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6074,23 +6074,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_empty_transaction_status_contains_no_roots() {
-        let blockstore_path = get_tmp_ledger_path!();
-        let blockstore = Blockstore::open(&blockstore_path).unwrap();
-        blockstore.set_roots(&[0]).unwrap();
-        let index_iterator = blockstore
-            .transaction_status_cf
-            .iter(IteratorMode::From(
-                cf::TransactionStatus::as_index(0),
-                IteratorDirection::Forward,
-            ))
-            .unwrap();
-        for ((_, _, slot), _) in index_iterator {
-            assert!(!blockstore.is_root(slot));
-        }
-    }
-
-    #[test]
     fn test_get_confirmed_signatures_for_address() {
         let blockstore_path = get_tmp_ledger_path!();
         {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1678,11 +1678,11 @@ impl Blockstore {
             .put(1, &TransactionStatusIndexMeta::default())?;
         // This dummy status improves compaction performance
         self.transaction_status_cf.put(
-            (2, Signature::default(), Slot::MAX),
+            cf::TransactionStatus::as_index(2),
             &TransactionStatusMeta::default(),
         )?;
         self.address_signatures_cf.put(
-            (2, Pubkey::default(), Slot::MAX, Signature::default()),
+            cf::AddressSignatures::as_index(2),
             &AddressSignatureMeta::default(),
         )
     }

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -629,7 +629,7 @@ pub mod tests {
                 .unwrap();
             let padding_entry = status_entry_iterator.next().unwrap().0;
             assert_eq!(padding_entry.0, 2);
-            assert_eq!(padding_entry.2, Slot::MAX);
+            assert_eq!(padding_entry.2, 0);
             assert!(status_entry_iterator.next().is_none());
             let mut address_transactions_iterator = blockstore
                 .db
@@ -640,7 +640,7 @@ pub mod tests {
                 .unwrap();
             let padding_entry = address_transactions_iterator.next().unwrap().0;
             assert_eq!(padding_entry.0, 2);
-            assert_eq!(padding_entry.2, Slot::MAX);
+            assert_eq!(padding_entry.2, 0);
             assert!(address_transactions_iterator.next().is_none());
             assert_eq!(
                 transaction_status_index_cf.get(0).unwrap().unwrap(),

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -629,7 +629,7 @@ pub mod tests {
                 .unwrap();
             let padding_entry = status_entry_iterator.next().unwrap().0;
             assert_eq!(padding_entry.0, 2);
-            assert_eq!(padding_entry.2, 0);
+            assert_eq!(padding_entry.2, Slot::MAX);
             assert!(status_entry_iterator.next().is_none());
             let mut address_transactions_iterator = blockstore
                 .db
@@ -640,7 +640,7 @@ pub mod tests {
                 .unwrap();
             let padding_entry = address_transactions_iterator.next().unwrap().0;
             assert_eq!(padding_entry.0, 2);
-            assert_eq!(padding_entry.2, 0);
+            assert_eq!(padding_entry.2, Slot::MAX);
             assert!(address_transactions_iterator.next().is_none());
             assert_eq!(
                 transaction_status_index_cf.get(0).unwrap().unwrap(),

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -58,6 +58,7 @@ pub enum BlockstoreError {
     SlotCleanedUp,
     UnpackError(#[from] UnpackError),
     UnableToSetOpenFileDescriptorLimit,
+    TransactionStatusSlotMismatch,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 


### PR DESCRIPTION
#### Problem
Because of how the blockstore transaction_status_cf is initialized (to optimize compaction), an iterator on the column can match a default Signature. If slot 0 is a root, this can cause a panic.

#### Summary of Changes
Prevent match on index outside bounds
Also return an error instead of panicking, for redundancy

cc @jstarry 