### PR TITLE
explorer: Display transaction even if getBlockTime returns an error

### DIFF
--- a/explorer/src/providers/transactions/index.tsx
+++ b/explorer/src/providers/transactions/index.tsx
@@ -232,7 +232,17 @@ export async function fetchTransactionStatus(
       });
 
       if (value !== null) {
-        let blockTime = await connection.getBlockTime(value.slot);
+        let blockTime = null;
+        try {
+          blockTime = await connection.getBlockTime(value.slot);
+        } catch (error) {
+          console.error(
+            "Failed to fetch block time for slot ",
+            value.slot,
+            ":",
+            error
+          );
+        }
         let timestamp: Timestamp =
           blockTime !== null ? blockTime : "unavailable";
 


### PR DESCRIPTION
https://explorer.solana.com/tx/39V8tR2Q8Ar3WwMBfVTRPFr7AakLHy5wp7skJNBL7ET6ARoikqc1TaMiuXEtHiNPLQKoeiVr5XnKH8QtjdonN4yM fails to display the first transaction ever because the getBlockTime RPC method doesn't return a block time for slot 1.   This isn't fatal and shouldn't cause the the explorer to devolve into a "Fetch Failed" error message.