### PR TITLE
CPI support for bpf_loader_deprecated

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     account::Account,
     account::KeyedAccount,
     account_info::AccountInfo,
-    bpf_loader,
+    bpf_loader, bpf_loader_deprecated,
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
     entrypoint_native::{InvokeContext, Logger},
     instruction::{AccountMeta, Instruction, InstructionError},
@@ -878,6 +878,7 @@ fn call<'a>(
         message_processor.add_program(*program_id, *process_instruction);
     }
     message_processor.add_loader(bpf_loader::id(), crate::process_instruction);
+    message_processor.add_loader(bpf_loader_deprecated::id(), crate::process_instruction);
     message_processor.set_cross_program_support(invoke_context.is_cross_program_supported());
 
     #[allow(clippy::deref_addrof)]


### PR DESCRIPTION
#### Problem

CPI does not support calling deprecated bpf loader

#### Summary of Changes

Add deprecated bpf loader program to CPI

Fixes #11686
