### PR TITLE
Route CPI instruction info back to the bank

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -258,6 +258,7 @@ mod tests {
         account::Account,
         entrypoint_native::{ComputeBudget, Logger, ProcessInstruction},
         instruction::CompiledInstruction,
+        instruction::Instruction,
         message::Message,
         rent::Rent,
     };
@@ -339,6 +340,7 @@ mod tests {
         fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
             Rc::new(RefCell::new(self.compute_meter.clone()))
         }
+        fn record_instruction(&self, _instruction: Instruction) {}
     }
 
     struct TestInstructionMeter {
@@ -583,6 +585,7 @@ mod tests {
                 invoke_units: 1000,
                 max_invoke_depth: 2,
             },
+            Rc::new(RefCell::new(vec![])),
         );
         assert_eq!(
             Err(InstructionError::Custom(194969602)),

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -908,7 +908,7 @@ fn call<'a>(
         ro_regions,
     )?;
     verify_instruction(syscall, &instruction, &signers)?;
-    let message = Message::new(&[instruction], None);
+    let message = Message::new(&[instruction.clone()], None);
     let callee_program_id_index = message.instructions[0].program_id_index as usize;
     let callee_program_id = message.account_keys[callee_program_id_index];
     let (accounts, account_refs) = syscall.translate_accounts(
@@ -973,6 +973,9 @@ fn call<'a>(
                 .clone_from_slice(&account.data[0..account_ref.data.len()]);
         }
     }
+
+    // We could record them at the beginning if we want to record failures.  Would miss recordings if the address translation, etc... failed
+    invoke_context.record_instruction(instruction);
 
     Ok(SUCCESS)
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1829,6 +1829,10 @@ impl Bank {
         );
         load_time.stop();
 
+        // This is rough, doesn't have to be in this form, just needs to be able to be
+        // conveyed through `InvokeContext` to the CPI syscall handler
+        let cpi_instructions = Rc::new(RefCell::new(vec![]));
+
         let mut execution_time = Measure::start("execution_time");
         let mut signature_count: u64 = 0;
         let executed: Vec<TransactionProcessResult> = loaded_accounts
@@ -1848,6 +1852,7 @@ impl Bank {
                         &account_refcells,
                         &self.rent_collector,
                         log_collector.clone(),
+                        cpi_instructions.clone(),
                     );
 
                     Self::refcells_to_accounts(
@@ -1866,6 +1871,11 @@ impl Bank {
             .collect();
 
         execution_time.stop();
+
+        // The instructions are available here
+        for (i, instruction) in cpi_instructions.borrow().iter().enumerate() {
+            println!("cpi instructions {:?}: {:?}\n", i, instruction);
+        }
 
         debug!(
             "load: {}us execute: {}us txs_len={}",

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
         ComputeBudget, ComputeMeter, ErasedProcessInstruction, ErasedProcessInstructionWithContext,
         InvokeContext, Logger, ProcessInstruction, ProcessInstructionWithContext,
     },
-    instruction::{CompiledInstruction, InstructionError},
+    instruction::{CompiledInstruction, Instruction, InstructionError},
     message::Message,
     native_loader,
     pubkey::Pubkey,
@@ -182,6 +182,7 @@ pub struct ThisInvokeContext {
     is_cross_program_supported: bool,
     compute_budget: ComputeBudget,
     compute_meter: Rc<RefCell<dyn ComputeMeter>>,
+    instructions: Rc<RefCell<Vec<Instruction>>>,
 }
 impl ThisInvokeContext {
     pub fn new(
@@ -192,6 +193,7 @@ impl ThisInvokeContext {
         log_collector: Option<Rc<LogCollector>>,
         is_cross_program_supported: bool,
         compute_budget: ComputeBudget,
+        instructions: Rc<RefCell<Vec<Instruction>>>,
     ) -> Self {
         let mut program_ids = Vec::with_capacity(compute_budget.max_invoke_depth);
         program_ids.push(*program_id);
@@ -206,6 +208,7 @@ impl ThisInvokeContext {
             compute_meter: Rc::new(RefCell::new(ThisComputeMeter {
                 remaining: compute_budget.max_units,
             })),
+            instructions,
         }
     }
 }
@@ -261,6 +264,9 @@ impl InvokeContext for ThisInvokeContext {
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         self.compute_meter.clone()
+    }
+    fn record_instruction(&self, instruction: Instruction) {
+        self.instructions.borrow_mut().push(instruction);
     }
 }
 pub struct ThisLogger {
@@ -633,6 +639,7 @@ impl MessageProcessor {
         accounts: &[Rc<RefCell<Account>>],
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
+        instructions: Rc<RefCell<Vec<Instruction>>>,
     ) -> Result<(), InstructionError> {
         let pre_accounts = Self::create_pre_accounts(message, instruction, accounts);
         let mut invoke_context = ThisInvokeContext::new(
@@ -643,6 +650,7 @@ impl MessageProcessor {
             log_collector,
             self.is_cross_program_supported,
             self.compute_budget,
+            instructions,
         );
         let keyed_accounts =
             Self::create_keyed_accounts(message, instruction, executable_accounts, accounts)?;
@@ -668,6 +676,7 @@ impl MessageProcessor {
         accounts: &[Rc<RefCell<Account>>],
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
+        instructions: Rc<RefCell<Vec<Instruction>>>,
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
             self.execute_instruction(
@@ -677,6 +686,7 @@ impl MessageProcessor {
                 accounts,
                 rent_collector,
                 log_collector.clone(),
+                instructions.clone(),
             )
             .map_err(|err| TransactionError::InstructionError(instruction_index as u8, err))?;
         }

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     account::Account, account::KeyedAccount, instruction::CompiledInstruction,
-    instruction::InstructionError, message::Message, pubkey::Pubkey,
+    instruction::Instruction, instruction::InstructionError, message::Message, pubkey::Pubkey,
 };
 use std::{cell::RefCell, rc::Rc};
 
@@ -214,6 +214,8 @@ pub trait InvokeContext {
     fn get_compute_budget(&self) -> ComputeBudget;
     /// Get this invocation's compute meter
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>>;
+    /// Add Instruction
+    fn record_instruction(&self, instruction: Instruction);
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
#### Problem

The explorer has no way to determine what CPI instructions were executed

#### Summary of Changes

Record and route information about what CPI instructions were executed back to the bank

Fixes #
