### PR TITLE
feat: use pubsub to confirm transactions

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -51,7 +51,7 @@ declare module '@solana/web3.js' {
   };
 
   export type ConfirmOptions = {
-    confirmations?: number;
+    commitment?: Commitment;
     skipPreflight?: boolean;
   };
 
@@ -384,8 +384,8 @@ declare module '@solana/web3.js' {
     getVoteAccounts(commitment?: Commitment): Promise<VoteAccountStatus>;
     confirmTransaction(
       signature: TransactionSignature,
-      confirmations?: number,
-    ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
+      commitment?: Commitment,
+    ): Promise<RpcResponseAndContext<SignatureResult>>;
     getSlot(commitment?: Commitment): Promise<number>;
     getSlotLeader(commitment?: Commitment): Promise<string>;
     getSignatureStatus(

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -64,7 +64,7 @@ declare module '@solana/web3.js' {
   };
 
   declare export type ConfirmOptions = {
-    confirmations: ?number,
+    commitment: ?Commitment,
     skipPreflight: ?boolean,
   };
 
@@ -388,8 +388,8 @@ declare module '@solana/web3.js' {
     getVoteAccounts(commitment: ?Commitment): Promise<VoteAccountStatus>;
     confirmTransaction(
       signature: TransactionSignature,
-      confirmations: ?number,
-    ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
+      commitment: ?Commitment,
+    ): Promise<RpcResponseAndContext<SignatureResult>>;
     getSlot(commitment: ?Commitment): Promise<number>;
     getSlotLeader(commitment: ?Commitment): Promise<string>;
     getSignatureStatus(

--- a/web3.js/src/util/promise-timeout.js
+++ b/web3.js/src/util/promise-timeout.js
@@ -1,0 +1,16 @@
+// @flow
+
+export function promiseTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T | null> {
+  let timeoutId: TimeoutID;
+  const timeoutPromise = new Promise(resolve => {
+    timeoutId = setTimeout(() => resolve(null), timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).then(result => {
+    clearTimeout(timeoutId);
+    return result;
+  });
+}

--- a/web3.js/src/util/send-and-confirm-raw-transaction.js
+++ b/web3.js/src/util/send-and-confirm-raw-transaction.js
@@ -7,7 +7,7 @@ import type {ConfirmOptions} from '../connection';
 /**
  * Send and confirm a raw transaction
  *
- * If `confirmations` count is not specified, wait for transaction to be finalized.
+ * If `commitment` option is not specified, defaults to 'max' commitment.
  *
  * @param {Connection} connection
  * @param {Buffer} rawTransaction
@@ -19,31 +19,23 @@ export async function sendAndConfirmRawTransaction(
   rawTransaction: Buffer,
   options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
-  const start = Date.now();
   const signature = await connection.sendRawTransaction(
     rawTransaction,
     options,
   );
+
   const status = (
     await connection.confirmTransaction(
       signature,
-      options && options.confirmations,
+      options && options.commitment,
     )
   ).value;
 
-  if (status) {
-    if (status.err) {
-      throw new Error(
-        `Raw transaction ${signature} failed (${JSON.stringify(status)})`,
-      );
-    }
-    return signature;
+  if (status.err) {
+    throw new Error(
+      `Raw transaction ${signature} failed (${JSON.stringify(status)})`,
+    );
   }
 
-  const duration = (Date.now() - start) / 1000;
-  throw new Error(
-    `Raw transaction '${signature}' was not confirmed in ${duration.toFixed(
-      2,
-    )} seconds`,
-  );
+  return signature;
 }

--- a/web3.js/src/util/send-and-confirm-transaction.js
+++ b/web3.js/src/util/send-and-confirm-transaction.js
@@ -9,7 +9,7 @@ import type {TransactionSignature} from '../transaction';
 /**
  * Sign, send and confirm a transaction.
  *
- * If `confirmations` count is not specified, wait for transaction to be finalized.
+ * If `commitment` option is not specified, defaults to 'max' commitment.
  *
  * @param {Connection} connection
  * @param {Transaction} transaction
@@ -23,32 +23,24 @@ export async function sendAndConfirmTransaction(
   signers: Array<Account>,
   options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
-  const start = Date.now();
   const signature = await connection.sendTransaction(
     transaction,
     signers,
     options,
   );
+
   const status = (
     await connection.confirmTransaction(
       signature,
-      options && options.confirmations,
+      options && options.commitment,
     )
   ).value;
 
-  if (status) {
-    if (status.err) {
-      throw new Error(
-        `Transaction ${signature} failed (${JSON.stringify(status)})`,
-      );
-    }
-    return signature;
+  if (status.err) {
+    throw new Error(
+      `Transaction ${signature} failed (${JSON.stringify(status)})`,
+    );
   }
 
-  const duration = (Date.now() - start) / 1000;
-  throw new Error(
-    `Transaction was not confirmed in ${duration.toFixed(
-      2,
-    )} seconds (${JSON.stringify(status)})`,
-  );
+  return signature;
 }

--- a/web3.js/test/__mocks__/rpc-websockets.js
+++ b/web3.js/test/__mocks__/rpc-websockets.js
@@ -1,29 +1,75 @@
 // @flow
 
 import {Client as LiveClient} from 'rpc-websockets';
+import EventEmitter from 'events';
+
+type RpcRequest = {
+  method: string,
+  params?: Array<any>,
+};
+
+type RpcResponse = {
+  context: {
+    slot: number,
+  },
+  value: any,
+};
 
 // Define TEST_LIVE in the environment to test against the real full node
 // identified by `url` instead of using the mock
 export const mockRpcEnabled = !process.env.TEST_LIVE;
 
-let mockNotice = true;
+export const mockRpcSocket: Array<[RpcRequest, RpcResponse]> = [];
 
-class MockClient {
-  constructor(url: string) {
-    if (mockNotice) {
-      console.log(
-        'Note: rpc-websockets mock is disabled, testing live against',
-        url,
-      );
-      mockNotice = false;
+class MockClient extends EventEmitter {
+  mockOpen = false;
+  subscriptionCounter = 0;
+
+  constructor() {
+    super();
+  }
+
+  connect() {
+    if (!this.mockOpen) {
+      this.mockOpen = true;
+      this.emit('open');
     }
   }
 
-  connect() {}
-  close() {}
-  on() {}
-  call(): Promise<Object> {
-    throw new Error('call unsupported');
+  close() {
+    if (this.mockOpen) {
+      this.mockOpen = false;
+      this.emit('close');
+    }
+  }
+
+  notify(): Promise<any> {
+    return Promise.resolve();
+  }
+
+  on(event: string, callback: Function): this {
+    return super.on(event, callback);
+  }
+
+  call(method: string, params: Array<any>): Promise<Object> {
+    expect(mockRpcSocket.length).toBeGreaterThanOrEqual(1);
+    const [mockRequest, mockResponse] = mockRpcSocket.shift();
+
+    expect(method).toBe(mockRequest.method);
+    expect(params).toMatchObject(mockRequest.params);
+
+    let id = this.subscriptionCounter++;
+    const response = {
+      subscription: id,
+      result: mockResponse,
+    };
+
+    setImmediate(() => {
+      const eventName = method.replace('Subscribe', 'Notification');
+      this.emit(eventName, response);
+    });
+
+    return Promise.resolve(id);
   }
 }
 

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -1,6 +1,5 @@
 // @flow
 
-import bs58 from 'bs58';
 import fs from 'mz/fs';
 
 import {
@@ -47,7 +46,7 @@ test('load BPF C program', async () => {
     programId: program.publicKey,
   });
   await sendAndConfirmTransaction(connection, transaction, [from], {
-    confirmations: 1,
+    commitment: 'single',
     skipPreflight: true,
   });
 });
@@ -90,22 +89,22 @@ describe('load BPF Rust program', () => {
       data,
       BPF_LOADER_PROGRAM_ID,
     );
+
     const transaction = new Transaction().add({
       keys: [
         {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
       ],
       programId: program.publicKey,
     });
-    await sendAndConfirmTransaction(connection, transaction, [payerAccount], {
-      skipPreflight: true,
-    });
 
-    if (transaction.signature === null) {
-      expect(transaction.signature).not.toBeNull();
-      return;
-    }
-
-    signature = bs58.encode(transaction.signature);
+    signature = await sendAndConfirmTransaction(
+      connection,
+      transaction,
+      [payerAccount],
+      {
+        skipPreflight: true,
+      },
+    );
   });
 
   test('get confirmed transaction', async () => {

--- a/web3.js/test/mockrpc/confirm-transaction.js
+++ b/web3.js/test/mockrpc/confirm-transaction.js
@@ -1,31 +1,19 @@
 // @flow
 
 import type {TransactionSignature} from '../../src/transaction';
-import {url} from '../url';
-import {mockRpc} from '../__mocks__/node-fetch';
+import {mockRpcSocket} from '../__mocks__/rpc-websockets';
 
 export function mockConfirmTransaction(signature: TransactionSignature) {
-  mockRpc.push([
-    url,
+  mockRpcSocket.push([
     {
-      method: 'getSignatureStatuses',
-      params: [[signature]],
+      method: 'signatureSubscribe',
+      params: [signature, {commitment: 'single'}],
     },
     {
-      error: null,
-      result: {
-        context: {
-          slot: 11,
-        },
-        value: [
-          {
-            slot: 0,
-            confirmations: null,
-            status: {Ok: null},
-            err: null,
-          },
-        ],
+      context: {
+        slot: 11,
       },
+      value: {err: null},
     },
   ]);
 }

--- a/web3.js/test/new-account-with-lamports.js
+++ b/web3.js/test/new-account-with-lamports.js
@@ -26,6 +26,11 @@ export async function newAccountWithLamports(
     ]);
   }
 
-  await connection.requestAirdrop(account.publicKey, lamports);
+  const signature = await connection.requestAirdrop(
+    account.publicKey,
+    lamports,
+  );
+  await connection.confirmTransaction(signature, 'single');
+
   return account;
 }

--- a/web3.js/test/nonce.test.js
+++ b/web3.js/test/nonce.test.js
@@ -64,7 +64,7 @@ test('create and query nonce account', async () => {
     minimumAmount * 2,
   );
   mockConfirmTransaction(signature);
-  await connection.confirmTransaction(signature, 0);
+  await connection.confirmTransaction(signature, 'single');
 
   mockRpc.push([
     url,
@@ -113,7 +113,7 @@ test('create and query nonce account', async () => {
     },
   );
   mockConfirmTransaction(nonceSignature);
-  await connection.confirmTransaction(nonceSignature, 0);
+  await connection.confirmTransaction(nonceSignature, 'single');
 
   mockRpc.push([
     url,
@@ -193,7 +193,7 @@ test('create and query nonce account with seed', async () => {
     minimumAmount * 2,
   );
   mockConfirmTransaction(signature);
-  await connection.confirmTransaction(signature, 0);
+  await connection.confirmTransaction(signature, 'single');
 
   mockRpc.push([
     url,
@@ -240,7 +240,7 @@ test('create and query nonce account with seed', async () => {
     skipPreflight: true,
   });
   mockConfirmTransaction(nonceSignature);
-  await connection.confirmTransaction(nonceSignature, 0);
+  await connection.confirmTransaction(nonceSignature, 'single');
 
   mockRpc.push([
     url,

--- a/web3.js/test/stake-program.test.js
+++ b/web3.js/test/stake-program.test.js
@@ -295,7 +295,7 @@ test('live staking actions', async () => {
       connection,
       createAndInitialize,
       [from, newStakeAccount],
-      {confirmations: 0, skipPreflight: true},
+      {commitment: 'single', skipPreflight: true},
     );
     expect(await connection.getBalance(newStakeAccount.publicKey)).toEqual(
       minimumAmount + 42,
@@ -307,7 +307,7 @@ test('live staking actions', async () => {
       votePubkey,
     });
     await sendAndConfirmTransaction(connection, delegation, [authorized], {
-      confirmations: 0,
+      commitment: 'single',
       skipPreflight: true,
     });
   }
@@ -334,7 +334,7 @@ test('live staking actions', async () => {
     connection,
     createAndInitializeWithSeed,
     [from],
-    {confirmations: 0, skipPreflight: true},
+    {commitment: 'single', skipPreflight: true},
   );
   let originalStakeBalance = await connection.getBalance(newAccountPubkey);
   expect(originalStakeBalance).toEqual(3 * minimumAmount + 42);
@@ -345,7 +345,7 @@ test('live staking actions', async () => {
     votePubkey,
   });
   await sendAndConfirmTransaction(connection, delegation, [authorized], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
 
@@ -359,7 +359,7 @@ test('live staking actions', async () => {
   });
   await expect(
     sendAndConfirmTransaction(connection, withdraw, [authorized], {
-      confirmations: 0,
+      commitment: 'single',
       skipPreflight: true,
     }),
   ).rejects.toThrow();
@@ -373,7 +373,7 @@ test('live staking actions', async () => {
     lamports: minimumAmount + 20,
   });
   await sendAndConfirmTransaction(connection, split, [authorized, newStake], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
 
@@ -388,7 +388,7 @@ test('live staking actions', async () => {
     stakeAuthorizationType: StakeAuthorizationLayout.Withdrawer,
   });
   await sendAndConfirmTransaction(connection, authorize, [authorized], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
   authorize = StakeProgram.authorize({
@@ -398,7 +398,7 @@ test('live staking actions', async () => {
     stakeAuthorizationType: StakeAuthorizationLayout.Staker,
   });
   await sendAndConfirmTransaction(connection, authorize, [authorized], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
 
@@ -412,7 +412,7 @@ test('live staking actions', async () => {
       connection,
       deactivateNotAuthorized,
       [authorized],
-      {confirmations: 0, skipPreflight: true},
+      {commitment: 'single', skipPreflight: true},
     ),
   ).rejects.toThrow();
 
@@ -422,7 +422,7 @@ test('live staking actions', async () => {
     authorizedPubkey: newAuthorized.publicKey,
   });
   await sendAndConfirmTransaction(connection, deactivate, [newAuthorized], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
 
@@ -434,7 +434,7 @@ test('live staking actions', async () => {
     lamports: minimumAmount + 20,
   });
   await sendAndConfirmTransaction(connection, withdraw, [newAuthorized], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
   const balance = await connection.getBalance(newAccountPubkey);

--- a/web3.js/test/system-program.test.js
+++ b/web3.js/test/system-program.test.js
@@ -290,7 +290,7 @@ test('live Nonce actions', async () => {
     connection,
     createNonceAccount,
     [from, nonceAccount],
-    {confirmations: 0, skipPreflight: true},
+    {commitment: 'single', skipPreflight: true},
   );
   const nonceBalance = await connection.getBalance(nonceAccount.publicKey);
   expect(nonceBalance).toEqual(minimumAmount);
@@ -319,7 +319,7 @@ test('live Nonce actions', async () => {
     }),
   );
   await sendAndConfirmTransaction(connection, advanceNonce, [from], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
   const nonceQuery3 = await connection.getNonce(nonceAccount.publicKey);
@@ -341,7 +341,7 @@ test('live Nonce actions', async () => {
     }),
   );
   await sendAndConfirmTransaction(connection, authorizeNonce, [from], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
 
@@ -359,7 +359,7 @@ test('live Nonce actions', async () => {
   };
 
   await sendAndConfirmTransaction(connection, transfer, [from, newAuthority], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
   const toBalance = await connection.getBalance(to.publicKey);
@@ -378,7 +378,7 @@ test('live Nonce actions', async () => {
     }),
   );
   await sendAndConfirmTransaction(connection, withdrawNonce, [newAuthority], {
-    confirmations: 0,
+    commitment: 'single',
     skipPreflight: true,
   });
   expect(await connection.getBalance(nonceAccount.publicKey)).toEqual(0);

--- a/web3.js/test/transaction-payer.test.js
+++ b/web3.js/test/transaction-payer.test.js
@@ -3,6 +3,7 @@ import {Account, Connection, SystemProgram, LAMPORTS_PER_SOL} from '../src';
 import {mockRpc, mockRpcEnabled} from './__mocks__/node-fetch';
 import {mockGetRecentBlockhash} from './mockrpc/get-recent-blockhash';
 import {url} from './url';
+import {mockConfirmTransaction} from './mockrpc/confirm-transaction';
 
 if (!mockRpcEnabled) {
   // The default of 5 seconds is too slow for live testing sometimes
@@ -99,35 +100,8 @@ test('transaction-payer', async () => {
     {skipPreflight: true},
   );
 
-  mockRpc.push([
-    url,
-    {
-      method: 'getSignatureStatuses',
-      params: [
-        [
-          '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
-        ],
-      ],
-    },
-    {
-      error: null,
-      result: {
-        context: {
-          slot: 11,
-        },
-        value: [
-          {
-            slot: 0,
-            confirmations: 1,
-            status: {Ok: null},
-            err: null,
-          },
-        ],
-      },
-    },
-  ]);
-
-  await connection.confirmTransaction(signature, 1);
+  mockConfirmTransaction(signature);
+  await connection.confirmTransaction(signature, 'single');
 
   mockRpc.push([
     url,


### PR DESCRIPTION
#### Problem
Confirming transactions is done by polling rather than subscribing to events via websockets. This results in a lot of http requests being made when confirming transactions to max commitment as well as loading bpf programs on-chain. Lots of http requests means lots of http load on our rpc nodes and it means hitting rate limits very quickly.

Summary:
- Polling transaction status is slower than pubsub
- Polling causes rate limit issues and a lot of http load
- BPF loading fails a lot

#### Summary of Changes
- Change `confirmTransaction` to use a signature subscription over websockets for confirmation
- Switch `confirmTransaction` options from using "confirmations" to using "commitment"
- Decrease BPF loader transaction send rate to accommodate rate limit of 5 RPS

Fixes https://github.com/solana-labs/solana-web3.js/issues/967
Fixes https://github.com/solana-labs/solana-web3.js/issues/982