### PR TITLE
fix: properly decode account notifications

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -2832,12 +2832,13 @@ export class Connection {
         const {result} = res;
         const {value, context} = result;
 
+        assert(value.data[1] === 'base64');
         sub.callback(
           {
             executable: value.executable,
             owner: new PublicKey(value.owner),
             lamports: value.lamports,
-            data: Buffer.from(value.data, 'base64'),
+            data: Buffer.from(value.data[0], 'base64'),
           },
           context,
         );


### PR DESCRIPTION
#### Problem
Account data is now returned as ["<DATA", "base64"] but pubsub account notification handling wasn't updated for this change

#### Summary of Changes
- Fix it

Fixes #
