### PR TITLE
chore: revert bump typescript from 3.9.7 to 4.0.2 in /web3.js

### DIFF
--- a/web3.js/package-lock.json
+++ b/web3.js/package-lock.json
@@ -10212,12 +10212,6 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        },
-        "typescript": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-          "dev": true
         }
       }
     },
@@ -22861,9 +22855,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "typescript-compiler": {

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -136,7 +136,7 @@
     "rollup-plugin-replace": "2.2.0",
     "rollup-plugin-terser": "^7.0.0",
     "semantic-release": "^17.0.2",
-    "typescript": "^4.0.2",
+    "typescript": "^3.8.3",
     "watch": "^1.0.2"
   }
 }


### PR DESCRIPTION
Reverts solana-labs/solana#11925