### PR TITLE
Fix off-by-one max payload checks

### DIFF
--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -27,7 +27,7 @@ fn producer(addr: &SocketAddr, exit: Arc<AtomicBool>) -> JoinHandle<()> {
         let mut num = 0;
         for p in &msgs.packets {
             let a = p.meta.addr();
-            assert!(p.meta.size < PACKET_DATA_SIZE);
+            assert!(p.meta.size <= PACKET_DATA_SIZE);
             send.send_to(&p.data[..p.meta.size], &a).unwrap();
             num += 1;
         }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2475,7 +2475,7 @@ fn deserialize_bs58_transaction(bs58_transaction: String) -> Result<(Vec<u8>, Tr
     let wire_transaction = bs58::decode(bs58_transaction)
         .into_vec()
         .map_err(|e| Error::invalid_params(format!("{:?}", e)))?;
-    if wire_transaction.len() >= PACKET_DATA_SIZE {
+    if wire_transaction.len() > PACKET_DATA_SIZE {
         let err = format!(
             "transaction too large: {} bytes (max: {} bytes)",
             wire_transaction.len(),

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -219,7 +219,7 @@ pub fn request_airdrop_transaction(
         Error::new(ErrorKind::Other, "Airdrop failed")
     })?;
     let transaction_length = LittleEndian::read_u16(&buffer) as usize;
-    if transaction_length >= PACKET_DATA_SIZE || transaction_length == 0 {
+    if transaction_length > PACKET_DATA_SIZE || transaction_length == 0 {
         return Err(Error::new(
             ErrorKind::Other,
             format!(

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -598,7 +598,7 @@ mod tests {
         tx0.message.instructions[0].data = vec![1, 2, 3];
         let message0a = tx0.message_data();
         let tx_bytes = serialize(&tx0).unwrap();
-        assert!(tx_bytes.len() < PACKET_DATA_SIZE);
+        assert!(tx_bytes.len() <= PACKET_DATA_SIZE);
         assert_eq!(
             memfind(&tx_bytes, &tx0.signatures[0].as_ref()),
             Some(SIG_OFFSET)


### PR DESCRIPTION
#### Problem
Transactions sent with size equal to max packet size are rejected (off-by-one) by the RPC API resulting in errors like this:

```
Error: failed to send transaction: transaction too large: 1232 bytes (max: 1232 bytes)
```

#### Summary of Changes
- Allow transactions as big as max packet size in RPC
- Fix a test and bench client that asserted packet size incorrectly

Fixes #
