### PR TITLE
uses rust intrinsics to convert hashes to u64

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -95,6 +95,9 @@ name = "banking_stage"
 name = "blockstore"
 
 [[bench]]
+name = "crds_gossip_pull"
+
+[[bench]]
 name = "gen_keys"
 
 [[bench]]

--- a/core/benches/crds_gossip_pull.rs
+++ b/core/benches/crds_gossip_pull.rs
@@ -1,0 +1,26 @@
+#![feature(test)]
+
+extern crate test;
+
+use rand::{thread_rng, Rng};
+use solana_core::crds_gossip_pull::CrdsFilter;
+use solana_sdk::hash::{Hash, HASH_BYTES};
+use test::Bencher;
+
+#[bench]
+fn bench_hash_as_u64(bencher: &mut Bencher) {
+    let mut rng = thread_rng();
+    let hashes: Vec<_> = (0..1000)
+        .map(|_| {
+            let mut buf = [0u8; HASH_BYTES];
+            rng.fill(&mut buf);
+            Hash::new(&buf)
+        })
+        .collect();
+    bencher.iter(|| {
+        hashes
+            .iter()
+            .map(CrdsFilter::hash_as_u64)
+            .collect::<Vec<_>>()
+    });
+}


### PR DESCRIPTION
#### Problem
`hash_as_u64` is using iteration to convert hashes to u64:
https://github.com/solana-labs/solana/blob/cfe9b8b7/core/src/crds_gossip_pull.rs#L79

#### Summary of Changes
switched to rust intrinsics and added benchmark which shows ~25% improvement.
