### PR TITLE
Cache block time in Blockstore

### DIFF
--- a/core/src/cache_block_time_service.rs
+++ b/core/src/cache_block_time_service.rs
@@ -1,0 +1,65 @@
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
+use solana_ledger::blockstore::Blockstore;
+use solana_runtime::bank::Bank;
+use solana_sdk::timing::slot_duration_from_slots_per_year;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread::{self, Builder, JoinHandle},
+    time::Duration,
+};
+
+pub type CacheBlockTimeReceiver = Receiver<Arc<Bank>>;
+pub type CacheBlockTimeSender = Sender<Arc<Bank>>;
+
+pub struct CacheBlockTimeService {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl CacheBlockTimeService {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        cache_block_time_receiver: CacheBlockTimeReceiver,
+        blockstore: Arc<Blockstore>,
+        exit: &Arc<AtomicBool>,
+    ) -> Self {
+        let exit = exit.clone();
+        let thread_hdl = Builder::new()
+            .name("solana-cache-block-time".to_string())
+            .spawn(move || loop {
+                if exit.load(Ordering::Relaxed) {
+                    break;
+                }
+                if let Err(RecvTimeoutError::Disconnected) =
+                    Self::cache_block_time(&cache_block_time_receiver, &blockstore)
+                {
+                    break;
+                }
+            })
+            .unwrap();
+        Self { thread_hdl }
+    }
+
+    fn cache_block_time(
+        cache_block_time_receiver: &CacheBlockTimeReceiver,
+        blockstore: &Arc<Blockstore>,
+    ) -> Result<(), RecvTimeoutError> {
+        let bank = cache_block_time_receiver.recv_timeout(Duration::from_secs(1))?;
+        let slot_duration = slot_duration_from_slots_per_year(bank.slots_per_year());
+        let epoch = bank.epoch_schedule().get_epoch(bank.slot());
+        let stakes = HashMap::new();
+        let stakes = bank.epoch_vote_accounts(epoch).unwrap_or(&stakes);
+
+        if let Err(e) = blockstore.cache_block_time(bank.slot(), slot_duration, stakes) {
+            error!("cache_block_time failed: slot {:?} {:?}", bank.slot(), e);
+        }
+        Ok(())
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod accounts_hash_verifier;
 pub mod banking_stage;
 pub mod bigtable_upload_service;
 pub mod broadcast_stage;
+pub mod cache_block_time_service;
 pub mod cluster_info_vote_listener;
 pub mod commitment_service;
 pub mod completed_data_sets_service;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3,6 +3,7 @@
 use crate::{
     bank_weight_fork_choice::BankWeightForkChoice,
     broadcast_stage::RetransmitSlotsSender,
+    cache_block_time_service::CacheBlockTimeSender,
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::VoteTracker,
     cluster_slots::ClusterSlots,
@@ -106,6 +107,7 @@ pub struct ReplayStageConfig {
     pub block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     pub transaction_status_sender: Option<TransactionStatusSender>,
     pub rewards_recorder_sender: Option<RewardsRecorderSender>,
+    pub cache_block_time_sender: Option<CacheBlockTimeSender>,
 }
 
 #[derive(Default)]
@@ -235,6 +237,7 @@ impl ReplayStage {
             block_commitment_cache,
             transaction_status_sender,
             rewards_recorder_sender,
+            cache_block_time_sender,
         } = config;
 
         trace!("replay stage");
@@ -494,6 +497,7 @@ impl ReplayStage {
                             &subscriptions,
                             &block_commitment_cache,
                             &mut heaviest_subtree_fork_choice,
+                            &cache_block_time_sender,
                         )?;
                     };
                     voting_time.stop();
@@ -1004,6 +1008,7 @@ impl ReplayStage {
         subscriptions: &Arc<RpcSubscriptions>,
         block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
+        cache_block_time_sender: &Option<CacheBlockTimeSender>,
     ) -> Result<()> {
         if bank.is_empty() {
             inc_new_counter_info!("replay_stage-voted_empty_bank", 1);
@@ -1029,6 +1034,12 @@ impl ReplayStage {
             blockstore
                 .set_roots(&rooted_slots)
                 .expect("Ledger set roots failed");
+            Self::cache_block_times(
+                blockstore,
+                bank_forks,
+                &rooted_slots,
+                cache_block_time_sender,
+            );
             let highest_confirmed_root = Some(
                 block_commitment_cache
                     .read()
@@ -1851,6 +1862,36 @@ impl ReplayStage {
                 rewards_recorder_sender
                     .send((bank.slot(), rewards.iter().copied().collect()))
                     .unwrap_or_else(|err| warn!("rewards_recorder_sender failed: {:?}", err));
+            }
+        }
+    }
+
+    fn cache_block_times(
+        blockstore: &Arc<Blockstore>,
+        bank_forks: &Arc<RwLock<BankForks>>,
+        rooted_slots: &[Slot],
+        cache_block_time_sender: &Option<CacheBlockTimeSender>,
+    ) {
+        if let Some(cache_block_time_sender) = cache_block_time_sender {
+            for slot in rooted_slots {
+                if blockstore
+                    .get_block_time2(*slot)
+                    .unwrap_or_default()
+                    .is_none()
+                {
+                    if let Some(rooted_bank) = bank_forks.read().unwrap().get(*slot) {
+                        cache_block_time_sender
+                            .send(rooted_bank.clone())
+                            .unwrap_or_else(|err| {
+                                warn!("cache_block_time_sender failed: {:?}", err)
+                            });
+                    } else {
+                        error!(
+                            "rooted_bank {:?} not available in BankForks; block time not cached",
+                            slot
+                        );
+                    }
+                }
             }
         }
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1875,7 +1875,7 @@ impl ReplayStage {
         if let Some(cache_block_time_sender) = cache_block_time_sender {
             for slot in rooted_slots {
                 if blockstore
-                    .get_block_time2(*slot)
+                    .get_block_time(*slot)
                     .unwrap_or_default()
                     .is_none()
                 {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -5,6 +5,7 @@ use crate::{
     accounts_background_service::AccountsBackgroundService,
     accounts_hash_verifier::AccountsHashVerifier,
     broadcast_stage::RetransmitSlotsSender,
+    cache_block_time_service::CacheBlockTimeSender,
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::{VerifiedVoteReceiver, VoteTracker},
     cluster_slots::ClusterSlots,
@@ -96,6 +97,7 @@ impl Tvu {
         cfg: Option<Arc<AtomicBool>>,
         transaction_status_sender: Option<TransactionStatusSender>,
         rewards_recorder_sender: Option<RewardsRecorderSender>,
+        cache_block_time_sender: Option<CacheBlockTimeSender>,
         snapshot_package_sender: Option<AccountsPackageSender>,
         vote_tracker: Arc<VoteTracker>,
         retransmit_slots_sender: RetransmitSlotsSender,
@@ -191,6 +193,7 @@ impl Tvu {
             block_commitment_cache,
             transaction_status_sender,
             rewards_recorder_sender,
+            cache_block_time_sender,
         };
 
         let replay_stage = ReplayStage::new(
@@ -323,6 +326,7 @@ pub mod tests {
             &exit,
             completed_slots_receiver,
             block_commitment_cache,
+            None,
             None,
             None,
             None,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -137,6 +137,7 @@ pub struct Blockstore {
     transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
     active_transaction_status_index: RwLock<u64>,
     rewards_cf: LedgerColumn<cf::Rewards>,
+    blocktime_cf: LedgerColumn<cf::Blocktime>,
     last_root: Arc<RwLock<Slot>>,
     insert_shreds_lock: Arc<Mutex<()>>,
     pub new_shreds_signals: Vec<SyncSender<bool>>,
@@ -292,6 +293,7 @@ impl Blockstore {
         let address_signatures_cf = db.column();
         let transaction_status_index_cf = db.column();
         let rewards_cf = db.column();
+        let blocktime_cf = db.column();
 
         let db = Arc::new(db);
 
@@ -336,6 +338,7 @@ impl Blockstore {
             transaction_status_index_cf,
             active_transaction_status_index: RwLock::new(active_transaction_status_index),
             rewards_cf,
+            blocktime_cf,
             new_shreds_signals: vec![],
             completed_slots_senders: vec![],
             insert_shreds_lock: Arc::new(Mutex::new(())),

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1651,6 +1651,23 @@ impl Blockstore {
         slots
     }
 
+    pub fn get_block_time2(
+        &self,
+        slot: Slot,
+    ) -> Result<Option<UnixTimestamp>> {
+        datapoint_info!(
+            "blockstore-rpc-api",
+            ("method", "get_block_time".to_string(), String)
+        );
+        let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
+        // lowest_cleanup_slot is the last slot that was not cleaned up by
+        // LedgerCleanupService
+        if *lowest_cleanup_slot > 0 && *lowest_cleanup_slot >= slot {
+            return Err(BlockstoreError::SlotCleanedUp);
+        }
+        self.blocktime_cf.get(slot)
+    }
+
     pub fn cache_block_time(
         &self,
         slot: Slot,

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -133,6 +133,10 @@ impl Blockstore {
             & self
                 .db
                 .delete_range_cf::<cf::Rewards>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
+                .delete_range_cf::<cf::Blocktime>(&mut write_batch, from_slot, to_slot)
                 .is_ok();
         let mut w_active_transaction_status_index =
             self.active_transaction_status_index.write().unwrap();
@@ -222,6 +226,10 @@ impl Blockstore {
                 .unwrap_or(false)
             && self
                 .rewards_cf
+                .compact_range(from_slot, to_slot)
+                .unwrap_or(false)
+            && self
+                .blocktime_cf
                 .compact_range(from_slot, to_slot)
                 .unwrap_or(false);
         compact_timer.stop();

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -10,7 +10,11 @@ use rocksdb::{
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use solana_runtime::hardened_unpack::UnpackError;
-use solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature};
+use solana_sdk::{
+    clock::{Slot, UnixTimestamp},
+    pubkey::Pubkey,
+    signature::Signature,
+};
 use solana_transaction_status::{Rewards, TransactionStatusMeta};
 use std::{collections::HashMap, fs, marker::PhantomData, path::Path, sync::Arc};
 use thiserror::Error;
@@ -46,6 +50,8 @@ const ADDRESS_SIGNATURES_CF: &str = "address_signatures";
 const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 /// Column family for Rewards
 const REWARDS_CF: &str = "rewards";
+/// Column family for Blocktime
+const BLOCKTIME_CF: &str = "blocktime";
 
 #[derive(Error, Debug)]
 pub enum BlockstoreError {
@@ -128,6 +134,10 @@ pub mod columns {
     #[derive(Debug)]
     /// The rewards column
     pub struct Rewards;
+
+    #[derive(Debug)]
+    /// The blocktime column
+    pub struct Blocktime;
 }
 
 pub enum AccessType {
@@ -187,8 +197,9 @@ impl Rocks {
         recovery_mode: Option<BlockstoreRecoveryMode>,
     ) -> Result<Rocks> {
         use columns::{
-            AddressSignatures, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans, Rewards,
-            Root, ShredCode, ShredData, SlotMeta, TransactionStatus, TransactionStatusIndex,
+            AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
+            Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
+            TransactionStatusIndex,
         };
 
         fs::create_dir_all(&path)?;
@@ -221,6 +232,8 @@ impl Rocks {
         let transaction_status_index_cf_descriptor =
             ColumnFamilyDescriptor::new(TransactionStatusIndex::NAME, get_cf_options());
         let rewards_cf_descriptor = ColumnFamilyDescriptor::new(Rewards::NAME, get_cf_options());
+        let blocktime_cf_descriptor =
+            ColumnFamilyDescriptor::new(Blocktime::NAME, get_cf_options());
 
         let cfs = vec![
             (SlotMeta::NAME, meta_cf_descriptor),
@@ -239,6 +252,7 @@ impl Rocks {
                 transaction_status_index_cf_descriptor,
             ),
             (Rewards::NAME, rewards_cf_descriptor),
+            (Blocktime::NAME, blocktime_cf_descriptor),
         ];
 
         // Open the database
@@ -276,8 +290,9 @@ impl Rocks {
 
     fn columns(&self) -> Vec<&'static str> {
         use columns::{
-            AddressSignatures, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans, Rewards,
-            Root, ShredCode, ShredData, SlotMeta, TransactionStatus, TransactionStatusIndex,
+            AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
+            Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
+            TransactionStatusIndex,
         };
 
         vec![
@@ -294,6 +309,7 @@ impl Rocks {
             AddressSignatures::NAME,
             TransactionStatusIndex::NAME,
             Rewards::NAME,
+            Blocktime::NAME,
         ]
     }
 
@@ -517,6 +533,14 @@ impl ColumnName for columns::Rewards {
 }
 impl TypedColumn for columns::Rewards {
     type Type = Rewards;
+}
+
+impl SlotColumn for columns::Blocktime {}
+impl ColumnName for columns::Blocktime {
+    const NAME: &'static str = BLOCKTIME_CF;
+}
+impl TypedColumn for columns::Blocktime {
+    type Type = UnixTimestamp;
 }
 
 impl Column for columns::ShredCode {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -68,6 +68,7 @@ pub enum BlockstoreError {
     UnableToSetOpenFileDescriptorLimit,
     TransactionStatusSlotMismatch,
     EmptyEpochStakes,
+    NoVoteTimestampsInRange,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -67,6 +67,7 @@ pub enum BlockstoreError {
     UnpackError(#[from] UnpackError),
     UnableToSetOpenFileDescriptorLimit,
     TransactionStatusSlotMismatch,
+    EmptyEpochStakes,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 


### PR DESCRIPTION
#### Problem
The `getBlockTime` rpc endpoint can return null for a block that hasn't been pruned from Blockstore. This is because we only keep the last 5 epochs of stake info, and stake info is needed for calculating a block timestamp on demand.

To address this problem, and generally offer better block-time support, we've made two changes to the original design (https://docs.solana.com/implemented-proposals/validator-timestamp-oracle):
1. The initial design called for block times to be calculated on demand in order to demonstrate that they are deterministic from the ledger. Caching block times saves this unnecessary every-call work; the block times are still deterministic from the ledger.
2. The initial design called for validators to vote every ~30min (4500 slots) in order to save space in Vote transactions. As of #10630 , validators are now timestamp every Vote. As a result, there are plenty of timestamps available to calculate a stake-weighted timestamp as soon as a block is rooted in Blockstre.

#### Summary of Changes
- Add Blockstore column family to cache blocktimes
- Add CacheBlockTimeService, triggered from ReplayStage::handle_votable_bank, to calculate and cache a block's timestamp as soon as a block is rooted
- Use cache in `getBlockTime` rpc
- Add block_time to `ConfirmedBlock` when populated

Fixes #10089 
Note: blocks before this PR is released may still return `null`
