### PR TITLE
Mark a withdraw authority as non-circulating

### DIFF
--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -78,6 +78,7 @@ solana_sdk::pubkeys!(
         "3o6xgkJ9sTmDeQWyfj3sxwon18fXJB9PV5LDc8sfgR4a",
         "GumSE5HsMV5HCwBTv2D2D81yy9x17aDkvobkqAfTRgmo",
         "AzVV9ZZDxTgW4wWfJmsG6ytaHpQGSe1yz76Nyy84VbQF",
+        "8CUUMKYNGxdgYio5CLHRHyzMEhhVRMcqefgE6dLqnVRK",
     ]
 );
 


### PR DESCRIPTION
#### Problem

Stake withdraws are tedious compared to system transfers.

#### Summary of Changes

Mark the withdraw authority of a non-circulating stake account as non-circulating, so that its tokens can be moved to that system account.