### PR TITLE
feat: create instructions instead of transaction from system program

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -868,21 +868,23 @@ declare module '@solana/web3.js' {
   export class SystemProgram {
     static programId: PublicKey;
 
-    static createAccount(params: CreateAccountParams): Transaction;
+    static createAccount(params: CreateAccountParams): TransactionInstruction;
     static createAccountWithSeed(
       params: CreateAccountWithSeedParams,
-    ): Transaction;
+    ): TransactionInstruction;
     static allocate(
       params: AllocateParams | AllocateWithSeedParams,
-    ): Transaction;
-    static assign(params: AssignParams | AssignWithSeedParams): Transaction;
-    static transfer(params: TransferParams): Transaction;
+    ): TransactionInstruction;
+    static assign(
+      params: AssignParams | AssignWithSeedParams,
+    ): TransactionInstruction;
+    static transfer(params: TransferParams): TransactionInstruction;
     static createNonceAccount(
       params: CreateNonceAccountParams | CreateNonceAccountWithSeedParams,
     ): Transaction;
     static nonceAdvance(params: AdvanceNonceParams): TransactionInstruction;
-    static nonceWithdraw(params: WithdrawNonceParams): Transaction;
-    static nonceAuthorize(params: AuthorizeNonceParams): Transaction;
+    static nonceWithdraw(params: WithdrawNonceParams): TransactionInstruction;
+    static nonceAuthorize(params: AuthorizeNonceParams): TransactionInstruction;
   }
 
   export type SystemInstructionType =

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -875,21 +875,23 @@ declare module '@solana/web3.js' {
   declare export class SystemProgram {
     static programId: PublicKey;
 
-    static createAccount(params: CreateAccountParams): Transaction;
+    static createAccount(params: CreateAccountParams): TransactionInstruction;
     static createAccountWithSeed(
       params: CreateAccountWithSeedParams,
-    ): Transaction;
+    ): TransactionInstruction;
     static allocate(
       params: AllocateParams | AllocateWithSeedParams,
-    ): Transaction;
-    static assign(params: AssignParams | AssignWithSeedParams): Transaction;
-    static transfer(params: TransferParams): Transaction;
+    ): TransactionInstruction;
+    static assign(
+      params: AssignParams | AssignWithSeedParams,
+    ): TransactionInstruction;
+    static transfer(params: TransferParams): TransactionInstruction;
     static createNonceAccount(
       params: CreateNonceAccountParams | CreateNonceAccountWithSeedParams,
     ): Transaction;
     static nonceAdvance(params: AdvanceNonceParams): TransactionInstruction;
-    static nonceWithdraw(params: WithdrawNonceParams): Transaction;
-    static nonceAuthorize(params: AuthorizeNonceParams): Transaction;
+    static nonceWithdraw(params: WithdrawNonceParams): TransactionInstruction;
+    static nonceAuthorize(params: AuthorizeNonceParams): TransactionInstruction;
   }
 
   declare export type SystemInstructionType =

--- a/web3.js/src/loader.js
+++ b/web3.js/src/loader.js
@@ -57,13 +57,15 @@ export class Loader {
       const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
         data.length,
       );
-      const transaction = SystemProgram.createAccount({
-        fromPubkey: payer.publicKey,
-        newAccountPubkey: program.publicKey,
-        lamports: balanceNeeded > 0 ? balanceNeeded : 1,
-        space: data.length,
-        programId,
-      });
+      const transaction = new Transaction().add(
+        SystemProgram.createAccount({
+          fromPubkey: payer.publicKey,
+          newAccountPubkey: program.publicKey,
+          lamports: balanceNeeded > 0 ? balanceNeeded : 1,
+          space: data.length,
+          programId,
+        }),
+      );
       await sendAndConfirmTransaction(
         connection,
         transaction,

--- a/web3.js/src/stake-program.js
+++ b/web3.js/src/stake-program.js
@@ -522,15 +522,18 @@ export class StakeProgram {
   static createAccountWithSeed(
     params: CreateStakeAccountWithSeedParams,
   ): Transaction {
-    let transaction = SystemProgram.createAccountWithSeed({
-      fromPubkey: params.fromPubkey,
-      newAccountPubkey: params.stakePubkey,
-      basePubkey: params.basePubkey,
-      seed: params.seed,
-      lamports: params.lamports,
-      space: this.space,
-      programId: this.programId,
-    });
+    const transaction = new Transaction();
+    transaction.add(
+      SystemProgram.createAccountWithSeed({
+        fromPubkey: params.fromPubkey,
+        newAccountPubkey: params.stakePubkey,
+        basePubkey: params.basePubkey,
+        seed: params.seed,
+        lamports: params.lamports,
+        space: this.space,
+        programId: this.programId,
+      }),
+    );
 
     const {stakePubkey, authorized, lockup} = params;
     return transaction.add(this.initialize({stakePubkey, authorized, lockup}));
@@ -540,13 +543,16 @@ export class StakeProgram {
    * Generate a Transaction that creates a new Stake account
    */
   static createAccount(params: CreateStakeAccountParams): Transaction {
-    let transaction = SystemProgram.createAccount({
-      fromPubkey: params.fromPubkey,
-      newAccountPubkey: params.stakePubkey,
-      lamports: params.lamports,
-      space: this.space,
-      programId: this.programId,
-    });
+    const transaction = new Transaction();
+    transaction.add(
+      SystemProgram.createAccount({
+        fromPubkey: params.fromPubkey,
+        newAccountPubkey: params.stakePubkey,
+        lamports: params.lamports,
+        space: this.space,
+        programId: this.programId,
+      }),
+    );
 
     const {stakePubkey, authorized, lockup} = params;
     return transaction.add(this.initialize({stakePubkey, authorized, lockup}));
@@ -648,13 +654,16 @@ export class StakeProgram {
   static split(params: SplitStakeParams): Transaction {
     const {stakePubkey, authorizedPubkey, splitStakePubkey, lamports} = params;
 
-    let transaction = SystemProgram.createAccount({
-      fromPubkey: authorizedPubkey,
-      newAccountPubkey: splitStakePubkey,
-      lamports: 0,
-      space: this.space,
-      programId: this.programId,
-    });
+    const transaction = new Transaction();
+    transaction.add(
+      SystemProgram.createAccount({
+        fromPubkey: authorizedPubkey,
+        newAccountPubkey: splitStakePubkey,
+        lamports: 0,
+        space: this.space,
+        programId: this.programId,
+      }),
+    );
     const type = STAKE_INSTRUCTION_LAYOUTS.Split;
     const data = encodeData(type, {lamports});
 

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -6,6 +6,7 @@ import {
   Account,
   Connection,
   SystemProgram,
+  Transaction,
   sendAndConfirmTransaction,
   LAMPORTS_PER_SOL,
   PublicKey,
@@ -131,10 +132,12 @@ test('get program accounts', async () => {
     },
   ]);
 
-  let transaction = SystemProgram.assign({
-    accountPubkey: account0.publicKey,
-    programId: programId.publicKey,
-  });
+  let transaction = new Transaction().add(
+    SystemProgram.assign({
+      accountPubkey: account0.publicKey,
+      programId: programId.publicKey,
+    }),
+  );
 
   mockConfirmTransaction(
     '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
@@ -156,10 +159,12 @@ test('get program accounts', async () => {
     },
   ]);
 
-  transaction = SystemProgram.assign({
-    accountPubkey: account1.publicKey,
-    programId: programId.publicKey,
-  });
+  transaction = new Transaction().add(
+    SystemProgram.assign({
+      accountPubkey: account1.publicKey,
+      programId: programId.publicKey,
+    }),
+  );
 
   mockConfirmTransaction(
     '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
@@ -1746,13 +1751,15 @@ test('transaction failure', async () => {
   ]);
 
   const newAccount = new Account();
-  let transaction = SystemProgram.createAccount({
-    fromPubkey: account.publicKey,
-    newAccountPubkey: newAccount.publicKey,
-    lamports: 1000,
-    space: 0,
-    programId: SystemProgram.programId,
-  });
+  let transaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: account.publicKey,
+      newAccountPubkey: newAccount.publicKey,
+      lamports: 1000,
+      space: 0,
+      programId: SystemProgram.programId,
+    }),
+  );
 
   mockConfirmTransaction(
     '3WE5w4B7v59x6qjyC4FbG2FEKYKQfvsJwqSxNVmtMjT8TQ31hsZieDHcSgqzxiAoTL56n2w5TncjqEKjLhtF4Vk',
@@ -1777,13 +1784,15 @@ test('transaction failure', async () => {
   ]);
 
   // This should fail because the account is already created
-  transaction = SystemProgram.createAccount({
-    fromPubkey: account.publicKey,
-    newAccountPubkey: newAccount.publicKey,
-    lamports: 10,
-    space: 0,
-    programId: SystemProgram.programId,
-  });
+  transaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: account.publicKey,
+      newAccountPubkey: newAccount.publicKey,
+      lamports: 10,
+      space: 0,
+      programId: SystemProgram.programId,
+    }),
+  );
   const signature = await connection.sendTransaction(
     transaction,
     [account, newAccount],
@@ -1957,11 +1966,13 @@ test('transaction', async () => {
     },
   ]);
 
-  const transaction = SystemProgram.transfer({
-    fromPubkey: accountFrom.publicKey,
-    toPubkey: accountTo.publicKey,
-    lamports: 10,
-  });
+  const transaction = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: accountFrom.publicKey,
+      toPubkey: accountTo.publicKey,
+      lamports: 10,
+    }),
+  );
   const signature = await connection.sendTransaction(
     transaction,
     [accountFrom],
@@ -1988,11 +1999,13 @@ test('transaction', async () => {
 
   // Send again and ensure that new blockhash is used
   const lastFetch = Date.now();
-  const transaction2 = SystemProgram.transfer({
-    fromPubkey: accountFrom.publicKey,
-    toPubkey: accountTo.publicKey,
-    lamports: 10,
-  });
+  const transaction2 = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: accountFrom.publicKey,
+      toPubkey: accountTo.publicKey,
+      lamports: 10,
+    }),
+  );
   const signature2 = await connection.sendTransaction(
     transaction2,
     [accountFrom],
@@ -2017,11 +2030,13 @@ test('transaction', async () => {
   ]);
 
   // Send new transaction and ensure that same blockhash is used
-  const transaction3 = SystemProgram.transfer({
-    fromPubkey: accountFrom.publicKey,
-    toPubkey: accountTo.publicKey,
-    lamports: 9,
-  });
+  const transaction3 = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: accountFrom.publicKey,
+      toPubkey: accountTo.publicKey,
+      lamports: 9,
+    }),
+  );
   const signature3 = await connection.sendTransaction(
     transaction3,
     [accountFrom],
@@ -2052,11 +2067,13 @@ test('transaction', async () => {
     },
   ]);
 
-  const transaction4 = SystemProgram.transfer({
-    fromPubkey: accountFrom.publicKey,
-    toPubkey: accountTo.publicKey,
-    lamports: 13,
-  });
+  const transaction4 = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: accountFrom.publicKey,
+      toPubkey: accountTo.publicKey,
+      lamports: 13,
+    }),
+  );
 
   const signature4 = await connection.sendTransaction(
     transaction4,
@@ -2150,17 +2167,21 @@ test('multi-instruction transaction', async () => {
 
   // 1. Move(accountFrom, accountTo)
   // 2. Move(accountTo, accountFrom)
-  const transaction = SystemProgram.transfer({
-    fromPubkey: accountFrom.publicKey,
-    toPubkey: accountTo.publicKey,
-    lamports: 100,
-  }).add(
-    SystemProgram.transfer({
-      fromPubkey: accountTo.publicKey,
-      toPubkey: accountFrom.publicKey,
-      lamports: 100,
-    }),
-  );
+  const transaction = new Transaction()
+    .add(
+      SystemProgram.transfer({
+        fromPubkey: accountFrom.publicKey,
+        toPubkey: accountTo.publicKey,
+        lamports: 100,
+      }),
+    )
+    .add(
+      SystemProgram.transfer({
+        fromPubkey: accountTo.publicKey,
+        toPubkey: accountFrom.publicKey,
+        lamports: 100,
+      }),
+    );
   signature = await connection.sendTransaction(
     transaction,
     [accountFrom, accountTo],
@@ -2213,11 +2234,13 @@ test('account change notification', async () => {
 
   await connection.requestAirdrop(owner.publicKey, LAMPORTS_PER_SOL);
   try {
-    let transaction = SystemProgram.transfer({
-      fromPubkey: owner.publicKey,
-      toPubkey: programAccount.publicKey,
-      lamports: balanceNeeded,
-    });
+    const transaction = new Transaction().add(
+      SystemProgram.transfer({
+        fromPubkey: owner.publicKey,
+        toPubkey: programAccount.publicKey,
+        lamports: balanceNeeded,
+      }),
+    );
     await sendAndConfirmTransaction(connection, transaction, [owner], {
       commitment: 'single',
       skipPreflight: true,
@@ -2280,11 +2303,13 @@ test('program account change notification', async () => {
 
   await connection.requestAirdrop(owner.publicKey, LAMPORTS_PER_SOL);
   try {
-    let transaction = SystemProgram.transfer({
-      fromPubkey: owner.publicKey,
-      toPubkey: programAccount.publicKey,
-      lamports: balanceNeeded,
-    });
+    const transaction = new Transaction().add(
+      SystemProgram.transfer({
+        fromPubkey: owner.publicKey,
+        toPubkey: programAccount.publicKey,
+        lamports: balanceNeeded,
+      }),
+    );
     await sendAndConfirmTransaction(connection, transaction, [owner], {
       commitment: 'single',
       skipPreflight: true,

--- a/web3.js/test/nonce.test.js
+++ b/web3.js/test/nonce.test.js
@@ -2,7 +2,13 @@
 
 import bs58 from 'bs58';
 
-import {Account, Connection, SystemProgram, PublicKey} from '../src';
+import {
+  Account,
+  Connection,
+  SystemProgram,
+  Transaction,
+  PublicKey,
+} from '../src';
 import {NONCE_ACCOUNT_LENGTH} from '../src/nonce-account';
 import {mockRpc, mockRpcEnabled} from './__mocks__/node-fetch';
 import {mockGetRecentBlockhash} from './mockrpc/get-recent-blockhash';
@@ -99,12 +105,14 @@ test('create and query nonce account', async () => {
     },
   ]);
 
-  const transaction = SystemProgram.createNonceAccount({
-    fromPubkey: from.publicKey,
-    noncePubkey: nonceAccount.publicKey,
-    authorizedPubkey: from.publicKey,
-    lamports: minimumAmount,
-  });
+  const transaction = new Transaction().add(
+    SystemProgram.createNonceAccount({
+      fromPubkey: from.publicKey,
+      noncePubkey: nonceAccount.publicKey,
+      authorizedPubkey: from.publicKey,
+      lamports: minimumAmount,
+    }),
+  );
   const nonceSignature = await connection.sendTransaction(
     transaction,
     [from, nonceAccount],
@@ -228,14 +236,16 @@ test('create and query nonce account with seed', async () => {
     },
   ]);
 
-  const transaction = SystemProgram.createNonceAccount({
-    fromPubkey: from.publicKey,
-    noncePubkey: noncePubkey,
-    basePubkey: from.publicKey,
-    seed,
-    authorizedPubkey: from.publicKey,
-    lamports: minimumAmount,
-  });
+  const transaction = new Transaction().add(
+    SystemProgram.createNonceAccount({
+      fromPubkey: from.publicKey,
+      noncePubkey: noncePubkey,
+      basePubkey: from.publicKey,
+      seed,
+      authorizedPubkey: from.publicKey,
+      lamports: minimumAmount,
+    }),
+  );
   const nonceSignature = await connection.sendTransaction(transaction, [from], {
     skipPreflight: true,
   });

--- a/web3.js/test/system-program.test.js
+++ b/web3.js/test/system-program.test.js
@@ -29,7 +29,9 @@ test('createAccount', () => {
     space: 0,
     programId: SystemProgram.programId,
   };
-  const transaction = SystemProgram.createAccount(params);
+  const transaction = new Transaction().add(
+    SystemProgram.createAccount(params),
+  );
   expect(transaction.instructions).toHaveLength(1);
   const [systemInstruction] = transaction.instructions;
   expect(params).toEqual(
@@ -43,7 +45,7 @@ test('transfer', () => {
     toPubkey: new Account().publicKey,
     lamports: 123,
   };
-  const transaction = SystemProgram.transfer(params);
+  const transaction = new Transaction().add(SystemProgram.transfer(params));
   expect(transaction.instructions).toHaveLength(1);
   const [systemInstruction] = transaction.instructions;
   expect(params).toEqual(SystemInstruction.decodeTransfer(systemInstruction));
@@ -54,7 +56,7 @@ test('allocate', () => {
     accountPubkey: new Account().publicKey,
     space: 42,
   };
-  const transaction = SystemProgram.allocate(params);
+  const transaction = new Transaction().add(SystemProgram.allocate(params));
   expect(transaction.instructions).toHaveLength(1);
   const [systemInstruction] = transaction.instructions;
   expect(params).toEqual(SystemInstruction.decodeAllocate(systemInstruction));
@@ -68,7 +70,7 @@ test('allocateWithSeed', () => {
     space: 42,
     programId: new Account().publicKey,
   };
-  const transaction = SystemProgram.allocate(params);
+  const transaction = new Transaction().add(SystemProgram.allocate(params));
   expect(transaction.instructions).toHaveLength(1);
   const [systemInstruction] = transaction.instructions;
   expect(params).toEqual(
@@ -81,7 +83,7 @@ test('assign', () => {
     accountPubkey: new Account().publicKey,
     programId: new Account().publicKey,
   };
-  const transaction = SystemProgram.assign(params);
+  const transaction = new Transaction().add(SystemProgram.assign(params));
   expect(transaction.instructions).toHaveLength(1);
   const [systemInstruction] = transaction.instructions;
   expect(params).toEqual(SystemInstruction.decodeAssign(systemInstruction));
@@ -94,7 +96,7 @@ test('assignWithSeed', () => {
     seed: '你好',
     programId: new Account().publicKey,
   };
-  const transaction = SystemProgram.assign(params);
+  const transaction = new Transaction().add(SystemProgram.assign(params));
   expect(transaction.instructions).toHaveLength(1);
   const [systemInstruction] = transaction.instructions;
   expect(params).toEqual(
@@ -113,7 +115,9 @@ test('createAccountWithSeed', () => {
     space: 0,
     programId: SystemProgram.programId,
   };
-  const transaction = SystemProgram.createAccountWithSeed(params);
+  const transaction = new Transaction().add(
+    SystemProgram.createAccountWithSeed(params),
+  );
   expect(transaction.instructions).toHaveLength(1);
   const [systemInstruction] = transaction.instructions;
   expect(params).toEqual(
@@ -130,7 +134,9 @@ test('createNonceAccount', () => {
     lamports: 123,
   };
 
-  const transaction = SystemProgram.createNonceAccount(params);
+  const transaction = new Transaction().add(
+    SystemProgram.createNonceAccount(params),
+  );
   expect(transaction.instructions).toHaveLength(2);
   const [createInstruction, initInstruction] = transaction.instructions;
 
@@ -165,7 +171,9 @@ test('createNonceAccount with seed', () => {
     lamports: 123,
   };
 
-  const transaction = SystemProgram.createNonceAccount(params);
+  const transaction = new Transaction().add(
+    SystemProgram.createNonceAccount(params),
+  );
   expect(transaction.instructions).toHaveLength(2);
   const [createInstruction, initInstruction] = transaction.instructions;
 
@@ -207,7 +215,9 @@ test('nonceWithdraw', () => {
     toPubkey: new Account().publicKey,
     lamports: 123,
   };
-  const transaction = SystemProgram.nonceWithdraw(params);
+  const transaction = new Transaction().add(
+    SystemProgram.nonceWithdraw(params),
+  );
   expect(transaction.instructions).toHaveLength(1);
   const [instruction] = transaction.instructions;
   expect(params).toEqual(SystemInstruction.decodeNonceWithdraw(instruction));
@@ -220,7 +230,9 @@ test('nonceAuthorize', () => {
     newAuthorizedPubkey: new Account().publicKey,
   };
 
-  const transaction = SystemProgram.nonceAuthorize(params);
+  const transaction = new Transaction().add(
+    SystemProgram.nonceAuthorize(params),
+  );
   expect(transaction.instructions).toHaveLength(1);
   const [instruction] = transaction.instructions;
   expect(params).toEqual(SystemInstruction.decodeNonceAuthorize(instruction));
@@ -280,12 +292,14 @@ test('live Nonce actions', async () => {
     'recent',
   );
 
-  let createNonceAccount = SystemProgram.createNonceAccount({
-    fromPubkey: from.publicKey,
-    noncePubkey: nonceAccount.publicKey,
-    authorizedPubkey: from.publicKey,
-    lamports: minimumAmount,
-  });
+  let createNonceAccount = new Transaction().add(
+    SystemProgram.createNonceAccount({
+      fromPubkey: from.publicKey,
+      noncePubkey: nonceAccount.publicKey,
+      authorizedPubkey: from.publicKey,
+      lamports: minimumAmount,
+    }),
+  );
   await sendAndConfirmTransaction(
     connection,
     createNonceAccount,
@@ -345,11 +359,13 @@ test('live Nonce actions', async () => {
     skipPreflight: true,
   });
 
-  let transfer = SystemProgram.transfer({
-    fromPubkey: from.publicKey,
-    toPubkey: to.publicKey,
-    lamports: minimumAmount,
-  });
+  let transfer = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: from.publicKey,
+      toPubkey: to.publicKey,
+      lamports: minimumAmount,
+    }),
+  );
   transfer.nonceInfo = {
     nonce,
     nonceInstruction: SystemProgram.nonceAdvance({

--- a/web3.js/test/transaction-payer.test.js
+++ b/web3.js/test/transaction-payer.test.js
@@ -1,5 +1,11 @@
 // @flow
-import {Account, Connection, SystemProgram, LAMPORTS_PER_SOL} from '../src';
+import {
+  Account,
+  Connection,
+  Transaction,
+  SystemProgram,
+  LAMPORTS_PER_SOL,
+} from '../src';
 import {mockRpc, mockRpcEnabled} from './__mocks__/node-fetch';
 import {mockGetRecentBlockhash} from './mockrpc/get-recent-blockhash';
 import {url} from './url';
@@ -88,11 +94,13 @@ test('transaction-payer', async () => {
     },
   ]);
 
-  const transaction = SystemProgram.transfer({
-    fromPubkey: accountFrom.publicKey,
-    toPubkey: accountTo.publicKey,
-    lamports: 10,
-  });
+  const transaction = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: accountFrom.publicKey,
+      toPubkey: accountTo.publicKey,
+      lamports: 10,
+    }),
+  );
 
   const signature = await connection.sendTransaction(
     transaction,


### PR DESCRIPTION
#### Problem
It's not possible to compose system instructions with the current API because the static methods return Transaction objects instead of TransactionInstruction objects

#### Summary of Changes
- Return `TransactionInstruction` instead of `Transaction`

Fixes #
