### PR TITLE
Don't fetch token transaction history for accounts with many holdings

### DIFF
--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -37,6 +37,12 @@ export function TokenHistoryCard({ pubkey }: { pubkey: PublicKey }) {
   const tokens = ownedTokens.data?.tokens;
   if (tokens === undefined || tokens.length === 0) return null;
 
+  if (tokens.length > 25) {
+    return (
+      <ErrorCard text="Token transaction history is not available for accounts with over 25 token accounts" />
+    );
+  }
+
   return <TokenHistoryTable tokens={tokens} />;
 }
 


### PR DESCRIPTION
#### Problem
The explorer will attempt to load the account history for each of an account's token accounts when loading token history. This can results in 10's of thousands of requests and will crash / freeze the browser

#### Summary of Changes
Don't fetch token history for accounts with over 25 token accounts for now

Related to https://github.com/solana-labs/solana/issues/12064
