### PR TITLE
docs: Fix 'Description will go into a meta tag in head' meta tag

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -92,7 +92,7 @@ function Home() {
   return (
     <Layout
       title="Homepage"
-      description="Solana Documentation"/>
+      description="Solana Documentation"
     >
       {/* <header className={clsx("hero hero--primary", styles.heroBanner)}> */}
       {/* <div className="container">

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -92,7 +92,7 @@ function Home() {
   return (
     <Layout
       title="Homepage"
-      description="Description will go into a meta tag in <head />"
+      description="Solana Documentation"/>
     >
       {/* <header className={clsx("hero hero--primary", styles.heroBanner)}> */}
       {/* <div className="container">


### PR DESCRIPTION
Fix this:
![image](https://user-images.githubusercontent.com/1281082/93363053-93fe7400-f7fb-11ea-94f7-ae688e9a510b.png)
