### PR TITLE
Update nofile flag in Docker to run Solana

### DIFF
--- a/sdk/docker-solana/README.md
+++ b/sdk/docker-solana/README.md
@@ -6,12 +6,12 @@ https://hub.docker.com/r/solanalabs/solana/
 ### Usage:
 Run the latest beta image:
 ```bash
-$ docker run --rm -p 8899:8899 solanalabs/solana:beta
+$ docker run --rm -p 8899:8899 --ulimit nofile=500000 solanalabs/solana:beta
 ```
 
 Run the latest edge image:
 ```bash
-$ docker run --rm -p 8899:8899 solanalabs/solana:edge
+$ docker run --rm -p 8899:8899 --ulimit nofile=500000 solanalabs/solana:edge
 ```
 
 Port *8899* is the JSON RPC port, which is used by clients to communicate with the network.

--- a/web3.js/bin/localnet.sh
+++ b/web3.js/bin/localnet.sh
@@ -88,6 +88,7 @@ up)
       --publish 8900:8900
       --publish 9900:9900
       --tty
+      --ulimit nofile=500000
       --env "RUST_LOG=$RUST_LOG"
     )
     if [[ -n $network ]]; then

--- a/web3.js/bin/localnet.sh
+++ b/web3.js/bin/localnet.sh
@@ -88,7 +88,7 @@ up)
       --publish 8900:8900
       --publish 9900:9900
       --tty
-      --ulimit nofile=500000
+      --ulimit "nofile=500000"
       --env "RUST_LOG=$RUST_LOG"
     )
     if [[ -n $network ]]; then


### PR DESCRIPTION
#### Problem

Currently, the Solana Docker container does not start because it requires `nofile` to be at least 500000, and the default behavior is 1024.

#### Summary of Changes

This fixes the documentation and running script to properly set the ulimit to 500000.

Fixes #
