### PR TITLE
genesis-programs: Simplify get_programs(), specify a real Preview activation epoch for new BPFLoader

### DIFF
--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -72,60 +72,40 @@ impl std::fmt::Debug for Program {
 
 // given operating_mode and epoch, return the entire set of enabled programs
 fn get_programs(operating_mode: OperatingMode) -> Vec<(Program, Epoch)> {
-    let mut programs = vec![];
-
     match operating_mode {
-        OperatingMode::Development => {
+        OperatingMode::Development => vec![
             // Programs used for testing
-            programs.extend(
-                vec![
-                    Program::BuiltinLoader(solana_bpf_loader_program!()),
-                    Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
-                    Program::Native(solana_vest_program!()),
-                    Program::Native(solana_budget_program!()),
-                    Program::Native(solana_exchange_program!()),
-                ]
-                .into_iter()
-                .map(|program| (program, 0))
-                .collect::<Vec<_>>(),
-            );
-        }
-        OperatingMode::Preview => {
-            programs.extend(
-                vec![
-                    Program::BuiltinLoader(solana_bpf_loader_program!()),
-                    Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
-                ]
-                .into_iter()
-                .map(|program| (program, 0))
-                .collect::<Vec<_>>(),
-            );
-            // The epoch of Epoch::max_value() is a placeholder and is expected
-            // to be reduced in a future network update.
-            programs.extend(
-                vec![]
-                    .into_iter()
-                    .map(|program| (program, Epoch::MAX))
-                    .collect::<Vec<_>>(),
-            );
-        }
-        OperatingMode::Stable => {
-            programs.extend(vec![(
+            Program::BuiltinLoader(solana_bpf_loader_program!()),
+            Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
+            Program::Native(solana_vest_program!()),
+            Program::Native(solana_budget_program!()),
+            Program::Native(solana_exchange_program!()),
+        ]
+        .into_iter()
+        .map(|program| (program, 0))
+        .collect::<Vec<_>>(),
+
+        OperatingMode::Preview => vec![
+            (
+                Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
+                0,
+            ),
+            (Program::BuiltinLoader(solana_bpf_loader_program!()), 89),
+        ],
+
+        OperatingMode::Stable => vec![
+            (
                 Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
                 34,
-            )]);
-            // The epoch of std::u64::MAX is a placeholder and is expected
-            // to be reduced in a future network update.
-            programs.extend(
-                vec![Program::BuiltinLoader(solana_bpf_loader_program!())]
-                    .into_iter()
-                    .map(|program| (program, Epoch::MAX))
-                    .collect::<Vec<_>>(),
-            );
-        }
-    };
-
-    programs
+            ),
+            (
+                Program::BuiltinLoader(solana_bpf_loader_program!()),
+                // The epoch of std::u64::MAX is a placeholder and is expected
+                // to be reduced in a future cluster update.
+                Epoch::MAX,
+            ),
+        ],
+    }
 }
 
 pub fn get_native_programs_for_genesis(operating_mode: OperatingMode) -> Vec<(String, Pubkey)> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2648,7 +2648,7 @@ impl Bank {
             assert!(callback_w.is_none(), "Already callback has been initiated");
             *callback_w = Some(entered_epoch_callback);
         }
-        // immedaitely fire the callback as initial invocation
+        // immediately fire the callback as initial invocation
         self.reinvoke_entered_epoch_callback(true);
     }
 


### PR DESCRIPTION
* Only need a single `vec![]` declaration for each operation mode.  The use of `.extend()` seemed overly verbose
* The new bpfloader needs to be activated at an actual epoch >= 0 for Preview to avoid an assertion when loading the snapshot that'll be used to restart testnet