### PR TITLE
Restore --expected-shred-version argument for mainnet-beta

### DIFF
--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -134,6 +134,7 @@ $ solana-validator \
     --dynamic-port-range 8000-8010 \
     --entrypoint mainnet-beta.solana.com:8001 \
     --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
+    --expected-shred-version 64864 \
     --limit-ledger-size
 ```
 


### PR DESCRIPTION
https://github.com/solana-labs/solana/pull/12288 didn't cleanly backport to v1.2.  Rather than debug the behavioural differences between 1.2 and 1.3 here, instead the removal of `--expected-shred-version` can ride the v1.3 release train to mainnet-beta so restore the `--expected-shred-version` argument in the mainnet-beta docs

