### PR TITLE
fix program test stubs

### DIFF
--- a/ci/nits.sh
+++ b/ci/nits.sh
@@ -26,6 +26,7 @@ declare print_free_tree=(
   ':runtime/src/**.rs'
   ':sdk/bpf/rust/rust-utils/**.rs'
   ':sdk/**.rs'
+  ':^sdk/src/program_stubs.rs'
   ':programs/**.rs'
   ':^**bin**.rs'
   ':^**bench**.rs'

--- a/sdk/src/program_stubs.rs
+++ b/sdk/src/program_stubs.rs
@@ -1,38 +1,24 @@
 //! @brief Syscall stubs when building for non-BPF targets
 
-#![cfg(feature = "program")]
-
-#[cfg(not(target_arch = "bpf"))]
-fn print_line_to_stdout(_message: &str) {
-    #[cfg(not(feature = "program"))]
-    {
-        use std::io::{self, Write};
-        io::stdout()
-            .write_all(format!("{}\n", _message).as_bytes())
-            .unwrap();
-        io::stdout().flush().unwrap();
-    }
-}
-
 #[cfg(not(target_arch = "bpf"))]
 #[no_mangle]
 /// # Safety
 pub unsafe fn sol_log_(message: *const u8, length: u64) {
     let slice = std::slice::from_raw_parts(message, length as usize);
     let string = std::str::from_utf8(&slice).unwrap();
-    print_line_to_stdout(string);
+    println!("{}", string);
 }
 
 #[cfg(not(target_arch = "bpf"))]
 #[no_mangle]
 pub fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
-    print_line_to_stdout(&format!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5));
+    println!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5);
 }
 
 #[cfg(not(target_arch = "bpf"))]
 #[no_mangle]
 pub fn sol_invoke_signed_rust() {
-    print_line_to_stdout("sol_invoke_signed_rust()");
+    println!("sol_invoke_signed_rust()");
 }
 
 #[macro_export]


### PR DESCRIPTION
#### Problem

Test stubs were not outputing diagnostic messages

#### Summary of Changes

Remove the `program` feature guards now that `program` use has been cleaned up

Fixes #
