### PR TITLE
Bump compute budget

### DIFF
--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -7,7 +7,7 @@ use solana_rbpf::EbpfVm;
 use solana_sdk::{
     account::Account,
     bpf_loader,
-    entrypoint_native::{ComputeMeter, InvokeContext, Logger, ProcessInstruction},
+    entrypoint_native::{ComputeBudget, ComputeMeter, InvokeContext, Logger, ProcessInstruction},
     instruction::{CompiledInstruction, InstructionError},
     message::Message,
     pubkey::Pubkey,
@@ -165,6 +165,9 @@ impl InvokeContext for MockInvokeContext {
     }
     fn is_cross_program_supported(&self) -> bool {
         true
+    }
+    fn get_compute_budget(&self) -> ComputeBudget {
+        ComputeBudget::default()
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         Rc::new(RefCell::new(self.mock_compute_meter.clone()))

--- a/programs/bpf_loader/src/bpf_verifier.rs
+++ b/programs/bpf_loader/src/bpf_verifier.rs
@@ -3,7 +3,7 @@ use solana_rbpf::ebpf;
 use thiserror::Error;
 
 /// Error definitions
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum VerifierError {
     /// ProgramLengthNotMultiple
     #[error("program length must be a multiple of {} octets", ebpf::INSN_SIZE)]

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -210,8 +210,41 @@ pub trait InvokeContext {
     fn get_logger(&self) -> Rc<RefCell<dyn Logger>>;
     /// Are cross program invocations supported
     fn is_cross_program_supported(&self) -> bool;
+    /// Get this invocation's compute budget
+    fn get_compute_budget(&self) -> ComputeBudget;
     /// Get this invocation's compute meter
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>>;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ComputeBudget {
+    /// Number of compute units that an instruction is allowed.  Compute units
+    /// are consumed by program execution, resources they use, etc...
+    pub max_units: u64,
+    /// Number of compute units consumed by a log call
+    pub log_units: u64,
+    /// Number of compute units consumed by a log_u64 call
+    pub log_64_units: u64,
+    /// Number of compute units consumed by a create_program_address call
+    pub create_program_address_units: u64,
+    /// Number of compute units consumed by an invoke call (not including the cost incured by
+    /// the called program)
+    pub invoke_units: u64,
+    /// Maximum cross-program invocation depth allowed including the orignal caller
+    pub max_invoke_depth: usize,
+}
+impl Default for ComputeBudget {
+    fn default() -> Self {
+        // Tuned for ~1ms
+        ComputeBudget {
+            max_units: 200_000,
+            log_units: 100,
+            log_64_units: 100,
+            create_program_address_units: 1500,
+            invoke_units: 1000,
+            max_invoke_depth: 2,
+        }
+    }
 }
 
 /// Compute meter


### PR DESCRIPTION
#### Problem

The maximum number of compute units a program can consume is 100k (1 to 1 with BPF instructions) which is ~.4 ms but folks are asking for more room.

#### Summary of Changes

- Bump max units up to 200k
- Tune the syscall costs
- Cleanup how the compute budget is communicated
- Improve epoch gating to include all the budget items
- Add tests

Fixes #
