### PR TITLE
fix: use recommended buffer api for decoding base64

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1716,7 +1716,7 @@ export class Connection {
 
       let data = resultData;
       if (!data.program) {
-        data = new Buffer(data, 'base64');
+        data = Buffer.from(data, 'base64');
       }
 
       value = {
@@ -1826,7 +1826,7 @@ export class Connection {
 
       let data = resultData;
       if (!data.program) {
-        data = new Buffer(data, 'base64');
+        data = Buffer.from(data, 'base64');
       }
 
       return {


### PR DESCRIPTION
#### Problem
```
(node:15069) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

#### Summary of Changes
- Use `Buffer.from` instead of `new Buffer`

Fixes #
