### PR TITLE
Increase message_processor logging to error level

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -499,7 +499,7 @@ fn start_logger(logfile: Option<String>) -> Option<JoinHandle<()>> {
 
     solana_logger::setup_with_default(
         &[
-            "solana=info", /* info logging for all solana modules */
+            "solana=info,solana_runtime::message_processor=error", /* info logging for all solana modules */
             "rpc=trace",   /* json_rpc request/response logging */
         ]
         .join(","),


### PR DESCRIPTION
#### Problem

message_processor spamming the logs at info level on mainnet due to constant transactions.

#### Summary of Changes

Up level to error.

Fixes #
