### PR TITLE
Disable web3.js and explorer CI on stability branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,8 @@ jobs:
 
     # explorer pull request
     - name: "explorer"
-      if: type = pull_request
+      if: type = pull_request AND branch = master
+
       language: node_js
       node_js:
         - "node"
@@ -86,7 +87,8 @@ jobs:
 
     # web3.js pull request
     - name: "web3.js"
-      if: type = pull_request
+      if: type = pull_request AND branch = master
+
       language: node_js
       node_js:
         - "lts/*"


### PR DESCRIPTION
#### Problem

web3.js and explorer CI run against stability branches, even though they are only deployed from master

#### Summary of Changes

Gate web3.js and explorer CI to only run on master

Fixes #11419
