### PR TITLE
Fix createProgramAdress for bundled applications

### DIFF
--- a/web3.js/src/publickey.js
+++ b/web3.js/src/publickey.js
@@ -110,7 +110,7 @@ export class PublicKey {
       Buffer.from('ProgramDerivedAddress'),
     ]);
     let hash = await sha256(new Uint8Array(buffer));
-    let publicKeyBytes = new BN(hash, 16).toBuffer();
+    let publicKeyBytes = new BN(hash, 16).toArray();
     if (is_on_curve(publicKeyBytes)) {
       throw new Error(`Invalid seeds, address must fall off the curve`);
     }


### PR DESCRIPTION
The way bn.js checks if Buffers are supported does not work with bundled applications that don't allow require at runtime.
Using toArray works nicely because most libraries (including the curve point check) do accept Uint8Array

https://github.com/indutny/bn.js/blob/5707aed66c02ae10f8c7d59f5244fcce1c24cdb6/lib/bn.js#L51-L55