### PR TITLE
Return an error from create_program_address syscall

### DIFF
--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -12,7 +12,7 @@ use solana_sdk::{
     info,
     program::{invoke, invoke_signed},
     program_error::ProgramError,
-    pubkey::Pubkey,
+    pubkey::{Pubkey, PubkeyError},
     system_instruction,
 };
 
@@ -97,9 +97,15 @@ fn process_instruction(
 
             info!("Test create_program_address");
             {
-                let address =
-                    Pubkey::create_program_address(&[b"You pass butter", &[nonce1]], program_id)?;
-                assert_eq!(&address, accounts[DERIVED_KEY1_INDEX].key);
+                assert_eq!(
+                    &Pubkey::create_program_address(&[b"You pass butter", &[nonce1]], program_id)?,
+                    accounts[DERIVED_KEY1_INDEX].key
+                );
+                assert_eq!(
+                    Pubkey::create_program_address(&[b"You pass butter"], &Pubkey::default())
+                        .unwrap_err(),
+                    PubkeyError::InvalidSeeds
+                );
             }
 
             info!("Test derived signers");

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -352,7 +352,8 @@ pub fn syscall_create_program_address(
     ro_regions: &[MemoryRegion],
     rw_regions: &[MemoryRegion],
 ) -> Result<u64, EbpfError<BPFError>> {
-    let untranslated_seeds = translate_slice!(&[&str], seeds_addr, seeds_len, ro_regions)?;
+    let untranslated_seeds = translate_slice!(&[&u8], seeds_addr, seeds_len, ro_regions)?;
+
     let seeds = untranslated_seeds
         .iter()
         .map(|untranslated_seed| {
@@ -365,8 +366,12 @@ pub fn syscall_create_program_address(
         })
         .collect::<Result<Vec<_>, EbpfError<BPFError>>>()?;
     let program_id = translate_type!(Pubkey, program_id_addr, ro_regions)?;
+
     let new_address =
-        Pubkey::create_program_address(&seeds, program_id).map_err(SyscallError::BadSeeds)?;
+        match Pubkey::create_program_address(&seeds, program_id).map_err(SyscallError::BadSeeds) {
+            Ok(address) => address,
+            Err(_) => return Ok(1),
+        };
     let address = translate_slice_mut!(u8, address_addr, 32, rw_regions)?;
     address.copy_from_slice(new_address.as_ref());
     Ok(0)


### PR DESCRIPTION
#### Problem

The `create_program_address` syscall bails from the program if it fails rather then return an error to the program

#### Summary of Changes

Return the appropriate error

Fixes #
