### PR TITLE
Add sysvar to look at tx instructions

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1823,6 +1823,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-instruction-introspection"
+version = "1.4.0"
+dependencies = [
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-bpf-rust-invoke"
 version = "1.4.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "rust/dup_accounts",
     "rust/error_handling",
     "rust/external_spend",
+    "rust/instruction_introspection",
     "rust/invoke",
     "rust/invoked",
     "rust/iter",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -72,6 +72,7 @@ fn main() {
             "dup_accounts",
             "error_handling",
             "external_spend",
+            "instruction_introspection",
             "invoke",
             "invoked",
             "iter",

--- a/programs/bpf/rust/instruction_introspection/Cargo.toml
+++ b/programs/bpf/rust/instruction_introspection/Cargo.toml
@@ -1,0 +1,26 @@
+
+# Note: This crate must be built using do.sh
+
+[package]
+name = "solana-bpf-rust-instruction-introspection"
+version = "1.4.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = false }
+
+[features]
+program = ["solana-sdk/program"]
+default = ["program", "solana-sdk/default"]
+
+[lib]
+name = "solana_bpf_rust_instruction_introspection"
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/instruction_introspection/Xargo.toml
+++ b/programs/bpf/rust/instruction_introspection/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/bpf/rust/instruction_introspection/src/lib.rs
+++ b/programs/bpf/rust/instruction_introspection/src/lib.rs
@@ -1,0 +1,45 @@
+//! @brief Example Rust-based BPF program that exercises instruction introspection
+
+extern crate solana_sdk;
+use solana_sdk::{
+    account_info::next_account_info, account_info::AccountInfo, entrypoint,
+    entrypoint::ProgramResult, info, program_error::ProgramError, pubkey::Pubkey,
+    sysvar::instructions,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    if instruction_data.is_empty() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let secp_instruction_index = instruction_data[0];
+    let account_info_iter = &mut accounts.iter();
+    let instruction_accounts = next_account_info(account_info_iter)?;
+    assert_eq!(*instruction_accounts.key, instructions::id());
+    let data_len = instruction_accounts.try_borrow_data()?.len();
+    if data_len < 2 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let instruction = instructions::get_instruction(
+        secp_instruction_index as usize,
+        &instruction_accounts.try_borrow_data()?,
+    )
+    .map_err(|_| ProgramError::InvalidAccountData)?;
+
+    let current_instruction =
+        instructions::get_current_instruction(&instruction_accounts.try_borrow_data()?);
+    let my_index = instruction_data[1] as u16;
+    assert_eq!(current_instruction, my_index);
+
+    info!(&format!("id: {}", instruction.program_id));
+
+    info!(&format!("data[0]: {}", instruction.data[0]));
+    info!(&format!("index: {}", current_instruction));
+    Ok(())
+}

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -1,0 +1,63 @@
+#![feature(test)]
+
+extern crate test;
+use bincode::{deserialize, serialize};
+use solana_sdk::instruction::{AccountMeta, Instruction};
+use solana_sdk::message::Message;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::sysvar::instructions;
+use test::Bencher;
+
+fn make_instructions() -> Vec<Instruction> {
+    let meta = AccountMeta::new(Pubkey::new_rand(), false);
+    let inst = Instruction::new(Pubkey::new_rand(), &[0; 10], vec![meta; 4]);
+    vec![inst; 4]
+}
+
+#[bench]
+fn bench_bincode_instruction_serialize(b: &mut Bencher) {
+    let instructions = make_instructions();
+    b.iter(|| {
+        test::black_box(serialize(&instructions).unwrap());
+    });
+}
+
+#[bench]
+fn bench_manual_instruction_serialize(b: &mut Bencher) {
+    let instructions = make_instructions();
+    let message = Message::new(&instructions, None);
+    b.iter(|| {
+        test::black_box(message.serialize_instructions());
+    });
+}
+
+#[bench]
+fn bench_bincode_instruction_deserialize(b: &mut Bencher) {
+    let instructions = make_instructions();
+    let serialized = serialize(&instructions).unwrap();
+    b.iter(|| {
+        test::black_box(deserialize::<Vec<Instruction>>(&serialized).unwrap());
+    });
+}
+
+#[bench]
+fn bench_manual_instruction_deserialize(b: &mut Bencher) {
+    let instructions = make_instructions();
+    let message = Message::new(&instructions, None);
+    let serialized = message.serialize_instructions();
+    b.iter(|| {
+        for i in 0..instructions.len() {
+            test::black_box(instructions::get_instruction(i, &serialized).unwrap());
+        }
+    });
+}
+
+#[bench]
+fn bench_manual_instruction_deserialize_single(b: &mut Bencher) {
+    let instructions = make_instructions();
+    let message = Message::new(&instructions, None);
+    let serialized = message.serialize_instructions();
+    b.iter(|| {
+        test::black_box(instructions::get_instruction(3, &serialized).unwrap());
+    });
+}

--- a/sdk/src/instruction.rs
+++ b/sdk/src/instruction.rs
@@ -169,7 +169,7 @@ pub enum InstructionError {
     ComputationalBudgetExceeded,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Instruction {
     /// Pubkey of the instruction processor that executes this instruction
     pub program_id: Pubkey,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -81,6 +81,7 @@ pub mod log;
 pub mod program;
 pub mod program_error;
 pub mod program_stubs;
+pub mod serialize_utils;
 
 // Modules not usable by on-chain programs
 #[cfg(not(feature = "program"))]

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -1,6 +1,9 @@
 //! A library for generating a message from a sequence of instructions
 
 use crate::sanitize::{Sanitize, SanitizeError};
+use crate::serialize_utils::{
+    append_slice, append_u16, append_u8, read_pubkey, read_slice, read_u16, read_u8,
+};
 use crate::{
     hash::Hash,
     instruction::{AccountMeta, CompiledInstruction, Instruction},
@@ -321,6 +324,98 @@ impl Message {
             }
         }
         (writable_keys, readonly_keys)
+    }
+
+    // First encode the number of instructions:
+    // [0..2 - num_instructions
+    //
+    // Then a table of offsets of where to find them in the data
+    //  3..2*num_instructions table of instruction offsets
+    //
+    // Each instruction is then encoded as:
+    //   0..2 - num_accounts
+    //   3 - meta_byte -> (bit 0 signer, bit 1 is_writable)
+    //   4..36 - pubkey - 32 bytes
+    //   36..64 - program_id
+    //     33..34 - data len - u16
+    //     35..data_len - data
+    pub fn serialize_instructions(&self) -> Vec<u8> {
+        // 64 bytes is a reasonable guess, calculating exactly is slower in benchmarks
+        let mut data = Vec::with_capacity(self.instructions.len() * (32 * 2));
+        append_u16(&mut data, self.instructions.len() as u16);
+        for _ in 0..self.instructions.len() {
+            append_u16(&mut data, 0);
+        }
+        for (i, instruction) in self.instructions.iter().enumerate() {
+            let start_instruction_offset = data.len() as u16;
+            let start = 2 + (2 * i);
+            data[start..start + 2].copy_from_slice(&start_instruction_offset.to_le_bytes());
+            append_u16(&mut data, instruction.accounts.len() as u16);
+            for account_index in &instruction.accounts {
+                let account_index = *account_index as usize;
+                let is_signer = self.is_signer(account_index);
+                let is_writable = self.is_writable(account_index);
+                let mut meta_byte = 0;
+                if is_signer {
+                    meta_byte |= 1 << Self::IS_SIGNER_BIT;
+                }
+                if is_writable {
+                    meta_byte |= 1 << Self::IS_WRITABLE_BIT;
+                }
+                append_u8(&mut data, meta_byte);
+                append_slice(&mut data, self.account_keys[account_index].as_ref());
+            }
+
+            let program_id = &self.account_keys[instruction.program_id_index as usize];
+            append_slice(&mut data, program_id.as_ref());
+            append_u16(&mut data, instruction.data.len() as u16);
+            append_slice(&mut data, &instruction.data);
+        }
+        data
+    }
+
+    const IS_SIGNER_BIT: usize = 0;
+    const IS_WRITABLE_BIT: usize = 1;
+
+    pub fn deserialize_instruction(
+        index: usize,
+        data: &[u8],
+    ) -> Result<Instruction, SanitizeError> {
+        let mut current = 0;
+        let _num_instructions = read_u16(&mut current, &data)?;
+
+        // index into the instruction byte-offset table.
+        current += index * 2;
+        let start = read_u16(&mut current, &data)?;
+
+        current = start as usize;
+        let num_accounts = read_u16(&mut current, &data)?;
+        let mut accounts = Vec::with_capacity(num_accounts as usize);
+        for _ in 0..num_accounts {
+            let meta_byte = read_u8(&mut current, &data)?;
+            let mut is_signer = false;
+            let mut is_writable = false;
+            if meta_byte & (1 << Self::IS_SIGNER_BIT) != 0 {
+                is_signer = true;
+            }
+            if meta_byte & (1 << Self::IS_WRITABLE_BIT) != 0 {
+                is_writable = true;
+            }
+            let pubkey = read_pubkey(&mut current, &data)?;
+            accounts.push(AccountMeta {
+                pubkey,
+                is_signer,
+                is_writable,
+            });
+        }
+        let program_id = read_pubkey(&mut current, &data)?;
+        let data_len = read_u16(&mut current, &data)?;
+        let data = read_slice(&mut current, &data, data_len as usize)?;
+        Ok(Instruction {
+            program_id,
+            data,
+            accounts,
+        })
     }
 }
 
@@ -672,5 +767,31 @@ mod tests {
             message.get_account_keys_by_lock_type(),
             (vec![&id1, &id0], vec![&id3, &id2, &program_id])
         );
+    }
+
+    #[test]
+    fn test_decompile_instructions() {
+        solana_logger::setup();
+        let program_id0 = Pubkey::new_rand();
+        let program_id1 = Pubkey::new_rand();
+        let id0 = Pubkey::new_rand();
+        let id1 = Pubkey::new_rand();
+        let id2 = Pubkey::new_rand();
+        let id3 = Pubkey::new_rand();
+        let instructions = vec![
+            Instruction::new(program_id0, &0, vec![AccountMeta::new(id0, false)]),
+            Instruction::new(program_id0, &0, vec![AccountMeta::new(id1, true)]),
+            Instruction::new(program_id1, &0, vec![AccountMeta::new_readonly(id2, false)]),
+            Instruction::new(program_id1, &0, vec![AccountMeta::new_readonly(id3, true)]),
+        ];
+
+        let message = Message::new(&instructions, Some(&id1));
+        let serialized = message.serialize_instructions();
+        for (i, instruction) in instructions.iter().enumerate() {
+            assert_eq!(
+                Message::deserialize_instruction(i, &serialized).unwrap(),
+                *instruction
+            );
+        }
     }
 }

--- a/sdk/src/serialize_utils.rs
+++ b/sdk/src/serialize_utils.rs
@@ -1,0 +1,65 @@
+use crate::pubkey::Pubkey;
+use crate::sanitize::SanitizeError;
+
+pub fn append_u16(buf: &mut Vec<u8>, data: u16) {
+    let start = buf.len();
+    buf.resize(buf.len() + 2, 0);
+    let end = buf.len();
+    buf[start..end].copy_from_slice(&data.to_le_bytes());
+}
+
+pub fn append_u8(buf: &mut Vec<u8>, data: u8) {
+    let start = buf.len();
+    buf.resize(buf.len() + 1, 0);
+    buf[start] = data;
+}
+
+pub fn append_slice(buf: &mut Vec<u8>, data: &[u8]) {
+    let start = buf.len();
+    buf.resize(buf.len() + data.len(), 0);
+    let end = buf.len();
+    buf[start..end].copy_from_slice(data);
+}
+
+pub fn read_u8(current: &mut usize, data: &[u8]) -> Result<u8, SanitizeError> {
+    if data.len() < *current + 1 {
+        return Err(SanitizeError::IndexOutOfBounds);
+    }
+    let e = data[*current];
+    *current += 1;
+    Ok(e)
+}
+
+pub fn read_pubkey(current: &mut usize, data: &[u8]) -> Result<Pubkey, SanitizeError> {
+    let len = std::mem::size_of::<Pubkey>();
+    if data.len() < *current + len {
+        return Err(SanitizeError::IndexOutOfBounds);
+    }
+    let e = Pubkey::new(&data[*current..*current + len]);
+    *current += len;
+    Ok(e)
+}
+
+pub fn read_u16(current: &mut usize, data: &[u8]) -> Result<u16, SanitizeError> {
+    if data.len() < *current + 2 {
+        return Err(SanitizeError::IndexOutOfBounds);
+    }
+    let mut fixed_data = [0u8; 2];
+    fixed_data.copy_from_slice(&data[*current..*current + 2]);
+    let e = u16::from_le_bytes(fixed_data);
+    *current += 2;
+    Ok(e)
+}
+
+pub fn read_slice(
+    current: &mut usize,
+    data: &[u8],
+    data_len: usize,
+) -> Result<Vec<u8>, SanitizeError> {
+    if data.len() < *current + data_len {
+        return Err(SanitizeError::IndexOutOfBounds);
+    }
+    let e = data[*current..*current + data_len].to_vec();
+    *current += data_len;
+    Ok(e)
+}

--- a/sdk/src/sysvar/instructions.rs
+++ b/sdk/src/sysvar/instructions.rs
@@ -1,0 +1,51 @@
+//! This account contains the serialized transaction instructions
+//!
+
+use crate::instruction::Instruction;
+use crate::sanitize::SanitizeError;
+use crate::sysvar::Sysvar;
+
+pub type Instructions = Vec<Instruction>;
+
+crate::declare_sysvar_id!("instructions1111111111111111111111111111111", Instructions);
+
+impl Sysvar for Instructions {}
+
+#[cfg(not(feature = "program"))]
+use crate::clock::Epoch;
+#[cfg(not(feature = "program"))]
+use crate::genesis_config::ClusterType;
+
+#[cfg(not(feature = "program"))]
+pub fn is_enabled(_epoch: Epoch, cluster_type: ClusterType) -> bool {
+    cluster_type == ClusterType::Development
+}
+
+pub fn get_current_instruction(data: &[u8]) -> u16 {
+    let mut instr_fixed_data = [0u8; 2];
+    let len = data.len();
+    instr_fixed_data.copy_from_slice(&data[len - 2..len]);
+    u16::from_le_bytes(instr_fixed_data)
+}
+
+pub fn store_current_instruction(data: &mut [u8], instruction_index: u16) {
+    let last_index = data.len() - 2;
+    data[last_index..last_index + 2].copy_from_slice(&instruction_index.to_le_bytes());
+}
+
+pub fn get_instruction(index: usize, data: &[u8]) -> Result<Instruction, SanitizeError> {
+    solana_sdk::message::Message::deserialize_instruction(index, data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_store_instruction() {
+        let mut data = [4u8; 10];
+        store_current_instruction(&mut data, 3);
+        assert_eq!(get_current_instruction(&data), 3);
+        assert_eq!([4u8; 8], data[0..8]);
+    }
+}

--- a/sdk/src/sysvar/mod.rs
+++ b/sdk/src/sysvar/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 pub mod clock;
 pub mod epoch_schedule;
 pub mod fees;
+pub mod instructions;
 pub mod recent_blockhashes;
 pub mod rent;
 pub mod rewards;
@@ -28,6 +29,7 @@ pub fn is_sysvar_id(id: &Pubkey) -> bool {
         || slot_hashes::check_id(id)
         || slot_history::check_id(id)
         || stake_history::check_id(id)
+        || instructions::check_id(id)
 }
 
 #[macro_export]


### PR DESCRIPTION
#### Problem

No way for a bpf program to look at the instructions in a transaction.

#### Summary of Changes

Add a sysvar to look at transactions.

Fixes #
