### PR TITLE
Update devnet activation epoch for token2 native mint

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2908,7 +2908,7 @@ pub mod tests {
         let largest_accounts: Vec<RpcAccountBalance> =
             serde_json::from_value(json["result"]["value"].clone())
                 .expect("actual response deserialization");
-        assert_eq!(largest_accounts.len(), 20);
+        assert_eq!(largest_accounts.len(), 19);
 
         // Get Alice balance
         let req = format!(
@@ -2945,7 +2945,7 @@ pub mod tests {
         let largest_accounts: Vec<RpcAccountBalance> =
             serde_json::from_value(json["result"]["value"].clone())
                 .expect("actual response deserialization");
-        assert_eq!(largest_accounts.len(), 19);
+        assert_eq!(largest_accounts.len(), 18);
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getLargestAccounts","params":[{"filter":"nonCirculating"}]}"#;
         let res = io.handle_request_sync(&req, meta);
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
@@ -5023,7 +5023,7 @@ pub mod tests {
             .expect("actual response deserialization");
         let accounts: Vec<RpcKeyedAccount> =
             serde_json::from_value(result["result"].clone()).unwrap();
-        assert_eq!(accounts.len(), 4);
+        assert_eq!(accounts.len(), 3);
 
         // Test returns only mint accounts
         let req = format!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2906,7 +2906,7 @@ impl Bank {
 
     fn reconfigure_token2_native_mint(self: &mut Bank) {
         let reconfigure_token2_native_mint = match self.operating_mode() {
-            OperatingMode::Development => true,
+            OperatingMode::Development => self.epoch() == 317,
             OperatingMode::Preview => self.epoch() == 95,
             OperatingMode::Stable => self.epoch() == 75,
         };
@@ -7844,7 +7844,7 @@ mod tests {
             .map(|_| bank.process_stale_slot_with_budget(0, force_to_return_alive_account))
             .collect::<Vec<_>>();
         consumed_budgets.sort();
-        assert_eq!(consumed_budgets, vec![0, 1, 9]);
+        assert_eq!(consumed_budgets, vec![0, 1, 8]);
     }
 
     #[test]
@@ -7945,14 +7945,6 @@ mod tests {
 
         let mut genesis_config =
             create_genesis_config_with_leader(5, &Pubkey::new_rand(), 0).genesis_config;
-
-        // OperatingMode::Development - Native mint exists immediately
-        assert_eq!(genesis_config.operating_mode, OperatingMode::Development);
-        let bank = Arc::new(Bank::new(&genesis_config));
-        assert_eq!(
-            bank.get_balance(&inline_spl_token_v2_0::native_mint::id()),
-            1000000000
-        );
 
         // OperatingMode::Preview - Native mint blinks into existence at epoch 95
         genesis_config.operating_mode = OperatingMode::Preview;


### PR DESCRIPTION
Adjust token2 activation epoch on devnet to avoid bank has mismatch.  

Future cleanup of Devnet vs. Development operating modes will be done via https://github.com/solana-labs/solana/issues/12039