### PR TITLE
Add blockstore column to store performance sampling data

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -137,6 +137,7 @@ pub struct Blockstore {
     active_transaction_status_index: RwLock<u64>,
     rewards_cf: LedgerColumn<cf::Rewards>,
     blocktime_cf: LedgerColumn<cf::Blocktime>,
+    perf_samples_cf: LedgerColumn<cf::PerfSamples>,
     last_root: Arc<RwLock<Slot>>,
     insert_shreds_lock: Arc<Mutex<()>>,
     pub new_shreds_signals: Vec<SyncSender<bool>>,
@@ -293,6 +294,7 @@ impl Blockstore {
         let transaction_status_index_cf = db.column();
         let rewards_cf = db.column();
         let blocktime_cf = db.column();
+        let perf_samples_cf = db.column();
 
         let db = Arc::new(db);
 
@@ -338,6 +340,7 @@ impl Blockstore {
             active_transaction_status_index: RwLock::new(active_transaction_status_index),
             rewards_cf,
             blocktime_cf,
+            perf_samples_cf,
             new_shreds_signals: vec![],
             completed_slots_senders: vec![],
             insert_shreds_lock: Arc::new(Mutex::new(())),
@@ -2301,6 +2304,22 @@ impl Blockstore {
                 timestamps
             })
             .collect())
+    }
+
+    pub fn get_recent_perf_samples(&self, num: usize) -> Result<Vec<(Slot, PerfSample)>> {
+        Ok(self
+            .db
+            .iter::<cf::PerfSamples>(IteratorMode::End)?
+            .take(num)
+            .map(|(slot, data)| {
+                let perf_sample = deserialize(&data).unwrap();
+                (slot, perf_sample)
+            })
+            .collect())
+    }
+
+    pub fn write_perf_sample(&self, index: Slot, perf_sample: &PerfSample) -> Result<()> {
+        self.perf_samples_cf.put(index, perf_sample)
     }
 
     /// Returns the entry vector for the slot starting with `shred_start_index`
@@ -6926,6 +6945,38 @@ pub mod tests {
                 assert_eq!(m.meta.as_ref().unwrap().fee, x as u64);
             }
             assert_eq!(map[4].meta, None);
+        }
+        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
+    }
+
+    #[test]
+    fn test_write_get_perf_samples() {
+        let blockstore_path = get_tmp_ledger_path!();
+        {
+            let blockstore = Blockstore::open(&blockstore_path).unwrap();
+            let num_entries: usize = 10;
+            let mut perf_samples: Vec<(Slot, PerfSample)> = vec![];
+            for x in 1..num_entries + 1 {
+                perf_samples.push((
+                    x as u64 * 50,
+                    PerfSample {
+                        num_transactions: 1000 + x as u64,
+                        num_slots: 50,
+                        sample_period_secs: 20,
+                    },
+                ));
+            }
+            for (slot, sample) in perf_samples.iter() {
+                blockstore.write_perf_sample(*slot, sample).unwrap();
+            }
+            for x in 0..num_entries {
+                let mut expected_samples = perf_samples[num_entries - 1 - x..].to_vec();
+                expected_samples.sort_by(|a, b| b.0.cmp(&a.0));
+                assert_eq!(
+                    blockstore.get_recent_perf_samples(x + 1).unwrap(),
+                    expected_samples
+                );
+            }
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -52,6 +52,8 @@ const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 const REWARDS_CF: &str = "rewards";
 /// Column family for Blocktime
 const BLOCKTIME_CF: &str = "blocktime";
+/// Column family for Performance Samples
+const PERF_SAMPLES_CF: &str = "perf_samples";
 
 #[derive(Error, Debug)]
 pub enum BlockstoreError {
@@ -140,6 +142,10 @@ pub mod columns {
     #[derive(Debug)]
     /// The blocktime column
     pub struct Blocktime;
+
+    #[derive(Debug)]
+    /// The performance samples column
+    pub struct PerfSamples;
 }
 
 pub enum AccessType {
@@ -200,7 +206,7 @@ impl Rocks {
     ) -> Result<Rocks> {
         use columns::{
             AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
-            Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
+            PerfSamples, Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
             TransactionStatusIndex,
         };
 
@@ -236,6 +242,8 @@ impl Rocks {
         let rewards_cf_descriptor = ColumnFamilyDescriptor::new(Rewards::NAME, get_cf_options());
         let blocktime_cf_descriptor =
             ColumnFamilyDescriptor::new(Blocktime::NAME, get_cf_options());
+        let perf_samples_cf_descriptor =
+            ColumnFamilyDescriptor::new(PerfSamples::NAME, get_cf_options());
 
         let cfs = vec![
             (SlotMeta::NAME, meta_cf_descriptor),
@@ -255,6 +263,7 @@ impl Rocks {
             ),
             (Rewards::NAME, rewards_cf_descriptor),
             (Blocktime::NAME, blocktime_cf_descriptor),
+            (PerfSamples::NAME, perf_samples_cf_descriptor),
         ];
 
         // Open the database
@@ -293,7 +302,7 @@ impl Rocks {
     fn columns(&self) -> Vec<&'static str> {
         use columns::{
             AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
-            Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
+            PerfSamples, Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
             TransactionStatusIndex,
         };
 
@@ -312,6 +321,7 @@ impl Rocks {
             TransactionStatusIndex::NAME,
             Rewards::NAME,
             Blocktime::NAME,
+            PerfSamples::NAME,
         ]
     }
 
@@ -543,6 +553,14 @@ impl ColumnName for columns::Blocktime {
 }
 impl TypedColumn for columns::Blocktime {
     type Type = UnixTimestamp;
+}
+
+impl SlotColumn for columns::PerfSamples {}
+impl ColumnName for columns::PerfSamples {
+    const NAME: &'static str = PERF_SAMPLES_CF;
+}
+impl TypedColumn for columns::PerfSamples {
+    type Type = blockstore_meta::PerfSample;
 }
 
 impl Column for columns::ShredCode {

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -243,6 +243,13 @@ pub struct AddressSignatureMeta {
     pub writeable: bool,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct PerfSample {
+    pub num_transactions: u64,
+    pub num_slots: u64,
+    pub sample_period_secs: u16,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
#### Problem
In order to move off of solanabeach apis, we need to store time-series data for some performance metrics, namely TPS (transaction count in period) and slot time (num slots in period).

#### Summary of Changes
- Add blockstore column to store performance samples

Toward #11771 

@oJshua , tag, you're it!