### PR TITLE
feat: add simulateTransaction API

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -121,6 +121,11 @@ declare module '@solana/web3.js' {
     version?: string;
   };
 
+  export type SimulatedTransactionResponse = {
+    err: TransactionError | string | null;
+    logs: Array<string> | null;
+  };
+
   export type ConfirmedTransactionMeta = {
     fee: number;
     preBalances: Array<number>;
@@ -404,6 +409,10 @@ declare module '@solana/web3.js' {
       wireTransaction: Buffer | Uint8Array | Array<number>,
       options?: SendOptions,
     ): Promise<TransactionSignature>;
+    simulateTransaction(
+      transaction: Transaction,
+      signers?: Array<Account>,
+    ): Promise<RpcResponseAndContext<SimulatedTransactionResponse>>;
     onAccountChange(
       publickey: PublicKey,
       callback: AccountChangeCallback,

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -143,6 +143,11 @@ declare module '@solana/web3.js' {
     version: string | null,
   };
 
+  declare export type SimulatedTransactionResponse = {
+    err: TransactionError | string | null,
+    logs: Array<string> | null,
+  };
+
   declare export type ConfirmedTransactionMeta = {
     fee: number,
     preBalances: Array<number>,
@@ -417,6 +422,10 @@ declare module '@solana/web3.js' {
       wireTransaction: Buffer | Uint8Array | Array<number>,
       options?: SendOptions,
     ): Promise<TransactionSignature>;
+    simulateTransaction(
+      transaction: Transaction,
+      signers?: Array<Account>,
+    ): Promise<RpcResponseAndContext<SimulatedTransactionResponse>>;
     onAccountChange(
       publickey: PublicKey,
       callback: AccountChangeCallback,

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -51,56 +51,156 @@ test('load BPF C program', async () => {
   });
 });
 
-test('load BPF Rust program', async () => {
+describe('load BPF Rust program', () => {
   if (mockRpcEnabled) {
     console.log('non-live test skipped');
     return;
   }
 
-  const data = await fs.readFile(
-    'test/fixtures/noop-rust/solana_bpf_rust_noop.so',
-  );
-
   const connection = new Connection(url, 'recent');
-  const {feeCalculator} = await connection.getRecentBlockhash();
-  const fees =
-    feeCalculator.lamportsPerSignature *
-    (BpfLoader.getMinNumSignatures(data.length) + NUM_RETRIES);
-  const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
-    data.length,
-  );
-  const from = await newAccountWithLamports(connection, fees + balanceNeeded);
 
-  const program = new Account();
-  await BpfLoader.load(connection, from, program, data);
-  const transaction = new Transaction().add({
-    keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
-    programId: program.publicKey,
+  let program: Account;
+  let signature: string;
+  let payerAccount: Account;
+
+  beforeAll(async () => {
+    const data = await fs.readFile(
+      'test/fixtures/noop-rust/solana_bpf_rust_noop.so',
+    );
+
+    const {feeCalculator} = await connection.getRecentBlockhash();
+    const fees =
+      feeCalculator.lamportsPerSignature *
+      (BpfLoader.getMinNumSignatures(data.length) + NUM_RETRIES);
+    const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
+      data.length,
+    );
+
+    payerAccount = await newAccountWithLamports(
+      connection,
+      fees + balanceNeeded,
+    );
+
+    program = new Account();
+    await BpfLoader.load(connection, payerAccount, program, data);
+    const transaction = new Transaction().add({
+      keys: [
+        {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
+      ],
+      programId: program.publicKey,
+    });
+    await sendAndConfirmTransaction(connection, transaction, [payerAccount], {
+      skipPreflight: true,
+    });
+
+    if (transaction.signature === null) {
+      expect(transaction.signature).not.toBeNull();
+      return;
+    }
+
+    signature = bs58.encode(transaction.signature);
   });
-  await sendAndConfirmTransaction(connection, transaction, [from], {
-    skipPreflight: true,
+
+  test('get confirmed transaction', async () => {
+    const parsedTx = await connection.getParsedConfirmedTransaction(signature);
+    if (parsedTx === null) {
+      expect(parsedTx).not.toBeNull();
+      return;
+    }
+    const {signatures, message} = parsedTx.transaction;
+    expect(signatures[0]).toEqual(signature);
+    const ix = message.instructions[0];
+    if (ix.parsed) {
+      expect('parsed' in ix).toBe(false);
+    } else {
+      expect(ix.programId.equals(program.publicKey)).toBe(true);
+      expect(ix.data).toEqual('');
+    }
   });
 
-  if (transaction.signature === null) {
-    expect(transaction.signature).not.toBeNull();
-    return;
-  }
+  test('simulate transaction', async () => {
+    const simulatedTransaction = new Transaction().add({
+      keys: [
+        {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
+      ],
+      programId: program.publicKey,
+    });
 
-  const confirmedSignature = bs58.encode(transaction.signature);
-  const parsedTx = await connection.getParsedConfirmedTransaction(
-    confirmedSignature,
-  );
-  if (parsedTx === null) {
-    expect(parsedTx).not.toBeNull();
-    return;
-  }
-  const {signatures, message} = parsedTx.transaction;
-  expect(signatures[0]).toEqual(confirmedSignature);
-  const ix = message.instructions[0];
-  if (ix.parsed) {
-    expect('parsed' in ix).toBe(false);
-  } else {
-    expect(ix.programId.equals(program.publicKey)).toBe(true);
-    expect(ix.data).toEqual('');
-  }
+    const {err, logs} = (
+      await connection.simulateTransaction(simulatedTransaction, [payerAccount])
+    ).value;
+    expect(err).toBeNull();
+
+    if (logs === null) {
+      expect(logs).not.toBeNull();
+      return;
+    }
+
+    expect(logs.length).toBeGreaterThanOrEqual(2);
+    expect(logs[0]).toEqual(`Call BPF program ${program.publicKey.toBase58()}`);
+    expect(logs[logs.length - 1]).toEqual(
+      `BPF program ${program.publicKey.toBase58()} success`,
+    );
+  });
+
+  test('simulate transaction without signature verification', async () => {
+    const simulatedTransaction = new Transaction().add({
+      keys: [
+        {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
+      ],
+      programId: program.publicKey,
+    });
+
+    const {err, logs} = (
+      await connection.simulateTransaction(simulatedTransaction)
+    ).value;
+    expect(err).toBeNull();
+
+    if (logs === null) {
+      expect(logs).not.toBeNull();
+      return;
+    }
+
+    expect(logs.length).toBeGreaterThanOrEqual(2);
+    expect(logs[0]).toEqual(`Call BPF program ${program.publicKey.toBase58()}`);
+    expect(logs[logs.length - 1]).toEqual(
+      `BPF program ${program.publicKey.toBase58()} success`,
+    );
+  });
+
+  test('simulate transaction with bad programId', async () => {
+    const simulatedTransaction = new Transaction().add({
+      keys: [
+        {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
+      ],
+      programId: new Account().publicKey,
+    });
+
+    const {err, logs} = (
+      await connection.simulateTransaction(simulatedTransaction)
+    ).value;
+    expect(err).toEqual('ProgramAccountNotFound');
+
+    if (logs === null) {
+      expect(logs).not.toBeNull();
+      return;
+    }
+
+    expect(logs.length).toEqual(0);
+  });
+
+  test('simulate transaction with bad signer', async () => {
+    const simulatedTransaction = new Transaction().add({
+      keys: [
+        {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
+      ],
+      programId: program.publicKey,
+    });
+
+    const {err, logs} = (
+      await connection.simulateTransaction(simulatedTransaction, [program])
+    ).value;
+    expect(err).toEqual('SignatureFailure');
+    expect(logs).toBeNull();
+  });
 });


### PR DESCRIPTION
#### Problem
Want to simulate transactions on the cluster without requiring the transaction to be signed

#### Summary of Changes
- Add `simulateTransaction` to `Connection`. Signing is optional

Fixes #
