### PR TITLE
Explorer: Bump web3 to v0.71.1

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -2720,9 +2720,9 @@
       }
     },
     "@solana/web3.js": {
-      "version": "0.70.3",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.70.3.tgz",
-      "integrity": "sha512-Q9byc2doeycUHai47IVkdM2DAWhpnV+K7OPxNivTph1a7bDRcULp0n9X7QTycJCz5E9+qx3KUduD1J2Xk/zH0Q==",
+      "version": "0.71.1",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-0.71.1.tgz",
+      "integrity": "sha512-LV8fwCIyL1n4OfaRTDCznjXxpPn4506YNESMU19BfERQl8IwQDWI6OKdWImpPpUQUEtGceaXbw9bPGtSMlqXJA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "^5.0.0",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@react-hook/debounce": "^3.0.0",
     "@sentry/react": "^5.21.1",
-    "@solana/web3.js": "^0.70.3",
+    "@solana/web3.js": "^0.71.1",
     "@testing-library/jest-dom": "^5.11.3",
     "@testing-library/react": "^10.4.8",
     "@testing-library/user-event": "^12.1.1",


### PR DESCRIPTION
#### Problem
- `getBlockTime` throws struct validation error when block time isn't found

#### Summary of Changes
- Update web3

Fixes #
