### PR TITLE
Fix explorer mint account validator to accept null owner

### DIFF
--- a/explorer/src/components/account/TokenAccountSection.tsx
+++ b/explorer/src/components/account/TokenAccountSection.tsx
@@ -110,7 +110,7 @@ function MintAccountCard({
             <td className="text-lg-right">Uninitialized</td>
           </tr>
         )}
-        {info.owner !== undefined && (
+        {info.owner && (
           <tr>
             <td>Owner</td>
             <td className="text-lg-right">

--- a/explorer/src/validators/accounts/token.ts
+++ b/explorer/src/validators/accounts/token.ts
@@ -38,7 +38,7 @@ export type MintAccountInfo = StructType<typeof MintAccountInfo>;
 export const MintAccountInfo = object({
   decimals: number(),
   isInitialized: boolean(),
-  owner: optional(Pubkey),
+  owner: nullable(optional(Pubkey)),
 });
 
 export type MultisigAccountInfo = StructType<typeof MultisigAccountInfo>;


### PR DESCRIPTION
#### Problem
Explorer mint account validator expects owner to not be present if not set but the API returns null

#### Summary of Changes
- Accept a null or undefined `owner` field for mint accounts

cc @CriesofCarrots 
