### PR TITLE
explorer: Auto-update transactions until they reach max confirmation

### DIFF
--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -106,17 +106,15 @@ function StatusCard({ signature }: Props) {
       !autoRefresh.isAutoRefresh &&
       status?.data?.info?.confirmations !== "max"
     ) {
-      let timeout = setTimeout(() => {
-        refresh(signature, true);
-        setAutoRefresh({
-          isAutoRefresh: false,
-          timeout: false,
-        });
-      }, AUTO_REFRESH_TIMEOUT);
-
       setAutoRefresh({
         isAutoRefresh: true,
-        timeout: timeout,
+        timeout: setTimeout(() => {
+          refresh(signature, true);
+          setAutoRefresh({
+            isAutoRefresh: false,
+            timeout: false,
+          });
+        }, AUTO_REFRESH_TIMEOUT),
       });
     }
   }, [autoRefresh, status, refresh, signature]);

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -85,6 +85,16 @@ function StatusCard({ signature }: Props) {
     }
   }, [signature, clusterStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  React.useEffect(() => {
+    if (!isAutoRefresh && status?.data?.info?.confirmations !== "max") {
+      setIsAutoRefresh(true);
+      setTimeout(() => {
+        refresh(signature, true);
+        setIsAutoRefresh(false);
+      }, AUTO_REFRESH_TIMEOUT);
+    }
+  }, [isAutoRefresh, status, refresh, signature]);
+
   if (
     !status ||
     (status.status === FetchStatus.Fetching && !status.isAutoRefresh)
@@ -108,14 +118,6 @@ function StatusCard({ signature }: Props) {
   }
 
   const { info } = status.data;
-
-  if (!isAutoRefresh && info.confirmations !== "max") {
-    setIsAutoRefresh(true);
-    setTimeout(() => {
-      refresh(signature, true);
-      setIsAutoRefresh(false);
-    }, AUTO_REFRESH_TIMEOUT);
-  }
 
   const renderResult = () => {
     let statusClass = "success";

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -290,11 +290,11 @@ function AccountsCard({
 
   if (autoRefresh === AutoRefresh.BailedOut || !status?.data?.info) {
     return null;
-  } else if (
-    !details ||
-    details.status === FetchStatus.Fetching ||
-    autoRefresh === AutoRefresh.Active
-  ) {
+  } else if (autoRefresh === AutoRefresh.Active) {
+    return (
+      <ErrorCard text="Details are not available until the transaction reaches MAX confirmations" />
+    );
+  } else if (!details || details.status === FetchStatus.Fetching) {
     return <LoadingCard />;
   } else if (details.status === FetchStatus.FetchFailed) {
     return <ErrorCard retry={refreshDetails} text="Fetch Failed" />;

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -161,7 +161,9 @@ function StatusCard({ signature, autoRefreshInProcess }: Props) {
     <div className="card">
       <div className="card-header align-items-center">
         <h3 className="card-header-title">Overview</h3>
-        {!autoRefreshInProcess ? (
+        {autoRefreshInProcess ? (
+          <span className="spinner-grow spinner-grow-sm"></span>
+        ) : (
           <button
             className="btn btn-white btn-sm"
             onClick={() => fetchStatus(signature)}
@@ -169,8 +171,6 @@ function StatusCard({ signature, autoRefreshInProcess }: Props) {
             <span className="fe fe-refresh-cw mr-2"></span>
             Refresh
           </button>
-        ) : (
-          <span className="spinner-grow spinner-grow-sm"></span>
         )}
       </div>
 

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -100,9 +100,10 @@ function StatusCard({ signature }: Props) {
   // Effect to set and clear interval for auto-refresh
   React.useEffect(() => {
     if (autoRefreshInProcess) {
-      let intervalHandle: NodeJS.Timeout = setInterval(() => {
-        fetchStatus(signature);
-      }, AUTO_REFRESH_TIMEOUT);
+      let intervalHandle: NodeJS.Timeout = setInterval(
+        () => fetchStatus(signature),
+        AUTO_REFRESH_TIMEOUT
+      );
 
       return () => {
         clearInterval(intervalHandle);

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -288,8 +288,15 @@ function AccountsCard({
     }
   }, [signature, details, status, fetchDetails]);
 
-  if (autoRefresh === AutoRefresh.BailedOut || !status?.data?.info) {
+  if (!status?.data?.info) {
     return null;
+  } else if (autoRefresh === AutoRefresh.BailedOut) {
+    return (
+      <ErrorCard
+        text="Details are not available until the transaction reaches MAX confirmations"
+        retry={refreshDetails}
+      />
+    );
   } else if (autoRefresh === AutoRefresh.Active) {
     return (
       <ErrorCard text="Details are not available until the transaction reaches MAX confirmations" />

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -39,8 +39,8 @@ type SignatureProps = {
 enum AutoRefresh {
   Active,
   Inactive,
-  BailedOut
-};
+  BailedOut,
+}
 
 type AutoRefreshProps = {
   autoRefresh: AutoRefresh;
@@ -57,15 +57,18 @@ export function TransactionDetailsPage({ signature: raw }: SignatureProps) {
   } catch (err) {}
 
   const status = useTransactionStatus(signature);
-  const [zeroConfirmationRetries, setZeroConfirmationRetries] = React.useState(0);
+  const [zeroConfirmationRetries, setZeroConfirmationRetries] = React.useState(
+    0
+  );
 
   React.useEffect(() => {
     if (
       status &&
       status.status === FetchStatus.Fetched &&
-      status.data?.info && status.data.info.confirmations === 0
+      status.data?.info &&
+      status.data.info.confirmations === 0
     ) {
-      setZeroConfirmationRetries(retries => retries + 1);
+      setZeroConfirmationRetries((retries) => retries + 1);
     }
   }, [status]);
 
@@ -73,10 +76,7 @@ export function TransactionDetailsPage({ signature: raw }: SignatureProps) {
 
   if (zeroConfirmationRetries >= ZERO_CONFIRMATION_BAILOUT) {
     autoRefresh = AutoRefresh.BailedOut;
-  } else if (
-    status?.data?.info &&
-    status.data.info.confirmations !== "max"
-  ) {
+  } else if (status?.data?.info && status.data.info.confirmations !== "max") {
     autoRefresh = AutoRefresh.Active;
   }
 
@@ -92,14 +92,8 @@ export function TransactionDetailsPage({ signature: raw }: SignatureProps) {
         <ErrorCard text={`Signature "${raw}" is not valid`} />
       ) : (
         <>
-          <StatusCard
-            signature={signature}
-            autoRefresh={autoRefresh}
-          />
-          <AccountsCard
-            signature={signature}
-            autoRefresh={autoRefresh}
-          />
+          <StatusCard signature={signature} autoRefresh={autoRefresh} />
+          <AccountsCard signature={signature} autoRefresh={autoRefresh} />
           <InstructionsSection signature={signature} />
         </>
       )}
@@ -139,7 +133,8 @@ function StatusCard({
 
   if (
     !status ||
-    (status.status === FetchStatus.Fetching && autoRefresh === AutoRefresh.Inactive)
+    (status.status === FetchStatus.Fetching &&
+      autoRefresh === AutoRefresh.Inactive)
   ) {
     return <LoadingCard />;
   } else if (status.status === FetchStatus.FetchFailed) {

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -47,8 +47,9 @@ export function TransactionDetailsPage({ signature: raw }: Props) {
 
   const status = useTransactionStatus(signature);
 
-  const autoRefreshInProcess = !(
-    status?.data?.info && status.data.info.confirmations === "max"
+  const autoRefreshInProcess = !!(
+    status?.data?.info &&
+    status.data.info.confirmations !== "max"
   );
 
   return (

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -30,7 +30,7 @@ import { TokenDetailsCard } from "components/instruction/token/TokenDetailsCard"
 import { FetchStatus } from "providers/cache";
 
 const AUTO_REFRESH_TIMEOUT = 2000;
-const ZERO_CONFIRMATION_BAILOUT = 20;
+const ZERO_CONFIRMATION_BAILOUT = 5;
 
 type SignatureProps = {
   signature: TransactionSignature;

--- a/explorer/src/providers/cache.tsx
+++ b/explorer/src/providers/cache.tsx
@@ -9,6 +9,7 @@ export enum FetchStatus {
 export type CacheEntry<T> = {
   status: FetchStatus;
   data?: T;
+  isAutoRefresh?: boolean;
 };
 
 export type State<T> = {
@@ -29,6 +30,7 @@ export type Update<T> = {
   key: string;
   status: FetchStatus;
   data?: T;
+  isAutoRefresh?: boolean;
 };
 
 export type Clear = {
@@ -100,6 +102,7 @@ export function reducer<T, U>(
           ...entry,
           status: action.status,
           data: reconciler(entry?.data, action.data),
+          isAutoRefresh: action.isAutoRefresh,
         },
       };
       return { ...state, entries };

--- a/explorer/src/providers/cache.tsx
+++ b/explorer/src/providers/cache.tsx
@@ -9,7 +9,6 @@ export enum FetchStatus {
 export type CacheEntry<T> = {
   status: FetchStatus;
   data?: T;
-  isAutoRefresh?: boolean;
 };
 
 export type State<T> = {
@@ -30,7 +29,6 @@ export type Update<T> = {
   key: string;
   status: FetchStatus;
   data?: T;
-  isAutoRefresh?: boolean;
 };
 
 export type Clear = {
@@ -102,7 +100,6 @@ export function reducer<T, U>(
           ...entry,
           status: action.status,
           data: reconciler(entry?.data, action.data),
-          isAutoRefresh: action.isAutoRefresh,
         },
       };
       return { ...state, entries };

--- a/explorer/src/providers/cache.tsx
+++ b/explorer/src/providers/cache.tsx
@@ -9,6 +9,7 @@ export enum FetchStatus {
 export type CacheEntry<T> = {
   status: FetchStatus;
   data?: T;
+  attempts: number;
 };
 
 export type State<T> = {
@@ -94,12 +95,21 @@ export function reducer<T, U>(
     case ActionType.Update: {
       const key = action.key;
       const entry = state.entries[key];
+
+      if (entry && entry.attempts === undefined) {
+        entry.attempts = 0;
+      }
+
+      if (action.status === FetchStatus.Fetched) {
+        entry.attempts++;
+      }
+
       const entries = {
         ...state.entries,
         [key]: {
           ...entry,
           status: action.status,
-          data: reconciler(entry?.data, action.data),
+          data: reconciler(entry?.data, action.data)
         },
       };
       return { ...state, entries };

--- a/explorer/src/providers/cache.tsx
+++ b/explorer/src/providers/cache.tsx
@@ -109,7 +109,7 @@ export function reducer<T, U>(
         [key]: {
           ...entry,
           status: action.status,
-          data: reconciler(entry?.data, action.data)
+          data: reconciler(entry?.data, action.data),
         },
       };
       return { ...state, entries };

--- a/explorer/src/providers/cache.tsx
+++ b/explorer/src/providers/cache.tsx
@@ -9,7 +9,6 @@ export enum FetchStatus {
 export type CacheEntry<T> = {
   status: FetchStatus;
   data?: T;
-  attempts: number;
 };
 
 export type State<T> = {
@@ -95,15 +94,6 @@ export function reducer<T, U>(
     case ActionType.Update: {
       const key = action.key;
       const entry = state.entries[key];
-
-      if (entry && entry.attempts === undefined) {
-        entry.attempts = 0;
-      }
-
-      if (action.status === FetchStatus.Fetched) {
-        entry.attempts++;
-      }
-
       const entries = {
         ...state.entries,
         [key]: {

--- a/explorer/src/providers/transactions/index.tsx
+++ b/explorer/src/providers/transactions/index.tsx
@@ -131,7 +131,7 @@ export function useTransactions() {
 }
 
 export function useTransactionStatus(
-  signature: TransactionSignature
+  signature: TransactionSignature | undefined
 ): Cache.CacheEntry<TransactionStatus> | undefined {
   const context = React.useContext(StateContext);
 
@@ -139,6 +139,10 @@ export function useTransactionStatus(
     throw new Error(
       `useTransactionStatus must be used within a TransactionsProvider`
     );
+  }
+
+  if (signature === undefined) {
+    return undefined;
   }
 
   return context.entries[signature];

--- a/explorer/src/providers/transactions/index.tsx
+++ b/explorer/src/providers/transactions/index.tsx
@@ -56,15 +56,13 @@ export function TransactionsProvider({ children }: TransactionsProviderProps) {
 export async function fetchTransactionStatus(
   dispatch: Dispatch,
   signature: TransactionSignature,
-  url: string,
-  isAutoRefresh: boolean
+  url: string
 ) {
   dispatch({
     type: ActionType.Update,
     key: signature,
     status: FetchStatus.Fetching,
     url,
-    isAutoRefresh,
   });
 
   let fetchStatus;
@@ -119,7 +117,6 @@ export async function fetchTransactionStatus(
     status: fetchStatus,
     data,
     url,
-    isAutoRefresh,
   });
 }
 
@@ -156,7 +153,7 @@ export function useFetchTransactionStatus() {
   }
 
   const { url } = useCluster();
-  return (signature: TransactionSignature, isAutoRefresh = false) => {
-    fetchTransactionStatus(dispatch, signature, url, isAutoRefresh);
+  return (signature: TransactionSignature) => {
+    fetchTransactionStatus(dispatch, signature, url);
   };
 }

--- a/explorer/src/providers/transactions/index.tsx
+++ b/explorer/src/providers/transactions/index.tsx
@@ -56,13 +56,15 @@ export function TransactionsProvider({ children }: TransactionsProviderProps) {
 export async function fetchTransactionStatus(
   dispatch: Dispatch,
   signature: TransactionSignature,
-  url: string
+  url: string,
+  isAutoRefresh: boolean
 ) {
   dispatch({
     type: ActionType.Update,
     key: signature,
     status: FetchStatus.Fetching,
     url,
+    isAutoRefresh,
   });
 
   let fetchStatus;
@@ -117,6 +119,7 @@ export async function fetchTransactionStatus(
     status: fetchStatus,
     data,
     url,
+    isAutoRefresh,
   });
 }
 
@@ -153,7 +156,7 @@ export function useFetchTransactionStatus() {
   }
 
   const { url } = useCluster();
-  return (signature: TransactionSignature) => {
-    fetchTransactionStatus(dispatch, signature, url);
+  return (signature: TransactionSignature, isAutoRefresh = false) => {
+    fetchTransactionStatus(dispatch, signature, url, isAutoRefresh);
   };
 }


### PR DESCRIPTION
#### Problem
When a transaction that hasn't reached max confirmations is entered, the user needs to mash the refresh button on the right until it reaches max confirmation.

#### Summary of Changes

Status card auto-refreshes every 2 seconds until the confirmation max is reached. Account card will display loading card while auto-refresh is in process. A loading indicator is placed in the top right. Once full confirmation is complete, the refresh button becomes available. Autorefresh will bailout if confirmations stuck at 0 due to transaction landing in a fork. 

Fixes https://github.com/solana-labs/solana/issues/11760
