### PR TITLE
Compress snapshot archive within the validator to reduce system dependencies, and default to zstd compression

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1059,7 +1059,7 @@ pub fn main() {
         exit(1);
     });
 
-    let mut snapshot_compression = CompressionType::Bzip2;
+    let mut snapshot_compression = CompressionType::Zstd;
     if let Ok(compression_str) = value_t!(matches, "snapshot_compression", String) {
         match compression_str.as_str() {
             "bz2" => snapshot_compression = CompressionType::Bzip2,


### PR DESCRIPTION
On mainnet-beta snapshot archives compress significantly faster with zstd than bzip2 (~3x faster) and the resulting increase in archive size is not notable. 

However `zstd` is not ubiquitously installed and asking all testnet/mainnet-beta validators current and future to ensure `zstd` is installed will be annoying and error prone.  Instead still exec the system `tar` for its sparse file support but compress the stream within the validator proper.  This avoids a system dependency on `zstd`, `bzip2`, and `gzip`.

With the barrier to using `zstd` now removed, set the default snapshot archive compression to zstd.