### PR TITLE
Explorer: Hide token holders table when none found

### DIFF
--- a/explorer/src/components/account/TokenLargestAccountsCard.tsx
+++ b/explorer/src/components/account/TokenLargestAccountsCard.tsx
@@ -40,6 +40,10 @@ export function TokenLargestAccountsCard({ pubkey }: { pubkey: PublicKey }) {
   }
 
   const accounts = largestAccounts.data.largest;
+  if (accounts.length === 0) {
+    return <ErrorCard text="No holders found" />;
+  }
+
   return (
     <>
       <div className="card">


### PR DESCRIPTION
#### Problem
Explorer shows an empty table when no token holders are found

#### Summary of Changes
- Display a "No holders found" message when no holders are found

Fixes #
