### PR TITLE
CI: Don't overwrite pre-existing $CHANNEL

### DIFF
--- a/ci/channel-info.sh
+++ b/ci/channel-info.sh
@@ -95,12 +95,14 @@ elif [[ -n $CI_BRANCH ]]; then
   BRANCH="$CI_BRANCH"
 fi
 
-if [[ $BRANCH = "$STABLE_CHANNEL" ]]; then
-  CHANNEL=stable
-elif [[ $BRANCH = "$EDGE_CHANNEL" ]]; then
-  CHANNEL=edge
-elif [[ $BRANCH = "$BETA_CHANNEL" ]]; then
-  CHANNEL=beta
+if [[ -z "$CHANNEL" ]]; then
+  if [[ $BRANCH = "$STABLE_CHANNEL" ]]; then
+    CHANNEL=stable
+  elif [[ $BRANCH = "$EDGE_CHANNEL" ]]; then
+    CHANNEL=edge
+  elif [[ $BRANCH = "$BETA_CHANNEL" ]]; then
+    CHANNEL=beta
+  fi
 fi
 
 echo EDGE_CHANNEL="$EDGE_CHANNEL"


### PR DESCRIPTION
#### Problem

`ci/channel-info.sh` blindly overwrites any pre-existing `CHANNEL` env var value, preventing workflows where one wants to run scripts from master against stabilizing branches (eg. rolling upgrade tests)

#### Summary of Changes

Only assign `CHANNEL` from `BRANCH` when `CHANNEL` is empty: