### PR TITLE
Fallback to base64 account encoding if json parse fails

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -35,7 +35,7 @@ pub enum UiAccountData {
 
 impl From<Vec<u8>> for UiAccountData {
     fn from(data: Vec<u8>) -> Self {
-        Self::Binary(bs58::encode(data).into_string())
+        Self::Binary64(base64::encode(data))
     }
 }
 

--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -33,12 +33,6 @@ pub enum UiAccountData {
     Binary64(String),
 }
 
-impl From<Vec<u8>> for UiAccountData {
-    fn from(data: Vec<u8>) -> Self {
-        Self::Binary64(base64::encode(data))
-    }
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum UiAccountEncoding {
@@ -54,7 +48,9 @@ impl UiAccount {
         additional_data: Option<AccountAdditionalData>,
     ) -> Self {
         let data = match encoding {
-            UiAccountEncoding::Binary => account.data.into(),
+            UiAccountEncoding::Binary => {
+                UiAccountData::Binary(bs58::encode(account.data).into_string())
+            }
             UiAccountEncoding::Binary64 => UiAccountData::Binary64(base64::encode(account.data)),
             UiAccountEncoding::JsonParsed => {
                 if let Ok(parsed_data) =
@@ -62,7 +58,7 @@ impl UiAccount {
                 {
                     UiAccountData::Json(parsed_data)
                 } else {
-                    account.data.into()
+                    UiAccountData::Binary64(base64::encode(account.data))
                 }
             }
         };


### PR DESCRIPTION
#### Problem
When RPC fails to encode account data as JSON, it falls back to binary. Now that base64 is supported, we should use it as the fallback instead of base58.

#### Summary of Changes
- Change fallback from base58 to base64

Not concerned about the breaking API change here, the jsonParsed encoding is relatively new. I can handle the web3 fix when this is merged

Fixes #
