### PR TITLE
Drop the recommendation that `--expected-shred-version` be set by validators

### DIFF
--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -45,7 +45,6 @@ $ solana-validator \
     --dynamic-port-range 8000-8010 \
     --entrypoint entrypoint.devnet.solana.com:8001 \
     --expected-genesis-hash Ap36zrBt2jLWpwUjaF48hRULVgmvSE3ViFxiQgjZX2XC \
-    --expected-shred-version 37460 \
     --limit-ledger-size
 ```
 
@@ -89,7 +88,6 @@ $ solana-validator \
     --dynamic-port-range 8000-8010 \
     --entrypoint entrypoint.testnet.solana.com:8001 \
     --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
-    --expected-shred-version 1579 \
     --limit-ledger-size
 ```
 
@@ -136,7 +134,6 @@ $ solana-validator \
     --dynamic-port-range 8000-8010 \
     --entrypoint mainnet-beta.solana.com:8001 \
     --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
-    --expected-shred-version 64864 \
     --limit-ledger-size
 ```
 

--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -21,7 +21,6 @@ solana-validator \
   --ledger <LEDGER_PATH> \
   --entrypoint <CLUSTER_ENTRYPOINT> \
   --expected-genesis-hash <EXPECTED_GENESIS_HASH> \
-  --expected-shred-version <EXPECTED_SHRED_VERSION> \
   --rpc-port 8899 \
   --no-voting \
   --enable-rpc-transaction-history \
@@ -32,7 +31,7 @@ solana-validator \
 
 Customize `--ledger` to your desired ledger storage location, and `--rpc-port` to the port you want to expose.
 
-The `--entrypoint`, `--expected-genesis-hash`, and `--expected-shred-version` parameters are all specific to the cluster you are joining. The shred version will change on any hard forks in the cluster, so including `--expected-shred-version` ensures you are receiving current data from the cluster you expect.
+The `--entrypoint` and `--expected-genesis-hash` parameters are all specific to the cluster you are joining.
 [Current parameters for Mainnet Beta](../clusters.md#example-solana-validator-command-line-2)
 
 The `--limit-ledger-size` parameter allows you to specify how many ledger [shreds](../terminology.md#shred) your node retains on disk. If you do not include this parameter, the validator will keep the entire ledger until it runs out of disk space. The default value is good for at least a couple days but larger values may be used by adding an argument to `--limit-ledger-size` if desired. Check `solana-validator --help` for the default limit value used by `--limit-ledger-size`

--- a/docs/src/running-validator/restart-cluster.md
+++ b/docs/src/running-validator/restart-cluster.md
@@ -21,7 +21,6 @@ call this NEW\_SHRED\_VERSION and NEW\_BANK\_HASH respectively.
 Adjust your validator's arugments:
 
 ```bash
- --expected-shred-version NEW_SHRED_VERSION
  --wait-for-supermajority SLOT_X
  --expected-bank-hash NEW_BANK_HASH
 ```
@@ -51,7 +50,6 @@ Post something like the following to #announcements (adjusting the text as appro
 > ```bash
 > solana-validator
 >   --wait-for-supermajority 12961040  # <-- NEW! IMPORTANT!
->   --expected-shred-version 56096     # <-- NEW! IMPORTANT!
 >   --expected-bank-hash 6q2oTgs8FiJxra2Zo1N8tzWqo5b6uGbjmFgoWDsXxchY    # <-- NEW! IMPORTANT!
 >   --hard-fork 56096                  # <-- NEW! IMPORTANT!
 >   --entrypoint 35.203.170.30:8001    # <-- Same as before


### PR DESCRIPTION
`--expected-shred-version` is another knob for users to get wrong and is
documentation that can get stale due to cluster restarts.  Turns out
it's also generally not required anymore either because:
1. The cluster entrypoint can always be expected to be using the correct
   shred version, and that shred version will be adopted by the new node
   (earlier this was not the case when the `solana-gossip spy` node on
   mainnet-beta.solana.com:8001 ran with shred version 0)
2. On a cluster restart, `--expected-bank-hash` is a much stronger
   assertion that the validator is starting from the correct place (and
   didn't exist when `--expected-shred-version` was first recommended)
