### PR TITLE
cli: account subcommand now requests binary64

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -40,7 +40,7 @@ pub enum UiAccountData {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum UiAccountEncoding {
-    Binary,
+    Binary, // SLOW! Avoid this encoding
     JsonParsed,
     Binary64,
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1120,7 +1120,7 @@ fn process_show_account(
     let cli_account = CliAccount {
         keyed_account: RpcKeyedAccount {
             pubkey: account_pubkey.to_string(),
-            account: UiAccount::encode(account_pubkey, account, UiAccountEncoding::Binary, None),
+            account: UiAccount::encode(account_pubkey, account, UiAccountEncoding::Binary64, None),
         },
         use_lamports_unit,
     };


### PR DESCRIPTION
`solana account ...` was still slow because although we now fetch the account as base64 over the wire, there was a client-side base58 conversion happening.  Avoid it by explicitly requesting base64 within the cli