### PR TITLE
RPC sendTransaction now returns transaction logs on simulation failure

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2170,11 +2170,6 @@ impl RpcSol for RpcSolImpl {
                 .map(|commitment| CommitmentConfig { commitment });
             let preflight_bank = &*meta.bank(preflight_commitment);
             if let (Err(err), logs) = preflight_bank.simulate_transaction(transaction.clone()) {
-                // Note: it's possible that the transaction simulation failed but the actual
-                // transaction would succeed, such as when a transaction depends on an earlier
-                // transaction that has yet to reach max confirmations. In these cases the user
-                // should use the config.skip_preflight flag, and potentially in the future
-                // additional controls over what bank is used for preflight should be exposed.
                 return Err(RpcCustomError::SendTransactionPreflightFailure {
                     message: format!("Transaction simulation failed: {}", err),
                     result: RpcSimulateTransactionResult {


### PR DESCRIPTION
When `sendTransaction` results in a simulation failure, the error response is not as helpful as it could be:
```json
{
  "code": -32002,
  "message": "Transaction simulation failed: Error processing Instruction 1: custom program error: 0x0"
}
```


Now the `sendTransaction` response populates the JSON RPC 2.0 error object's `data` field with a response that matches what `simulateTransaction` would have returned: 
```json
{
  "code": -32002,
  "data": {
    "err": {
      "InstructionError": [
        1,
        {
          "Custom": 0
        }
      ]
    },
    "logs": [
      "Call BPF program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
      "Program log: Instruction: InitializeMint",
      "Program log: Error: Lamport balance below rent-exempt threshold",
      "BPF program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: custom program error: 0x0"
    ]
  },
  "message": "Transaction simulation failed: Error processing Instruction 1: custom program error: 0x0"
}
```
unlocking:
1. Easy programatic parsing of the actual err (no need to regex the old `message` field)
2. Transaction logs for easier developer debugging