### PR TITLE
Add ability to fork a local cluster from the latest mainnet-beta snapshot

### DIFF
--- a/multinode-demo/setup-from-mainnet-beta.sh
+++ b/multinode-demo/setup-from-mainnet-beta.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+here=$(dirname "$0")
+# shellcheck source=multinode-demo/common.sh
+source "$here"/common.sh
+
+
+rm -rf "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot
+mkdir -p "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot
+(
+  cd "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot || exit 1
+  set -x
+  wget http://api.mainnet-beta.solana.com/genesis.tar.bz2
+  wget --trust-server-names http://api.mainnet-beta.solana.com/snapshot.tar.bz2
+)
+
+snapshot=$(ls "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot/snapshot-[0-9]*-*.tar.bz2)
+if [[ -z $snapshot ]]; then
+  echo Error: Unable to find latest snapshot
+  exit 1
+fi
+
+if [[ ! $snapshot =~ snapshot-([0-9]*)-.*.tar.bz2 ]]; then
+  echo Error: Unable to determine snapshot slot for "$snapshot"
+  exit 1
+fi
+
+snapshot_slot="${BASH_REMATCH[1]}"
+
+rm -rf "$SOLANA_CONFIG_DIR"/bootstrap-validator
+mkdir -p "$SOLANA_CONFIG_DIR"/bootstrap-validator
+
+
+# Create genesis ledger
+if [[ -r $FAUCET_KEYPAIR ]]; then
+  cp -f "$FAUCET_KEYPAIR" "$SOLANA_CONFIG_DIR"/faucet.json
+else
+  $solana_keygen new --no-passphrase -fso "$SOLANA_CONFIG_DIR"/faucet.json
+fi
+
+if [[ -f $BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR ]]; then
+  cp -f "$BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR" "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity.json
+else
+  $solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity.json
+fi
+
+$solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-account.json
+$solana_keygen new --no-passphrase -so "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-account.json
+
+
+cp "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot/genesis.tar.bz2 \
+  "$SOLANA_CONFIG_DIR"/bootstrap-validator
+
+$solana_ledger_tool modify-genesis \
+  --ledger "$SOLANA_CONFIG_DIR"/bootstrap-validator \
+  --hashes-per-tick sleep \
+  #--operating-mode preview \
+
+$solana_ledger_tool create-snapshot \
+  --hashes-per-tick sleep \
+  --ledger "$SOLANA_CONFIG_DIR"/latest-mainnet-beta-snapshot \
+  --faucet-pubkey "$SOLANA_CONFIG_DIR"/faucet.json \
+  --faucet-lamports 500000000000000000 \
+  --bootstrap-validator "$SOLANA_CONFIG_DIR"/bootstrap-validator/identity.json \
+                        "$SOLANA_CONFIG_DIR"/bootstrap-validator/vote-account.json \
+                        "$SOLANA_CONFIG_DIR"/bootstrap-validator/stake-account.json \
+  "$snapshot_slot" "$SOLANA_CONFIG_DIR"/bootstrap-validator

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -679,16 +679,6 @@ impl Bank {
         );
         assert_eq!(bank.epoch_schedule, genesis_config.epoch_schedule);
         assert_eq!(bank.epoch, bank.epoch_schedule.get_epoch(bank.slot));
-        assert_eq!(
-            bank.rent_collector,
-            RentCollector::new(
-                bank.epoch,
-                &bank.epoch_schedule,
-                bank.slots_per_year,
-                &genesis_config.rent,
-                genesis_config.operating_mode,
-            )
-        );
 
         bank
     }
@@ -1247,6 +1237,14 @@ impl Bank {
 
     pub fn set_compute_budget(&mut self, budget: ComputeBudget) {
         self.message_processor.set_compute_budget(budget);
+    }
+
+    pub fn set_rent_burn_percentage(&mut self, burn_percent: u8) {
+        self.rent_collector.rent.burn_percent = burn_percent;
+    }
+
+    pub fn set_hashes_per_tick(&mut self, hashes_per_tick: Option<u64>) {
+        self.hashes_per_tick = hashes_per_tick;
     }
 
     /// Return the last block hash registered.


### PR DESCRIPTION
Replace `./multinode-demo/setup.sh` with `./multinode-demo/setup-from-mainnet-beta.sh` in your dev workflow to boot from the tip of mainnet-beta replacing the mainnet-beta validators with your validator.  `multinode-demo/faucet.sh` works as expected too.

TODO:
* [x] Correct leader schedule
* [x] Add ability to override hashes-per-tick in mainnet-beta genesis.  Not using `sleep` is extremely painful in a debug build because PoH ticks much too slowly