### PR TITLE
fix: use bpf-loader-deprecated explicitly

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -938,17 +938,20 @@ declare module '@solana/web3.js' {
   }
 
   // === src/bpf-loader.js ===
+  export const BPF_LOADER_PROGRAM_ID: PublicKey;
   export class BpfLoader {
-    static programId(version?: number): PublicKey;
     static getMinNumSignatures(dataLength: number): number;
     static load(
       connection: Connection,
       payer: Account,
       program: Account,
       elfBytes: Buffer | Uint8Array | Array<number>,
-      version?: number,
+      loaderProgramId: PublicKey,
     ): Promise<PublicKey>;
   }
+
+  // === src/bpf-loader-deprecated.js ===
+  export const BPF_LOADER_DEPRECATED_PROGRAM_ID: PublicKey;
 
   // === src/util/send-and-confirm-transaction.js ===
   export function sendAndConfirmTransaction(

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -708,7 +708,7 @@ declare module '@solana/web3.js' {
     stakePubkey: PublicKey,
     authorityBase: PublicKey,
     authoritySeed: string,
-    authorityOwner: PublicKey;
+    authorityOwner: PublicKey,
     newAuthorizedPubkey: PublicKey,
     stakeAuthorizationType: StakeAuthorizationType,
   |};
@@ -953,17 +953,20 @@ declare module '@solana/web3.js' {
   }
 
   // === src/bpf-loader.js ===
+  declare export var BPF_LOADER_PROGRAM_ID;
   declare export class BpfLoader {
-    static programId(version: ?number): PublicKey;
     static getMinNumSignatures(dataLength: number): number;
     static load(
       connection: Connection,
       payer: Account,
       program: Account,
       elfBytes: Buffer | Uint8Array | Array<number>,
-      version: ?number,
+      loaderProgramId: PublicKey,
     ): Promise<PublicKey>;
   }
+
+  // === src/bpf-loader-deprecated.js ===
+  declare export var BPF_LOADER_DEPRECATED_PROGRAM_ID;
 
   // === src/util/send-and-confirm-transaction.js ===
   declare export function sendAndConfirmTransaction(

--- a/web3.js/src/bpf-loader-deprecated.js
+++ b/web3.js/src/bpf-loader-deprecated.js
@@ -1,0 +1,7 @@
+// @flow
+
+import {PublicKey} from './publickey';
+
+export const BPF_LOADER_DEPRECATED_PROGRAM_ID = new PublicKey(
+  'BPFLoader1111111111111111111111111111111111',
+);

--- a/web3.js/src/bpf-loader.js
+++ b/web3.js/src/bpf-loader.js
@@ -5,21 +5,14 @@ import {PublicKey} from './publickey';
 import {Loader} from './loader';
 import type {Connection} from './connection';
 
+export const BPF_LOADER_PROGRAM_ID = new PublicKey(
+  'BPFLoader2111111111111111111111111111111111',
+);
+
 /**
  * Factory class for transactions to interact with a program loader
  */
 export class BpfLoader {
-  /**
-   * Public key that identifies the BpfLoader
-   */
-  static programId(version: number = 2): PublicKey {
-    if (version === 1) {
-      return new PublicKey('BPFLoader1111111111111111111111111111111111');
-    } else {
-      return new PublicKey('BPFLoader2111111111111111111111111111111111');
-    }
-  }
-
   /**
    * Minimum number of signatures required to load a program not including
    * retries
@@ -37,21 +30,15 @@ export class BpfLoader {
    * @param payer Account that will pay program loading fees
    * @param program Account to load the program into
    * @param elf The entire ELF containing the BPF program
-   * @param version The version of the BPF loader to use
+   * @param loaderProgramId The program id of the BPF loader to use
    */
   static load(
     connection: Connection,
     payer: Account,
     program: Account,
     elf: Buffer | Uint8Array | Array<number>,
-    version: number = 2,
+    loaderProgramId: PublicKey,
   ): Promise<void> {
-    return Loader.load(
-      connection,
-      payer,
-      program,
-      BpfLoader.programId(version),
-      elf,
-    );
+    return Loader.load(connection, payer, program, loaderProgramId, elf);
   }
 }

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1752,11 +1752,7 @@ export class Connection {
     publicKey: PublicKey,
     commitment: ?Commitment,
   ): Promise<RpcResponseAndContext<AccountInfo<Buffer> | null>> {
-    const args = this._buildArgs(
-      [publicKey.toBase58()],
-      commitment,
-      'base64',
-    );
+    const args = this._buildArgs([publicKey.toBase58()], commitment, 'base64');
     const unsafeRes = await this._rpcRequest('getAccountInfo', args);
     const res = GetAccountInfoAndContextRpcResult(unsafeRes);
     if (res.error) {
@@ -1866,11 +1862,7 @@ export class Connection {
     programId: PublicKey,
     commitment: ?Commitment,
   ): Promise<Array<{pubkey: PublicKey, account: AccountInfo<Buffer>}>> {
-    const args = this._buildArgs(
-      [programId.toBase58()],
-      commitment,
-      'base64',
-    );
+    const args = this._buildArgs([programId.toBase58()], commitment, 'base64');
     const unsafeRes = await this._rpcRequest('getProgramAccounts', args);
     const res = GetProgramAccountsRpcResult(unsafeRes);
     if (res.error) {

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -13,6 +13,7 @@ import {
 import {mockRpcEnabled} from './__mocks__/node-fetch';
 import {url} from './url';
 import {newAccountWithLamports} from './new-account-with-lamports';
+import {BPF_LOADER_PROGRAM_ID} from '../src/bpf-loader';
 
 if (!mockRpcEnabled) {
   // The default of 5 seconds is too slow for live testing sometimes
@@ -40,7 +41,7 @@ test('load BPF C program', async () => {
   const from = await newAccountWithLamports(connection, fees + balanceNeeded);
 
   const program = new Account();
-  await BpfLoader.load(connection, from, program, data);
+  await BpfLoader.load(connection, from, program, data, BPF_LOADER_PROGRAM_ID);
   const transaction = new Transaction().add({
     keys: [{pubkey: from.publicKey, isSigner: true, isWritable: true}],
     programId: program.publicKey,
@@ -82,7 +83,13 @@ describe('load BPF Rust program', () => {
     );
 
     program = new Account();
-    await BpfLoader.load(connection, payerAccount, program, data);
+    await BpfLoader.load(
+      connection,
+      payerAccount,
+      program,
+      data,
+      BPF_LOADER_PROGRAM_ID,
+    );
     const transaction = new Transaction().add({
       keys: [
         {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},


### PR DESCRIPTION
#### Problem

BPF loader program ids don't really line up to version numbers

#### Summary of Changes

Make it clearer which loader is being used by specifying them explicitly 

Fixes #
