### PR TITLE
Bigtable bug fixes

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -424,8 +424,9 @@ impl LedgerStorage {
                     row_key
                 ))
             })?;
-            let cell_data: Vec<TransactionByAddrInfo> =
+            let mut cell_data: Vec<TransactionByAddrInfo> =
                 bigtable::deserialize_cell_data(&data, "tx-by-addr", row_key)?;
+            cell_data.reverse();
             for tx_by_addr_info in cell_data.into_iter() {
                 // Filter out records before `before_transaction_index`
                 if slot == first_slot && tx_by_addr_info.index >= before_transaction_index {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -397,12 +397,14 @@ impl LedgerStorage {
 
         let mut infos = vec![];
 
-        let starting_slot_tx_by_addr_infos = bigtable
+        let starting_slot_tx_len = bigtable
             .get_bincode_cell::<Vec<TransactionByAddrInfo>>(
                 "tx-by-addr",
                 format!("{}{}", address_prefix, slot_to_key(!first_slot)),
             )
-            .await?;
+            .await
+            .map(|txs| txs.len())
+            .unwrap_or(0);
 
         // Return the next tx-by-addr data of amount `limit` plus extra to account for the largest
         // number that might be flitered out
@@ -411,7 +413,7 @@ impl LedgerStorage {
                 "tx-by-addr",
                 Some(format!("{}{}", address_prefix, slot_to_key(!first_slot))),
                 Some(format!("{}{}", address_prefix, slot_to_key(!last_slot))),
-                limit as i64 + starting_slot_tx_by_addr_infos.len() as i64,
+                limit as i64 + starting_slot_tx_len as i64,
             )
             .await?;
 


### PR DESCRIPTION
#### Problem
The Bigtable `get_confirmed_signatures_for_address` method has been exploiting the (incorrect) behavior of `get_bincode_cell` to return data even if the key is not found. When I tightened up `get_bincode_cell` in https://github.com/solana-labs/solana/pull/11999, it caused `get_confirmed_signatures_for_address` to error.

In debugging the above, I noticed that signatures within the same block are being returned oldest-to-newest, making it very difficult to use `--before` and `--until` on very-active accounts. This bug has been around since get_confirmed_signatures_for_address` was first implemented for Bigtable.

#### Summary of Changes
- Prevent `get_confirmed_signatures_for_address` from erroring out when finding the starting-slot transaction length. If the key in question cannot be found, `0` is obv the correct transaction length.
- Reverse sort signatures within the same slot so that they return newest-to-oldest, like signatures across slots.
