### PR TITLE
Update to Rust 1.46.0

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM solanalabs/rust:1.45.1
+FROM solanalabs/rust:1.46.0
 ARG date
 
 RUN set -x \

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -1,6 +1,6 @@
 # Note: when the rust version is changed also modify
 # ci/rust-version.sh to pick up the new image tag
-FROM rust:1.45.1
+FROM rust:1.46.0
 
 # Add Google Protocol Buffers for Libra's metrics library.
 ENV PROTOC_VERSION 3.8.0

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -18,7 +18,7 @@
 if [[ -n $RUST_STABLE_VERSION ]]; then
   stable_version="$RUST_STABLE_VERSION"
 else
-  stable_version=1.45.1
+  stable_version=1.46.0
 fi
 
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -58,12 +58,16 @@ macro_rules! declare_name {
                 // `declare_name(foo)`
                 //
                 // See the `respan!` macro for more details.
+                // This should use `crate::respan!` once
+                // https://github.com/rust-lang/rust/pull/72121 is merged:
+                // see https://github.com/solana-labs/solana/issues/10933.
+                // For now, we need to use `::solana_sdk`
                 //
                 // `respan!` respans the path `$crate::id`, which we then call (hence the extra
                 // parens)
                 (
                     stringify!($filename).to_string(),
-                    $crate::respan!($crate::$id, $name)(),
+                    ::solana_sdk::respan!($crate::$id, $name)(),
                 )
             };
         }


### PR DESCRIPTION
<s>Progress towards https://github.com/solana-labs/solana/issues/11976.  This gets CI using Rust 1.46.0 but is expected to fail until the source changes to adapt to rust 1.46.0 are made</s>

Fixes #11976 