### PR TITLE
Bigtable: get_bincode_cell get index

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -446,7 +446,7 @@ impl BigTable {
         T: serde::de::DeserializeOwned,
     {
         let row_data = self.get_row_data(table, Some(key.clone()), None, 1).await?;
-        let (row_key, data) = &row_data[0];
+        let (row_key, data) = &row_data.get(0).ok_or_else(|| Error::RowNotFound)?;
 
         deserialize_cell_data(data, table, row_key.to_string())
     }


### PR DESCRIPTION
#### Problem
`BigTable;:get_row_data` successfully returns an empty vector if a row does not exist, causing an indexing panic in `get_bincode_cell`

#### Summary of Changes
Use `get()` and return error instead
