### PR TITLE
Add lockups via solana-tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4437,6 +4437,7 @@ dependencies = [
 name = "solana-tokens"
 version = "1.4.0"
 dependencies = [
+ "bincode",
  "chrono",
  "clap",
  "console",

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -32,6 +32,7 @@ tokio = "0.2"
 url = "2.1"
 
 [dev-dependencies]
+bincode = "1.3.1"
 solana-banks-server = { path = "../banks-server", version = "1.4.0" }
 solana-core = { path = "../core", version = "1.4.0" }
 solana-runtime = { path = "../runtime", version = "1.4.0" }

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -159,6 +159,14 @@ where
                         .help("Withdraw Authority Keypair"),
                 )
                 .arg(
+                    Arg::with_name("lockup_authority")
+                        .long("lockup-authority")
+                        .takes_value(true)
+                        .value_name("KEYPAIR")
+                        .validator(is_valid_signer)
+                        .help("Lockup Authority Keypair"),
+                )
+                .arg(
                     Arg::with_name("fee_payer")
                         .long("fee-payer")
                         .required(true)
@@ -310,11 +318,23 @@ fn parse_distribute_stake_args(
         &mut wallet_manager,
     )?;
 
+    let lockup_authority_str = value_t!(matches, "lockup_authority", String).ok();
+    let lockup_authority = match lockup_authority_str {
+        Some(path) => Some(signer_from_path(
+            &signer_matches,
+            &path,
+            "lockup authority",
+            &mut wallet_manager,
+        )?),
+        None => None,
+    };
+
     let stake_args = StakeArgs {
         stake_account_address,
         sol_for_fees: value_t_or_exit!(matches, "sol_for_fees", f64),
         stake_authority,
         withdraw_authority,
+        lockup_authority,
     };
     Ok(DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),

--- a/tokens/src/args.rs
+++ b/tokens/src/args.rs
@@ -16,6 +16,7 @@ pub struct StakeArgs {
     pub stake_account_address: Pubkey,
     pub stake_authority: Box<dyn Signer>,
     pub withdraw_authority: Box<dyn Signer>,
+    pub lockup_authority: Option<Box<dyn Signer>>,
 }
 
 pub struct BalancesArgs {

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -909,7 +909,7 @@ mod tests {
             assert_eq!(lockup_args.epoch, None); // Don't change the epoch
             assert_eq!(lockup_args.custodian, None); // Don't change the lockup authority
         } else {
-            assert!(false, "expected SetLockup instruction");
+            panic!("expected SetLockup instruction");
         }
     }
 }

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -13,6 +13,7 @@ pub struct TransactionInfo {
     pub finalized_date: Option<DateTime<Utc>>,
     pub transaction: Transaction,
     pub last_valid_slot: Slot,
+    pub lockup_date: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
@@ -37,6 +38,7 @@ impl Default for TransactionInfo {
             finalized_date: None,
             transaction,
             last_valid_slot: 0,
+            lockup_date: None,
         }
     }
 }
@@ -106,6 +108,7 @@ pub fn set_transaction_info(
     new_stake_account_address: Option<&Pubkey>,
     finalized: bool,
     last_valid_slot: Slot,
+    lockup_date: Option<DateTime<Utc>>,
 ) -> Result<(), Error> {
     let finalized_date = if finalized { Some(Utc::now()) } else { None };
     let transaction_info = TransactionInfo {
@@ -115,6 +118,7 @@ pub fn set_transaction_info(
         finalized_date,
         transaction: transaction.clone(),
         last_valid_slot,
+        lockup_date,
     };
     let signature = transaction.signatures[0];
     db.set(&signature.to_string(), &transaction_info)?;

--- a/tokens/src/main.rs
+++ b/tokens/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     match command_args.command {
         Command::DistributeTokens(args) => {
-            runtime.block_on(commands::process_distribute_tokens(
+            runtime.block_on(commands::process_allocations(
                 &mut banks_client,
                 &args,
             ))?;

--- a/tokens/src/main.rs
+++ b/tokens/src/main.rs
@@ -27,10 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     match command_args.command {
         Command::DistributeTokens(args) => {
-            runtime.block_on(commands::process_allocations(
-                &mut banks_client,
-                &args,
-            ))?;
+            runtime.block_on(commands::process_allocations(&mut banks_client, &args))?;
         }
         Command::Balances(args) => {
             runtime.block_on(commands::process_balances(&mut banks_client, &args))?;


### PR DESCRIPTION
#### Problem

Sometimes we want to distribute tokens to stake accounts where each recipient is under a different lockup dates (and sometimes to the same recipient but with different lockups). `solana-tokens distribute-stake` currently inherits the lockup date from the stake account it is split from. To workaround, we split the CSV files by lockup date, and that's getting old.

#### Summary of Changes

Set lockup dates in each allocation that specifies a lockup date.