### PR TITLE
RPC: getConfirmedSignaturesForAddress2 only returns confirmed signatures

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2047,6 +2047,7 @@ impl Blockstore {
                         && key_address == address
                         && slot >= first_available_block
                     {
+                        println!("{:?} {:?}", i, slot);
                         address_signatures.push((slot, signature));
                         continue;
                     }
@@ -2078,6 +2079,7 @@ impl Blockstore {
                     && key_address == address
                     && slot >= first_available_block
                 {
+                    println!("{:?} {:?}", i, slot);
                     address_signatures.push((slot, signature));
                     continue;
                 }
@@ -6337,7 +6339,7 @@ pub mod tests {
             let address0 = Pubkey::new_rand();
             let address1 = Pubkey::new_rand();
 
-            for slot in 2..=7 {
+            for slot in 2..=8 {
                 let entries = make_slot_entries_with_transaction_addresses(&[
                     address0, address1, address0, address1,
                 ]);
@@ -6363,8 +6365,9 @@ pub mod tests {
                     }
                 }
             }
-            blockstore.set_roots(&[1, 2, 3, 4, 5, 6, 7]).unwrap();
-            let highest_confirmed_root = 7;
+            // Leave one slot unrooted to test only returns confirmed signatures
+            blockstore.set_roots(&[1, 2, 4, 5, 6, 7, 8]).unwrap();
+            let highest_confirmed_root = 8;
 
             // Fetch all signatures for address 0 at once...
             let all0 = blockstore

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2047,8 +2047,9 @@ impl Blockstore {
                         && key_address == address
                         && slot >= first_available_block
                     {
-                        println!("{:?} {:?}", i, slot);
-                        address_signatures.push((slot, signature));
+                        if self.is_root(slot) {
+                            address_signatures.push((slot, signature));
+                        }
                         continue;
                     }
                 }
@@ -2079,8 +2080,9 @@ impl Blockstore {
                     && key_address == address
                     && slot >= first_available_block
                 {
-                    println!("{:?} {:?}", i, slot);
-                    address_signatures.push((slot, signature));
+                    if self.is_root(slot) {
+                        address_signatures.push((slot, signature));
+                    }
                     continue;
                 }
             }


### PR DESCRIPTION
#### Problem
`getConfirmedSignaturesForAddress2` is returning unconfirmed signatures. The api refactor dropped the `Blockstore::is_root()` slot check included in `find_address_signatures`, and there was no test case covering it. 😬 

#### Summary of Changes
- Check if a signature's slot `is_root` before adding to the return collection

cc @jstarry @mvines 

Fixes #11611 
