### PR TITLE
Remove not found disclaimer when full history is available

### DIFF
--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -74,7 +74,7 @@ function StatusCard({ signature }: Props) {
       <ErrorCard retry={() => fetchStatus(signature)} text="Fetch Failed" />
     );
   } else if (!status.data?.info) {
-    if (firstAvailableBlock !== undefined) {
+    if (firstAvailableBlock !== undefined && firstAvailableBlock > 1) {
       return (
         <ErrorCard
           retry={() => fetchStatus(signature)}


### PR DESCRIPTION
#### Problem
The explorer displays a disclaimer that transactions may not be found due to incomplete ledger history. This no longer applies to mainnet.

#### Summary of Changes
Don't show the disclaimer if the first available block is <= 1

Fixes #
