### PR TITLE
Add tests for the Debug and activation Vecs

### DIFF
--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -70,7 +70,7 @@ impl std::fmt::Debug for Program {
     }
 }
 
-// given operating_mode and epoch, return the entire set of enabled programs
+// given operating_mode, return the entire set of enabled programs
 fn get_programs(operating_mode: OperatingMode) -> Vec<(Program, Epoch)> {
     match operating_mode {
         OperatingMode::Development => vec![
@@ -82,13 +82,13 @@ fn get_programs(operating_mode: OperatingMode) -> Vec<(Program, Epoch)> {
             Program::Native(solana_exchange_program!()),
         ]
         .into_iter()
-        .map(|program| (program, 0))
+        .map(|program| (program, GENESIS_EPOCH))
         .collect::<Vec<_>>(),
 
         OperatingMode::Preview => vec![
             (
                 Program::BuiltinLoader(solana_bpf_loader_deprecated_program!()),
-                0,
+                GENESIS_EPOCH,
             ),
             (Program::BuiltinLoader(solana_bpf_loader_program!()), 89),
         ],
@@ -163,16 +163,31 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
+    fn do_test_uniqueness(programs: Vec<(Program, Epoch)>) {
+        let mut unique_ids = HashSet::new();
+        let mut unique_names = HashSet::new();
+        let mut prev_start_epoch = GENESIS_EPOCH;
+        for (program, next_start_epoch) in programs {
+            assert!(next_start_epoch >= prev_start_epoch);
+            match program {
+                Program::Native((name, id)) => {
+                    assert!(unique_ids.insert(id));
+                    assert!(unique_names.insert(name));
+                }
+                Program::BuiltinLoader((name, id, _)) => {
+                    assert!(unique_ids.insert(id));
+                    assert!(unique_names.insert(name));
+                }
+            }
+            prev_start_epoch = next_start_epoch;
+        }
+    }
+
     #[test]
     fn test_id_uniqueness() {
-        let mut unique = HashSet::new();
-        let programs = get_programs(OperatingMode::Development);
-        for (program, _start_epoch) in programs {
-            match program {
-                Program::Native((name, id)) => assert!(unique.insert((name, id))),
-                Program::BuiltinLoader((name, id, _)) => assert!(unique.insert((name, id))),
-            }
-        }
+        do_test_uniqueness(get_programs(OperatingMode::Development));
+        do_test_uniqueness(get_programs(OperatingMode::Preview));
+        do_test_uniqueness(get_programs(OperatingMode::Stable));
     }
 
     #[test]
@@ -213,5 +228,10 @@ mod tests {
     #[test]
     fn test_softlaunch_programs() {
         assert!(!get_programs(OperatingMode::Stable).is_empty());
+    }
+
+    #[test]
+    fn test_debug() {
+        assert!(!format!("{:?}", get_programs(OperatingMode::Development)).is_empty());
     }
 }

--- a/genesis-programs/src/lib.rs
+++ b/genesis-programs/src/lib.rs
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn test_id_uniqueness() {
+    fn test_uniqueness() {
         do_test_uniqueness(get_programs(OperatingMode::Development));
         do_test_uniqueness(get_programs(OperatingMode::Preview));
         do_test_uniqueness(get_programs(OperatingMode::Stable));

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8242,7 +8242,7 @@ mod tests {
             _ka: &[KeyedAccount],
             _data: &[u8],
         ) -> std::result::Result<(), InstructionError> {
-            Err(InstructionError::Custom(42))
+            Ok(())
         }
 
         let slot = 123;
@@ -8281,7 +8281,7 @@ mod tests {
             _data: &[u8],
             _context: &mut dyn solana_sdk::entrypoint_native::InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
-            Err(InstructionError::Custom(42))
+            Ok(())
         }
 
         let slot = 123;

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -75,8 +75,28 @@ mod tests {
         pubkey::Pubkey,
     };
 
+    use std::collections::HashSet;
     use std::str::FromStr;
     use std::sync::Arc;
+
+    fn do_test_uniqueness(builtins: Vec<(Builtin, Epoch)>) {
+        let mut unique_ids = HashSet::new();
+        let mut unique_names = HashSet::new();
+        let mut prev_start_epoch = 0;
+        for (builtin, next_start_epoch) in builtins {
+            assert!(next_start_epoch >= prev_start_epoch);
+            assert!(unique_ids.insert(builtin.name));
+            assert!(unique_names.insert(builtin.id));
+            prev_start_epoch = next_start_epoch;
+        }
+    }
+
+    #[test]
+    fn test_uniqueness() {
+        do_test_uniqueness(get_builtins(OperatingMode::Development));
+        do_test_uniqueness(get_builtins(OperatingMode::Preview));
+        do_test_uniqueness(get_builtins(OperatingMode::Stable));
+    }
 
     #[test]
     fn test_get_builtins() {

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -300,6 +300,7 @@ impl std::fmt::Debug for MessageProcessor {
             loaders: Vec<String>,
             native_loader: &'a NativeLoader,
             is_cross_program_supported: bool,
+            compute_budget: ComputeBudget,
         }
         // rustc doesn't compile due to bug without this work around
         // https://github.com/rust-lang/rust/issues/50280
@@ -323,6 +324,7 @@ impl std::fmt::Debug for MessageProcessor {
                 .collect::<Vec<_>>(),
             native_loader: &self.native_loader,
             is_cross_program_supported: self.is_cross_program_supported,
+            compute_budget: self.compute_budget,
         };
 
         write!(f, "{:?}", processor)
@@ -1553,5 +1555,30 @@ mod tests {
                 case.1
             );
         }
+    }
+
+    #[test]
+    fn test_debug() {
+        let mut message_processor = MessageProcessor::default();
+        fn mock_process_instruction(
+            _program_id: &Pubkey,
+            _keyed_accounts: &[KeyedAccount],
+            _data: &[u8],
+        ) -> Result<(), InstructionError> {
+            Ok(())
+        }
+        fn mock_ix_processor(
+            _pubkey: &Pubkey,
+            _ka: &[KeyedAccount],
+            _data: &[u8],
+            _context: &mut dyn solana_sdk::entrypoint_native::InvokeContext,
+        ) -> std::result::Result<(), InstructionError> {
+            Ok(())
+        }
+        let program_id = Pubkey::new_rand();
+        message_processor.add_program(program_id, mock_process_instruction);
+        message_processor.add_loader(program_id, mock_ix_processor);
+
+        assert!(!format!("{:?}", message_processor).is_empty());
     }
 }


### PR DESCRIPTION
#### Problem

- We could be in bad scheduling when specifying epochs to activate native programs
- `Debug` for `Programs` and `MessageProcessor` isn't tested. (The `Debug` impls aren't derived; it's manually written due to rustc bug/limitation around function pointer).

#### Summary of Changes

- Extend sanity checks for the scheduling data of programs by epoch. Let's make scheduling less error-prone.
- Add very simple tests for `Debug`.

#### Context

follow up of #11736 