### PR TITLE
fix: speed up get leader schedule

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -325,7 +325,7 @@ type LeaderSchedule = {
 
 const GetLeaderScheduleResult = struct.record([
   'string',
-  struct.array(['number']),
+  'any', // validating struct.array(['number']) is extremely slow
 ]);
 
 /**


### PR DESCRIPTION
#### Problem
Fetching the leader schedule is extremely slow due to the json validation that runs on the large response payload.

#### Summary of Changes
Loosen json validation to speed up fetches

Fixes #
