### PR TITLE
fix: undefined is a valid result for getBlockTime

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -575,7 +575,7 @@ const GetBlockTimeRpcResult = struct({
   jsonrpc: struct.literal('2.0'),
   id: 'string',
   error: 'any?',
-  result: struct.union(['null', 'number']),
+  result: struct.union(['null', 'number', 'undefined']),
 });
 
 /**


### PR DESCRIPTION
#### Problem
When `getBlockTime` fails, `result` is undefined but the struct validator enforced `null | number`

#### Summary of Changes
- Add `undefined` to struct validator

Fixes #
