### PR TITLE
explorer: Fix search bar paste on mobile

### DIFF
--- a/explorer/src/components/SearchBar.tsx
+++ b/explorer/src/components/SearchBar.tsx
@@ -40,6 +40,11 @@ export function SearchBar() {
             blurInputOnSelect
             onMenuClose={() => selectRef.current?.blur()}
             onChange={onChange}
+            styles={{
+              /* work around for https://github.com/JedWatson/react-select/issues/3857 */
+              placeholder: (style) => ({ ...style, pointerEvents: "none" }),
+              input: (style) => ({ ...style, width: "100%" }),
+            }}
             onInputChange={onInputChange}
             components={{ DropdownIndicator }}
             classNamePrefix="search-bar"

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -190,3 +190,11 @@ h4.slot-pill {
     max-width: 120px;
   }
 }
+
+// work around for https://github.com/JedWatson/react-select/issues/3857
+.search-bar__input {
+  width: 100% !important;
+  input {
+    width: 100% !important;
+  }
+}


### PR DESCRIPTION
#### Problem
`react-select` has a bug where the input is not paste friendly on mobile https://github.com/JedWatson/react-select/issues/3857

#### Summary of Changes
- Work around by overriding styles

Fixes #
