### PR TITLE
fix: expose getConfirmedSignaturesForAddress2 method in type defs

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -355,6 +355,10 @@ declare module '@solana/web3.js' {
       startSlot: number,
       endSlot: number,
     ): Promise<Array<TransactionSignature>>;
+    getConfirmedSignaturesForAddress2(
+      address: PublicKey,
+      options?: ConfirmedSignaturesForAddress2Options,
+    ): Promise<Array<ConfirmedSignatureInfo>>;
     getVoteAccounts(commitment?: Commitment): Promise<VoteAccountStatus>;
     confirmTransaction(
       signature: TransactionSignature,

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -367,6 +367,10 @@ declare module '@solana/web3.js' {
       startSlot: number,
       endSlot: number,
     ): Promise<Array<TransactionSignature>>;
+    getConfirmedSignaturesForAddress2(
+      address: PublicKey,
+      options: ?ConfirmedSignaturesForAddress2Options,
+    ): Promise<Array<ConfirmedSignatureInfo>>;
     getVoteAccounts(commitment: ?Commitment): Promise<VoteAccountStatus>;
     confirmTransaction(
       signature: TransactionSignature,


### PR DESCRIPTION
#### Problem
`getConfirmedSignaturesForAddress2` wasn't added to type defs

#### Summary of Changes
- Add to type defs

Fixes #
