### PR TITLE
Update minimum rustc version to 1.45.0 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ source $HOME/.cargo/env
 $ rustup component add rustfmt
 ```
 
-If your rustc version is lower than 1.45.0, please update it:
+Please sure you are always using the latest stable rust version by running:
 
 ```bash
 $ rustup update

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ source $HOME/.cargo/env
 $ rustup component add rustfmt
 ```
 
-If your rustc version is lower than 1.39.0, please update it:
+If your rustc version is lower than 1.45.0, please update it:
 
 ```bash
 $ rustup update


### PR DESCRIPTION
#### Problem
Building with rustc lower than 1.43.0:
```error[E0599]: no associated item named `MAX` found for type `u64` in the current scope```
Building with rustc lower than 1.45.0:
 ```error[E0658]: use of unstable library feature 'str_strip': newly added```

#### Summary of Changes
I'm bumping the minimum version in the readme _under the assumption_ there's not enough demand to stay compatible with older versions.
FWIW I found only [one use](https://github.com/solana-labs/solana/blob/master/remote-wallet/src/remote_wallet.rs#L348) of `strip_suffix` but there are dozens of uses of [`u64::max`](https://doc.rust-lang.org/std/primitive.u64.html#associatedconstant.MAX).
