### PR TITLE
Rpc: Return error if block does not exist

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -625,7 +625,7 @@ impl JsonRpcRequestProcessor {
             self.check_slot_cleaned_up(&result, slot)?;
             Ok(result.ok())
         } else {
-            Ok(None)
+            Err(RpcCustomError::BlockNotAvailable { slot }.into())
         }
     }
 
@@ -697,7 +697,7 @@ impl JsonRpcRequestProcessor {
             self.check_slot_cleaned_up(&result, slot)?;
             Ok(result.ok().unwrap_or(None))
         } else {
-            Ok(None)
+            Err(RpcCustomError::BlockNotAvailable { slot }.into())
         }
     }
 
@@ -4484,7 +4484,7 @@ pub mod tests {
             slot
         );
         let res = io.handle_request_sync(&req, meta);
-        let expected = r#"{"jsonrpc":"2.0","result":null,"id":1}"#;
+        let expected = r#"{"jsonrpc":"2.0","error":{"code":-32004,"message":"Block not available for slot 12345"},"id":1}"#;
         let expected: Response =
             serde_json::from_str(&expected).expect("expected response deserialization");
         let result: Response = serde_json::from_str(&res.expect("actual response"))

--- a/core/src/rpc_error.rs
+++ b/core/src/rpc_error.rs
@@ -4,6 +4,7 @@ use solana_sdk::clock::Slot;
 const JSON_RPC_SERVER_ERROR_1: i64 = -32001;
 const JSON_RPC_SERVER_ERROR_2: i64 = -32002;
 const JSON_RPC_SERVER_ERROR_3: i64 = -32003;
+const JSON_RPC_SERVER_ERROR_4: i64 = -32004;
 
 pub enum RpcCustomError {
     BlockCleanedUp {
@@ -14,6 +15,9 @@ pub enum RpcCustomError {
         message: String,
     },
     SendTransactionIsNotSigned,
+    BlockNotAvailable {
+        slot: Slot,
+    },
 }
 
 impl From<RpcCustomError> for Error {
@@ -38,6 +42,11 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::SendTransactionIsNotSigned => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_3),
                 message: "Transaction is not signed".to_string(),
+                data: None,
+            },
+            RpcCustomError::BlockNotAvailable { slot } => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_4),
+                message: format!("Block not available for slot {}", slot,),
                 data: None,
             },
         }

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -241,7 +241,7 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "m
 
 ### getBlockTime
 
-Returns the estimated production time of a block.
+Returns the estimated production time of a confirmed block.
 
 Each validator reports their UTC time to the ledger on a regular interval by
 intermittently adding a timestamp to a Vote for a particular block. A requested
@@ -259,8 +259,8 @@ query a node that is built from genesis and retains the entire ledger.
 
 #### Results:
 
-- `<null>` - block has not yet been produced
-- `<i64>` - estimated production time, as Unix timestamp (seconds since the Unix epoch)
+* `<i64>` - estimated production time, as Unix timestamp (seconds since the Unix epoch)
+* `<null>` - timestamp is not available for this block
 
 #### Example:
 


### PR DESCRIPTION
#### Problem
The endpoints `getConfirmedBlock` and `getBlockTime` return success, but `null` data when a block is not available. This is particularly confusing in the latter case, since `getBlockTime` also returns `null` if the block time is not available.

#### Summary of Changes
Return a JSON-RPC error if block is not available for a slot
