### PR TITLE
web3: Fix `docker ps` commands in localnet.sh for Travis

### DIFF
--- a/web3.js/bin/localnet.sh
+++ b/web3.js/bin/localnet.sh
@@ -112,7 +112,7 @@ up)
 down)
   (
     set -x
-    if [[ -n "$(docker ps --filter "name=^solana-localnet$" -q)" ]]; then
+    if [[ $(docker ps --filter "name=^/solana-localnet$" -q) ]]; then
       docker stop --time 0 solana-localnet
     fi
   )
@@ -128,7 +128,7 @@ logs)
   fi
 
   while $follow; do
-    if [[ -n $(docker ps -q -f name=solana-localnet) ]]; then
+    if [[ $(docker ps -q -f "name=^/solana-localnet$") ]]; then
       (
         set -x
         docker logs solana-localnet -f


### PR DESCRIPTION
#### Problem

The web3 script to manage the Solana container, localnet.sh, fails in the Travis CI environment, because `docker ps --filter` does not properly find the running container.

#### Summary of Changes

Add a slash at the start of the name to correctly identify that the `solana-localnet` container is running.

Fixes #
