### PR TITLE
CLI: Use Base58 encoding rather than deprecated Binary for TX decode

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -837,7 +837,7 @@ pub fn parse_command(
         ("decode-transaction", Some(matches)) => {
             let blob = value_t_or_exit!(matches, "transaction", String);
             let encoding = match matches.value_of("encoding").unwrap() {
-                "base58" => UiTransactionEncoding::Binary,
+                "base58" => UiTransactionEncoding::Base58,
                 "base64" => UiTransactionEncoding::Base64,
                 _ => unreachable!(),
             };


### PR DESCRIPTION
#### Problem

`solana decode-transaction` uses deprecated `Binary` encoding specification to decode base58 encoded transactions.  `solana_transaction_status::decode()` however, returns `None` for this specification.

#### Summary of Changes

Use `Base58` specification explicitly