### PR TITLE
Reduce cap by rent's leftover as temporary measure

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2027,7 +2027,7 @@ impl Bank {
         &self,
         vote_account_hashmap: &HashMap<Pubkey, (u64, Account)>,
         rent_to_be_distributed: u64,
-    ) {
+    ) -> u64 {
         let mut total_staked = 0;
         let mut rent_distributed_in_initial_round = 0;
 
@@ -2083,6 +2083,7 @@ impl Bank {
                 account.lamports += rent_to_be_paid;
                 self.store_account(&pubkey, &account);
             });
+        leftover_lamports
     }
 
     fn distribute_rent(&self) {
@@ -2100,7 +2101,9 @@ impl Bank {
             return;
         }
 
-        self.distribute_rent_to_validators(&self.vote_accounts(), rent_to_be_distributed);
+        let leftover =
+            self.distribute_rent_to_validators(&self.vote_accounts(), rent_to_be_distributed);
+        self.capitalization.fetch_sub(leftover, Ordering::Relaxed);
     }
 
     fn collect_rent(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2103,7 +2103,10 @@ impl Bank {
 
         let leftover =
             self.distribute_rent_to_validators(&self.vote_accounts(), rent_to_be_distributed);
-        self.capitalization.fetch_sub(leftover, Ordering::Relaxed);
+        if leftover != 0 {
+            warn!("There was leftover from rent distribution: {}", leftover);
+            self.capitalization.fetch_sub(leftover, Ordering::Relaxed);
+        }
     }
 
     fn collect_rent(

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -14,7 +14,12 @@ use fs_extra::dir::CopyOptions;
 use log::*;
 use regex::Regex;
 use solana_measure::measure::Measure;
-use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash, pubkey::Pubkey};
+use solana_sdk::{
+    clock::Slot,
+    genesis_config::{ClusterType, GenesisConfig},
+    hash::Hash,
+    pubkey::Pubkey,
+};
 use std::{
     cmp::Ordering,
     fmt,
@@ -591,6 +596,17 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     if !bank.verify_snapshot_bank() {
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());
     }
+    if genesis_config.cluster_type == ClusterType::Testnet {
+        let old = bank.set_capitalization();
+        if old != bank.capitalization() {
+            warn!(
+                "Capitalization was recalculated: {} => {}",
+                old,
+                bank.capitalization()
+            )
+        }
+    }
+
     measure.stop();
     info!("{}", measure);
 


### PR DESCRIPTION
#### Problem

testnet's cap is busted now.

#### Summary of Changes

This is temporary fix, which can go without gating.

The underlying bug is now identified and the bug even resides in mainnet-beta/v1.2......

#### Context

found via capitalization work and blocking #11927 
