### PR TITLE
Fix web3 blockhash race

### DIFF
--- a/web3.js/src/stake-program.js
+++ b/web3.js/src/stake-program.js
@@ -289,7 +289,12 @@ export class StakeInstruction {
   ): AuthorizeWithSeedStakeParams {
     this.checkProgramId(instruction.programId);
     this.checkKeyLength(instruction.keys, 2);
-    const {newAuthorized, stakeAuthorizationType, authoritySeed, authorityOwner} = decodeData(
+    const {
+      newAuthorized,
+      stakeAuthorizationType,
+      authoritySeed,
+      authorityOwner,
+    } = decodeData(
       STAKE_INSTRUCTION_LAYOUTS.AuthorizeWithSeed,
       instruction.data,
     );

--- a/web3.js/test/stake-program.test.js
+++ b/web3.js/test/stake-program.test.js
@@ -146,7 +146,9 @@ test('authorizeWithSeed', () => {
   const transaction = StakeProgram.authorizeWithSeed(params);
   expect(transaction.instructions).toHaveLength(1);
   const [stakeInstruction] = transaction.instructions;
-  expect(params).toEqual(StakeInstruction.decodeAuthorizeWithSeed(stakeInstruction));
+  expect(params).toEqual(
+    StakeInstruction.decodeAuthorizeWithSeed(stakeInstruction),
+  );
 });
 
 test('split', () => {


### PR DESCRIPTION
#### Problem
Web3 polls for new blockhashes when sending transactions. When many transactions are sent at the same time, there is no lock preventing multiple poll from happening concurrently

#### Summary of Changes
Check if polling before checking recent blockhash

Fixes #
