### PR TITLE
Use updated sha2 in runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.3",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +546,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,7 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.8.1",
  "rand_core 0.5.1",
  "subtle 2.2.2",
  "zeroize",
@@ -705,6 +720,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -799,7 +823,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.8.2",
  "zeroize",
 ]
 
@@ -1289,7 +1313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -2140,6 +2164,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -3093,10 +3123,10 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -3111,10 +3141,23 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3834,7 +3877,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.8.2",
  "solana-budget-program",
  "solana-genesis-programs",
  "solana-logger 1.4.0",
@@ -4141,6 +4184,7 @@ dependencies = [
  "byteorder",
  "bzip2",
  "crossbeam-channel",
+ "digest 0.9.0",
  "dir-diff",
  "flate2",
  "fnv",
@@ -4160,6 +4204,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
+ "sha2 0.9.1",
  "solana-config-program",
  "solana-logger 1.4.0",
  "solana-measure",
@@ -4216,7 +4261,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.8.2",
  "solana-crate-features 1.3.4",
  "solana-logger 1.3.4",
  "solana-sdk-macro 1.3.4",
@@ -4253,7 +4298,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.8.2",
  "solana-crate-features 1.4.0",
  "solana-logger 1.4.0",
  "solana-sdk-macro 1.4.0",
@@ -5013,7 +5058,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.7.3",
  "rustc-hash",
- "sha2",
+ "sha2 0.8.2",
  "unicode-normalization",
 ]
 

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -108,6 +108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.3",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,7 +339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder 1.3.4",
- "digest",
+ "digest 0.8.1",
  "rand_core",
  "subtle 2.2.2",
  "zeroize",
@@ -337,6 +352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.3",
 ]
 
 [[package]]
@@ -374,7 +398,7 @@ dependencies = [
  "ed25519",
  "rand",
  "serde",
- "sha2",
+ "sha2 0.8.2",
  "zeroize",
 ]
 
@@ -687,7 +711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.8.1",
 ]
 
 [[package]]
@@ -1095,6 +1119,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parking_lot"
@@ -1577,10 +1607,23 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1850,6 +1893,7 @@ dependencies = [
  "byteorder 1.3.4",
  "bzip2",
  "crossbeam-channel",
+ "digest 0.9.0",
  "dir-diff",
  "flate2",
  "fnv",
@@ -1869,6 +1913,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
+ "sha2 0.9.1",
  "solana-config-program",
  "solana-logger",
  "solana-measure",
@@ -1914,7 +1959,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.8.2",
  "solana-crate-features",
  "solana-logger",
  "solana-sdk-macro",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -43,6 +43,8 @@ solana-stake-program = { path = "../programs/stake", version = "1.4.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.4.0" }
 symlink = "0.1.0"
 tar = "0.4.28"
+sha2 = "0.9.1"
+digest = "0.9.0"
 tempfile = "3.1.0"
 thiserror = "1.0"
 zstd = "0.5.1"

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -23,11 +23,13 @@ use crate::{
     append_vec::{AppendVec, StoredAccount, StoredMeta},
 };
 use byteorder::{ByteOrder, LittleEndian};
+use digest::Digest;
 use lazy_static::lazy_static;
 use log::*;
 use rand::{thread_rng, Rng};
 use rayon::{prelude::*, ThreadPool};
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 use solana_measure::measure::Measure;
 use solana_rayon_threadlimit::get_thread_count;
 use solana_sdk::{
@@ -36,6 +38,7 @@ use solana_sdk::{
     hash::{Hash, Hasher},
     pubkey::Pubkey,
 };
+use std::convert::TryFrom;
 use std::{
     collections::{HashMap, HashSet},
     io::{Error as IOError, Result as IOResult},
@@ -1325,30 +1328,30 @@ impl AccountsDB {
             return Hash::default();
         }
 
-        let mut hasher = Hasher::default();
+        let mut hasher = Sha256::new();
         let mut buf = [0u8; 8];
 
         LittleEndian::write_u64(&mut buf[..], lamports);
-        hasher.hash(&buf);
+        hasher.update(&buf);
 
         LittleEndian::write_u64(&mut buf[..], slot);
-        hasher.hash(&buf);
+        hasher.update(&buf);
 
         LittleEndian::write_u64(&mut buf[..], rent_epoch);
-        hasher.hash(&buf);
+        hasher.update(&buf);
 
-        hasher.hash(&data);
+        hasher.update(&data);
 
         if executable {
-            hasher.hash(&[1u8; 1]);
+            hasher.update(&[1u8; 1]);
         } else {
-            hasher.hash(&[0u8; 1]);
+            hasher.update(&[0u8; 1]);
         }
 
-        hasher.hash(&owner.as_ref());
-        hasher.hash(&pubkey.as_ref());
+        hasher.update(&owner.as_ref());
+        hasher.update(&pubkey.as_ref());
 
-        hasher.result()
+        Hash(<[u8; solana_sdk::hash::HASH_BYTES]>::try_from(hasher.finalize().as_slice()).unwrap())
     }
 
     fn bulk_assign_write_version(&self, count: usize) -> u64 {

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -10,7 +10,7 @@ pub const HASH_BYTES: usize = 32;
     Serialize, Deserialize, Clone, Copy, Default, Eq, PartialEq, Ord, PartialOrd, Hash, AbiExample,
 )]
 #[repr(transparent)]
-pub struct Hash([u8; HASH_BYTES]);
+pub struct Hash(pub [u8; HASH_BYTES]);
 
 #[derive(Clone, Default)]
 pub struct Hasher {


### PR DESCRIPTION
#### Problem

Hashing account data is a bottleneck with larger accounts.

#### Summary of Changes

Use update sha2 crate for the runtime.

Fixes #
