### PR TITLE
web3.js: fix: retry after a brief delay upon a 429 response

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -507,7 +507,25 @@ function createRpcRequest(url): RpcRequest {
     };
 
     try {
-      const res = await fetch(url, options);
+      let too_many_requests_retries = 5;
+      let res = {};
+
+      for (;;) {
+        res = await fetch(url, options);
+        if (
+          res.status !== 429 /* Too many requests */ ||
+          too_many_requests_retries === 0
+        ) {
+          break;
+        }
+
+        console.log(
+          `Server responded with ${res.status} ${res.statusText}.  Retrying after brief delay...`,
+        );
+        await sleep(500);
+        too_many_requests_retries -= 1;
+      }
+
       const text = await res.text();
       if (res.ok) {
         callback(null, text);


### PR DESCRIPTION
solana-web3.js now retries on HTTP 429 errors, matching RpcClient.