### PR TITLE
RPC: Limit request payload size to 50kB

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -78,6 +78,8 @@ use std::{
 };
 use tokio::runtime;
 
+pub const MAX_REQUEST_PAYLOAD_SIZE: usize = 50 * (1 << 10); // 50kB
+
 fn new_response<T>(bank: &Bank, value: T) -> RpcResponse<T> {
     let context = RpcResponseContext { slot: bank.slot() };
     Response { context, value }

--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -1,6 +1,7 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
 
 use crate::{
+    rpc::MAX_REQUEST_PAYLOAD_SIZE,
     rpc_pubsub::{RpcSolPubSub, RpcSolPubSubImpl},
     rpc_subscriptions::RpcSubscriptions,
 };
@@ -44,7 +45,7 @@ impl PubSubService {
                         session
                 })
                 .max_connections(1000) // Arbitrary, default of 100 is too low
-                .max_payload(10 * 1024 * 1024 + 1024) // max account size (10MB) + extra (1K)
+                .max_payload(MAX_REQUEST_PAYLOAD_SIZE)
                 .start(&pubsub_addr);
 
                 if let Err(e) = server {

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -353,6 +353,7 @@ impl JsonRpcService {
                 ]))
                 .cors_max_age(86400)
                 .request_middleware(request_middleware)
+                .max_request_body_size(MAX_REQUEST_PAYLOAD_SIZE)
                 .start_http(&rpc_addr);
 
                 if let Err(e) = server {


### PR DESCRIPTION
#### Problem

Our RPC servers use upstream default request payload values which are quite a bit larger than our expected usage.

#### Summary of Changes

Limit RPC request payloads to 50kB