### PR TITLE
feat: add support for bpf_loader2

### DIFF
--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -944,7 +944,7 @@ declare module '@solana/web3.js' {
 
   // === src/bpf-loader.js ===
   declare export class BpfLoader {
-    static programId: PublicKey;
+    static programId(version: ?number): PublicKey;
     static getMinNumSignatures(dataLength: number): number;
     static load(
       connection: Connection,

--- a/web3.js/src/bpf-loader.js
+++ b/web3.js/src/bpf-loader.js
@@ -12,8 +12,12 @@ export class BpfLoader {
   /**
    * Public key that identifies the BpfLoader
    */
-  static get programId(): PublicKey {
-    return new PublicKey('BPFLoader1111111111111111111111111111111111');
+  static programId(version: number = 2): PublicKey {
+    if (version === 1) {
+      return new PublicKey('BPFLoader1111111111111111111111111111111111');
+    } else {
+      return new PublicKey('BPFLoader2111111111111111111111111111111111');
+    }
   }
 
   /**
@@ -40,6 +44,6 @@ export class BpfLoader {
     program: Account,
     elf: Buffer | Uint8Array | Array<number>,
   ): Promise<void> {
-    return Loader.load(connection, payer, program, BpfLoader.programId, elf);
+    return Loader.load(connection, payer, program, BpfLoader.programId(), elf);
   }
 }


### PR DESCRIPTION
#### Problem

A new loader program id is being added to handle a backward-incompatible change to the runtime <--> program ABI.  bpf_loader2 should be used for all future program loading and requires that programs be built against an SDK that contains `src/bpf_loader2.rs`

#### Summary of Changes

Load programs into accounts owned by bpf_loader2

depends on the network upgrading to: https://github.com/solana-labs/solana/pull/11384

Fixes #
