### PR TITLE
fix: update rpc-websockets to fix pubsub race

### DIFF
--- a/web3.js/package-lock.json
+++ b/web3.js/package-lock.json
@@ -15257,6 +15257,11 @@
       "integrity": "sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=",
       "dev": true
     },
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -20722,15 +20727,16 @@
       }
     },
     "rpc-websockets": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.0.0.tgz",
-      "integrity": "sha512-N/U9OfuCTdG3K/Fi3/6H/yThKa4JOPKqxslj0dbXYxjEeb5/NDLDZAf+tEk4sZTUuNZHuLHhv16EZtOfDaZsuQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.1.0.tgz",
+      "integrity": "sha512-baq7hZ3VoQT70mDx5jLow5Os/7gxe4xa4ei2djscYX70UJaVzvMtTm7YLVf129k/wxodflAGMHo9/JwjfNxKbw==",
       "requires": {
         "@babel/runtime": "^7.8.7",
         "assert-args": "^1.2.1",
         "babel-runtime": "^6.26.0",
         "circular-json": "^0.5.9",
         "eventemitter3": "^3.1.2",
+        "next-tick": "^1.1.0",
         "uuid": "^3.4.0",
         "ws": "^5.2.2"
       },

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -83,7 +83,7 @@
     "mz": "^2.7.0",
     "node-fetch": "^2.2.0",
     "npm-run-all": "^4.1.5",
-    "rpc-websockets": "^7.0.0",
+    "rpc-websockets": "^7.1.0",
     "superstruct": "^0.8.3",
     "tweetnacl": "^1.0.0",
     "ws": "^7.0.0"


### PR DESCRIPTION
#### Problem
`rpc-websockets` dependency resolves subscription responses async but emits subscription notifications synchronously causing a race condition where notifications for a subscription id are received before the SDK knows about that id.

#### Summary of Changes
- Update to version of `rpc-websockets` with the fix

Fixes https://github.com/solana-labs/solana/issues/11806
