### PR TITLE
Temporary hotfix for explicitly enabling cross program support after epoch 63

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -472,6 +472,11 @@ impl Bank {
             }
         }
 
+        // HOTFIX
+        if new.epoch() >= 63 {
+            new.set_cross_program_support(true)
+        }
+
         new.update_epoch_stakes(leader_schedule_epoch);
         new.ancestors.insert(new.slot(), 0);
         new.parents().iter().enumerate().for_each(|(i, p)| {


### PR DESCRIPTION
#### Problem
If a validator restarts within the same epoch as the snapshot they restart with it looks like genesis-programs won't have an epoch boundary to trigger on and that validator may spend the rest of the epoch with a different configuration then the rest of the network.

#### Summary of Changes
Explicitly enable cross program support on banks in epochs >= 63 without waiting for epoch boundary

Fixes #
