### PR TITLE
Make ledger-tool accounts print rent_epoch and slot

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2690,6 +2690,10 @@ impl Bank {
             .load_by_program(&self.ancestors, program_id)
     }
 
+    pub fn get_all_accounts_with_modified_slots(&self) -> Vec<(Pubkey, Account, Slot)> {
+        self.rc.accounts.load_all(&self.ancestors)
+    }
+
     pub fn get_program_accounts_modified_since_parent(
         &self,
         program_id: &Pubkey,


### PR DESCRIPTION
#### Problem

there is no way to print account's modified slots and rent_epochs.

#### Summary of Changes

a bit similar and stripped-down version of #9490

I've specifically took extra attention not to deteriorate the other codepath's performance. So, this should be safe to add.

#### Context

now manual bash magic is possible; a somewhat degrateded solution of #10090

origin: https://discord.com/channels/428295358100013066/738253477331075162/747960202527244299

```
    As for above re: oldest / newest account slots, why is interval (1.6 million) greater than an epoch (432,000)?

@KP  Well, I've looked into that. In short, this is intended behavior. Strictly speaking, the 432000 cap is applied to the number of slots with live account, not the number of live appendvec (mmap). There is small discrepancy between the two. That is caused to properly handle deleted (0-lamport) accounts in append only fashion. Even if there are those tombstones, it's possible some stale appendvec to survive (we're doing pseudo gc here for appendvec liveness check). In general, you can just ignore it..
[
8:26 AM
]
ryoqun
:

﻿
$ tar tvf target/tds10/snapshot-32782294-2epfky3sf9nccrg3Weh1TxzB9NU5yQQkb4ziCXW6PeNk.tar.bz2 | grep accounts/. | awk '{print $6}' | grep -o '/...' | sort | uniq -c 
     33 /310
     75 /311
     53 /312
     53 /313
     53 /314
     87 /315
    213 /316
    302 /317
    281 /318
    277 /319
    319 /320
    340 /321
    333 /322
  19079 /323
  38682 /324
  48014 /325
  48097 /326
  39443 /327
$ ./target/release/solana-ledger-tool accounts --include-sysvars --ledger target/tds10/ --halt-at-slot 32782825 >| accounts.yml
$ less accounts.yml | grep slot: | sort | sed -n '2p;$p'
  - slot: 32350833
  - slot: 32782825
$ echo $((32782825 - 32350833))
431992
```