### PR TITLE
Bump spl-token to clean up magic number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,12 +4638,12 @@ dependencies = [
 
 [[package]]
 name = "spl-token"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c8482ae4aac6bb7d73aef79df5fb403a16a0cfbe200442532cff6b98613383"
+checksum = "7e8bee8b59279b46d0627490b544c3bc38e440ff4da9851a34a26ab0a24bfe7d"
 dependencies = [
  "cbindgen",
- "num-derive 0.2.5",
+ "num-derive 0.3.0",
  "num-traits",
  "remove_dir_all",
  "solana-sdk 1.2.17",

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -19,7 +19,7 @@ solana-config-program = { path = "../programs/config", version = "1.4.0" }
 solana-sdk = { path = "../sdk", version = "1.4.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.4.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.4.0" }
-spl-token-v1-0 = { package = "spl-token", version = "1.0.6", features = ["skip-no-mangle"] }
+spl-token-v1-0 = { package = "spl-token", version = "1.0.8", features = ["skip-no-mangle"] }
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.56"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,7 +67,7 @@ solana-transaction-status = { path = "../transaction-status", version = "1.4.0" 
 solana-version = { path = "../version", version = "1.4.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.4.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.4.0" }
-spl-token-v1-0 = { package = "spl-token", version = "1.0.6", features = ["skip-no-mangle"] }
+spl-token-v1-0 = { package = "spl-token", version = "1.0.8", features = ["skip-no-mangle"] }
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1383,9 +1383,7 @@ fn get_token_program_id_and_mint(
 /// program_id) and decimals
 fn get_mint_owner_and_decimals(bank: &Arc<Bank>, mint: &Pubkey) -> Result<(Pubkey, u8)> {
     if mint == &spl_token_v1_0_native_mint() {
-        // Uncomment the following once spl_token is bumped to a version that includes native_mint::DECIMALS
-        // Ok((spl_token_id_v1_0(), spl_token_v1_0::native_mint::DECIMALS))
-        Ok((spl_token_id_v1_0(), 9))
+        Ok((spl_token_id_v1_0(), spl_token_v1_0::native_mint::DECIMALS))
     } else {
         let mint_account = bank.get_account(mint).ok_or_else(|| {
             Error::invalid_params("Invalid param: could not find mint".to_string())

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -19,7 +19,7 @@ solana-sdk = { path = "../sdk", version = "1.4.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.4.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.4.0" }
 spl-memo-v1-0 = { package = "spl-memo", version = "1.0.7", features = ["skip-no-mangle"] }
-spl-token-v1-0 = { package = "spl-token", version = "1.0.6", features = ["skip-no-mangle"] }
+spl-token-v1-0 = { package = "spl-token", version = "1.0.8", features = ["skip-no-mangle"] }
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.56"


### PR DESCRIPTION
The `spl_token` on crates.io now includes native_mint::DECIMALS.
Remove comment and clean up magic number
