### PR TITLE
Move forward token2 native mint testnet epoch

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3288,7 +3288,7 @@ impl Bank {
     fn reconfigure_token2_native_mint(&mut self) {
         let reconfigure_token2_native_mint = match self.operating_mode() {
             OperatingMode::Development => true,
-            OperatingMode::Preview => self.epoch() == 95,
+            OperatingMode::Preview => self.epoch() == 93,
             OperatingMode::Stable => self.epoch() == 75,
         };
 
@@ -8451,7 +8451,7 @@ mod tests {
             1000000000
         );
 
-        // OperatingMode::Preview - Native mint blinks into existence at epoch 95
+        // OperatingMode::Preview - Native mint blinks into existence at epoch 93
         genesis_config.operating_mode = OperatingMode::Preview;
         let bank = Arc::new(Bank::new(&genesis_config));
         assert_eq!(
@@ -8463,7 +8463,7 @@ mod tests {
         let bank = Bank::new_from_parent(
             &bank,
             &Pubkey::default(),
-            genesis_config.epoch_schedule.get_first_slot_in_epoch(95),
+            genesis_config.epoch_schedule.get_first_slot_in_epoch(93),
         );
 
         let native_mint_account = bank


### PR DESCRIPTION
In accordance with this:

https://github.com/solana-labs/solana/pull/11996#pullrequestreview-481439902

> If we're going to roll this out on testnet epoch 93, please speed up this activation to 93 as well!
> 
> https://github.com/solana-labs/solana/blob/af08221aecc613eaf695a032a44ef66ed7fa9618/runtime/src/bank.rs#L3289

