### PR TITLE
fix: base64 decode account data

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1716,7 +1716,7 @@ export class Connection {
 
       let data = resultData;
       if (!data.program) {
-        data = bs58.decode(data);
+        data = new Buffer(data, 'base64');
       }
 
       value = {
@@ -1826,7 +1826,7 @@ export class Connection {
 
       let data = resultData;
       if (!data.program) {
-        data = bs58.decode(data);
+        data = new Buffer(data, 'base64');
       }
 
       return {


### PR DESCRIPTION
#### Problem
Fallback encoding changed from `base58` to `base64` for parsed accounts

#### Summary of Changes
- Base64 decode account data if it's not parsed

Fixes #
