### PR TITLE
feat: require feePayer account before tx serialization

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -636,7 +636,7 @@ declare module '@solana/web3.js' {
     compileMessage(): Message;
     serializeMessage(): Buffer;
     sign(...signers: Array<Account>): void;
-    signPartial(...partialSigners: Array<Account>): void;
+    partialSign(...partialSigners: Array<Account>): void;
     addSignature(pubkey: PublicKey, signature: Buffer): void;
     setSigners(...signer: Array<PublicKey>): void;
     verifySignatures(): boolean;

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -623,6 +623,7 @@ declare module '@solana/web3.js' {
     instructions: Array<TransactionInstruction>;
     recentBlockhash?: Blockhash;
     nonceInfo?: NonceInformation;
+    feePayer: PublicKey | null;
 
     constructor(opts?: TransactionCtorFields);
     static from(buffer: Buffer | Uint8Array | Array<number>): Transaction;
@@ -635,9 +636,9 @@ declare module '@solana/web3.js' {
     compileMessage(): Message;
     serializeMessage(): Buffer;
     sign(...signers: Array<Account>): void;
-    signPartial(...partialSigners: Array<PublicKey | Account>): void;
+    signPartial(...partialSigners: Array<Account>): void;
     addSignature(pubkey: PublicKey, signature: Buffer): void;
-    addSigner(signer: Account): void;
+    setSigners(...signer: Array<PublicKey>): void;
     verifySignatures(): boolean;
     serialize(): Buffer;
   }

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -12,6 +12,7 @@
 
 import {Buffer} from 'buffer';
 import * as BufferLayout from 'buffer-layout';
+import {PublicKey} from './src/publickey';
 
 declare module '@solana/web3.js' {
   // === src/publickey.js ===
@@ -626,6 +627,7 @@ declare module '@solana/web3.js' {
     instructions: Array<TransactionInstruction>;
     recentBlockhash: ?Blockhash;
     nonceInfo: ?NonceInformation;
+    feePayer: PublicKey | null;
 
     constructor(opts?: TransactionCtorFields): Transaction;
     static from(buffer: Buffer | Uint8Array | Array<number>): Transaction;
@@ -638,9 +640,9 @@ declare module '@solana/web3.js' {
     compileMessage(): Message;
     serializeMessage(): Buffer;
     sign(...signers: Array<Account>): void;
-    signPartial(...partialSigners: Array<PublicKey | Account>): void;
-    addSigner(signer: Account): void;
+    signPartial(...partialSigners: Array<Account>): void;
     addSignature(pubkey: PublicKey, signature: Buffer): void;
+    setSigners(...signers: Array<PublicKey>): void;
     verifySignatures(): boolean;
     serialize(): Buffer;
   }

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -640,7 +640,7 @@ declare module '@solana/web3.js' {
     compileMessage(): Message;
     serializeMessage(): Buffer;
     sign(...signers: Array<Account>): void;
-    signPartial(...partialSigners: Array<Account>): void;
+    partialSign(...partialSigners: Array<Account>): void;
     addSignature(pubkey: PublicKey, signature: Buffer): void;
     setSigners(...signers: Array<PublicKey>): void;
     verifySignatures(): boolean;

--- a/web3.js/src/message.js
+++ b/web3.js/src/message.js
@@ -13,7 +13,8 @@ import * as shortvec from './util/shortvec-encoding';
  * The message header, identifying signed and read-only account
  *
  * @typedef {Object} MessageHeader
- * @property {number} numRequiredSignatures The number of signatures required for this message to be considered valid
+ * @property {number} numRequiredSignatures The number of signatures required for this message to be considered valid. The
+ * signatures must match the first `numRequiredSignatures` of `accountKeys`.
  * @property {number} numReadonlySignedAccounts: The last `numReadonlySignedAccounts` of the signed keys are read-only accounts
  * @property {number} numReadonlyUnsignedAccounts The last `numReadonlySignedAccounts` of the unsigned keys are read-only accounts
  */

--- a/web3.js/src/transaction.js
+++ b/web3.js/src/transaction.js
@@ -358,7 +358,7 @@ export class Transaction {
    * Specify the public keys which will be used to sign the Transaction.
    * The first signer will be used as the transaction fee payer account.
    *
-   * Signatures can be added with either `signPartial` or `addSignature`
+   * Signatures can be added with either `partialSign` or `addSignature`
    */
   setSigners(...signers: Array<PublicKey>) {
     if (signers.length === 0) {
@@ -390,16 +390,16 @@ export class Transaction {
       publicKey: signer.publicKey,
     }));
 
-    this.signPartial(...signers);
+    this.partialSign(...signers);
   }
 
   /**
    * Partially sign a transaction with the specified accounts. All accounts must
    * correspond to a public key that was previously provided to `setSigners`.
    *
-   * All the caveats from the `sign` method apply to `signPartial`
+   * All the caveats from the `sign` method apply to `partialSign`
    */
-  signPartial(...signers: Array<Account>) {
+  partialSign(...signers: Array<Account>) {
     if (signers.length === 0) {
       throw new Error('No signers');
     }

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -157,6 +157,7 @@ describe('load BPF Rust program', () => {
       programId: program.publicKey,
     });
 
+    simulatedTransaction.feePayer = payerAccount.publicKey;
     const {err, logs} = (
       await connection.simulateTransaction(simulatedTransaction)
     ).value;
@@ -182,6 +183,7 @@ describe('load BPF Rust program', () => {
       programId: new Account().publicKey,
     });
 
+    simulatedTransaction.feePayer = payerAccount.publicKey;
     const {err, logs} = (
       await connection.simulateTransaction(simulatedTransaction)
     ).value;
@@ -206,7 +208,13 @@ describe('load BPF Rust program', () => {
     const {err, logs} = (
       await connection.simulateTransaction(simulatedTransaction, [program])
     ).value;
-    expect(err).toEqual('SignatureFailure');
-    expect(logs).toBeNull();
+    expect(err).toEqual('SanitizeFailure');
+
+    if (logs === null) {
+      expect(logs).not.toBeNull();
+      return;
+    }
+
+    expect(logs.length).toEqual(0);
   });
 });

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -157,7 +157,7 @@ describe('load BPF Rust program', () => {
       programId: program.publicKey,
     });
 
-    simulatedTransaction.feePayer = payerAccount.publicKey;
+    simulatedTransaction.setSigners(payerAccount.publicKey);
     const {err, logs} = (
       await connection.simulateTransaction(simulatedTransaction)
     ).value;
@@ -183,7 +183,7 @@ describe('load BPF Rust program', () => {
       programId: new Account().publicKey,
     });
 
-    simulatedTransaction.feePayer = payerAccount.publicKey;
+    simulatedTransaction.setSigners(payerAccount.publicKey);
     const {err, logs} = (
       await connection.simulateTransaction(simulatedTransaction)
     ).value;

--- a/web3.js/test/transaction.test.js
+++ b/web3.js/test/transaction.test.js
@@ -75,7 +75,7 @@ describe('compileMessage', () => {
   });
 });
 
-test('signPartial', () => {
+test('partialSign', () => {
   const account1 = new Account();
   const account2 = new Account();
   const recentBlockhash = account1.publicKey.toBase58(); // Fake recentBlockhash
@@ -92,7 +92,7 @@ test('signPartial', () => {
   partialTransaction.setSigners(account1.publicKey, account2.publicKey);
   expect(partialTransaction.signatures[0].signature).toBeNull();
   expect(partialTransaction.signatures[1].signature).toBeNull();
-  partialTransaction.signPartial(account1, account2);
+  partialTransaction.partialSign(account1, account2);
 
   expect(partialTransaction).toEqual(transaction);
 });
@@ -300,7 +300,7 @@ test('serialize unsigned transaction', () => {
   expectedTransaction.serializeMessage();
 
   // Properly signed transaction succeeds
-  expectedTransaction.signPartial(sender);
+  expectedTransaction.partialSign(sender);
   expect(expectedTransaction.signatures.length).toBe(1);
   const expectedSerialization = Buffer.from(
     'AVuErQHaXv0SG0/PchunfxHKt8wMRfMZzqV0tkC5qO6owYxWU2v871AoWywGoFQr4z+q/7mE8lIufNl/' +


### PR DESCRIPTION
#### Problem
A transaction message is not valid if it doesn't specify a fee payer and the web3 sdk cannot correctly determine which account is intended to be the fee payer. Currently the web3 sdk tries to guess the fee payer which can cause subtle bugs.

Main issues:
- fee payer is not explicitly required before compiling a transaction message
- payer account is *not* always first account meta

#### Summary of Changes
- Make fee payer required before compiling a tx message
- Ensure that payer account is always the first account meta
- Do not set extra signers as writable
- Add `setSigners` method for specifying all signer public keys upfront to allow message creation before any signing
- Rename `signPartial` to `partialSign` and split off some of its functionality into `setSigners`

Fixes https://github.com/solana-labs/solana/issues/12082
