### PR TITLE
net.sh: $extraPrimordialStakes is never empty

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -1003,7 +1003,7 @@ if [[ -n "$maybeWaitForSupermajority" && -n "$maybeWarpSlot" ]]; then
   fi
 fi
 
-if [[ -n "$extraPrimordialStakes" ]]; then
+if [[ $extraPrimordialStakes -gt 0 ]]; then
   # Extra primoridial stakes require that all of the validators start at
   # the same time. Force async init and wait for supermajority here.
   waitForNodeInit=false


### PR DESCRIPTION
#### Problem

`net/net.sh` erroneously checks `extraPrimordialStakes` for being empty, when it's default value is `0`.  This leads to forcing `--wait-for-supermajority` on when it is not desired.

#### Summary of Changes

Check for `> 0` instead

Thanks to @behzadnouri for reporting