### PR TITLE
Return blockstore signatures-for-address despite bigtable error

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -904,17 +904,21 @@ impl JsonRpcRequestProcessor {
                         before = results.last().map(|x| x.signature);
                     }
 
-                    let mut bigtable_results = self
-                        .runtime_handle
-                        .block_on(
-                            bigtable_ledger_storage.get_confirmed_signatures_for_address(
-                                &address,
-                                before.as_ref(),
-                                limit,
-                            ),
-                        )
-                        .map_err(|err| Error::invalid_params(format!("{}", err)))?;
-                    results.append(&mut bigtable_results)
+                    let bigtable_results = self.runtime_handle.block_on(
+                        bigtable_ledger_storage.get_confirmed_signatures_for_address(
+                            &address,
+                            before.as_ref(),
+                            limit,
+                        ),
+                    );
+                    match bigtable_results {
+                        Ok(mut bigtable_results) => {
+                            results.append(&mut bigtable_results);
+                        }
+                        Err(err) => {
+                            warn!("{:?}", err);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Problem
Sometimes `getConfirmedSignaturesForAddress2` returns a bigtable "Row not found" error, even though the address has history.

This happens in cases where an address returns blockstore history from `get_confirmed_signatures_for_address2`, but that history has not been loaded into bigtable yet (eg. if bigtable is super behind, like right now).

Specifically, the rpc api passes the last blockstore signature to the bigtable `get_confirmed_signatures_for_address` api as the `before` parameter. If that signature doesn’t exist, bigtable returns “Row not found”, even though there may be older valid data in bigtable for the address.

#### Summary of Changes
- Suppress errors from bigtable `get_confirmed_signatures_for_address` in Rpc `get_confirmed_signatures_for_address2` and return any blockstore-provided signatures

A more robust solution will involve passing either the source (blockstore vs user) or slot of the `before` parameter into the bigtable api to identify when a missing `before` signature is valid but late, and return older bigtable data instead of erroring.

cc @mvines 
cc @t-nelson 
