### PR TITLE
Specify loader when bootstrapping BPF programs

### DIFF
--- a/fetch-spl.sh
+++ b/fetch-spl.sh
@@ -10,10 +10,11 @@ fetch_program() {
   declare name=$1
   declare version=$2
   declare address=$3
+  declare loader=$4
 
   declare so=spl_$name-$version.so
 
-  genesis_args+=(--bpf-program "$address" "$so")
+  genesis_args+=(--bpf-program "$address" "$loader" "$so")
 
   if [[ -r $so ]]; then
     return
@@ -36,8 +37,8 @@ fetch_program() {
 
 }
 
-fetch_program token 1.0.0 TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o
-fetch_program memo  1.0.0 Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo
+fetch_program token 1.0.0 TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o BPFLoader1111111111111111111111111111111111
+fetch_program memo  1.0.0 Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo BPFLoader1111111111111111111111111111111111
 
 echo "${genesis_args[@]}" > spl-genesis-args.sh
 


### PR DESCRIPTION
#### Problem

Genesis is assuming the default loader when adding BPF programs and the default loader has been recently updated.  Programs compatible with the old loader fail when loaded by the new one.

#### Summary of Changes

Allow callers to specify what loader to use when adding the program and also update the SPL scripts to specify the compatible loader

Fixes #
