### PR TITLE
feat: remove hex public key decoding support

### DIFF
--- a/web3.js/src/publickey.js
+++ b/web3.js/src/publickey.js
@@ -21,17 +21,12 @@ export class PublicKey {
    */
   constructor(value: number | string | Buffer | Uint8Array | Array<number>) {
     if (typeof value === 'string') {
-      // hexadecimal number
-      if (value.startsWith('0x')) {
-        this._bn = new BN(value.substring(2), 16);
-      } else {
-        // assume base 58 encoding by default
-        const decoded = bs58.decode(value);
-        if (decoded.length != 32) {
-          throw new Error(`Invalid public key input`);
-        }
-        this._bn = new BN(decoded);
+      // assume base 58 encoding by default
+      const decoded = bs58.decode(value);
+      if (decoded.length != 32) {
+        throw new Error(`Invalid public key input`);
       }
+      this._bn = new BN(decoded);
     } else {
       this._bn = new BN(value);
     }
@@ -90,7 +85,7 @@ export class PublicKey {
       programId.toBuffer(),
     ]);
     const hash = await sha256(new Uint8Array(buffer));
-    return new PublicKey('0x' + hash);
+    return new PublicKey(Buffer.from(hash, 'hex'));
   }
 
   /**

--- a/web3.js/test/publickey.test.js
+++ b/web3.js/test/publickey.test.js
@@ -48,6 +48,12 @@ test('invalid', () => {
 
   expect(() => {
     new PublicKey(
+      '0x300000000000000000000000000000000000000000000000000000000000000',
+    );
+  }).toThrow();
+
+  expect(() => {
+    new PublicKey(
       '135693854574979916511997248057056142015550763280047535983739356259273198796800000',
     );
   }).toThrow();
@@ -92,21 +98,15 @@ test('equals', () => {
     0,
     0,
   ]);
-  const hexKey = new PublicKey(
-    '0x300000000000000000000000000000000000000000000000000000000000000',
-  );
-  const base56Key = new PublicKey(
+  const base58Key = new PublicKey(
     'CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3',
   );
 
-  expect(arrayKey.equals(hexKey)).toBe(true);
-  expect(arrayKey.equals(base56Key)).toBe(true);
+  expect(arrayKey.equals(base58Key)).toBe(true);
 });
 
 test('toBase58', () => {
-  const key = new PublicKey(
-    '0x300000000000000000000000000000000000000000000000000000000000000',
-  );
+  const key = new PublicKey('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
   expect(key.toBase58()).toBe('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
   expect(key.toString()).toBe('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
 
@@ -155,25 +155,17 @@ test('toBase58', () => {
 });
 
 test('toBuffer', () => {
-  const key = new PublicKey(
-    '0x300000000000000000000000000000000000000000000000000000000000000',
-  );
+  const key = new PublicKey('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
   expect(key.toBuffer()).toHaveLength(32);
   expect(key.toBase58()).toBe('CiDwVBFgWV9E5MvXWoLgnEgn2hK7rJikbvfWavzAQz3');
 
-  const key2 = new PublicKey(
-    '0x000000000000000000000000000000000000000000000000000000000000000',
-  );
+  const key2 = new PublicKey('11111111111111111111111111111111');
   expect(key2.toBuffer()).toHaveLength(32);
   expect(key2.toBase58()).toBe('11111111111111111111111111111111');
 
   const key3 = new PublicKey(0);
   expect(key3.toBuffer()).toHaveLength(32);
   expect(key3.toBase58()).toBe('11111111111111111111111111111111');
-
-  const key4 = new PublicKey('0x0');
-  expect(key4.toBuffer()).toHaveLength(32);
-  expect(key4.toBase58()).toBe('11111111111111111111111111111111');
 });
 
 test('equals (II)', () => {

--- a/web3.js/test/stake-program.test.js
+++ b/web3.js/test/stake-program.test.js
@@ -264,7 +264,7 @@ test('live staking actions', async () => {
       fromPubkey: from.publicKey,
       stakePubkey: newStakeAccount.publicKey,
       authorized: new Authorized(authorized.publicKey, authorized.publicKey),
-      lockup: new Lockup(0, 0, new PublicKey('0x00')),
+      lockup: new Lockup(0, 0, new PublicKey(0)),
       lamports: minimumAmount + 42,
     });
 
@@ -303,7 +303,7 @@ test('live staking actions', async () => {
     basePubkey: from.publicKey,
     seed,
     authorized: new Authorized(authorized.publicKey, authorized.publicKey),
-    lockup: new Lockup(0, 0, new PublicKey('0x00')),
+    lockup: new Lockup(0, 0, new PublicKey(0)),
     lamports: 3 * minimumAmount + 42,
   });
 


### PR DESCRIPTION
#### Problem
We don't use hex encoding for addresses anywhere in the stack but support it for creating `PublicKey`s in the web3 sdk. If anyone uses a hex encoded address, it's likely a mistake (ie. passing an ethereum address). 

#### Summary of Changes
- Remove support for hex encoded addresses

Fixes #
