### PR TITLE
Introduce sanity/compatibility test for live clusters

### DIFF
--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -174,8 +174,8 @@ all_test_steps() {
       - "queue=cuda"
   - command: "ci/live-cluster-sanity.sh"
     name: "live-cluster-sanity"
-    timeout_in_minutes: 40
-    artifact_paths: "log-*.txt"
+    timeout_in_minutes: 20
+    artifact_paths: "*-validator.log"
     agents:
       - "queue=gce-deploy"
 EOF

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -176,8 +176,9 @@ all_test_steps() {
     name: "live-cluster-sanity"
     timeout_in_minutes: 20
     artifact_paths:
-      - "*-validator.log"
-      - "*-sys-tuner.log"
+      - "*/validator.log"
+      - "*/sys-tuner.log"
+      - "*/snapshot-*.tar.*"
     agents:
       - "queue=gce-deploy"
 EOF

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -171,7 +171,7 @@ all_test_steps() {
       - "queue=cuda"
   - command: "ci/live-cluster-sanity.sh"
     name: "live-cluster"
-    timeout_in_minutes: 40
+    timeout_in_minutes: 60
     artifact_paths:
       - "*/validator.log"
       - "*/sys-tuner.log"

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -175,7 +175,9 @@ all_test_steps() {
   - command: "ci/live-cluster-sanity.sh"
     name: "live-cluster-sanity"
     timeout_in_minutes: 20
-    artifact_paths: "*-validator.log"
+    artifact_paths:
+      - "*-validator.log"
+      - "*-sys-tuner.log"
     agents:
       - "queue=gce-deploy"
 EOF

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -125,8 +125,8 @@ wait_step() {
 }
 
 all_test_steps() {
-  #command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
-  #wait_step
+  command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
+  wait_step
 
   # Coverage...
   if affects \

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -125,9 +125,8 @@ wait_step() {
 }
 
 all_test_steps() {
-  #command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
-  #wait_step
-  true
+  command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
+  wait_step
 
   # Coverage...
   if affects \
@@ -138,18 +137,16 @@ all_test_steps() {
              ^ci/test-coverage.sh \
              ^scripts/coverage.sh \
       ; then
-    #command_step coverage ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-coverage.sh" 30
-    #wait_step
-    true
+    command_step coverage ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-coverage.sh" 30
+    wait_step
   else
     annotate --style info --context test-coverage \
       "Coverage skipped as no .rs files were modified"
   fi
 
   # Full test suite
-  # command_step stable ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-stable.sh" 60
-  #wait_step
-  true
+  command_step stable ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-stable.sh" 60
+  wait_step
 
   # Perf test suite
   if affects \
@@ -232,8 +229,8 @@ EOF
 }
 
 pull_or_push_steps() {
-  #command_step sanity "ci/test-sanity.sh" 5
-  #wait_step
+  command_step sanity "ci/test-sanity.sh" 5
+  wait_step
 
   # Check for any .sh file changes
   if affects .sh$; then

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -171,7 +171,7 @@ all_test_steps() {
       - "queue=cuda"
   - command: "ci/live-cluster-sanity.sh"
     name: "live-cluster"
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     artifact_paths:
       - "*/validator.log"
       - "*/sys-tuner.log"

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -171,7 +171,7 @@ all_test_steps() {
       - "queue=cuda"
   - command: "ci/live-cluster-sanity.sh"
     name: "live-cluster"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 40
     artifact_paths:
       - "*/validator.log"
       - "*/sys-tuner.log"

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -170,7 +170,7 @@ all_test_steps() {
     agents:
       - "queue=cuda"
   - command: "ci/live-cluster-sanity.sh"
-    name: "live-cluster-sanity"
+    name: "live-cluster"
     timeout_in_minutes: 20
     artifact_paths:
       - "*/validator.log"

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -236,7 +236,6 @@ pull_or_push_steps() {
   if affects .sh$; then
     command_step shellcheck "ci/shellcheck.sh" 5
     wait_step
-    true
   fi
 
   # Run the full test suite by default, skipping only if modifications are local

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -125,8 +125,9 @@ wait_step() {
 }
 
 all_test_steps() {
-  command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
-  wait_step
+  #command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
+  #wait_step
+  true
 
   # Coverage...
   if affects \
@@ -137,16 +138,18 @@ all_test_steps() {
              ^ci/test-coverage.sh \
              ^scripts/coverage.sh \
       ; then
-    command_step coverage ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-coverage.sh" 30
-    wait_step
+    #command_step coverage ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-coverage.sh" 30
+    #wait_step
+    true
   else
     annotate --style info --context test-coverage \
       "Coverage skipped as no .rs files were modified"
   fi
 
   # Full test suite
-  command_step stable ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-stable.sh" 60
-  wait_step
+  # command_step stable ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_stable_docker_image ci/test-stable.sh" 60
+  #wait_step
+  true
 
   # Perf test suite
   if affects \
@@ -169,6 +172,12 @@ all_test_steps() {
     artifact_paths: "log-*.txt"
     agents:
       - "queue=cuda"
+  - command: "ci/live-cluster-sanity.sh"
+    name: "live-cluster-sanity"
+    timeout_in_minutes: 40
+    artifact_paths: "log-*.txt"
+    agents:
+      - "queue=gce-deploy"
 EOF
   else
     annotate --style info \
@@ -220,13 +229,14 @@ EOF
 }
 
 pull_or_push_steps() {
-  command_step sanity "ci/test-sanity.sh" 5
-  wait_step
+  #command_step sanity "ci/test-sanity.sh" 5
+  #wait_step
 
   # Check for any .sh file changes
   if affects .sh$; then
-    command_step shellcheck "ci/shellcheck.sh" 5
-    wait_step
+    #command_step shellcheck "ci/shellcheck.sh" 5
+    #wait_step
+    true
   fi
 
   # Run the full test suite by default, skipping only if modifications are local

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -125,8 +125,8 @@ wait_step() {
 }
 
 all_test_steps() {
-  command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
-  wait_step
+  #command_step checks ". ci/rust-version.sh; ci/docker-run.sh \$\$rust_nightly_docker_image ci/test-checks.sh" 20
+  #wait_step
 
   # Coverage...
   if affects \

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -234,8 +234,8 @@ pull_or_push_steps() {
 
   # Check for any .sh file changes
   if affects .sh$; then
-    #command_step shellcheck "ci/shellcheck.sh" 5
-    #wait_step
+    command_step shellcheck "ci/shellcheck.sh" 5
+    wait_step
     true
   fi
 

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -4,7 +4,6 @@ cd "$(dirname "$0")/.."
 
 source ci/_
 source ci/rust-version.sh stable
-source ci/upload-ci-artifact.sh
 
 escaped_branch=$(echo "$BUILDKITE_BRANCH" | tr -c "[:alnum:]" - | sed -r "s#(^-*|-*head-*|-*$)##g")
 instance_prefix="testnet-live-sanity-$escaped_branch"
@@ -18,8 +17,6 @@ on_trap() {
   if [[ -z $instance_deleted ]]; then
     (
       set +e
-      upload-ci-artifact cluster-sanity/testnet-validator.log
-      upload-ci-artifact cluster-sanity/mainnet-beta-validator.log
       _ ./net/gce.sh delete -p "$instance_prefix"
     )
   fi
@@ -41,7 +38,7 @@ test_with_live_cluster() {
   ./net/ssh.sh "$instance_ip" rm -rf cluster-sanity
   ./net/ssh.sh "$instance_ip" mkdir cluster-sanity
 
-  validator_log="cluster-sanity/$cluster_label-validator.log"
+  validator_log="$cluster_label-validator.log"
   (./net/ssh.sh "$instance_ip" -Llocalhost:18899:localhost:18899 ./solana-validator \
     --no-untrusted-rpc \
     --ledger cluster-sanity/ledger \
@@ -121,8 +118,6 @@ test_with_live_cluster() {
   (sleep 3 && kill "$tail_pid") &
   kill_pid=$!
   wait "$ssh_pid" "$tail_pid" "$kill_pid"
-
-  upload-ci-artifact "$validator_log"
 }
 
 # UPDATE docs/src/clusters.md TOO!!

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -143,6 +143,7 @@ test_with_live_cluster "testnet" \
     --trusted-validator ta1Uvfb7W5BRPrdGnhP9RmeCGKzBySGM1hTE4rBRy6T \
     --trusted-validator Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN \
     --trusted-validator 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv \
+    --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
     # for your pain-less copy-paste
 
 ./net/gce.sh delete -p "$instance_prefix" && instance_deleted=yes

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -125,18 +125,24 @@ test_with_live_cluster() {
   upload-ci-artifact "$validator_log"
 }
 
+# UPDATE docs/src/clusters.md TOO!!
 test_with_live_cluster "mainnet-beta" \
+    --entrypoint mainnet-beta.solana.com:8001 \
     --trusted-validator 7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2 \
     --trusted-validator GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ \
     --trusted-validator DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ \
-    --entrypoint mainnet-beta.solana.com:8001 \
+    --trusted-validator CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S \
     --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
-    --expected-shred-version 64864
+    --expected-shred-version 64864 \
+    # for your pain-less copy-paste
 
+# UPDATE docs/src/clusters.md TOO!!
 test_with_live_cluster "testnet" \
+    --entrypoint entrypoint.testnet.solana.com:8001 \
     --trusted-validator 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on \
-    --entrypoint 35.203.170.30:8001 \
-    --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
-    --expected-shred-version 1579 \
+    --trusted-validator ta1Uvfb7W5BRPrdGnhP9RmeCGKzBySGM1hTE4rBRy6T \
+    --trusted-validator Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN \
+    --trusted-validator 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv \
+    # for your pain-less copy-paste
 
 ./net/gce.sh delete -p "$instance_prefix" && instance_deleted=yes

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -53,7 +53,6 @@ test_with_live_cluster() {
   ssh_pid=$!
   tail -F "$validator_log" > cluster-sanity/log-tail 2> /dev/null &
   tail_pid=$!
-  sleep 3
 
   attempts=100
   while ! ./net/ssh.sh "$instance_ip" test -f cluster-sanity/init-completed &> /dev/null ; do
@@ -70,7 +69,7 @@ test_with_live_cluster() {
     echo "##### validator is starting... (until timeout: $attempts) #####"
     if find cluster-sanity/log-tail -not -empty | grep ^ > /dev/null; then
       echo "##### new log:"
-      timeout 1 cat cluster-sanity/log-tail | tail -n 3 | cut -c 1-200 || true
+      timeout 1 cat cluster-sanity/log-tail | tail -n 3 | cut -c 1-300 || true
       truncate --size 0 cluster-sanity/log-tail
       echo
     fi
@@ -102,7 +101,7 @@ test_with_live_cluster() {
     echo "##### validator is running ($current_root/$goal_root)... (until timeout: $attempts) #####"
     if find cluster-sanity/log-tail -not -empty | grep ^ > /dev/null; then
       echo "##### new log:"
-      timeout 1 cat cluster-sanity/log-tail | tail -n 3 | cut -c 1-200 || true
+      timeout 1 cat cluster-sanity/log-tail | tail -n 3 | cut -c 1-300 || true
       truncate --size 0 cluster-sanity/log-tail
       echo
     fi
@@ -113,7 +112,6 @@ test_with_live_cluster() {
     -H 'Content-Type: application/json' \
     -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
     http://localhost:18899
-  sleep 10
 
   (sleep 3 && kill "$tail_pid") &
   kill_pid=$!

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -84,17 +84,17 @@ test_with_live_cluster() {
     show_log
   done
 
+  echo "--- Monitoring validator $cluster_label"
+
   snapshot_slot=$(./net/ssh.sh "$instance_ip" ls -t cluster-sanity/ledger/snapshot* |
     head -n 1 |
     grep -o 'snapshot-[0-9]*-' |
     grep -o '[0-9]*'
   )
-
-  echo "--- Monitoring validator $cluster_label"
-
-  attempts=100
   current_root=$snapshot_slot
   goal_root=$((snapshot_slot + 100))
+
+  attempts=100
   while [[ $current_root -le $goal_root ]]; do
     attempts=$((attempts - 1))
     if [[ (($attempts == 0)) || ! -d "/proc/$ssh_pid" ]]; then

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -30,8 +30,8 @@ echo 500000 | ./net/ssh.sh "$instance_ip" sudo tee /proc/sys/vm/max_map_count > 
 on_error() {
   status=$1
   set +e
-  kill $ssh_pid $tail_pid
-  wait $ssh_pid $tail_pid
+  kill "$ssh_pid" "$tail_pid"
+  wait "$ssh_pid" "$tail_pid"
   echo "Error: validator failed to $status"
   exit 1
 }

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$0")/.."
+
+source ci/_
+source ci/rust-version.sh stable
+source ci/upload-ci-artifact.sh
+
+escaped_branch=$(echo "$BUILDKITE_BRANCH" | tr -c "[:alnum:]" - | sed -r "s#(^-*|-*head-*|-*$)##g")
+instance_prefix="testnet-live-sanity-$escaped_branch"
+# ensure to delete leftover cluster
+./net/gce.sh delete -p "$instance_prefix" || true
+# only bootstrap, no normal validator
+./net/gce.sh create -p "$instance_prefix" -n 0
+instance_ip=$(./net/gce.sh info | grep bootstrap-validator | awk '{print $3}')
+
+on_trap() {
+  if [[ -z $instance_deleted ]]; then
+    (
+      set +e
+      upload-ci-artifact cluster-sanity/testnet-validator.log
+      upload-ci-artifact cluster-sanity/mainnet-beta-validator.log
+      _ ./net/gce.sh delete -p "$instance_prefix"
+    )
+  fi
+}
+trap on_trap INT TERM EXIT
+
+_ cargo +"$rust_stable" build --bins --release
+_ ./net/scp.sh ./target/release/solana-validator "$instance_ip":.
+echo 500000 | ./net/ssh.sh "$instance_ip" sudo tee /proc/sys/vm/max_map_count > /dev/null
+
+test_with_live_cluster() {
+  cluster_label="$1"
+  shift
+
+  echo "--- Starting validator $cluster_label"
+
+  rm -rf cluster-sanity
+  mkdir cluster-sanity
+  ./net/ssh.sh "$instance_ip" rm -rf cluster-sanity
+  ./net/ssh.sh "$instance_ip" mkdir cluster-sanity
+
+  validator_log="cluster-sanity/$cluster_label-validator.log"
+  (./net/ssh.sh "$instance_ip" -Llocalhost:18899:localhost:18899 ./solana-validator \
+    --no-untrusted-rpc \
+    --ledger cluster-sanity/ledger \
+    --log - \
+    --init-complete-file cluster-sanity/init-completed \
+    --enable-rpc-exit \
+    --private-rpc \
+    --rpc-port 18899 \
+    --rpc-bind-address localhost \
+    --snapshot-interval-slots 0 \
+    "$@" ) &> "$validator_log" &
+  ssh_pid=$!
+  tail -F "$validator_log" > cluster-sanity/log-tail 2> /dev/null &
+  tail_pid=$!
+  sleep 3
+
+  attempts=100
+  while ! ./net/ssh.sh "$instance_ip" test -f cluster-sanity/init-completed &> /dev/null ; do
+    attempts=$((attempts - 1))
+    if [[ (($attempts == 0)) || ! -d "/proc/$ssh_pid" ]]; then
+       set +e
+       kill $ssh_pid $tail_pid
+       wait $ssh_pid $tail_pid
+       echo "Error: validator failed to boot"
+       exit 1
+    fi
+
+    sleep 3
+    echo "##### validator is starting... (until timeout: $attempts) #####"
+    if find cluster-sanity/log-tail -not -empty | grep ^ > /dev/null; then
+      echo "##### new log:"
+      timeout 1 cat cluster-sanity/log-tail | tail -n 3 || true
+      truncate --size 0 cluster-sanity/log-tail
+      echo
+    fi
+  done
+
+  snapshot_slot=$(./net/ssh.sh "$instance_ip" ls -t cluster-sanity/ledger/snapshot* |
+    head -n 1 |
+    grep -o 'snapshot-[0-9]*-' |
+    grep -o '[0-9]*'
+  )
+
+  echo "--- Monitoring validator $cluster_label"
+
+  attempts=100
+  current_root=$snapshot_slot
+  goal_root=$((snapshot_slot + 100))
+  while [[ $current_root -le $goal_root ]]; do
+    attempts=$((attempts - 1))
+    if [[ (($attempts == 0)) || ! -d "/proc/$ssh_pid" ]]; then
+       set +e
+       kill $ssh_pid $tail_pid
+       wait $ssh_pid $tail_pid
+       echo "Error: validator failed to boot"
+       exit 1
+    fi
+
+    sleep 3
+    current_root=$(./target/release/solana --url http://localhost:18899 slot --commitment root)
+    echo "##### validator is running ($current_root/$goal_root)... (until timeout: $attempts) #####"
+    if find cluster-sanity/log-tail -not -empty | grep ^ > /dev/null; then
+      echo "##### new log:"
+      timeout 1 cat cluster-sanity/log-tail | tail -n 3 || true
+      truncate --size 0 cluster-sanity/log-tail
+      echo
+    fi
+  done
+
+  _ curl \
+    -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
+    http://localhost:18899
+  sleep 10
+
+  (sleep 3 && kill "$tail_pid") &
+  kill_pid=$!
+  wait "$ssh_pid" "$tail_pid" "$kill_pid"
+
+  upload-ci-artifact "$validator_log"
+}
+
+test_with_live_cluster "mainnet-beta" \
+    --trusted-validator 7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2 \
+    --trusted-validator GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ \
+    --trusted-validator DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ \
+    --entrypoint mainnet-beta.solana.com:8001 \
+    --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
+    --expected-shred-version 64864
+
+test_with_live_cluster "testnet" \
+    --trusted-validator 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on \
+    --entrypoint 35.203.170.30:8001 \
+    --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
+    --expected-shred-version 1579 \
+
+./net/gce.sh delete -p "$instance_prefix" && instance_deleted=yes

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -61,7 +61,6 @@ test_with_live_cluster "mainnet-beta" \
     --trusted-validator DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ \
     --trusted-validator CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S \
     --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
-    --expected-shred-version 64864 \
     # for your pain-less copy-paste
 
 # UPDATE docs/src/clusters.md TOO!!
@@ -72,5 +71,4 @@ test_with_live_cluster "testnet" \
     --trusted-validator Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN \
     --trusted-validator 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv \
     --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
-    --expected-shred-version 1579 \
     # for your pain-less copy-paste

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -31,7 +31,14 @@ _ ./net/scp.sh \
   "$instance_ip:."
 
 test_with_live_cluster() {
-  ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@"
+  cluster_label="$1"
+
+  _ ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@"
+
+  # good it existed successfully; let's collect logs for profit!
+  for log in $(./net/ssh.sh ls -l '*.log'); do
+    _ ./net/scp.sh "$instance_ip:$log" .
+  done
 }
 
 # UPDATE docs/src/clusters.md TOO!!

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -29,6 +29,8 @@ _ ./net/scp.sh \
   ./ci/remote-live-cluster-sanity.sh \
   ./target/release/{solana,solana-validator,solana-ledger-tool,solana-sys-tuner} \
   "$instance_ip:."
+_ ./net/ssh.sh "$instance_ip" mkdir deps
+_ ./net/scp.sh ./target/release/deps/libsolana_bpf_loader_program.so "$instance_ip:./deps/"
 
 test_with_live_cluster() {
   cluster_label="$1"

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -34,7 +34,7 @@ test_with_live_cluster() {
   _ ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@"
 
   # good it existed successfully; let's collect logs for profit!
-  for log in $(./net/ssh.sh ls -l '*.log'); do
+  for log in $(./net/ssh.sh "$instance_ip" ls -l '*.log'); do
     _ ./net/scp.sh "$instance_ip:$log" .
   done
 }

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -29,8 +29,6 @@ _ ./net/scp.sh \
   ./ci/remote-live-cluster-sanity.sh \
   ./target/release/{solana,solana-validator,solana-ledger-tool,solana-sys-tuner} \
   "$instance_ip:."
-_ ./net/ssh.sh "$instance_ip" mkdir deps
-_ ./net/scp.sh ./target/release/deps/libsolana_bpf_loader_program.so "$instance_ip:./deps/"
 
 test_with_live_cluster() {
   cluster_label="$1"

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -56,6 +56,10 @@ test_with_live_cluster() {
 # UPDATE docs/src/clusters.md TOO!!
 test_with_live_cluster "mainnet-beta" \
     --entrypoint mainnet-beta.solana.com:8001 \
+    --entrypoint entrypoint2.mainnet-beta.solana.com:8001 \
+    --entrypoint entrypoint3.mainnet-beta.solana.com:8001 \
+    --entrypoint entrypoint4.mainnet-beta.solana.com:8001 \
+    --entrypoint entrypoint5.mainnet-beta.solana.com:8001 \
     --trusted-validator 7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2 \
     --trusted-validator GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ \
     --trusted-validator DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ \

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -27,7 +27,7 @@ trap on_trap INT TERM EXIT
 _ cargo +"$rust_stable" build --bins --release
 _ ./net/scp.sh \
   ./ci/remote-live-cluster-sanity.sh \
-  ./target/release/{solana,solana-validator,solana-sys-tuner} \
+  ./target/release/{solana,solana-validator,solana-ledger-tool,solana-sys-tuner} \
   "$instance_ip:."
 
 test_with_live_cluster() {

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -72,4 +72,5 @@ test_with_live_cluster "testnet" \
     --trusted-validator Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN \
     --trusted-validator 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv \
     --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
+    --expected-shred-version 1579 \
     # for your pain-less copy-paste

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -31,12 +31,16 @@ _ ./net/scp.sh \
   "$instance_ip:."
 
 test_with_live_cluster() {
+  cluster_label="$1"
+  rm -rf "./$cluster_label"
+  mkdir "./$cluster_label"
+
   validator_failed=
   _ ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@" || validator_failed=$?
 
   # let's collect logs for profit!
-  for log in $(./net/ssh.sh "$instance_ip" ls '*.log' 'cluster-sanity/ledger/snapshot-*.tar.*'); do
-    _ ./net/scp.sh "$instance_ip:$log" .
+  for log in $(./net/ssh.sh "$instance_ip" ls 'cluster-sanity/'{'*.log','ledger/snapshot-*.tar.*'}); do
+    _ ./net/scp.sh "$instance_ip:$log" "./$cluster_label"
   done
 
   if [[ -n $validator_failed ]]; then

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -27,7 +27,7 @@ trap on_trap INT TERM EXIT
 _ cargo +"$rust_stable" build --bins --release
 _ ./net/scp.sh \
   ./ci/remote-live-cluster-sanity.sh \
-  ./target/release/{solana,solana-validator,solana-ledger-tool,solana-sys-tuner} \
+  ./target/release/{solana,solana-keygen,solana-validator,solana-ledger-tool,solana-sys-tuner} \
   "$instance_ip:."
 
 test_with_live_cluster() {

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -31,8 +31,6 @@ _ ./net/scp.sh \
   "$instance_ip:."
 
 test_with_live_cluster() {
-  cluster_label="$1"
-
   _ ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@"
 
   # good it existed successfully; let's collect logs for profit!

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -31,12 +31,17 @@ _ ./net/scp.sh \
   "$instance_ip:."
 
 test_with_live_cluster() {
-  _ ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@"
+  validator_failed=
+  _ ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@" || validator_failed=$?
 
-  # good it existed successfully; let's collect logs for profit!
-  for log in $(./net/ssh.sh "$instance_ip" ls '*.log'); do
+  # let's collect logs for profit!
+  for log in $(./net/ssh.sh "$instance_ip" ls '*.log' 'cluster-sanity/ledger/snapshot-*.tar.*'); do
     _ ./net/scp.sh "$instance_ip:$log" .
   done
+
+  if [[ -n $validator_failed ]]; then
+    (exit "$validator_failed")
+  fi
 }
 
 # UPDATE docs/src/clusters.md TOO!!

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -34,7 +34,7 @@ test_with_live_cluster() {
   _ ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@"
 
   # good it existed successfully; let's collect logs for profit!
-  for log in $(./net/ssh.sh "$instance_ip" ls -l '*.log'); do
+  for log in $(./net/ssh.sh "$instance_ip" ls '*.log'); do
     _ ./net/scp.sh "$instance_ip:$log" .
   done
 }

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -13,9 +13,9 @@ else
 fi
 
 # ensure to delete leftover cluster
-./net/gce.sh delete -p "$instance_prefix" || true
+_ ./net/gce.sh delete -p "$instance_prefix" || true
 # only bootstrap, no normal validator
-./net/gce.sh create -p "$instance_prefix" -n 0 --self-destruct-hours 1
+_ ./net/gce.sh create -p "$instance_prefix" -n 0 --self-destruct-hours 1
 instance_ip=$(./net/gce.sh info | grep bootstrap-validator | awk '{print $3}')
 
 on_trap() {
@@ -25,98 +25,13 @@ on_trap() {
 trap on_trap INT TERM EXIT
 
 _ cargo +"$rust_stable" build --bins --release
-_ ./net/scp.sh ./target/release/solana-validator "$instance_ip:."
-echo 500000 | ./net/ssh.sh "$instance_ip" sudo tee /proc/sys/vm/max_map_count > /dev/null
-
-on_error() {
-  status=$1
-  set +e
-  kill "$ssh_pid" "$tail_pid"
-  wait "$ssh_pid" "$tail_pid"
-  echo "Error: validator failed to $status"
-  exit 1
-}
-
-show_log() {
-  if find cluster-sanity/log-tail -not -empty | grep ^ > /dev/null; then
-    echo "##### new log:"
-    timeout 1 cat cluster-sanity/log-tail | tail -n 3 | cut -c 1-300 || true
-    truncate --size 0 cluster-sanity/log-tail
-    echo
-  fi
-}
+_ ./net/scp.sh \
+  ./ci/remote-live-cluster-sanity.sh \
+  ./target/release/{solana,solana-validator,solana-sys-tuner} \
+  "$instance_ip:."
 
 test_with_live_cluster() {
-  cluster_label="$1"
-  shift
-
-  echo "--- Starting validator $cluster_label"
-
-  rm -rf cluster-sanity
-  mkdir cluster-sanity
-  ./net/ssh.sh "$instance_ip" rm -rf cluster-sanity
-  ./net/ssh.sh "$instance_ip" mkdir cluster-sanity
-
-  validator_log="$cluster_label-validator.log"
-  ./net/ssh.sh "$instance_ip" -Llocalhost:18899:localhost:18899 ./solana-validator \
-    --no-untrusted-rpc \
-    --ledger cluster-sanity/ledger \
-    --log - \
-    --init-complete-file cluster-sanity/init-completed \
-    --enable-rpc-exit \
-    --private-rpc \
-    --rpc-port 18899 \
-    --rpc-bind-address localhost \
-    --snapshot-interval-slots 0 \
-    "$@" &> "$validator_log" &
-  ssh_pid=$!
-  tail -F "$validator_log" > cluster-sanity/log-tail 2> /dev/null &
-  tail_pid=$!
-
-  attempts=100
-  while ! ./net/ssh.sh "$instance_ip" test -f cluster-sanity/init-completed &> /dev/null ; do
-    attempts=$((attempts - 1))
-    if [[ (($attempts == 0)) || ! -d "/proc/$ssh_pid" ]]; then
-      on_error "start"
-    fi
-
-    sleep 3
-    echo "##### validator is starting... (until timeout: $attempts) #####"
-    show_log
-  done
-
-  echo "--- Monitoring validator $cluster_label"
-
-  snapshot_slot=$(./net/ssh.sh "$instance_ip" ls -t cluster-sanity/ledger/snapshot* |
-    head -n 1 |
-    grep -o 'snapshot-[0-9]*-' |
-    grep -o '[0-9]*'
-  )
-  current_root=$snapshot_slot
-  goal_root=$((snapshot_slot + 100))
-
-  attempts=100
-  while [[ $current_root -le $goal_root ]]; do
-    attempts=$((attempts - 1))
-    if [[ (($attempts == 0)) || ! -d "/proc/$ssh_pid" ]]; then
-      on_error "root new slots"
-    fi
-
-    sleep 3
-    current_root=$(./target/release/solana --url http://localhost:18899 slot --commitment root)
-    echo "##### validator is running ($current_root/$goal_root)... (until timeout: $attempts) #####"
-    show_log
-  done
-
-  _ curl \
-    -X POST \
-    -H 'Content-Type: application/json' \
-    -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
-    http://localhost:18899
-
-  (sleep 3 && kill "$tail_pid") &
-  kill_pid=$!
-  timeout 30 wait "$ssh_pid" "$tail_pid" "$kill_pid"
+  ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@"
 }
 
 # UPDATE docs/src/clusters.md TOO!!

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -9,13 +9,13 @@ if [[ -n $CI ]]; then
   escaped_branch=$(echo "$BUILDKITE_BRANCH" | tr -c "[:alnum:]" - | sed -r "s#(^-*|-*head-*|-*$)##g")
   instance_prefix="testnet-live-sanity-$escaped_branch"
 else
-  instance_prefix="testnet-live-sanity-$(whoami)" --self-destruct-hours 1
+  instance_prefix="testnet-live-sanity-$(whoami)"
 fi
 
 # ensure to delete leftover cluster
 ./net/gce.sh delete -p "$instance_prefix" || true
 # only bootstrap, no normal validator
-./net/gce.sh create -p "$instance_prefix" -n 0
+./net/gce.sh create -p "$instance_prefix" -n 0 --self-destruct-hours 1
 instance_ip=$(./net/gce.sh info | grep bootstrap-validator | awk '{print $3}')
 
 on_trap() {

--- a/ci/live-cluster-sanity.sh
+++ b/ci/live-cluster-sanity.sh
@@ -39,11 +39,16 @@ test_with_live_cluster() {
   _ ./net/ssh.sh "$instance_ip" ./remote-live-cluster-sanity.sh "$@" || validator_failed=$?
 
   # let's collect logs for profit!
-  for log in $(./net/ssh.sh "$instance_ip" ls 'cluster-sanity/'{'*.log','ledger/snapshot-*.tar.*'}); do
+  for log in $(./net/ssh.sh "$instance_ip" ls 'cluster-sanity/*.log'); do
     _ ./net/scp.sh "$instance_ip:$log" "./$cluster_label"
   done
 
   if [[ -n $validator_failed ]]; then
+    # let's even collect snapshot for diagnostics
+    for log in $(./net/ssh.sh "$instance_ip" ls 'cluster-sanity/ledger/snapshot-*.tar.*'); do
+      _ ./net/scp.sh "$instance_ip:$log" "./$cluster_label"
+    done
+
     (exit "$validator_failed")
   fi
 }

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -89,7 +89,7 @@ curl \
   -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
   http://localhost:8899
 
-(sleep 3 && kill "$tail_pid" && sudo kill "$sys_tuner_pid") &
+(set -x && sleep 3 && sudo kill "$sys_tuner_pid" && kill "$tail_pid") &
 kill_pid=$!
 
 wait "$validator_pid" "$sys_tuner_pid" "$tail_pid" "$kill_pid"

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -30,6 +30,7 @@ validator_log="cluster-sanity/validator.log"
 sys_tuner_log="cluster-sanity/sys-tuner.log"
 metrics_host="https://metrics.solana.com:8086"
 export SOLANA_METRICS_CONFIG="host=$metrics_host,db=testnet-live-cluster,u=scratch_writer,p=topsecret"
+export RUST_LOG=warn
 
 # shellcheck disable=SC2024 # create log as non-root user
 sudo ./solana-sys-tuner --user "$(whoami)" &> "$sys_tuner_log" &

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -56,7 +56,7 @@ validator_then_ledger_tool_pid=$!
 tail -F "$validator_log" > cluster-sanity/log-tail 2> /dev/null &
 tail_pid=$!
 
-attempts=100
+attempts=200
 while ! [[ -f cluster-sanity/init-completed ]]; do
   attempts=$((attempts - 1))
   if [[ (($attempts == 0)) || ! -d "/proc/$validator_then_ledger_tool_pid" ]]; then
@@ -80,7 +80,7 @@ snapshot_slot=$(ls -t cluster-sanity/ledger/snapshot-*.tar.* |
 current_root=$snapshot_slot
 goal_root=$((snapshot_slot + 50))
 
-attempts=100
+attempts=200
 while [[ $current_root -le $goal_root ]]; do
   attempts=$((attempts - 1))
   if [[ (($attempts == 0)) || ! -d "/proc/$validator_then_ledger_tool_pid" ]]; then
@@ -100,7 +100,7 @@ curl \
   -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
   http://localhost:8899
 
-attempts=100
+attempts=200
 while [[ -d "/proc/$validator_then_ledger_tool_pid" ]]; do
   attempts=$((attempts - 1))
   if [[ (($attempts == 0)) ]]; then

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -90,7 +90,7 @@ curl \
   http://localhost:8899
 
 ps auxf
-(set -x && sleep 3 && sudo kill "$sys_tuner_pid" && kill "$tail_pid" && sudo pkill sys-tuner) &
+(set -x && sleep 3 && kill "$tail_pid" && sudo pkill -f solana-sys-tuner) &
 kill_pid=$!
 
 wait "$validator_pid" "$sys_tuner_pid" "$tail_pid" "$kill_pid"

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -30,7 +30,7 @@ validator_log="cluster-sanity/validator.log"
 sys_tuner_log="cluster-sanity/sys-tuner.log"
 metrics_host="https://metrics.solana.com:8086"
 export SOLANA_METRICS_CONFIG="host=$metrics_host,db=testnet-live-cluster,u=scratch_writer,p=topsecret"
-export RUST_LOG=warn
+export RUST_LOG="warn,solana_runtime::bank=info"
 
 # shellcheck disable=SC2024 # create log as non-root user
 sudo ./solana-sys-tuner --user "$(whoami)" &> "$sys_tuner_log" &

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -101,7 +101,7 @@ curl \
 attempts=100
 while true; do
   attempts=$((attempts - 1))
-  if [[ (($attempts == 0)) || ! -d "/proc/$validator_pid" ]]; then
+  if [[ (($attempts == 0)) ]]; then
     handle_error "ledger tool"
   fi
 

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -30,7 +30,7 @@ validator_log="cluster-sanity/validator.log"
 sys_tuner_log="cluster-sanity/sys-tuner.log"
 metrics_host="https://metrics.solana.com:8086"
 export SOLANA_METRICS_CONFIG="host=$metrics_host,db=testnet-live-cluster,u=scratch_writer,p=topsecret"
-export RUST_LOG="warn,solana_runtime::bank=info"
+export RUST_LOG="warn,solana_runtime::bank=info,solana_validator=info,solana_core=info,solana_ledger=info"
 
 # shellcheck disable=SC2024 # create log as non-root user
 sudo ./solana-sys-tuner --user "$(whoami)" &> "$sys_tuner_log" &

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -26,8 +26,8 @@ shift
 
 echo "--- Starting validator $cluster_label"
 
-validator_log="$cluster_label-validator.log"
-sys_tuner_log="$cluster_label-sys-tuner.log"
+validator_log="cluster-sanity/validator.log"
+sys_tuner_log="cluster-sanity/sys-tuner.log"
 metrics_host="https://metrics.solana.com:8086"
 export SOLANA_METRICS_CONFIG="host=$metrics_host,db=testnet-live-cluster,u=scratch_writer,p=topsecret"
 

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -52,14 +52,14 @@ sys_tuner_pid=$!
     verify
 ) &> "$validator_log" &
 
-validator_pid=$!
+validator_and_ledger_tool_pid=$!
 tail -F "$validator_log" > cluster-sanity/log-tail 2> /dev/null &
 tail_pid=$!
 
 attempts=100
 while ! [[ -f cluster-sanity/init-completed ]]; do
   attempts=$((attempts - 1))
-  if [[ (($attempts == 0)) || ! -d "/proc/$validator_pid" ]]; then
+  if [[ (($attempts == 0)) || ! -d "/proc/$validator_and_ledger_tool_pid" ]]; then
     handle_error "start"
   fi
 
@@ -78,12 +78,12 @@ snapshot_slot=$(ls -t cluster-sanity/ledger/snapshot-*.tar.* |
   grep -o '[0-9]*'
 )
 current_root=$snapshot_slot
-goal_root=$((snapshot_slot + 100))
+goal_root=$((snapshot_slot + 50))
 
 attempts=100
 while [[ $current_root -le $goal_root ]]; do
   attempts=$((attempts - 1))
-  if [[ (($attempts == 0)) || ! -d "/proc/$validator_pid" ]]; then
+  if [[ (($attempts == 0)) || ! -d "/proc/$validator_and_ledger_tool_pid" ]]; then
     handle_error "root new slots"
   fi
 
@@ -101,7 +101,7 @@ curl \
   http://localhost:8899
 
 attempts=100
-while [[ -d "/proc/$validator_pid" ]]; do
+while [[ -d "/proc/$validator_and_ledger_tool_pid" ]]; do
   attempts=$((attempts - 1))
   if [[ (($attempts == 0)) ]]; then
     handle_error "ledger tool"
@@ -117,4 +117,4 @@ echo "##### ledger-tool finished running! #####"
 (set -x && sleep 3 && kill "$tail_pid" && sudo pkill -f solana-sys-tuner) &
 kill_pid=$!
 
-wait "$validator_pid" "$sys_tuner_pid" "$tail_pid" "$kill_pid"
+wait "$validator_and_ledger_tool_pid" "$sys_tuner_pid" "$tail_pid" "$kill_pid"

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -37,7 +37,7 @@ validator_log="$cluster_label-validator.log"
     --rpc-port 8899 \
     --rpc-bind-address localhost \
     --snapshot-interval-slots 0 \
-    "$@" &> "$validator_log"
+    "$@" &> "$validator_log" &
 
 validator_pid=$!
 tail -F "$validator_log" > cluster-sanity/log-tail 2> /dev/null &

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -28,6 +28,9 @@ echo "--- Starting validator $cluster_label"
 
 validator_log="$cluster_label-validator.log"
 sys_tuner_log="$cluster_label-sys-tuner.log"
+metrics_host="https://metrics.solana.com:8086"
+export SOLANA_METRICS_CONFIG="host=$metrics_host,db=testnet-live-cluster,u=scratch_writer,p=topsecret"
+
 # shellcheck disable=SC2024 # create log as non-root user
 sudo ./solana-sys-tuner --user "$(whoami)" &> "$sys_tuner_log" &
 sys_tuner_pid=$!
@@ -62,7 +65,7 @@ done
 echo "--- Monitoring validator $cluster_label"
 
 # shellcheck disable=SC2012 # ls here is handy for sorted snapshots
-snapshot_slot=$(ls -t cluster-sanity/ledger/snapshot* |
+snapshot_slot=$(ls -t cluster-sanity/ledger/snapshot-*.tar.* |
   head -n 1 |
   grep -o 'snapshot-[0-9]*-' |
   grep -o '[0-9]*'
@@ -89,7 +92,7 @@ curl \
   -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
   http://localhost:8899
 
-ps auxf
+# well, kill $sys_tuner_pid didn't work for some reason, maybe sudo doen't relay signals?
 (set -x && sleep 3 && kill "$tail_pid" && sudo pkill -f solana-sys-tuner) &
 kill_pid=$!
 

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -43,6 +43,7 @@ sys_tuner_pid=$!
     --identity ./identity.json \
     --ledger ./cluster-sanity/ledger \
     --no-untrusted-rpc \
+    --no-poh-speed-test \
     --log - \
     --init-complete-file ./cluster-sanity/init-completed \
     --private-rpc \

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -30,7 +30,7 @@ validator_log="cluster-sanity/validator.log"
 sys_tuner_log="cluster-sanity/sys-tuner.log"
 metrics_host="https://metrics.solana.com:8086"
 export SOLANA_METRICS_CONFIG="host=$metrics_host,db=testnet-live-cluster,u=scratch_writer,p=topsecret"
-export RUST_LOG="warn,solana_runtime::bank=info,solana_validator=info,solana_core=info,solana_ledger=info"
+export RUST_LOG="warn,solana_runtime::bank=info,solana_validator=info,solana_core=info,solana_ledger=info,solana_core::repair_service=warn"
 
 # shellcheck disable=SC2024 # create log as non-root user
 sudo ./solana-sys-tuner --user "$(whoami)" &> "$sys_tuner_log" &

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -67,6 +67,7 @@ while ! [[ -f cluster-sanity/init-completed ]]; do
   echo "##### validator is starting... (until timeout: $attempts) #####"
   show_log
 done
+echo "##### validator finished starting! #####"
 
 echo "--- Monitoring validator $cluster_label"
 
@@ -91,6 +92,7 @@ while [[ $current_root -le $goal_root ]]; do
   echo "##### validator is running ($current_root/$goal_root)... (until timeout: $attempts) #####"
   show_log
 done
+echo "##### validator finished running! #####"
 
 curl \
   -X POST \
@@ -99,7 +101,7 @@ curl \
   http://localhost:8899
 
 attempts=100
-while true; do
+while [[ -d "/proc/$validator_pid" ]]; do
   attempts=$((attempts - 1))
   if [[ (($attempts == 0)) ]]; then
     handle_error "ledger tool"
@@ -109,6 +111,7 @@ while true; do
   echo "##### ledger-tool is running... (until timeout: $attempts) #####"
   show_log
 done
+echo "##### ledger-tool finished running! #####"
 
 # well, kill $sys_tuner_pid didn't work for some reason, maybe sudo doen't relay signals?
 (set -x && sleep 3 && kill "$tail_pid" && sudo pkill -f solana-sys-tuner) &

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -102,7 +102,7 @@ echo "##### validator finished running! #####"
 
 ./solana-validator \
   --ledger cluster-sanity/ledger \
-  exit
+  exit --force
 
 attempts=4000
 while [[ -d "/proc/$validator_then_ledger_tool_pid" ]]; do

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -38,11 +38,13 @@ sys_tuner_pid=$!
 
 (
   echo "$(date): VALIDATOR STARTED." &&
+  ./solana-keygen new --no-passphrase -so ./identity.json &&
   ./solana-validator \
-    --ledger cluster-sanity/ledger \
+    --identity ./identity.json \
+    --ledger ./cluster-sanity/ledger \
     --no-untrusted-rpc \
     --log - \
-    --init-complete-file cluster-sanity/init-completed \
+    --init-complete-file ./cluster-sanity/init-completed \
     --private-rpc \
     --rpc-port 8899 \
     --rpc-bind-address localhost \

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -104,7 +104,7 @@ curl \
   -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
   http://localhost:8899
 
-attempts=400
+attempts=4000
 while [[ -d "/proc/$validator_then_ledger_tool_pid" ]]; do
   attempts=$((attempts - 1))
   if [[ (($attempts == 0)) ]]; then

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -89,7 +89,8 @@ curl \
   -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
   http://localhost:8899
 
-(set -x && sleep 3 && sudo kill "$sys_tuner_pid" && kill "$tail_pid") &
+ps auxf
+(set -x && sleep 3 && sudo kill "$sys_tuner_pid" && kill "$tail_pid" && sudo pkill sys-tuner) &
 kill_pid=$!
 
 wait "$validator_pid" "$sys_tuner_pid" "$tail_pid" "$kill_pid"

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -43,7 +43,6 @@ sys_tuner_pid=$!
     --no-untrusted-rpc \
     --log - \
     --init-complete-file cluster-sanity/init-completed \
-    --enable-rpc-exit \
     --private-rpc \
     --rpc-port 8899 \
     --rpc-bind-address localhost \
@@ -98,11 +97,9 @@ while [[ $current_root -le $goal_root ]]; do
 done
 echo "##### validator finished running! #####"
 
-curl \
-  -X POST \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
-  http://localhost:8899
+./solana-validator \
+  --ledger cluster-sanity/ledger \
+  exit
 
 attempts=4000
 while [[ -d "/proc/$validator_then_ledger_tool_pid" ]]; do

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -3,8 +3,8 @@
 handle_error() {
   action=$1
   set +e
-  kill "$ssh_pid" "$tail_pid"
-  wait "$ssh_pid" "$tail_pid"
+  kill "$validator_pid" "$tail_pid"
+  wait "$validator_pid" "$tail_pid"
   echo "--- Error: validator failed to $action"
   exit 1
 }
@@ -57,6 +57,7 @@ done
 
 echo "--- Monitoring validator $cluster_label"
 
+# shellcheck disable=SC2012
 snapshot_slot=$(ls -t cluster-sanity/ledger/snapshot* |
   head -n 1 |
   grep -o 'snapshot-[0-9]*-' |

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -71,7 +71,7 @@ snapshot_slot=$(ls -t cluster-sanity/ledger/snapshot-*.tar.* |
   grep -o '[0-9]*'
 )
 current_root=$snapshot_slot
-goal_root=$((snapshot_slot + 100))
+goal_root=$((snapshot_slot + 400))
 
 attempts=100
 while [[ $current_root -le $goal_root ]]; do

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -28,7 +28,7 @@ echo "--- Starting validator $cluster_label"
 
 validator_log="$cluster_label-validator.log"
 sys_tuner_log="$cluster_label-sys-tuner.log"
-sudo ./solana-sys-tuner --user $(whoami) > "$sys_tuner_log" &
+sudo ./solana-sys-tuner --user "$(whoami)" > "$sys_tuner_log" &
 sys_tuner_pid=$!
 
 ./solana-validator  \

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -38,7 +38,7 @@ sys_tuner_pid=$!
 
 (
   echo "$(date): VALIDATOR STARTED." &&
-  ./solana-keygen new --no-passphrase -so ./identity.json &&
+  ./solana-keygen new --force --no-passphrase --silent --outfile ./identity.json &&
   ./solana-validator \
     --identity ./identity.json \
     --ledger ./cluster-sanity/ledger \

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -28,7 +28,8 @@ echo "--- Starting validator $cluster_label"
 
 validator_log="$cluster_label-validator.log"
 sys_tuner_log="$cluster_label-sys-tuner.log"
-sudo ./solana-sys-tuner --user "$(whoami)" > "$sys_tuner_log" &
+# shellcheck disable=SC2024 # create log as non-root user
+sudo ./solana-sys-tuner --user "$(whoami)" &> "$sys_tuner_log" &
 sys_tuner_pid=$!
 
 ./solana-validator  \
@@ -60,7 +61,7 @@ done
 
 echo "--- Monitoring validator $cluster_label"
 
-# shellcheck disable=SC2012
+# shellcheck disable=SC2012 # ls here is handy for sorted snapshots
 snapshot_slot=$(ls -t cluster-sanity/ledger/snapshot* |
   head -n 1 |
   grep -o 'snapshot-[0-9]*-' |

--- a/ci/remote-live-cluster-sanity.sh
+++ b/ci/remote-live-cluster-sanity.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+handle_error() {
+  action=$1
+  set +e
+  kill "$ssh_pid" "$tail_pid"
+  wait "$ssh_pid" "$tail_pid"
+  echo "--- Error: validator failed to $action"
+  exit 1
+}
+
+show_log() {
+  if find cluster-sanity/log-tail -not -empty | grep ^ > /dev/null; then
+    echo "##### new log:"
+    timeout 1 cat cluster-sanity/log-tail | tail -n 3 | cut -c 1-300 || true
+    truncate --size 0 cluster-sanity/log-tail
+    echo
+  fi
+}
+
+rm -rf cluster-sanity
+mkdir cluster-sanity
+
+cluster_label="$1"
+shift
+
+echo "--- Starting validator $cluster_label"
+
+validator_log="$cluster_label-validator.log"
+./solana-validator  \
+    --no-untrusted-rpc \
+    --ledger cluster-sanity/ledger \
+    --log - \
+    --init-complete-file cluster-sanity/init-completed \
+    --enable-rpc-exit \
+    --private-rpc \
+    --rpc-port 8899 \
+    --rpc-bind-address localhost \
+    --snapshot-interval-slots 0 \
+    "$@" &> "$validator_log"
+
+validator_pid=$!
+tail -F "$validator_log" > cluster-sanity/log-tail 2> /dev/null &
+tail_pid=$!
+
+attempts=100
+while ! [[ -f cluster-sanity/init-completed ]]; do
+  attempts=$((attempts - 1))
+  if [[ (($attempts == 0)) || ! -d "/proc/$validator_pid" ]]; then
+    handle_error "start"
+  fi
+
+  sleep 3
+  echo "##### validator is starting... (until timeout: $attempts) #####"
+  show_log
+done
+
+echo "--- Monitoring validator $cluster_label"
+
+snapshot_slot=$(ls -t cluster-sanity/ledger/snapshot* |
+  head -n 1 |
+  grep -o 'snapshot-[0-9]*-' |
+  grep -o '[0-9]*'
+)
+current_root=$snapshot_slot
+goal_root=$((snapshot_slot + 100))
+
+attempts=100
+while [[ $current_root -le $goal_root ]]; do
+  attempts=$((attempts - 1))
+  if [[ (($attempts == 0)) || ! -d "/proc/$validator_pid" ]]; then
+    handle_error "root new slots"
+  fi
+
+  sleep 3
+  current_root=$(./solana --url http://localhost:8899 slot --commitment root)
+  echo "##### validator is running ($current_root/$goal_root)... (until timeout: $attempts) #####"
+  show_log
+done
+
+curl \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1, "method":"validatorExit"}' \
+  http://localhost:8899
+
+(sleep 3 && kill "$tail_pid") &
+(sleep 30 && kill -KILL "$validator_pid" "$tail_pid") &
+kill_pid=$!
+wait "$validator_pid" "$tail_pid" "$kill_pid"

--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -85,7 +85,8 @@ solana config set --url https://api.testnet.solana.com
 
 ##### Example `solana-validator` command-line
 
-[comment]: <> (UPDATE ci/live-cluster-sanity.sh TOO!!)
+[comment]: # (UPDATE ci/live-cluster-sanity.sh TOO!!)
+
 ```bash
 $ solana-validator \
     --entrypoint entrypoint.testnet.solana.com:8001 \
@@ -141,7 +142,8 @@ solana config set --url https://api.mainnet-beta.solana.com
 
 ##### Example `solana-validator` command-line
 
-[comment]: <> (UPDATE ci/live-cluster-sanity.sh TOO!!)
+[comment]: # (UPDATE ci/live-cluster-sanity.sh TOO!!)
+
 ```bash
 $ solana-validator \
     --entrypoint entrypoint.mainnet-beta.solana.com:8001 \

--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -42,15 +42,13 @@ solana config set --url https://api.devnet.solana.com
 
 ```bash
 $ solana-validator \
-    --identity validator-keypair.json \
-    --vote-account vote-account-keypair.json \
     --trusted-validator dv1LfzJvDF7S1fBKpFgKoKXK5yoSosmkAdfbxBo1GqJ \
+    --identity ~/validator-keypair.json \
+    --vote-account ~/vote-account-keypair.json \
     --no-untrusted-rpc \
     --ledger ledger \
     --rpc-port 8899 \
     --dynamic-port-range 8000-8010 \
-    --entrypoint entrypoint.devnet.solana.com:8001 \
-    --expected-genesis-hash EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG \
     --wal-recovery-mode skip_any_corrupted_record \
     --limit-ledger-size
 ```
@@ -87,22 +85,23 @@ solana config set --url https://api.testnet.solana.com
 
 ##### Example `solana-validator` command-line
 
+[comment]: <> (UPDATE ci/live-cluster-sanity.sh TOO!)
 ```bash
 $ solana-validator \
-    --identity validator-keypair.json \
-    --vote-account vote-account-keypair.json \
+    --entrypoint entrypoint.testnet.solana.com:8001 \
+    --entrypoint entrypoint2.testnet.solana.com:8001 \
+    --entrypoint entrypoint3.testnet.solana.com:8001 \
     --trusted-validator 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on \
     --trusted-validator 7XSY3MrYnK8vq693Rju17bbPkCN3Z7KvvfvJx4kdrsSY \
     --trusted-validator Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN \
     --trusted-validator 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv \
+    --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
+    --identity ~/validator-keypair.json \
+    --vote-account ~/vote-account-keypair.json \
     --no-untrusted-rpc \
     --ledger ledger \
     --rpc-port 8899 \
     --dynamic-port-range 8000-8010 \
-    --entrypoint entrypoint.testnet.solana.com:8001 \
-    --entrypoint entrypoint2.testnet.solana.com:8001 \
-    --entrypoint entrypoint3.testnet.solana.com:8001 \
-    --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
     --wal-recovery-mode skip_any_corrupted_record \
     --limit-ledger-size
 ```
@@ -142,25 +141,27 @@ solana config set --url https://api.mainnet-beta.solana.com
 
 ##### Example `solana-validator` command-line
 
+[comment]: <> (UPDATE ci/live-cluster-sanity.sh TOO!)
 ```bash
 $ solana-validator \
-    --identity ~/validator-keypair.json \
-    --vote-account ~/vote-account-keypair.json \
-    --trusted-validator 7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2 \
-    --trusted-validator GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ \
-    --trusted-validator DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ \
-    --trusted-validator CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S \
-    --no-untrusted-rpc \
-    --ledger ledger \
-    --rpc-port 8899 \
-    --private-rpc \
-    --dynamic-port-range 8000-8010 \
     --entrypoint entrypoint.mainnet-beta.solana.com:8001 \
     --entrypoint entrypoint2.mainnet-beta.solana.com:8001 \
     --entrypoint entrypoint3.mainnet-beta.solana.com:8001 \
     --entrypoint entrypoint4.mainnet-beta.solana.com:8001 \
     --entrypoint entrypoint5.mainnet-beta.solana.com:8001 \
+    --trusted-validator 7Np41oeYqPefeNQEHSv1UDhYrehxin3NStELsSKCT4K2 \
+    --trusted-validator GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ \
+    --trusted-validator DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ \
+    --trusted-validator CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S \
     --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
+    --expected-shred-version 64864 \
+    --identity ~/validator-keypair.json \
+    --vote-account ~/vote-account-keypair.json \
+    --no-untrusted-rpc \
+    --ledger ledger \
+    --rpc-port 8899 \
+    --private-rpc \
+    --dynamic-port-range 8000-8010 \
     --wal-recovery-mode skip_any_corrupted_record \
     --limit-ledger-size
 ```

--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -85,7 +85,7 @@ solana config set --url https://api.testnet.solana.com
 
 ##### Example `solana-validator` command-line
 
-[comment]: <> (UPDATE ci/live-cluster-sanity.sh TOO!)
+[comment]: <> (UPDATE ci/live-cluster-sanity.sh TOO!!)
 ```bash
 $ solana-validator \
     --entrypoint entrypoint.testnet.solana.com:8001 \
@@ -141,7 +141,7 @@ solana config set --url https://api.mainnet-beta.solana.com
 
 ##### Example `solana-validator` command-line
 
-[comment]: <> (UPDATE ci/live-cluster-sanity.sh TOO!)
+[comment]: <> (UPDATE ci/live-cluster-sanity.sh TOO!!)
 ```bash
 $ solana-validator \
     --entrypoint entrypoint.mainnet-beta.solana.com:8001 \

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3898,8 +3898,8 @@ impl Bank {
         let cycle_params = self.determine_collection_cycle_params(epoch);
         let (_, _, in_multi_epoch_cycle, _, _, partition_count) = cycle_params;
 
-        // use common codepath for both very likely and very unlikely for the sake of minimized
-        // risk of any miscalculation instead of negligibly faster computation per slot for the
+        // use common code-path for both very-likely and very-unlikely for the sake of minimized
+        // risk of any mis-calculation instead of negligible faster computation per slot for the
         // likely case.
         let mut start_partition_index =
             Self::partition_index_from_slot_index(start_slot_index, cycle_params);
@@ -3911,7 +3911,7 @@ impl Bank {
         let in_middle_of_cycle = start_partition_index > 0;
         if in_multi_epoch_cycle && is_special_new_epoch && in_middle_of_cycle {
             // Adjust slot indexes so that the final partition ranges are continuous!
-            // This is need because the caller gives us off-by-one indexes when
+            // This is needed because the caller gives us off-by-one indexes when
             // an epoch boundary is crossed.
             // Usually there is no need for this adjustment because cycles are aligned
             // with epochs. But for multi-epoch cycles, adjust the indexes if it


### PR DESCRIPTION
#### Problem

**bisecting is hurting...** (hard-labored fruit this time: https://github.com/solana-labs/solana/pull/12176)

#### Summary of Changes

I think if ci time and resource is allowed, this should be run on each prs instead of nightly ci job. and it seems that running this doesn't take much time.

~~- [ ] todo what to do if the tested cluster is dead? Maybe easy turn-off knob like github's `skip-live-cluster` label?~~ (EDIT: Well, let's skip this for now? clusters are pretty stable nowadays)

~~- [ ] todo if the cluster is dead, fallback to some periodic backup of snapshot + minimum ledger?~~ (EDIT: Well, let's skip this for now? clusters are pretty stable nowadays)