### PR TITLE
feat: support restarting failed bpf loader deploys

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -951,7 +951,7 @@ declare module '@solana/web3.js' {
       program: Account,
       programId: PublicKey,
       data: Buffer | Uint8Array | Array<number>,
-    ): Promise<PublicKey>;
+    ): Promise<boolean>;
   }
 
   // === src/bpf-loader.js ===
@@ -964,7 +964,7 @@ declare module '@solana/web3.js' {
       program: Account,
       elfBytes: Buffer | Uint8Array | Array<number>,
       loaderProgramId: PublicKey,
-    ): Promise<PublicKey>;
+    ): Promise<boolean>;
   }
 
   // === src/bpf-loader-deprecated.js ===

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -958,7 +958,7 @@ declare module '@solana/web3.js' {
       program: Account,
       programId: PublicKey,
       data: Buffer | Uint8Array | Array<number>,
-    ): Promise<PublicKey>;
+    ): Promise<boolean>;
   }
 
   // === src/bpf-loader.js ===
@@ -971,7 +971,7 @@ declare module '@solana/web3.js' {
       program: Account,
       elfBytes: Buffer | Uint8Array | Array<number>,
       loaderProgramId: PublicKey,
-    ): Promise<PublicKey>;
+    ): Promise<boolean>;
   }
 
   // === src/bpf-loader-deprecated.js ===

--- a/web3.js/src/bpf-loader.js
+++ b/web3.js/src/bpf-loader.js
@@ -31,6 +31,7 @@ export class BpfLoader {
    * @param program Account to load the program into
    * @param elf The entire ELF containing the BPF program
    * @param loaderProgramId The program id of the BPF loader to use
+   * @return true if program was loaded successfully, false if program was already loaded
    */
   static load(
     connection: Connection,
@@ -38,7 +39,7 @@ export class BpfLoader {
     program: Account,
     elf: Buffer | Uint8Array | Array<number>,
     loaderProgramId: PublicKey,
-  ): Promise<void> {
+  ): Promise<boolean> {
     return Loader.load(connection, payer, program, loaderProgramId, elf);
   }
 }

--- a/web3.js/src/loader.js
+++ b/web3.js/src/loader.js
@@ -68,6 +68,7 @@ export class Loader {
       let transaction: Transaction | null = null;
       if (programInfo !== null) {
         if (programInfo.executable) {
+          console.error('Program load failed, account is already executable');
           return false;
         }
 

--- a/web3.js/src/loader.js
+++ b/web3.js/src/loader.js
@@ -45,6 +45,7 @@ export class Loader {
    * @param program Account to load the program into
    * @param programId Public key that identifies the loader
    * @param data Program octets
+   * @return true if program was loaded successfully, false if program was already loaded
    */
   static async load(
     connection: Connection,
@@ -52,29 +53,79 @@ export class Loader {
     program: Account,
     programId: PublicKey,
     data: Buffer | Uint8Array | Array<number>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     {
       const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
         data.length,
       );
-      const transaction = new Transaction().add(
-        SystemProgram.createAccount({
-          fromPubkey: payer.publicKey,
-          newAccountPubkey: program.publicKey,
-          lamports: balanceNeeded > 0 ? balanceNeeded : 1,
-          space: data.length,
-          programId,
-        }),
+
+      // Fetch program account info to check if it has already been created
+      const programInfo = await connection.getAccountInfo(
+        program.publicKey,
+        'single',
       );
-      await sendAndConfirmTransaction(
-        connection,
-        transaction,
-        [payer, program],
-        {
-          commitment: 'single',
-          skipPreflight: true,
-        },
-      );
+
+      let transaction: Transaction | null = null;
+      if (programInfo !== null) {
+        if (programInfo.executable) {
+          return false;
+        }
+
+        if (programInfo.data.length !== data.length) {
+          transaction = transaction || new Transaction();
+          transaction.add(
+            SystemProgram.allocate({
+              accountPubkey: program.publicKey,
+              space: data.length,
+            }),
+          );
+        }
+
+        if (!programInfo.owner.equals(programId)) {
+          transaction = transaction || new Transaction();
+          transaction.add(
+            SystemProgram.assign({
+              accountPubkey: program.publicKey,
+              programId,
+            }),
+          );
+        }
+
+        if (programInfo.lamports < balanceNeeded) {
+          transaction = transaction || new Transaction();
+          transaction.add(
+            SystemProgram.transfer({
+              fromPubkey: payer.publicKey,
+              toPubkey: program.publicKey,
+              lamports: balanceNeeded - programInfo.lamports,
+            }),
+          );
+        }
+      } else {
+        transaction = new Transaction().add(
+          SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: program.publicKey,
+            lamports: balanceNeeded > 0 ? balanceNeeded : 1,
+            space: data.length,
+            programId,
+          }),
+        );
+      }
+
+      // If the account is already created correctly, skip this step
+      // and proceed directly to loading instructions
+      if (transaction !== null) {
+        await sendAndConfirmTransaction(
+          connection,
+          transaction,
+          [payer, program],
+          {
+            commitment: 'single',
+            skipPreflight: true,
+          },
+        );
+      }
     }
 
     const dataLayout = BufferLayout.struct([
@@ -165,5 +216,8 @@ export class Loader {
         },
       );
     }
+
+    // success
+    return true;
   }
 }


### PR DESCRIPTION
#### Problem
After a failed bpf loader attempt, the program account has usually already been created which prevents calling the bpf loader a second time because accounts cannot be "created" if they already exist. However, bpf loading should be recoverable as long as the create transaction is skipped.

#### Summary of Changes
- Check if program account already exists before attempting to load a program
- If a program already exists, check if it is setup with the correct allocation, owner, and balance
- If program exists and is setup correctly, proceed directly to loading instructions
- If a program already exists and is executable, exit early

Fixes https://github.com/solana-labs/solana-web3.js/issues/962
