### PR TITLE
Update system tuning and docs

### DIFF
--- a/ci/setup-new-buildkite-agent/setup-buildkite.sh
+++ b/ci/setup-new-buildkite-agent/setup-buildkite.sh
@@ -76,7 +76,7 @@ RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
 TimeoutStopSec=0
 KillMode=process
-LimitNOFILE=65536
+LimitNOFILE=500000
 
 [Install]
 WantedBy=multi-user.target

--- a/ci/setup-new-buildkite-agent/setup-limits.sh
+++ b/ci/setup-new-buildkite-agent/setup-limits.sh
@@ -8,5 +8,5 @@ source "$HERE"/utils.sh
 ensure_env || exit 1
 
 # Allow more files to be opened by a user
-sed -i 's/^\(# End of file\)/* soft nofile 65535\n\n\1/' /etc/security/limits.conf
+echo "* - nofile 500000" > /etc/security/limits.d/90-solana-nofiles.conf
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3257,7 +3257,7 @@ fn adjust_ulimit_nofile() -> Result<()> {
 fn adjust_ulimit_nofile() -> Result<()> {
     // Rocks DB likes to have many open files.  The default open file descriptor limit is
     // usually not enough
-    let desired_nofile = 65000;
+    let desired_nofile = 500000;
 
     fn get_nofile() -> libc::rlimit {
         let mut nofile = libc::rlimit {

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -93,7 +93,7 @@ fn tune_kernel_udp_buffers_and_vmmap() {
     sysctl_write("net.core.wmem_default", "134217728");
 
     // increase mmap counts for many append_vecs
-    sysctl_write("vm.max_map_count", "1000000");
+    sysctl_write("vm.max_map_count", "500000");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
#### Problem

System tuning parameters in code have fallen out of sync with recommended values and were never documented

#### Summary of Changes

* Synchronize `vm.max_map_count` and `ulimit -n`
* Document system tuning to ease support