### PR TITLE
fix: Add space to ParsedAccountData

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -185,6 +185,7 @@ declare module '@solana/web3.js' {
   export type ParsedAccountData = {
     program: string;
     parsed: any;
+    space: number;
   };
 
   export type KeyedAccountInfo = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -174,6 +174,7 @@ declare module '@solana/web3.js' {
   declare export type ParsedAccountData = {
     program: string,
     parsed: any,
+    space: number,
   };
 
   declare export type ParsedMessageAccount = {

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -712,6 +712,7 @@ const GetParsedTokenAccountsByOwner = jsonRpcResultAndContext(
         data: struct.pick({
           program: 'string',
           parsed: 'any',
+          space: 'number',
         }),
         rentEpoch: 'number?',
       }),
@@ -776,6 +777,7 @@ const ParsedAccountInfoResult = struct.object({
     struct.pick({
       program: 'string',
       parsed: 'any',
+      space: 'number',
     }),
   ]),
   rentEpoch: 'number?',
@@ -1168,10 +1170,12 @@ type SlotInfo = {
  * @typedef {Object} ParsedAccountData
  * @property {string} program Name of the program that owns this account
  * @property {any} parsed Parsed account data
+ * @property {number} space Space used by account data
  */
 type ParsedAccountData = {
   program: string,
   parsed: any,
+  space: number,
 };
 
 /**


### PR DESCRIPTION
#### Problem
`space` field was added to the parsed-account struct in https://github.com/solana-labs/solana/pull/11506 and backports. 

#### Summary of Changes
Add it to web3 types

@jstarry how have you been handling breaking changes like this that are coming, but not yet deployed to mnb api nodes?
