### PR TITLE
Fix solana CLI deploy

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1321,7 +1321,7 @@ fn process_deploy(
 
     let mut write_transactions = vec![];
     for message in write_messages.into_iter() {
-        let mut tx = Transaction::new_unsigned(message.clone());
+        let mut tx = Transaction::new_unsigned(message);
         tx.try_sign(&signers, blockhash)?;
         write_transactions.push(tx);
     }


### PR DESCRIPTION
#### Problem
Deploying large programs using the solana cli is flaky. Frequently, the process will stall out at `Finalizing transaction ...` for the very last transaction (`loader_instruction::finalize`) and ultimately return an error after many seconds.

This is because `process_deploy` requests just one blockhash before building any of the transactions. The `loader_instruction::write` transactions may receive a refreshed blockhash inside `send_and_confirm_transactions_with_spinner()` if they fail to confirm, but `loader_instruction::finalize` does not. As a result, the blockhash sometimes expires before the finalize transaction is submitted/processed, thus that transaction is never confirmed.

#### Summary of Changes
- Refresh the blockhash before `loader_instruction::finalize`; also refresh the blockhash before the `loader_instruction::write` transactions are signed to increase the chances of their success first time.
- Also, a minor refactor of confirmation checks inside `send_and_confirm_transactions_with_spinner` using current methods and saving an RPC call per transaction. (All the `get_signature_status` requests were essentially a waste because they require max commitment. As such, they always return None, even when the transaction meets the threshold of > 1 confirmation.

Fixes #11444 
