### PR TITLE
fix: update rpc-websockets to fix reconnect issue

### DIFF
--- a/web3.js/package-lock.json
+++ b/web3.js/package-lock.json
@@ -20756,9 +20756,9 @@
       }
     },
     "rpc-websockets": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.3.2.tgz",
-      "integrity": "sha512-13+luhSPKMd+LYNXb1PUb3eqZsOdwBjfqgFfs9ShTapXYI3wwq5CSLiRYdAucdRH2qOlcpMaqBkRxwvjuKtapQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.4.0.tgz",
+      "integrity": "sha512-FCPhQyD2Lfg1rOm8SOVL/FiDw7/3e9MDVeLqSSb4KBWUWmcJb/WcWtjkIXm6ecarbNmHntVLx8KH3Exyj0hMDA==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "assert-args": "^1.2.1",

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -83,7 +83,7 @@
     "mz": "^2.7.0",
     "node-fetch": "^2.2.0",
     "npm-run-all": "^4.1.5",
-    "rpc-websockets": "^7.3.2",
+    "rpc-websockets": "^7.4.0",
     "superstruct": "^0.8.3",
     "tweetnacl": "^1.0.0",
     "ws": "^7.0.0"


### PR DESCRIPTION
#### Problem
The rpc-websockets library had a bug that prevented a socket from being reconnected once closed. The latest version fixes that bug. Details: https://github.com/elpheria/rpc-websockets/pull/89

#### Summary of Changes
- Bump rpc-websockets to 7.4.0

Fixes #
