### PR TITLE
Add token supply info to mint account page

### DIFF
--- a/explorer/src/components/account/TokenLargestAccountsCard.tsx
+++ b/explorer/src/components/account/TokenLargestAccountsCard.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { PublicKey, TokenAccountBalancePair } from "@solana/web3.js";
+import { LoadingCard } from "components/common/LoadingCard";
+import { ErrorCard } from "components/common/ErrorCard";
+import { Address } from "components/common/Address";
+import { useTokenSupply } from "providers/mints/supply";
+import {
+  useTokenLargestTokens,
+  useFetchTokenLargestAccounts,
+} from "providers/mints/largest";
+import { FetchStatus } from "providers/cache";
+
+export function TokenLargestAccountsCard({ pubkey }: { pubkey: PublicKey }) {
+  const mintAddress = pubkey.toBase58();
+  const supply = useTokenSupply(mintAddress);
+  const largestAccounts = useTokenLargestTokens(mintAddress);
+  const fetchLargestAccounts = useFetchTokenLargestAccounts();
+  const refreshLargest = () => fetchLargestAccounts(pubkey);
+
+  React.useEffect(() => {
+    if (!largestAccounts) refreshLargest();
+  }, [mintAddress]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const supplyTotal = supply?.data?.uiAmount;
+  if (!supplyTotal || !largestAccounts) {
+    return null;
+  }
+
+  if (largestAccounts?.data === undefined) {
+    if (largestAccounts.status === FetchStatus.Fetching) {
+      return <LoadingCard message="Loading largest accounts" />;
+    }
+
+    return (
+      <ErrorCard
+        retry={refreshLargest}
+        text="Failed to fetch largest accounts"
+      />
+    );
+  }
+
+  const accounts = largestAccounts.data.largest;
+  return (
+    <>
+      <div className="card">
+        <div className="card-header">
+          <div className="row align-items-center">
+            <div className="col">
+              <h4 className="card-header-title">Largest Accounts</h4>
+            </div>
+          </div>
+        </div>
+
+        <div className="table-responsive mb-0">
+          <table className="table table-sm table-nowrap card-table">
+            <thead>
+              <tr>
+                <th className="text-muted">Rank</th>
+                <th className="text-muted">Address</th>
+                <th className="text-muted text-right">Balance</th>
+                <th className="text-muted text-right">% of Total Supply</th>
+              </tr>
+            </thead>
+            <tbody className="list">
+              {accounts.map((account, index) =>
+                renderAccountRow(account, index, supplyTotal)
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </>
+  );
+}
+
+const renderAccountRow = (
+  account: TokenAccountBalancePair,
+  index: number,
+  supply: number
+) => {
+  return (
+    <tr key={index}>
+      <td>
+        <span className="badge badge-soft-gray badge-pill">{index + 1}</span>
+      </td>
+      <td>
+        <Address pubkey={account.address} link />
+      </td>
+      <td className="text-right">{account.uiAmount}</td>
+      <td className="text-right">{`${(
+        (100 * account.uiAmount) /
+        supply
+      ).toFixed(3)}%`}</td>
+    </tr>
+  );
+};

--- a/explorer/src/index.tsx
+++ b/explorer/src/index.tsx
@@ -10,6 +10,7 @@ import { SupplyProvider } from "./providers/supply";
 import { TransactionsProvider } from "./providers/transactions";
 import { AccountsProvider } from "./providers/accounts";
 import { StatsProvider } from "providers/stats";
+import { MintsProvider } from "providers/mints";
 
 ReactDOM.render(
   <Router>
@@ -18,9 +19,11 @@ ReactDOM.render(
         <SupplyProvider>
           <RichListProvider>
             <AccountsProvider>
-              <TransactionsProvider>
-                <App />
-              </TransactionsProvider>
+              <MintsProvider>
+                <TransactionsProvider>
+                  <App />
+                </TransactionsProvider>
+              </MintsProvider>
             </AccountsProvider>
           </RichListProvider>
         </SupplyProvider>

--- a/explorer/src/providers/mints/index.tsx
+++ b/explorer/src/providers/mints/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { SupplyProvider } from "./supply";
+import { LargestAccountsProvider } from "./largest";
+
+type ProviderProps = { children: React.ReactNode };
+export function MintsProvider({ children }: ProviderProps) {
+  return (
+    <SupplyProvider>
+      <LargestAccountsProvider>{children}</LargestAccountsProvider>
+    </SupplyProvider>
+  );
+}

--- a/explorer/src/providers/mints/largest.tsx
+++ b/explorer/src/providers/mints/largest.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { useCluster } from "providers/cluster";
+import * as Cache from "providers/cache";
+import { ActionType, FetchStatus } from "providers/cache";
+import {
+  PublicKey,
+  Connection,
+  TokenAccountBalancePair,
+} from "@solana/web3.js";
+
+type LargestAccounts = {
+  largest: TokenAccountBalancePair[];
+};
+
+type State = Cache.State<LargestAccounts>;
+type Dispatch = Cache.Dispatch<LargestAccounts>;
+
+const StateContext = React.createContext<State | undefined>(undefined);
+const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+
+type ProviderProps = { children: React.ReactNode };
+export function LargestAccountsProvider({ children }: ProviderProps) {
+  const { url } = useCluster();
+  const [state, dispatch] = Cache.useReducer<LargestAccounts>(url);
+
+  // Clear cache whenever cluster is changed
+  React.useEffect(() => {
+    dispatch({ type: ActionType.Clear, url });
+  }, [dispatch, url]);
+
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </StateContext.Provider>
+  );
+}
+
+async function fetchLargestAccounts(
+  dispatch: Dispatch,
+  pubkey: PublicKey,
+  url: string
+) {
+  dispatch({
+    type: ActionType.Update,
+    key: pubkey.toBase58(),
+    status: Cache.FetchStatus.Fetching,
+    url,
+  });
+
+  let data;
+  let fetchStatus;
+  try {
+    data = {
+      largest: (
+        await new Connection(url, "single").getTokenLargestAccounts(pubkey)
+      ).value,
+    };
+    fetchStatus = FetchStatus.Fetched;
+  } catch (error) {
+    fetchStatus = FetchStatus.FetchFailed;
+  }
+  dispatch({
+    type: ActionType.Update,
+    status: fetchStatus,
+    data,
+    key: pubkey.toBase58(),
+    url,
+  });
+}
+
+export function useFetchTokenLargestAccounts() {
+  const dispatch = React.useContext(DispatchContext);
+  if (!dispatch) {
+    throw new Error(
+      `useFetchTokenLargestAccounts must be used within a MintsProvider`
+    );
+  }
+
+  const { url } = useCluster();
+  return (pubkey: PublicKey) => {
+    fetchLargestAccounts(dispatch, pubkey, url);
+  };
+}
+
+export function useTokenLargestTokens(
+  address: string
+): Cache.CacheEntry<LargestAccounts> | undefined {
+  const context = React.useContext(StateContext);
+
+  if (!context) {
+    throw new Error(
+      `useTokenLargestTokens must be used within a MintsProvider`
+    );
+  }
+
+  return context.entries[address];
+}

--- a/explorer/src/providers/mints/supply.tsx
+++ b/explorer/src/providers/mints/supply.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { useCluster } from "providers/cluster";
+import * as Cache from "providers/cache";
+import { ActionType, FetchStatus } from "providers/cache";
+import { TokenAmount, PublicKey, Connection } from "@solana/web3.js";
+
+type State = Cache.State<TokenAmount>;
+type Dispatch = Cache.Dispatch<TokenAmount>;
+
+const StateContext = React.createContext<State | undefined>(undefined);
+const DispatchContext = React.createContext<Dispatch | undefined>(undefined);
+
+type ProviderProps = { children: React.ReactNode };
+export function SupplyProvider({ children }: ProviderProps) {
+  const { url } = useCluster();
+  const [state, dispatch] = Cache.useReducer<TokenAmount>(url);
+
+  // Clear cache whenever cluster is changed
+  React.useEffect(() => {
+    dispatch({ type: ActionType.Clear, url });
+  }, [dispatch, url]);
+
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </StateContext.Provider>
+  );
+}
+
+async function fetchSupply(dispatch: Dispatch, pubkey: PublicKey, url: string) {
+  dispatch({
+    type: ActionType.Update,
+    key: pubkey.toBase58(),
+    status: Cache.FetchStatus.Fetching,
+    url,
+  });
+
+  let data;
+  let fetchStatus;
+  try {
+    data = (await new Connection(url, "single").getTokenSupply(pubkey)).value;
+
+    fetchStatus = FetchStatus.Fetched;
+  } catch (error) {
+    fetchStatus = FetchStatus.FetchFailed;
+  }
+  dispatch({
+    type: ActionType.Update,
+    status: fetchStatus,
+    data,
+    key: pubkey.toBase58(),
+    url,
+  });
+}
+
+export function useFetchTokenSupply() {
+  const dispatch = React.useContext(DispatchContext);
+  if (!dispatch) {
+    throw new Error(`useFetchTokenSupply must be used within a MintsProvider`);
+  }
+
+  const { url } = useCluster();
+  return (pubkey: PublicKey) => {
+    fetchSupply(dispatch, pubkey, url);
+  };
+}
+
+export function useTokenSupply(
+  address: string
+): Cache.CacheEntry<TokenAmount> | undefined {
+  const context = React.useContext(StateContext);
+
+  if (!context) {
+    throw new Error(`useTokenSupply must be used within a MintsProvider`);
+  }
+
+  return context.entries[address];
+}


### PR DESCRIPTION
#### Problem
Want to see distribution of current token supply among holders

#### Summary of Changes
- Add `/holders` url path for mint accounts
- Show largest accounts in "Holders" tab
- Display total supply in mint account info table
- Hide (owned) "Tokens" tab for all token accounts

Fixes https://github.com/solana-labs/solana/issues/11241
