### PR TITLE
Improve solana-tokens UX

### DIFF
--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -83,7 +83,7 @@ impl Config {
         }
         let mut url = json_rpc_url.unwrap();
         let port = url.port_or_known_default().unwrap_or(80);
-        url.set_port(Some(port + 2)).expect("unable to set port");
+        url.set_port(Some(port + 3)).expect("unable to set port");
         url.to_string()
     }
 
@@ -138,21 +138,21 @@ mod test {
     fn compute_rpc_banks_url() {
         assert_eq!(
             Config::compute_rpc_banks_url(&"http://devnet.solana.com"),
-            "http://devnet.solana.com:82/".to_string()
+            "http://devnet.solana.com:83/".to_string()
         );
 
         assert_eq!(
             Config::compute_rpc_banks_url(&"https://devnet.solana.com"),
-            "https://devnet.solana.com:445/".to_string()
+            "https://devnet.solana.com:446/".to_string()
         );
 
         assert_eq!(
             Config::compute_rpc_banks_url(&"http://example.com:8899"),
-            "http://example.com:8901/".to_string()
+            "http://example.com:8902/".to_string()
         );
         assert_eq!(
             Config::compute_rpc_banks_url(&"https://example.com:1234"),
-            "https://example.com:1236/".to_string()
+            "https://example.com:1237/".to_string()
         );
 
         assert_eq!(Config::compute_rpc_banks_url(&"garbage"), String::new());

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -7,38 +7,38 @@ expected amount are sent. The command-line tool here automates that process.
 
 ## Distribute tokens
 
-Send tokens to the recipients in `<BIDS_CSV>`.
+Send tokens to the recipients in `<RECIPIENTS_CSV>`.
 
-Example bids.csv:
+Example recipients.csv:
 
 ```text
-primary_address,accepted_amount_dollars
-6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,6.6
+recipient,amount,lockup_date
+3ihfUy1n9gaqihM5bJCiTAGLgWc5zo3DqVUS6T736NLM,42.0,
+CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT,43.0,
 ```
 
 ```bash
-solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --fee-payer <KEYPAIR>
+solana-tokens distribute-tokens --from <KEYPAIR> --input-csv <RECIPIENTS_CSV> --fee-payer <KEYPAIR>
 ```
 
 Example transaction log before:
 
 ```text
-recipient,amount,signature
-6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,30,1111111111111111111111111111111111111111111111111111111111111111
+recipient,amount,finalized_date,signature
+6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,70.0,2020-09-15T23:29:26.879747Z,UB168XhBhecxzeD1w2ZRUhwTHpPSqv2WNh8NrZHqz1F2EqxxbSW6iFfVtsg3HkU9NX2cD7R92D8VRLSyArZ9xKQ
 ```
 
-Send tokens to the recipients in `<BIDS_CSV>` if the distribution is
+Send tokens to the recipients in `<RECIPIENTS_CSV>` if the distribution is
 not already recorded in the transaction log.
 
 ```bash
-solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --fee-payer <KEYPAIR>
+solana-tokens distribute-tokens --from <KEYPAIR> --input-csv <RECIPIENTS_CSV> --fee-payer <KEYPAIR>
 ```
 
 Example output:
 
 ```text
-Recipient                                     Amount
-6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv  70
+Recipient                                     Expected Balance (◎)
 3ihfUy1n9gaqihM5bJCiTAGLgWc5zo3DqVUS6T736NLM  42
 UKUcTXgbeTYh65RaVV5gSf6xBHevqHvAXMo3e8Q6np8k  43
 ```
@@ -52,10 +52,9 @@ solana-tokens transaction-log --output-path transactions.csv
 
 ```text
 recipient,amount,signature
-6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,30,1111111111111111111111111111111111111111111111111111111111111111
-6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,70,1111111111111111111111111111111111111111111111111111111111111111
-3ihfUy1n9gaqihM5bJCiTAGLgWc5zo3DqVUS6T736NLM,42,1111111111111111111111111111111111111111111111111111111111111111
-UKUcTXgbeTYh65RaVV5gSf6xBHevqHvAXMo3e8Q6np8k,43,1111111111111111111111111111111111111111111111111111111111111111
+6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,70.0,2020-09-15T23:29:26.879747Z,UB168XhBhecxzeD1w2ZRUhwTHpPSqv2WNh8NrZHqz1F2EqxxbSW6iFfVtsg3HkU9NX2cD7R92D8VRLSyArZ9xKQ
+3ihfUy1n9gaqihM5bJCiTAGLgWc5zo3DqVUS6T736NLM,42.0,2020-09-15T23:31:50.264241Z,53AVNEVpQBteJBRAKp6naxXsgESDjqe1ge9Dg2HeCSpYWTuGTLqHrBpkHTnpvPJURNgKWxkJfihuRa5STVRjL2hy
+CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT,43.0,2020-09-15T23:33:53.680821Z,4XsMfLx9D2ZxVpdJ5xdkV2w4X4SKEQ5zbQhcH4NcRwgZDkdRNiZjvnMFaWaWHUh5eF1LwFPpQdjn6mzSsiCVj3L7
 ```
 
 ### Calculate what tokens should be sent
@@ -64,26 +63,23 @@ List the differences between a list of expected distributions and the record of 
 transactions have already been sent.
 
 ```bash
-solana-tokens distribute-tokens --dollars-per-sol <NUMBER> --dry-run --from-bids --input-csv <BIDS_CSV>
+solana-tokens distribute-tokens --dry-run --input-csv <RECIPIENTS_CSV>
 ```
 
-Example bids.csv:
+Example recipients.csv:
 
 ```text
-primary_address,accepted_amount_dollars
-6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,6.6
-6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,15.4
-3ihfUy1n9gaqihM5bJCiTAGLgWc5zo3DqVUS6T736NLM,9.24
-UKUcTXgbeTYh65RaVV5gSf6xBHevqHvAXMo3e8Q6np8k,9.46
+recipient,amount,lockup_date
+6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,80,
+7aHDubg5FBYj1SgmyBgU3ZJdtfuqYCQsJQK2pTR5JUqr,42,
 ```
 
 Example output:
 
 ```text
-Recipient                                     Amount
-6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv  70
-3ihfUy1n9gaqihM5bJCiTAGLgWc5zo3DqVUS6T736NLM  42
-UKUcTXgbeTYh65RaVV5gSf6xBHevqHvAXMo3e8Q6np8k  43
+Recipient                                     Expected Balance (◎)
+6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv  10
+7aHDubg5FBYj1SgmyBgU3ZJdtfuqYCQsJQK2pTR5JUqr  42
 ```
 
 ## Distribute stake accounts

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -12,7 +12,7 @@ Send tokens to the recipients in `<BIDS_CSV>`.
 Example bids.csv:
 
 ```text
-primary_address,bid_amount_dollars
+primary_address,accepted_amount_dollars
 6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,6.6
 ```
 
@@ -28,7 +28,7 @@ recipient,amount,signature
 ```
 
 Send tokens to the recipients in `<BIDS_CSV>` if the distribution is
-not already recordered in the transaction log.
+not already recorded in the transaction log.
 
 ```bash
 solana-tokens distribute-tokens --from <KEYPAIR> --dollars-per-sol <NUMBER> --from-bids --input-csv <BIDS_CSV> --fee-payer <KEYPAIR>
@@ -70,7 +70,7 @@ solana-tokens distribute-tokens --dollars-per-sol <NUMBER> --dry-run --from-bids
 Example bids.csv:
 
 ```text
-primary_address,bid_amount_dollars
+primary_address,accepted_amount_dollars
 6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,6.6
 6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,15.4
 3ihfUy1n9gaqihM5bJCiTAGLgWc5zo3DqVUS6T736NLM,9.24

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -75,6 +75,14 @@ where
                         .help("Do not execute any transfers"),
                 )
                 .arg(
+                    Arg::with_name("output_path")
+                        .long("output-path")
+                        .short("o")
+                        .value_name("FILE")
+                        .takes_value(true)
+                        .help("Write the transaction log to this file"),
+                )
+                .arg(
                     Arg::with_name("sender_keypair")
                         .long("from")
                         .required(true)
@@ -115,6 +123,14 @@ where
                     Arg::with_name("dry_run")
                         .long("dry-run")
                         .help("Do not execute any transfers"),
+                )
+                .arg(
+                    Arg::with_name("output_path")
+                        .long("output-path")
+                        .short("o")
+                        .value_name("FILE")
+                        .takes_value(true)
+                        .help("Write the transaction log to this file"),
                 )
                 .arg(
                     Arg::with_name("sender_keypair")
@@ -268,6 +284,7 @@ fn parse_distribute_tokens_args(
         input_csv: value_t_or_exit!(matches, "input_csv", String),
         from_bids: matches.is_present("from_bids"),
         transaction_db: create_db_path(value_t!(matches, "campaign_name", String).ok()),
+        output_path: matches.value_of("output_path").map(|path| path.to_string()),
         dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
         sender_keypair,
@@ -344,6 +361,7 @@ fn parse_distribute_stake_args(
         input_csv: value_t_or_exit!(matches, "input_csv", String),
         from_bids: false,
         transaction_db: create_db_path(value_t!(matches, "campaign_name", String).ok()),
+        output_path: matches.value_of("output_path").map(|path| path.to_string()),
         dollars_per_sol: None,
         dry_run: matches.is_present("dry_run"),
         sender_keypair,

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -53,26 +53,12 @@ where
                         ),
                 )
                 .arg(
-                    Arg::with_name("from_bids")
-                        .long("from-bids")
-                        .requires("dollars_per_sol")
-                        .help("Input CSV contains bids in dollars, not allocations in SOL"),
-                )
-                .arg(
                     Arg::with_name("input_csv")
                         .long("input-csv")
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
                         .help("Input CSV file"),
-                )
-                .arg(
-                    Arg::with_name("dollars_per_sol")
-                        .long("dollars-per-sol")
-                        .takes_value(true)
-                        .value_name("NUMBER")
-                        .requires("from_bids")
-                        .help("Dollars per SOL, if input CSV contains bids"),
                 )
                 .arg(
                     Arg::with_name("dry_run")
@@ -214,20 +200,6 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help("Bids CSV file"),
-                )
-                .arg(
-                    Arg::with_name("from_bids")
-                        .long("from-bids")
-                        .requires("dollars_per_sol")
-                        .help("Input CSV contains bids in dollars, not allocations in SOL"),
-                )
-                .arg(
-                    Arg::with_name("dollars_per_sol")
-                        .long("dollars-per-sol")
-                        .takes_value(true)
-                        .value_name("NUMBER")
-                        .requires("from_bids")
-                        .help("Dollars per SOL"),
                 ),
         )
         .subcommand(
@@ -277,10 +249,8 @@ fn parse_distribute_tokens_args(
 
     Ok(DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
-        from_bids: matches.is_present("from_bids"),
         transaction_db: value_t_or_exit!(matches, "db_path", String),
         output_path: matches.value_of("output_path").map(|path| path.to_string()),
-        dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
         dry_run: matches.is_present("dry_run"),
         sender_keypair,
         fee_payer,
@@ -354,10 +324,8 @@ fn parse_distribute_stake_args(
     };
     Ok(DistributeTokensArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
-        from_bids: false,
         transaction_db: value_t_or_exit!(matches, "db_path", String),
         output_path: matches.value_of("output_path").map(|path| path.to_string()),
-        dollars_per_sol: None,
         dry_run: matches.is_present("dry_run"),
         sender_keypair,
         fee_payer,
@@ -368,8 +336,6 @@ fn parse_distribute_stake_args(
 fn parse_balances_args(matches: &ArgMatches<'_>) -> BalancesArgs {
     BalancesArgs {
         input_csv: value_t_or_exit!(matches, "input_csv", String),
-        from_bids: matches.is_present("from_bids"),
-        dollars_per_sol: value_t!(matches, "dollars_per_sol", f64).ok(),
     }
 }
 

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -50,6 +50,7 @@ where
                 .arg(
                     Arg::with_name("from_bids")
                         .long("from-bids")
+                        .requires("dollars_per_sol")
                         .help("Input CSV contains bids in dollars, not allocations in SOL"),
                 )
                 .arg(
@@ -65,6 +66,7 @@ where
                         .long("dollars-per-sol")
                         .takes_value(true)
                         .value_name("NUMBER")
+                        .requires("from_bids")
                         .help("Dollars per SOL, if input CSV contains bids"),
                 )
                 .arg(
@@ -190,6 +192,7 @@ where
                 .arg(
                     Arg::with_name("from_bids")
                         .long("from-bids")
+                        .requires("dollars_per_sol")
                         .help("Input CSV contains bids in dollars, not allocations in SOL"),
                 )
                 .arg(
@@ -197,6 +200,7 @@ where
                         .long("dollars-per-sol")
                         .takes_value(true)
                         .value_name("NUMBER")
+                        .requires("from_bids")
                         .help("Dollars per SOL"),
                 ),
         )

--- a/tokens/src/args.rs
+++ b/tokens/src/args.rs
@@ -4,6 +4,7 @@ pub struct DistributeTokensArgs {
     pub input_csv: String,
     pub from_bids: bool,
     pub transaction_db: String,
+    pub output_path: Option<String>,
     pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
     pub sender_keypair: Box<dyn Signer>,

--- a/tokens/src/args.rs
+++ b/tokens/src/args.rs
@@ -2,10 +2,8 @@ use solana_sdk::{pubkey::Pubkey, signature::Signer};
 
 pub struct DistributeTokensArgs {
     pub input_csv: String,
-    pub from_bids: bool,
     pub transaction_db: String,
     pub output_path: Option<String>,
-    pub dollars_per_sol: Option<f64>,
     pub dry_run: bool,
     pub sender_keypair: Box<dyn Signer>,
     pub fee_payer: Box<dyn Signer>,
@@ -22,8 +20,6 @@ pub struct StakeArgs {
 
 pub struct BalancesArgs {
     pub input_csv: String,
-    pub from_bids: bool,
-    pub dollars_per_sol: Option<f64>,
 }
 
 pub struct TransactionLogArgs {

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -323,15 +323,6 @@ pub async fn process_allocations(
         return Ok(confirmations);
     }
 
-    println!(
-        "{}",
-        style(format!(
-            "{:<44}  {:>24}",
-            "Recipient", "Expected Balance (◎)"
-        ))
-        .bold()
-    );
-
     let distributed_tokens: f64 = transaction_infos.iter().map(|x| x.amount).sum();
     let undistributed_tokens: f64 = allocations.iter().map(|x| x.amount).sum();
     println!("{} ◎{}", style("Distributed:").bold(), distributed_tokens,);
@@ -366,6 +357,15 @@ pub async fn process_allocations(
             (distributed_tokens + undistributed_tokens) * dollars_per_sol,
         );
     }
+
+    println!(
+        "{}",
+        style(format!(
+            "{:<44}  {:>24}",
+            "Recipient", "Expected Balance (◎)"
+        ))
+        .bold()
+    );
 
     distribute_allocations(client, &mut db, &allocations, args).await?;
 

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -250,7 +250,7 @@ async fn distribute_allocations(
                     &allocation.recipient.parse().unwrap(),
                     allocation.amount,
                     &transaction,
-                    Some(&new_stake_account_address),
+                    args.stake_args.as_ref().map(|_| &new_stake_account_address),
                     false,
                     last_valid_slot,
                     lockup_date,

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -20,6 +20,7 @@ pub struct TransactionInfo {
 struct SignedTransactionInfo {
     recipient: String,
     amount: f64,
+    #[serde(skip_serializing_if = "String::is_empty", default)]
     new_stake_account_address: String,
     finalized_date: Option<DateTime<Utc>>,
     signature: String,

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -178,6 +178,33 @@ pub fn update_finalized_transaction(
     Ok(None)
 }
 
+use csv::{ReaderBuilder, Trim};
+pub(crate) fn check_output_file(path: &str, db: &PickleDb) {
+    let mut rdr = ReaderBuilder::new()
+        .trim(Trim::All)
+        .from_path(path)
+        .unwrap();
+    let logged_infos: Vec<SignedTransactionInfo> =
+        rdr.deserialize().map(|entry| entry.unwrap()).collect();
+
+    let mut transaction_infos = read_transaction_infos(db);
+    transaction_infos.sort_by(compare_transaction_infos);
+    let transaction_infos: Vec<SignedTransactionInfo> = transaction_infos
+        .iter()
+        .map(|info| SignedTransactionInfo {
+            recipient: info.recipient.to_string(),
+            amount: info.amount,
+            new_stake_account_address: info
+                .new_stake_account_address
+                .map(|x| x.to_string())
+                .unwrap_or_else(|| "".to_string()),
+            finalized_date: info.finalized_date,
+            signature: info.transaction.signatures[0].to_string(),
+        })
+        .collect();
+    assert_eq!(logged_infos, transaction_infos);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
#### Problem
Solana-tokens already has much of the plumbing needed for a transfer-to-many tool (as in #12221 ). However, with a little cleanup it would be a lot easier to use and build on.

Also solana-tokens on master/v1.3 currently doesn't work against a local node at all because it assumes the wrong BanksServer port.

#### Summary of Changes
- Fix computed banks port
- Update readme to be accurate for the existing examples
- If input csv cannot be read, return error instead of panicking. (There are a lot of opportunities to panic in this module. Follow-up work should handle error reporting more generally.)
- Add dry-run check for fee-payer and spender balances, echoing existing functionality in solana-cli
- Small clap improvement to prepare for additional/conflicting args needed for transfer-to-many
- Write a distribution transaction-log anytime an outfile is specified, instead of requiring an extra process
