### PR TITLE
Fix rooted accounts cleanup, simplify locking

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -88,7 +88,7 @@ fn main() {
     for x in 0..iterations {
         if clean {
             let mut time = Measure::start("clean");
-            accounts.accounts_db.clean_accounts();
+            accounts.accounts_db.clean_accounts(None);
             time.stop();
             println!("{}", time);
             for slot in 0..num_slots {

--- a/core/src/accounts_background_service.rs
+++ b/core/src/accounts_background_service.rs
@@ -35,8 +35,6 @@ impl AccountsBackgroundService {
                 }
                 let bank = bank_forks.read().unwrap().root_bank().clone();
 
-                bank.process_dead_slots();
-
                 consumed_budget = bank
                     .process_stale_slot_with_budget(consumed_budget, SHRUNKEN_ACCOUNT_PER_INTERVAL);
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,6 @@
 #[macro_use]
 extern crate solana_bpf_loader_program;
 
-pub mod accounts_background_service;
 pub mod accounts_hash_verifier;
 pub mod banking_stage;
 pub mod bigtable_upload_service;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -29,8 +29,8 @@ use solana_ledger::{
 use solana_measure::{measure::Measure, thread_mem_usage};
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::{
-    bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache,
-    snapshot_package::AccountsPackageSender, vote_sender_types::ReplayVoteSender,
+    accounts_background_service::SnapshotRequestSender, bank::Bank, bank_forks::BankForks,
+    commitment::BlockCommitmentCache, vote_sender_types::ReplayVoteSender,
 };
 use solana_sdk::{
     clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
@@ -103,7 +103,7 @@ pub struct ReplayStageConfig {
     pub subscriptions: Arc<RpcSubscriptions>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
     pub latest_root_senders: Vec<Sender<Slot>>,
-    pub accounts_hash_sender: Option<AccountsPackageSender>,
+    pub snapshot_request_sender: Option<SnapshotRequestSender>,
     pub block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     pub transaction_status_sender: Option<TransactionStatusSender>,
     pub rewards_recorder_sender: Option<RewardsRecorderSender>,
@@ -234,7 +234,7 @@ impl ReplayStage {
             subscriptions,
             leader_schedule_cache,
             latest_root_senders,
-            accounts_hash_sender,
+            snapshot_request_sender,
             block_commitment_cache,
             transaction_status_sender,
             rewards_recorder_sender,
@@ -455,7 +455,7 @@ impl ReplayStage {
                             &blockstore,
                             &leader_schedule_cache,
                             &lockouts_sender,
-                            &accounts_hash_sender,
+                            &snapshot_request_sender,
                             &latest_root_senders,
                             &mut all_pubkeys,
                             &subscriptions,
@@ -1025,7 +1025,7 @@ impl ReplayStage {
         blockstore: &Arc<Blockstore>,
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         lockouts_sender: &Sender<CommitmentAggregationData>,
-        accounts_hash_sender: &Option<AccountsPackageSender>,
+        snapshot_request_sender: &Option<SnapshotRequestSender>,
         latest_root_senders: &[Sender<Slot>],
         all_pubkeys: &mut PubkeyReferences,
         subscriptions: &Arc<RpcSubscriptions>,
@@ -1081,7 +1081,7 @@ impl ReplayStage {
                 new_root,
                 &bank_forks,
                 progress,
-                accounts_hash_sender,
+                snapshot_request_sender,
                 all_pubkeys,
                 highest_confirmed_root,
                 heaviest_subtree_fork_choice,
@@ -1778,7 +1778,7 @@ impl ReplayStage {
         new_root: Slot,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
-        accounts_hash_sender: &Option<AccountsPackageSender>,
+        snapshot_request_sender: &Option<SnapshotRequestSender>,
         all_pubkeys: &mut PubkeyReferences,
         highest_confirmed_root: Option<Slot>,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
@@ -1786,7 +1786,7 @@ impl ReplayStage {
         let old_epoch = bank_forks.read().unwrap().root_bank().epoch();
         bank_forks.write().unwrap().set_root(
             new_root,
-            accounts_hash_sender,
+            snapshot_request_sender,
             highest_confirmed_root,
         );
         let r_bank_forks = bank_forks.read().unwrap();

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -2,7 +2,6 @@
 //! validation pipeline in software.
 
 use crate::{
-    accounts_background_service::AccountsBackgroundService,
     accounts_hash_verifier::AccountsHashVerifier,
     broadcast_stage::RetransmitSlotsSender,
     cache_block_time_service::CacheBlockTimeSender,
@@ -28,8 +27,9 @@ use solana_ledger::{
     leader_schedule_cache::LeaderScheduleCache,
 };
 use solana_runtime::{
-    bank_forks::BankForks, commitment::BlockCommitmentCache,
-    snapshot_package::AccountsPackageSender, vote_sender_types::ReplayVoteSender,
+    accounts_background_service::AccountsBackgroundService, bank_forks::BankForks,
+    commitment::BlockCommitmentCache, snapshot_package::AccountsPackageSender,
+    vote_sender_types::ReplayVoteSender,
 };
 use solana_sdk::{
     pubkey::Pubkey,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -173,12 +173,15 @@ impl Tvu {
             }
         };
         info!("snapshot_interval_slots: {}", snapshot_interval_slots);
+        let (snapshot_config, accounts_package_sender) = snapshot_config_and_package_sender
+            .map(|(snapshot_config, accounts_package_sender)| {
+                (Some(snapshot_config), Some(accounts_package_sender))
+            })
+            .unwrap_or((None, None));
         let (accounts_hash_sender, accounts_hash_receiver) = channel();
         let accounts_hash_verifier = AccountsHashVerifier::new(
             accounts_hash_receiver,
-            snapshot_config_and_package_sender
-                .as_ref()
-                .map(|(_, accounts_package_sender)| accounts_package_sender.clone()),
+            accounts_package_sender,
             exit,
             &cluster_info,
             tvu_config.trusted_validators.clone(),
@@ -188,8 +191,8 @@ impl Tvu {
         );
 
         let (snapshot_request_sender, snapshot_items) = {
-            snapshot_config_and_package_sender
-                .map(|(snapshot_config, _)| {
+            snapshot_config
+                .map(|snapshot_config| {
                     let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
                     (
                         Some(snapshot_request_sender),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -27,7 +27,7 @@ use solana_ledger::{
     leader_schedule_cache::LeaderScheduleCache,
 };
 use solana_runtime::{
-    accounts_background_service::{AccountsBackgroundService, SnapshotItems},
+    accounts_background_service::{AccountsBackgroundService, SnapshotRequestHandler},
     bank_forks::{BankForks, SnapshotConfig},
     commitment::BlockCommitmentCache,
     snapshot_package::AccountsPackageSender,
@@ -190,13 +190,13 @@ impl Tvu {
             snapshot_interval_slots,
         );
 
-        let (snapshot_request_sender, snapshot_items) = {
+        let (snapshot_request_sender, snapshot_request_handler) = {
             snapshot_config
                 .map(|snapshot_config| {
                     let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
                     (
                         Some(snapshot_request_sender),
-                        Some(SnapshotItems {
+                        Some(SnapshotRequestHandler {
                             snapshot_config,
                             snapshot_request_receiver,
                             accounts_package_sender: accounts_hash_sender,
@@ -246,7 +246,7 @@ impl Tvu {
         });
 
         let accounts_background_service =
-            AccountsBackgroundService::new(bank_forks.clone(), &exit, snapshot_items);
+            AccountsBackgroundService::new(bank_forks.clone(), &exit, snapshot_request_handler);
 
         Tvu {
             fetch_stage,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -454,13 +454,16 @@ impl Validator {
             cluster_info.set_entrypoint(cluster_entrypoint.clone());
         }
 
-        let (snapshot_packager_service, snapshot_package_sender) =
-            if config.snapshot_config.is_some() {
+        let (snapshot_packager_service, snapshot_config_and_package_sender) =
+            if let Some(snapshot_config) = config.snapshot_config.clone() {
                 // Start a snapshot packaging service
                 let (sender, receiver) = channel();
                 let snapshot_packager_service =
                     SnapshotPackagerService::new(receiver, snapshot_hash, &exit, &cluster_info);
-                (Some(snapshot_packager_service), Some(sender))
+                (
+                    Some(snapshot_packager_service),
+                    Some((snapshot_config, sender)),
+                )
             } else {
                 (None, None)
             };
@@ -523,7 +526,7 @@ impl Validator {
             transaction_status_sender.clone(),
             rewards_recorder_sender,
             cache_block_time_sender,
-            snapshot_package_sender,
+            snapshot_config_and_package_sender,
             vote_tracker.clone(),
             retransmit_slots_sender,
             verified_vote_receiver,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -43,7 +43,7 @@ mod tests {
         snapshot_packager_service::SnapshotPackagerService,
     };
     use solana_runtime::{
-        accounts_background_service::AccountsBackgroundService,
+        accounts_background_service::SnapshotRequestHandler,
         bank::{Bank, BankSlotDelta},
         bank_forks::{BankForks, CompressionType, SnapshotConfig},
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -188,6 +188,11 @@ mod tests {
         let (s, snapshot_request_receiver) = unbounded();
         let (accounts_package_sender, _r) = channel();
         let snapshot_request_sender = Some(s);
+        let snapshot_request_handler = SnapshotRequestHandler {
+            snapshot_config: snapshot_test_config.snapshot_config.clone(),
+            snapshot_request_receiver,
+            accounts_package_sender,
+        };
         for slot in 0..last_slot {
             let mut bank = Bank::new_from_parent(&bank_forks[slot], &Pubkey::default(), slot + 1);
             f(&mut bank, &mint_keypair);
@@ -198,11 +203,7 @@ mod tests {
             if slot % set_root_interval == 0 || slot == last_slot - 1 {
                 // set_root should send a snapshot request
                 bank_forks.set_root(bank.slot(), &snapshot_request_sender, None);
-                AccountsBackgroundService::process_snapshot_requests(
-                    &snapshot_test_config.snapshot_config,
-                    &snapshot_request_receiver,
-                    &accounts_package_sender,
-                );
+                snapshot_request_handler.handle_snapshot_requests();
             }
         }
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -35,12 +35,15 @@ macro_rules! DEFINE_SNAPSHOT_VERSION_PARAMETERIZED_TEST_FUNCTIONS {
 #[cfg(test)]
 mod tests {
     use bincode::serialize_into;
+    use crossbeam_channel::unbounded;
     use fs_extra::dir::CopyOptions;
     use itertools::Itertools;
-    use solana_core::cluster_info::ClusterInfo;
-    use solana_core::contact_info::ContactInfo;
-    use solana_core::snapshot_packager_service::SnapshotPackagerService;
+    use solana_core::{
+        cluster_info::ClusterInfo, contact_info::ContactInfo,
+        snapshot_packager_service::SnapshotPackagerService,
+    };
     use solana_runtime::{
+        accounts_background_service::AccountsBackgroundService,
         bank::{Bank, BankSlotDelta},
         bank_forks::{BankForks, CompressionType, SnapshotConfig},
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -182,8 +185,9 @@ mod tests {
         let bank_forks = &mut snapshot_test_config.bank_forks;
         let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
 
-        let (s, _r) = channel();
-        let sender = Some(s);
+        let (s, snapshot_request_receiver) = unbounded();
+        let (accounts_package_sender, _r) = channel();
+        let snapshot_request_sender = Some(s);
         for slot in 0..last_slot {
             let mut bank = Bank::new_from_parent(&bank_forks[slot], &Pubkey::default(), slot + 1);
             f(&mut bank, &mint_keypair);
@@ -192,7 +196,13 @@ mod tests {
             // and to allow snapshotting of bank and the purging logic on status_cache to
             // kick in
             if slot % set_root_interval == 0 || slot == last_slot - 1 {
-                bank_forks.set_root(bank.slot(), &sender, None);
+                // set_root should send a snapshot request
+                bank_forks.set_root(bank.slot(), &snapshot_request_sender, None);
+                AccountsBackgroundService::process_snapshot_requests(
+                    &snapshot_test_config.snapshot_config,
+                    &snapshot_request_receiver,
+                    &accounts_package_sender,
+                );
             }
         }
 
@@ -207,7 +217,7 @@ mod tests {
             last_bank,
             &last_slot_snapshot_path,
             snapshot_path,
-            &last_bank.src.roots(),
+            last_bank.src.slot_deltas(&last_bank.src.roots()),
             &snapshot_config.snapshot_package_output_path,
             last_bank.get_snapshot_storages(),
             CompressionType::Bzip2,
@@ -312,7 +322,6 @@ mod tests {
             assert_eq!(bank.process_transaction(&tx), Ok(()));
             bank.squash();
             let accounts_hash = bank.update_accounts_hash();
-            bank_forks.insert(bank);
 
             let package_sender = {
                 if slot == saved_slot as u64 {
@@ -325,10 +334,18 @@ mod tests {
                 }
             };
 
-            bank_forks
-                .generate_accounts_package(slot, &[], &package_sender)
-                .unwrap();
+            snapshot_utils::snapshot_bank(
+                &bank,
+                vec![],
+                &package_sender,
+                &snapshot_path,
+                &snapshot_package_output_path,
+                snapshot_config.snapshot_version,
+                &snapshot_config.compression,
+            )
+            .unwrap();
 
+            bank_forks.insert(bank);
             if slot == saved_slot as u64 {
                 let options = CopyOptions::new();
                 fs_extra::dir::copy(accounts_dir, &saved_accounts_dir, &options).unwrap();
@@ -359,7 +376,7 @@ mod tests {
 
         // Purge all the outdated snapshots, including the ones needed to generate the package
         // currently sitting in the channel
-        bank_forks.purge_old_snapshots();
+        snapshot_utils::purge_old_snapshots(&snapshot_path);
         assert!(snapshot_utils::get_snapshot_paths(&snapshots_dir)
             .into_iter()
             .map(|path| path.slot)
@@ -418,7 +435,7 @@ mod tests {
         let num_set_roots = MAX_CACHE_ENTRIES * 2;
 
         for add_root_interval in &[1, 3, 9] {
-            let (snapshot_sender, _snapshot_receiver) = channel();
+            let (snapshot_sender, _snapshot_receiver) = unbounded();
             // Make sure this test never clears bank.slots_since_snapshot
             let mut snapshot_test_config = SnapshotTestConfig::new(
                 snapshot_version,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1805,7 +1805,7 @@ fn main() {
                     );
                     assert!(bank.is_complete());
                     bank.squash();
-                    bank.clean_accounts(None);
+                    bank.clean_accounts(Some(bank.slot() - 1));
                     bank.update_accounts_hash();
                     if rehash {
                         bank.rehash();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1805,7 +1805,7 @@ fn main() {
                     );
                     assert!(bank.is_complete());
                     bank.squash();
-                    bank.clean_accounts();
+                    bank.clean_accounts(None);
                     bank.update_accounts_hash();
                     if rehash {
                         bank.rehash();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1823,7 +1823,7 @@ fn main() {
                                 &bank,
                                 &slot_snapshot_paths,
                                 &temp_dir,
-                                &bank.src.roots(),
+                                bank.src.slot_deltas(&bank.src.roots()),
                                 output_directory,
                                 storages,
                                 CompressionType::Bzip2,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1805,7 +1805,7 @@ fn main() {
                     );
                     assert!(bank.is_complete());
                     bank.squash();
-                    bank.clean_accounts(Some(bank.slot() - 1));
+                    bank.clean_accounts(true);
                     bank.update_accounts_hash();
                     if rehash {
                         bank.rehash();

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -137,6 +137,6 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
         accounts.add_root(i);
     }
     bencher.iter(|| {
-        accounts.accounts_db.clean_accounts();
+        accounts.accounts_db.clean_accounts(None);
     });
 }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1810,7 +1810,7 @@ mod tests {
             }
         }
         info!("done..cleaning..");
-        accounts.accounts_db.clean_accounts();
+        accounts.accounts_db.clean_accounts(None);
     }
 
     fn load_accounts_no_store(

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -115,7 +115,7 @@ impl AccountsBackgroundService {
                     if bank.block_height() - last_cleaned_slot
                         > (CLEAN_INTERVAL_SLOTS + thread_rng().gen_range(0, 10))
                     {
-                        bank.clean_accounts();
+                        bank.clean_accounts(None);
                         last_cleaned_slot = bank.block_height();
                     }
                 }
@@ -144,6 +144,10 @@ impl AccountsBackgroundService {
                     snapshot_root_bank,
                     status_cache_slot_deltas,
                 } = snapshot_request;
+
+                snapshot_root_bank.clean_accounts(Some(snapshot_root_bank.slot()));
+                snapshot_root_bank.process_stale_slot_with_budget(0, SHRUNKEN_ACCOUNT_PER_INTERVAL);
+
                 // Generate an accounts package
                 let mut snapshot_time = Measure::start("total-snapshot-ms");
                 let r = Self::generate_accounts_package(

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -133,7 +133,11 @@ impl AccountsBackgroundService {
                     status_cache_slot_deltas,
                 } = snapshot_request;
 
-                snapshot_root_bank.clean_accounts(Some(snapshot_root_bank.slot()));
+                // Don't clean the slot we're snapshotting becaue it may have zero-lamport
+                // accounts that were included in the bank delta hash when the bank was frozen,
+                // and if we clean them here, the newly created snapshot's hash may not match
+                // the frozen hash.
+                snapshot_root_bank.clean_accounts(Some(snapshot_root_bank.slot() - 1));
                 snapshot_root_bank.process_stale_slot_with_budget(0, SHRUNKEN_ACCOUNT_PER_INTERVAL);
 
                 // Generate an accounts package

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -2,8 +2,9 @@
 //
 // This can be expensive since we have to walk the append vecs being cleaned up.
 
+use crate::bank_forks::BankForks;
+use log::*;
 use rand::{thread_rng, Rng};
-use solana_runtime::bank_forks::BankForks;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, RwLock,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -11,7 +11,6 @@ use crate::{
 use crossbeam_channel::{Receiver, Sender};
 use log::*;
 use solana_measure::measure::Measure;
-use solana_sdk::clock::Slot;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, RwLock,
@@ -32,10 +31,57 @@ pub struct SnapshotRequest {
     pub status_cache_slot_deltas: Vec<BankSlotDelta>,
 }
 
-pub struct SnapshotItems {
+pub struct SnapshotRequestHandler {
     pub snapshot_config: SnapshotConfig,
     pub snapshot_request_receiver: SnapshotRequestReceiver,
     pub accounts_package_sender: AccountsPackageSender,
+}
+
+impl SnapshotRequestHandler {
+    // Returns the latest requested snapshot slot, if one exists
+    pub fn handle_snapshot_requests(&self) -> Option<Arc<Bank>> {
+        self.snapshot_request_receiver
+            .try_iter()
+            .last()
+            .map(|snapshot_request| {
+                let SnapshotRequest {
+                    snapshot_root_bank,
+                    status_cache_slot_deltas,
+                } = snapshot_request;
+
+                snapshot_root_bank.process_stale_slot_with_budget(0, SHRUNKEN_ACCOUNT_PER_INTERVAL);
+                // Don't clean the slot we're snapshotting because it may have zero-lamport
+                // accounts that were included in the bank delta hash when the bank was frozen,
+                // and if we clean them here, the newly created snapshot's hash may not match
+                // the frozen hash.
+                snapshot_root_bank.clean_accounts(Some(snapshot_root_bank.slot() - 1));
+
+                // Generate an accounts package
+                let mut snapshot_time = Measure::start("total-snapshot-ms");
+                let r = snapshot_utils::snapshot_bank(
+                    &snapshot_root_bank,
+                    status_cache_slot_deltas,
+                    &self.accounts_package_sender,
+                    &self.snapshot_config.snapshot_path,
+                    &self.snapshot_config.snapshot_package_output_path,
+                    self.snapshot_config.snapshot_version,
+                    &self.snapshot_config.compression,
+                );
+                if r.is_err() {
+                    warn!(
+                        "Error generating snapshot for bank: {}, err: {:?}",
+                        snapshot_root_bank.slot(),
+                        r
+                    );
+                }
+
+                // Cleanup outdated snapshots
+                snapshot_utils::purge_old_snapshots(&self.snapshot_config.snapshot_path);
+                snapshot_time.stop();
+                inc_new_counter_info!("total-snapshot-ms", snapshot_time.as_ms() as usize);
+                snapshot_root_bank
+            })
+    }
 }
 
 pub struct AccountsBackgroundService {
@@ -46,12 +92,12 @@ impl AccountsBackgroundService {
     pub fn new(
         bank_forks: Arc<RwLock<BankForks>>,
         exit: &Arc<AtomicBool>,
-        snapshot_items: Option<SnapshotItems>,
+        snapshot_request_handler: Option<SnapshotRequestHandler>,
     ) -> Self {
         info!("AccountsBackgroundService active");
         let exit = exit.clone();
         let mut consumed_budget = 0;
-        let mut last_cleaned_slot = 0;
+        let mut last_cleaned_block_height = 0;
         let t_background = Builder::new()
             .name("solana-accounts-background".to_string())
             .spawn(move || loop {
@@ -75,23 +121,18 @@ impl AccountsBackgroundService {
                 // but did not see the snapshot for `N`. However, this is impossible because BankForks.set_root()
                 // will always flush the snapshot request for `N` to the snapshot request channel
                 // before setting a root `M > N`.
-                let snapshotted_slot = snapshot_items.as_ref().and_then(|snapshot_items| {
-                    let SnapshotItems {
-                        snapshot_config,
-                        snapshot_request_receiver,
-                        accounts_package_sender,
-                    } = snapshot_items;
-                    Self::process_snapshot_requests(
-                        snapshot_config,
-                        snapshot_request_receiver,
-                        accounts_package_sender,
-                    )
-                });
+                let snapshot_root_bank =
+                    snapshot_request_handler
+                        .as_ref()
+                        .and_then(|snapshot_request_handler| {
+                            snapshot_request_handler.handle_snapshot_requests()
+                        });
 
-                if let Some(snapshotted_slot) = snapshotted_slot {
+                if let Some(snapshot_root_bank) = snapshot_root_bank {
+                    let snapshot_block_height = snapshot_root_bank.block_height();
                     // Safe, see proof above
-                    assert!(last_cleaned_slot <= snapshotted_slot);
-                    last_cleaned_slot = snapshotted_slot;
+                    assert!(last_cleaned_block_height <= snapshot_block_height);
+                    last_cleaned_block_height = snapshot_block_height;
                 } else {
                     consumed_budget = bank.process_stale_slot_with_budget(
                         consumed_budget,
@@ -107,54 +148,5 @@ impl AccountsBackgroundService {
 
     pub fn join(self) -> thread::Result<()> {
         self.t_background.join()
-    }
-
-    // Returns the latest rquested snapshot slot, if one exists
-    pub fn process_snapshot_requests(
-        snapshot_config: &SnapshotConfig,
-        snapshot_request_receiver: &SnapshotRequestReceiver,
-        accounts_package_sender: &AccountsPackageSender,
-    ) -> Option<Slot> {
-        snapshot_request_receiver
-            .try_iter()
-            .last()
-            .map(|snapshot_request| {
-                let SnapshotRequest {
-                    snapshot_root_bank,
-                    status_cache_slot_deltas,
-                } = snapshot_request;
-
-                snapshot_root_bank.process_stale_slot_with_budget(0, SHRUNKEN_ACCOUNT_PER_INTERVAL);
-                // Don't clean the slot we're snapshotting becaue it may have zero-lamport
-                // accounts that were included in the bank delta hash when the bank was frozen,
-                // and if we clean them here, the newly created snapshot's hash may not match
-                // the frozen hash.
-                snapshot_root_bank.clean_accounts(Some(snapshot_root_bank.slot() - 1));
-
-                // Generate an accounts package
-                let mut snapshot_time = Measure::start("total-snapshot-ms");
-                let r = snapshot_utils::snapshot_bank(
-                    &snapshot_root_bank,
-                    status_cache_slot_deltas,
-                    accounts_package_sender,
-                    &snapshot_config.snapshot_path,
-                    &snapshot_config.snapshot_package_output_path,
-                    snapshot_config.snapshot_version,
-                    &snapshot_config.compression,
-                );
-                if r.is_err() {
-                    warn!(
-                        "Error generating snapshot for bank: {}, err: {:?}",
-                        snapshot_root_bank.slot(),
-                        r
-                    );
-                }
-
-                // Cleanup outdated snapshots
-                snapshot_utils::purge_old_snapshots(&snapshot_config.snapshot_path);
-                snapshot_time.stop();
-                inc_new_counter_info!("total-snapshot-ms", snapshot_time.as_ms() as usize);
-                snapshot_root_bank.slot()
-            })
     }
 }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -2,19 +2,25 @@
 //
 // This can be expensive since we have to walk the append vecs being cleaned up.
 
-use crate::bank_forks::BankForks;
+use crate::{
+    bank::{Bank, BankSlotDelta},
+    bank_forks::{BankForks, SnapshotConfig},
+    snapshot_package::{AccountsPackageSendError, AccountsPackageSender},
+    snapshot_utils::{self, SnapshotError},
+    status_cache::MAX_CACHE_ENTRIES,
+};
+use crossbeam_channel::{Receiver, Sender};
 use log::*;
 use rand::{thread_rng, Rng};
+use solana_measure::measure::Measure;
+use solana_sdk::clock::Slot;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, RwLock,
 };
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::Duration;
-
-pub struct AccountsBackgroundService {
-    t_background: JoinHandle<()>,
-}
+use thiserror::Error;
 
 const INTERVAL_MS: u64 = 100;
 const SHRUNKEN_ACCOUNT_PER_SEC: usize = 250;
@@ -22,8 +28,40 @@ const SHRUNKEN_ACCOUNT_PER_INTERVAL: usize =
     SHRUNKEN_ACCOUNT_PER_SEC / (1000 / INTERVAL_MS as usize);
 const CLEAN_INTERVAL_SLOTS: u64 = 100;
 
+pub type SnapshotRequestSender = Sender<SnapshotRequest>;
+pub type SnapshotRequestReceiver = Receiver<SnapshotRequest>;
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("snapshot error")]
+    SnapshotError(#[from] SnapshotError),
+
+    #[error("accounts package send error")]
+    AccountsPackageSendError(#[from] AccountsPackageSendError),
+}
+
+pub struct SnapshotRequest {
+    pub snapshot_root_bank: Arc<Bank>,
+    pub status_cache_slot_deltas: Vec<BankSlotDelta>,
+}
+
+pub struct SnapshotItems {
+    pub snapshot_config: SnapshotConfig,
+    pub snapshot_request_receiver: SnapshotRequestReceiver,
+    pub accounts_package_sender: AccountsPackageSender,
+}
+
+pub struct AccountsBackgroundService {
+    t_background: JoinHandle<()>,
+}
+
 impl AccountsBackgroundService {
-    pub fn new(bank_forks: Arc<RwLock<BankForks>>, exit: &Arc<AtomicBool>) -> Self {
+    pub fn new(
+        bank_forks: Arc<RwLock<BankForks>>,
+        exit: &Arc<AtomicBool>,
+        snapshot_items: Option<SnapshotItems>,
+    ) -> Self {
         info!("AccountsBackgroundService active");
         let exit = exit.clone();
         let mut consumed_budget = 0;
@@ -34,16 +72,52 @@ impl AccountsBackgroundService {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
+
+                // Grab the current root bank
                 let bank = bank_forks.read().unwrap().root_bank().clone();
 
-                consumed_budget = bank
-                    .process_stale_slot_with_budget(consumed_budget, SHRUNKEN_ACCOUNT_PER_INTERVAL);
+                // Check to see if there were any requests for snapshotting banks
+                // < the current root bank `bank` above.
 
-                if bank.block_height() - last_cleaned_slot
-                    > (CLEAN_INTERVAL_SLOTS + thread_rng().gen_range(0, 10))
-                {
-                    bank.clean_accounts();
-                    last_cleaned_slot = bank.block_height();
+                // Claim: Any snapshot request for slot `N` found here means that cleanup has
+                // been called at most on slot `N`
+                //
+                // Proof: Assume for contradiction that we find a snapshot request for slot `N` here,
+                // but cleanup has already happened on some slot `M > N`.
+                //
+                // Then that means on some previous iteration of this loop, we found `bank_forks.root_bank() == M`,
+                // but did not see the snapshot for `N`. However, this is impossible because BankForks.set_root()
+                // will always flush the snapshot request for `N` to the snapshot request channel
+                // before setting a root `M > N`.
+                let snapshotted_slot = snapshot_items.as_ref().and_then(|snapshot_items| {
+                    let SnapshotItems {
+                        snapshot_config,
+                        snapshot_request_receiver,
+                        accounts_package_sender,
+                    } = snapshot_items;
+                    Self::process_snapshot_requests(
+                        snapshot_config,
+                        snapshot_request_receiver,
+                        accounts_package_sender,
+                    )
+                });
+
+                if let Some(snapshotted_slot) = snapshotted_slot {
+                    // Safe, see proof above
+                    assert!(last_cleaned_slot <= snapshotted_slot);
+                    last_cleaned_slot = snapshotted_slot;
+                } else {
+                    consumed_budget = bank.process_stale_slot_with_budget(
+                        consumed_budget,
+                        SHRUNKEN_ACCOUNT_PER_INTERVAL,
+                    );
+
+                    if bank.block_height() - last_cleaned_slot
+                        > (CLEAN_INTERVAL_SLOTS + thread_rng().gen_range(0, 10))
+                    {
+                        bank.clean_accounts();
+                        last_cleaned_slot = bank.block_height();
+                    }
                 }
 
                 sleep(Duration::from_millis(INTERVAL_MS));
@@ -54,5 +128,102 @@ impl AccountsBackgroundService {
 
     pub fn join(self) -> thread::Result<()> {
         self.t_background.join()
+    }
+
+    // Returns the latest rquested snapshot slot, if one exists
+    pub fn process_snapshot_requests(
+        snapshot_config: &SnapshotConfig,
+        snapshot_request_receiver: &SnapshotRequestReceiver,
+        accounts_package_sender: &AccountsPackageSender,
+    ) -> Option<Slot> {
+        snapshot_request_receiver
+            .try_iter()
+            .last()
+            .map(|snapshot_request| {
+                let SnapshotRequest {
+                    snapshot_root_bank,
+                    status_cache_slot_deltas,
+                } = snapshot_request;
+                // Generate an accounts package
+                let mut snapshot_time = Measure::start("total-snapshot-ms");
+                let r = Self::generate_accounts_package(
+                    &snapshot_root_bank,
+                    status_cache_slot_deltas,
+                    accounts_package_sender,
+                    snapshot_config,
+                );
+                if r.is_err() {
+                    warn!(
+                        "Error generating snapshot for bank: {}, err: {:?}",
+                        snapshot_root_bank.slot(),
+                        r
+                    );
+                }
+
+                // Cleanup outdated snapshots
+                Self::purge_old_snapshots(snapshot_config);
+                snapshot_time.stop();
+                inc_new_counter_info!("total-snapshot-ms", snapshot_time.as_ms() as usize);
+                snapshot_root_bank.slot()
+            })
+    }
+
+    // Gather the necessary elements for a snapshot of the given `root_bank`
+    pub fn generate_accounts_package(
+        root_bank: &Bank,
+        status_cache_slot_deltas: Vec<BankSlotDelta>,
+        accounts_package_sender: &AccountsPackageSender,
+        snapshot_config: &SnapshotConfig,
+    ) -> Result<()> {
+        let storages: Vec<_> = root_bank.get_snapshot_storages();
+        let mut add_snapshot_time = Measure::start("add-snapshot-ms");
+        snapshot_utils::add_snapshot(
+            &snapshot_config.snapshot_path,
+            &root_bank,
+            &storages,
+            snapshot_config.snapshot_version,
+        )?;
+        add_snapshot_time.stop();
+        inc_new_counter_info!("add-snapshot-ms", add_snapshot_time.as_ms() as usize);
+
+        // Package the relevant snapshots
+        let slot_snapshot_paths =
+            snapshot_utils::get_snapshot_paths(&snapshot_config.snapshot_path);
+        let latest_slot_snapshot_paths = slot_snapshot_paths
+            .last()
+            .expect("no snapshots found in config snapshot_path");
+        // We only care about the last bank's snapshot.
+        // We'll ask the bank for MAX_CACHE_ENTRIES (on the rooted path) worth of statuses
+        let package = snapshot_utils::package_snapshot(
+            &root_bank,
+            latest_slot_snapshot_paths,
+            &snapshot_config.snapshot_path,
+            status_cache_slot_deltas,
+            &snapshot_config.snapshot_package_output_path,
+            storages,
+            snapshot_config.compression.clone(),
+            snapshot_config.snapshot_version,
+        )?;
+
+        accounts_package_sender.send(package)?;
+
+        Ok(())
+    }
+
+    pub fn purge_old_snapshots(snapshot_config: &SnapshotConfig) {
+        // Remove outdated snapshots
+        let slot_snapshot_paths =
+            snapshot_utils::get_snapshot_paths(&snapshot_config.snapshot_path);
+        let num_to_remove = slot_snapshot_paths.len().saturating_sub(MAX_CACHE_ENTRIES);
+        for slot_files in &slot_snapshot_paths[..num_to_remove] {
+            let r =
+                snapshot_utils::remove_snapshot(slot_files.slot, &snapshot_config.snapshot_path);
+            if r.is_err() {
+                warn!(
+                    "Couldn't remove snapshot at: {:?}",
+                    snapshot_config.snapshot_path
+                );
+            }
+        }
     }
 }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -41,7 +41,7 @@ pub struct SnapshotRequestHandler {
 
 impl SnapshotRequestHandler {
     // Returns the latest requested snapshot slot, if one exists
-    pub fn handle_snapshot_requests(&self) -> Option<Arc<Bank>> {
+    pub fn handle_snapshot_requests(&self) -> Option<u64> {
         self.snapshot_request_receiver
             .try_iter()
             .last()
@@ -99,7 +99,7 @@ impl SnapshotRequestHandler {
                         i64
                     )
                 );
-                snapshot_root_bank
+                snapshot_root_bank.block_height()
             })
     }
 }
@@ -141,15 +141,14 @@ impl AccountsBackgroundService {
                 // but did not see the snapshot for `N`. However, this is impossible because BankForks.set_root()
                 // will always flush the snapshot request for `N` to the snapshot request channel
                 // before setting a root `M > N`.
-                let snapshot_root_bank =
+                let snapshot_block_height =
                     snapshot_request_handler
                         .as_ref()
                         .and_then(|snapshot_request_handler| {
                             snapshot_request_handler.handle_snapshot_requests()
                         });
 
-                if let Some(snapshot_root_bank) = snapshot_root_bank {
-                    let snapshot_block_height = snapshot_root_bank.block_height();
+                if let Some(snapshot_block_height) = snapshot_block_height {
                     // Safe, see proof above
                     assert!(last_cleaned_block_height <= snapshot_block_height);
                     last_cleaned_block_height = snapshot_block_height;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -781,6 +781,24 @@ impl AccountsDB {
         }
     }
 
+    // Removes the accounts in the input `reclaims` from the tracked "count" of
+    // their corresponding  storage entries. Note this does not actually free
+    // the memory from the storage entries until all the storage entries for
+    // a given slot `S` are empty, at which point `process_dead_slots` will
+    // remove all the storage entries for `S`.
+    //
+    /// # Arguments
+    /// * `reclaims` - The accounts to remove from storage entries' "count"
+    /// * `expected_slot` - A correctness assertion. If this is equal to `Some(S)`,
+    /// then the function will check that the only slot being cleaned up in `reclaims`
+    /// is the slot == `S`. This is true for instance when `handle_reclaims` is called
+    /// from store or slot shrinking, as those should only touch the slot they are
+    /// currently storing to or shrinking.
+    /// * `is_cleanup_possible` - A correctness assertion. If this is equal to
+    /// `false`, the function will check that no slots are cleaned up/removed via
+    /// `process_dead_slots`. For instance, on store, no slots should be cleaned up,
+    /// but during the background clean accounts purges accounts from old rooted slots,
+    /// so outdated slots may be removed.
     fn handle_reclaims(
         &self,
         reclaims: SlotSlice<AccountInfo>,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -510,6 +510,10 @@ impl AccountsDB {
         new
     }
 
+    pub fn file_size(&self) -> u64 {
+        self.file_size
+    }
+
     #[cfg(test)]
     pub fn new_single() -> Self {
         AccountsDB {
@@ -1975,7 +1979,7 @@ impl AccountsDB {
         );
         scan.stop();
         let mut merge = Measure::start("merge");
-        let mut account_maps = accumulator.pop().unwrap();
+        let mut account_maps = HashMap::new();
         while let Some(maps) = accumulator.pop() {
             AccountsDB::merge(&mut account_maps, &maps);
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -579,7 +579,7 @@ impl AccountsDB {
 
     #[cfg(test)]
     fn reset_uncleaned_roots(&self) {
-        self.do_reset_uncleaned_roots(&mut self.shrink_candidate_slots.lock().unwrap());
+        self.do_reset_uncleaned_roots(&mut self.shrink_candidate_slots.lock().unwrap(), None);
     }
 
     fn calc_delete_dependencies(
@@ -2638,7 +2638,7 @@ pub mod tests {
             .accounts_index
             .read()
             .unwrap()
-            .get(&key, Some(&ancestors))
+            .get(&key, Some(&ancestors), None)
             .is_some());
         assert_load_account(&db, unrooted_slot, key, 1);
 
@@ -2659,7 +2659,7 @@ pub mod tests {
             .accounts_index
             .read()
             .unwrap()
-            .get(&key, Some(&ancestors))
+            .get(&key, Some(&ancestors), None)
             .is_none());
 
         // Test we can store for the same slot again and get the right information
@@ -2963,7 +2963,7 @@ pub mod tests {
         let ancestors = vec![(0, 0)].into_iter().collect();
         let id = {
             let index = accounts.accounts_index.read().unwrap();
-            let (list, idx) = index.get(&pubkey, Some(&ancestors)).unwrap();
+            let (list, idx) = index.get(&pubkey, Some(&ancestors), None).unwrap();
             list[idx].1.store_id
         };
         accounts.add_root(1);

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -117,9 +117,9 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
         rv
     }
 
-    // Checks that the given slot is both:
-    // 1) Rooted
-    // 2) Less than or equal to an optionally specified `max_root`
+    // Checks that the given slot is either:
+    // 1) in the `ancestors` set
+    // 2) or is a root
     fn is_ancestor_or_root(&self, ancestors: Option<&Ancestors>, slot: Slot) -> bool {
         ancestors.map_or(false, |ancestors| ancestors.contains_key(&slot)) || (self.is_root(slot))
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1310,7 +1310,11 @@ impl Bank {
     // concurrent cleaning logic in AccountsBackgroundService
     pub fn exhaustively_free_unused_resource(&self) {
         let mut clean = Measure::start("clean");
-        self.clean_accounts(None);
+        // Don't clean the slot we're snapshotting becaue it may have zero-lamport
+        // accounts that were included in the bank delta hash when the bank was frozen,
+        // and if we clean them here, any newly created snapshot's hash for this bank
+        // may not match the frozen hash.
+        self.clean_accounts(Some(self.slot() - 1));
         clean.stop();
 
         let mut shrink = Measure::start("shrink");

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5259,7 +5259,7 @@ mod tests {
     impl Bank {
         fn slots_by_pubkey(&self, pubkey: &Pubkey, ancestors: &Ancestors) -> Vec<Slot> {
             let accounts_index = self.rc.accounts.accounts_db.accounts_index.read().unwrap();
-            let (accounts, _) = accounts_index.get(&pubkey, Some(&ancestors)).unwrap();
+            let (accounts, _) = accounts_index.get(&pubkey, Some(&ancestors), None).unwrap();
             accounts
                 .iter()
                 .map(|(slot, _)| *slot)
@@ -5634,7 +5634,7 @@ mod tests {
         }
 
         let hash = bank.update_accounts_hash();
-        bank.clean_accounts();
+        bank.clean_accounts(None);
         assert_eq!(bank.update_accounts_hash(), hash);
 
         let bank0 = Arc::new(new_from_parent(&bank));
@@ -5654,14 +5654,14 @@ mod tests {
 
         info!("bank0 purge");
         let hash = bank0.update_accounts_hash();
-        bank0.clean_accounts();
+        bank0.clean_accounts(None);
         assert_eq!(bank0.update_accounts_hash(), hash);
 
         assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
 
         info!("bank1 purge");
-        bank1.clean_accounts();
+        bank1.clean_accounts(None);
 
         assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
@@ -5679,7 +5679,7 @@ mod tests {
         // keypair should have 0 tokens on both forks
         assert_eq!(bank0.get_account(&keypair.pubkey()), None);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
-        bank1.clean_accounts();
+        bank1.clean_accounts(None);
 
         assert!(bank1.verify_bank_hash());
     }
@@ -8570,7 +8570,7 @@ mod tests {
         goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank).unwrap());
 
         bank.squash();
-        bank.clean_accounts();
+        bank.clean_accounts(None);
         let force_to_return_alive_account = 0;
         assert_eq!(
             bank.process_stale_slot_with_budget(22, force_to_return_alive_account),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1307,10 +1307,6 @@ impl Bank {
     }
 
     pub fn exhaustively_free_unused_resource(&self) {
-        let mut reclaim = Measure::start("reclaim");
-        self.process_dead_slots();
-        reclaim.stop();
-
         let mut clean = Measure::start("clean");
         self.clean_accounts();
         clean.stop();
@@ -1320,8 +1316,10 @@ impl Bank {
         shrink.stop();
 
         info!(
-            "exhaustively_free_unused_resource(): {} {} {}",
-            reclaim, clean, shrink,
+            "exhaustively_free_unused_resource()
+            clean: {},
+            shrink: {}",
+            clean, shrink,
         );
     }
 
@@ -3536,10 +3534,6 @@ impl Bank {
 
     pub fn clean_accounts(&self) {
         self.rc.accounts.accounts_db.clean_accounts();
-    }
-
-    pub fn process_dead_slots(&self) {
-        self.rc.accounts.accounts_db.process_dead_slots(None);
     }
 
     pub fn shrink_all_slots(&self) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1310,7 +1310,7 @@ impl Bank {
     // concurrent cleaning logic in AccountsBackgroundService
     pub fn exhaustively_free_unused_resource(&self) {
         let mut clean = Measure::start("clean");
-        // Don't clean the slot we're snapshotting becaue it may have zero-lamport
+        // Don't clean the slot we're snapshotting because it may have zero-lamport
         // accounts that were included in the bank delta hash when the bank was frozen,
         // and if we clean them here, any newly created snapshot's hash for this bank
         // may not match the frozen hash.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 pub mod accounts;
+pub mod accounts_background_service;
 pub mod accounts_db;
 pub mod accounts_index;
 pub mod append_vec;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -159,7 +159,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
     bank: &Bank,
     snapshot_files: &SlotSnapshotPaths,
     snapshot_path: Q,
-    slots_to_snapshot: &[Slot],
+    status_cache_slot_deltas: Vec<BankSlotDelta>,
     snapshot_package_output_path: P,
     snapshot_storages: SnapshotStorages,
     compression: CompressionType,
@@ -188,7 +188,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
     let package = AccountsPackage::new(
         bank.slot(),
         bank.block_height(),
-        bank.src.slot_deltas(slots_to_snapshot),
+        status_cache_slot_deltas,
         snapshot_hard_links_dir,
         snapshot_storages,
         snapshot_package_output_file,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5,7 +5,8 @@ use crate::{
     serde_snapshot::{
         bank_from_stream, bank_to_stream, SerdeStyle, SnapshotStorage, SnapshotStorages,
     },
-    snapshot_package::AccountsPackage,
+    snapshot_package::{AccountsPackage, AccountsPackageSendError, AccountsPackageSender},
+    status_cache::MAX_CACHE_ENTRIES,
 };
 use bincode::{config::Options, serialize_into};
 use bzip2::bufread::BzDecoder;
@@ -124,6 +125,9 @@ pub enum SnapshotError {
 
     #[error("Unpack error: {0}")]
     UnpackError(#[from] UnpackError),
+
+    #[error("accounts package send error")]
+    AccountsPackageSendError(#[from] AccountsPackageSendError),
 }
 pub type Result<T> = std::result::Result<T, SnapshotError>;
 
@@ -844,6 +848,57 @@ pub fn verify_snapshot_archive<P, Q, R>(
     // Check the account entries are the same
     let unpacked_accounts = unpack_dir.join(&TAR_ACCOUNTS_DIR);
     assert!(!dir_diff::is_different(&storages_to_verify, unpacked_accounts).unwrap());
+}
+
+pub fn purge_old_snapshots(snapshot_path: &Path) {
+    // Remove outdated snapshots
+    let slot_snapshot_paths = get_snapshot_paths(snapshot_path);
+    let num_to_remove = slot_snapshot_paths.len().saturating_sub(MAX_CACHE_ENTRIES);
+    for slot_files in &slot_snapshot_paths[..num_to_remove] {
+        let r = remove_snapshot(slot_files.slot, snapshot_path);
+        if r.is_err() {
+            warn!("Couldn't remove snapshot at: {:?}", snapshot_path);
+        }
+    }
+}
+
+// Gather the necessary elements for a snapshot of the given `root_bank`
+pub fn snapshot_bank(
+    root_bank: &Bank,
+    status_cache_slot_deltas: Vec<BankSlotDelta>,
+    accounts_package_sender: &AccountsPackageSender,
+    snapshot_path: &Path,
+    snapshot_package_output_path: &Path,
+    snapshot_version: SnapshotVersion,
+    compression: &CompressionType,
+) -> Result<()> {
+    let storages: Vec<_> = root_bank.get_snapshot_storages();
+    let mut add_snapshot_time = Measure::start("add-snapshot-ms");
+    add_snapshot(snapshot_path, &root_bank, &storages, snapshot_version)?;
+    add_snapshot_time.stop();
+    inc_new_counter_info!("add-snapshot-ms", add_snapshot_time.as_ms() as usize);
+
+    // Package the relevant snapshots
+    let slot_snapshot_paths = get_snapshot_paths(snapshot_path);
+    let latest_slot_snapshot_paths = slot_snapshot_paths
+        .last()
+        .expect("no snapshots found in config snapshot_path");
+    // We only care about the last bank's snapshot.
+    // We'll ask the bank for MAX_CACHE_ENTRIES (on the rooted path) worth of statuses
+    let package = package_snapshot(
+        &root_bank,
+        latest_slot_snapshot_paths,
+        snapshot_path,
+        status_cache_slot_deltas,
+        snapshot_package_output_path,
+        storages,
+        compression.clone(),
+        snapshot_version,
+    )?;
+
+    accounts_package_sender.send(package)?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1073,7 +1073,7 @@ mod tests {
             .transfer_and_confirm(50, &alice_keypair, &Pubkey::new_rand())
             .unwrap();
 
-        // super fun time; callback chooses to .clean_accounts() or not
+        // super fun time; callback chooses to .clean_accounts(None) or not
         callback(&*bank);
 
         // create a normal account at the same pubkey as the zero-lamports account
@@ -1091,7 +1091,7 @@ mod tests {
             bank.squash();
             // do clean and assert that it actually did its job
             assert_eq!(3, bank.get_snapshot_storages().len());
-            bank.clean_accounts();
+            bank.clean_accounts(None);
             assert_eq!(2, bank.get_snapshot_storages().len());
         });
     }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1091,7 +1091,7 @@ mod tests {
             bank.squash();
             // do clean and assert that it actually did its job
             assert_eq!(3, bank.get_snapshot_storages().len());
-            bank.clean_accounts(None);
+            bank.clean_accounts(false);
             assert_eq!(2, bank.get_snapshot_storages().len());
         });
     }


### PR DESCRIPTION
#### Problem
1) There were some race conditions between accounts cleanup and accounts store
2) Cleanup logic was divided into too many areas getting very complicated/hard to understand

#### Summary of Changes
1) No more cleanup of old rooted storage entries in store(), store() now only purges storage entries from the same slot 
2) Cleaning up rooted storage entries only occurs in clean() and do_shrink_slots(), via a single `handle_reclaims()` function
3) `handle_reclaims` no longer blocks the store() pipe;ine, so it will always force clean, removing the need for the dead slots counter



Fixes #
