### PR TITLE
Explorer: Fix account history load more behavior

### DIFF
--- a/explorer/src/providers/accounts/history.tsx
+++ b/explorer/src/providers/accounts/history.tsx
@@ -43,7 +43,7 @@ function reconcile(
   history: AccountHistory | undefined,
   update: HistoryUpdate | undefined
 ) {
-  if (update?.history === undefined) return;
+  if (update?.history === undefined) return history;
   return {
     fetched: combineFetched(
       update.history.fetched,


### PR DESCRIPTION
#### Problem
When fetching more account history, the provider reconciler discarded the previous history state.

#### Summary of Changes
- Preserve previous state when fetching history

Fixes #
