### PR TITLE
Bigtable: Use index to filter address-signatures correctly

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -371,7 +371,7 @@ impl LedgerStorage {
         let address_prefix = format!("{}/", address);
 
         // Figure out where to start listing from based on `before_signature`
-        let (first_slot, mut first_transaction_index) = match before_signature {
+        let (first_slot, mut before_transaction_index) = match before_signature {
             None => (Slot::MAX, 0),
             Some(before_signature) => {
                 let TransactionInfo { slot, index, .. } = bigtable
@@ -421,7 +421,7 @@ impl LedgerStorage {
 
             for tx_by_addr_info in tx_by_addr_infos
                 .into_iter()
-                .filter(|tx_by_addr_info| tx_by_addr_info.index < first_transaction_index)
+                .filter(|tx_by_addr_info| tx_by_addr_info.index < before_transaction_index)
             {
                 infos.push(ConfirmedTransactionStatusWithSignature {
                     signature: tx_by_addr_info.signature,
@@ -434,7 +434,7 @@ impl LedgerStorage {
                 }
             }
 
-            first_transaction_index = u32::MAX;
+            before_transaction_index = u32::MAX;
         }
         Ok(infos)
     }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -384,12 +384,20 @@ impl LedgerStorage {
 
         let mut infos = vec![];
 
-        // Return the next `limit` tx-by-addr keys
+        let starting_slot_tx_by_addr_infos = bigtable
+            .get_bincode_cell::<Vec<TransactionByAddrInfo>>(
+                "tx-by-addr",
+                format!("{}{}", address_prefix, slot_to_key(!first_slot)),
+            )
+            .await?;
+
+        // Return the next tx-by-addr keys of amount `limit` plus extra to account for the largest
+        // number that might be flitered out
         let tx_by_addr_info_keys = bigtable
             .get_row_keys(
                 "tx-by-addr",
                 Some(format!("{}{}", address_prefix, slot_to_key(!first_slot))),
-                limit as i64,
+                limit as i64 + starting_slot_tx_by_addr_infos.len() as i64,
             )
             .await?;
 

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -378,7 +378,7 @@ impl LedgerStorage {
                     .get_bincode_cell("tx", before_signature.to_string())
                     .await?;
 
-                (slot, index + 1)
+                (slot, index)
             }
         };
 
@@ -413,7 +413,7 @@ impl LedgerStorage {
 
             for tx_by_addr_info in tx_by_addr_infos
                 .into_iter()
-                .skip(first_transaction_index as usize)
+                .filter(|tx_by_addr_info| tx_by_addr_info.index < first_transaction_index)
             {
                 infos.push(ConfirmedTransactionStatusWithSignature {
                     signature: tx_by_addr_info.signature,
@@ -426,7 +426,7 @@ impl LedgerStorage {
                 }
             }
 
-            first_transaction_index = 0;
+            first_transaction_index = u32::MAX;
         }
         Ok(infos)
     }


### PR DESCRIPTION
#### Problem
Bigtable `get_confirmed_signatures_for_address` api is using the block-index of the `before` signature to skip into the iterator of Address-Slot records. This iterator is a subset of transactions in the block (only those involving the address), while the block-index is relative to all the transactions in the block. So the `skip()` skips many more transactions than it should... in practice right now on mainnet-beta, usually all of them.

The result is returned data that is missing one or more signatures it should have, and is also shorter than `limit`.

#### Summary of Changes
- Use the `first_transaction_index` to filter the Address-Slot iterator instead of skip

Indexes:
```
$ solana-ledger-tool -- -l ledger bigtable confirm -v R4jwzLPLWFyCv4skqZsBQSnzz8LiM9No49LRiyqdDbiUfNVpW3iRV6L2pgAEwXwdb3epxuFGyE2n5tYEVcn7Nuk
slot 27821735 index 29 // Added print
...

$ solana-ledger-tool -l ledger bigtable confirm -v 4awMCZ6qbmD4ykwExfg1S7yZoP7sRWATNxhFqRdKivXL9y5v12szESHj1f1FW6rfDjNXYs2bS3J4iXZc9ER4AnNW
slot 27821735 index 30 // Added print
...
```

Before: (notice also that the return is only 2 signatures)
```
$ solana-ledger-tool -l ledger bigtable transaction-history TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o 3 --before 4awMCZ6qbmD4ykwExfg1S7yZoP7sRWATNxhFqRdKivXL9y5v12szESHj1f1FW6rfDjNXYs2bS3J4iXZc9ER4AnNW

2p15NSSiVYtDTjypRbaq3Qa3aGU3JfEiFXv27LASzikFUmrLXqGMrJQrBPPebdcmQtJTSfMMY2ivKvZtZjS8X5hk
5chhHtA14sHW4NXAW9BmqUN42F6MXURmhHvrtDqkrp4VKwsxYYWV3rKSDZRhpqZRJx5vEWmLTT96Ny993bmyJsuF
```

After:
```
$ solana-ledger-tool -l ledger bigtable transaction-history TokenSVp5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o 3 --before 4awMCZ6qbmD4ykwExfg1S7yZoP7sRWATNxhFqRdKivXL9y5v12szESHj1f1FW6rfDjNXYs2bS3J4iXZc9ER4AnNW

R4jwzLPLWFyCv4skqZsBQSnzz8LiM9No49LRiyqdDbiUfNVpW3iRV6L2pgAEwXwdb3epxuFGyE2n5tYEVcn7Nuk
2p15NSSiVYtDTjypRbaq3Qa3aGU3JfEiFXv27LASzikFUmrLXqGMrJQrBPPebdcmQtJTSfMMY2ivKvZtZjS8X5hk
5chhHtA14sHW4NXAW9BmqUN42F6MXURmhHvrtDqkrp4VKwsxYYWV3rKSDZRhpqZRJx5vEWmLTT96Ny993bmyJsuF
```
