### PR TITLE
Cleanup test utilities 

### DIFF
--- a/core/src/repair_weighted_traversal.rs
+++ b/core/src/repair_weighted_traversal.rs
@@ -150,6 +150,7 @@ pub mod test {
     use super::*;
     use solana_ledger::{get_tmp_ledger_path, shred::Shred};
     use solana_runtime::bank_utils;
+    use solana_sdk::hash::Hash;
     use trees::tr;
 
     #[test]
@@ -246,7 +247,13 @@ pub mod test {
         repairs = vec![];
         let best_overall_slot = heaviest_subtree_fork_choice.best_overall_slot();
         assert_eq!(heaviest_subtree_fork_choice.best_overall_slot(), 4);
-        blockstore.add_tree(tr(best_overall_slot) / (tr(6) / tr(7)), true, false);
+        blockstore.add_tree(
+            tr(best_overall_slot) / (tr(6) / tr(7)),
+            true,
+            false,
+            2,
+            Hash::default(),
+        );
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
             &blockstore,
@@ -300,7 +307,7 @@ pub mod test {
         // Adding incomplete children with higher weighted parents, even if
         // the parents are complete should still be repaired
         repairs = vec![];
-        blockstore.add_tree(tr(2) / (tr(8)), true, false);
+        blockstore.add_tree(tr(2) / (tr(8)), true, false, 2, Hash::default());
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
             &blockstore,
@@ -322,7 +329,7 @@ pub mod test {
         let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
         // Add a branch to slot 2, make sure it doesn't repair child
         // 4 again when the Unvisited(2) event happens
-        blockstore.add_tree(tr(2) / (tr(6) / tr(7)), true, false);
+        blockstore.add_tree(tr(2) / (tr(6) / tr(7)), true, false, 2, Hash::default());
         let mut repairs = vec![];
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
@@ -368,7 +375,7 @@ pub mod test {
         // Adding slot 2 to ignore should not remove its unexplored children from
         // the repair set
         repairs = vec![];
-        blockstore.add_tree(tr(2) / (tr(6) / tr(7)), true, false);
+        blockstore.add_tree(tr(2) / (tr(6) / tr(7)), true, false, 2, Hash::default());
         ignore_set.insert(2);
         get_best_repair_shreds(
             &heaviest_subtree_fork_choice,
@@ -420,7 +427,7 @@ pub mod test {
         let forks = tr(0) / (tr(1) / (tr(2) / (tr(4))) / (tr(3) / (tr(5))));
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&ledger_path).unwrap();
-        blockstore.add_tree(forks.clone(), false, false);
+        blockstore.add_tree(forks.clone(), false, false, 2, Hash::default());
 
         (blockstore, HeaviestSubtreeForkChoice::new_from_tree(forks))
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -4035,7 +4035,7 @@ pub mod tests {
         (
             Arc::new(RwLock::new(BankForks::new(bank))),
             mint_keypair,
-            voting_keypair,
+            Arc::new(voting_keypair),
         )
     }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -863,8 +863,8 @@ impl TestValidator {
         } = create_genesis_config_with_leader_ex(
             mint_lamports,
             &contact_info.id,
-            Arc::new(Keypair::new()),
-            Arc::new(Keypair::new()),
+            &Keypair::new(),
+            &Pubkey::new_rand(),
             42,
             bootstrap_validator_lamports,
         );
@@ -882,12 +882,13 @@ impl TestValidator {
             )),
             ..ValidatorConfig::default()
         };
+        let vote_pubkey = voting_keypair.pubkey();
         let node = Validator::new(
             node,
             &node_keypair,
             &ledger_path,
             &voting_keypair.pubkey(),
-            vec![voting_keypair.clone()],
+            vec![Arc::new(voting_keypair)],
             None,
             true,
             &config,
@@ -899,7 +900,7 @@ impl TestValidator {
             alice: mint_keypair,
             ledger_path,
             genesis_hash: blockhash,
-            vote_pubkey: voting_keypair.pubkey(),
+            vote_pubkey,
         }
     }
 }
@@ -1117,7 +1118,7 @@ mod tests {
                         .genesis_config;
                 let (validator_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
                 ledger_paths.push(validator_ledger_path.clone());
-                let vote_account_keypair = Arc::new(Keypair::new());
+                let vote_account_keypair = Keypair::new();
                 let config = ValidatorConfig {
                     rpc_ports: Some((
                         validator_node.info.rpc.port(),
@@ -1131,7 +1132,7 @@ mod tests {
                     &Arc::new(validator_keypair),
                     &validator_ledger_path,
                     &vote_account_keypair.pubkey(),
-                    vec![vote_account_keypair.clone()],
+                    vec![Arc::new(vote_account_keypair)],
                     Some(&leader_node.info),
                     true,
                     &config,

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -233,7 +233,9 @@ pub fn cluster_info_scale() {
 
     let nodes: Vec<_> = vote_keypairs
         .into_iter()
-        .map(|keypairs| test_node_with_bank(keypairs.node_keypair, &exit, bank_forks.clone()))
+        .map(|keypairs| {
+            test_node_with_bank(Arc::new(keypairs.node_keypair), &exit, bank_forks.clone())
+        })
         .collect();
     let ci0 = nodes[0].0.my_contact_info();
     for node in &nodes[1..] {


### PR DESCRIPTION
#### Problem
1) `blockstore::add_tree()` does not make replayable/verifiable slots for tests
2) `ValidatorVoteKeypair` is inconsistent with 1.2, making backports ugly

#### Summary of Changes
Resolve above

Fixes #
