### PR TITLE
Cache re-usable work performed by the loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3431e8f72b90f8a7af91dec890d9814000cb371258e0ec7370d93e085361f531"
+checksum = "d508492eeb1e5c38ee696371bf7b9fc33c83d46a7d451606b96458fbbbdc2dec"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -2270,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25af5fc872ba284d8d84608bf8a0fa9b5376c96c23f503b007dfd9e34dde5606"
+checksum = "84f328a6a63192b333fce5fbb4be79db6758a4d518dfac6d54412f1492f72d32"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.19",
@@ -4659,9 +4659,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185f68b54660652e2244bbdef792b369f12045da856a4af75b776e6e72757831"
+checksum = "962f8f04ac7239fe4dd45fa4ce706ec78b59a0da9f41def463832857e36c60b0"
 dependencies = [
  "byteorder",
  "combine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,12 +26,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
-name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,7 +1281,6 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
- "ahash",
  "autocfg 1.0.0",
 ]
 
@@ -1863,15 +1856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "lru"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
-dependencies = [
- "hashbrown",
 ]
 
 [[package]]
@@ -4209,7 +4193,6 @@ dependencies = [
  "libc",
  "libloading 0.6.2",
  "log 0.4.8",
- "lru",
  "memmap",
  "num-derive 0.3.0",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1287,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
 dependencies = [
+ "ahash",
  "autocfg 1.0.0",
 ]
 
@@ -1856,6 +1863,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -4193,6 +4209,7 @@ dependencies = [
  "libc",
  "libloading 0.6.2",
  "log 0.4.8",
+ "lru",
  "memmap",
  "num-derive 0.3.0",
  "num-traits",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -16,6 +16,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +724,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
+dependencies = [
+ "ahash",
+ "autocfg",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +978,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lru"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -1916,6 +1941,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "lru",
  "memmap",
  "num-derive 0.3.0",
  "num-traits",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.14"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3431e8f72b90f8a7af91dec890d9814000cb371258e0ec7370d93e085361f531"
+checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -1186,14 +1186,11 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.14"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25af5fc872ba284d8d84608bf8a0fa9b5376c96c23f503b007dfd9e34dde5606"
+checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.19",
- "quote 1.0.6",
- "syn 1.0.27",
 ]
 
 [[package]]
@@ -2043,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185f68b54660652e2244bbdef792b369f12045da856a4af75b776e6e72757831"
+checksum = "962f8f04ac7239fe4dd45fa4ce706ec78b59a0da9f41def463832857e36c60b0"
 dependencies = [
  "byteorder 1.3.4",
  "combine",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -16,12 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
-name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,16 +718,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
-dependencies = [
- "ahash",
- "autocfg",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,15 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "lru"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111b945ac72ec09eb7bc62a0fbdc3cc6e80555a7245f52a69d3921a75b53b153"
-dependencies = [
- "hashbrown",
 ]
 
 [[package]]
@@ -1941,7 +1916,6 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru",
  "memmap",
  "num-derive 0.3.0",
  "num-traits",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -26,7 +26,7 @@ solana-bpf-loader-program = { path = "../bpf_loader", version = "1.4.0" }
 solana-logger = { path = "../../logger", version = "1.4.0" }
 solana-runtime = { path = "../../runtime", version = "1.4.0" }
 solana-sdk = { path = "../../sdk", version = "1.4.0" }
-solana_rbpf = "=0.1.30"
+solana_rbpf = "=0.1.31"
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -6,8 +6,7 @@ extern crate test;
 extern crate solana_bpf_loader_program;
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
-use solana_bpf_loader_program::serialization::{deserialize_parameters, serialize_parameters};
-use solana_rbpf::EbpfVm;
+use solana_rbpf::vm::EbpfVm;
 use solana_runtime::{
     bank::Bank,
     bank_client::BankClient,
@@ -15,11 +14,13 @@ use solana_runtime::{
     loader_utils::load_program,
 };
 use solana_sdk::{
-    account::{create_keyed_readonly_accounts, Account},
-    bpf_loader, bpf_loader_deprecated,
+    account::Account,
+    bpf_loader,
     client::SyncClient,
     entrypoint::SUCCESS,
-    entrypoint_native::{ComputeBudget, ComputeMeter, InvokeContext, Logger, ProcessInstruction},
+    entrypoint_native::{
+        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
+    },
     instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
     message::Message,
     pubkey::Pubkey,
@@ -40,10 +41,6 @@ fn create_bpf_path(name: &str) -> PathBuf {
     pathbuf.push(name);
     pathbuf.set_extension(PLATFORM_FILE_EXTENSION_BPF);
     pathbuf
-}
-
-fn empty_check(_prog: &[u8]) -> Result<(), solana_bpf_loader_program::BPFError> {
-    Ok(())
 }
 
 fn load_elf(name: &str) -> Result<Vec<u8>, std::io::Error> {
@@ -71,15 +68,13 @@ const ARMSTRONG_LIMIT: u64 = 500;
 const ARMSTRONG_EXPECTED: u64 = 5;
 
 #[bench]
-fn bench_program_verify(bencher: &mut Bencher) {
+fn bench_program_create_executable(bencher: &mut Bencher) {
     let elf = load_elf("bench_alu").unwrap();
-    let mut vm = EbpfVm::<solana_bpf_loader_program::BPFError>::new(None).unwrap();
-    vm.set_verifier(empty_check).unwrap();
-    vm.set_elf(&elf).unwrap();
 
     bencher.iter(|| {
-        vm.set_verifier(solana_bpf_loader_program::bpf_verifier::check)
-            .unwrap();
+        let _ =
+            EbpfVm::<solana_bpf_loader_program::BPFError>::create_executable_from_elf(&elf, None)
+                .unwrap();
     });
 }
 
@@ -96,8 +91,16 @@ fn bench_program_alu(bencher: &mut Bencher) {
     let mut invoke_context = MockInvokeContext::default();
 
     let elf = load_elf("bench_alu").unwrap();
-    let (mut vm, _) =
-        solana_bpf_loader_program::create_vm(&loader_id, &elf, &[], &mut invoke_context).unwrap();
+    let executable =
+        EbpfVm::<solana_bpf_loader_program::BPFError>::create_executable_from_elf(&elf, None)
+            .unwrap();
+    let (mut vm, _) = solana_bpf_loader_program::create_vm(
+        &loader_id,
+        executable.as_ref(),
+        &[],
+        &mut invoke_context,
+    )
+    .unwrap();
 
     println!("Interpreted:");
     assert_eq!(
@@ -186,62 +189,6 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
     });
 }
 
-fn create_serialization_create_params() -> (Vec<u8>, Vec<(Pubkey, RefCell<Account>)>) {
-    let accounts = vec![
-        (
-            Pubkey::new_rand(),
-            RefCell::new(Account::new(0, 100, &Pubkey::new_rand())),
-        ),
-        (
-            Pubkey::new_rand(),
-            RefCell::new(Account::new(0, 100, &Pubkey::new_rand())),
-        ),
-        (
-            Pubkey::new_rand(),
-            RefCell::new(Account::new(0, 250, &Pubkey::new_rand())),
-        ),
-        (
-            Pubkey::new_rand(),
-            RefCell::new(Account::new(0, 1000, &Pubkey::new_rand())),
-        ),
-    ];
-    (vec![0xee; 100], accounts)
-}
-
-#[bench]
-fn bench_serialization_aligned(bencher: &mut Bencher) {
-    let (data, accounts) = create_serialization_create_params();
-    let keyed_accounts = create_keyed_readonly_accounts(&accounts);
-
-    bencher.iter(|| {
-        let buffer = serialize_parameters(
-            &bpf_loader_deprecated::id(),
-            &Pubkey::new_rand(),
-            &keyed_accounts,
-            &data,
-        )
-        .unwrap();
-        deserialize_parameters(&bpf_loader_deprecated::id(), &keyed_accounts, &buffer).unwrap();
-    });
-}
-
-#[bench]
-fn bench_serialization_unaligned(bencher: &mut Bencher) {
-    let (data, accounts) = create_serialization_create_params();
-    let keyed_accounts = create_keyed_readonly_accounts(&accounts);
-
-    bencher.iter(|| {
-        let buffer = serialize_parameters(
-            &bpf_loader_deprecated::id(),
-            &Pubkey::new_rand(),
-            &keyed_accounts,
-            &data,
-        )
-        .unwrap();
-        deserialize_parameters(&bpf_loader_deprecated::id(), &keyed_accounts, &buffer).unwrap();
-    });
-}
-
 #[derive(Debug, Default)]
 pub struct MockInvokeContext {
     key: Pubkey,
@@ -278,6 +225,10 @@ impl InvokeContext for MockInvokeContext {
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         Rc::new(RefCell::new(self.mock_compute_meter.clone()))
+    }
+    fn add_executor(&mut self, _pubkey: &Pubkey, _executor: Arc<dyn Executor>) {}
+    fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
+        None
     }
 }
 #[derive(Debug, Default, Clone)]

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -154,8 +154,6 @@ fn bench_program_alu(bencher: &mut Bencher) {
 
 #[bench]
 fn bench_program_execute_noop(bencher: &mut Bencher) {
-    // solana_logger::setup(); // TODO remove
-
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -180,7 +178,6 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
         .send_and_confirm_message(&[&mint_keypair], message.clone())
         .unwrap();
 
-    println!("start bench");
     bencher.iter(|| {
         bank.clear_signatures();
         bank_client

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 [dependencies]
 bincode = "1.3.1"
 byteorder = "1.3.4"
-num-derive = { version = "0.3" }
-num-traits = { version = "0.2" }
+num-derive = "0.3"
+num-traits = "0.2"
 solana-runtime = { path = "../../runtime", version = "1.4.0" }
 solana-sdk = { path = "../../sdk", version = "1.4.0" }
-solana_rbpf = "=0.1.30"
+solana_rbpf = "=0.1.31"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1,9 +1,10 @@
 use crate::{alloc, BPFError};
 use alloc::Alloc;
 use solana_rbpf::{
-    ebpf::{EbpfError, SyscallObject, ELF_INSN_DUMP_OFFSET, MM_HEAP_START},
+    ebpf::{ELF_INSN_DUMP_OFFSET, MM_HEAP_START},
+    error::EbpfError,
     memory_region::{translate_addr, MemoryRegion},
-    EbpfVm,
+    vm::{EbpfVm, SyscallObject},
 };
 use solana_runtime::message_processor::MessageProcessor;
 use solana_sdk::{
@@ -1282,7 +1283,7 @@ mod tests {
         assert_eq!(
             Err(EbpfError::AccessViolation(
                 "programs/bpf_loader/src/syscalls.rs".to_string(),
-                247,
+                248,
                 100,
                 32,
                 "  regions: \n0x64-0x73".to_string()

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,7 +24,6 @@ lazy_static = "1.4.0"
 libc = "0.2.72"
 libloading = "0.6.2"
 log = "0.4.8"
-lru = "0.6.0"
 memmap = "0.7.0"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,6 +24,7 @@ lazy_static = "1.4.0"
 libc = "0.2.72"
 libloading = "0.6.2"
 log = "0.4.8"
+lru = "0.6.0"
 memmap = "0.7.0"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8783,7 +8783,7 @@ mod tests {
         executors.insert(key4, executor.clone());
         let executors = Rc::new(RefCell::new(executors));
         executors.borrow_mut().is_dirty = false;
-        bank.update_executors(executors.clone());
+        bank.update_executors(executors);
         let executors = bank.get_executors(&message, loaders);
         assert_eq!(executors.borrow().executors.len(), 0);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -149,6 +149,7 @@ impl Builtin {
 const MAX_CACHED_EXECUTORS: usize = 100; // 10 MB assuming programs are around 100k
 
 /// LFU Cache of executors
+#[derive(AbiExample)]
 struct CachedExecutors {
     max: usize,
     executors: HashMap<Pubkey, (AtomicU64, Arc<dyn Executor>)>,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1349,7 +1349,7 @@ mod tests {
             &accounts,
             &rent_collector,
             None,
-            executors.clone(),
+            executors,
         );
         assert_eq!(
             result,
@@ -1504,7 +1504,7 @@ mod tests {
             &accounts,
             &rent_collector,
             None,
-            executors.clone(),
+            executors,
         );
         assert_eq!(result, Ok(()));
         assert_eq!(accounts[0].borrow().lamports, 80);

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -8,7 +8,7 @@ use solana_sdk::{
     clock::Epoch,
     entrypoint_native::{
         ComputeBudget, ComputeMeter, ErasedProcessInstruction, ErasedProcessInstructionWithContext,
-        InvokeContext, Logger, ProcessInstruction, ProcessInstructionWithContext,
+        Executor, InvokeContext, Logger, ProcessInstruction, ProcessInstructionWithContext,
     },
     instruction::{CompiledInstruction, InstructionError},
     message::Message,
@@ -18,7 +18,29 @@ use solana_sdk::{
     system_program,
     transaction::TransactionError,
 };
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
+
+pub struct Executors {
+    pub executors: HashMap<Pubkey, Arc<dyn Executor>>,
+    pub is_dirty: bool,
+}
+impl Default for Executors {
+    fn default() -> Self {
+        Self {
+            executors: HashMap::default(),
+            is_dirty: false,
+        }
+    }
+}
+impl Executors {
+    pub fn insert(&mut self, key: Pubkey, executor: Arc<dyn Executor>) {
+        let _ = self.executors.insert(key, executor);
+        self.is_dirty = true;
+    }
+    pub fn get(&self, key: &Pubkey) -> Option<Arc<dyn Executor>> {
+        self.executors.get(key).cloned()
+    }
+}
 
 // The relevant state of an account before an Instruction executes, used
 // to verify account integrity after the Instruction completes
@@ -182,6 +204,7 @@ pub struct ThisInvokeContext {
     is_cross_program_supported: bool,
     compute_budget: ComputeBudget,
     compute_meter: Rc<RefCell<dyn ComputeMeter>>,
+    executors: Rc<RefCell<Executors>>,
 }
 impl ThisInvokeContext {
     pub fn new(
@@ -192,6 +215,7 @@ impl ThisInvokeContext {
         log_collector: Option<Rc<LogCollector>>,
         is_cross_program_supported: bool,
         compute_budget: ComputeBudget,
+        executors: Rc<RefCell<Executors>>,
     ) -> Self {
         let mut program_ids = Vec::with_capacity(compute_budget.max_invoke_depth);
         program_ids.push(*program_id);
@@ -206,6 +230,7 @@ impl ThisInvokeContext {
             compute_meter: Rc::new(RefCell::new(ThisComputeMeter {
                 remaining: compute_budget.max_units,
             })),
+            executors,
         }
     }
 }
@@ -261,6 +286,12 @@ impl InvokeContext for ThisInvokeContext {
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         self.compute_meter.clone()
+    }
+    fn add_executor(&mut self, pubkey: &Pubkey, executor: Arc<dyn Executor>) {
+        self.executors.borrow_mut().insert(*pubkey, executor);
+    }
+    fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
+        self.executors.borrow().get(&pubkey)
     }
 }
 pub struct ThisLogger {
@@ -633,6 +664,7 @@ impl MessageProcessor {
         accounts: &[Rc<RefCell<Account>>],
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
+        executors: Rc<RefCell<Executors>>,
     ) -> Result<(), InstructionError> {
         let pre_accounts = Self::create_pre_accounts(message, instruction, accounts);
         let mut invoke_context = ThisInvokeContext::new(
@@ -643,6 +675,7 @@ impl MessageProcessor {
             log_collector,
             self.is_cross_program_supported,
             self.compute_budget,
+            executors,
         );
         let keyed_accounts =
             Self::create_keyed_accounts(message, instruction, executable_accounts, accounts)?;
@@ -668,6 +701,7 @@ impl MessageProcessor {
         accounts: &[Rc<RefCell<Account>>],
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
+        executors: Rc<RefCell<Executors>>,
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
             self.execute_instruction(
@@ -677,6 +711,7 @@ impl MessageProcessor {
                 accounts,
                 rent_collector,
                 log_collector.clone(),
+                executors.clone(),
             )
             .map_err(|err| TransactionError::InstructionError(instruction_index as u8, err))?;
         }
@@ -733,6 +768,7 @@ mod tests {
             None,
             true,
             ComputeBudget::default(),
+            Rc::new(RefCell::new(Executors::default())),
         );
 
         // Check call depth increases and has a limit
@@ -1244,6 +1280,8 @@ mod tests {
         let account = RefCell::new(create_loadable_account("mock_system_program"));
         loaders.push(vec![(mock_system_program_id, account)]);
 
+        let executors = Rc::new(RefCell::new(Executors::default()));
+
         let from_pubkey = Pubkey::new_rand();
         let to_pubkey = Pubkey::new_rand();
         let account_metas = vec![
@@ -1259,8 +1297,14 @@ mod tests {
             Some(&from_pubkey),
         );
 
-        let result =
-            message_processor.process_message(&message, &loaders, &accounts, &rent_collector, None);
+        let result = message_processor.process_message(
+            &message,
+            &loaders,
+            &accounts,
+            &rent_collector,
+            None,
+            executors.clone(),
+        );
         assert_eq!(result, Ok(()));
         assert_eq!(accounts[0].borrow().lamports, 100);
         assert_eq!(accounts[1].borrow().lamports, 0);
@@ -1274,8 +1318,14 @@ mod tests {
             Some(&from_pubkey),
         );
 
-        let result =
-            message_processor.process_message(&message, &loaders, &accounts, &rent_collector, None);
+        let result = message_processor.process_message(
+            &message,
+            &loaders,
+            &accounts,
+            &rent_collector,
+            None,
+            executors.clone(),
+        );
         assert_eq!(
             result,
             Err(TransactionError::InstructionError(
@@ -1293,8 +1343,14 @@ mod tests {
             Some(&from_pubkey),
         );
 
-        let result =
-            message_processor.process_message(&message, &loaders, &accounts, &rent_collector, None);
+        let result = message_processor.process_message(
+            &message,
+            &loaders,
+            &accounts,
+            &rent_collector,
+            None,
+            executors.clone(),
+        );
         assert_eq!(
             result,
             Err(TransactionError::InstructionError(
@@ -1375,6 +1431,8 @@ mod tests {
         let account = RefCell::new(create_loadable_account("mock_system_program"));
         loaders.push(vec![(mock_program_id, account)]);
 
+        let executors = Rc::new(RefCell::new(Executors::default()));
+
         let from_pubkey = Pubkey::new_rand();
         let to_pubkey = Pubkey::new_rand();
         let dup_pubkey = from_pubkey;
@@ -1393,8 +1451,14 @@ mod tests {
             )],
             Some(&from_pubkey),
         );
-        let result =
-            message_processor.process_message(&message, &loaders, &accounts, &rent_collector, None);
+        let result = message_processor.process_message(
+            &message,
+            &loaders,
+            &accounts,
+            &rent_collector,
+            None,
+            executors.clone(),
+        );
         assert_eq!(
             result,
             Err(TransactionError::InstructionError(
@@ -1412,8 +1476,14 @@ mod tests {
             )],
             Some(&from_pubkey),
         );
-        let result =
-            message_processor.process_message(&message, &loaders, &accounts, &rent_collector, None);
+        let result = message_processor.process_message(
+            &message,
+            &loaders,
+            &accounts,
+            &rent_collector,
+            None,
+            executors.clone(),
+        );
         assert_eq!(result, Ok(()));
 
         // Do work on the same account but at different location in keyed_accounts[]
@@ -1428,8 +1498,14 @@ mod tests {
             )],
             Some(&from_pubkey),
         );
-        let result =
-            message_processor.process_message(&message, &loaders, &accounts, &rent_collector, None);
+        let result = message_processor.process_message(
+            &message,
+            &loaders,
+            &accounts,
+            &rent_collector,
+            None,
+            executors.clone(),
+        );
         assert_eq!(result, Ok(()));
         assert_eq!(accounts[0].borrow().lamports, 80);
         assert_eq!(accounts[1].borrow().lamports, 20);
@@ -1504,6 +1580,7 @@ mod tests {
             None,
             true,
             ComputeBudget::default(),
+            Rc::new(RefCell::new(Executors::default())),
         );
         let metas = vec![
             AccountMeta::new(owned_key, false),

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -1,5 +1,7 @@
 //! @brief Solana Native program entry point
 
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
+use crate::abi_example::AbiExample;
 use crate::{
     account::Account, account::KeyedAccount, instruction::CompiledInstruction,
     instruction::InstructionError, message::Message, pubkey::Pubkey,
@@ -281,4 +283,22 @@ pub trait Executor: Send + Sync {
         instruction_data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError>;
+}
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
+impl AbiExample for Arc<dyn Executor> {
+    fn example() -> Self {
+        struct ExampleExecutor {}
+        impl Executor for ExampleExecutor {
+            fn execute(
+                &self,
+                _program_id: &Pubkey,
+                _keyed_accounts: &[KeyedAccount],
+                _instruction_data: &[u8],
+                _invoke_context: &mut dyn InvokeContext,
+            ) -> std::result::Result<(), InstructionError> {
+                Ok(())
+            }
+        }
+        Arc::new(ExampleExecutor {})
+    }
 }


### PR DESCRIPTION
#### Problem

The BPF loader relocates and fixes up the ELF located in the program's account data each time the program is executed

#### Summary of Changes

Load and cache the results during `Finalize` or during execution if the cache entry has expired

Fixes #
