### PR TITLE
RPC: Allow the sendTransaction preflight commitment level to be configured

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -567,6 +567,7 @@ impl CliConfig<'_> {
         config.commitment = CommitmentConfig::recent();
         config.send_transaction_config = RpcSendTransactionConfig {
             skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
         };
         config
     }
@@ -1183,6 +1184,7 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
                     &transaction,
                     RpcSendTransactionConfig {
                         skip_preflight: true,
+                        ..RpcSendTransactionConfig::default()
                     },
                 )
                 .ok();
@@ -1360,6 +1362,7 @@ fn process_deploy(
             config.commitment,
             RpcSendTransactionConfig {
                 skip_preflight: true,
+                ..RpcSendTransactionConfig::default()
             },
         )
         .map_err(|e| {

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -12,12 +12,14 @@ pub struct RpcSignatureStatusConfig {
 #[serde(rename_all = "camelCase")]
 pub struct RpcSendTransactionConfig {
     pub skip_preflight: bool,
+    pub preflight_commitment: Option<CommitmentConfig>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcSimulateTransactionConfig {
     pub sig_verify: bool,
+    pub commitment: Option<CommitmentConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2132,7 +2132,10 @@ impl RpcSol for RpcSolImpl {
                 .into());
             }
 
-            if let (Err(err), _log_output) = bank.simulate_transaction(transaction.clone()) {
+            let preflight_bank = &*meta.bank(config.preflight_commitment);
+            if let (Err(err), _log_output) =
+                preflight_bank.simulate_transaction(transaction.clone())
+            {
                 // Note: it's possible that the transaction simulation failed but the actual
                 // transaction would succeed, such as when a transaction depends on an earlier
                 // transaction that has yet to reach max confirmations. In these cases the user
@@ -2164,7 +2167,7 @@ impl RpcSol for RpcSolImpl {
             Ok(())
         };
 
-        let bank = &*meta.bank(None);
+        let bank = &*meta.bank(config.commitment);
         let logs = if result.is_ok() {
             let (transaction_result, log_messages) = bank.simulate_transaction(transaction);
             result = transaction_result;

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1353,6 +1353,7 @@ Before submitting, the following preflight checks are performed:
 - `<string>` - fully-signed Transaction, as base-58 encoded string
 - `<object>` - (optional) Configuration object containing the following field:
   - `skipPreflight: <bool>` - if true, skip the preflight transaction checks (default: false)
+  - `preflightCommitment: <object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to use for preflight (default: max).
 
 #### Results:
 
@@ -1377,6 +1378,7 @@ Simulate sending a transaction
 - `<string>` - Transaction, as base-58 encoded string. The transaction must have a valid blockhash, but is not required to be signed.
 - `<object>` - (optional) Configuration object containing the following field:
   - `sigVerify: <bool>` - if true the transaction signatures will be verified (default: false)
+  - `commitment: <object>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to simulate the transaction at (default: max).
 
 #### Results:
 

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -494,6 +494,7 @@ mod test {
                 ),
                 RpcSendTransactionConfig {
                     skip_preflight: true,
+                    ..RpcSendTransactionConfig::default()
                 },
             )
             .unwrap();
@@ -549,6 +550,7 @@ mod test {
                 ),
                 RpcSendTransactionConfig {
                     skip_preflight: true,
+                    ..RpcSendTransactionConfig::default()
                 },
             )
             .unwrap();
@@ -594,6 +596,7 @@ mod test {
                 ),
                 RpcSendTransactionConfig {
                     skip_preflight: true,
+                    ..RpcSendTransactionConfig::default()
                 },
             )
             .unwrap();
@@ -632,6 +635,7 @@ mod test {
                 ),
                 RpcSendTransactionConfig {
                     skip_preflight: true,
+                    ..RpcSendTransactionConfig::default()
                 },
             )
             .unwrap();


### PR DESCRIPTION
The commitment level used by the the `sendTransaction` and `simulateTransaction` RPC methods is currently hard coded to `max`.  However there have now been multiple times when a different commitment level would have been useful to the user, so allow them to override `max` with their preferred commitment.