### PR TITLE
chore: improve docs for Connection.confirmTransaction method

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1949,7 +1949,10 @@ export class Connection {
   }
 
   /**
-   * Confirm the transaction identified by the specified signature
+   * Confirm the transaction identified by the specified signature.
+   *
+   * If `confirmations` count is not specified, wait for transaction to be finalized.
+   *
    */
   async confirmTransaction(
     signature: TransactionSignature,
@@ -1962,7 +1965,7 @@ export class Connection {
     for (;;) {
       const status = statusResponse.value;
       if (status) {
-        // Received a status, if not an error wait for confirmation
+        // 'status.confirmations === null' implies that the tx has been finalized
         if (
           status.err ||
           status.confirmations === null ||


### PR DESCRIPTION
#### Summary of Changes
I've improved the documentation for the Connection.confirmTransaction method in web3.

#### Background

I've noticed that the sendAndConfirmTransaction function mentions in its docs that it waits for the tx to be finalized if no confirmations arg is given. It does so via the Connection.confirmTransaction method in web3. The docs for that method, however, do not mention that it waits for the tx to be finalized if no confirmations arg is given.

#### Fix

I've copied the method docs from sendAndConfirmTransaction to Connection.confirmTransaction. I've also removed a comment that, imo, was unnecessary since the code is very clear regarding the comment. I've added a comment explaining how finality is understood by the method, a fact that would've otherwise been implicit and for the developer to guess.