### PR TITLE
Fix signature subscription panic

### DIFF
--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -634,7 +634,7 @@ impl RpcSubscriptions {
     ) {
         let (commitment, enable_received_notification) = signature_subscribe_config
             .map(|config| (config.commitment, config.enable_received_notification))
-            .unwrap_or((None, Some(false)));
+            .unwrap_or_default();
 
         let commitment_level = commitment
             .unwrap_or_else(CommitmentConfig::recent)
@@ -970,9 +970,7 @@ impl RpcSubscriptions {
                     },
                 ) in hashmap.iter()
                 {
-                    if is_received_notification_enabled
-                        .expect("All signature subscriptions must have this config field set")
-                    {
+                    if is_received_notification_enabled.unwrap_or_default() {
                         notifier.notify(
                             Response {
                                 context: RpcResponseContext {


### PR DESCRIPTION
#### Problem
Signature subscriptions do not always set a `enable_received_notification` config but code expected it to always be set. This results in a panic:

```
thread 'solana-rpc-notifications' panicked at 'All signature subscriptions must have this config field set', core/src/rpc_subscriptions.rs:973:24
```

#### Summary of Changes
- Remove `expect` unwrap for `enable_received_notification` and default to false

Fixes #
