### PR TITLE
Switch accounts storage lock to DashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +549,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+dependencies = [
+ "getrandom",
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +764,17 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle 2.2.2",
  "zeroize",
+]
+
+[[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "num_cpus",
 ]
 
 [[package]]
@@ -4293,6 +4333,7 @@ dependencies = [
  "byteorder",
  "bzip2",
  "crossbeam-channel",
+ "dashmap",
  "dir-diff",
  "flate2",
  "fnv",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -16,6 +16,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +288,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+dependencies = [
+ "getrandom",
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +430,17 @@ dependencies = [
  "rand_core",
  "subtle 2.2.2",
  "zeroize",
+]
+
+[[package]]
+name = "dashmap"
+version = "3.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f260e2fc850179ef410018660006951c1b55b79e8087e87111a2c388994b9b5"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2027,6 +2067,7 @@ dependencies = [
  "byteorder 1.3.4",
  "bzip2",
  "crossbeam-channel",
+ "dashmap",
  "dir-diff",
  "flate2",
  "fnv",

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -105,13 +105,8 @@ fn process_transaction_and_record_inner(
     let signature = tx.signatures.get(0).unwrap().clone();
     let txs = vec![tx];
     let tx_batch = bank.prepare_batch(&txs, None);
-    let (mut results, _, mut inner, _transaction_logs) = bank.load_execute_and_commit_transactions(
-        &tx_batch,
-        MAX_PROCESSING_AGE,
-        false,
-        true,
-        false,
-    );
+    let (mut results, _, mut inner, _transaction_logs) =
+        bank.load_execute_and_commit_transactions(&tx_batch, MAX_PROCESSING_AGE, false, true, false);
     let inner_instructions = inner.swap_remove(0);
     let result = results
         .fee_collection_results

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -105,8 +105,13 @@ fn process_transaction_and_record_inner(
     let signature = tx.signatures.get(0).unwrap().clone();
     let txs = vec![tx];
     let tx_batch = bank.prepare_batch(&txs, None);
-    let (mut results, _, mut inner, _transaction_logs) =
-        bank.load_execute_and_commit_transactions(&tx_batch, MAX_PROCESSING_AGE, false, true, false);
+    let (mut results, _, mut inner, _transaction_logs) = bank.load_execute_and_commit_transactions(
+        &tx_batch,
+        MAX_PROCESSING_AGE,
+        false,
+        true,
+        false,
+    );
     let inner_instructions = inner.swap_remove(0);
     let result = results
         .fee_collection_results

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,6 +14,7 @@ blake3 = "0.3.6"
 bv = { version = "0.11.1", features = ["serde"] }
 byteorder = "1.3.4"
 bzip2 = "0.3.3"
+dashmap = "3.11.10"
 crossbeam-channel = "0.4"
 dir-diff = "0.3.2"
 flate2 = "1.0.14"

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -148,7 +148,10 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
 fn bench_concurrent_read_write(bencher: &mut Bencher) {
     let num_readers = 5;
     let accounts = Arc::new(Accounts::new(
-        vec![PathBuf::from("concurrent_read_write")],
+        vec![
+            PathBuf::from(std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string()))
+                .join("concurrent_read_write"),
+        ],
         &ClusterType::Development,
     ));
     let num_keys = 1000;
@@ -174,7 +177,7 @@ fn bench_concurrent_read_write(bencher: &mut Bencher) {
                 let mut rng = rand::thread_rng();
                 loop {
                     let i = rng.gen_range(0, num_keys);
-                    accounts.load_slow(&HashMap::new(), &pubkeys[i]);
+                    test::black_box(accounts.load_slow(&HashMap::new(), &pubkeys[i]).unwrap());
                 }
             })
             .unwrap();

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -2,6 +2,7 @@
 
 extern crate test;
 
+use rand::Rng;
 use solana_runtime::{
     accounts::{create_test_accounts, Accounts},
     bank::*,
@@ -11,7 +12,7 @@ use solana_sdk::{
     genesis_config::{create_genesis_config, ClusterType},
     pubkey::Pubkey,
 };
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc, thread::Builder};
 use test::Bencher;
 
 fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) {
@@ -140,4 +141,55 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
     bencher.iter(|| {
         accounts.accounts_db.clean_accounts(None);
     });
+}
+
+#[bench]
+#[ignore]
+fn bench_concurrent_read_write(bencher: &mut Bencher) {
+    let num_readers = 5;
+    let accounts = Arc::new(Accounts::new(
+        vec![PathBuf::from("concurrent_read_write")],
+        &ClusterType::Development,
+    ));
+    let num_keys = 1000;
+    let slot = 0;
+    accounts.add_root(slot);
+    let pubkeys: Arc<Vec<_>> = Arc::new(
+        (0..num_keys)
+            .map(|_| {
+                let pubkey = Pubkey::new_rand();
+                let account = Account::new(1, 0, &Account::default().owner);
+                accounts.store_slow(slot, &pubkey, &account);
+                pubkey
+            })
+            .collect(),
+    );
+
+    for _ in 0..num_readers {
+        let accounts = accounts.clone();
+        let pubkeys = pubkeys.clone();
+        Builder::new()
+            .name("readers".to_string())
+            .spawn(move || {
+                let mut rng = rand::thread_rng();
+                loop {
+                    let i = rng.gen_range(0, num_keys);
+                    accounts.load_slow(&HashMap::new(), &pubkeys[i]);
+                }
+            })
+            .unwrap();
+    }
+
+    let num_new_keys = 1000;
+    let new_accounts: Vec<_> = (0..num_new_keys)
+        .map(|_| Account::new(1, 0, &Account::default().owner))
+        .collect();
+    bencher.iter(|| {
+        for account in &new_accounts {
+            // Write to a different slot than the one being read from. Because
+            // there's a new account pubkey being written to every time, will
+            // compete for the accounts index lock on every store
+            accounts.store_slow(slot + 1, &Pubkey::new_rand(), &account);
+        }
+    })
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -303,7 +303,6 @@ impl Accounts {
         //PERF: hold the lock to scan for the references, but not to clone the accounts
         //TODO: two locks usually leads to deadlocks, should this be one structure?
         let accounts_index = self.accounts_db.accounts_index.read().unwrap();
-        let storage = self.accounts_db.storage.read().unwrap();
 
         let fee_config = FeeConfig {
             secp256k1_program_enabled: feature_set
@@ -328,7 +327,7 @@ impl Accounts {
                     };
 
                     let load_res = self.load_tx_accounts(
-                        &storage,
+                        &self.accounts_db.storage,
                         ancestors,
                         &accounts_index,
                         tx,
@@ -343,7 +342,7 @@ impl Accounts {
                     };
 
                     let load_res = Self::load_loaders(
-                        &storage,
+                        &self.accounts_db.storage,
                         ancestors,
                         &accounts_index,
                         tx,
@@ -1507,10 +1506,9 @@ mod tests {
         let ancestors = vec![(0, 0)].into_iter().collect();
 
         let accounts_index = accounts.accounts_db.accounts_index.read().unwrap();
-        let storage = accounts.accounts_db.storage.read().unwrap();
         assert_eq!(
             Accounts::load_executable_accounts(
-                &storage,
+                &accounts.accounts_db.storage,
                 &ancestors,
                 &accounts_index,
                 &Pubkey::new_rand(),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -125,20 +125,14 @@ impl Versioned for (u64, AccountInfo) {
 pub struct AccountStorage(pub DashMap<Slot, SlotStores>);
 
 impl AccountStorage {
-    fn scan_accounts(&self, account_info: &AccountInfo, slot: Slot) -> Option<(Account, Slot)> {
+    fn get_account_storage_entry(
+        &self,
+        account_info: &AccountInfo,
+        slot: Slot,
+    ) -> Option<Arc<AccountStorageEntry>> {
         self.0
             .get(&slot)
             .and_then(|storage_map| storage_map.value().get(&account_info.store_id).cloned())
-            .and_then(|store| {
-                Some(
-                    store
-                        .accounts
-                        .get_account(account_info.offset)?
-                        .0
-                        .clone_account(),
-                )
-            })
-            .map(|account| (account, slot))
     }
 
     fn slot_store_count(&self, slot: Slot, store_id: AppendVecId) -> Option<usize> {
@@ -272,6 +266,15 @@ impl AccountStorageEntry {
 
     pub fn flush(&self) -> Result<(), IOError> {
         self.accounts.flush()
+    }
+
+    fn get_account(&self, account_info: &AccountInfo) -> Option<Account> {
+        Some(
+            self.accounts
+                .get_account(account_info.offset)?
+                .0
+                .clone_account(),
+        )
     }
 
     fn add_account(&self) {
@@ -1222,12 +1225,11 @@ impl AccountsDB {
         let mut collector = A::default();
         let accounts_index = self.accounts_index.read().unwrap();
         accounts_index.scan_accounts(ancestors, |pubkey, (account_info, slot)| {
-            scan_func(
-                &mut collector,
-                self.storage
-                    .scan_accounts(account_info, slot)
-                    .map(|(account, slot)| (pubkey, account, slot)),
-            )
+            let account_storage_entry = self.storage.get_account_storage_entry(account_info, slot);
+            let account_slot = account_storage_entry
+                .and_then(|account_storage_entry| account_storage_entry.get_account(account_info))
+                .map(|account| (pubkey, account, slot));
+            scan_func(&mut collector, account_slot)
         });
         collector
     }
@@ -1241,12 +1243,11 @@ impl AccountsDB {
         let mut collector = A::default();
         let accounts_index = self.accounts_index.read().unwrap();
         accounts_index.range_scan_accounts(ancestors, range, |pubkey, (account_info, slot)| {
-            scan_func(
-                &mut collector,
-                self.storage
-                    .scan_accounts(account_info, slot)
-                    .map(|(account, slot)| (pubkey, account, slot)),
-            )
+            let account_storage_entry = self.storage.get_account_storage_entry(account_info, slot);
+            let account_slot = account_storage_entry
+                .and_then(|account_storage_entry| account_storage_entry.get_account(account_info))
+                .map(|account| (pubkey, account, slot));
+            scan_func(&mut collector, account_slot)
         });
         collector
     }
@@ -1330,9 +1331,8 @@ impl AccountsDB {
         let accounts_index = self.accounts_index.read().unwrap();
         let (lock, index) = accounts_index.get(pubkey, Some(ancestors), None).unwrap();
         let slot = lock[index].0;
-        let slot_storage = self.storage.0.get(&slot).unwrap();
         let info = &lock[index].1;
-        let entry = slot_storage.get(&info.store_id).unwrap();
+        let entry = self.storage.get_account_storage_entry(&info, slot).unwrap();
         let account = entry.accounts.get_account(info.offset);
         *account.as_ref().unwrap().0.hash
     }
@@ -2120,16 +2120,14 @@ impl AccountsDB {
             if let Some(expected_slot) = expected_slot {
                 assert_eq!(*slot, expected_slot);
             }
-            if let Some(slot_storage) = self.storage.0.get(slot) {
-                if let Some(store) = slot_storage.get(&account_info.store_id) {
-                    assert_eq!(
-                        *slot, store.slot,
-                        "AccountDB::accounts_index corrupted. Storage should only point to one slot"
-                    );
-                    let count = store.remove_account();
-                    if count == 0 {
-                        dead_slots.insert(*slot);
-                    }
+            if let Some(store) = self.storage.get_account_storage_entry(&account_info, *slot) {
+                assert_eq!(
+                    *slot, store.slot,
+                    "AccountDB::accounts_index corrupted. Storage should only point to one slot"
+                );
+                let count = store.remove_account();
+                if count == 0 {
+                    dead_slots.insert(*slot);
                 }
             }
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -23,6 +23,7 @@ use crate::{
     append_vec::{AppendVec, StoredAccount, StoredMeta},
 };
 use blake3::traits::digest::Digest;
+use dashmap::DashMap;
 use lazy_static::lazy_static;
 use log::*;
 use rand::{thread_rng, Rng};
@@ -46,7 +47,7 @@ use std::{
     ops::RangeBounds,
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
-    sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard},
+    sync::{Arc, Mutex, MutexGuard, RwLock, RwLockWriteGuard},
     time::Instant,
 };
 use tempfile::TempDir;
@@ -121,13 +122,13 @@ impl Versioned for (u64, AccountInfo) {
 }
 
 #[derive(Clone, Default, Debug)]
-pub struct AccountStorage(pub HashMap<Slot, SlotStores>);
+pub struct AccountStorage(pub DashMap<Slot, SlotStores>);
 
 impl AccountStorage {
     fn scan_accounts(&self, account_info: &AccountInfo, slot: Slot) -> Option<(Account, Slot)> {
         self.0
             .get(&slot)
-            .and_then(|storage_map| storage_map.get(&account_info.store_id))
+            .and_then(|storage_map| storage_map.value().get(&account_info.store_id).cloned())
             .and_then(|store| {
                 Some(
                     store
@@ -145,6 +146,10 @@ impl AccountStorage {
             .get(&slot)
             .and_then(|slot_storages| slot_storages.get(&store_id))
             .map(|store| store.count_and_status.read().unwrap().0)
+    }
+
+    fn all_slots(&self) -> Vec<Slot> {
+        self.0.iter().map(|iter_item| *iter_item.key()).collect()
     }
 }
 
@@ -394,7 +399,7 @@ pub struct AccountsDB {
     /// Keeps tracks of index into AppendVec on a per slot basis
     pub accounts_index: RwLock<AccountsIndex<AccountInfo>>,
 
-    pub storage: RwLock<AccountStorage>,
+    pub storage: AccountStorage,
 
     /// distribute the accounts across storage lists
     pub next_id: AtomicUsize,
@@ -471,7 +476,7 @@ impl Default for AccountsDB {
         bank_hashes.insert(0, BankHashInfo::default());
         AccountsDB {
             accounts_index: RwLock::new(AccountsIndex::default()),
-            storage: RwLock::new(AccountStorage(HashMap::new())),
+            storage: AccountStorage(DashMap::new()),
             next_id: AtomicUsize::new(0),
             shrink_candidate_slots: Mutex::new(Vec::new()),
             write_version: AtomicU64::new(0),
@@ -792,8 +797,6 @@ impl AccountsDB {
                     key_set.insert(*key);
                     let count = self
                         .storage
-                        .read()
-                        .unwrap()
                         .slot_store_count(*slot, account_info.store_id)
                         .unwrap()
                         - 1;
@@ -965,8 +968,7 @@ impl AccountsDB {
         let mut stored_accounts = vec![];
         let mut storage_read_elapsed = Measure::start("storage_read_elapsed");
         {
-            let slot_storages = self.storage.read().unwrap().0.get(&slot).cloned();
-            if let Some(stores) = slot_storages {
+            if let Some(stores) = self.storage.0.get(&slot) {
                 let mut alive_count = 0;
                 let mut stored_count = 0;
                 for store in stores.values() {
@@ -1105,8 +1107,7 @@ impl AccountsDB {
             handle_reclaims_elapsed = start.as_us();
 
             let mut start = Measure::start("write_storage_elapsed");
-            let mut storage = self.storage.write().unwrap();
-            if let Some(slot_storage) = storage.0.get_mut(&slot) {
+            if let Some(mut slot_storage) = self.storage.0.get_mut(&slot) {
                 slot_storage.retain(|_key, store| {
                     if store.count() == 0 {
                         dead_storages.push(store.clone());
@@ -1178,8 +1179,7 @@ impl AccountsDB {
     }
 
     fn all_slots_in_storage(&self) -> Vec<Slot> {
-        let storage = self.storage.read().unwrap();
-        storage.0.keys().cloned().collect()
+        self.storage.all_slots()
     }
 
     pub fn process_stale_slot(&self) -> usize {
@@ -1221,11 +1221,10 @@ impl AccountsDB {
     {
         let mut collector = A::default();
         let accounts_index = self.accounts_index.read().unwrap();
-        let storage = self.storage.read().unwrap();
         accounts_index.scan_accounts(ancestors, |pubkey, (account_info, slot)| {
             scan_func(
                 &mut collector,
-                storage
+                self.storage
                     .scan_accounts(account_info, slot)
                     .map(|(account, slot)| (pubkey, account, slot)),
             )
@@ -1241,11 +1240,10 @@ impl AccountsDB {
     {
         let mut collector = A::default();
         let accounts_index = self.accounts_index.read().unwrap();
-        let storage = self.storage.read().unwrap();
         accounts_index.range_scan_accounts(ancestors, range, |pubkey, (account_info, slot)| {
             scan_func(
                 &mut collector,
-                storage
+                self.storage
                     .scan_accounts(account_info, slot)
                     .map(|(account, slot)| (pubkey, account, slot)),
             )
@@ -1260,27 +1258,20 @@ impl AccountsDB {
         F: Fn(&StoredAccount, AppendVecId, &mut B) + Send + Sync,
         B: Send + Default,
     {
-        self.scan_account_storage_inner(slot, scan_func, &self.storage.read().unwrap())
+        self.scan_account_storage_inner(slot, scan_func)
     }
 
-    // The input storage must come from self.storage.read().unwrap()
-    fn scan_account_storage_inner<F, B>(
-        &self,
-        slot: Slot,
-        scan_func: F,
-        storage: &RwLockReadGuard<AccountStorage>,
-    ) -> Vec<B>
+    fn scan_account_storage_inner<F, B>(&self, slot: Slot, scan_func: F) -> Vec<B>
     where
         F: Fn(&StoredAccount, AppendVecId, &mut B) + Send + Sync,
         B: Send + Default,
     {
-        let storage_maps: Vec<Arc<AccountStorageEntry>> = storage
+        let storage_maps: Vec<Arc<AccountStorageEntry>> = self
+            .storage
             .0
             .get(&slot)
-            .unwrap_or(&HashMap::new())
-            .values()
-            .cloned()
-            .collect();
+            .map(|res| res.value().values().cloned().collect())
+            .unwrap_or_default();
         self.thread_pool.install(|| {
             storage_maps
                 .into_par_iter()
@@ -1339,8 +1330,7 @@ impl AccountsDB {
         let accounts_index = self.accounts_index.read().unwrap();
         let (lock, index) = accounts_index.get(pubkey, Some(ancestors), None).unwrap();
         let slot = lock[index].0;
-        let storage = self.storage.read().unwrap();
-        let slot_storage = storage.0.get(&slot).unwrap();
+        let slot_storage = self.storage.0.get(&slot).unwrap();
         let info = &lock[index].1;
         let entry = slot_storage.get(&info.store_id).unwrap();
         let account = entry.accounts.get_account(info.offset);
@@ -1349,15 +1339,13 @@ impl AccountsDB {
 
     pub fn load_slow(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
         let accounts_index = self.accounts_index.read().unwrap();
-        let storage = self.storage.read().unwrap();
-        Self::load(&storage, ancestors, &accounts_index, pubkey)
+        Self::load(&self.storage, ancestors, &accounts_index, pubkey)
     }
 
     fn find_storage_candidate(&self, slot: Slot) -> Arc<AccountStorageEntry> {
         let mut create_extra = false;
-        let stores = self.storage.read().unwrap();
-
-        if let Some(slot_stores) = stores.0.get(&slot) {
+        let slot_stores_guard = self.storage.0.get(&slot);
+        if let Some(ref slot_stores) = slot_stores_guard {
             if !slot_stores.is_empty() {
                 if slot_stores.len() <= self.min_num_stores {
                     let mut total_accounts = 0;
@@ -1377,7 +1365,7 @@ impl AccountsDB {
                 for (i, store) in slot_stores.values().cycle().skip(to_skip).enumerate() {
                     if store.try_available() {
                         let ret = store.clone();
-                        drop(stores);
+                        drop(slot_stores_guard);
                         if create_extra {
                             self.create_and_insert_store(slot, self.file_size);
                         }
@@ -1391,7 +1379,7 @@ impl AccountsDB {
             }
         }
 
-        drop(stores);
+        drop(slot_stores_guard);
 
         let store = self.create_and_insert_store(slot, self.file_size);
         store.try_available();
@@ -1403,9 +1391,7 @@ impl AccountsDB {
         let store =
             Arc::new(self.new_storage_entry(slot, &Path::new(&self.paths[path_index]), size));
         let store_for_index = store.clone();
-
-        let mut stores = self.storage.write().unwrap();
-        let slot_storage = stores.0.entry(slot).or_insert_with(HashMap::new);
+        let mut slot_storage = self.storage.0.entry(slot).or_insert_with(HashMap::new);
         slot_storage.insert(store.id, store_for_index);
         store
     }
@@ -1424,17 +1410,13 @@ impl AccountsDB {
             .filter(|slot| !accounts_index.is_root(**slot))
             .collect();
         drop(accounts_index);
-        let mut storage_lock_elapsed = Measure::start("storage_lock_elapsed");
-        let mut storage = self.storage.write().unwrap();
-        storage_lock_elapsed.stop();
-
         let mut all_removed_slot_storages = vec![];
         let mut total_removed_storage_entries = 0;
         let mut total_removed_bytes = 0;
 
         let mut remove_storages_elapsed = Measure::start("remove_storages_elapsed");
         for slot in non_roots {
-            if let Some(slot_removed_storages) = storage.0.remove(&slot) {
+            if let Some((_, slot_removed_storages)) = self.storage.0.remove(&slot) {
                 total_removed_storage_entries += slot_removed_storages.len();
                 total_removed_bytes += slot_removed_storages
                     .values()
@@ -1444,7 +1426,6 @@ impl AccountsDB {
             }
         }
         remove_storages_elapsed.stop();
-        drop(storage);
 
         let num_slots_removed = all_removed_slot_storages.len();
 
@@ -1456,7 +1437,6 @@ impl AccountsDB {
 
         datapoint_info!(
             "purge_slots_time",
-            ("storage_lock_elapsed", storage_lock_elapsed.as_us(), i64),
             (
                 "remove_storages_elapsed",
                 remove_storages_elapsed.as_us(),
@@ -1503,7 +1483,7 @@ impl AccountsDB {
         // 1) Remove old bank hash from self.bank_hashes
         // 2) Purge this slot's storage entries from self.storage
         self.handle_reclaims(&reclaims, Some(remove_slot), false, None);
-        assert!(self.storage.read().unwrap().0.get(&remove_slot).is_none());
+        assert!(self.storage.0.get(&remove_slot).is_none());
     }
 
     fn include_owner(cluster_type: &ClusterType, slot: Slot) -> bool {
@@ -1777,8 +1757,9 @@ impl AccountsDB {
         let mut max_slot = 0;
         let mut newest_slot = 0;
         let mut oldest_slot = std::u64::MAX;
-        let stores = self.storage.read().unwrap();
-        for (slot, slot_stores) in &stores.0 {
+        for iter_item in self.storage.0.iter() {
+            let slot = iter_item.key();
+            let slot_stores = iter_item.value();
             total_count += slot_stores.len();
             if slot_stores.len() < min {
                 min = slot_stores.len();
@@ -1797,7 +1778,6 @@ impl AccountsDB {
                 oldest_slot = *slot;
             }
         }
-        drop(stores);
         info!("total_stores: {}, newest_slot: {}, oldest_slot: {}, max_slot: {} (num={}), min_slot: {} (num={})",
               total_count, newest_slot, oldest_slot, max_slot, max, min_slot, min);
         datapoint_info!("accounts_db-stores", ("total_count", total_count, i64));
@@ -1935,7 +1915,6 @@ impl AccountsDB {
         use BankHashVerificationError::*;
         let mut scan = Measure::start("scan");
         let accounts_index = self.accounts_index.read().unwrap();
-        let storage = self.storage.read().unwrap();
         let keys: Vec<_> = accounts_index.account_maps.keys().collect();
         let mismatch_found = AtomicU64::new(0);
         let hashes: Vec<_> = keys
@@ -1944,10 +1923,12 @@ impl AccountsDB {
                 if let Some((list, index)) = accounts_index.get(pubkey, Some(ancestors), None) {
                     let (slot, account_info) = &list[index];
                     if account_info.lamports != 0 {
-                        storage
+                        self.storage
                             .0
                             .get(&slot)
-                            .and_then(|storage_map| storage_map.get(&account_info.store_id))
+                            .and_then(|storage_map| {
+                                storage_map.value().get(&account_info.store_id).cloned()
+                            })
                             .and_then(|store| {
                                 let account = store.accounts.get_account(account_info.offset)?.0;
                                 let balance = Self::account_balance_for_capitalization(
@@ -2128,7 +2109,6 @@ impl AccountsDB {
         expected_slot: Option<Slot>,
         mut reclaimed_offsets: Option<&mut AppendVecOffsets>,
     ) -> HashSet<Slot> {
-        let storage = self.storage.read().unwrap();
         let mut dead_slots = HashSet::new();
         for (slot, account_info) in reclaims {
             if let Some(ref mut reclaimed_offsets) = reclaimed_offsets {
@@ -2140,7 +2120,7 @@ impl AccountsDB {
             if let Some(expected_slot) = expected_slot {
                 assert_eq!(*slot, expected_slot);
             }
-            if let Some(slot_storage) = storage.0.get(slot) {
+            if let Some(slot_storage) = self.storage.0.get(slot) {
                 if let Some(store) = slot_storage.get(&account_info.store_id) {
                     assert_eq!(
                         *slot, store.slot,
@@ -2155,7 +2135,7 @@ impl AccountsDB {
         }
 
         dead_slots.retain(|slot| {
-            if let Some(slot_storage) = storage.0.get(&slot) {
+            if let Some(slot_storage) = self.storage.0.get(&slot) {
                 for x in slot_storage.values() {
                     if x.count() != 0 {
                         return false;
@@ -2175,16 +2155,14 @@ impl AccountsDB {
     ) {
         {
             let mut measure = Measure::start("clean_dead_slots-ms");
-            let storage = self.storage.read().unwrap();
             let mut stores: Vec<Arc<AccountStorageEntry>> = vec![];
             for slot in dead_slots.iter() {
-                if let Some(slot_storage) = storage.0.get(slot) {
+                if let Some(slot_storage) = self.storage.0.get(slot) {
                     for store in slot_storage.values() {
                         stores.push(store.clone());
                     }
                 }
             }
-            drop(storage);
             datapoint_debug!("clean_dead_slots", ("stores", stores.len(), i64));
             let slot_pubkeys: HashSet<(Slot, Pubkey)> = {
                 self.thread_pool_clean.install(|| {
@@ -2334,15 +2312,16 @@ impl AccountsDB {
 
     pub fn get_snapshot_storages(&self, snapshot_slot: Slot) -> SnapshotStorages {
         let accounts_index = self.accounts_index.read().unwrap();
-        let r_storage = self.storage.read().unwrap();
-        r_storage
+        self.storage
             .0
             .iter()
-            .filter(|(slot, _slot_stores)| {
-                **slot <= snapshot_slot && accounts_index.is_root(**slot)
+            .filter(|iter_item| {
+                let slot = *iter_item.key();
+                slot <= snapshot_slot && accounts_index.is_root(slot)
             })
-            .map(|(_slot, slot_stores)| {
-                slot_stores
+            .map(|iter_item| {
+                iter_item
+                    .value()
                     .values()
                     .filter(|x| x.has_accounts())
                     .cloned()
@@ -2368,8 +2347,7 @@ impl AccountsDB {
 
     pub fn generate_index(&self) {
         let mut accounts_index = self.accounts_index.write().unwrap();
-        let storage = self.storage.read().unwrap();
-        let mut slots: Vec<Slot> = storage.0.keys().cloned().collect();
+        let mut slots: Vec<Slot> = self.storage.all_slots();
         slots.sort();
 
         let mut last_log_update = Instant::now();
@@ -2396,7 +2374,6 @@ impl AccountsDB {
                             .or_insert_with(Vec::new);
                         entry.push((stored_account.meta.write_version, account_info));
                     },
-                    &storage,
                 );
 
             let mut accounts_map: HashMap<Pubkey, Vec<(u64, AccountInfo)>> = HashMap::new();
@@ -2432,8 +2409,8 @@ impl AccountsDB {
                 *counts.entry(account_entry.store_id).or_insert(0) += 1;
             }
         }
-        for slot_stores in storage.0.values() {
-            for (id, store) in slot_stores {
+        for slot_stores in self.storage.0.iter() {
+            for (id, store) in slot_stores.value() {
                 if let Some(count) = counts.get(&id) {
                     trace!(
                         "id: {} setting count: {} cur: {}",
@@ -2476,12 +2453,11 @@ impl AccountsDB {
     }
 
     fn print_count_and_status(&self, label: &'static str) {
-        let storage = self.storage.read().unwrap();
-        let mut slots: Vec<_> = storage.0.keys().cloned().collect();
+        let mut slots: Vec<_> = self.storage.all_slots();
         slots.sort();
         info!("{}: count_and status for {} slots:", label, slots.len());
         for slot in &slots {
-            let slot_stores = storage.0.get(slot).unwrap();
+            let slot_stores = self.storage.0.get(slot).unwrap();
 
             let mut ids: Vec<_> = slot_stores.keys().cloned().collect();
             ids.sort();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -99,7 +99,7 @@ pub type SnapshotStorage = Vec<Arc<AccountStorageEntry>>;
 pub type SnapshotStorages = Vec<SnapshotStorage>;
 
 // Each slot has a set of storage entries.
-pub(crate) type SlotStores = HashMap<usize, Arc<AccountStorageEntry>>;
+pub(crate) type SlotStores = Arc<RwLock<HashMap<usize, Arc<AccountStorageEntry>>>>;
 
 type AccountSlots = HashMap<Pubkey, HashSet<Slot>>;
 type AppendVecOffsets = HashMap<AppendVecId, HashSet<usize>>;
@@ -122,7 +122,7 @@ impl Versioned for (u64, AccountInfo) {
 }
 
 #[derive(Clone, Default, Debug)]
-pub struct AccountStorage(pub DashMap<Slot, Arc<RwLock<SlotStores>>>);
+pub struct AccountStorage(pub DashMap<Slot, SlotStores>);
 
 impl AccountStorage {
     fn get_account_storage_entry(
@@ -135,7 +135,7 @@ impl AccountStorage {
             .and_then(|storage_map| storage_map.value().read().unwrap().get(&store_id).cloned())
     }
 
-    fn get_slot_stores(&self, slot: Slot) -> Option<Arc<RwLock<SlotStores>>> {
+    fn get_slot_stores(&self, slot: Slot) -> Option<SlotStores> {
         self.0.get(&slot).map(|result| result.value().clone())
     }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -265,7 +265,7 @@ where
     E: Into<AccountStorageEntry>,
     P: AsRef<Path>,
 {
-    let accounts_db = AccountsDB::new(account_paths.to_vec(), cluster_type);
+    let mut accounts_db = AccountsDB::new(account_paths.to_vec(), cluster_type);
 
     let AccountsDbFields(storage, version, slot, bank_hash_info) = accounts_db_fields;
 
@@ -348,8 +348,7 @@ where
         .expect("At least one storage entry must exist from deserializing stream");
 
     {
-        let mut stores = accounts_db.storage.write().unwrap();
-        stores.0.extend(storage);
+        accounts_db.storage.0.extend(storage);
     }
 
     accounts_db.next_id.store(max_id + 1, Ordering::Relaxed);

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -33,7 +33,7 @@ use {
         io::{BufReader, BufWriter, Read, Write},
         path::{Path, PathBuf},
         result::Result,
-        sync::{atomic::Ordering, Arc},
+        sync::{atomic::Ordering, Arc, RwLock},
         time::Instant,
     },
 };
@@ -348,7 +348,11 @@ where
         .expect("At least one storage entry must exist from deserializing stream");
 
     {
-        accounts_db.storage.0.extend(storage);
+        accounts_db.storage.0.extend(
+            storage.into_iter().map(|(slot, slot_storage_entry)| {
+                (slot, Arc::new(RwLock::new(slot_storage_entry)))
+            }),
+        );
     }
 
     accounts_db.next_id.store(max_id + 1, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
Accounts scans from RPC hold:

1) the account storage lock duration the entire duration of the scan, which blocks replay on `create_and_insert_store()` during account commit.

2)  the account index lock duration the entire duration of the scan, which blocks replay in AccountsDb `store()->update_index()` during account commit. 

#### Summary of Changes
Experimenting with switching global accounts storage (part 1 above) lock to `DashMap`: https://github.com/xacrimon/dashmap, a concurrent hashmap implemented by sharding the table. This removes the need to hold the global `AccountStorage` read lock in `scan_accounts` which is blocking `create_and_insert_store()`

TODO: This can also potentially be expanded to replace the accounts index lock in part 2 above

TODO: Reason about correctness of places where I've replaced the large account_storage read locks, specifically around cleaning and shrinking. @ryoqun would really appreciate a review in those areas!

Pertinent gotchas with v3 of `DashMap`: https://github.com/xacrimon/dashmap/issues/74

Other candidates that were considered but not chosen:

1) chashmap: No iterator support
2) evmap: Poorer write performance under heavy read contention
3) flurry (Java concurrent hashmap port): Not as performant as DashMap

Fixes #
