### PR TITLE
Return delegated amount as UiTokenAmount

### DIFF
--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -35,18 +35,17 @@ pub fn parse_token(
                 "no mint_decimals provided to parse spl-token account".to_string(),
             )
         })?;
-        let ui_token_amount = token_amount_to_ui_amount(account.amount, decimals);
         Ok(TokenAccountType::Account(UiTokenAccount {
             mint: account.mint.to_string(),
             owner: account.owner.to_string(),
-            token_amount: ui_token_amount,
+            token_amount: token_amount_to_ui_amount(account.amount, decimals),
             delegate: match account.delegate {
                 COption::Some(pubkey) => Some(pubkey.to_string()),
                 COption::None => None,
             },
             is_initialized: account.is_initialized,
             is_native: account.is_native,
-            delegated_amount: account.delegated_amount,
+            delegated_amount: token_amount_to_ui_amount(account.delegated_amount, decimals),
         }))
     } else if data.len() == size_of::<Mint>() {
         let mint: Mint = *unpack(&mut data)
@@ -102,7 +101,7 @@ pub struct UiTokenAccount {
     pub delegate: Option<String>,
     pub is_initialized: bool,
     pub is_native: bool,
-    pub delegated_amount: u64,
+    pub delegated_amount: UiTokenAmount,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -177,7 +176,11 @@ mod test {
                 delegate: None,
                 is_initialized: true,
                 is_native: false,
-                delegated_amount: 0,
+                delegated_amount: UiTokenAmount {
+                    ui_amount: 0.0,
+                    decimals: 2,
+                    amount: "0".to_string()
+                },
             }),
         );
 

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -98,9 +98,11 @@ pub struct UiTokenAccount {
     pub mint: String,
     pub owner: String,
     pub token_amount: UiTokenAmount,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delegate: Option<String>,
     pub is_initialized: bool,
     pub is_native: bool,
+    #[serde(skip_serializing_if = "UiTokenAmount::is_zero")]
     pub delegated_amount: UiTokenAmount,
 }
 
@@ -110,6 +112,16 @@ pub struct UiTokenAmount {
     pub ui_amount: f64,
     pub decimals: u8,
     pub amount: StringAmount,
+}
+
+impl UiTokenAmount {
+    fn is_zero(&self) -> bool {
+        if let Ok(amount) = self.amount.parse::<u64>() {
+            amount == 0
+        } else {
+            false
+        }
+    }
 }
 
 pub fn token_amount_to_ui_amount(amount: u64, decimals: u8) -> UiTokenAmount {


### PR DESCRIPTION
#### Problem

1. When encoding token accounts to JSON in RPC, tokenAmount is a UiAmount but delegatedAmount is a number. They should be treated the same.
2. The delegate property is returning null when unset. I would expect it to be omitted.


#### Summary of Changes
- Update delegatedAmount to return UiTokenAmount
- Omit delegate and delegatedAmount when unset/0 respectively

Fixes #11471 
