### PR TITLE
fix: ignore extra space field in parsed accounts

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -658,7 +658,7 @@ const GetParsedTokenAccountsByOwner = jsonRpcResultAndContext(
         executable: 'boolean',
         owner: 'string',
         lamports: 'number',
-        data: struct.object({
+        data: struct.pick({
           program: 'string',
           parsed: 'any',
         }),
@@ -722,7 +722,7 @@ const ParsedAccountInfoResult = struct.object({
   lamports: 'number',
   data: struct.union([
     'string',
-    struct.object({
+    struct.pick({
       program: 'string',
       parsed: 'any',
     }),


### PR DESCRIPTION
#### Problem
Recently added a `space` field to parsed accounts but web3 currently doesn't allow other fields when validating account responses.

#### Summary of Changes
Relax account data validation to allow unknown fields

Fixes #
