### PR TITLE
Disable explorer block time fetching errors

### DIFF
--- a/explorer/src/providers/transactions/index.tsx
+++ b/explorer/src/providers/transactions/index.tsx
@@ -85,9 +85,11 @@ export async function fetchTransactionStatus(
         try {
           blockTime = await connection.getBlockTime(value.slot);
         } catch (error) {
-          Sentry.captureException(error, {
-            tags: { slot: `${value.slot}`, url },
-          });
+          if (cluster === Cluster.MainnetBeta) {
+            Sentry.captureException(error, {
+              tags: { slot: `${value.slot}` },
+            });
+          }
         }
         let timestamp: Timestamp =
           blockTime !== null ? blockTime : "unavailable";


### PR DESCRIPTION
#### Problem
Non mainnet-beta clusters don't have full block time histories and so errors are expected

#### Summary of Changes
Filter out non-mainnet getBlockTime errors
