### PR TITLE
sdk: Pubkey::create_program_address is now available in program unit tests

### DIFF
--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "program")]
+#[cfg(all(feature = "program", target_arch = "bpf"))]
 use crate::entrypoint::SUCCESS;
-#[cfg(not(feature = "program"))]
+#[cfg(not(all(feature = "program", target_arch = "bpf")))]
 use crate::hash::Hasher;
 use crate::{decode_error::DecodeError, hash::hashv};
 use num_derive::{FromPrimitive, ToPrimitive};
@@ -107,7 +107,7 @@ impl Pubkey {
     ) -> Result<Pubkey, PubkeyError> {
         // Perform the calculation inline, calling this from within a program is
         // not supported
-        #[cfg(not(feature = "program"))]
+        #[cfg(not(all(feature = "program", target_arch = "bpf")))]
         {
             let mut hasher = Hasher::default();
             for seed in seeds.iter() {
@@ -129,7 +129,7 @@ impl Pubkey {
             Ok(Pubkey::new(hash.as_ref()))
         }
         // Call via a system call to perform the calculation
-        #[cfg(feature = "program")]
+        #[cfg(all(feature = "program", target_arch = "bpf"))]
         {
             extern "C" {
                 fn sol_create_program_address(


### PR DESCRIPTION
Running `./do.sh test token-swap` in SPL produces:
```
  = note: Undefined symbols for architecture x86_64:
            "_sol_create_program_address", referenced from:
                solana_sdk::pubkey::Pubkey::create_program_address::h3c1ec60877703153 in libsolana_sdk-a079a223062b45fc.rlib(solana_sdk-a079a223062b45fc.solana_sdk.55riuunb-cgu.12.rcgu.o)
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
because `create_program_address()` is not available when the program feature is defined and not building for btf.