### PR TITLE
Take v0.19.3 of perf libs which improves sigverify perf 2x and CL PoH verify

### DIFF
--- a/fetch-perf-libs.sh
+++ b/fetch-perf-libs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PERF_LIBS_VERSION=v0.19.1
+PERF_LIBS_VERSION=v0.19.3
 VERSION=$PERF_LIBS_VERSION-1
 
 set -e


### PR DESCRIPTION
#### Problem

v0.19.3 of perf libs not picked up which adds 2x sigverify GPU perf and also PoH verify for OpenCL

#### Summary of Changes

Take v0.19.3 solana perf libs.

Fixes #
