### PR TITLE
Remove circular dep between InstructionError and SystemError

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1032,6 +1032,7 @@ mod tests {
     use solana_sdk::{
         instruction::InstructionError,
         signature::{Keypair, Signer},
+        system_instruction::SystemError,
         system_transaction,
         transaction::TransactionError,
     };
@@ -1397,7 +1398,7 @@ mod tests {
             results[0] = (
                 Err(TransactionError::InstructionError(
                     1,
-                    InstructionError::new_result_with_negative_lamports(),
+                    SystemError::ResultWithNegativeLamports.into(),
                 )),
                 Some(HashAgeKind::Extant),
             );

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -981,9 +981,9 @@ pub mod tests {
     use solana_sdk::{
         epoch_schedule::EpochSchedule,
         hash::Hash,
-        instruction::InstructionError,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
+        system_instruction::SystemError,
         system_transaction,
         transaction::{Transaction, TransactionError},
     };
@@ -2401,7 +2401,7 @@ pub mod tests {
             bank.transfer(10_001, &mint_keypair, &pubkey),
             Err(TransactionError::InstructionError(
                 0,
-                InstructionError::new_result_with_negative_lamports(),
+                SystemError::ResultWithNegativeLamports.into(),
             ))
         );
         assert_eq!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3149,7 +3149,8 @@ mod tests {
         poh_config::PohConfig,
         rent::Rent,
         signature::{Keypair, Signer},
-        system_instruction, system_program,
+        system_instruction::{self, SystemError},
+        system_program,
         sysvar::{fees::Fees, rewards::Rewards},
         timing::duration_as_s,
     };
@@ -5060,10 +5061,7 @@ mod tests {
         let tx = Transaction::new(&[&mint_keypair], message, genesis_config.hash());
         assert_eq!(
             bank.process_transaction(&tx).unwrap_err(),
-            TransactionError::InstructionError(
-                1,
-                InstructionError::new_result_with_negative_lamports(),
-            )
+            TransactionError::InstructionError(1, SystemError::ResultWithNegativeLamports.into())
         );
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 1);
         assert_eq!(bank.get_balance(&key1), 0);
@@ -5105,7 +5103,7 @@ mod tests {
             bank.process_transaction(&tx),
             Err(TransactionError::InstructionError(
                 0,
-                InstructionError::new_result_with_negative_lamports(),
+                SystemError::ResultWithNegativeLamports.into(),
             ))
         );
 
@@ -5141,7 +5139,7 @@ mod tests {
             bank.transfer(10_001, &mint_keypair, &pubkey),
             Err(TransactionError::InstructionError(
                 0,
-                InstructionError::new_result_with_negative_lamports(),
+                SystemError::ResultWithNegativeLamports.into(),
             ))
         );
         assert_eq!(bank.transaction_count(), 1);
@@ -5410,7 +5408,7 @@ mod tests {
             (
                 Err(TransactionError::InstructionError(
                     1,
-                    InstructionError::new_result_with_negative_lamports(),
+                    SystemError::ResultWithNegativeLamports.into(),
                 )),
                 Some(HashAgeKind::Extant),
             ),
@@ -6525,7 +6523,7 @@ mod tests {
             bank.transfer(10_001, &mint_keypair, &Pubkey::new_rand()),
             Err(TransactionError::InstructionError(
                 0,
-                InstructionError::new_result_with_negative_lamports(),
+                SystemError::ResultWithNegativeLamports.into(),
             ))
         );
 
@@ -7171,7 +7169,7 @@ mod tests {
             bank.process_transaction(&durable_tx),
             Err(TransactionError::InstructionError(
                 1,
-                system_instruction::SystemError::ResultWithNegativeLamports.into()
+                system_instruction::SystemError::ResultWithNegativeLamports.into(),
             ))
         );
         /* Check fee charged and nonce has advanced */

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -1,7 +1,7 @@
 //! Defines a composable Instruction type and a memory-efficient CompiledInstruction.
 
 use crate::sanitize::Sanitize;
-use crate::{pubkey::Pubkey, short_vec, system_instruction::SystemError};
+use crate::{pubkey::Pubkey, short_vec};
 use bincode::serialize;
 use serde::Serialize;
 use thiserror::Error;
@@ -159,12 +159,6 @@ pub enum InstructionError {
     /// Provided seeds do not result in a valid address
     #[error("Provided seeds do not result in a valid address")]
     InvalidSeeds,
-}
-
-impl InstructionError {
-    pub fn new_result_with_negative_lamports() -> Self {
-        SystemError::ResultWithNegativeLamports.into()
-    }
 }
 
 #[derive(Debug, PartialEq, Clone)]


### PR DESCRIPTION
#### Problem

Like all programs, the system program depends on the instruction module. Awkwardly, the instruction module depends back on the system instruction module for just one error code.

#### Summary of Changes

Inline and remove `InstructionError::new_result_with_negative_lamports()`.
