### PR TITLE
Cli: Fix use-deprecated-loader arg

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2248,8 +2248,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .help("The signer for the desired address of the program [default: new random address]")
                 )
                 .arg(
-                    Arg::with_name("use-deprecated-loader")
-                        .long("use_deprecated_loader")
+                    Arg::with_name("use_deprecated_loader")
+                        .long("use-deprecated-loader")
                         .takes_value(false)
                         .hidden(true) // Don't document this argument to discourage its use
                         .help("Use the deprecated BPF loader")


### PR DESCRIPTION
#### Problem
Cli arg parsing checks for an arg that doesn't exist here https://github.com/solana-labs/solana/blob/f8bb93a0f48bd805beba3ad1d47e8255cfdd8e08/cli/src/cli.rs#L681 probably because snake- and kebab-case were switched in the arg constructor.

The result is that `solana deploy .. --use-deprecated-loader` always resolves to BPFloader2, which may be problematic if you are, say, trying to deploy to a cluster like mainnet-beta that does not support BPFloader2...

#### Summary of Changes
Fix use-deprecated-loader arg to (a) work; and (b) be case-consistent with other cli args
