### PR TITLE
Add blockstore column to store performance sampling data

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod banking_stage;
 pub mod bigtable_upload_service;
 pub mod broadcast_stage;
 pub mod cache_block_time_service;
+pub mod sample_performance_service;
 pub mod cluster_info_vote_listener;
 pub mod commitment_service;
 pub mod completed_data_sets_service;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,7 +12,6 @@ pub mod banking_stage;
 pub mod bigtable_upload_service;
 pub mod broadcast_stage;
 pub mod cache_block_time_service;
-pub mod sample_performance_service;
 pub mod cluster_info_vote_listener;
 pub mod commitment_service;
 pub mod completed_data_sets_service;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,11 +12,11 @@ pub mod banking_stage;
 pub mod bigtable_upload_service;
 pub mod broadcast_stage;
 pub mod cache_block_time_service;
-pub mod sample_performance_service;
 pub mod cluster_info_vote_listener;
 pub mod commitment_service;
 pub mod completed_data_sets_service;
 mod deprecated;
+pub mod sample_performance_service;
 pub mod shred_fetch_stage;
 #[macro_use]
 pub mod contact_info;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -33,7 +33,10 @@ use solana_client::{
     rpc_response::*,
 };
 use solana_faucet::faucet::request_airdrop_transaction;
-use solana_ledger::{blockstore::Blockstore, blockstore_db::BlockstoreError, get_tmp_ledger_path, blockstore_meta::PerfSample};
+use solana_ledger::{
+    blockstore::Blockstore, blockstore_db::BlockstoreError, blockstore_meta::PerfSample,
+    get_tmp_ledger_path,
+};
 use solana_perf::packet::PACKET_DATA_SIZE;
 use solana_runtime::{
     accounts::AccountAddressFilter,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -33,7 +33,7 @@ use solana_client::{
     rpc_response::*,
 };
 use solana_faucet::faucet::request_airdrop_transaction;
-use solana_ledger::{blockstore::Blockstore, blockstore_db::BlockstoreError, get_tmp_ledger_path, ::blockstore_meta::PerfSample};
+use solana_ledger::{blockstore::Blockstore, blockstore_db::BlockstoreError, get_tmp_ledger_path, blockstore_meta::PerfSample};
 use solana_perf::packet::PACKET_DATA_SIZE;
 use solana_runtime::{
     accounts::AccountAddressFilter,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -33,8 +33,7 @@ use solana_client::{
     rpc_response::*,
 };
 use solana_faucet::faucet::request_airdrop_transaction;
-use solana_ledger::blockstore_meta::PerfSample;
-use solana_ledger::{blockstore::Blockstore, blockstore_db::BlockstoreError, get_tmp_ledger_path};
+use solana_ledger::{blockstore::Blockstore, blockstore_db::BlockstoreError, get_tmp_ledger_path, ::blockstore_meta::PerfSample};
 use solana_perf::packet::PACKET_DATA_SIZE;
 use solana_runtime::{
     accounts::AccountAddressFilter,

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -17,14 +17,6 @@ pub struct SamplePerformanceSnapshot {
     pub num_slots: u64,
 }
 
-const SAMPLE_INTERVAL: u64 = 60;
-const SLEEP_INTERVAL: u64 = 500;
-
-pub struct SamplePerformanceSnapshot {
-    pub num_transactions: u64,
-    pub num_slots: u64,
-}
-
 pub struct SamplePerformanceService {
     thread_hdl: JoinHandle<()>,
 }

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -50,7 +50,7 @@ impl SamplePerformanceService {
         exit: Arc<AtomicBool>,
     ) {
         let forks = bank_forks.read().unwrap();
-        let bank = forks.working_bank();
+        let bank = forks.root_bank().clone();
         let highest_slot = forks.highest_slot();
         drop(forks);
 
@@ -70,13 +70,13 @@ impl SamplePerformanceService {
             if elapsed.as_secs() >= SAMPLE_INTERVAL {
                 now = Instant::now();
                 let bank_forks = bank_forks.read().unwrap();
-                let bank = bank_forks.working_bank();
+                let bank = bank_forks.root_bank().clone();
                 let highest_slot = bank_forks.highest_slot();
                 drop(bank_forks);
 
                 let perf_sample = PerfSample {
-                    num_slots: highest_slot - sample_snapshot.num_slots,
-                    num_transactions: bank.transaction_count() - sample_snapshot.num_transactions,
+                    num_slots: highest_slot.checked_sub(sample_snapshot.num_slots).unwrap_or_default(),
+                    num_transactions: bank.transaction_count().checked_sub(sample_snapshot.num_transactions).unwrap_or_default(),
                     sample_period_secs: elapsed.as_secs() as u16,
                 };
 

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -75,8 +75,13 @@ impl SamplePerformanceService {
                 drop(bank_forks);
 
                 let perf_sample = PerfSample {
-                    num_slots: highest_slot.checked_sub(sample_snapshot.num_slots).unwrap_or_default(),
-                    num_transactions: bank.transaction_count().checked_sub(sample_snapshot.num_transactions).unwrap_or_default(),
+                    num_slots: highest_slot
+                        .checked_sub(sample_snapshot.num_slots)
+                        .unwrap_or_default(),
+                    num_transactions: bank
+                        .transaction_count()
+                        .checked_sub(sample_snapshot.num_transactions)
+                        .unwrap_or_default(),
                     sample_period_secs: elapsed.as_secs() as u16,
                 };
 

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -1,53 +1,103 @@
 use solana_runtime::{
     bank_forks::{BankForks},
 };
+use solana_ledger::blockstore::Blockstore;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
         RwLock
     },
-    thread::{self, Builder, JoinHandle},
-    time::Duration,
+    thread::{self, Builder, JoinHandle, sleep},
+    time::{SystemTime, UNIX_EPOCH, Duration},
 };
+use solana_ledger::blockstore_meta::PerfSample;
+
+pub struct SamplePerformanceDelta {
+    pub num_transactions: u64,
+    pub num_slots: u64
+}
 
 pub struct SamplePerformanceService {
     thread_hdl: JoinHandle<()>,
 }
 
+const SAMPLE_INTERVAL: u64 = 10;
+
 impl SamplePerformanceService {
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
         bank_forks: &Arc<RwLock<BankForks>>,
+        blockstore: &Arc<Blockstore>,
         exit: &Arc<AtomicBool>,
     ) -> Self {
         let exit = exit.clone();
+        let blockstore = blockstore.clone();
         let bank_forks = bank_forks.clone();
+
         info!("Starting SamplePerformance service");
         let thread_hdl = Builder::new()
             .name("sample-performance".to_string())
             .spawn(move || {
-                loop {
-                    if exit.load(Ordering::Relaxed) {
-                        break;
-                    }
-        
-                    let forks = bank_forks.read().unwrap();
-
-                    let bank = forks.working_bank();
-       
-                    print!("Sample performance\n");
-        
-                    println!("{:?}", forks.highest_slot());
-        
-                    println!("{:?}", bank.transaction_count());
-        
-                    std::thread::sleep(Duration::from_secs(1));
-                }
+                Self::run(
+                    bank_forks,
+                    &blockstore,
+                    exit
+                );
             })
             .unwrap();
 
         Self { thread_hdl }
+    }
+
+    pub fn run(
+        bank_forks: Arc<RwLock<BankForks>>,
+        blockstore: &Arc<Blockstore>,
+        exit: Arc<AtomicBool>,
+    ) {
+
+        let mut sample_deltas: Option<SamplePerformanceDelta> = None;
+
+        loop {
+            if exit.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let start = SystemTime::now();
+            let since_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis() as u64;
+            let elapsed_offset = since_epoch % (SAMPLE_INTERVAL * 1000);
+
+            if elapsed_offset < 500 {
+                let forks = bank_forks.read().unwrap();
+                let bank = forks.working_bank();
+                let highest_slot = forks.highest_slot();
+                drop(forks);
+
+                match sample_deltas {
+                    None => info!("Initialized SamplePerformance service"),
+                    Some(ref snapshot) => {
+                        let perf_sample = PerfSample {
+                            num_slots: highest_slot - snapshot.num_slots,
+                            num_transactions: bank.transaction_count() - snapshot.num_transactions,
+                            sample_period_secs: SAMPLE_INTERVAL as u16
+                        };
+
+                        if let Err(e) = blockstore.write_perf_sample(highest_slot, &perf_sample) {
+                            error!("write_perf_sample failed: slot {:?} {:?}", highest_slot, e);
+                        }
+                    },
+                }
+
+                sample_deltas = Some(SamplePerformanceDelta {
+                    num_transactions: bank.transaction_count(),
+                    num_slots: highest_slot,
+                });
+
+                sleep(Duration::from_millis(500 - elapsed_offset));
+            } else {
+                sleep(Duration::from_millis(500));
+            }
+        }
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -8,6 +8,12 @@ use std::{
     thread::{self, sleep, Builder, JoinHandle},
     time::{Duration, Instant},
 };
+use solana_ledger::blockstore_meta::PerfSample;
+
+pub struct SamplePerformanceDelta {
+    pub num_transactions: u64,
+    pub num_slots: u64
+}
 
 const SAMPLE_INTERVAL: u64 = 60;
 const SLEEP_INTERVAL: u64 = 500;
@@ -20,6 +26,8 @@ pub struct SamplePerformanceSnapshot {
 pub struct SamplePerformanceService {
     thread_hdl: JoinHandle<()>,
 }
+
+const SAMPLE_INTERVAL: u64 = 10;
 
 impl SamplePerformanceService {
     #[allow(clippy::new_ret_no_self)]

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -82,8 +82,13 @@ impl SamplePerformanceService {
                 drop(bank_forks);
 
                 let perf_sample = PerfSample {
-                    num_slots: highest_slot.checked_sub(sample_snapshot.num_slots).unwrap_or_default(),
-                    num_transactions: bank.transaction_count().checked_sub(sample_snapshot.num_transactions).unwrap_or_default(),
+                    num_slots: highest_slot
+                        .checked_sub(sample_snapshot.num_slots)
+                        .unwrap_or_default(),
+                    num_transactions: bank
+                        .transaction_count()
+                        .checked_sub(sample_snapshot.num_transactions)
+                        .unwrap_or_default(),
                     sample_period_secs: elapsed.as_secs() as u16,
                 };
 

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -12,7 +12,7 @@ use std::{
 const SAMPLE_INTERVAL: u64 = 60;
 const SLEEP_INTERVAL: u64 = 500;
 
-pub struct SamplePerformanceDelta {
+pub struct SamplePerformanceSnapshot {
     pub num_transactions: u64,
     pub num_slots: u64,
 }

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -8,11 +8,13 @@ use std::{
     thread::{self, sleep, Builder, JoinHandle},
     time::{Duration, Instant},
 };
-use solana_ledger::blockstore_meta::PerfSample;
+
+const SAMPLE_INTERVAL: u64 = 60;
+const SLEEP_INTERVAL: u64 = 500;
 
 pub struct SamplePerformanceDelta {
     pub num_transactions: u64,
-    pub num_slots: u64
+    pub num_slots: u64,
 }
 
 const SAMPLE_INTERVAL: u64 = 60;
@@ -26,8 +28,6 @@ pub struct SamplePerformanceSnapshot {
 pub struct SamplePerformanceService {
     thread_hdl: JoinHandle<()>,
 }
-
-const SAMPLE_INTERVAL: u64 = 10;
 
 impl SamplePerformanceService {
     #[allow(clippy::new_ret_no_self)]

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -1,5 +1,4 @@
-use solana_ledger::blockstore::Blockstore;
-use solana_ledger::blockstore_meta::PerfSample;
+use solana_ledger::{blockstore::Blockstore, blockstore_meta::PerfSample};
 use solana_runtime::bank_forks::BankForks;
 use std::{
     sync::{

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -1,0 +1,56 @@
+use solana_runtime::{
+    bank_forks::{BankForks},
+};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+        RwLock
+    },
+    thread::{self, Builder, JoinHandle},
+    time::Duration,
+};
+
+pub struct SamplePerformanceService {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl SamplePerformanceService {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(
+        bank_forks: &Arc<RwLock<BankForks>>,
+        exit: &Arc<AtomicBool>,
+    ) -> Self {
+        let exit = exit.clone();
+        let bank_forks = bank_forks.clone();
+        info!("Starting SamplePerformance service");
+        let thread_hdl = Builder::new()
+            .name("sample-performance".to_string())
+            .spawn(move || {
+                loop {
+                    if exit.load(Ordering::Relaxed) {
+                        break;
+                    }
+        
+                    let forks = bank_forks.read().unwrap();
+
+                    let bank = forks.working_bank();
+       
+                    print!("Sample performance\n");
+        
+                    println!("{:?}", forks.highest_slot());
+        
+                    println!("{:?}", bank.transaction_count());
+        
+                    std::thread::sleep(Duration::from_secs(1));
+                }
+            })
+            .unwrap();
+
+        Self { thread_hdl }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+}

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -13,7 +13,7 @@ use std::{
 const SAMPLE_INTERVAL: u64 = 60;
 const SLEEP_INTERVAL: u64 = 500;
 
-pub struct SamplePerformanceDelta {
+pub struct SamplePerformanceSnapshot {
     pub num_transactions: u64,
     pub num_slots: u64,
 }
@@ -49,7 +49,7 @@ impl SamplePerformanceService {
         blockstore: &Arc<Blockstore>,
         exit: Arc<AtomicBool>,
     ) {
-        let mut sample_deltas: Option<SamplePerformanceDelta> = None;
+        let mut sample_snapshot: Option<SamplePerformanceSnapshot> = None;
 
         loop {
             if exit.load(Ordering::Relaxed) {
@@ -69,7 +69,7 @@ impl SamplePerformanceService {
                 let highest_slot = bank_forks.highest_slot();
                 drop(bank_forks);
 
-                match sample_deltas {
+                match sample_snapshot {
                     None => info!("Initializing SamplePerformance service"),
                     Some(ref snapshot) => {
                         let perf_sample = PerfSample {
@@ -84,7 +84,7 @@ impl SamplePerformanceService {
                     }
                 }
 
-                sample_deltas = Some(SamplePerformanceDelta {
+                sample_snapshot = Some(SamplePerformanceSnapshot {
                     num_transactions: bank.transaction_count(),
                     num_slots: highest_slot,
                 });

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -1,28 +1,26 @@
-use solana_runtime::{
-    bank_forks::{BankForks},
-};
 use solana_ledger::blockstore::Blockstore;
+use solana_ledger::blockstore_meta::PerfSample;
+use solana_runtime::bank_forks::BankForks;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
-        RwLock
+        Arc, RwLock,
     },
-    thread::{self, Builder, JoinHandle, sleep},
-    time::{SystemTime, UNIX_EPOCH, Duration},
+    thread::{self, sleep, Builder, JoinHandle},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use solana_ledger::blockstore_meta::PerfSample;
+
+const SAMPLE_INTERVAL: u64 = 60;
+const SLEEP_INTERVAL: u64 = 500;
 
 pub struct SamplePerformanceDelta {
     pub num_transactions: u64,
-    pub num_slots: u64
+    pub num_slots: u64,
 }
 
 pub struct SamplePerformanceService {
     thread_hdl: JoinHandle<()>,
 }
-
-const SAMPLE_INTERVAL: u64 = 10;
 
 impl SamplePerformanceService {
     #[allow(clippy::new_ret_no_self)]
@@ -39,11 +37,7 @@ impl SamplePerformanceService {
         let thread_hdl = Builder::new()
             .name("sample-performance".to_string())
             .spawn(move || {
-                Self::run(
-                    bank_forks,
-                    &blockstore,
-                    exit
-                );
+                Self::run(bank_forks, &blockstore, exit);
             })
             .unwrap();
 
@@ -55,7 +49,6 @@ impl SamplePerformanceService {
         blockstore: &Arc<Blockstore>,
         exit: Arc<AtomicBool>,
     ) {
-
         let mut sample_deltas: Option<SamplePerformanceDelta> = None;
 
         loop {
@@ -64,28 +57,31 @@ impl SamplePerformanceService {
             }
 
             let start = SystemTime::now();
-            let since_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis() as u64;
+            let since_epoch = start
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_millis() as u64;
             let elapsed_offset = since_epoch % (SAMPLE_INTERVAL * 1000);
 
-            if elapsed_offset < 500 {
-                let forks = bank_forks.read().unwrap();
-                let bank = forks.working_bank();
-                let highest_slot = forks.highest_slot();
-                drop(forks);
+            if elapsed_offset < SLEEP_INTERVAL {
+                let bank_forks = bank_forks.read().unwrap();
+                let bank = bank_forks.working_bank();
+                let highest_slot = bank_forks.highest_slot();
+                drop(bank_forks);
 
                 match sample_deltas {
-                    None => info!("Initialized SamplePerformance service"),
+                    None => info!("Initializing SamplePerformance service"),
                     Some(ref snapshot) => {
                         let perf_sample = PerfSample {
                             num_slots: highest_slot - snapshot.num_slots,
                             num_transactions: bank.transaction_count() - snapshot.num_transactions,
-                            sample_period_secs: SAMPLE_INTERVAL as u16
+                            sample_period_secs: SAMPLE_INTERVAL as u16,
                         };
 
                         if let Err(e) = blockstore.write_perf_sample(highest_slot, &perf_sample) {
                             error!("write_perf_sample failed: slot {:?} {:?}", highest_slot, e);
                         }
-                    },
+                    }
                 }
 
                 sample_deltas = Some(SamplePerformanceDelta {
@@ -93,9 +89,9 @@ impl SamplePerformanceService {
                     num_slots: highest_slot,
                 });
 
-                sleep(Duration::from_millis(500 - elapsed_offset));
+                sleep(Duration::from_millis(SLEEP_INTERVAL - elapsed_offset));
             } else {
-                sleep(Duration::from_millis(500));
+                sleep(Duration::from_millis(SLEEP_INTERVAL));
             }
         }
     }

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -57,7 +57,7 @@ impl SamplePerformanceService {
         exit: Arc<AtomicBool>,
     ) {
         let forks = bank_forks.read().unwrap();
-        let bank = forks.root_bank().clone();
+        let bank = forks.working_bank();
         let highest_slot = forks.highest_slot();
         drop(forks);
 
@@ -82,13 +82,8 @@ impl SamplePerformanceService {
                 drop(bank_forks);
 
                 let perf_sample = PerfSample {
-                    num_slots: highest_slot
-                        .checked_sub(sample_snapshot.num_slots)
-                        .unwrap_or_default(),
-                    num_transactions: bank
-                        .transaction_count()
-                        .checked_sub(sample_snapshot.num_transactions)
-                        .unwrap_or_default(),
+                    num_slots: highest_slot - sample_snapshot.num_slots,
+                    num_transactions: bank.transaction_count() - sample_snapshot.num_transactions,
                     sample_period_secs: elapsed.as_secs() as u16,
                 };
 

--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -57,7 +57,7 @@ impl SamplePerformanceService {
         exit: Arc<AtomicBool>,
     ) {
         let forks = bank_forks.read().unwrap();
-        let bank = forks.working_bank();
+        let bank = forks.root_bank().clone();
         let highest_slot = forks.highest_slot();
         drop(forks);
 
@@ -82,8 +82,8 @@ impl SamplePerformanceService {
                 drop(bank_forks);
 
                 let perf_sample = PerfSample {
-                    num_slots: highest_slot - sample_snapshot.num_slots,
-                    num_transactions: bank.transaction_count() - sample_snapshot.num_transactions,
+                    num_slots: highest_slot.checked_sub(sample_snapshot.num_slots).unwrap_or_default(),
+                    num_transactions: bank.transaction_count().checked_sub(sample_snapshot.num_transactions).unwrap_or_default(),
                     sample_period_secs: elapsed.as_secs() as u16,
                 };
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -3,7 +3,6 @@
 use crate::{
     broadcast_stage::BroadcastStageType,
     cache_block_time_service::{CacheBlockTimeSender, CacheBlockTimeService},
-    sample_performance_service::{SamplePerformanceService},
     cluster_info::{ClusterInfo, Node},
     cluster_info_vote_listener::VoteTracker,
     completed_data_sets_service::CompletedDataSetsService,
@@ -17,6 +16,7 @@ use crate::{
     rpc_pubsub_service::PubSubService,
     rpc_service::JsonRpcService,
     rpc_subscriptions::RpcSubscriptions,
+    sample_performance_service::SamplePerformanceService,
     serve_repair::ServeRepair,
     serve_repair_service::ServeRepairService,
     sigverify,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -281,11 +281,16 @@ impl Validator {
         let bank = bank_forks.working_bank();
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
-        let sample_performance_service = Some(SamplePerformanceService::new(
-            &bank_forks,
-            &blockstore,
-            &exit,
-        ));
+        let sample_performance_service =
+            if config.rpc_addrs.is_some() && config.rpc_config.enable_rpc_transaction_history {
+                Some(SamplePerformanceService::new(
+                    &bank_forks,
+                    &blockstore,
+                    &exit,
+                ))
+            } else {
+                None
+            };
 
         info!("Starting validator with working bank slot {}", bank.slot());
         {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -3,6 +3,7 @@
 use crate::{
     broadcast_stage::BroadcastStageType,
     cache_block_time_service::{CacheBlockTimeSender, CacheBlockTimeService},
+    sample_performance_service::{SamplePerformanceService},
     cluster_info::{ClusterInfo, Node},
     cluster_info_vote_listener::VoteTracker,
     completed_data_sets_service::CompletedDataSetsService,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -283,6 +283,7 @@ impl Validator {
 
         let sample_performance_service = Some(SamplePerformanceService::new(
             &bank_forks,
+            &blockstore,
             &exit,
         ));
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -17,7 +17,6 @@ use crate::{
     rpc_pubsub_service::PubSubService,
     rpc_service::JsonRpcService,
     rpc_subscriptions::RpcSubscriptions,
-    sample_performance_service::SamplePerformanceService,
     serve_repair::ServeRepair,
     serve_repair_service::ServeRepairService,
     sigverify,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -137,6 +137,7 @@ pub struct Blockstore {
     active_transaction_status_index: RwLock<u64>,
     rewards_cf: LedgerColumn<cf::Rewards>,
     blocktime_cf: LedgerColumn<cf::Blocktime>,
+    perf_samples_cf: LedgerColumn<cf::PerfSamples>,
     last_root: Arc<RwLock<Slot>>,
     insert_shreds_lock: Arc<Mutex<()>>,
     pub new_shreds_signals: Vec<SyncSender<bool>>,
@@ -293,6 +294,7 @@ impl Blockstore {
         let transaction_status_index_cf = db.column();
         let rewards_cf = db.column();
         let blocktime_cf = db.column();
+        let perf_samples_cf = db.column();
 
         let db = Arc::new(db);
 
@@ -338,6 +340,7 @@ impl Blockstore {
             active_transaction_status_index: RwLock::new(active_transaction_status_index),
             rewards_cf,
             blocktime_cf,
+            perf_samples_cf,
             new_shreds_signals: vec![],
             completed_slots_senders: vec![],
             insert_shreds_lock: Arc::new(Mutex::new(())),
@@ -2301,6 +2304,22 @@ impl Blockstore {
                 timestamps
             })
             .collect())
+    }
+
+    pub fn get_recent_perf_samples(&self, num: usize) -> Result<Vec<(Slot, PerfSample)>> {
+        Ok(self
+            .db
+            .iter::<cf::PerfSamples>(IteratorMode::End)?
+            .take(num)
+            .map(|(slot, data)| {
+                let perf_sample = deserialize(&data).unwrap();
+                (slot, perf_sample)
+            })
+            .collect())
+    }
+
+    pub fn write_perf_sample(&self, index: Slot, perf_sample: &PerfSample) -> Result<()> {
+        self.perf_samples_cf.put(index, perf_sample)
     }
 
     /// Returns the entry vector for the slot starting with `shred_start_index`
@@ -6926,6 +6945,38 @@ pub mod tests {
                 assert_eq!(m.meta.as_ref().unwrap().fee, x as u64);
             }
             assert_eq!(map[4].meta, None);
+        }
+        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
+    }
+
+    #[test]
+    fn test_write_get_perf_samples() {
+        let blockstore_path = get_tmp_ledger_path!();
+        {
+            let blockstore = Blockstore::open(&blockstore_path).unwrap();
+            let num_entries: usize = 10;
+            let mut perf_samples: Vec<(Slot, PerfSample)> = vec![];
+            for x in 1..num_entries + 1 {
+                perf_samples.push((
+                    x as u64 * 50,
+                    PerfSample {
+                        num_transactions: 1000 + x as u64,
+                        num_slots: 50,
+                        sample_period_secs: 20,
+                    },
+                ));
+            }
+            for (slot, sample) in perf_samples.iter() {
+                blockstore.write_perf_sample(*slot, sample).unwrap();
+            }
+            for x in 0..num_entries {
+                let mut expected_samples = perf_samples[num_entries - 1 - x..].to_vec();
+                expected_samples.sort_by(|a, b| b.0.cmp(&a.0));
+                assert_eq!(
+                    blockstore.get_recent_perf_samples(x + 1).unwrap(),
+                    expected_samples
+                );
+            }
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -137,6 +137,10 @@ impl Blockstore {
             & self
                 .db
                 .delete_range_cf::<cf::Blocktime>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
+                .delete_range_cf::<cf::PerfSamples>(&mut write_batch, from_slot, to_slot)
                 .is_ok();
         let mut w_active_transaction_status_index =
             self.active_transaction_status_index.write().unwrap();
@@ -230,6 +234,10 @@ impl Blockstore {
                 .unwrap_or(false)
             && self
                 .blocktime_cf
+                .compact_range(from_slot, to_slot)
+                .unwrap_or(false)
+            && self
+                .perf_samples_cf
                 .compact_range(from_slot, to_slot)
                 .unwrap_or(false);
         compact_timer.stop();

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -52,6 +52,8 @@ const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 const REWARDS_CF: &str = "rewards";
 /// Column family for Blocktime
 const BLOCKTIME_CF: &str = "blocktime";
+/// Column family for Performance Samples
+const PERF_SAMPLES_CF: &str = "perf_samples";
 
 #[derive(Error, Debug)]
 pub enum BlockstoreError {
@@ -140,6 +142,10 @@ pub mod columns {
     #[derive(Debug)]
     /// The blocktime column
     pub struct Blocktime;
+
+    #[derive(Debug)]
+    /// The performance samples column
+    pub struct PerfSamples;
 }
 
 pub enum AccessType {
@@ -200,7 +206,7 @@ impl Rocks {
     ) -> Result<Rocks> {
         use columns::{
             AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
-            Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
+            PerfSamples, Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
             TransactionStatusIndex,
         };
 
@@ -236,6 +242,8 @@ impl Rocks {
         let rewards_cf_descriptor = ColumnFamilyDescriptor::new(Rewards::NAME, get_cf_options());
         let blocktime_cf_descriptor =
             ColumnFamilyDescriptor::new(Blocktime::NAME, get_cf_options());
+        let perf_samples_cf_descriptor =
+            ColumnFamilyDescriptor::new(PerfSamples::NAME, get_cf_options());
 
         let cfs = vec![
             (SlotMeta::NAME, meta_cf_descriptor),
@@ -255,6 +263,7 @@ impl Rocks {
             ),
             (Rewards::NAME, rewards_cf_descriptor),
             (Blocktime::NAME, blocktime_cf_descriptor),
+            (PerfSamples::NAME, perf_samples_cf_descriptor),
         ];
 
         // Open the database
@@ -293,7 +302,7 @@ impl Rocks {
     fn columns(&self) -> Vec<&'static str> {
         use columns::{
             AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
-            Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
+            PerfSamples, Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
             TransactionStatusIndex,
         };
 
@@ -312,6 +321,7 @@ impl Rocks {
             TransactionStatusIndex::NAME,
             Rewards::NAME,
             Blocktime::NAME,
+            PerfSamples::NAME,
         ]
     }
 
@@ -543,6 +553,14 @@ impl ColumnName for columns::Blocktime {
 }
 impl TypedColumn for columns::Blocktime {
     type Type = UnixTimestamp;
+}
+
+impl SlotColumn for columns::PerfSamples {}
+impl ColumnName for columns::PerfSamples {
+    const NAME: &'static str = PERF_SAMPLES_CF;
+}
+impl TypedColumn for columns::PerfSamples {
+    type Type = blockstore_meta::PerfSample;
 }
 
 impl Column for columns::ShredCode {

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -243,6 +243,13 @@ pub struct AddressSignatureMeta {
     pub writeable: bool,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct PerfSample {
+    pub num_transactions: u64,
+    pub num_slots: u64,
+    pub sample_period_secs: u16,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
#### Problem
In order to move off of solanabeach apis, we need to store time-series data for some performance metrics, namely TPS (transaction count in period) and slot time (num slots in period).

#### Summary of Changes
- Add blockstore column to store performance samples
- Add sample performance service that populates performance samples blockstore column
- Add GetRecentPerformanceSamples rpc call

Toward #11771 