### PR TITLE
fix: export bpf loader program id consts

### DIFF
--- a/web3.js/src/index.js
+++ b/web3.js/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 export {Account} from './account';
-export {BpfLoader} from './bpf-loader';
+export {BPF_LOADER_DEPRECATED_PROGRAM_ID} from './bpf-loader-deprecated';
+export {BpfLoader, BPF_LOADER_PROGRAM_ID} from './bpf-loader';
 export {Connection} from './connection';
 export {Loader} from './loader';
 export {Message} from './message';


### PR DESCRIPTION
#### Problem
`BPF_LOADER_PROGRAM_ID` and `BPF_LOADER_DEPRECATED_PROGRAM_ID` are exported in type defs but not exported in `index.js` which means they will be undefined for any clients that try to use them

#### Summary of Changes
- Export consts

Fixes #
