### PR TITLE
Docs.rs version replacement

### DIFF
--- a/docs/set-solana-release-tag.sh
+++ b/docs/set-solana-release-tag.sh
@@ -22,7 +22,10 @@ if [[ -z "$LATEST_SOLANA_RELEASE_VERSION" ]]; then
   exit 1
 fi
 
+VERSION_FOR_DOCS_RS="${LATEST_SOLANA_RELEASE_VERSION:1}"
+
 set -x
 if [[ -n $CI ]]; then
   find src/ -name \*.md -exec sed -i "s/LATEST_SOLANA_RELEASE_VERSION/$LATEST_SOLANA_RELEASE_VERSION/g" {} \;
+  find src/ -name \*.md -exec sed -i "s/VERSION_FOR_DOCS_RS/$VERSION_FOR_DOCS_RS/g" {} \;
 fi

--- a/docs/src/apps/builtins.md
+++ b/docs/src/apps/builtins.md
@@ -21,14 +21,14 @@ programs, as well include instructions from third-party programs.
 Create accounts and transfer lamports between them
 
 - Program ID: `11111111111111111111111111111111`
-- Instructions: [SystemInstruction](https://docs.rs/solana-sdk/LATEST_SOLANA_RELEASE_VERSION/solana_sdk/system_instruction/enum.SystemInstruction.html)
+- Instructions: [SystemInstruction](https://docs.rs/solana-sdk/VERSION_FOR_DOCS_RS/solana_sdk/system_instruction/enum.SystemInstruction.html)
 
 ## Config Program
 
 Add configuration data to the chain and the list of public keys that are permitted to modify it
 
 - Program ID: `Config1111111111111111111111111111111111111`
-- Instructions: [config_instruction](https://docs.rs/solana-config-program/LATEST_SOLANA_RELEASE_VERSION/solana_config_program/config_instruction/index.html)
+- Instructions: [config_instruction](https://docs.rs/solana-config-program/VERSION_FOR_DOCS_RS/solana_config_program/config_instruction/index.html)
 
 Unlike the other programs, the Config program does not define any individual
 instructions. It has just one implicit instruction, a "store" instruction. Its
@@ -40,21 +40,21 @@ data to store in it.
 Create stake accounts and delegate it to validators
 
 - Program ID: `Stake11111111111111111111111111111111111111`
-- Instructions: [StakeInstruction](https://docs.rs/solana-stake-program/LATEST_SOLANA_RELEASE_VERSION/solana_stake_program/stake_instruction/enum.StakeInstruction.html)
+- Instructions: [StakeInstruction](https://docs.rs/solana-stake-program/VERSION_FOR_DOCS_RS/solana_stake_program/stake_instruction/enum.StakeInstruction.html)
 
 ## Vote Program
 
 Create vote accounts and vote on blocks
 
 - Program ID: `Vote111111111111111111111111111111111111111`
-- Instructions: [VoteInstruction](https://docs.rs/solana-vote-program/LATEST_SOLANA_RELEASE_VERSION/solana_vote_program/vote_instruction/enum.VoteInstruction.html)
+- Instructions: [VoteInstruction](https://docs.rs/solana-vote-program/VERSION_FOR_DOCS_RS/solana_vote_program/vote_instruction/enum.VoteInstruction.html)
 
 ## BPF Loader
 
 Add programs to the chain.
 
 - Program ID: `BPFLoader1111111111111111111111111111111111`
-- Instructions: [LoaderInstruction](https://docs.rs/solana-sdk/LATEST_SOLANA_RELEASE_VERSION/solana_sdk/loader_instruction/enum.LoaderInstruction.html)
+- Instructions: [LoaderInstruction](https://docs.rs/solana-sdk/VERSION_FOR_DOCS_RS/solana_sdk/loader_instruction/enum.LoaderInstruction.html)
 
 The BPF Loader marks itself as its "owner" of the executable account it
 creates to store your program. When a user invokes an instruction via a


### PR DESCRIPTION
#### Problem
Instruction links on https://docs.solana.com/apps/builtins are broken because docs.rs doesn't expect "v" in the version (from `LATEST_SOLANA_RELEASE_VERSION`

#### Summary of Changes
Add new env var without "v" for docs.rs
