### PR TITLE
Fix failing window build on master on travis

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -125,7 +125,7 @@ fi
   set -x
   # deps dir can be empty
   shopt -s nullglob
-  for dep in target/$buildVariant/deps/libsolana*program.*; do
+  for dep in target/"$buildVariant"/deps/libsolana*program.*; do
     cp -fv "$dep" "$installDir/bin/deps"
   done
 )

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -123,7 +123,11 @@ fi
 
 (
   set -x
-  cp -fv target/$buildVariant/deps/libsolana*program.* "$installDir/bin/deps"
+  # deps dir can be empty
+  shopt -s nullglob
+  for dep in target/$buildVariant/deps/libsolana*program.*; do
+    cp -fv "$dep" "$installDir/bin/deps"
+  done
 )
 
 echo "Done after $SECONDS seconds"


### PR DESCRIPTION
#### Problem

Build started to fail on 88d8d3d  https://travis-ci.com/github/solana-labs/solana/builds/179008847 https://travis-ci.com/github/solana-labs/solana/jobs/370020574#L867:

```
    Finished release [optimized] target(s) in 26m 31s
+ cp -fv 'target/release/deps/libsolana*program.*' /c/Users/travis/build/solana-labs/solana/solana-release/bin/deps
cp: cannot stat 'target/release/deps/libsolana*program.*': No such file or directory
```

Last successfu build:  03263c8 https://travis-ci.com/github/solana-labs/solana/builds/178682556 https://travis-ci.com/github/solana-labs/solana/jobs/369181068#L875:

```
    Finished release [optimized] target(s) in 24m 48s
+ cp -fv target/release/deps/libsolana_budget_program.rlib /c/Users/travis/build/solana-labs/solana/solana-release/bin/deps
+ tar cvf solana-release-x86_64-pc-windows-msvc.tar solana-release
```

#### Summary of Changes

Fixes #
