### PR TITLE
Add support for deprecated loader

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1670,6 +1670,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-deprecated_loader"
+version = "1.4.0"
+dependencies = [
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-bpf-rust-dup-accounts"
 version = "1.4.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "rust/128bit_dep",
     "rust/alloc",
     "rust/dep_crate",
+    "rust/deprecated_loader",
     "rust/dup_accounts",
     "rust/error_handling",
     "rust/external_spend",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -68,6 +68,7 @@ fn main() {
             "128bit",
             "alloc",
             "dep_crate",
+            "deprecated_loader",
             "dup_accounts",
             "error_handling",
             "external_spend",

--- a/programs/bpf/c/src/deprecated_loader/deprecated_loader.c
+++ b/programs/bpf/c/src/deprecated_loader/deprecated_loader.c
@@ -1,0 +1,23 @@
+/**
+ * @brief Example C-based BPF program that prints out the parameters
+ * passed to it
+ */
+#include <solana_sdk.h>
+#include <deserialize_deprecated.h>
+
+extern uint64_t entrypoint(const uint8_t *input) {
+  SolAccountInfo ka[1];
+  SolParameters params = (SolParameters) { .ka = ka };
+
+  sol_log(__FILE__);
+
+  if (!sol_deserialize_deprecated(input, &params, SOL_ARRAY_SIZE(ka))) {
+    return ERROR_INVALID_ARGUMENT;
+  }
+
+  // Log the provided input parameters.  In the case of  the no-op
+  // program, no account keys or input data are expected but real
+  // programs will have specific requirements so they can do their work.
+  sol_log_params(&params);
+  return SUCCESS;
+}

--- a/programs/bpf/rust/deprecated_loader/Cargo.toml
+++ b/programs/bpf/rust/deprecated_loader/Cargo.toml
@@ -1,0 +1,26 @@
+
+# Note: This crate must be built using do.sh
+
+[package]
+name = "solana-bpf-rust-deprecated_loader"
+version = "1.4.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = false }
+
+[features]
+program = ["solana-sdk/program"]
+default = ["program", "solana-sdk/default"]
+
+[lib]
+name = "solana_bpf_rust_deprecated_loader"
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/deprecated_loader/Xargo.toml
+++ b/programs/bpf/rust/deprecated_loader/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/bpf/rust/deprecated_loader/src/lib.rs
+++ b/programs/bpf/rust/deprecated_loader/src/lib.rs
@@ -1,0 +1,77 @@
+//! @brief Example Rust-based BPF program that supports the deprecated loader
+
+#![allow(unreachable_code)]
+
+extern crate solana_sdk;
+use solana_sdk::{
+    account_info::AccountInfo, bpf_loader, entrypoint_deprecated,
+    entrypoint_deprecated::ProgramResult, info, log::*, pubkey::Pubkey,
+};
+
+#[derive(Debug, PartialEq)]
+struct SStruct {
+    x: u64,
+    y: u64,
+    z: u64,
+}
+
+#[inline(never)]
+fn return_sstruct() -> SStruct {
+    SStruct { x: 1, y: 2, z: 3 }
+}
+
+entrypoint_deprecated!(process_instruction);
+fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    info!("Program identifier:");
+    program_id.log();
+
+    assert!(!bpf_loader::check_id(program_id));
+
+    // Log the provided account keys and instruction input data.  In the case of
+    // the no-op program, no account keys or input data are expected but real
+    // programs will have specific requirements so they can do their work.
+    info!("Account keys and instruction input data:");
+    sol_log_params(accounts, instruction_data);
+
+    {
+        // Test - use std methods, unwrap
+
+        // valid bytes, in a stack-allocated array
+        let sparkle_heart = [240, 159, 146, 150];
+        let result_str = std::str::from_utf8(&sparkle_heart).unwrap();
+        assert_eq!(4, result_str.len());
+        assert_eq!("💖", result_str);
+        info!(result_str);
+    }
+
+    {
+        // Test - struct return
+
+        let s = return_sstruct();
+        assert_eq!(s.x + s.y + s.z, 6);
+    }
+
+    {
+        // Test - arch config
+        #[cfg(not(target_arch = "bpf"))]
+        panic!();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    // Pull in syscall stubs when building for non-BPF targets
+    solana_sdk::program_stubs!();
+
+    #[test]
+    fn test_return_sstruct() {
+        assert_eq!(SStruct { x: 1, y: 2, z: 3 }, return_sstruct());
+    }
+}

--- a/sdk/bpf/c/inc/deserialize_deprecated.h
+++ b/sdk/bpf/c/inc/deserialize_deprecated.h
@@ -1,0 +1,115 @@
+#pragma once
+/**
+ * @brief Solana bpf_loader_deprecated deserializer to used when deploying
+ * a program with `BPFLoader1111111111111111111111111111111111`
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * De-serializes the input parameters into usable types
+ *
+ * Use this function to deserialize the buffer passed to the program entrypoint
+ * into usable types.  This function does not perform copy deserialization,
+ * instead it populates the pointers and lengths in SolAccountInfo and data so
+ * that any modification to lamports or account data take place on the original
+ * buffer.  Doing so also eliminates the need to serialize back into the buffer
+ * at the end of the program.
+ *
+ * @param input Source buffer containing serialized input parameters
+ * @param params Pointer to a SolParameters structure
+ * @return Boolean true if successful.
+ */
+static bool sol_deserialize_deprecated(
+  const uint8_t *input,
+  SolParameters *params,
+  uint64_t ka_num
+) {
+  if (NULL == input || NULL == params) {
+    return false;
+  }
+  params->ka_num = *(uint64_t *) input;
+  input += sizeof(uint64_t);
+
+  for (int i = 0; i < params->ka_num; i++) {
+    uint8_t dup_info = input[0];
+    input += sizeof(uint8_t);
+
+    if (i >= ka_num) {
+      if (dup_info == UINT8_MAX) {
+        input += sizeof(uint8_t);
+        input += sizeof(uint8_t);
+        input += sizeof(SolPubkey);
+        input += sizeof(uint64_t);
+        input += *(uint64_t *) input;
+        input += sizeof(uint64_t);
+        input += sizeof(SolPubkey);
+        input += sizeof(uint8_t);
+        input += sizeof(uint64_t);
+      }
+      continue;
+    }
+    if (dup_info == UINT8_MAX) {
+      // is signer?
+      params->ka[i].is_signer = *(uint8_t *) input != 0;
+      input += sizeof(uint8_t);
+
+      // is writable?
+      params->ka[i].is_writable = *(uint8_t *) input != 0;
+      input += sizeof(uint8_t);
+
+      // key
+      params->ka[i].key = (SolPubkey *) input;
+      input += sizeof(SolPubkey);
+
+      // lamports
+      params->ka[i].lamports = (uint64_t *) input;
+      input += sizeof(uint64_t);
+
+      // account data
+      params->ka[i].data_len = *(uint64_t *) input;
+      input += sizeof(uint64_t);
+      params->ka[i].data = (uint8_t *) input;
+      input += params->ka[i].data_len;
+
+      // owner
+      params->ka[i].owner = (SolPubkey *) input;
+      input += sizeof(SolPubkey);
+
+      // executable?
+      params->ka[i].executable = *(uint8_t *) input;
+      input += sizeof(uint8_t);
+
+      // rent epoch
+      params->ka[i].rent_epoch = *(uint64_t *) input;
+      input += sizeof(uint64_t);
+    } else {
+      params->ka[i].is_signer = params->ka[dup_info].is_signer;
+      params->ka[i].key = params->ka[dup_info].key;
+      params->ka[i].lamports = params->ka[dup_info].lamports;
+      params->ka[i].data_len = params->ka[dup_info].data_len;
+      params->ka[i].data = params->ka[dup_info].data;
+      params->ka[i].owner = params->ka[dup_info].owner;
+      params->ka[i].executable = params->ka[dup_info].executable;
+      params->ka[i].rent_epoch = params->ka[dup_info].rent_epoch;
+    }
+  }
+
+  params->data_len = *(uint64_t *) input;
+  input += sizeof(uint64_t);
+  params->data = input;
+  input += params->data_len;
+
+  params->program_id = (SolPubkey *) input;
+  input += sizeof(SolPubkey);
+
+  return true;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**@}*/

--- a/sdk/src/bpf_loader.rs
+++ b/sdk/src/bpf_loader.rs
@@ -1,1 +1,17 @@
+//! @brief The latest Solana BPF loader.
+//!
+//! The BPF loader is responsible for loading, finalizing, and executing BPF
+//! programs.  Not all networks may support the latest loader.  You can use the
+//! command-line tools to check if this version of the loader is supported by
+//! requesting the account info for the public key below.
+//!
+//! The program format may change between loaders, and it is crucial to build
+//! your program against the proper entrypoint semantics.  All programs being
+//! deployed to this BPF loader must build against the latest entrypoint version
+//! located in `entrypoint.rs`.
+//!
+//! Note: Programs built for older loaders must use a matching entrypoint
+//! version.  An example is `bpf_loader_deprecated.rs` which requires
+//! `entrypoint_deprecated.rs`.
+
 crate::declare_id!("BPFLoader2111111111111111111111111111111111");

--- a/sdk/src/bpf_loader_deprecated.rs
+++ b/sdk/src/bpf_loader_deprecated.rs
@@ -1,1 +1,14 @@
+//! @brief The original and now deprecated Solana BPF loader.
+//!
+//! The BPF loader is responsible for loading, finalizing, and executing BPF
+//! programs.
+//!
+//! This loader is deprecated, and it is strongly encouraged to build for and
+//! deploy to the latest BPF loader.  For more information see `bpf_loader.rs`
+//!
+//! The program format may change between loaders, and it is crucial to build
+//! your program against the proper entrypoint semantics.  All programs being
+//! deployed to this BPF loader must build against the deprecated entrypoint
+//! version located in `entrypoint_deprecated.rs`.
+
 crate::declare_id!("BPFLoader1111111111111111111111111111111111");

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -75,6 +75,7 @@ pub use solana_sdk_macro::respan;
 // On-chain program specific modules
 pub mod account_info;
 pub mod entrypoint;
+pub mod entrypoint_deprecated;
 pub mod log;
 pub mod program;
 pub mod program_error;


### PR DESCRIPTION
#### Problem

The default bpf loader keeps tabs on the latest but not all our networks support the new loader yet.  

#### Summary of Changes

Add support to the sdk to build and deploy the old loader

Fixes #
