### PR TITLE
Fully enable cross program support in mainnet-beta

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -474,9 +474,6 @@ impl Bank {
         bank.update_rent();
         bank.update_epoch_schedule();
         bank.update_recent_blockhashes();
-        if bank.operating_mode == Some(OperatingMode::Stable) {
-            bank.message_processor.set_cross_program_support(false);
-        }
         bank
     }
 


### PR DESCRIPTION
#### Problem
Cross program support should have been fully enabled on mainnet-beta at epoch 63 but not all of the disable calls were reverted from https://github.com/solana-labs/solana/pull/11272 in https://github.com/solana-labs/solana/pull/11404

#### Summary of Changes
- Remove call to disable CPI support in message processor

Fixes https://github.com/solana-labs/solana/issues/11687
