### PR TITLE
`solana-validator --rpc-bind-address` argument now works as expected

### DIFF
--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -201,10 +201,10 @@ impl LocalCluster {
         let (leader_ledger_path, _blockhash) = create_new_tmp_ledger!(&genesis_config);
         let leader_contact_info = leader_node.info.clone();
         let mut leader_config = config.validator_configs[0].clone();
-        leader_config.rpc_ports = Some((
-            leader_node.info.rpc.port(),
-            leader_node.info.rpc_pubsub.port(),
-            leader_node.info.rpc_banks.port(),
+        leader_config.rpc_addrs = Some((
+            leader_node.info.rpc,
+            leader_node.info.rpc_pubsub,
+            leader_node.info.rpc_banks,
         ));
         leader_config.account_paths = vec![leader_ledger_path.join("accounts")];
         let leader_keypair = Arc::new(Keypair::from_bytes(&leader_keypair.to_bytes()).unwrap());
@@ -351,10 +351,10 @@ impl LocalCluster {
         }
 
         let mut config = validator_config.clone();
-        config.rpc_ports = Some((
-            validator_node.info.rpc.port(),
-            validator_node.info.rpc_pubsub.port(),
-            validator_node.info.rpc_banks.port(),
+        config.rpc_addrs = Some((
+            validator_node.info.rpc,
+            validator_node.info.rpc_pubsub,
+            validator_node.info.rpc_banks,
         ));
         config.account_paths = vec![ledger_path.join("accounts")];
         let voting_keypair = voting_keypair.unwrap();
@@ -625,11 +625,8 @@ impl Cluster for LocalCluster {
         // Update the stored ContactInfo for this node
         let node = Node::new_localhost_with_pubkey(&pubkey);
         cluster_validator_info.info.contact_info = node.info.clone();
-        cluster_validator_info.config.rpc_ports = Some((
-            node.info.rpc.port(),
-            node.info.rpc_pubsub.port(),
-            node.info.rpc_banks.port(),
-        ));
+        cluster_validator_info.config.rpc_addrs =
+            Some((node.info.rpc, node.info.rpc_pubsub, node.info.rpc_banks));
 
         let entry_point_info = {
             if *pubkey == self.entry_point_info.id {

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -99,6 +99,7 @@ args+=(
   --identity "$identity"
   --vote-account "$vote_account"
   --rpc-faucet-address 127.0.0.1:9900
+  #--rpc-bind-address 192.168.1.207
 )
 default_arg --gossip-port 8001
 default_arg --log -


### PR DESCRIPTION
`--rpc-bind-address` was never making it into `Validator::new()` where the actual RPC ports are opened.   

The port plumbing is still pretty yucky, certainly room for future refactoring to improve the situation around these parts