### PR TITLE
short_vec::decode_len() returns wrong size for aliased values

### DIFF
--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -131,7 +131,8 @@ fn do_get_packet_offsets(
     }
 
     // read the length of Transaction.signatures (serialized with short_vec)
-    let (sig_len_untrusted, sig_size) = decode_len(&packet.data)?;
+    let (sig_len_untrusted, sig_size) =
+        decode_len(&packet.data).map_err(|_| PacketError::InvalidShortVec)?;
 
     // Using msg_start_offset which is based on sig_len_untrusted introduces uncertainty.
     // Ultimately, the actual sigverify will determine the uncertainty.
@@ -156,8 +157,8 @@ fn do_get_packet_offsets(
     }
 
     // read the length of Message.account_keys (serialized with short_vec)
-    let (pubkey_len, pubkey_len_size) =
-        decode_len(&packet.data[message_account_keys_len_offset..])?;
+    let (pubkey_len, pubkey_len_size) = decode_len(&packet.data[message_account_keys_len_offset..])
+        .map_err(|_| PacketError::InvalidShortVec)?;
 
     if (message_account_keys_len_offset + pubkey_len * size_of::<Pubkey>() + pubkey_len_size)
         > packet.meta.size

--- a/sdk/src/short_vec.rs
+++ b/sdk/src/short_vec.rs
@@ -199,10 +199,20 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for ShortVec<T> {
 }
 
 /// Return the decoded value and how many bytes it consumed.
-pub fn decode_len(bytes: &[u8]) -> Result<(usize, usize), Box<bincode::ErrorKind>> {
-    let short_len: ShortU16 = bincode::deserialize(bytes)?;
-    let num_bytes = bincode::serialized_size(&short_len)?;
-    Ok((short_len.0 as usize, num_bytes as usize))
+pub fn decode_len(bytes: &[u8]) -> Result<(usize, usize), ()> {
+    let mut len = 0;
+    let mut size = 0;
+    for byte in bytes.iter() {
+        match visit_byte(*byte, len, size) {
+            VisitResult::More(l, s) => {
+                len = l;
+                size = s;
+            }
+            VisitResult::Done(len, size) => return Ok((len, size)),
+            VisitResult::Err => return Err(()),
+        }
+    }
+    Err(())
 }
 
 #[cfg(test)]

--- a/sdk/src/short_vec.rs
+++ b/sdk/src/short_vec.rs
@@ -246,4 +246,17 @@ mod tests {
         let s = serde_json::to_string(&vec).unwrap();
         assert_eq!(s, "[[3],0,1,2]");
     }
+
+    #[test]
+    fn test_decode_len_aliased_values() {
+        let one1 = [0x01];
+        let one2 = [0x81, 0x00];
+        let one3 = [0x81, 0x80, 0x00];
+        let one4 = [0x81, 0x80, 0x80, 0x00];
+
+        assert_eq!(decode_len(&one1).unwrap(), (1, 1));
+        assert_eq!(decode_len(&one2).unwrap(), (1, 2));
+        assert_eq!(decode_len(&one3).unwrap(), (1, 3));
+        assert!(decode_len(&one4).is_err());
+    }
 }


### PR DESCRIPTION
#### Problem

`short_vec::decode_len()` always returns the byte size of the most compact encoding, despite the existence of larger aliases.  In conjunction with `ShortVec` this allows for interesting deserialization games to be played.

h/t @svenski123 :heart: 

#### Summary of Changes

Add failing test
Factor byte visitation logic out of `ShortU16` deserializer to a helper
Reimplement `decode_len()` using aforementioned helper