### PR TITLE
Rename to ClusterType and restore devnet compat.

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -5,7 +5,7 @@ use solana_runtime::{
     accounts::{create_test_accounts, update_accounts, Accounts},
     accounts_index::Ancestors,
 };
-use solana_sdk::{genesis_config::OperatingMode, pubkey::Pubkey};
+use solana_sdk::{genesis_config::ClusterType, pubkey::Pubkey};
 use std::fs;
 use std::path::PathBuf;
 
@@ -54,7 +54,7 @@ fn main() {
     if fs::remove_dir_all(path.clone()).is_err() {
         println!("Warning: Couldn't remove {:?}", path);
     }
-    let accounts = Accounts::new(vec![path], &OperatingMode::Preview);
+    let accounts = Accounts::new(vec![path], &ClusterType::Testnet);
     println!("Creating {} accounts", num_accounts);
     let mut create_time = Measure::start("create accounts");
     let pubkeys: Vec<_> = (0..num_slots)

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -8,6 +8,7 @@ use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     clock::UnixTimestamp,
     commitment_config::CommitmentConfig,
+    genesis_config::ClusterType,
     native_token::sol_to_lamports,
     pubkey::Pubkey,
     signature::{read_keypair_file, Keypair, Signature, Signer},
@@ -176,6 +177,10 @@ pub fn resolve_signer(
 
 pub fn lamports_of_sol(matches: &ArgMatches<'_>, name: &str) -> Option<u64> {
     value_of(matches, name).map(sol_to_lamports)
+}
+
+pub fn cluster_type_of(matches: &ArgMatches<'_>, name: &str) -> Option<ClusterType> {
+    value_of(matches, name)
 }
 
 pub fn commitment_of(matches: &ArgMatches<'_>, name: &str) -> Option<CommitmentConfig> {

--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -99,7 +99,7 @@ mod tests {
     use solana_sdk::{
         account::Account,
         epoch_schedule::EpochSchedule,
-        genesis_config::{GenesisConfig, OperatingMode},
+        genesis_config::{ClusterType, GenesisConfig},
     };
     use solana_stake_program::stake_state::{Authorized, Lockup, Meta, StakeState};
     use std::{collections::BTreeMap, sync::Arc};
@@ -150,7 +150,7 @@ mod tests {
         let genesis_config = GenesisConfig {
             accounts,
             epoch_schedule: EpochSchedule::new(slots_per_epoch),
-            operating_mode: OperatingMode::Stable,
+            cluster_type: ClusterType::MainnetBeta,
             ..GenesisConfig::default()
         };
         let mut bank = Arc::new(Bank::new(&genesis_config));

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -33,7 +33,7 @@ use solana_runtime::{
 };
 use solana_sdk::{
     clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
-    genesis_config::OperatingMode,
+    genesis_config::ClusterType,
     hash::Hash,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
@@ -281,7 +281,7 @@ impl ReplayStage {
                 let root_bank = bank_forks.read().unwrap().root_bank().clone();
                 let root = root_bank.slot();
                 let unlock_heaviest_subtree_fork_choice_slot =
-                    Self::get_unlock_heaviest_subtree_fork_choice(root_bank.operating_mode());
+                    Self::get_unlock_heaviest_subtree_fork_choice(root_bank.cluster_type());
                 let mut heaviest_subtree_fork_choice =
                     HeaviestSubtreeForkChoice::new_from_frozen_banks(root, &frozen_banks);
                 let mut bank_weight_fork_choice = BankWeightForkChoice::default();
@@ -1129,7 +1129,7 @@ impl ReplayStage {
         let node_keypair = cluster_info.keypair.clone();
 
         // Send our last few votes along with the new one
-        let vote_ix = if bank.slot() > Self::get_unlock_switch_vote_slot(bank.operating_mode()) {
+        let vote_ix = if bank.slot() > Self::get_unlock_switch_vote_slot(bank.cluster_type()) {
             switch_fork_decision
                 .to_vote_instruction(
                     vote,
@@ -1855,23 +1855,25 @@ impl ReplayStage {
         }
     }
 
-    pub fn get_unlock_switch_vote_slot(operating_mode: OperatingMode) -> Slot {
-        match operating_mode {
-            OperatingMode::Development => 0,
-            // 400_000 slots into epoch 61
-            OperatingMode::Stable => 26_752_000,
+    pub fn get_unlock_switch_vote_slot(cluster_type: ClusterType) -> Slot {
+        match cluster_type {
+            ClusterType::Development => 0,
+            ClusterType::Devnet => 0,
             // Epoch 63
-            OperatingMode::Preview => 21_692_256,
+            ClusterType::Testnet => 21_692_256,
+            // 400_000 slots into epoch 61
+            ClusterType::MainnetBeta => 26_752_000,
         }
     }
 
-    pub fn get_unlock_heaviest_subtree_fork_choice(operating_mode: OperatingMode) -> Slot {
-        match operating_mode {
-            OperatingMode::Development => 0,
-            // 400_000 slots into epoch 61
-            OperatingMode::Stable => 26_752_000,
+    pub fn get_unlock_heaviest_subtree_fork_choice(cluster_type: ClusterType) -> Slot {
+        match cluster_type {
+            ClusterType::Development => 0,
+            ClusterType::Devnet => 0,
             // Epoch 63
-            OperatingMode::Preview => 21_692_256,
+            ClusterType::Testnet => 21_692_256,
+            // 400_000 slots into epoch 61
+            ClusterType::MainnetBeta => 26_752_000,
         }
     }
 

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -407,7 +407,7 @@ mod tests {
     use solana_runtime::{
         bank::Bank, bank_forks::CompressionType, snapshot_utils::SnapshotVersion,
     };
-    use solana_sdk::{genesis_config::OperatingMode, signature::Signer};
+    use solana_sdk::{genesis_config::ClusterType, signature::Signer};
     use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
@@ -462,7 +462,7 @@ mod tests {
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(10_000);
-        genesis_config.operating_mode = OperatingMode::Stable;
+        genesis_config.cluster_type = ClusterType::MainnetBeta;
         let bank = Bank::new(&genesis_config);
         Arc::new(RwLock::new(BankForks::new(bank)))
     }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -428,12 +428,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     match matches.value_of("hashes_per_tick").unwrap() {
         "auto" => match cluster_type {
-            ClusterType::Development | ClusterType::Devnet => {
+            ClusterType::Development => {
                 let hashes_per_tick =
                     compute_hashes_per_tick(poh_config.target_tick_duration, 1_000_000);
                 poh_config.hashes_per_tick = Some(hashes_per_tick);
             }
-            ClusterType::Testnet | ClusterType::MainnetBeta => {
+            ClusterType::Devnet | ClusterType::Testnet | ClusterType::MainnetBeta => {
                 poh_config.hashes_per_tick =
                     Some(clock::DEFAULT_HASHES_PER_SECOND / clock::DEFAULT_TICKS_PER_SECOND);
             }
@@ -450,8 +450,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         value_t_or_exit!(matches, "slots_per_epoch", u64)
     } else {
         match cluster_type {
-            ClusterType::Development | ClusterType::Devnet => clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
-            ClusterType::Testnet | ClusterType::MainnetBeta => clock::DEFAULT_SLOTS_PER_EPOCH,
+            ClusterType::Development => clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
+            ClusterType::Devnet | ClusterType::Testnet | ClusterType::MainnetBeta => {
+                clock::DEFAULT_SLOTS_PER_EPOCH
+            }
         }
     };
     let epoch_schedule = EpochSchedule::custom(

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -2,7 +2,7 @@
 
 use clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg, ArgMatches};
 use solana_clap_utils::{
-    input_parsers::{pubkey_of, pubkeys_of, unix_timestamp_from_rfc3339_datetime},
+    input_parsers::{cluster_type_of, pubkey_of, pubkeys_of, unix_timestamp_from_rfc3339_datetime},
     input_validators::{is_pubkey_or_keypair, is_rfc3339_datetime, is_valid_percentage},
 };
 use solana_genesis::{genesis_accounts::add_genesis_accounts, Base64Account};
@@ -329,10 +329,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         .arg(
             Arg::with_name("cluster_type")
                 .long("cluster-type")
-                .possible_value("development")
-                .possible_value("devnet")
-                .possible_value("testnet")
-                .possible_value("mainnet-beta")
+                .possible_values(&ClusterType::STRINGS)
                 .takes_value(true)
                 .default_value(default_cluster_type)
                 .help(
@@ -427,13 +424,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Duration::from_micros(default_target_tick_duration)
     };
 
-    let cluster_type = match matches.value_of("cluster_type").unwrap() {
-        "development" => ClusterType::Development,
-        "devnet" => ClusterType::Devnet,
-        "testnet" => ClusterType::Testnet,
-        "mainnet-beta" => ClusterType::MainnetBeta,
-        _ => unreachable!(),
-    };
+    let cluster_type = cluster_type_of(&matches, "cluster_type").unwrap();
 
     match matches.value_of("hashes_per_tick").unwrap() {
         "auto" => match cluster_type {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
     clock,
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeRateGovernor,
-    genesis_config::{GenesisConfig, OperatingMode},
+    genesis_config::{ClusterType, GenesisConfig},
     native_token::sol_to_lamports,
     poh_config::PohConfig,
     pubkey::Pubkey,
@@ -130,7 +130,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let default_target_tick_duration =
         timing::duration_as_us(&PohConfig::default().target_tick_duration);
     let default_ticks_per_slot = &clock::DEFAULT_TICKS_PER_SLOT.to_string();
-    let default_operating_mode = "stable";
+    let default_cluster_type = "mainnet-beta";
     let default_genesis_archive_unpacked_size = MAX_GENESIS_ARCHIVE_UNPACKED_SIZE.to_string();
 
     let matches = App::new(crate_name!())
@@ -327,13 +327,14 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .help("The location of pubkey for primordial accounts and balance"),
         )
         .arg(
-            Arg::with_name("operating_mode")
-                .long("operating-mode")
+            Arg::with_name("cluster_type")
+                .long("cluster-type")
                 .possible_value("development")
-                .possible_value("preview")
-                .possible_value("stable")
+                .possible_value("devnet")
+                .possible_value("testnet")
+                .possible_value("mainnet-beta")
                 .takes_value(true)
-                .default_value(default_operating_mode)
+                .default_value(default_cluster_type)
                 .help(
                     "Selects the features that will be enabled for the cluster"
                 ),
@@ -426,21 +427,22 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Duration::from_micros(default_target_tick_duration)
     };
 
-    let operating_mode = match matches.value_of("operating_mode").unwrap() {
-        "development" => OperatingMode::Development,
-        "stable" => OperatingMode::Stable,
-        "preview" => OperatingMode::Preview,
+    let cluster_type = match matches.value_of("cluster_type").unwrap() {
+        "development" => ClusterType::Development,
+        "devnet" => ClusterType::Devnet,
+        "testnet" => ClusterType::Testnet,
+        "mainnet-beta" => ClusterType::MainnetBeta,
         _ => unreachable!(),
     };
 
     match matches.value_of("hashes_per_tick").unwrap() {
-        "auto" => match operating_mode {
-            OperatingMode::Development => {
+        "auto" => match cluster_type {
+            ClusterType::Development | ClusterType::Devnet => {
                 let hashes_per_tick =
                     compute_hashes_per_tick(poh_config.target_tick_duration, 1_000_000);
                 poh_config.hashes_per_tick = Some(hashes_per_tick);
             }
-            OperatingMode::Stable | OperatingMode::Preview => {
+            ClusterType::Testnet | ClusterType::MainnetBeta => {
                 poh_config.hashes_per_tick =
                     Some(clock::DEFAULT_HASHES_PER_SECOND / clock::DEFAULT_TICKS_PER_SECOND);
             }
@@ -456,9 +458,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let slots_per_epoch = if matches.value_of("slots_per_epoch").is_some() {
         value_t_or_exit!(matches, "slots_per_epoch", u64)
     } else {
-        match operating_mode {
-            OperatingMode::Development => clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
-            OperatingMode::Stable | OperatingMode::Preview => clock::DEFAULT_SLOTS_PER_EPOCH,
+        match cluster_type {
+            ClusterType::Development | ClusterType::Devnet => clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
+            ClusterType::Testnet | ClusterType::MainnetBeta => clock::DEFAULT_SLOTS_PER_EPOCH,
         }
     };
     let epoch_schedule = EpochSchedule::custom(
@@ -468,8 +470,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     );
 
     let native_instruction_processors =
-        solana_genesis_programs::get_native_programs_for_genesis(operating_mode);
-    let inflation = solana_genesis_programs::get_inflation(operating_mode, 0).unwrap();
+        solana_genesis_programs::get_native_programs_for_genesis(cluster_type);
+    let inflation = solana_genesis_programs::get_inflation(cluster_type, 0).unwrap();
 
     let mut genesis_config = GenesisConfig {
         native_instruction_processors,
@@ -479,7 +481,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         fee_rate_governor,
         rent,
         poh_config,
-        operating_mode,
+        cluster_type,
         ..GenesisConfig::default()
     };
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -28,7 +28,7 @@ use solana_runtime::{
 use solana_sdk::{
     account::Account,
     clock::{Epoch, Slot},
-    genesis_config::{GenesisConfig, OperatingMode},
+    genesis_config::{ClusterType, GenesisConfig},
     hash::Hash,
     inflation::Inflation,
     native_token::{lamports_to_sol, sol_to_lamports, Sol},
@@ -947,11 +947,12 @@ fn main() {
             .arg(&max_genesis_archive_unpacked_size_arg)
             .arg(&hashes_per_tick)
             .arg(
-                Arg::with_name("operating_mode")
-                    .long("operating-mode")
+                Arg::with_name("cluster_type")
+                    .long("cluster-type")
                     .possible_value("development")
-                    .possible_value("preview")
-                    .possible_value("stable")
+                    .possible_value("devnet")
+                    .possible_value("testnet")
+                    .possible_value("mainnet-beta")
                     .takes_value(true)
                     .help(
                         "Selects the features that will be enabled for the cluster"
@@ -1333,11 +1334,12 @@ fn main() {
             let mut genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
             let output_directory = PathBuf::from(arg_matches.value_of("output_directory").unwrap());
 
-            if let Some(operating_mode) = arg_matches.value_of("operating_mode") {
-                genesis_config.operating_mode = match operating_mode {
-                    "development" => OperatingMode::Development,
-                    "stable" => OperatingMode::Stable,
-                    "preview" => OperatingMode::Preview,
+            if let Some(cluster_type) = arg_matches.value_of("cluster_type") {
+                genesis_config.cluster_type = match cluster_type {
+                    "development" => ClusterType::Development,
+                    "devnet" => ClusterType::Devnet,
+                    "testnet" => ClusterType::Testnet,
+                    "mainnet-beta" => ClusterType::MainnetBeta,
                     _ => unreachable!(),
                 };
             }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -6,7 +6,7 @@ use log::*;
 use regex::Regex;
 use serde_json::json;
 use solana_clap_utils::{
-    input_parsers::{pubkey_of, pubkeys_of},
+    input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
     input_validators::{is_parsable, is_pubkey_or_keypair, is_slot, is_valid_percentage},
 };
 use solana_ledger::entry::Entry;
@@ -949,10 +949,7 @@ fn main() {
             .arg(
                 Arg::with_name("cluster_type")
                     .long("cluster-type")
-                    .possible_value("development")
-                    .possible_value("devnet")
-                    .possible_value("testnet")
-                    .possible_value("mainnet-beta")
+                    .possible_values(&ClusterType::STRINGS)
                     .takes_value(true)
                     .help(
                         "Selects the features that will be enabled for the cluster"
@@ -1334,14 +1331,8 @@ fn main() {
             let mut genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
             let output_directory = PathBuf::from(arg_matches.value_of("output_directory").unwrap());
 
-            if let Some(cluster_type) = arg_matches.value_of("cluster_type") {
-                genesis_config.cluster_type = match cluster_type {
-                    "development" => ClusterType::Development,
-                    "devnet" => ClusterType::Devnet,
-                    "testnet" => ClusterType::Testnet,
-                    "mainnet-beta" => ClusterType::MainnetBeta,
-                    _ => unreachable!(),
-                };
+            if let Some(cluster_type) = cluster_type_of(arg_matches, "cluster_type") {
+                genesis_config.cluster_type = cluster_type;
             }
 
             if let Some(hashes_per_tick) = arg_matches.value_of("hashes_per_tick") {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -313,7 +313,7 @@ fn initiate_callback(mut bank: &mut Arc<Bank>, genesis_config: &GenesisConfig) {
     Arc::get_mut(&mut bank)
         .unwrap()
         .initiate_entered_epoch_callback(solana_genesis_programs::get_entered_epoch_callback(
-            genesis_config.operating_mode,
+            genesis_config.cluster_type,
         ));
 }
 
@@ -3173,7 +3173,7 @@ pub mod tests {
             mut genesis_config, ..
         } = create_genesis_config(123);
 
-        genesis_config.operating_mode = solana_sdk::genesis_config::OperatingMode::Stable;
+        genesis_config.cluster_type = solana_sdk::genesis_config::ClusterType::MainnetBeta;
         let (ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
         let blockstore = Blockstore::open(&ledger_path).unwrap();
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -20,7 +20,7 @@ use solana_sdk::{
     clock::{DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
     commitment_config::CommitmentConfig,
     epoch_schedule::EpochSchedule,
-    genesis_config::{GenesisConfig, OperatingMode},
+    genesis_config::{ClusterType, GenesisConfig},
     message::Message,
     poh_config::PohConfig,
     pubkey::Pubkey,
@@ -64,7 +64,7 @@ pub struct ClusterConfig {
     pub stakers_slot_offset: u64,
     pub skip_warmup_slots: bool,
     pub native_instruction_processors: Vec<(String, Pubkey)>,
-    pub operating_mode: OperatingMode,
+    pub cluster_type: ClusterType,
     pub poh_config: PohConfig,
 }
 
@@ -80,7 +80,7 @@ impl Default for ClusterConfig {
             slots_per_epoch: DEFAULT_DEV_SLOTS_PER_EPOCH,
             stakers_slot_offset: DEFAULT_DEV_SLOTS_PER_EPOCH,
             native_instruction_processors: vec![],
-            operating_mode: OperatingMode::Development,
+            cluster_type: ClusterType::Development,
             poh_config: PohConfig::default(),
             skip_warmup_slots: false,
         }
@@ -166,21 +166,21 @@ impl LocalCluster {
             config.stakers_slot_offset,
             !config.skip_warmup_slots,
         );
-        genesis_config.operating_mode = config.operating_mode;
+        genesis_config.cluster_type = config.cluster_type;
         genesis_config.poh_config = config.poh_config.clone();
 
-        match genesis_config.operating_mode {
-            OperatingMode::Stable | OperatingMode::Preview => {
+        match genesis_config.cluster_type {
+            ClusterType::MainnetBeta | ClusterType::Testnet => {
                 genesis_config.native_instruction_processors =
                     solana_genesis_programs::get_native_programs_for_genesis(
-                        genesis_config.operating_mode,
+                        genesis_config.cluster_type,
                     )
             }
             _ => (),
         }
 
         genesis_config.inflation =
-            solana_genesis_programs::get_inflation(genesis_config.operating_mode, 0).unwrap();
+            solana_genesis_programs::get_inflation(genesis_config.cluster_type, 0).unwrap();
 
         genesis_config
             .native_instruction_processors

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -32,7 +32,7 @@ use solana_sdk::{
     clock::{self, Slot},
     commitment_config::CommitmentConfig,
     epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
-    genesis_config::OperatingMode,
+    genesis_config::ClusterType,
     hash::Hash,
     poh_config::PohConfig,
     pubkey::Pubkey,
@@ -734,11 +734,11 @@ fn test_listener_startup() {
 
 #[test]
 #[serial]
-fn test_stable_operating_mode() {
+fn test_mainnet_beta_cluster_type() {
     solana_logger::setup();
 
     let config = ClusterConfig {
-        operating_mode: OperatingMode::Stable,
+        cluster_type: ClusterType::MainnetBeta,
         node_stakes: vec![100; 1],
         cluster_lamports: 1_000,
         validator_configs: vec![ValidatorConfig::default(); 1],

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -46,6 +46,6 @@ default_arg --ledger "$SOLANA_CONFIG_DIR"/bootstrap-validator
 default_arg --faucet-pubkey "$SOLANA_CONFIG_DIR"/faucet.json
 default_arg --faucet-lamports 500000000000000000
 default_arg --hashes-per-tick auto
-default_arg --operating-mode development
+default_arg --cluster-type development
 
 $solana_genesis "${args[@]}"

--- a/net/net.sh
+++ b/net/net.sh
@@ -94,9 +94,9 @@ Operate a configured testnet
    --deploy-if-newer                  - Only deploy if newer software is
                                         available (requires -t or -T)
 
-   --operating-mode development|softlaunch
+   --cluster-type development|devnet|testnet|mainnet-beta
                                       - Specify whether or not to launch the cluster in "development" mode with all features enabled at epoch 0,
-                                        or "softlaunch" mode with some features disabled at epoch 0 (default: development)
+                                        or various other live clusters' feature set (default: development)
    --warp-slot WARP_SLOT              - Boot from a snapshot that has warped ahead to WARP_SLOT rather than a slot 0 genesis.
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
@@ -779,12 +779,12 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --faucet-lamports ]]; then
       genesisOptions="$genesisOptions $1 $2"
       shift 2
-    elif [[ $1 = --operating-mode ]]; then
+    elif [[ $1 = --cluster-type ]]; then
       case "$2" in
-        development|softlaunch)
+        development|devnet|testnet|mainnet-beta)
           ;;
         *)
-          echo "Unexpected operating mode: \"$2\""
+          echo "Unexpected cluster type: \"$2\""
           exit 1
           ;;
       esac

--- a/run.sh
+++ b/run.sh
@@ -78,7 +78,7 @@ else
       "$dataDir"/validator-vote-account.json \
       "$dataDir"/validator-stake-account.json \
     --ledger "$ledgerDir" \
-    --operating-mode development \
+    --cluster-type development \
     $SPL_GENESIS_ARGS \
     $SOLANA_RUN_SH_GENESIS_ARGS
 fi

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -8,7 +8,7 @@ use solana_runtime::{
 };
 use solana_sdk::{
     account::Account,
-    genesis_config::{create_genesis_config, OperatingMode},
+    genesis_config::{create_genesis_config, ClusterType},
     pubkey::Pubkey,
 };
 use std::{path::PathBuf, sync::Arc};
@@ -71,7 +71,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
 fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let accounts = Accounts::new(
         vec![PathBuf::from("bench_accounts_hash_internal")],
-        &OperatingMode::Development,
+        &ClusterType::Development,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 60000, 0);
@@ -85,7 +85,7 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
     solana_logger::setup();
     let accounts = Accounts::new(
         vec![PathBuf::from("update_accounts_hash")],
-        &OperatingMode::Development,
+        &ClusterType::Development,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
@@ -100,7 +100,7 @@ fn test_accounts_delta_hash(bencher: &mut Bencher) {
     solana_logger::setup();
     let accounts = Accounts::new(
         vec![PathBuf::from("accounts_delta_hash")],
-        &OperatingMode::Development,
+        &ClusterType::Development,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100_000, 0);
@@ -114,7 +114,7 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
     solana_logger::setup();
     let accounts = Accounts::new(
         vec![PathBuf::from("accounts_delete_deps")],
-        &OperatingMode::Development,
+        &ClusterType::Development,
     );
     let mut old_pubkey = Pubkey::default();
     let zero_account = Account::new(0, 0, &Account::default().owner);

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -820,7 +820,7 @@ mod tests {
     ) -> Vec<(Result<TransactionLoadResult>, Option<HashAgeKind>)> {
         let mut hash_queue = BlockhashQueue::new(100);
         hash_queue.register_hash(&tx.message().recent_blockhash, &fee_calculator);
-        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
         for ka in ka.iter() {
             accounts.store_slow(0, &ka.0, &ka.1);
         }
@@ -1030,7 +1030,7 @@ mod tests {
                 lamports_per_byte_year: 42,
                 ..Rent::default()
             },
-            ClusterType::Devnet,
+            ClusterType::Development,
         );
         let min_balance = rent_collector.rent.minimum_balance(nonce::State::size());
         let fee_calculator = FeeCalculator::new(min_balance);
@@ -1386,7 +1386,7 @@ mod tests {
 
     #[test]
     fn test_load_by_program_slot() {
-        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
 
         // Load accounts owned by various programs into AccountsDB
         let pubkey0 = Pubkey::new_rand();
@@ -1409,7 +1409,7 @@ mod tests {
 
     #[test]
     fn test_accounts_account_not_found() {
-        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
         let mut error_counters = ErrorCounters::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
 
@@ -1431,7 +1431,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_accounts_empty_bank_hash() {
-        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
         accounts.bank_hash_at(1);
     }
 
@@ -1447,7 +1447,7 @@ mod tests {
         let account2 = Account::new(3, 0, &Pubkey::default());
         let account3 = Account::new(4, 0, &Pubkey::default());
 
-        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
         accounts.store_slow(0, &keypair0.pubkey(), &account0);
         accounts.store_slow(0, &keypair1.pubkey(), &account1);
         accounts.store_slow(0, &keypair2.pubkey(), &account2);
@@ -1559,7 +1559,7 @@ mod tests {
         let account1 = Account::new(2, 0, &Pubkey::default());
         let account2 = Account::new(3, 0, &Pubkey::default());
 
-        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
         accounts.store_slow(0, &keypair0.pubkey(), &account0);
         accounts.store_slow(0, &keypair1.pubkey(), &account1);
         accounts.store_slow(0, &keypair2.pubkey(), &account2);
@@ -1689,7 +1689,7 @@ mod tests {
 
         let mut loaded = vec![loaded0, loaded1];
 
-        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
         {
             let mut readonly_locks = accounts.readonly_locks.write().unwrap();
             let readonly_locks = readonly_locks.as_mut().unwrap();
@@ -1740,7 +1740,7 @@ mod tests {
     #[test]
     fn huge_clean() {
         solana_logger::setup();
-        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
         let mut old_pubkey = Pubkey::default();
         let zero_account = Account::new(0, 0, &Account::default().owner);
         info!("storing..");

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -18,7 +18,7 @@ use solana_sdk::{
     account::Account,
     clock::Slot,
     fee_calculator::FeeCalculator,
-    genesis_config::OperatingMode,
+    genesis_config::ClusterType,
     hash::Hash,
     message::Message,
     native_loader, nonce,
@@ -67,10 +67,10 @@ pub enum AccountAddressFilter {
 }
 
 impl Accounts {
-    pub fn new(paths: Vec<PathBuf>, operating_mode: &OperatingMode) -> Self {
+    pub fn new(paths: Vec<PathBuf>, cluster_type: &ClusterType) -> Self {
         Self {
             slot: 0,
-            accounts_db: Arc::new(AccountsDB::new(paths, operating_mode)),
+            accounts_db: Arc::new(AccountsDB::new(paths, cluster_type)),
             account_locks: Mutex::new(HashSet::new()),
             readonly_locks: Arc::new(RwLock::new(Some(HashMap::new()))),
         }
@@ -796,7 +796,7 @@ mod tests {
         account::Account,
         epoch_schedule::EpochSchedule,
         fee_calculator::FeeCalculator,
-        genesis_config::OperatingMode,
+        genesis_config::ClusterType,
         hash::Hash,
         instruction::CompiledInstruction,
         message::Message,
@@ -820,7 +820,7 @@ mod tests {
     ) -> Vec<(Result<TransactionLoadResult>, Option<HashAgeKind>)> {
         let mut hash_queue = BlockhashQueue::new(100);
         hash_queue.register_hash(&tx.message().recent_blockhash, &fee_calculator);
-        let accounts = Accounts::new(Vec::new(), &OperatingMode::Development);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
         for ka in ka.iter() {
             accounts.store_slow(0, &ka.0, &ka.1);
         }
@@ -1030,7 +1030,7 @@ mod tests {
                 lamports_per_byte_year: 42,
                 ..Rent::default()
             },
-            OperatingMode::Development,
+            ClusterType::Devnet,
         );
         let min_balance = rent_collector.rent.minimum_balance(nonce::State::size());
         let fee_calculator = FeeCalculator::new(min_balance);
@@ -1386,7 +1386,7 @@ mod tests {
 
     #[test]
     fn test_load_by_program_slot() {
-        let accounts = Accounts::new(Vec::new(), &OperatingMode::Development);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
 
         // Load accounts owned by various programs into AccountsDB
         let pubkey0 = Pubkey::new_rand();
@@ -1409,7 +1409,7 @@ mod tests {
 
     #[test]
     fn test_accounts_account_not_found() {
-        let accounts = Accounts::new(Vec::new(), &OperatingMode::Development);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
         let mut error_counters = ErrorCounters::default();
         let ancestors = vec![(0, 0)].into_iter().collect();
 
@@ -1431,7 +1431,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_accounts_empty_bank_hash() {
-        let accounts = Accounts::new(Vec::new(), &OperatingMode::Development);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
         accounts.bank_hash_at(1);
     }
 
@@ -1447,7 +1447,7 @@ mod tests {
         let account2 = Account::new(3, 0, &Pubkey::default());
         let account3 = Account::new(4, 0, &Pubkey::default());
 
-        let accounts = Accounts::new(Vec::new(), &OperatingMode::Development);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
         accounts.store_slow(0, &keypair0.pubkey(), &account0);
         accounts.store_slow(0, &keypair1.pubkey(), &account1);
         accounts.store_slow(0, &keypair2.pubkey(), &account2);
@@ -1559,7 +1559,7 @@ mod tests {
         let account1 = Account::new(2, 0, &Pubkey::default());
         let account2 = Account::new(3, 0, &Pubkey::default());
 
-        let accounts = Accounts::new(Vec::new(), &OperatingMode::Development);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
         accounts.store_slow(0, &keypair0.pubkey(), &account0);
         accounts.store_slow(0, &keypair1.pubkey(), &account1);
         accounts.store_slow(0, &keypair2.pubkey(), &account2);
@@ -1689,7 +1689,7 @@ mod tests {
 
         let mut loaded = vec![loaded0, loaded1];
 
-        let accounts = Accounts::new(Vec::new(), &OperatingMode::Development);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
         {
             let mut readonly_locks = accounts.readonly_locks.write().unwrap();
             let readonly_locks = readonly_locks.as_mut().unwrap();
@@ -1740,7 +1740,7 @@ mod tests {
     #[test]
     fn huge_clean() {
         solana_logger::setup();
-        let accounts = Accounts::new(Vec::new(), &OperatingMode::Development);
+        let accounts = Accounts::new(Vec::new(), &ClusterType::Devnet);
         let mut old_pubkey = Pubkey::default();
         let zero_account = Account::new(0, 0, &Account::default().owner);
         info!("storing..");

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -4,15 +4,15 @@ use crate::{
 };
 use solana_sdk::{
     clock::{Epoch, GENESIS_EPOCH},
-    genesis_config::OperatingMode,
+    genesis_config::ClusterType,
     system_program,
 };
 
 use log::*;
 
-/// The entire set of available builtin programs that should be active at the given operating_mode
-pub fn get_builtins(operating_mode: OperatingMode) -> Vec<(Builtin, Epoch)> {
-    trace!("get_builtins: {:?}", operating_mode);
+/// The entire set of available builtin programs that should be active at the given cluster_type
+pub fn get_builtins(cluster_type: ClusterType) -> Vec<(Builtin, Epoch)> {
+    trace!("get_builtins: {:?}", cluster_type);
     let mut builtins = vec![];
 
     builtins.extend(
@@ -43,9 +43,9 @@ pub fn get_builtins(operating_mode: OperatingMode) -> Vec<(Builtin, Epoch)> {
         .collect::<Vec<_>>(),
     );
 
-    // repurpose Preview for test_get_builtins because the Development is overloaded...
+    // repurpose Testnet for test_get_builtins because the Development is overloaded...
     #[cfg(test)]
-    if operating_mode == OperatingMode::Preview {
+    if cluster_type == ClusterType::Testnet {
         use solana_sdk::instruction::InstructionError;
         use solana_sdk::{account::KeyedAccount, pubkey::Pubkey};
         use std::str::FromStr;
@@ -71,7 +71,7 @@ mod tests {
     use super::*;
     use crate::bank::Bank;
     use solana_sdk::{
-        genesis_config::{create_genesis_config, OperatingMode},
+        genesis_config::{create_genesis_config, ClusterType},
         pubkey::Pubkey,
     };
 
@@ -93,15 +93,16 @@ mod tests {
 
     #[test]
     fn test_uniqueness() {
-        do_test_uniqueness(get_builtins(OperatingMode::Development));
-        do_test_uniqueness(get_builtins(OperatingMode::Preview));
-        do_test_uniqueness(get_builtins(OperatingMode::Stable));
+        do_test_uniqueness(get_builtins(ClusterType::Development));
+        do_test_uniqueness(get_builtins(ClusterType::Devnet));
+        do_test_uniqueness(get_builtins(ClusterType::Testnet));
+        do_test_uniqueness(get_builtins(ClusterType::MainnetBeta));
     }
 
     #[test]
     fn test_get_builtins() {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
-        genesis_config.operating_mode = OperatingMode::Preview;
+        genesis_config.cluster_type = ClusterType::Testnet;
         let bank0 = Arc::new(Bank::new(&genesis_config));
 
         let restored_slot1 = genesis_config.epoch_schedule.get_first_slot_in_epoch(2);

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -21,8 +21,8 @@ use {
         clock::{Epoch, Slot, UnixTimestamp},
         epoch_schedule::EpochSchedule,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
+        genesis_config::ClusterType,
         genesis_config::GenesisConfig,
-        genesis_config::OperatingMode,
         hard_forks::HardForks,
         hash::Hash,
         inflation::Inflation,
@@ -233,7 +233,7 @@ where
         accounts_db_fields,
         account_paths,
         append_vecs_path,
-        &genesis_config.operating_mode,
+        &genesis_config.cluster_type,
     )?;
     accounts_db.freeze_accounts(&bank_fields.ancestors, frozen_account_pubkeys);
 
@@ -247,13 +247,13 @@ fn reconstruct_accountsdb_from_fields<E, P>(
     accounts_db_fields: AccountsDbFields<E>,
     account_paths: &[PathBuf],
     stream_append_vecs_path: P,
-    operating_mode: &OperatingMode,
+    cluster_type: &ClusterType,
 ) -> Result<AccountsDB, Error>
 where
     E: Into<AccountStorageEntry>,
     P: AsRef<Path>,
 {
-    let accounts_db = AccountsDB::new(account_paths.to_vec(), operating_mode);
+    let accounts_db = AccountsDB::new(account_paths.to_vec(), cluster_type);
 
     let AccountsDbFields(storage, version, slot, bank_hash_info) = accounts_db_fields;
 

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -11,7 +11,7 @@ use {
     solana_sdk::{
         account::Account,
         clock::Slot,
-        genesis_config::{create_genesis_config, OperatingMode},
+        genesis_config::{create_genesis_config, ClusterType},
         pubkey::Pubkey,
         signature::{Keypair, Signer},
     },
@@ -69,7 +69,7 @@ where
         C::deserialize_accounts_db_fields(stream)?,
         account_paths,
         stream_append_vecs_path,
-        &OperatingMode::Development,
+        &ClusterType::Development,
     )
 }
 
@@ -121,7 +121,7 @@ where
 fn test_accounts_serialize_style(serde_style: SerdeStyle) {
     solana_logger::setup();
     let (_accounts_dir, paths) = get_temp_accounts_paths(4).unwrap();
-    let accounts = Accounts::new(paths, &OperatingMode::Development);
+    let accounts = Accounts::new(paths, &ClusterType::Development);
 
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100, 0);

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -25,18 +25,38 @@ use std::{
     fs::{File, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
+    str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 // deprecated default that is no longer used
 pub const UNUSED_DEFAULT: u64 = 1024;
 
+// The order can't align with release lifecycle only to remain ABI-compatible...
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, AbiEnumVisitor, AbiExample)]
 pub enum ClusterType {
     Testnet,
     MainnetBeta,
     Devnet,
     Development,
+}
+
+impl ClusterType {
+    pub const STRINGS: [&'static str; 4] = ["development", "devnet", "testnet", "mainnet-beta"];
+}
+
+impl FromStr for ClusterType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "development" => Ok(ClusterType::Development),
+            "devnet" => Ok(ClusterType::Devnet),
+            "testnet" => Ok(ClusterType::Testnet),
+            "mainnet-beta" => Ok(ClusterType::MainnetBeta),
+            _ => Err(format!("{} is unrecognized for cluster type", s)),
+        }
+    }
 }
 
 #[frozen_abi(digest = "AM75NxYJj5s45rtkFV5S1RCHg2kNMgACjTu5HPfEt4Fp")]

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -32,13 +32,14 @@ use std::{
 pub const UNUSED_DEFAULT: u64 = 1024;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, AbiEnumVisitor, AbiExample)]
-pub enum OperatingMode {
-    Preview,     // Next set of cluster features to be promoted to Stable
-    Stable,      // Stable cluster features
-    Development, // All features (including experimental features)
+pub enum ClusterType {
+    Testnet,
+    MainnetBeta,
+    Devnet,
+    Development,
 }
 
-#[frozen_abi(digest = "2KQs7m2DbLxkEx6pY9Z6qwYJAhN2Q4AdoNgUcULmscgB")]
+#[frozen_abi(digest = "AM75NxYJj5s45rtkFV5S1RCHg2kNMgACjTu5HPfEt4Fp")]
 #[derive(Serialize, Deserialize, Debug, Clone, AbiExample)]
 pub struct GenesisConfig {
     /// when the network (bootstrap validator) was started relative to the UNIX Epoch
@@ -65,7 +66,7 @@ pub struct GenesisConfig {
     /// how slots map to epochs
     pub epoch_schedule: EpochSchedule,
     /// network runlevel
-    pub operating_mode: OperatingMode,
+    pub cluster_type: ClusterType,
 }
 
 // useful for basic tests
@@ -101,7 +102,7 @@ impl Default for GenesisConfig {
             fee_rate_governor: FeeRateGovernor::default(),
             rent: Rent::default(),
             epoch_schedule: EpochSchedule::default(),
-            operating_mode: OperatingMode::Development,
+            cluster_type: ClusterType::Development,
         }
     }
 }
@@ -212,7 +213,7 @@ impl fmt::Display for GenesisConfig {
             f,
             "\
              Creation time: {}\n\
-             Operating mode: {:?}\n\
+             Cluster type: {:?}\n\
              Genesis hash: {}\n\
              Shred version: {}\n\
              Ticks per slot: {:?}\n\
@@ -225,7 +226,7 @@ impl fmt::Display for GenesisConfig {
              Capitalization: {} SOL in {} accounts\n\
              ",
             Utc.timestamp(self.creation_time, 0).to_rfc3339(),
-            self.operating_mode,
+            self.cluster_type,
             self.hash(),
             compute_shred_version(&self.hash(), None),
             self.ticks_per_slot,

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -361,7 +361,7 @@ mod test {
     use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
     use solana_sdk::{
         commitment_config::CommitmentConfig,
-        genesis_config::OperatingMode,
+        genesis_config::ClusterType,
         message::Message,
         native_token::sol_to_lamports,
         signature::{Keypair, Signer},
@@ -378,7 +378,7 @@ mod test {
 
         let one_sol = sol_to_lamports(1.0);
         let cluster = LocalCluster::new(&ClusterConfig {
-            operating_mode: OperatingMode::Stable,
+            cluster_type: ClusterType::MainnetBeta,
             node_stakes: vec![10; 1],
             cluster_lamports: sol_to_lamports(1_000_000_000.0),
             validator_configs: vec![ValidatorConfig {


### PR DESCRIPTION
#### Problem

OperatingMode doesn't match with the reality.

#### Summary of Changes

Refactor and restore compatibility for devnet.

I'll create parallel prs against ~v1.2~ and [v1.3](#12069 ) to apply them at once. (Edit: I figured out backporting this should wait until @jackcmay's master backporting work (#11568) is completed first to avoid needless large merge conflicts due to inverted cherry-pick order)  

Sibling: #12069

Fixes #12039 
