### PR TITLE
Github issues with 1 year of inactivity are now marked stale, and will be closed 7 days later.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,3 @@
-only: pulls
-
-# Number of days of inactivity before a pull request becomes stale
-daysUntilStale: 7
-
-# Number of days of inactivity before a stale pull request is closed
-daysUntilClose: 7
-
 # Issues with these labels will never be considered stale
 exemptLabels:
   - security
@@ -14,12 +6,34 @@ exemptLabels:
 # Label to use when marking a pull request as stale
 staleLabel: stale
 
-# Comment to post when marking a pull request as stale. Set to `false` to disable
-markComment: >
-  This pull request has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs.
+pulls:
+  # Number of days of inactivity before a pull request becomes stale
+  daysUntilStale: 7
 
-# Comment to post when closing a stale pull request. Set to `false` to disable
-closeComment: >
-  This stale pull request has been automatically closed.
-  Thank you for your contributions.
+  # Number of days of inactivity before a stale pull request is closed
+  daysUntilClose: 7
+  # Comment to post when marking a pull request as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs.
+
+  # Comment to post when closing a stale pull request. Set to `false` to disable
+  closeComment: >
+    This stale pull request has been automatically closed.
+    Thank you for your contributions.
+
+issues:
+  # Number of days of inactivity before a issue becomes stale
+  daysUntilStale: 365
+
+  # Number of days of inactivity before a stale issue is closed
+  daysUntilClose: 7
+  # Comment to post when marking a issue as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs.
+
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    This stale issue has been automatically closed.
+    Thank you for your contributions.


### PR DESCRIPTION
We have 500+ issues that may or may not be relevant.   Nobody wants to take the time to go through all of them and make the tough call.  Make a bot do it for us.  If you see something you care about get marked stale and then closed, then bring it back.