### PR TITLE
Switch programs activation to whole-set based gating

### DIFF
--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -109,14 +109,6 @@ pub fn get_native_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<(
     native_programs
 }
 
-fn recheck_cross_program_support(bank: &mut Bank) {
-    if OperatingMode::Stable == bank.operating_mode() {
-        bank.set_cross_program_support(bank.epoch() >= 63);
-    } else {
-        bank.set_cross_program_support(true);
-    }
-}
-
 pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpochCallback {
     Box::new(move |bank: &mut Bank| {
         // Be careful to add arbitrary logic here; this should be idempotent and can be called
@@ -137,8 +129,6 @@ pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpoch
                 }
             }
         }
-
-        recheck_cross_program_support(bank);
     })
 }
 

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -49,102 +49,94 @@ enum Program {
     BuiltinLoader((String, Pubkey, ProcessInstructionWithContext)),
 }
 
-fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Option<Vec<Program>> {
+// given operating_mode and epoch, return the entire set of enabled programs
+fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
+    let mut programs = vec![];
+
     match operating_mode {
         OperatingMode::Development => {
-            if epoch == 0 {
-                // Programs used for testing
-                Some(vec![
-                    Program::BuiltinLoader(solana_bpf_loader_program!()),
-                    Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
-                    Program::Native(solana_vest_program!()),
-                    Program::Native(solana_budget_program!()),
-                    Program::Native(solana_exchange_program!()),
-                ])
-            } else if epoch == std::u64::MAX {
+            // Programs used for testing
+            programs.extend(vec![
+                Program::BuiltinLoader(solana_bpf_loader_program!()),
+                Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
+                Program::Native(solana_vest_program!()),
+                Program::Native(solana_budget_program!()),
+                Program::Native(solana_exchange_program!()),
+            ]);
+
+            if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.
-                Some(vec![Program::BuiltinLoader(solana_bpf_loader_program!())])
-            } else {
-                None
-            }
-        }
-        OperatingMode::Stable => {
-            if epoch == std::u64::MAX {
-                // The epoch of std::u64::MAX is a placeholder and is expected
-                // to be reduced in a future network update.
-                Some(vec![
-                    Program::BuiltinLoader(solana_bpf_loader_program!()),
-                    Program::Native(solana_vest_program!()),
-                ])
-            } else {
-                None
+                programs.extend(vec![Program::BuiltinLoader(solana_bpf_loader_program!())]);
             }
         }
         OperatingMode::Preview => {
-            if epoch == std::u64::MAX {
+            if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.
-                Some(vec![
+                programs.extend(vec![
                     Program::BuiltinLoader(solana_bpf_loader_program!()),
                     Program::Native(solana_vest_program!()),
                 ])
-            } else {
-                None
             }
         }
-    }
+        OperatingMode::Stable => {
+            // at which epoch, bpf_loader_program is enabled??
+
+            if epoch >= std::u64::MAX {
+                // The epoch of std::u64::MAX is a placeholder and is expected
+                // to be reduced in a future network update.
+                programs.extend(vec![
+                    Program::BuiltinLoader(solana_bpf_loader_program!()),
+                    Program::Native(solana_vest_program!()),
+                ]);
+            }
+        }
+    };
+
+    programs
 }
 
-pub fn get_native_programs(
-    operating_mode: OperatingMode,
-    epoch: Epoch,
-) -> Option<Vec<(String, Pubkey)>> {
-    match get_programs(operating_mode, epoch) {
-        Some(programs) => {
-            let mut native_programs = vec![];
-            for program in programs {
-                if let Program::Native((string, key)) = program {
-                    native_programs.push((string, key));
-                }
-            }
-            Some(native_programs)
+pub fn get_native_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<(String, Pubkey)> {
+    let mut native_programs = vec![];
+    for program in get_programs(operating_mode, epoch) {
+        if let Program::Native((string, key)) = program {
+            native_programs.push((string, key));
         }
-        None => None,
+    }
+    native_programs
+}
+
+fn recheck_cross_program_support(bank: &mut Bank) {
+    if OperatingMode::Stable == bank.operating_mode() {
+        bank.set_cross_program_support(bank.epoch() >= 63);
+    } else {
+        bank.set_cross_program_support(true);
     }
 }
 
 pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpochCallback {
     Box::new(move |bank: &mut Bank| {
+        // Be careful to add arbitrary logic here; this should be idempotent and can be called
+        // at arbitrary point in an epoch not only epoch boundaries.
+        // This is because this closure need to be executed immediately after snapshot restoration,
+        // in addition to usual epoch boundaries
         if let Some(inflation) = get_inflation(operating_mode, bank.epoch()) {
             info!("Entering new epoch with inflation {:?}", inflation);
             bank.set_inflation(inflation);
         }
-        if let Some(programs) = get_programs(operating_mode, bank.epoch()) {
-            for program in programs {
-                match program {
-                    Program::Native((name, program_id)) => {
-                        bank.add_native_program(&name, &program_id);
-                    }
-                    Program::BuiltinLoader((
-                        name,
-                        program_id,
-                        process_instruction_with_context,
-                    )) => {
-                        bank.add_builtin_loader(
-                            &name,
-                            program_id,
-                            process_instruction_with_context,
-                        );
-                    }
+        for program in get_programs(operating_mode, bank.epoch()) {
+            match program {
+                Program::Native((name, program_id)) => {
+                    bank.add_native_program(&name, &program_id);
+                }
+                Program::BuiltinLoader((name, program_id, process_instruction_with_context)) => {
+                    bank.add_builtin_loader(&name, program_id, process_instruction_with_context);
                 }
             }
         }
-        if OperatingMode::Stable == operating_mode {
-            bank.set_cross_program_support(bank.epoch() >= 63);
-        } else {
-            bank.set_cross_program_support(true);
-        }
+
+        recheck_cross_program_support(bank);
     })
 }
 
@@ -156,7 +148,7 @@ mod tests {
     #[test]
     fn test_id_uniqueness() {
         let mut unique = HashSet::new();
-        let programs = get_programs(OperatingMode::Development, 0).unwrap();
+        let programs = get_programs(OperatingMode::Development, 0);
         for program in programs {
             match program {
                 Program::Native((name, id)) => assert!(unique.insert((name, id))),
@@ -176,22 +168,14 @@ mod tests {
 
     #[test]
     fn test_development_programs() {
-        assert_eq!(
-            get_programs(OperatingMode::Development, 0).unwrap().len(),
-            5
-        );
-        assert!(get_programs(OperatingMode::Development, 1).is_none());
+        assert_eq!(get_programs(OperatingMode::Development, 0).len(), 5);
+        assert_eq!(get_programs(OperatingMode::Development, 1).len(), 5);
     }
 
     #[test]
     fn test_native_development_programs() {
-        assert_eq!(
-            get_native_programs(OperatingMode::Development, 0)
-                .unwrap()
-                .len(),
-            3
-        );
-        assert!(get_native_programs(OperatingMode::Development, 1).is_none());
+        assert_eq!(get_native_programs(OperatingMode::Development, 0).len(), 3);
+        assert_eq!(get_native_programs(OperatingMode::Development, 0).len(), 3);
     }
 
     #[test]
@@ -209,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_softlaunch_programs() {
-        assert!(get_programs(OperatingMode::Stable, 1).is_none());
-        assert!(get_programs(OperatingMode::Stable, std::u64::MAX).is_some());
+        assert!(get_programs(OperatingMode::Stable, 1).is_empty());
+        assert!(!get_programs(OperatingMode::Stable, std::u64::MAX).is_empty());
     }
 }

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -64,6 +64,7 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
                 Program::Native(solana_exchange_program!()),
             ]);
 
+            #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.
@@ -71,6 +72,7 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
             }
         }
         OperatingMode::Preview => {
+            #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.
@@ -82,7 +84,7 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
         }
         OperatingMode::Stable => {
             // at which epoch, bpf_loader_program is enabled??
-
+            #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -468,7 +468,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
 
     let native_instruction_processors =
-        solana_genesis_programs::get_native_programs(operating_mode, 0).unwrap_or_else(Vec::new);
+        solana_genesis_programs::get_native_programs(operating_mode, 0);
     let inflation = solana_genesis_programs::get_inflation(operating_mode, 0).unwrap();
 
     let mut genesis_config = GenesisConfig {

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -173,7 +173,6 @@ impl LocalCluster {
             OperatingMode::Stable | OperatingMode::Preview => {
                 genesis_config.native_instruction_processors =
                     solana_genesis_programs::get_native_programs(genesis_config.operating_mode, 0)
-                        .unwrap_or_default()
             }
             _ => (),
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10,7 +10,7 @@ use crate::{
     accounts_db::{ErrorCounters, SnapshotStorages},
     accounts_index::Ancestors,
     blockhash_queue::BlockhashQueue,
-    builtins::{get_builtins, get_epoch_activated_builtins},
+    builtins::get_builtins,
     epoch_stakes::{EpochStakes, NodeVoteAccounts},
     log_collector::LogCollector,
     message_processor::MessageProcessor,
@@ -557,17 +557,7 @@ impl Bank {
 
         let leader_schedule_epoch = epoch_schedule.get_leader_schedule_epoch(slot);
         if parent.epoch() < new.epoch() {
-            if let Some(entered_epoch_callback) =
-                parent.entered_epoch_callback.read().unwrap().as_ref()
-            {
-                entered_epoch_callback(&mut new)
-            }
-
-            if let Some(builtins) = get_epoch_activated_builtins(new.operating_mode(), new.epoch) {
-                for program in builtins.iter() {
-                    new.add_builtin(&program.name, program.id, program.entrypoint);
-                }
-            }
+            new.refresh_programs_and_inflation();
         }
 
         new.update_epoch_stakes(leader_schedule_epoch);
@@ -584,6 +574,7 @@ impl Bank {
         if !new.fix_recent_blockhashes_sysvar_delay() {
             new.update_recent_blockhashes();
         }
+        dbg!(&new.message_processor);
         new
     }
 
@@ -2598,10 +2589,7 @@ impl Bank {
     }
 
     pub fn finish_init(&mut self) {
-        let builtins = get_builtins();
-        for program in builtins.iter() {
-            self.add_builtin(&program.name, program.id, program.entrypoint);
-        }
+        self.refresh_programs_and_inflation();
     }
 
     pub fn set_parent(&mut self, parent: &Arc<Bank>) {
@@ -3176,6 +3164,20 @@ impl Bank {
             }
         }
         consumed_budget.saturating_sub(budget_recovery_delta)
+    }
+
+    // This is called from snapshot restore and for each epoch boundary
+    // The entire code path herein must be idempotent
+    pub fn refresh_programs_and_inflation(&mut self) {
+        if let Some(entered_epoch_callback) =
+            self.entered_epoch_callback.clone().read().unwrap().as_ref()
+        {
+            entered_epoch_callback(self)
+        }
+
+        for program in get_builtins(self.operating_mode(), self.epoch()) {
+            self.add_builtin(&program.name, program.id, program.entrypoint);
+        }
     }
 
     fn fix_recent_blockhashes_sysvar_delay(&self) -> bool {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -574,7 +574,6 @@ impl Bank {
         if !new.fix_recent_blockhashes_sysvar_delay() {
             new.update_recent_blockhashes();
         }
-        dbg!(&new.message_processor);
         new
     }
 

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -4,9 +4,11 @@ use crate::{
 };
 use solana_sdk::{clock::Epoch, genesis_config::OperatingMode, system_program};
 
-/// All builtin programs that should be active at the given (operating_mode, epoch)
-pub fn get_builtins() -> Vec<Builtin> {
-    vec![
+/// The entire set of available builtin programs that should be active at the given (operating_mode, epoch)
+pub fn get_builtins(_operating_mode: OperatingMode, _epoch: Epoch) -> Vec<Builtin> {
+    let mut builtins = vec![];
+
+    builtins.extend(vec![
         Builtin::new(
             "system_program",
             system_program::id(),
@@ -27,13 +29,10 @@ pub fn get_builtins() -> Vec<Builtin> {
             solana_vote_program::id(),
             Entrypoint::Program(solana_vote_program::vote_instruction::process_instruction),
         ),
-    ]
-}
+    ]);
 
-/// Builtin programs that activate at the given (operating_mode, epoch)
-pub fn get_epoch_activated_builtins(
-    _operating_mode: OperatingMode,
-    _epoch: Epoch,
-) -> Option<Vec<Builtin>> {
-    None
+    // if we ever add gated builtins, add here like this
+    // if _epoch >= 10 { builtins.extend(....) }
+
+    builtins
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -277,12 +277,13 @@ impl std::fmt::Debug for MessageProcessor {
                 .programs
                 .iter()
                 .map(|(pubkey, instruction)| {
-                    let erased_instruction: fn(
+                    type ErasedProcessInstruction = fn(
                         &'static Pubkey,
                         &'static [KeyedAccount<'static>],
                         &'static [u8],
                     )
-                        -> Result<(), InstructionError> = *instruction;
+                        -> Result<(), InstructionError>;
+                    let erased_instruction: ErasedProcessInstruction = *instruction;
                     format!("{}: {:p}", pubkey, erased_instruction)
                 })
                 .collect::<Vec<_>>(),
@@ -290,13 +291,14 @@ impl std::fmt::Debug for MessageProcessor {
                 .loaders
                 .iter()
                 .map(|(pubkey, instruction)| {
-                    let erased_instruction: fn(
+                    type ErasedProcessInstructionWithContext = fn(
                         &'static Pubkey,
                         &'static [KeyedAccount<'static>],
                         &'static [u8],
                         &'static mut dyn InvokeContext,
                     )
-                        -> Result<(), InstructionError> = *instruction;
+                        -> Result<(), InstructionError>;
+                    let erased_instruction: ErasedProcessInstructionWithContext = *instruction;
                     format!("{}: {:p}", pubkey, erased_instruction)
                 })
                 .collect::<Vec<_>>(),

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -364,6 +364,10 @@ impl MessageProcessor {
         self.is_cross_program_supported = is_supported;
     }
 
+    pub fn get_cross_program_support(&mut self) -> bool {
+        self.is_cross_program_supported
+    }
+
     /// Create the KeyedAccounts that will be passed to the program
     fn create_keyed_accounts<'a>(
         message: &'a Message,


### PR DESCRIPTION
#### Problem

`get_entered_epoch_callback` isn't called when restoring from snapshots, which is too confusing and error-prone.
Also, we can't simply call it immediately after snapshot restoration because it expects to be called **exactly once at each epoch boundary**

`get_programs` and `get_builtins` returns delta set. i.e. _add these new additions of programs to the current available set at the given epoch_. This works nicely in the ideal world, where we're running the validator since genesis without ever restarting a perfect bug-free validator.

In reality, we must rely on snapshots 99.999% of time. When restoring from snapshots, the delta set doesn't work quite: we don't persist _the current available set_ (namely `bank.message_processor` is effectively `serde(skip)`).

#### Summary of Changes

So, just reflect the reality by making these functions snapshot-friendly by returning whole-set of available programs at the given epoch. And make it callable  from `finish_init()`, which is called after snapshot restoration.

Also, fix a bunch of other dangerous code along the way.

Also, this is intended to be back-port friendly; so the fix is intentionally not exhaustive. Still, `get_entered_epoch_callback` is a bit error-prone. Specifically, it must be **idempotent**. (We could solve this by artificially introducing some intermediate `struct` like `ScheduledBankFeatures` or the like instead of mind-opening way of passing `&mut Bank`).

Fixes #
