### PR TITLE
Clarify comments and names in inflation code

### DIFF
--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -55,6 +55,7 @@ impl Inflation {
     }
     /// inflation rate at year
     pub fn total(&self, year: f64) -> f64 {
+        assert!(year >= 0.0);
         let tapered = self.initial * ((1.0 - self.taper).powf(year));
 
         if tapered > self.terminal {


### PR DESCRIPTION
#### Problem

There is somewhat outdated/wrong comment and misleading identifier names for the inflation code.

Also, we could add a sanity assertion for `year` being `>= 0`.

#### Summary of Changes

Do them.

There should be no function change.

#### Context

folllow-up #10914