### PR TITLE
Unified signature for create_program_address

### DIFF
--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     entrypoint,
     entrypoint::ProgramResult,
     info,
-    program::{create_program_address, invoke, invoke_signed},
+    program::{invoke, invoke_signed},
     program_error::ProgramError,
     pubkey::Pubkey,
     system_instruction,
@@ -97,7 +97,8 @@ fn process_instruction(
 
             info!("Test create_program_address");
             {
-                let address = create_program_address(&[b"You pass butter", &[nonce1]], program_id)?;
+                let address =
+                    Pubkey::create_program_address(&[b"You pass butter", &[nonce1]], program_id)?;
                 assert_eq!(&address, accounts[DERIVED_KEY1_INDEX].key);
             }
 

--- a/sdk/src/program.rs
+++ b/sdk/src/program.rs
@@ -2,38 +2,8 @@
 
 use crate::{
     account_info::AccountInfo, entrypoint::ProgramResult, entrypoint::SUCCESS,
-    instruction::Instruction, program_error::ProgramError, pubkey::Pubkey,
+    instruction::Instruction,
 };
-
-pub fn create_program_address(
-    seeds: &[&[u8]],
-    program_id: &Pubkey,
-) -> Result<Pubkey, ProgramError> {
-    let bytes = [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0,
-    ];
-    let result = unsafe {
-        sol_create_program_address(
-            seeds as *const _ as *const u8,
-            seeds.len() as u64,
-            program_id as *const _ as *const u8,
-            &bytes as *const _ as *const u8,
-        )
-    };
-    match result {
-        SUCCESS => Ok(Pubkey::new(&bytes)),
-        _ => Err(result.into()),
-    }
-}
-extern "C" {
-    fn sol_create_program_address(
-        seeds_addr: *const u8,
-        seeds_len: u64,
-        program_id_addr: *const u8,
-        address_bytes_addr: *const u8,
-    ) -> u64;
-}
 
 /// Invoke a cross-program instruction
 pub fn invoke(instruction: &Instruction, account_infos: &[AccountInfo]) -> ProgramResult {


### PR DESCRIPTION
#### Problem

Two different function signatures for `create_program_address` whether you are calling from program or not

#### Summary of Changes

Unify them

Fixes #
