### PR TITLE
solana-tokens: Add capability to perform the same transfer to a batch of recipients

### DIFF
--- a/tokens/README.md
+++ b/tokens/README.md
@@ -82,6 +82,32 @@ Recipient                                     Expected Balance (◎)
 7aHDubg5FBYj1SgmyBgU3ZJdtfuqYCQsJQK2pTR5JUqr  42
 ```
 
+## Distribute tokens: transfer-amount
+
+This tool also makes it straightforward to transfer the same amount of tokens to a simple list of recipients. Just add the `--transfer-amount` arg to specify the amount:
+
+Example recipients.csv:
+
+```text
+recipient
+6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv
+7aHDubg5FBYj1SgmyBgU3ZJdtfuqYCQsJQK2pTR5JUqr
+CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT
+```
+
+```bash
+solana-tokens distribute-tokens --transfer-amount 10 --from <KEYPAIR> --input-csv <RECIPIENTS_CSV> --fee-payer <KEYPAIR>
+```
+
+Example output:
+
+```text
+Recipient                                     Expected Balance (◎)
+6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv  10
+7aHDubg5FBYj1SgmyBgU3ZJdtfuqYCQsJQK2pTR5JUqr  10
+CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT  10
+```
+
 ## Distribute stake accounts
 
 Distributing tokens via stake accounts works similarly to how tokens are distributed. The

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -3,7 +3,8 @@ use crate::args::{
 };
 use clap::{value_t, value_t_or_exit, App, Arg, ArgMatches, SubCommand};
 use solana_clap_utils::{
-    input_validators::{is_valid_pubkey, is_valid_signer},
+    input_parsers::value_of,
+    input_validators::{is_amount, is_valid_pubkey, is_valid_signer},
     keypair::{pubkey_from_path, signer_from_path},
 };
 use solana_cli_config::CONFIG_FILE;
@@ -59,6 +60,14 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help("Input CSV file"),
+                )
+                .arg(
+                    Arg::with_name("transfer_amount")
+                        .long("transfer-amount")
+                        .takes_value(true)
+                        .value_name("AMOUNT")
+                        .validator(is_amount)
+                        .help("The amount to send to each recipient, in SOL"),
                 )
                 .arg(
                     Arg::with_name("dry_run")
@@ -255,6 +264,7 @@ fn parse_distribute_tokens_args(
         sender_keypair,
         fee_payer,
         stake_args: None,
+        transfer_amount: value_of(matches, "transfer_amount"),
     })
 }
 
@@ -330,6 +340,7 @@ fn parse_distribute_stake_args(
         sender_keypair,
         fee_payer,
         stake_args: Some(stake_args),
+        transfer_amount: None,
     })
 }
 

--- a/tokens/src/args.rs
+++ b/tokens/src/args.rs
@@ -8,6 +8,7 @@ pub struct DistributeTokensArgs {
     pub sender_keypair: Box<dyn Signer>,
     pub fee_payer: Box<dyn Signer>,
     pub stake_args: Option<StakeArgs>,
+    pub transfer_amount: Option<f64>,
 }
 
 pub struct StakeArgs {

--- a/tokens/tests/commands.rs
+++ b/tokens/tests/commands.rs
@@ -20,7 +20,7 @@ fn test_process_distribute_with_rpc_client() {
 
     Runtime::new().unwrap().block_on(async {
         let mut banks_client = start_tcp_client(leader_data.rpc_banks).await.unwrap();
-        test_process_distribute_tokens_with_client(&mut banks_client, alice).await
+        test_process_distribute_tokens_with_client(&mut banks_client, alice, None).await
     });
 
     // Explicit cleanup, otherwise "pure virtual method called" crash in Docker


### PR DESCRIPTION
#### Problem
Downstream users would like an easy way to transfer the same amount of SOL to a bunch of different addresses, as in a public airdrop. The `solana-tokens` tool already has much of the plumbing needed; but we can make it simpler to use for this use case.

#### Summary of Changes
Add `--transfer-amount` argument to enable generating the same transfer to a bunch of recipients (and passing in a simplified input CSV).

Closes #12221 

Example input CSV:
```
recipient
6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv
7aHDubg5FBYj1SgmyBgU3ZJdtfuqYCQsJQK2pTR5JUqr
CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT
```

Example command:
```
solana-tokens distribute-tokens --transfer-amount 10 --from ~/keypair.json -fee-payer ~/keypair.json --input-csv ~/recipients.csv --db-path ~/distribution.db
```

Example output:
```
Total in input_csv: ◎30
Distributed: ◎0
Undistributed: ◎30
Total: ◎30
Recipient                                         Expected Balance (◎)
6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv              10.000000000
7aHDubg5FBYj1SgmyBgU3ZJdtfuqYCQsJQK2pTR5JUqr              10.000000000
CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT              10.000000000
```

Example transaction log:
```
recipient,amount,finalized_date,signature
7aHDubg5FBYj1SgmyBgU3ZJdtfuqYCQsJQK2pTR5JUqr,10.0,2020-09-16T00:58:51.759584Z,5T8zi5pMrRdL1fkuWicN29GNev7AKTxzLJEfsWUx4mh3vpNUF5w6MvhDNocVpBaZE6PEp4dEEomPATF9PvBXMu6L
CYRJWqiSjLitBAcRxPvWpgX3s5TvmN2SuRY3eEYypFvT,10.0,2020-09-16T00:58:51.767865Z,2oZjvL4fqkcBa262UdawGGDBDrVcggbxwpaGkEPrPVe2cED4xEPhgxKELNYjAPnem9fk2kFDCLZZVSBU3NqPELHD
6Vo87BaDhp4v4GHwVDhw5huhxVF8CyxSXYtkUwVHbbPv,10.0,2020-09-16T00:58:51.776257Z,5UWzc9G392RTJ7TfqktfspEYMzEqjSiouxPA2p9fC96rRVHvdVD1Wbx4BdYh4Swnq4qjhKXuoLcM1A4jivj3t9Hv
```

Depends on #12253 