### PR TITLE
chore: fix failing getBlockTime integration test

### DIFF
--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1238,7 +1238,7 @@ test('get block time', async () => {
     url,
     {
       method: 'getBlockTime',
-      params: [1],
+      params: [2],
     },
     {
       error: null,
@@ -1246,7 +1246,7 @@ test('get block time', async () => {
     },
   ]);
 
-  const blockTime = await connection.getBlockTime(1);
+  const blockTime = await connection.getBlockTime(2);
   if (blockTime === null) {
     expect(blockTime).not.toBeNull();
   } else {


### PR DESCRIPTION
#### Problem
Seems that https://github.com/solana-labs/solana/pull/10630 caused a regression where the first block is no longer timestamped. This causes the getBlockTime integration test to fail because it asserts that the first block has a timestamp

#### Summary of Changes
- Check block 2 instead of 1

Fixes #
