### PR TITLE
Avoid overflow when computing rent distribution

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2425,7 +2425,7 @@ impl Bank {
             });
 
         if enforce_fix {
-            assert!(leftover_lamports == 0);
+            assert_eq!(leftover_lamports, 0);
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2379,8 +2379,9 @@ impl Bank {
     // We can't use collector_id (which is rotated according to stake-weighted leader schedule)
     // as an approximation to the ideal rent distribution to simplify and avoid this per-slot
     // computation for the distribution (time: N log N, space: N acct. stores; N = # of
-    // validators):
-    // - rent fee doesn't need to be incentivized for throughput unlike transaction fees
+    // validators).
+    // The reason is that rent fee doesn't need to be incentivized for throughput unlike transaction
+    // fees
     //
     // Ref: collect_fees
     #[allow(clippy::needless_collect)]
@@ -4547,12 +4548,9 @@ mod tests {
         const VALIDATOR_STAKE: u64 = 374_999_998_287_840;
 
         let validator_pubkey = Pubkey::new_rand();
-        let mut genesis_config = create_genesis_config_with_leader(
-            10,
-            &validator_pubkey,
-            VALIDATOR_STAKE,
-        )
-        .genesis_config;
+       let mut genesis_config =
+            create_genesis_config_with_leader(10, &validator_pubkey, VALIDATOR_STAKE)
+                .genesis_config;
 
         let bank = Bank::new(&genesis_config);
         let old_validator_lamports = bank.get_balance(&validator_pubkey);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4548,7 +4548,7 @@ mod tests {
         const VALIDATOR_STAKE: u64 = 374_999_998_287_840;
 
         let validator_pubkey = Pubkey::new_rand();
-       let mut genesis_config =
+        let mut genesis_config =
             create_genesis_config_with_leader(10, &validator_pubkey, VALIDATOR_STAKE)
                 .genesis_config;
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2381,8 +2381,7 @@ impl Bank {
     // computation for the distribution (time: N log N, space: N acct. stores; N = # of
     // validators):
     // - rent fee doesn't need to be incentivized for throughput unlike transaction fees
-    // - leader schedule could be manipulated to locate certain validators more often at the
-    //   start of epoch to unfairly earn more rent for the epoch.
+    //
     // Ref: collect_fees
     #[allow(clippy::needless_collect)]
     fn distribute_rent_to_validators(
@@ -4548,11 +4547,10 @@ mod tests {
         const VALIDATOR_STAKE: u64 = 374_999_998_287_840;
 
         let validator_pubkey = Pubkey::new_rand();
-        let bootstrap_validator_stake_lamports = VALIDATOR_STAKE;
         let mut genesis_config = create_genesis_config_with_leader(
             10,
             &validator_pubkey,
-            bootstrap_validator_stake_lamports,
+            VALIDATOR_STAKE,
         )
         .genesis_config;
 

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -51,7 +51,7 @@ lazy_static! {
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),
         (bpf_loader2_program::id(), "bpf_loader2 program"),
         (compute_budget_config2::id(), "1ms compute budget"),
-        (sha256_syscall_enabled::id(), "sha256 syscall")
+        (sha256_syscall_enabled::id(), "sha256 syscall"),
         (no_overflow_rent_distribution::id(), "no overflow rent distribution"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -37,6 +37,10 @@ pub mod sha256_syscall_enabled {
     solana_sdk::declare_id!("D7KfP7bZxpkYtD4Pc38t9htgs1k5k47Yhxe4rp6WDVi8");
 }
 
+pub mod no_overflow_rent_distribution {
+    solana_sdk::declare_id!("4kpdyrcj5jS47CZb2oJGfVxjYbsMm2Kx97gFyZrxxwXz");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -48,6 +52,7 @@ lazy_static! {
         (bpf_loader2_program::id(), "bpf_loader2 program"),
         (compute_budget_config2::id(), "1ms compute budget"),
         (sha256_syscall_enabled::id(), "sha256 syscall")
+        (no_overflow_rent_distribution::id(), "no overflow rent distribution"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -607,6 +607,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());
     }
     if genesis_config.cluster_type == ClusterType::Testnet {
+        // remove me after we transitions to the fixed rent distribution with no overflow
         let old = bank.set_capitalization();
         if old != bank.capitalization() {
             warn!(


### PR DESCRIPTION
#### Problem

rent calculation overflows.

#### Summary of Changes

Fix it. Also, make any native token distribution code a bit talkative...

- [x] write more details
- [x] add tests....

#### Context

Found via bank capitalization

This bug has been introduced at https://github.com/solana-labs/solana/pull/7396