### PR TITLE
fix: ensure signatures are ordered correctly

### DIFF
--- a/web3.js/src/message.js
+++ b/web3.js/src/message.js
@@ -83,6 +83,16 @@ export class Message {
     );
   }
 
+  findSignerIndex(signer: PublicKey): number {
+    const index = this.accountKeys.findIndex(accountKey => {
+      return accountKey.equals(signer);
+    });
+    if (index < 0) {
+      throw new Error(`unknown signer: ${signer.toString()}`);
+    }
+    return index;
+  }
+
   serialize(): Buffer {
     const numKeys = this.accountKeys.length;
 

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -196,25 +196,4 @@ describe('load BPF Rust program', () => {
 
     expect(logs.length).toEqual(0);
   });
-
-  test('simulate transaction with bad signer', async () => {
-    const simulatedTransaction = new Transaction().add({
-      keys: [
-        {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
-      ],
-      programId: program.publicKey,
-    });
-
-    const {err, logs} = (
-      await connection.simulateTransaction(simulatedTransaction, [program])
-    ).value;
-    expect(err).toEqual('SanitizeFailure');
-
-    if (logs === null) {
-      expect(logs).not.toBeNull();
-      return;
-    }
-
-    expect(logs.length).toEqual(0);
-  });
 });


### PR DESCRIPTION
#### Problem
The sign(..) and setSigners(..) methods determine the order of the transaction signatures but that order doesn't always match the account keys order from message compilation. Compiling the transaction message will order signer keys by first using the fee payer key and then by ordered appearance in instruction keys so it's possible this order doesn't match the signatures order causing sig verification errors.

#### Summary of Changes
- Ensure signatures are in the same order as signer account keys
- Throw error if any signers are missing or if extra signers are added
- De-dupe signers
- Create shallow copy of account metas when compile message to avoid mutating state

Fixes https://github.com/solana-labs/solana/issues/12155
Fixes: https://github.com/solana-labs/solana/issues/12197
