### PR TITLE
Forbid bogus account assignment to native_loaders

### DIFF
--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -89,6 +89,13 @@ impl PreAccount {
             return Err(InstructionError::ModifiedProgramId);
         }
 
+        if self.owner != post.owner
+            && (solana_sdk::native_loader::check_id(&post.owner)
+                || solana_sdk::sysvar::check_id(&post.owner))
+        {
+            return Err(InstructionError::ModifiedProgramId);
+        }
+
         // An account not assigned to the program cannot have its balance decrease.
         if *program_id != self.owner // line coverage used to get branch coverage
          && self.lamports > post.lamports


### PR DESCRIPTION
#### Problem

Transactions can assign account to `NativeLoader1111` for no good reason.

#### Summary of Changes

Forbid doing so just like sysvars.

Obviously, this creates dos attack window when upgrading.

Note that, I'm intentionally omitting to gate this change. Considering recent our practices, this should be acceptable? (CC: @mvines )

Alternatively, if this is concerning too much, we can resort to adding `account.executable` to this existing condition: https://github.com/solana-labs/solana/blob/5b1aca1a9108a1a22a1cfec487770ce276872c14/runtime/src/bank.rs#L1201

and to-be-pushed new capitalization calculation at #11927.

#### context

following up: #11750 

~blocking: #11927~ (This is not a blocker anymore; as this requires proper gating, I've unblocked #11927).
