### PR TITLE
net.sh: Don't force --warp-slot w/o --wait-for-supermajority

### DIFF
--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -251,7 +251,7 @@ EOF
         shift
       done
 
-      if [[ -z "$maybeWarpSlot" ]]; then
+      if [[ -z "$maybeWarpSlot" && -n "$maybeWaitForSupermajority" ]]; then
         maybeWarpSlot="--warp-slot $maybeWaitForSupermajority"
       fi
 


### PR DESCRIPTION
#### Problem

Since https://github.com/solana-labs/solana/pull/12123, `--warp-slot` is always forced unless specified.  This breaks when `--wait-for-supermajority` is also unspecified, which is the usual case.

#### Summary of Changes

Also gate on `--wait-for-supermajority` having been specified

h/t @carllin for noticing!