### PR TITLE
Switch programs activation to whole-set based gating

### DIFF
--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -67,6 +67,7 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
                 Program::Native(solana_exchange_program!()),
             ]);
 
+            #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.
@@ -74,6 +75,7 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
             }
         }
         OperatingMode::Preview => {
+            #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.
@@ -85,7 +87,7 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
         }
         OperatingMode::Stable => {
             // at which epoch, bpf_loader_program is enabled??
-
+            #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -52,94 +52,89 @@ enum Program {
     BuiltinLoader((String, Pubkey, ProcessInstructionWithContext)),
 }
 
-fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Option<Vec<Program>> {
+// given operating_mode and epoch, return the entire set of enabled programs
+fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
+    let mut programs = vec![];
+
     match operating_mode {
         OperatingMode::Development => {
-            if epoch == 0 {
-                // Programs used for testing
-                Some(vec![
-                    Program::BuiltinLoader(solana_bpf_loader_program!()),
-                    Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
-                    Program::Native(solana_vest_program!()),
-                    Program::Native(solana_budget_program!()),
-                    Program::Native(solana_exchange_program!()),
-                ])
-            } else if epoch == std::u64::MAX {
+            // Programs used for testing
+            programs.extend(vec![
+                Program::BuiltinLoader(solana_bpf_loader_program!()),
+                Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
+                Program::Native(solana_vest_program!()),
+                Program::Native(solana_budget_program!()),
+                Program::Native(solana_exchange_program!()),
+            ]);
+
+            if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.
-                Some(vec![Program::BuiltinLoader(solana_bpf_loader_program!())])
-            } else {
-                None
-            }
-        }
-        OperatingMode::Stable => {
-            if epoch == std::u64::MAX {
-                // The epoch of std::u64::MAX is a placeholder and is expected
-                // to be reduced in a future network update.
-                Some(vec![
-                    Program::BuiltinLoader(solana_bpf_loader_program!()),
-                    Program::Native(solana_vest_program!()),
-                ])
-            } else {
-                None
+                programs.extend(vec![Program::BuiltinLoader(solana_bpf_loader_program!())]);
             }
         }
         OperatingMode::Preview => {
-            if epoch == std::u64::MAX {
+            if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
                 // to be reduced in a future network update.
-                Some(vec![
+                programs.extend(vec![
                     Program::BuiltinLoader(solana_bpf_loader_program!()),
                     Program::Native(solana_vest_program!()),
                 ])
-            } else {
-                None
             }
         }
-    }
+        OperatingMode::Stable => {
+            // at which epoch, bpf_loader_program is enabled??
+
+            if epoch >= std::u64::MAX {
+                // The epoch of std::u64::MAX is a placeholder and is expected
+                // to be reduced in a future network update.
+                programs.extend(vec![
+                    Program::BuiltinLoader(solana_bpf_loader_program!()),
+                    Program::Native(solana_vest_program!()),
+                ]);
+            }
+        }
+    };
+
+    programs
 }
 
-pub fn get_native_programs(
-    operating_mode: OperatingMode,
-    epoch: Epoch,
-) -> Option<Vec<(String, Pubkey)>> {
-    match get_programs(operating_mode, epoch) {
-        Some(programs) => {
-            let mut native_programs = vec![];
-            for program in programs {
-                if let Program::Native((string, key)) = program {
-                    native_programs.push((string, key));
-                }
-            }
-            Some(native_programs)
+pub fn get_native_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<(String, Pubkey)> {
+    let mut native_programs = vec![];
+    for program in get_programs(operating_mode, epoch) {
+        if let Program::Native((string, key)) = program {
+            native_programs.push((string, key));
         }
-        None => None,
+    }
+    native_programs
+}
+
+fn recheck_cross_program_support(bank: &mut Bank) {
+    if OperatingMode::Stable == bank.operating_mode() {
+        bank.set_cross_program_support(bank.epoch() >= 63);
+    } else {
+        bank.set_cross_program_support(true);
     }
 }
 
 pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpochCallback {
     Box::new(move |bank: &mut Bank| {
+        // Be careful to add arbitrary logic here; this should be idempotent and can be called
+        // at arbitrary point in an epoch not only epoch boundaries.
+        // This is because this closure need to be executed immediately after snapshot restoration,
+        // in addition to usual epoch boundaries
         if let Some(inflation) = get_inflation(operating_mode, bank.epoch()) {
             info!("Entering new epoch with inflation {:?}", inflation);
             bank.set_inflation(inflation);
         }
-        if let Some(programs) = get_programs(operating_mode, bank.epoch()) {
-            for program in programs {
-                match program {
-                    Program::Native((name, program_id)) => {
-                        bank.add_native_program(&name, &program_id);
-                    }
-                    Program::BuiltinLoader((
-                        name,
-                        program_id,
-                        process_instruction_with_context,
-                    )) => {
-                        bank.add_builtin_loader(
-                            &name,
-                            program_id,
-                            process_instruction_with_context,
-                        );
-                    }
+        for program in get_programs(operating_mode, bank.epoch()) {
+            match program {
+                Program::Native((name, program_id)) => {
+                    bank.add_native_program(&name, &program_id);
+                }
+                Program::BuiltinLoader((name, program_id, process_instruction_with_context)) => {
+                    bank.add_builtin_loader(&name, program_id, process_instruction_with_context);
                 }
             }
         }
@@ -151,6 +146,8 @@ pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpoch
 
         bank.set_max_invoke_depth(DEFAULT_MAX_INVOKE_DEPTH);
         bank.set_compute_budget(DEFAULT_COMPUTE_BUDGET);
+
+        recheck_cross_program_support(bank);
     })
 }
 
@@ -162,7 +159,7 @@ mod tests {
     #[test]
     fn test_id_uniqueness() {
         let mut unique = HashSet::new();
-        let programs = get_programs(OperatingMode::Development, 0).unwrap();
+        let programs = get_programs(OperatingMode::Development, 0);
         for program in programs {
             match program {
                 Program::Native((name, id)) => assert!(unique.insert((name, id))),
@@ -182,22 +179,14 @@ mod tests {
 
     #[test]
     fn test_development_programs() {
-        assert_eq!(
-            get_programs(OperatingMode::Development, 0).unwrap().len(),
-            5
-        );
-        assert!(get_programs(OperatingMode::Development, 1).is_none());
+        assert_eq!(get_programs(OperatingMode::Development, 0).len(), 5);
+        assert_eq!(get_programs(OperatingMode::Development, 1).len(), 5);
     }
 
     #[test]
     fn test_native_development_programs() {
-        assert_eq!(
-            get_native_programs(OperatingMode::Development, 0)
-                .unwrap()
-                .len(),
-            3
-        );
-        assert!(get_native_programs(OperatingMode::Development, 1).is_none());
+        assert_eq!(get_native_programs(OperatingMode::Development, 0).len(), 3);
+        assert_eq!(get_native_programs(OperatingMode::Development, 0).len(), 3);
     }
 
     #[test]
@@ -215,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_softlaunch_programs() {
-        assert!(get_programs(OperatingMode::Stable, 1).is_none());
-        assert!(get_programs(OperatingMode::Stable, std::u64::MAX).is_some());
+        assert!(get_programs(OperatingMode::Stable, 1).is_empty());
+        assert!(!get_programs(OperatingMode::Stable, std::u64::MAX).is_empty());
     }
 }

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -13,7 +13,7 @@ use solana_runtime::{
     message_processor::{DEFAULT_COMPUTE_BUDGET, DEFAULT_MAX_INVOKE_DEPTH},
 };
 use solana_sdk::{
-    clock::Epoch,
+    clock::{Epoch, GENESIS_EPOCH},
     entrypoint_native::{ErasedProcessInstructionWithContext, ProcessInstructionWithContext},
     genesis_config::OperatingMode,
     inflation::Inflation,
@@ -74,71 +74,80 @@ impl std::fmt::Debug for Program {
 }
 
 // given operating_mode and epoch, return the entire set of enabled programs
-fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
+fn get_programs(operating_mode: OperatingMode) -> Vec<(Program, Epoch)> {
     let mut programs = vec![];
 
     match operating_mode {
         OperatingMode::Development => {
             // Programs used for testing
-            programs.extend(vec![
-                Program::BuiltinLoader(solana_bpf_loader_program!()),
-                Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
-                Program::Native(solana_vest_program!()),
-                Program::Native(solana_budget_program!()),
-                Program::Native(solana_exchange_program!()),
-            ]);
+            programs.extend(
+                vec![
+                    Program::BuiltinLoader(solana_bpf_loader_program!()),
+                    Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
+                    Program::Native(solana_vest_program!()),
+                    Program::Native(solana_budget_program!()),
+                    Program::Native(solana_exchange_program!()),
+                ]
+                .into_iter()
+                .map(|program| (program, 0))
+                .collect::<Vec<_>>(),
+            );
         }
         OperatingMode::Preview => {
             // tds enabled async cluster restart with smart contract being enabled
             // at slot 2196960 (midway epoch 17) with v1.0.1 on Mar 1, 2020
-            if epoch >= 17 {
-                programs.extend(vec![Program::BuiltinLoader(
-                    solana_bpf_loader_deprecated_program!(),
-                )]);
-            }
-            #[allow(clippy::absurd_extreme_comparisons)]
-            if epoch >= std::u64::MAX {
-                // The epoch of std::u64::MAX is a placeholder and is expected
-                // to be reduced in a future network update.
-                programs.extend(vec![
+            programs.extend(vec![(
+                Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
+                17,
+            )]);
+            // The epoch of Epoch::max_value() is a placeholder and is expected
+            // to be reduced in a future network update.
+            programs.extend(
+                vec![
                     Program::BuiltinLoader(solana_bpf_loader_program!()),
                     Program::Native(solana_vest_program!()),
-                ])
-            }
+                ]
+                .into_iter()
+                .map(|program| (program, Epoch::MAX))
+                .collect::<Vec<_>>(),
+            );
         }
         OperatingMode::Stable => {
-            if epoch >= 34 {
-                programs.extend(vec![Program::BuiltinLoader(
-                    solana_bpf_loader_deprecated_program!(),
-                )]);
-            }
-            #[allow(clippy::absurd_extreme_comparisons)]
-            if epoch >= std::u64::MAX {
-                // The epoch of std::u64::MAX is a placeholder and is expected
-                // to be reduced in a future network update.
-                programs.extend(vec![
+            programs.extend(vec![(
+                Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
+                34,
+            )]);
+            // The epoch of std::u64::MAX is a placeholder and is expected
+            // to be reduced in a future network update.
+            programs.extend(
+                vec![
                     Program::BuiltinLoader(solana_bpf_loader_program!()),
                     Program::Native(solana_vest_program!()),
-                ]);
-            }
+                ]
+                .into_iter()
+                .map(|program| (program, Epoch::MAX))
+                .collect::<Vec<_>>(),
+            );
         }
     };
 
     programs
 }
 
-pub fn get_native_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<(String, Pubkey)> {
+pub fn get_native_programs_for_genesis(operating_mode: OperatingMode) -> Vec<(String, Pubkey)> {
     let mut native_programs = vec![];
-    for program in get_programs(operating_mode, epoch) {
+    for (program, start_epoch) in get_programs(operating_mode) {
         if let Program::Native((string, key)) = program {
-            native_programs.push((string, key));
+            if start_epoch == GENESIS_EPOCH {
+                native_programs.push((string, key));
+            }
         }
     }
     native_programs
 }
 
 pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpochCallback {
-    Box::new(move |bank: &mut Bank| {
+    Box::new(move |bank: &mut Bank, initial: bool| {
         // Be careful to add arbitrary logic here; this should be idempotent and can be called
         // at arbitrary point in an epoch not only epoch boundaries.
         // This is because this closure need to be executed immediately after snapshot restoration,
@@ -150,13 +159,25 @@ pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpoch
             info!("Entering new epoch with inflation {:?}", inflation);
             bank.set_inflation(inflation);
         }
-        for program in get_programs(operating_mode, bank.epoch()) {
-            match program {
-                Program::Native((name, program_id)) => {
-                    bank.add_native_program(&name, &program_id);
-                }
-                Program::BuiltinLoader((name, program_id, process_instruction_with_context)) => {
-                    bank.add_builtin_loader(&name, program_id, process_instruction_with_context);
+        for (program, start_epoch) in get_programs(operating_mode) {
+            let should_populate =
+                initial && bank.epoch() >= start_epoch || !initial && bank.epoch() == start_epoch;
+            if should_populate {
+                match program {
+                    Program::Native((name, program_id)) => {
+                        bank.add_native_program(&name, &program_id);
+                    }
+                    Program::BuiltinLoader((
+                        name,
+                        program_id,
+                        process_instruction_with_context,
+                    )) => {
+                        bank.add_builtin_loader(
+                            &name,
+                            program_id,
+                            process_instruction_with_context,
+                        );
+                    }
                 }
             }
         }
@@ -174,8 +195,8 @@ mod tests {
     #[test]
     fn test_id_uniqueness() {
         let mut unique = HashSet::new();
-        let programs = get_programs(OperatingMode::Development, 0);
-        for program in programs {
+        let programs = get_programs(OperatingMode::Development);
+        for (program, _start_epoch) in programs {
             match program {
                 Program::Native((name, id)) => assert!(unique.insert((name, id))),
                 Program::BuiltinLoader((name, id, _)) => assert!(unique.insert((name, id))),
@@ -194,14 +215,15 @@ mod tests {
 
     #[test]
     fn test_development_programs() {
-        assert_eq!(get_programs(OperatingMode::Development, 0).len(), 5);
-        assert_eq!(get_programs(OperatingMode::Development, 1).len(), 5);
+        assert_eq!(get_programs(OperatingMode::Development).len(), 5);
     }
 
     #[test]
     fn test_native_development_programs() {
-        assert_eq!(get_native_programs(OperatingMode::Development, 0).len(), 3);
-        assert_eq!(get_native_programs(OperatingMode::Development, 1).len(), 3);
+        assert_eq!(
+            get_native_programs_for_genesis(OperatingMode::Development).len(),
+            3
+        );
     }
 
     #[test]
@@ -219,7 +241,6 @@ mod tests {
 
     #[test]
     fn test_softlaunch_programs() {
-        assert!(get_programs(OperatingMode::Stable, 1).is_empty());
-        assert!(!get_programs(OperatingMode::Stable, std::u64::MAX).is_empty());
+        assert!(!get_programs(OperatingMode::Stable).is_empty());
     }
 }

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -143,18 +143,14 @@ pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpoch
         // at arbitrary point in an epoch not only epoch boundaries.
         // This is because this closure need to be executed immediately after snapshot restoration,
         // in addition to usual epoch boundaries
-        let (epoch, slot_index) = bank.get_epoch_and_slot_index(bank.slot());
-        if slot_index != 0 {
-            // bank should be frozen (restored from snapshot) unless entering into a new epoch
-            assert!(bank.is_frozen());
-        }
-        // we must initialize some skip(serde) fields here, regardless frozen or not
+        // In other words, this callback initializes some skip(serde) fields, regardless
+        // frozen or not
 
-        if let Some(inflation) = get_inflation(operating_mode, epoch) {
+        if let Some(inflation) = get_inflation(operating_mode, bank.epoch()) {
             info!("Entering new epoch with inflation {:?}", inflation);
             bank.set_inflation(inflation);
         }
-        for program in get_programs(operating_mode, epoch) {
+        for program in get_programs(operating_mode, bank.epoch()) {
             match program {
                 Program::Native((name, program_id)) => {
                     bank.add_native_program(&name, &program_id);

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -112,14 +112,6 @@ pub fn get_native_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<(
     native_programs
 }
 
-fn recheck_cross_program_support(bank: &mut Bank) {
-    if OperatingMode::Stable == bank.operating_mode() {
-        bank.set_cross_program_support(bank.epoch() >= 63);
-    } else {
-        bank.set_cross_program_support(true);
-    }
-}
-
 pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpochCallback {
     Box::new(move |bank: &mut Bank| {
         // Be careful to add arbitrary logic here; this should be idempotent and can be called
@@ -148,8 +140,6 @@ pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpoch
 
         bank.set_max_invoke_depth(DEFAULT_MAX_INVOKE_DEPTH);
         bank.set_compute_budget(DEFAULT_COMPUTE_BUDGET);
-
-        recheck_cross_program_support(bank);
     })
 }
 

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -89,6 +89,13 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
             ]);
         }
         OperatingMode::Preview => {
+            // tds enabled async cluster restart with smart contract being enabled
+            // at slot 2196960 (midway epoch 17) with v1.0.1 on Mar 1, 2020
+            if epoch >= 17 {
+                programs.extend(vec![Program::BuiltinLoader(
+                    solana_bpf_loader_deprecated_program!(),
+                )]);
+            }
             #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
@@ -105,7 +112,6 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
                     solana_bpf_loader_deprecated_program!(),
                 )]);
             }
-            // at which epoch, bpf_loader_program is enabled??
             #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {
                 // The epoch of std::u64::MAX is a placeholder and is expected
@@ -197,7 +203,7 @@ mod tests {
     #[test]
     fn test_native_development_programs() {
         assert_eq!(get_native_programs(OperatingMode::Development, 0).len(), 3);
-        assert_eq!(get_native_programs(OperatingMode::Development, 0).len(), 3);
+        assert_eq!(get_native_programs(OperatingMode::Development, 1).len(), 3);
     }
 
     #[test]

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -66,13 +66,6 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
                 Program::Native(solana_budget_program!()),
                 Program::Native(solana_exchange_program!()),
             ]);
-
-            #[allow(clippy::absurd_extreme_comparisons)]
-            if epoch >= std::u64::MAX {
-                // The epoch of std::u64::MAX is a placeholder and is expected
-                // to be reduced in a future network update.
-                programs.extend(vec![Program::BuiltinLoader(solana_bpf_loader_program!())]);
-            }
         }
         OperatingMode::Preview => {
             #[allow(clippy::absurd_extreme_comparisons)]
@@ -86,6 +79,11 @@ fn get_programs(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Program> {
             }
         }
         OperatingMode::Stable => {
+            if epoch >= 34 {
+                programs.extend(vec![Program::BuiltinLoader(
+                    solana_bpf_loader_deprecated_program!(),
+                )]);
+            }
             // at which epoch, bpf_loader_program is enabled??
             #[allow(clippy::absurd_extreme_comparisons)]
             if epoch >= std::u64::MAX {

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -8,10 +8,7 @@ extern crate solana_exchange_program;
 extern crate solana_vest_program;
 
 use log::*;
-use solana_runtime::{
-    bank::{Bank, EnteredEpochCallback},
-    message_processor::{DEFAULT_COMPUTE_BUDGET, DEFAULT_MAX_INVOKE_DEPTH},
-};
+use solana_runtime::bank::{Bank, EnteredEpochCallback};
 use solana_sdk::{
     clock::{Epoch, GENESIS_EPOCH},
     entrypoint_native::{ErasedProcessInstructionWithContext, ProcessInstructionWithContext},
@@ -181,9 +178,6 @@ pub fn get_entered_epoch_callback(operating_mode: OperatingMode) -> EnteredEpoch
                 }
             }
         }
-
-        bank.set_max_invoke_depth(DEFAULT_MAX_INVOKE_DEPTH);
-        bank.set_compute_budget(DEFAULT_COMPUTE_BUDGET);
     })
 }
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -468,7 +468,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
 
     let native_instruction_processors =
-        solana_genesis_programs::get_native_programs(operating_mode, 0).unwrap_or_else(Vec::new);
+        solana_genesis_programs::get_native_programs(operating_mode, 0);
     let inflation = solana_genesis_programs::get_inflation(operating_mode, 0).unwrap();
 
     let mut genesis_config = GenesisConfig {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -468,7 +468,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
 
     let native_instruction_processors =
-        solana_genesis_programs::get_native_programs(operating_mode, 0);
+        solana_genesis_programs::get_native_programs_for_genesis(operating_mode);
     let inflation = solana_genesis_programs::get_inflation(operating_mode, 0).unwrap();
 
     let mut genesis_config = GenesisConfig {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3118,7 +3118,7 @@ pub mod tests {
 
         assert_eq!(bank_forks.working_bank().slot(), 0);
         assert_eq!(
-            bank_forks.working_bank().loader_program_ids(),
+            bank_forks.working_bank().builtin_loader_ids(),
             vec![
                 solana_sdk::bpf_loader::id(),
                 solana_sdk::bpf_loader_deprecated::id()
@@ -3145,7 +3145,7 @@ pub mod tests {
 
         // this is similar to snapshot deserialization
         bank1.reset_callback_and_message_processor();
-        assert_eq!(bank1.loader_program_ids(), vec![]);
+        assert_eq!(bank1.builtin_loader_ids(), vec![]);
 
         let bank1 = Arc::new(bank1);
         let (bank_forks, _leader_schedule) = process_blockstore_from_root(
@@ -3159,7 +3159,7 @@ pub mod tests {
         .unwrap();
         assert_eq!(bank_forks.working_bank().slot(), restored_slot);
         assert_eq!(
-            bank_forks.working_bank().loader_program_ids(),
+            bank_forks.working_bank().builtin_loader_ids(),
             vec![
                 solana_sdk::bpf_loader::id(),
                 solana_sdk::bpf_loader_deprecated::id()
@@ -3181,17 +3181,17 @@ pub mod tests {
         let (bank_forks, _leader_schedule) =
             process_blockstore(&genesis_config, &blockstore, vec![], opts).unwrap();
         let bank0 = bank_forks.working_bank();
-        assert_eq!(bank0.loader_program_ids(), vec![]);
+        assert_eq!(bank0.builtin_loader_ids(), vec![]);
 
         let restored_slot = genesis_config.epoch_schedule.get_first_slot_in_epoch(34);
         let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), restored_slot);
 
         assert_eq!(bank0.slot(), 0);
-        assert_eq!(bank0.loader_program_ids(), vec![]);
+        assert_eq!(bank0.builtin_loader_ids(), vec![]);
 
         assert_eq!(bank1.slot(), restored_slot);
         assert_eq!(
-            bank1.loader_program_ids(),
+            bank1.builtin_loader_ids(),
             vec![solana_sdk::bpf_loader_deprecated::id()]
         );
     }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3180,15 +3180,18 @@ pub mod tests {
         let opts = ProcessOptions::default();
         let (bank_forks, _leader_schedule) =
             process_blockstore(&genesis_config, &blockstore, vec![], opts).unwrap();
-        let bank = bank_forks.working_bank();
-        assert_eq!(bank.loader_program_ids(), vec![]);
+        let bank0 = bank_forks.working_bank();
+        assert_eq!(bank0.loader_program_ids(), vec![]);
 
         let restored_slot = genesis_config.epoch_schedule.get_first_slot_in_epoch(34);
-        let bank = Bank::new_from_parent(&bank, &Pubkey::default(), restored_slot);
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), restored_slot);
 
-        assert_eq!(bank.slot(), restored_slot);
+        assert_eq!(bank0.slot(), 0);
+        assert_eq!(bank0.loader_program_ids(), vec![]);
+
+        assert_eq!(bank1.slot(), restored_slot);
         assert_eq!(
-            bank.loader_program_ids(),
+            bank1.loader_program_ids(),
             vec![solana_sdk::bpf_loader_deprecated::id()]
         );
     }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2573,7 +2573,11 @@ pub mod tests {
         blockstore.set_roots(&[3, 5]).unwrap();
 
         // Set up bank1
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let mut bank0 = Bank::new(&genesis_config);
+        let callback =
+            solana_genesis_programs::get_entered_epoch_callback(genesis_config.operating_mode);
+        callback(&mut bank0);
+        let bank0 = Arc::new(bank0);
         let opts = ProcessOptions {
             poh_verify: true,
             ..ProcessOptions::default()

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -340,7 +340,7 @@ pub fn process_blockstore(
 pub fn process_blockstore_from_root(
     genesis_config: &GenesisConfig,
     blockstore: &Blockstore,
-    bank: Arc<Bank>,
+    mut bank: Arc<Bank>,
     opts: &ProcessOptions,
     recyclers: &VerifyRecyclers,
     transaction_status_sender: Option<TransactionStatusSender>,
@@ -355,9 +355,9 @@ pub fn process_blockstore_from_root(
     let now = Instant::now();
     let mut root = start_slot;
 
-    bank.set_entered_epoch_callback(solana_genesis_programs::get_entered_epoch_callback(
-        genesis_config.operating_mode,
-    ));
+    Arc::get_mut(&mut bank).unwrap().set_entered_epoch_callback(
+        solana_genesis_programs::get_entered_epoch_callback(genesis_config.operating_mode),
+    );
 
     if let Some(ref new_hard_forks) = opts.new_hard_forks {
         let hard_forks = bank.hard_forks();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2610,7 +2610,8 @@ pub mod tests {
         blockstore.set_roots(&[3, 5]).unwrap();
 
         // Set up bank1
-        let bank0 = Arc::new(Bank::new(&genesis_config));
+        let mut bank0 = Arc::new(Bank::new(&genesis_config));
+        initiate_callback(&mut bank0, &genesis_config);
         let opts = ProcessOptions {
             poh_verify: true,
             ..ProcessOptions::default()
@@ -2631,13 +2632,14 @@ pub mod tests {
         bank1.squash();
 
         // Test process_blockstore_from_root() from slot 1 onwards
-        let (bank_forks, _leader_schedule) = process_blockstore_from_root(
+        let (bank_forks, _leader_schedule) = do_process_blockstore_from_root(
             &genesis_config,
             &blockstore,
             bank1,
             &opts,
             &recyclers,
             None,
+            false,
         )
         .unwrap();
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -173,7 +173,6 @@ impl LocalCluster {
             OperatingMode::Stable | OperatingMode::Preview => {
                 genesis_config.native_instruction_processors =
                     solana_genesis_programs::get_native_programs(genesis_config.operating_mode, 0)
-                        .unwrap_or_default()
             }
             _ => (),
         }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -172,7 +172,9 @@ impl LocalCluster {
         match genesis_config.operating_mode {
             OperatingMode::Stable | OperatingMode::Preview => {
                 genesis_config.native_instruction_processors =
-                    solana_genesis_programs::get_native_programs(genesis_config.operating_mode, 0)
+                    solana_genesis_programs::get_native_programs_for_genesis(
+                        genesis_config.operating_mode,
+                    )
             }
             _ => (),
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -556,15 +556,14 @@ impl Bank {
         );
 
         let leader_schedule_epoch = epoch_schedule.get_leader_schedule_epoch(slot);
-        if parent.epoch() < new.epoch() {
-            new.refresh_programs_and_inflation();
-        }
-
         new.update_epoch_stakes(leader_schedule_epoch);
         new.ancestors.insert(new.slot(), 0);
         new.parents().iter().enumerate().for_each(|(i, p)| {
             new.ancestors.insert(p.slot(), i + 1);
         });
+        if parent.epoch() < new.epoch() {
+            new.refresh_programs_and_inflation();
+        }
 
         new.update_slot_hashes();
         new.update_rewards(parent.epoch());
@@ -574,6 +573,7 @@ impl Bank {
         if !new.fix_recent_blockhashes_sysvar_delay() {
             new.update_recent_blockhashes();
         }
+
         new
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -574,7 +574,6 @@ impl Bank {
         if !new.fix_recent_blockhashes_sysvar_delay() {
             new.update_recent_blockhashes();
         }
-        dbg!(&new.message_processor);
         new
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6380,14 +6380,17 @@ mod tests {
                 })
             });
 
+        // set_entered_eepoc_callbak fires the initial call
+        assert_eq!(callback_count.load(Ordering::SeqCst), 1);
+
         let _bank1 =
             Bank::new_from_parent(&bank0, &Pubkey::default(), bank0.get_slots_in_epoch(0) - 1);
         // No callback called while within epoch 0
-        assert_eq!(callback_count.load(Ordering::SeqCst), 0);
+        assert_eq!(callback_count.load(Ordering::SeqCst), 1);
 
         let _bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), bank0.get_slots_in_epoch(0));
         // Callback called as bank1 is in epoch 1
-        assert_eq!(callback_count.load(Ordering::SeqCst), 1);
+        assert_eq!(callback_count.load(Ordering::SeqCst), 2);
 
         callback_count.store(0, Ordering::SeqCst);
         let _bank1 = Bank::new_from_parent(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3191,7 +3191,7 @@ impl Bank {
         consumed_budget.saturating_sub(budget_recovery_delta)
     }
 
-    // This is called from snapshot restore and for each epoch boundary
+    // This is called from snapshot restore AND for each epoch boundary
     // The entire code path herein must be idempotent
     pub fn apply_feature_activations(&mut self) {
         if let Some(entered_epoch_callback) =
@@ -3226,8 +3226,13 @@ impl Bank {
     }
 
     // only used for testing
-    pub fn loader_program_ids(&self) -> Vec<Pubkey> {
-        self.message_processor.loader_program_ids()
+    pub fn builtin_loader_ids(&self) -> Vec<Pubkey> {
+        self.message_processor.builtin_loader_ids()
+    }
+
+    // only used for testing
+    pub fn builtin_program_ids(&self) -> Vec<Pubkey> {
+        self.message_processor.builtin_program_ids()
     }
 
     // only used for testing
@@ -6395,7 +6400,6 @@ mod tests {
             .unwrap()
             .initiate_entered_epoch_callback({
                 let callback_count = callback_count.clone();
-                //Box::new(move |_bank: &mut Bank| {
                 Box::new(move |_| {
                     callback_count.fetch_add(1, Ordering::SeqCst);
                 })

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -13,7 +13,7 @@ use crate::{
     builtins::get_builtins,
     epoch_stakes::{EpochStakes, NodeVoteAccounts},
     log_collector::LogCollector,
-    message_processor::MessageProcessor,
+    message_processor::{MessageProcessor, DEFAULT_COMPUTE_BUDGET, DEFAULT_MAX_INVOKE_DEPTH},
     nonce_utils,
     rent_collector::RentCollector,
     stakes::Stakes,
@@ -3209,6 +3209,8 @@ impl Bank {
         self.ensure_builtins(init_finish_or_warp);
         self.reinvoke_entered_epoch_callback(initiate_callback);
         self.recheck_cross_program_support();
+        self.set_max_invoke_depth(DEFAULT_MAX_INVOKE_DEPTH);
+        self.set_compute_budget(DEFAULT_COMPUTE_BUDGET);
     }
 
     fn ensure_builtins(&mut self, init_or_warp: bool) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2631,8 +2631,15 @@ impl Bank {
         self.hard_forks.clone()
     }
 
-    pub fn set_entered_epoch_callback(&mut self, entered_epoch_callback: EnteredEpochCallback) {
-        *self.entered_epoch_callback.write().unwrap() = Some(entered_epoch_callback);
+    pub fn initiate_entered_epoch_callback(
+        &mut self,
+        entered_epoch_callback: EnteredEpochCallback,
+    ) {
+        {
+            let mut callback_w = self.entered_epoch_callback.write().unwrap();
+            assert!(callback_w.is_none(), "Already callback has been initiated");
+            *callback_w = Some(entered_epoch_callback);
+        }
         self.apply_feature_activations();
     }
 
@@ -6372,7 +6379,7 @@ mod tests {
 
         Arc::get_mut(&mut bank0)
             .unwrap()
-            .set_entered_epoch_callback({
+            .initiate_entered_epoch_callback({
                 let callback_count = callback_count.clone();
                 //Box::new(move |_bank: &mut Bank| {
                 Box::new(move |_| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3186,6 +3186,16 @@ impl Bank {
         for program in get_builtins(self.operating_mode(), self.epoch()) {
             self.add_builtin(&program.name, program.id, program.entrypoint);
         }
+
+        self.recheck_cross_program_support();
+    }
+
+    fn recheck_cross_program_support(self: &mut Bank) {
+        if OperatingMode::Stable == self.operating_mode() {
+            self.set_cross_program_support(self.epoch() >= 63);
+        } else {
+            self.set_cross_program_support(true);
+        }
     }
 
     fn fix_recent_blockhashes_sysvar_delay(&self) -> bool {
@@ -8100,5 +8110,18 @@ mod tests {
             Err(TransactionError::ClusterMaintenance)
         );
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 496); // no transaction fee charged
+    }
+
+    #[test]
+    fn test_finish_init() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        let mut bank = Bank::new(&genesis_config);
+        bank.message_processor = MessageProcessor::default();
+        bank.message_processor.set_cross_program_support(false);
+
+        // simulate bank is just after deserialized from snapshot
+        bank.finish_init();
+
+        assert_eq!(bank.message_processor.get_cross_program_support(), true);
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -561,6 +561,8 @@ impl Bank {
         new.parents().iter().enumerate().for_each(|(i, p)| {
             new.ancestors.insert(p.slot(), i + 1);
         });
+
+        // Following code may touch AccountsDB, requiring proper ancestors
         if parent.epoch() < new.epoch() {
             new.apply_feature_activations();
         }

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -4,9 +4,11 @@ use crate::{
 };
 use solana_sdk::{clock::Epoch, genesis_config::OperatingMode, system_program};
 
-/// All builtin programs that should be active at the given (operating_mode, epoch)
-pub fn get_builtins() -> Vec<Builtin> {
-    vec![
+/// The entire set of available builtin programs that should be active at the given (operating_mode, epoch)
+pub fn get_builtins(_operating_mode: OperatingMode, _epoch: Epoch) -> Vec<Builtin> {
+    let mut builtins = vec![];
+
+    builtins.extend(vec![
         Builtin::new(
             "system_program",
             system_program::id(),
@@ -27,13 +29,10 @@ pub fn get_builtins() -> Vec<Builtin> {
             solana_vote_program::id(),
             Entrypoint::Program(solana_vote_program::vote_instruction::process_instruction),
         ),
-    ]
-}
+    ]);
 
-/// Builtin programs that activate at the given (operating_mode, epoch)
-pub fn get_epoch_activated_builtins(
-    _operating_mode: OperatingMode,
-    _epoch: Epoch,
-) -> Option<Vec<Builtin>> {
-    None
+    // if we ever add gated builtins, add here like this
+    // if _epoch >= 10 { builtins.extend(....) }
+
+    builtins
 }

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -4,8 +4,11 @@ use crate::{
 };
 use solana_sdk::{clock::Epoch, genesis_config::OperatingMode, system_program};
 
+use log::*;
+
 /// The entire set of available builtin programs that should be active at the given (operating_mode, epoch)
-pub fn get_builtins(_operating_mode: OperatingMode, _epoch: Epoch) -> Vec<Builtin> {
+pub fn get_builtins(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Builtin> {
+    trace!("get_builtins: {:?}, {:?}", operating_mode, epoch);
     let mut builtins = vec![];
 
     builtins.extend(vec![
@@ -31,8 +34,109 @@ pub fn get_builtins(_operating_mode: OperatingMode, _epoch: Epoch) -> Vec<Builti
         ),
     ]);
 
-    // if we ever add gated builtins, add here like this
-    // if _epoch >= 10 { builtins.extend(....) }
+    #[cfg(test)]
+    if operating_mode == OperatingMode::Development && epoch >= 2 {
+        use solana_sdk::instruction::InstructionError;
+        use solana_sdk::{account::KeyedAccount, pubkey::Pubkey};
+        use std::str::FromStr;
+        fn mock_ix_processor(
+            _pubkey: &Pubkey,
+            _ka: &[KeyedAccount],
+            _data: &[u8],
+        ) -> std::result::Result<(), InstructionError> {
+            Err(InstructionError::Custom(42))
+        }
+        let program_id = Pubkey::from_str("7saCc6X5a2syoYANA5oUUnPZLcLMfKoSjiDhFU5fbpoK").unwrap();
+        builtins.extend(vec![Builtin::new(
+            "mock",
+            program_id,
+            Entrypoint::Program(mock_ix_processor),
+        )]);
+    }
 
     builtins
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bank::Bank;
+    use solana_sdk::{genesis_config::create_genesis_config, pubkey::Pubkey};
+
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_get_builtins() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        let bank0 = Arc::new(Bank::new(&genesis_config));
+
+        let restored_slot1 = genesis_config.epoch_schedule.get_first_slot_in_epoch(2);
+        let bank1 = Arc::new(Bank::new_from_parent(
+            &bank0,
+            &Pubkey::default(),
+            restored_slot1,
+        ));
+
+        let restored_slot2 = genesis_config.epoch_schedule.get_first_slot_in_epoch(3);
+        let bank2 = Arc::new(Bank::new_from_parent(
+            &bank1,
+            &Pubkey::default(),
+            restored_slot2,
+        ));
+
+        let warped_slot = genesis_config.epoch_schedule.get_first_slot_in_epoch(999);
+        let warped_bank = Arc::new(Bank::new_from_parent(
+            &bank0,
+            &Pubkey::default(),
+            warped_slot,
+        ));
+
+        assert_eq!(bank0.slot(), 0);
+        assert_eq!(
+            bank0.builtin_program_ids(),
+            vec![
+                system_program::id(),
+                solana_config_program::id(),
+                solana_stake_program::id(),
+                solana_vote_program::id(),
+            ]
+        );
+
+        assert_eq!(bank1.slot(), restored_slot1);
+        assert_eq!(
+            bank1.builtin_program_ids(),
+            vec![
+                system_program::id(),
+                solana_config_program::id(),
+                solana_stake_program::id(),
+                solana_vote_program::id(),
+                Pubkey::from_str("7saCc6X5a2syoYANA5oUUnPZLcLMfKoSjiDhFU5fbpoK").unwrap(),
+            ]
+        );
+
+        assert_eq!(bank2.slot(), restored_slot2);
+        assert_eq!(
+            bank2.builtin_program_ids(),
+            vec![
+                system_program::id(),
+                solana_config_program::id(),
+                solana_stake_program::id(),
+                solana_vote_program::id(),
+                Pubkey::from_str("7saCc6X5a2syoYANA5oUUnPZLcLMfKoSjiDhFU5fbpoK").unwrap(),
+            ]
+        );
+
+        assert_eq!(warped_bank.slot(), warped_slot);
+        assert_eq!(
+            warped_bank.builtin_program_ids(),
+            vec![
+                system_program::id(),
+                solana_config_program::id(),
+                solana_stake_program::id(),
+                solana_vote_program::id(),
+                Pubkey::from_str("7saCc6X5a2syoYANA5oUUnPZLcLMfKoSjiDhFU5fbpoK").unwrap(),
+            ]
+        );
+    }
 }

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -34,8 +34,9 @@ pub fn get_builtins(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Builtin>
         ),
     ]);
 
+    // repurpose Preview for test_get_builtins because the Development is overloaded...
     #[cfg(test)]
-    if operating_mode == OperatingMode::Development && epoch >= 2 {
+    if operating_mode == OperatingMode::Preview && epoch >= 2 {
         use solana_sdk::instruction::InstructionError;
         use solana_sdk::{account::KeyedAccount, pubkey::Pubkey};
         use std::str::FromStr;
@@ -61,14 +62,18 @@ pub fn get_builtins(operating_mode: OperatingMode, epoch: Epoch) -> Vec<Builtin>
 mod tests {
     use super::*;
     use crate::bank::Bank;
-    use solana_sdk::{genesis_config::create_genesis_config, pubkey::Pubkey};
+    use solana_sdk::{
+        genesis_config::{create_genesis_config, OperatingMode},
+        pubkey::Pubkey,
+    };
 
     use std::str::FromStr;
     use std::sync::Arc;
 
     #[test]
     fn test_get_builtins() {
-        let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        genesis_config.operating_mode = OperatingMode::Preview;
         let bank0 = Arc::new(Bank::new(&genesis_config));
 
         let restored_slot1 = genesis_config.epoch_schedule.get_first_slot_in_epoch(2);

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -293,6 +293,55 @@ pub struct MessageProcessor {
     #[serde(skip)]
     compute_budget: u64,
 }
+
+impl std::fmt::Debug for MessageProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        #[derive(Debug)]
+        struct MessageProcessor<'a> {
+            programs: Vec<String>,
+            loaders: Vec<String>,
+            native_loader: &'a NativeLoader,
+            is_cross_program_supported: bool,
+        }
+        // rustc doesn't compile due to bug without this work around
+        // https://github.com/rust-lang/rust/issues/50280
+        // https://users.rust-lang.org/t/display-function-pointer/17073/2
+        let processor = MessageProcessor {
+            programs: self
+                .programs
+                .iter()
+                .map(|(pubkey, instruction)| {
+                    let erased_instruction: fn(
+                        &'static Pubkey,
+                        &'static [KeyedAccount<'static>],
+                        &'static [u8],
+                    )
+                        -> Result<(), InstructionError> = *instruction;
+                    format!("{}: {:p}", pubkey, erased_instruction)
+                })
+                .collect::<Vec<_>>(),
+            loaders: self
+                .loaders
+                .iter()
+                .map(|(pubkey, instruction)| {
+                    let erased_instruction: fn(
+                        &'static Pubkey,
+                        &'static [KeyedAccount<'static>],
+                        &'static [u8],
+                        &'static mut dyn InvokeContext,
+                    )
+                        -> Result<(), InstructionError> = *instruction;
+                    format!("{}: {:p}", pubkey, erased_instruction)
+                })
+                .collect::<Vec<_>>(),
+            native_loader: &self.native_loader,
+            is_cross_program_supported: self.is_cross_program_supported,
+        };
+
+        write!(f, "{:?}", processor)
+    }
+}
+
 impl Default for MessageProcessor {
     fn default() -> Self {
         Self {

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -311,12 +311,13 @@ impl std::fmt::Debug for MessageProcessor {
                 .programs
                 .iter()
                 .map(|(pubkey, instruction)| {
-                    let erased_instruction: fn(
+                    type ErasedProcessInstruction = fn(
                         &'static Pubkey,
                         &'static [KeyedAccount<'static>],
                         &'static [u8],
                     )
-                        -> Result<(), InstructionError> = *instruction;
+                        -> Result<(), InstructionError>;
+                    let erased_instruction: ErasedProcessInstruction = *instruction;
                     format!("{}: {:p}", pubkey, erased_instruction)
                 })
                 .collect::<Vec<_>>(),
@@ -324,13 +325,14 @@ impl std::fmt::Debug for MessageProcessor {
                 .loaders
                 .iter()
                 .map(|(pubkey, instruction)| {
-                    let erased_instruction: fn(
+                    type ErasedProcessInstructionWithContext = fn(
                         &'static Pubkey,
                         &'static [KeyedAccount<'static>],
                         &'static [u8],
                         &'static mut dyn InvokeContext,
                     )
-                        -> Result<(), InstructionError> = *instruction;
+                        -> Result<(), InstructionError>;
+                    let erased_instruction: ErasedProcessInstructionWithContext = *instruction;
                     format!("{}: {:p}", pubkey, erased_instruction)
                 })
                 .collect::<Vec<_>>(),

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -399,6 +399,7 @@ impl MessageProcessor {
         self.compute_budget = compute_budget;
     }
 
+    #[cfg(test)]
     pub fn get_cross_program_support(&mut self) -> bool {
         self.is_cross_program_supported
     }
@@ -693,8 +694,13 @@ impl MessageProcessor {
     }
 
     // only used for testing
-    pub fn loader_program_ids(&self) -> Vec<Pubkey> {
+    pub fn builtin_loader_ids(&self) -> Vec<Pubkey> {
         self.loaders.iter().map(|a| a.0).collect::<Vec<_>>()
+    }
+
+    // only used for testing
+    pub fn builtin_program_ids(&self) -> Vec<Pubkey> {
+        self.programs.iter().map(|a| a.0).collect::<Vec<_>>()
     }
 }
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -7,7 +7,8 @@ use solana_sdk::{
     account::{create_keyed_readonly_accounts, Account, KeyedAccount},
     clock::Epoch,
     entrypoint_native::{
-        ComputeMeter, InvokeContext, Logger, ProcessInstruction, ProcessInstructionWithContext,
+        ComputeMeter, ErasedProcessInstruction, ErasedProcessInstructionWithContext, InvokeContext,
+        Logger, ProcessInstruction, ProcessInstructionWithContext,
     },
     instruction::{CompiledInstruction, InstructionError},
     message::Message,
@@ -311,12 +312,6 @@ impl std::fmt::Debug for MessageProcessor {
                 .programs
                 .iter()
                 .map(|(pubkey, instruction)| {
-                    type ErasedProcessInstruction = fn(
-                        &'static Pubkey,
-                        &'static [KeyedAccount<'static>],
-                        &'static [u8],
-                    )
-                        -> Result<(), InstructionError>;
                     let erased_instruction: ErasedProcessInstruction = *instruction;
                     format!("{}: {:p}", pubkey, erased_instruction)
                 })
@@ -325,13 +320,6 @@ impl std::fmt::Debug for MessageProcessor {
                 .loaders
                 .iter()
                 .map(|(pubkey, instruction)| {
-                    type ErasedProcessInstructionWithContext = fn(
-                        &'static Pubkey,
-                        &'static [KeyedAccount<'static>],
-                        &'static [u8],
-                        &'static mut dyn InvokeContext,
-                    )
-                        -> Result<(), InstructionError>;
                     let erased_instruction: ErasedProcessInstructionWithContext = *instruction;
                     format!("{}: {:p}", pubkey, erased_instruction)
                 })

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -411,6 +411,10 @@ impl MessageProcessor {
         self.compute_budget = compute_budget;
     }
 
+    pub fn get_cross_program_support(&mut self) -> bool {
+        self.is_cross_program_supported
+    }
+
     /// Create the KeyedAccounts that will be passed to the program
     fn create_keyed_accounts<'a>(
         message: &'a Message,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -691,6 +691,11 @@ impl MessageProcessor {
         }
         Ok(())
     }
+
+    // only used for testing
+    pub fn loader_program_ids(&self) -> Vec<Pubkey> {
+        self.loaders.iter().map(|a| a.0).collect::<Vec<_>>()
+    }
 }
 
 #[cfg(test)]

--- a/sdk/src/abi_example.rs
+++ b/sdk/src/abi_example.rs
@@ -305,6 +305,13 @@ impl<T> AbiExample for Box<dyn Fn(&mut T) + Sync + Send> {
     }
 }
 
+impl<T, U> AbiExample for Box<dyn Fn(&mut T, U) + Sync + Send> {
+    fn example() -> Self {
+        info!("AbiExample for (Box<T, U>): {}", type_name::<Self>());
+        Box::new(move |_t: &mut T, _u: U| {})
+    }
+}
+
 impl<T: AbiExample> AbiExample for Box<[T]> {
     fn example() -> Self {
         info!("AbiExample for (Box<[T]>): {}", type_name::<Self>());

--- a/sdk/src/clock.rs
+++ b/sdk/src/clock.rs
@@ -57,6 +57,8 @@ pub type Slot = u64;
 ///  some number of Slots.
 pub type Epoch = u64;
 
+pub const GENESIS_EPOCH: Epoch = 0;
+
 /// SlotIndex is an index to the slots of a epoch
 pub type SlotIndex = u64;
 

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -175,6 +175,20 @@ pub type ProcessInstruction = fn(&Pubkey, &[KeyedAccount], &[u8]) -> Result<(), 
 pub type ProcessInstructionWithContext =
     fn(&Pubkey, &[KeyedAccount], &[u8], &mut dyn InvokeContext) -> Result<(), InstructionError>;
 
+// These are just type aliases for work around of Debug-ing above function pointers
+pub type ErasedProcessInstructionWithContext = fn(
+    &'static Pubkey,
+    &'static [KeyedAccount<'static>],
+    &'static [u8],
+    &'static mut dyn InvokeContext,
+) -> Result<(), InstructionError>;
+
+pub type ErasedProcessInstruction = fn(
+    &'static Pubkey,
+    &'static [KeyedAccount<'static>],
+    &'static [u8],
+) -> Result<(), InstructionError>;
+
 /// Invocation context passed to loaders
 pub trait InvokeContext {
     /// Push a program ID on to the invocation stack


### PR DESCRIPTION
#### Problem

`get_entered_epoch_callback` isn't called when restoring from snapshots, which is too confusing and error-prone.
Also, we can't simply call it immediately after snapshot restoration because it expects to be called **exactly once at each epoch boundary**

`get_programs` and `get_builtins` returns delta set. i.e. _add these new additions of programs to the current available set at the given epoch_. This works nicely in the ideal world, where we're running the validator since genesis without ever restarting a perfect bug-free validator.

In reality, we must rely on snapshots 99.999% of time. When restoring from snapshots, the delta set doesn't work quite: we don't persist _the current available set_ (namely `bank.message_processor` is effectively `serde(skip)`).

#### Summary of Changes

So, just reflect the reality by making these functions snapshot-friendly by returning whole-set of available programs at the given epoch. And make it callable  from `finish_init()`, which is called after snapshot restoration.

Also, fix a bunch of other dangerous code along the way.

Also, this is intended to be back-port friendly; so the fix is intentionally not exhaustive. Still, `get_entered_epoch_callback` is a bit error-prone. Specifically, it must be **idempotent**. (We could solve this by artificially introducing some intermediate `struct` like `ScheduledBankFeatures` or the like instead of mind-opening way of passing `&mut Bank`).

Deprecates #11736 