### PR TITLE
Ensure highest_confirmed_root only grows

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -235,9 +235,19 @@ impl AggregateCommitmentService {
 mod tests {
     use super::*;
     use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
-    use solana_sdk::pubkey::Pubkey;
+    use solana_runtime::{
+        bank_forks::BankForks,
+        genesis_utils::{create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs},
+    };
+    use solana_sdk::{
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+    };
     use solana_stake_program::stake_state;
-    use solana_vote_program::vote_state::{self, VoteStateVersions};
+    use solana_vote_program::{
+        vote_state::{self, VoteStateVersions},
+        vote_transaction,
+    };
 
     #[test]
     fn test_get_highest_confirmed_root() {
@@ -459,5 +469,120 @@ mod tests {
         }
         assert_eq!(rooted_stake.len(), 2);
         assert_eq!(get_highest_confirmed_root(rooted_stake, 100), 1)
+    }
+
+    #[test]
+    fn test_highest_confirmed_root_advance() {
+        fn get_vote_account_root_slot(vote_pubkey: Pubkey, bank: &Arc<Bank>) -> Slot {
+            let account = &bank.vote_accounts()[&vote_pubkey].1;
+            let vote_state = VoteState::from(account).unwrap();
+            vote_state.root_slot.unwrap()
+        }
+
+        let block_commitment_cache = RwLock::new(BlockCommitmentCache::new_for_tests());
+
+        let node_keypair = Arc::new(Keypair::new());
+        let vote_keypair = Arc::new(Keypair::new());
+        let stake_keypair = Arc::new(Keypair::new());
+        let validator_keypairs = vec![ValidatorVoteKeypairs {
+            node_keypair: node_keypair.clone(),
+            vote_keypair: vote_keypair.clone(),
+            stake_keypair,
+        }];
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair: _,
+            voting_keypair: _,
+        } = create_genesis_config_with_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![100; 1],
+        );
+
+        let bank0 = Bank::new(&genesis_config);
+        let mut bank_forks = BankForks::new(bank0);
+
+        // Fill bank_forks with banks with votes landing in the next slot
+        // Create enough banks such that vote account will root slots 0 and 1
+        for x in 0..33 {
+            let previous_bank = bank_forks.get(x).unwrap();
+            let bank = Bank::new_from_parent(previous_bank, &Pubkey::default(), x + 1);
+            let vote = vote_transaction::new_vote_transaction(
+                vec![x],
+                previous_bank.hash(),
+                previous_bank.last_blockhash(),
+                &node_keypair,
+                &vote_keypair,
+                &vote_keypair,
+                None,
+            );
+            bank.process_transaction(&vote).unwrap();
+            bank_forks.insert(bank);
+        }
+
+        let working_bank = bank_forks.working_bank();
+        let root = get_vote_account_root_slot(vote_keypair.pubkey(), &working_bank);
+        for x in 0..root {
+            bank_forks.set_root(x, &None, None);
+        }
+
+        // Add an additional bank/vote that will root slot 2
+        let bank33 = bank_forks.get(33).unwrap();
+        let bank34 = Bank::new_from_parent(bank33, &Pubkey::default(), 34);
+        let vote33 = vote_transaction::new_vote_transaction(
+            vec![33],
+            bank33.hash(),
+            bank33.last_blockhash(),
+            &node_keypair,
+            &vote_keypair,
+            &vote_keypair,
+            None,
+        );
+        bank34.process_transaction(&vote33).unwrap();
+        bank_forks.insert(bank34);
+
+        let working_bank = bank_forks.working_bank();
+        let root = get_vote_account_root_slot(vote_keypair.pubkey(), &working_bank);
+        let ancestors = working_bank.status_cache_ancestors();
+        let _ = AggregateCommitmentService::update_commitment_cache(
+            &block_commitment_cache,
+            CommitmentAggregationData {
+                bank: working_bank,
+                root: 0,
+                total_stake: 100,
+            },
+            ancestors,
+        );
+        let highest_confirmed_root = block_commitment_cache
+            .read()
+            .unwrap()
+            .highest_confirmed_root();
+        bank_forks.set_root(root, &None, Some(highest_confirmed_root));
+        let highest_confirmed_root_bank = bank_forks.get(highest_confirmed_root);
+        assert!(highest_confirmed_root_bank.is_some());
+
+        // Add a forked bank. Because the vote for bank 33 landed in the non-ancestor, the vote
+        // account's root (and thus the highest_confirmed_root) rolls back to slot 1
+        let bank33 = bank_forks.get(33).unwrap();
+        let bank35 = Bank::new_from_parent(bank33, &Pubkey::default(), 35);
+        bank_forks.insert(bank35);
+
+        let working_bank = bank_forks.working_bank();
+        let ancestors = working_bank.status_cache_ancestors();
+        let _ = AggregateCommitmentService::update_commitment_cache(
+            &block_commitment_cache,
+            CommitmentAggregationData {
+                bank: working_bank,
+                root: 1,
+                total_stake: 100,
+            },
+            ancestors,
+        );
+        let highest_confirmed_root = block_commitment_cache
+            .read()
+            .unwrap()
+            .highest_confirmed_root();
+        let highest_confirmed_root_bank = bank_forks.get(highest_confirmed_root);
+        assert!(highest_confirmed_root_bank.is_some());
     }
 }


### PR DESCRIPTION
#### Problem
RPC requests against a node when the cluster is experiencing heavy forking can produce this error on v1.2: `Error -32000 (Cluster largest_confirmed_root <X> does not exist on node. Node root: <Y>)`, where X < Y

BankForks retains banks back to the highest_confirmed_root. When a node switches forks, the new bank can have a highest_confirmed_root that is lower than the previous one, meaning it may have already been dropped from BankForks. Hence the error.

The RPC error only evidences on v1.2; v1.3+ includes a fallback to the node's root if the highest_confirmed_root bank does not exist. But this PR will ensure that 1.3 rpc nodes return the most-current cluster-confirmed data as often as possible.

#### Summary of Changes
- Ensure that a node's recognized highest_confirmed_root only grows by storing the max of previous highest_confirmed_root and new highest_confirmed_root
