### PR TITLE
Blockstore address signatures: handle slots that cross primary indexes, and refactor get_confirmed_signatures_for_address2

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1902,7 +1902,7 @@ impl Blockstore {
                 }
             }
         }
-        signatures.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        signatures.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap().then(a.1.cmp(&b.1)));
         Ok(signatures)
     }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -235,6 +235,9 @@ impl Blockstore {
         Ok(result)
     }
 
+    /// Purges special columns (using a non-Slot primary-index) exactly, by deserializing each slot
+    /// being purged and iterating through all transactions to determine the keys of individual
+    /// records. **This method is very slow.**
     fn purge_special_columns_exact(
         &self,
         batch: &mut WriteBatch,
@@ -279,6 +282,8 @@ impl Blockstore {
         Ok(())
     }
 
+    /// Purges special columns (using a non-Slot primary-index) by range. Purge occurs if frozen
+    /// primary index has a max-slot less than the highest slot being purged.
     fn purge_special_columns_with_primary_index(
         &self,
         write_batch: &mut WriteBatch,

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -40,7 +40,9 @@ const CODE_SHRED_CF: &str = "code_shred";
 const TRANSACTION_STATUS_CF: &str = "transaction_status";
 /// Column family for Address Signatures
 const ADDRESS_SIGNATURES_CF: &str = "address_signatures";
-/// Column family for Transaction Status Index
+/// Column family for the Transaction Status Index.
+/// This column family is used for tracking the active primary index for columns that for
+/// query performance reasons should not be indexed by Slot.
 const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 /// Column family for Rewards
 const REWARDS_CF: &str = "rewards";


### PR DESCRIPTION
#### Problem
Transaction history queries time out on mainnet-beta. This is because the loop in `Blockstore::get_confirmed_signatures_for_address2` loops through all slots between the requested slot (default highest_confirmed_root) and the address' lowest_slot when `limit` is not met. Mainnet-beta api nodes retain millions of slots of data, so this loop could execute millions of times, if an account is low activity and its lowest_slot is near the node's first-available-slot.

Also, a test edit shows that `get_confirmed_signatures_for_address2` may not return consistently ordered results when the columns primary index changes in the middle of a slot. (This could definitely happen in practice. The primary index changes on a blockstore purge, and blockstore writes continue throughout.)

#### Summary of Changes
- Add secondary sort to `Blockstore::find_address_signatures` so that signature order is consistent with get_confirmed_block for the address, even if address-signatures span a primary-index swap
- Refactor `Blockstore::get_confirmed_signatures_for_address2` to use the column Iterator. One side effect of this change is that addresses are now returned in reverse order within a slot.

I added some metrics and booted an api node against mainnet-beta. With this PR, the slowest step is now the status lookup here, by far: https://github.com/solana-labs/solana/blob/a4f5f3e978ed3dfa4df2c7aad0b80a93aefcf0b7/ledger/src/blockstore.rs#L2052
It takes 25-50x as long as the signature lookups

Addresses tested: `Bbqg1M4YVVfbhEzwA9SpC9FhsaG83YMTYoR4a8oTDLX` and `TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o`, which each have ~250 transactions stretching back about 3.5mill slots on the mainnet-beta api nodes. Both timeout when http://api.mainnet-beta.solana.com is queried.

get_status_info ~13ms
the rest combined ~400us

Fixes #11479 
