### PR TITLE
Rpc: Add until parameter for getConfirmedSignaturesForAddress2

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -216,6 +216,7 @@ pub enum CliCommand {
     TransactionHistory {
         address: Pubkey,
         before: Option<Signature>,
+        until: Option<Signature>,
         limit: usize,
     },
     // Nonce commands
@@ -1508,8 +1509,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::TransactionHistory {
             address,
             before,
+            until,
             limit,
-        } => process_transaction_history(&rpc_client, config, address, *before, *limit),
+        } => process_transaction_history(&rpc_client, config, address, *before, *until, *limit),
 
         // Nonce Commands
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -444,12 +444,21 @@ pub fn parse_transaction_history(
         ),
         None => None,
     };
+    let until = match matches.value_of("until") {
+        Some(signature) => Some(
+            signature
+                .parse()
+                .map_err(|err| CliError::BadParameter(format!("Invalid signature: {}", err)))?,
+        ),
+        None => None,
+    };
     let limit = value_t_or_exit!(matches, "limit", usize);
 
     Ok(CliCommandInfo {
         command: CliCommand::TransactionHistory {
             address,
             before,
+            until,
             limit,
         },
         signers: vec![],
@@ -1311,11 +1320,13 @@ pub fn process_transaction_history(
     config: &CliConfig,
     address: &Pubkey,
     before: Option<Signature>,
+    until: Option<Signature>,
     limit: usize,
 ) -> ProcessResult {
     let results = rpc_client.get_confirmed_signatures_for_address2_with_config(
         address,
         before,
+        until,
         Some(limit),
     )?;
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -11,7 +11,7 @@ use solana_clap_utils::{
 };
 use solana_client::{
     pubsub_client::{PubsubClient, SlotInfoMessage},
-    rpc_client::RpcClient,
+    rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient},
     rpc_config::{RpcLargestAccountsConfig, RpcLargestAccountsFilter},
 };
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
@@ -1325,9 +1325,11 @@ pub fn process_transaction_history(
 ) -> ProcessResult {
     let results = rpc_client.get_confirmed_signatures_for_address2_with_config(
         address,
-        before,
-        until,
-        Some(limit),
+        GetConfirmedSignaturesForAddress2Config {
+            before,
+            until,
+            limit: Some(limit),
+        },
     )?;
 
     let transactions_found = format!("{} transactions found", results.len());

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -299,17 +299,19 @@ impl RpcClient {
         &self,
         address: &Pubkey,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.get_confirmed_signatures_for_address2_with_config(address, None, None)
+        self.get_confirmed_signatures_for_address2_with_config(address, None, None, None)
     }
 
     pub fn get_confirmed_signatures_for_address2_with_config(
         &self,
         address: &Pubkey,
         before: Option<Signature>,
+        until: Option<Signature>,
         limit: Option<usize>,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         let config = RpcGetConfirmedSignaturesForAddress2Config {
             before: before.map(|signature| signature.to_string()),
+            until: until.map(|signature| signature.to_string()),
             limit,
         };
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -299,20 +299,21 @@ impl RpcClient {
         &self,
         address: &Pubkey,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        self.get_confirmed_signatures_for_address2_with_config(address, None, None, None)
+        self.get_confirmed_signatures_for_address2_with_config(
+            address,
+            GetConfirmedSignaturesForAddress2Config::default(),
+        )
     }
 
     pub fn get_confirmed_signatures_for_address2_with_config(
         &self,
         address: &Pubkey,
-        before: Option<Signature>,
-        until: Option<Signature>,
-        limit: Option<usize>,
+        config: GetConfirmedSignaturesForAddress2Config,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         let config = RpcGetConfirmedSignaturesForAddress2Config {
-            before: before.map(|signature| signature.to_string()),
-            until: until.map(|signature| signature.to_string()),
-            limit,
+            before: config.before.map(|signature| signature.to_string()),
+            until: config.until.map(|signature| signature.to_string()),
+            limit: config.limit,
         };
 
         let result: Vec<RpcConfirmedTransactionStatusWithSignature> = self.send(
@@ -1134,6 +1135,13 @@ impl RpcClient {
         serde_json::from_value(response)
             .map_err(|err| ClientError::new_with_request(err.into(), request))
     }
+}
+
+#[derive(Debug, Default)]
+pub struct GetConfirmedSignaturesForAddress2Config {
+    pub before: Option<Signature>,
+    pub until: Option<Signature>,
+    pub limit: Option<usize>,
 }
 
 fn new_spinner_progress_bar() -> ProgressBar {

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -71,5 +71,6 @@ pub enum RpcTokenAccountsFilter {
 #[serde(rename_all = "camelCase")]
 pub struct RpcGetConfirmedSignaturesForAddress2Config {
     pub before: Option<String>, // Signature as base-58 string
+    pub until: Option<String>,  // Signature as base-58 string
     pub limit: Option<usize>,
 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -888,6 +888,7 @@ impl JsonRpcRequestProcessor {
                     address,
                     highest_confirmed_root,
                     before,
+                    None,
                     limit,
                 )
                 .map_err(|err| Error::invalid_params(format!("{}", err)))?;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -903,6 +903,7 @@ impl JsonRpcRequestProcessor {
                         bigtable_ledger_storage.get_confirmed_signatures_for_address(
                             &address,
                             before.as_ref(),
+                            None,
                             limit,
                         ),
                     );

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -873,6 +873,7 @@ impl JsonRpcRequestProcessor {
         &self,
         address: Pubkey,
         mut before: Option<Signature>,
+        until: Option<Signature>,
         mut limit: usize,
     ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>> {
         if self.config.enable_rpc_transaction_history {
@@ -888,7 +889,7 @@ impl JsonRpcRequestProcessor {
                     address,
                     highest_confirmed_root,
                     before,
-                    None,
+                    until,
                     limit,
                 )
                 .map_err(|err| Error::invalid_params(format!("{}", err)))?;
@@ -904,7 +905,7 @@ impl JsonRpcRequestProcessor {
                         bigtable_ledger_storage.get_confirmed_signatures_for_address(
                             &address,
                             before.as_ref(),
-                            None,
+                            until.as_ref(),
                             limit,
                         ),
                     );
@@ -2314,6 +2315,11 @@ impl RpcSol for RpcSolImpl {
         } else {
             None
         };
+        let until = if let Some(until) = config.until {
+            Some(verify_signature(&until)?)
+        } else {
+            None
+        };
         let limit = config
             .limit
             .unwrap_or(MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT);
@@ -2325,7 +2331,7 @@ impl RpcSol for RpcSolImpl {
             )));
         }
 
-        meta.get_confirmed_signatures_for_address2(address, before, limit)
+        meta.get_confirmed_signatures_for_address2(address, before, until, limit)
     }
 
     fn get_first_available_block(&self, meta: Self::Metadata) -> Result<Slot> {

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -310,13 +310,19 @@ pub async fn transaction_history(
     address: &Pubkey,
     mut limit: usize,
     mut before: Option<Signature>,
+    until: Option<Signature>,
     verbose: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bigtable = solana_storage_bigtable::LedgerStorage::new(true).await?;
 
     while limit > 0 {
         let results = bigtable
-            .get_confirmed_signatures_for_address(address, before.as_ref(), limit.min(1000))
+            .get_confirmed_signatures_for_address(
+                address,
+                before.as_ref(),
+                until.as_ref(),
+                limit.min(1000),
+            )
             .await?;
 
         if results.is_empty() {
@@ -481,6 +487,13 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .help("Start with the first signature older than this one"),
                         )
                         .arg(
+                            Arg::with_name("until")
+                                .long("until")
+                                .value_name("TRANSACTION_SIGNATURE")
+                                .takes_value(true)
+                                .help("End with the last signature newer than this one"),
+                        )
+                        .arg(
                             Arg::with_name("verbose")
                                 .short("v")
                                 .long("verbose")
@@ -537,9 +550,12 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let before = arg_matches
                 .value_of("before")
                 .map(|signature| signature.parse().expect("Invalid signature"));
+            let until = arg_matches
+                .value_of("until")
+                .map(|signature| signature.parse().expect("Invalid signature"));
             let verbose = arg_matches.is_present("verbose");
 
-            runtime.block_on(transaction_history(&address, limit, before, verbose))
+            runtime.block_on(transaction_history(&address, limit, before, until, verbose))
         }
         _ => unreachable!(),
     };

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -287,10 +287,14 @@ impl BigTable {
     ///
     /// If `start_at` is provided, the row key listing will start with key.
     /// Otherwise the listing will start from the start of the table.
+    ///
+    /// If `end_at` is provided, the row key listing will end at the key. Otherwise it will
+    /// continue until the `limit` is reached or the end of the table, whichever comes first.
     pub async fn get_row_keys(
         &mut self,
         table_name: &str,
         start_at: Option<RowKey>,
+        end_at: Option<RowKey>,
         rows_limit: i64,
     ) -> Result<Vec<RowKey>> {
         self.refresh_access_token().await;
@@ -301,16 +305,13 @@ impl BigTable {
                 rows_limit,
                 rows: Some(RowSet {
                     row_keys: vec![],
-                    row_ranges: if let Some(row_key) = start_at {
-                        vec![RowRange {
-                            start_key: Some(row_range::StartKey::StartKeyClosed(
-                                row_key.into_bytes(),
-                            )),
-                            end_key: None,
-                        }]
-                    } else {
-                        vec![]
-                    },
+                    row_ranges: vec![RowRange {
+                        start_key: start_at.map(|row_key| {
+                            row_range::StartKey::StartKeyClosed(row_key.into_bytes())
+                        }),
+                        end_key: end_at
+                            .map(|row_key| row_range::EndKey::EndKeyClosed(row_key.into_bytes())),
+                    }],
                 }),
                 filter: Some(RowFilter {
                     filter: Some(row_filter::Filter::Chain(row_filter::Chain {
@@ -339,21 +340,39 @@ impl BigTable {
         Ok(rows.into_iter().map(|r| r.0).collect())
     }
 
-    /// Get latest data from `limit` rows of `table`, starting inclusively at the `row_key` row.
+    /// Get latest data from `table`.
     ///
     /// All column families are accepted, and only the latest version of each column cell will be
     /// returned.
-    pub async fn get_row_data(&mut self, table_name: &str, row_key: RowKey) -> Result<RowData> {
+    ///
+    /// If `start_at` is provided, the row key listing will start with key.
+    /// Otherwise the listing will start from the start of the table.
+    ///
+    /// If `end_at` is provided, the row key listing will end at the key. Otherwise it will
+    /// continue until the `limit` is reached or the end of the table, whichever comes first.
+    pub async fn get_row_data(
+        &mut self,
+        table_name: &str,
+        start_at: Option<RowKey>,
+        end_at: Option<RowKey>,
+        rows_limit: i64,
+    ) -> Result<Vec<(RowKey, RowData)>> {
         self.refresh_access_token().await;
 
         let response = self
             .client
             .read_rows(ReadRowsRequest {
                 table_name: format!("{}{}", self.table_prefix, table_name),
-                rows_limit: 1,
+                rows_limit,
                 rows: Some(RowSet {
-                    row_keys: vec![row_key.into_bytes()],
-                    row_ranges: vec![],
+                    row_keys: vec![],
+                    row_ranges: vec![RowRange {
+                        start_key: start_at.map(|row_key| {
+                            row_range::StartKey::StartKeyClosed(row_key.into_bytes())
+                        }),
+                        end_key: end_at
+                            .map(|row_key| row_range::EndKey::EndKeyClosed(row_key.into_bytes())),
+                    }],
                 }),
                 filter: Some(RowFilter {
                     // Only return the latest version of each cell
@@ -364,11 +383,7 @@ impl BigTable {
             .await?
             .into_inner();
 
-        let rows = Self::decode_read_rows_response(response).await?;
-        rows.into_iter()
-            .next()
-            .map(|r| r.1)
-            .ok_or_else(|| Error::RowNotFound)
+        Self::decode_read_rows_response(response).await
     }
 
     /// Store data for one or more `table` rows in the `family_name` Column family
@@ -429,12 +444,13 @@ impl BigTable {
     where
         T: serde::de::DeserializeOwned,
     {
-        let row_data = self.get_row_data(table, key.clone()).await?;
+        let row_data = self.get_row_data(table, Some(key.clone()), None, 1).await?;
+        let (row_key, data) = &row_data[0];
 
-        let value = row_data
+        let value = &data
             .into_iter()
             .find(|(name, _)| name == "bin")
-            .ok_or_else(|| Error::ObjectNotFound(format!("{}/{}", table, key)))?
+            .ok_or_else(|| Error::ObjectNotFound(format!("{}/{}", table, row_key)))?
             .1;
 
         let data = decompress(&value)?;

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -276,7 +276,7 @@ impl LedgerStorage {
     /// Return the available slot that contains a block
     pub async fn get_first_available_block(&self) -> Result<Option<Slot>> {
         let mut bigtable = self.connection.client();
-        let blocks = bigtable.get_row_keys("blocks", None, 1).await?;
+        let blocks = bigtable.get_row_keys("blocks", None, None, 1).await?;
         if blocks.is_empty() {
             return Ok(None);
         }
@@ -290,7 +290,7 @@ impl LedgerStorage {
     pub async fn get_confirmed_blocks(&self, start_slot: Slot, limit: usize) -> Result<Vec<Slot>> {
         let mut bigtable = self.connection.client();
         let blocks = bigtable
-            .get_row_keys("blocks", Some(slot_to_key(start_slot)), limit as i64)
+            .get_row_keys("blocks", Some(slot_to_key(start_slot)), None, limit as i64)
             .await?;
         Ok(blocks.into_iter().filter_map(|s| key_to_slot(&s)).collect())
     }
@@ -397,6 +397,7 @@ impl LedgerStorage {
             .get_row_keys(
                 "tx-by-addr",
                 Some(format!("{}{}", address_prefix, slot_to_key(!first_slot))),
+                None,
                 limit as i64 + starting_slot_tx_by_addr_infos.len() as i64,
             )
             .await?;


### PR DESCRIPTION
#### Problem
`getConfirmedSignaturesForAccount2` allows searching before a certain signature but doesn't support searching recent history up until a signature that you already have. Using `until` would be useful when refreshing the explorer UI to check if any new signatures have been confirmed since the last fetch.

#### Summary of Changes
- Add back-end handling in bigtable and blockstore needed to support `until` requests
- Also refactor bigtable apis to enable getting a range of row data, and to use `get_row_data` range in `get_confirmed_signatures_for_address`
- Add `until` parameter to `getConfirmedSignaturesForAccount2` rpc
- Plumb `until` through client/cli apis

Fixes #11446 
