### PR TITLE
sdk: Make PubKey::create_program_address available in program unit tests

### DIFF
--- a/programs/bpf/rust/128bit/Cargo.toml
+++ b/programs/bpf/rust/128bit/Cargo.toml
@@ -17,7 +17,7 @@ solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "1.4.0" }
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_128bit"

--- a/programs/bpf/rust/128bit/Cargo.toml
+++ b/programs/bpf/rust/128bit/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = false }
-solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "1.4.0" }
+solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "1.4.0", default-features = false }
 
 [features]
 program = ["solana-sdk/program"]

--- a/programs/bpf/rust/128bit_dep/Cargo.toml
+++ b/programs/bpf/rust/128bit_dep/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/alloc/Cargo.toml
+++ b/programs/bpf/rust/alloc/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_alloc"

--- a/programs/bpf/rust/dep_crate/Cargo.toml
+++ b/programs/bpf/rust/dep_crate/Cargo.toml
@@ -17,7 +17,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_dep_crate"

--- a/programs/bpf/rust/dup_accounts/Cargo.toml
+++ b/programs/bpf/rust/dup_accounts/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_dup_accounts"

--- a/programs/bpf/rust/error_handling/Cargo.toml
+++ b/programs/bpf/rust/error_handling/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0"
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_error_handling"

--- a/programs/bpf/rust/external_spend/Cargo.toml
+++ b/programs/bpf/rust/external_spend/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_external_spend"

--- a/programs/bpf/rust/invoke/Cargo.toml
+++ b/programs/bpf/rust/invoke/Cargo.toml
@@ -17,7 +17,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_invoke"

--- a/programs/bpf/rust/invoke/Cargo.toml
+++ b/programs/bpf/rust/invoke/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://solana.com/"
 edition = "2018"
 
 [dependencies]
-solana-bpf-rust-invoked = { path = "../invoked"}
+solana-bpf-rust-invoked = { path = "../invoked", default-features = false }
 solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = false }
 
 [features]

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -252,5 +252,17 @@ fn process_instruction(
     Ok(())
 }
 
-// Pull in syscall stubs when building for non-BPF targets
-solana_sdk::program_stubs!();
+#[cfg(test)]
+mod test {
+    use super::*;
+    // Pull in syscall stubs when building for non-BPF targets
+    solana_sdk::program_stubs!();
+
+    #[test]
+    fn create_program_address_is_defined() {
+        assert_eq!(
+            Pubkey::create_program_address(&[b"You pass butter"], &Pubkey::default()).unwrap_err(),
+            PubkeyError::InvalidSeeds
+        );
+    }
+}

--- a/programs/bpf/rust/invoked/Cargo.toml
+++ b/programs/bpf/rust/invoked/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_invoked"

--- a/programs/bpf/rust/iter/Cargo.toml
+++ b/programs/bpf/rust/iter/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_iter"

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -17,7 +17,7 @@ solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "1.4.0" }
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_many_args"

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = false }
-solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "1.4.0" }
+solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "1.4.0", default-features = false }
 
 [features]
 program = ["solana-sdk/program"]

--- a/programs/bpf/rust/many_args_dep/Cargo.toml
+++ b/programs/bpf/rust/many_args_dep/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_noop"

--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_panic"

--- a/programs/bpf/rust/param_passing/Cargo.toml
+++ b/programs/bpf/rust/param_passing/Cargo.toml
@@ -17,7 +17,7 @@ solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_param_passing"

--- a/programs/bpf/rust/param_passing/Cargo.toml
+++ b/programs/bpf/rust/param_passing/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = false }
-solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "1.4.0" }
+solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "1.4.0", default-features = false }
 
 [features]
 program = ["solana-sdk/program"]

--- a/programs/bpf/rust/param_passing_dep/Cargo.toml
+++ b/programs/bpf/rust/param_passing_dep/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/sysval/Cargo.toml
+++ b/programs/bpf/rust/sysval/Cargo.toml
@@ -16,7 +16,7 @@ solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = 
 
 [features]
 program = ["solana-sdk/program"]
-default = ["program"]
+default = ["program", "solana-sdk/default"]
 
 [lib]
 name = "solana_bpf_rust_sysval"

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "program")]
+#[cfg(all(feature = "program", target_arch = "bpf"))]
 use crate::entrypoint::SUCCESS;
-#[cfg(not(feature = "program"))]
+#[cfg(not(all(feature = "program", target_arch = "bpf")))]
 use crate::hash::Hasher;
 use crate::{decode_error::DecodeError, hash::hashv};
 use num_derive::{FromPrimitive, ToPrimitive};
@@ -107,7 +107,7 @@ impl Pubkey {
     ) -> Result<Pubkey, PubkeyError> {
         // Perform the calculation inline, calling this from within a program is
         // not supported
-        #[cfg(not(feature = "program"))]
+        #[cfg(not(all(feature = "program", target_arch = "bpf")))]
         {
             let mut hasher = Hasher::default();
             for seed in seeds.iter() {
@@ -129,7 +129,7 @@ impl Pubkey {
             Ok(Pubkey::new(hash.as_ref()))
         }
         // Call via a system call to perform the calculation
-        #[cfg(feature = "program")]
+        #[cfg(all(feature = "program", target_arch = "bpf"))]
         {
             extern "C" {
                 fn sol_create_program_address(


### PR DESCRIPTION
#### Problem

This finishes the work started in #11604.  `create_program_address` is unavailable when `target_arch` is not `bpf` and
`program` is enabled.  There is an undefined reference error to `sol_create_program_address`, which is only defined in `bpf`.

#### Summary of Changes

Use `sol_create_program_address` only if the architecture is `bpf` and the `program` feature is enabled, otherwise use the default version.

All programs additionally require the default `solana-sdk` features. This doesn't cause a problem with
existing bpf programs since they are built with `build.sh`, which always specifies `--no-default-features`.  This also aligns the internal `solana` programs with the  `solana-program-library` configurations.

A small test to simply call the function has been added in order to catch the problem in the future.

Fixes #11604 solana-labs/solana-program-library#268
