### PR TITLE
`solana-gossip spy` can now be given an identity keypair (`--identity` argument)

### DIFF
--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -149,6 +149,7 @@ fn main() {
 
     info!("Finding cluster entry: {:?}", entrypoint_addr);
     let (nodes, _validators) = discover(
+        None,
         Some(&entrypoint_addr),
         None,
         Some(60),


### PR DESCRIPTION
Sometimes you want to run a gossip spy with a specific keypair