### PR TITLE
Explorer: update superstruct to coerce nullable types

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -15435,7 +15435,7 @@
       }
     },
     "superstruct": {
-      "version": "github:solana-labs/superstruct#097ee6e2553ea609331bb3b2965a3b778d42015f",
+      "version": "github:solana-labs/superstruct#2a96e608d149085e1d4331d0bdcc3a75676ccb95",
       "from": "github:solana-labs/superstruct"
     },
     "supports-color": {


### PR DESCRIPTION
#### Problem
The [`superstruct` fork](https://github.com/solana-labs/superstruct) didn't coerce custom types wrapped in `nullable`

#### Summary of Changes
- Update superstruct

Fixes #
