### PR TITLE
net.sh: Support multiple validators with active stake from the start

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -63,6 +63,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --wait-for-supermajority ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --expected-bank-hash ]]; then
+      args+=("$1" "$2")
+      shift 2
     else
       echo "Unknown argument: $1"
       $program --help

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -151,6 +151,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --wait-for-supermajority ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --expected-bank-hash ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = -h ]]; then
       usage "$@"
     else


### PR DESCRIPTION
#### Problem

`net/net.sh` has no way to start a cluster with multiple validators having active stake

#### Summary of Changes

Add `--extra-primordial-stakes` flag and plumb it

This is part of #10361