### PR TITLE
Add new validator options for running in more restrictive environments

### DIFF
--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -115,10 +115,15 @@ impl CrdsGossip {
 
     /// refresh the push active set
     /// * ratio - number of actives to rotate
-    pub fn refresh_push_active_set(&mut self, stakes: &HashMap<Pubkey, u64>) {
+    pub fn refresh_push_active_set(
+        &mut self,
+        stakes: &HashMap<Pubkey, u64>,
+        gossip_validators: Option<&HashSet<Pubkey>>,
+    ) {
         self.push.refresh_push_active_set(
             &self.crds,
             stakes,
+            gossip_validators,
             &self.id,
             self.shred_version,
             self.pull.pull_request_time.len(),
@@ -130,6 +135,7 @@ impl CrdsGossip {
     pub fn new_pull_request(
         &self,
         now: u64,
+        gossip_validators: Option<&HashSet<Pubkey>>,
         stakes: &HashMap<Pubkey, u64>,
         bloom_size: usize,
     ) -> Result<(Pubkey, Vec<CrdsFilter>, CrdsValue), CrdsGossipError> {
@@ -138,6 +144,7 @@ impl CrdsGossip {
             &self.id,
             self.shred_version,
             now,
+            gossip_validators,
             stakes,
             bloom_size,
         )
@@ -271,7 +278,7 @@ mod test {
                 0,
             )
             .unwrap();
-        crds_gossip.refresh_push_active_set(&HashMap::new());
+        crds_gossip.refresh_push_active_set(&HashMap::new(), None);
         let now = timestamp();
         //incorrect dest
         let mut res = crds_gossip.process_prune_msg(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -87,6 +87,7 @@ pub struct ValidatorConfig {
     pub new_hard_forks: Option<Vec<Slot>>,
     pub trusted_validators: Option<HashSet<Pubkey>>, // None = trust all
     pub repair_validators: Option<HashSet<Pubkey>>,  // None = repair from all
+    pub gossip_validators: Option<HashSet<Pubkey>>,  // None = gossip with all
     pub halt_on_trusted_validators_accounts_hash_mismatch: bool,
     pub accounts_hash_fault_injection_slots: u64, // 0 = no fault injection
     pub frozen_accounts: Vec<Pubkey>,
@@ -116,6 +117,7 @@ impl Default for ValidatorConfig {
             new_hard_forks: None,
             trusted_validators: None,
             repair_validators: None,
+            gossip_validators: None,
             halt_on_trusted_validators_accounts_hash_mismatch: false,
             accounts_hash_fault_injection_slots: 0,
             frozen_accounts: vec![],
@@ -395,6 +397,7 @@ impl Validator {
             &cluster_info,
             Some(bank_forks.clone()),
             node.sockets.gossip,
+            config.gossip_validators.clone(),
             &exit,
         );
 

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -222,7 +222,7 @@ fn network_simulator(network: &mut Network, max_convergance: f64) {
     network_values.par_iter().for_each(|node| {
         node.lock()
             .unwrap()
-            .refresh_push_active_set(&HashMap::new());
+            .refresh_push_active_set(&HashMap::new(), None);
     });
     let mut total_bytes = bytes_tx;
     for second in 1..num {
@@ -361,7 +361,7 @@ fn network_run_push(network: &mut Network, start: usize, end: usize) -> (usize, 
             network_values.par_iter().for_each(|node| {
                 node.lock()
                     .unwrap()
-                    .refresh_push_active_set(&HashMap::new());
+                    .refresh_push_active_set(&HashMap::new(), None);
             });
         }
         total = network_values
@@ -408,7 +408,7 @@ fn network_run_pull(
                 .filter_map(|from| {
                     from.lock()
                         .unwrap()
-                        .new_pull_request(now, &HashMap::new(), cluster_info::MAX_BLOOM_SIZE)
+                        .new_pull_request(now, None, &HashMap::new(), cluster_info::MAX_BLOOM_SIZE)
                         .ok()
                 })
                 .collect()
@@ -581,7 +581,7 @@ fn test_prune_errors() {
             0,
         )
         .unwrap();
-    crds_gossip.refresh_push_active_set(&HashMap::new());
+    crds_gossip.refresh_push_active_set(&HashMap::new(), None);
     let now = timestamp();
     //incorrect dest
     let mut res = crds_gossip.process_prune_msg(

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -19,7 +19,8 @@ fn test_node(exit: &Arc<AtomicBool>) -> (Arc<ClusterInfo>, GossipService, UdpSoc
     let keypair = Arc::new(Keypair::new());
     let mut test_node = Node::new_localhost_with_pubkey(&keypair.pubkey());
     let cluster_info = Arc::new(ClusterInfo::new(test_node.info.clone(), keypair));
-    let gossip_service = GossipService::new(&cluster_info, None, test_node.sockets.gossip, exit);
+    let gossip_service =
+        GossipService::new(&cluster_info, None, test_node.sockets.gossip, None, exit);
     let _ = cluster_info.my_contact_info();
     (
         cluster_info,
@@ -39,6 +40,7 @@ fn test_node_with_bank(
         &cluster_info,
         Some(bank_forks),
         test_node.sockets.gossip,
+        None,
         exit,
     );
     let _ = cluster_info.my_contact_info();

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -142,6 +142,7 @@ fn start_gossip_node(
     gossip_addr: &SocketAddr,
     gossip_socket: UdpSocket,
     expected_shred_version: Option<u16>,
+    gossip_validators: Option<HashSet<Pubkey>>,
 ) -> (Arc<ClusterInfo>, Arc<AtomicBool>, GossipService) {
     let cluster_info = ClusterInfo::new(
         ClusterInfo::gossip_contact_info(
@@ -155,7 +156,13 @@ fn start_gossip_node(
     let cluster_info = Arc::new(cluster_info);
 
     let gossip_exit_flag = Arc::new(AtomicBool::new(false));
-    let gossip_service = GossipService::new(&cluster_info, None, gossip_socket, &gossip_exit_flag);
+    let gossip_service = GossipService::new(
+        &cluster_info,
+        None,
+        gossip_socket,
+        gossip_validators,
+        &gossip_exit_flag,
+    );
     (cluster_info, gossip_exit_flag, gossip_service)
 }
 
@@ -862,7 +869,18 @@ pub fn main() {
                 .multiple(true)
                 .takes_value(true)
                 .help("A list of validators to request repairs from. If specified, repair will not \
-                       request from validators outside this set [default: request repairs from all validators]")
+                       request from validators outside this set [default: all validators]")
+        )
+        .arg(
+            Arg::with_name("gossip_validators")
+                .long("gossip-validator")
+                .validator(is_pubkey)
+                .value_name("PUBKEY")
+                .multiple(true)
+                .takes_value(true)
+                .help("A list of validators to gossip with.  If specified, gossip \
+                      will not pull/pull from from validators outside this set. \
+                      [default: all validators]")
         )
         .arg(
             Arg::with_name("no_rocksdb_compaction")
@@ -979,6 +997,12 @@ pub fn main() {
         "repair_validators",
         "--repair-validator",
     );
+    let gossip_validators = validators_set(
+        &identity_keypair.pubkey(),
+        &matches,
+        "gossip_validators",
+        "--gossip-validator",
+    );
 
     let bind_address = solana_net_utils::parse_host(matches.value_of("bind_address").unwrap())
         .expect("invalid bind_address");
@@ -1029,6 +1053,7 @@ pub fn main() {
         wait_for_supermajority: value_t!(matches, "wait_for_supermajority", Slot).ok(),
         trusted_validators,
         repair_validators,
+        gossip_validators,
         frozen_accounts: values_t!(matches, "frozen_accounts", Pubkey).unwrap_or_default(),
         no_rocksdb_compaction,
         wal_recovery_mode,
@@ -1329,6 +1354,7 @@ pub fn main() {
                         &node.info.gossip,
                         node.sockets.gossip.try_clone().unwrap(),
                         validator_config.expected_shred_version,
+                        validator_config.gossip_validators.clone(),
                     ));
                 }
 


### PR DESCRIPTION
* `--gossip-pull-validator PUBKEY`: analogous to `--repair-validator` but for gossip pull requests.  That is, only pull from the explicitly provided validators
* `--restricted-repair-only-mode`: advertise no ports over gossip.  This will prevent the rest of the cluster from pushing packets to the validator, and essentially require that it continually repair only.   Useful in a setup where the validator will be mostly firewalled off from the rest of the cluster, to prevent the rest of the cluster from transmitting into a black hole

TODO:
* [x] Add some tests
