### PR TITLE
Record and store invoked instructions in transaction meta

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -534,7 +534,7 @@ impl BankingStage {
         let (
             mut loaded_accounts,
             results,
-            invoked_instructions,
+            inner_instructions,
             mut retryable_txs,
             tx_count,
             signature_count,
@@ -580,7 +580,7 @@ impl BankingStage {
                     batch.iteration_order_vec(),
                     tx_results.processing_results,
                     TransactionBalancesSet::new(pre_balances, post_balances),
-                    invoked_instructions,
+                    inner_instructions,
                     sender,
                 );
             }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -531,8 +531,14 @@ impl BankingStage {
         } else {
             vec![]
         };
-        let (mut loaded_accounts, results, mut retryable_txs, tx_count, signature_count) =
-            bank.load_and_execute_transactions(batch, MAX_PROCESSING_AGE, None);
+        let (
+            mut loaded_accounts,
+            results,
+            invoked_instructions,
+            mut retryable_txs,
+            tx_count,
+            signature_count,
+        ) = bank.load_and_execute_transactions(batch, MAX_PROCESSING_AGE, None);
         load_execute_time.stop();
 
         let freeze_lock = bank.freeze_lock();
@@ -569,6 +575,7 @@ impl BankingStage {
                     batch.iteration_order_vec(),
                     tx_results.processing_results,
                     TransactionBalancesSet::new(pre_balances, post_balances),
+                    invoked_instructions,
                     sender,
                 );
             }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -538,7 +538,12 @@ impl BankingStage {
             mut retryable_txs,
             tx_count,
             signature_count,
-        ) = bank.load_and_execute_transactions(batch, MAX_PROCESSING_AGE, None);
+        ) = bank.load_and_execute_transactions(
+            batch,
+            MAX_PROCESSING_AGE,
+            None,
+            transaction_status_sender.is_some(),
+        );
         load_execute_time.stop();
 
         let freeze_lock = bank.freeze_lock();

--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -1,11 +1,12 @@
 use crossbeam_channel::{Receiver, RecvTimeoutError};
+use itertools::izip;
 use solana_ledger::{blockstore::Blockstore, blockstore_processor::TransactionStatusBatch};
 use solana_runtime::{
     bank::{Bank, HashAgeKind},
     nonce_utils,
     transaction_utils::OrderedIterator,
 };
-use solana_transaction_status::TransactionStatusMeta;
+use solana_transaction_status::{InvokedInstructions, TransactionStatusMeta};
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -54,15 +55,23 @@ impl TransactionStatusService {
             iteration_order,
             statuses,
             balances,
+            invoked_instructions,
         } = write_transaction_status_receiver.recv_timeout(Duration::from_secs(1))?;
 
         let slot = bank.slot();
-        for ((((_, transaction), (status, hash_age_kind)), pre_balances), post_balances) in
-            OrderedIterator::new(&transactions, iteration_order.as_deref())
-                .zip(statuses)
-                .zip(balances.pre_balances)
-                .zip(balances.post_balances)
-        {
+        for (
+            (_, transaction),
+            (status, hash_age_kind),
+            pre_balances,
+            post_balances,
+            invoked_instructions,
+        ) in izip!(
+            OrderedIterator::new(&transactions, iteration_order.as_deref()),
+            statuses,
+            balances.pre_balances,
+            balances.post_balances,
+            invoked_instructions
+        ) {
             if Bank::can_commit(&status) && !transaction.signatures.is_empty() {
                 let fee_calculator = match hash_age_kind {
                     Some(HashAgeKind::DurableNonce(_, account)) => {
@@ -77,6 +86,17 @@ impl TransactionStatusService {
                 );
                 let (writable_keys, readonly_keys) =
                     transaction.message.get_account_keys_by_lock_type();
+
+                let invoked_instructions = invoked_instructions
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, instructions)| InvokedInstructions {
+                        index: index as u8,
+                        instructions,
+                    })
+                    .filter(|i| !i.instructions.is_empty())
+                    .collect();
+
                 blockstore
                     .write_transaction_status(
                         slot,
@@ -88,6 +108,7 @@ impl TransactionStatusService {
                             fee,
                             pre_balances,
                             post_balances,
+                            invoked: Some(invoked_instructions),
                         },
                     )
                     .expect("Expect database write to succeed");

--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -87,15 +87,17 @@ impl TransactionStatusService {
                 let (writable_keys, readonly_keys) =
                     transaction.message.get_account_keys_by_lock_type();
 
-                let invoked_instructions = invoked_instructions
-                    .into_iter()
-                    .enumerate()
-                    .map(|(index, instructions)| InvokedInstructions {
-                        index: index as u8,
-                        instructions,
-                    })
-                    .filter(|i| !i.instructions.is_empty())
-                    .collect();
+                let invoked = invoked_instructions.map(|invoked_instructions| {
+                    invoked_instructions
+                        .into_iter()
+                        .enumerate()
+                        .map(|(index, instructions)| InvokedInstructions {
+                            index: index as u8,
+                            instructions,
+                        })
+                        .filter(|i| !i.instructions.is_empty())
+                        .collect()
+                });
 
                 blockstore
                     .write_transaction_status(
@@ -108,7 +110,7 @@ impl TransactionStatusService {
                             fee,
                             pre_balances,
                             post_balances,
-                            invoked: Some(invoked_instructions),
+                            invoked,
                         },
                     )
                     .expect("Expect database write to succeed");

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -332,7 +332,7 @@ The result field will be an object with the following fields:
       - `fee: <u64>` - fee this transaction was charged, as u64 integer
       - `preBalances: <array>` - array of u64 account balances from before the transaction was processed
       - `postBalances: <array>` - array of u64 account balances after the transaction was processed
-      - `invoked: <array|undefined>` - List of [invoked instructions](#invoked-instructions-structure) or omitted if invoked instruction recording was not yet enabled during this transaction
+      - `innerInstructions: <array|undefined>` - List of [inner instructions](#inner-instructions-structure) or omitted if inner instruction recording was not yet enabled during this transaction
       - DEPRECATED: `status: <object>` - Transaction status
         - `"Ok": <null>` - Transaction was successful
         - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -348,13 +348,13 @@ The result field will be an object with the following fields:
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, "json"]}' localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"blockTime":null,"blockhash":"3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA","parentSlot":429,"previousBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"invoked":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"transaction":{"message":{"accountKeys":["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe","AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":1},"instructions":[{"accounts":[1,2,3,0],"data":"37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1","programIdIndex":4}],"recentBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"},"signatures":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"]}}]},"id":1}
+{"jsonrpc":"2.0","result":{"blockTime":null,"blockhash":"3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA","parentSlot":429,"previousBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"innerInstructions":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"transaction":{"message":{"accountKeys":["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe","AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":1},"instructions":[{"accounts":[1,2,3,0],"data":"37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1","programIdIndex":4}],"recentBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"},"signatures":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"]}}]},"id":1}
 
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, "base64"]}' localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"blockTime":null,"blockhash":"3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA","parentSlot":429,"previousBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"invoked":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"transaction":["AVj7dxHlQ9IrvdYVIjuiRFs1jLaDMHixgrv+qtHBwz51L4/ImLZhszwiyEJDIp7xeBSpm/TX5B7mYzxa+fPOMw0BAAMFJMJVqLw+hJYheizSoYlLm53KzgT82cDVmazarqQKG2GQsLgiqktA+a+FDR4/7xnDX7rsusMwryYVUdixfz1B1Qan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAAtxOUhPBp2WSjUNJEgfvy70BbxI00fZyEPvFHNfxrtEAQQEAQIDADUCAAAAAQAAAAAAAACtAQAAAAAAAAdUE18R96XTJCe+YfRfUp6WP+YKCy/72ucOL8AoBFSpAA==","base64"]}]},"id":1}
+{"jsonrpc":"2.0","result":{"blockTime":null,"blockhash":"3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA","parentSlot":429,"previousBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"innerInstructions":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"transaction":["AVj7dxHlQ9IrvdYVIjuiRFs1jLaDMHixgrv+qtHBwz51L4/ImLZhszwiyEJDIp7xeBSpm/TX5B7mYzxa+fPOMw0BAAMFJMJVqLw+hJYheizSoYlLm53KzgT82cDVmazarqQKG2GQsLgiqktA+a+FDR4/7xnDX7rsusMwryYVUdixfz1B1Qan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAAtxOUhPBp2WSjUNJEgfvy70BbxI00fZyEPvFHNfxrtEAQQEAQIDADUCAAAAAQAAAAAAAACtAQAAAAAAAAdUE18R96XTJCe+YfRfUp6WP+YKCy/72ucOL8AoBFSpAA==","base64"]}]},"id":1}
 ```
 
 #### Transaction Structure
@@ -376,14 +376,14 @@ The JSON structure of a transaction is defined as follows:
     - `accounts: <array[number]>` - List of ordered indices into the `message.accountKeys` array indicating which accounts to pass to the program.
     - `data: <string>` - The program input data encoded in a base-58 string.
 
-#### Invoked Instructions Structure
+#### Inner Instructions Structure
 
 The Solana runtime records the cross-program instructions that are invoked during transaction processing and makes these available for greater transparency of what was executed on-chain per transaction instruction. Invoked instructions are grouped by the originating transaction instruction and are listed in order of processing.
 
-The JSON structure of invoked instructions is defined as a list of objects in the following structure:
+The JSON structure of inner instructions is defined as a list of objects in the following structure:
 
-- `index: number` - Index of the transaction instruction from which the invoked instruction(s) originated
-- `instructions: <array[object]>` - Ordered List of program instructions that were invoked during a single transaction instruction.
+- `index: number` - Index of the transaction instruction from which the inner instruction(s) originated
+- `instructions: <array[object]>` - Ordered list of inner program instructions that were invoked during a single transaction instruction.
   - `programIdIndex: <number>` - Index into the `message.accountKeys` array indicating the program account that executes this instruction.
   - `accounts: <array[number]>` - List of ordered indices into the `message.accountKeys` array indicating which accounts to pass to the program.
   - `data: <string>` - The program input data encoded in a base-58 string.
@@ -498,7 +498,7 @@ N encoding attempts to use program-specific instruction parsers to return more h
     - `fee: <u64>` - fee this transaction was charged, as u64 integer
     - `preBalances: <array>` - array of u64 account balances from before the transaction was processed
     - `postBalances: <array>` - array of u64 account balances after the transaction was processed
-    - `invoked: <array|undefined>` - List of [invoked instructions](#invoked-instructions-structure) or omitted if invoked instruction recording was not yet enabled during this transaction
+    - `innerInstructions: <array|undefined>` - List of [inner instructions](#inner-instructions-structure) or omitted if inner instruction recording was not yet enabled during this transaction
     - DEPRECATED: `status: <object>` - Transaction status
       - `"Ok": <null>` - Transaction was successful
       - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -510,13 +510,13 @@ N encoding attempts to use program-specific instruction parsers to return more h
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedTransaction","params":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv", "json"]}' localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"meta":{"err":null,"fee":5000,"invoked":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"slot":430,"transaction":{"message":{"accountKeys":["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe","AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":1},"instructions":[{"accounts":[1,2,3,0],"data":"37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1","programIdIndex":4}],"recentBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"},"signatures":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"]}},"id":1}
+{"jsonrpc":"2.0","result":{"meta":{"err":null,"fee":5000,"innerInstructions":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"slot":430,"transaction":{"message":{"accountKeys":["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe","AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":1},"instructions":[{"accounts":[1,2,3,0],"data":"37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1","programIdIndex":4}],"recentBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"},"signatures":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"]}},"id":1}
 
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedTransaction","params":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv", "base64"]}' localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"meta":{"err":null,"fee":5000,"invoked":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"slot":430,"transaction":["AVj7dxHlQ9IrvdYVIjuiRFs1jLaDMHixgrv+qtHBwz51L4/ImLZhszwiyEJDIp7xeBSpm/TX5B7mYzxa+fPOMw0BAAMFJMJVqLw+hJYheizSoYlLm53KzgT82cDVmazarqQKG2GQsLgiqktA+a+FDR4/7xnDX7rsusMwryYVUdixfz1B1Qan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAAtxOUhPBp2WSjUNJEgfvy70BbxI00fZyEPvFHNfxrtEAQQEAQIDADUCAAAAAQAAAAAAAACtAQAAAAAAAAdUE18R96XTJCe+YfRfUp6WP+YKCy/72ucOL8AoBFSpAA==","base64"]},"id":1}
+{"jsonrpc":"2.0","result":{"meta":{"err":null,"fee":5000,"innerInstructions":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"slot":430,"transaction":["AVj7dxHlQ9IrvdYVIjuiRFs1jLaDMHixgrv+qtHBwz51L4/ImLZhszwiyEJDIp7xeBSpm/TX5B7mYzxa+fPOMw0BAAMFJMJVqLw+hJYheizSoYlLm53KzgT82cDVmazarqQKG2GQsLgiqktA+a+FDR4/7xnDX7rsusMwryYVUdixfz1B1Qan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAAtxOUhPBp2WSjUNJEgfvy70BbxI00fZyEPvFHNfxrtEAQQEAQIDADUCAAAAAQAAAAAAAACtAQAAAAAAAAdUE18R96XTJCe+YfRfUp6WP+YKCy/72ucOL8AoBFSpAA==","base64"]},"id":1}
 ```
 
 ### getEpochInfo

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -332,6 +332,7 @@ The result field will be an object with the following fields:
       - `fee: <u64>` - fee this transaction was charged, as u64 integer
       - `preBalances: <array>` - array of u64 account balances from before the transaction was processed
       - `postBalances: <array>` - array of u64 account balances after the transaction was processed
+      - `invoked: <array|undefined>` - List of [invoked instructions](#invoked-instructions-structure) or omitted if invoked instruction recording was not yet enabled during this transaction
       - DEPRECATED: `status: <object>` - Transaction status
         - `"Ok": <null>` - Transaction was successful
         - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -347,13 +348,13 @@ The result field will be an object with the following fields:
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, "json"]}' localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"blockTime":null,"blockhash":"3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA","parentSlot":429,"previousBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"transaction":{"message":{"accountKeys":["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe","AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":1},"instructions":[{"accounts":[1,2,3,0],"data":"37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1","programIdIndex":4}],"recentBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"},"signatures":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"]}}]},"id":1}
+{"jsonrpc":"2.0","result":{"blockTime":null,"blockhash":"3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA","parentSlot":429,"previousBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"invoked":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"transaction":{"message":{"accountKeys":["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe","AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":1},"instructions":[{"accounts":[1,2,3,0],"data":"37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1","programIdIndex":4}],"recentBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"},"signatures":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"]}}]},"id":1}
 
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, "base64"]}' localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"blockTime":null,"blockhash":"3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA","parentSlot":429,"previousBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"transaction":["AVj7dxHlQ9IrvdYVIjuiRFs1jLaDMHixgrv+qtHBwz51L4/ImLZhszwiyEJDIp7xeBSpm/TX5B7mYzxa+fPOMw0BAAMFJMJVqLw+hJYheizSoYlLm53KzgT82cDVmazarqQKG2GQsLgiqktA+a+FDR4/7xnDX7rsusMwryYVUdixfz1B1Qan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAAtxOUhPBp2WSjUNJEgfvy70BbxI00fZyEPvFHNfxrtEAQQEAQIDADUCAAAAAQAAAAAAAACtAQAAAAAAAAdUE18R96XTJCe+YfRfUp6WP+YKCy/72ucOL8AoBFSpAA==","base64"]}]},"id":1}
+{"jsonrpc":"2.0","result":{"blockTime":null,"blockhash":"3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA","parentSlot":429,"previousBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B","rewards":[],"transactions":[{"meta":{"err":null,"fee":5000,"invoked":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"transaction":["AVj7dxHlQ9IrvdYVIjuiRFs1jLaDMHixgrv+qtHBwz51L4/ImLZhszwiyEJDIp7xeBSpm/TX5B7mYzxa+fPOMw0BAAMFJMJVqLw+hJYheizSoYlLm53KzgT82cDVmazarqQKG2GQsLgiqktA+a+FDR4/7xnDX7rsusMwryYVUdixfz1B1Qan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAAtxOUhPBp2WSjUNJEgfvy70BbxI00fZyEPvFHNfxrtEAQQEAQIDADUCAAAAAQAAAAAAAACtAQAAAAAAAAdUE18R96XTJCe+YfRfUp6WP+YKCy/72ucOL8AoBFSpAA==","base64"]}]},"id":1}
 ```
 
 #### Transaction Structure
@@ -374,6 +375,18 @@ The JSON structure of a transaction is defined as follows:
     - `programIdIndex: <number>` - Index into the `message.accountKeys` array indicating the program account that executes this instruction.
     - `accounts: <array[number]>` - List of ordered indices into the `message.accountKeys` array indicating which accounts to pass to the program.
     - `data: <string>` - The program input data encoded in a base-58 string.
+
+#### Invoked Instructions Structure
+
+The Solana runtime records the cross-program instructions that are invoked during transaction processing and makes these available for greater transparency of what was executed on-chain per transaction instruction. Invoked instructions are grouped by the originating transaction instruction and are listed in order of processing.
+
+The JSON structure of invoked instructions is defined as a list of objects in the following structure:
+
+- `index: number` - Index of the transaction instruction from which the invoked instruction(s) originated
+- `instructions: <array[object]>` - Ordered List of program instructions that were invoked during a single transaction instruction.
+  - `programIdIndex: <number>` - Index into the `message.accountKeys` array indicating the program account that executes this instruction.
+  - `accounts: <array[number]>` - List of ordered indices into the `message.accountKeys` array indicating which accounts to pass to the program.
+  - `data: <string>` - The program input data encoded in a base-58 string.
 
 ### getConfirmedBlocks
 
@@ -485,6 +498,7 @@ N encoding attempts to use program-specific instruction parsers to return more h
     - `fee: <u64>` - fee this transaction was charged, as u64 integer
     - `preBalances: <array>` - array of u64 account balances from before the transaction was processed
     - `postBalances: <array>` - array of u64 account balances after the transaction was processed
+    - `invoked: <array|undefined>` - List of [invoked instructions](#invoked-instructions-structure) or omitted if invoked instruction recording was not yet enabled during this transaction
     - DEPRECATED: `status: <object>` - Transaction status
       - `"Ok": <null>` - Transaction was successful
       - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -496,13 +510,13 @@ N encoding attempts to use program-specific instruction parsers to return more h
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedTransaction","params":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv", "json"]}' localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"meta":{"err":null,"fee":5000,"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"slot":430,"transaction":{"message":{"accountKeys":["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe","AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":1},"instructions":[{"accounts":[1,2,3,0],"data":"37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1","programIdIndex":4}],"recentBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"},"signatures":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"]}},"id":1}
+{"jsonrpc":"2.0","result":{"meta":{"err":null,"fee":5000,"invoked":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"slot":430,"transaction":{"message":{"accountKeys":["3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe","AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc","SysvarS1otHashes111111111111111111111111111","SysvarC1ock11111111111111111111111111111111","Vote111111111111111111111111111111111111111"],"header":{"numReadonlySignedAccounts":0,"numReadonlyUnsignedAccounts":3,"numRequiredSignatures":1},"instructions":[{"accounts":[1,2,3,0],"data":"37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1","programIdIndex":4}],"recentBlockhash":"mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B"},"signatures":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv"]}},"id":1}
 
 // Request
 curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedTransaction","params":["2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv", "base64"]}' localhost:8899
 
 // Result
-{"jsonrpc":"2.0","result":{"meta":{"err":null,"fee":5000,"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"slot":430,"transaction":["AVj7dxHlQ9IrvdYVIjuiRFs1jLaDMHixgrv+qtHBwz51L4/ImLZhszwiyEJDIp7xeBSpm/TX5B7mYzxa+fPOMw0BAAMFJMJVqLw+hJYheizSoYlLm53KzgT82cDVmazarqQKG2GQsLgiqktA+a+FDR4/7xnDX7rsusMwryYVUdixfz1B1Qan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAAtxOUhPBp2WSjUNJEgfvy70BbxI00fZyEPvFHNfxrtEAQQEAQIDADUCAAAAAQAAAAAAAACtAQAAAAAAAAdUE18R96XTJCe+YfRfUp6WP+YKCy/72ucOL8AoBFSpAA==","base64"]},"id":1}
+{"jsonrpc":"2.0","result":{"meta":{"err":null,"fee":5000,"invoked":[],"postBalances":[499998932500,26858640,1,1,1],"preBalances":[499998937500,26858640,1,1,1],"status":{"Ok":null}},"slot":430,"transaction":["AVj7dxHlQ9IrvdYVIjuiRFs1jLaDMHixgrv+qtHBwz51L4/ImLZhszwiyEJDIp7xeBSpm/TX5B7mYzxa+fPOMw0BAAMFJMJVqLw+hJYheizSoYlLm53KzgT82cDVmazarqQKG2GQsLgiqktA+a+FDR4/7xnDX7rsusMwryYVUdixfz1B1Qan1RcZLwqvxvJl4/t3zHragsUp0L47E24tAFUgAAAABqfVFxjHdMkoVmOYaR1etoteuKObS21cc1VbIQAAAAAHYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAAAtxOUhPBp2WSjUNJEgfvy70BbxI00fZyEPvFHNfxrtEAQQEAQIDADUCAAAAAQAAAAAAAACtAQAAAAAAAAdUE18R96XTJCe+YfRfUp6WP+YKCy/72ucOL8AoBFSpAA==","base64"]},"id":1}
 ```
 
 ### getEpochInfo

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3474,7 +3474,7 @@ pub mod tests {
         signature::Signature,
         transaction::TransactionError,
     };
-    use solana_transaction_status::InvokedInstructions;
+    use solana_transaction_status::InnerInstructions;
     use solana_vote_program::{vote_instruction, vote_state::Vote};
     use std::{iter::FromIterator, time::Duration};
 
@@ -5672,7 +5672,7 @@ pub mod tests {
                             fee: 42,
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
-                            invoked: Some(vec![]),
+                            inner_instructions: Some(vec![]),
                         },
                     )
                     .unwrap();
@@ -5685,7 +5685,7 @@ pub mod tests {
                             fee: 42,
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
-                            invoked: Some(vec![]),
+                            inner_instructions: Some(vec![]),
                         },
                     )
                     .unwrap();
@@ -5696,7 +5696,7 @@ pub mod tests {
                         fee: 42,
                         pre_balances,
                         post_balances,
-                        invoked: Some(vec![]),
+                        inner_instructions: Some(vec![]),
                     }),
                 }
             })
@@ -5989,7 +5989,7 @@ pub mod tests {
 
             let pre_balances_vec = vec![1, 2, 3];
             let post_balances_vec = vec![3, 2, 1];
-            let invoked_instructions_vec = vec![InvokedInstructions {
+            let inner_instructions_vec = vec![InnerInstructions {
                 index: 0,
                 instructions: vec![CompiledInstruction::new(1, &(), vec![0])],
             }];
@@ -6011,7 +6011,7 @@ pub mod tests {
                         fee: 5u64,
                         pre_balances: pre_balances_vec.clone(),
                         post_balances: post_balances_vec.clone(),
-                        invoked: Some(invoked_instructions_vec.clone()),
+                        inner_instructions: Some(inner_instructions_vec.clone()),
                     },
                 )
                 .is_ok());
@@ -6022,7 +6022,7 @@ pub mod tests {
                 fee,
                 pre_balances,
                 post_balances,
-                invoked,
+                inner_instructions,
             } = transaction_status_cf
                 .get((0, Signature::default(), 0))
                 .unwrap()
@@ -6031,7 +6031,7 @@ pub mod tests {
             assert_eq!(fee, 5u64);
             assert_eq!(pre_balances, pre_balances_vec);
             assert_eq!(post_balances, post_balances_vec);
-            assert_eq!(invoked.unwrap(), invoked_instructions_vec);
+            assert_eq!(inner_instructions.unwrap(), inner_instructions_vec);
 
             // insert value
             assert!(transaction_status_cf
@@ -6042,7 +6042,7 @@ pub mod tests {
                         fee: 9u64,
                         pre_balances: pre_balances_vec.clone(),
                         post_balances: post_balances_vec.clone(),
-                        invoked: Some(invoked_instructions_vec.clone()),
+                        inner_instructions: Some(inner_instructions_vec.clone()),
                     },
                 )
                 .is_ok());
@@ -6053,7 +6053,7 @@ pub mod tests {
                 fee,
                 pre_balances,
                 post_balances,
-                invoked,
+                inner_instructions,
             } = transaction_status_cf
                 .get((0, Signature::new(&[2u8; 64]), 9))
                 .unwrap()
@@ -6064,7 +6064,7 @@ pub mod tests {
             assert_eq!(fee, 9u64);
             assert_eq!(pre_balances, pre_balances_vec);
             assert_eq!(post_balances, post_balances_vec);
-            assert_eq!(invoked.unwrap(), invoked_instructions_vec);
+            assert_eq!(inner_instructions.unwrap(), inner_instructions_vec);
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }
@@ -6291,7 +6291,7 @@ pub mod tests {
                 fee: 42u64,
                 pre_balances: pre_balances_vec,
                 post_balances: post_balances_vec,
-                invoked: Some(vec![]),
+                inner_instructions: Some(vec![]),
             };
 
             let signature1 = Signature::new(&[1u8; 64]);
@@ -6421,7 +6421,7 @@ pub mod tests {
                     pre_balances.push(i as u64 * 10);
                     post_balances.push(i as u64 * 11);
                 }
-                let invoked_instructions = Some(vec![InvokedInstructions {
+                let inner_instructions = Some(vec![InnerInstructions {
                     index: 0,
                     instructions: vec![CompiledInstruction::new(1, &(), vec![0])],
                 }]);
@@ -6435,7 +6435,7 @@ pub mod tests {
                             fee: 42,
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
-                            invoked: invoked_instructions.clone(),
+                            inner_instructions: inner_instructions.clone(),
                         },
                     )
                     .unwrap();
@@ -6446,7 +6446,7 @@ pub mod tests {
                         fee: 42,
                         pre_balances,
                         post_balances,
-                        invoked: invoked_instructions,
+                        inner_instructions,
                     }),
                 }
             })
@@ -6886,7 +6886,7 @@ pub mod tests {
                             fee: x,
                             pre_balances: vec![],
                             post_balances: vec![],
-                            invoked: Some(vec![]),
+                            inner_instructions: Some(vec![]),
                         },
                     )
                     .unwrap();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3474,6 +3474,7 @@ pub mod tests {
         signature::Signature,
         transaction::TransactionError,
     };
+    use solana_transaction_status::InvokedInstructions;
     use solana_vote_program::{vote_instruction, vote_state::Vote};
     use std::{iter::FromIterator, time::Duration};
 
@@ -5671,6 +5672,7 @@ pub mod tests {
                             fee: 42,
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
+                            invoked: Some(vec![]),
                         },
                     )
                     .unwrap();
@@ -5683,6 +5685,7 @@ pub mod tests {
                             fee: 42,
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
+                            invoked: Some(vec![]),
                         },
                     )
                     .unwrap();
@@ -5693,6 +5696,7 @@ pub mod tests {
                         fee: 42,
                         pre_balances,
                         post_balances,
+                        invoked: Some(vec![]),
                     }),
                 }
             })
@@ -5985,6 +5989,10 @@ pub mod tests {
 
             let pre_balances_vec = vec![1, 2, 3];
             let post_balances_vec = vec![3, 2, 1];
+            let invoked_instructions_vec = vec![InvokedInstructions {
+                index: 0,
+                instructions: vec![CompiledInstruction::new(1, &(), vec![0])],
+            }];
 
             // result not found
             assert!(transaction_status_cf
@@ -6003,6 +6011,7 @@ pub mod tests {
                         fee: 5u64,
                         pre_balances: pre_balances_vec.clone(),
                         post_balances: post_balances_vec.clone(),
+                        invoked: Some(invoked_instructions_vec.clone()),
                     },
                 )
                 .is_ok());
@@ -6013,6 +6022,7 @@ pub mod tests {
                 fee,
                 pre_balances,
                 post_balances,
+                invoked,
             } = transaction_status_cf
                 .get((0, Signature::default(), 0))
                 .unwrap()
@@ -6021,6 +6031,7 @@ pub mod tests {
             assert_eq!(fee, 5u64);
             assert_eq!(pre_balances, pre_balances_vec);
             assert_eq!(post_balances, post_balances_vec);
+            assert_eq!(invoked.unwrap(), invoked_instructions_vec);
 
             // insert value
             assert!(transaction_status_cf
@@ -6031,6 +6042,7 @@ pub mod tests {
                         fee: 9u64,
                         pre_balances: pre_balances_vec.clone(),
                         post_balances: post_balances_vec.clone(),
+                        invoked: Some(invoked_instructions_vec.clone()),
                     },
                 )
                 .is_ok());
@@ -6041,6 +6053,7 @@ pub mod tests {
                 fee,
                 pre_balances,
                 post_balances,
+                invoked,
             } = transaction_status_cf
                 .get((0, Signature::new(&[2u8; 64]), 9))
                 .unwrap()
@@ -6051,6 +6064,7 @@ pub mod tests {
             assert_eq!(fee, 9u64);
             assert_eq!(pre_balances, pre_balances_vec);
             assert_eq!(post_balances, post_balances_vec);
+            assert_eq!(invoked.unwrap(), invoked_instructions_vec);
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }
@@ -6277,6 +6291,7 @@ pub mod tests {
                 fee: 42u64,
                 pre_balances: pre_balances_vec,
                 post_balances: post_balances_vec,
+                invoked: Some(vec![]),
             };
 
             let signature1 = Signature::new(&[1u8; 64]);
@@ -6406,6 +6421,10 @@ pub mod tests {
                     pre_balances.push(i as u64 * 10);
                     post_balances.push(i as u64 * 11);
                 }
+                let invoked_instructions = Some(vec![InvokedInstructions {
+                    index: 0,
+                    instructions: vec![CompiledInstruction::new(1, &(), vec![0])],
+                }]);
                 let signature = transaction.signatures[0];
                 blockstore
                     .transaction_status_cf
@@ -6416,6 +6435,7 @@ pub mod tests {
                             fee: 42,
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
+                            invoked: invoked_instructions.clone(),
                         },
                     )
                     .unwrap();
@@ -6426,6 +6446,7 @@ pub mod tests {
                         fee: 42,
                         pre_balances,
                         post_balances,
+                        invoked: invoked_instructions,
                     }),
                 }
             })
@@ -6865,6 +6886,7 @@ pub mod tests {
                             fee: x,
                             pre_balances: vec![],
                             post_balances: vec![],
+                            invoked: Some(vec![]),
                         },
                     )
                     .unwrap();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -108,6 +108,7 @@ fn execute_batch(
             batch,
             MAX_PROCESSING_AGE,
             transaction_status_sender.is_some(),
+            transaction_status_sender.is_some(),
         );
 
     bank_utils::find_and_send_votes(batch.transactions(), &tx_results, replay_vote_sender);
@@ -1053,8 +1054,9 @@ pub struct TransactionStatusBatch {
     pub iteration_order: Option<Vec<usize>>,
     pub statuses: Vec<TransactionProcessResult>,
     pub balances: TransactionBalancesSet,
-    pub invoked_instructions: Vec<InvokedInstructionsList>,
+    pub invoked_instructions: Vec<Option<InvokedInstructionsList>>,
 }
+
 pub type TransactionStatusSender = Sender<TransactionStatusBatch>;
 
 pub fn send_transaction_status_batch(
@@ -1063,7 +1065,7 @@ pub fn send_transaction_status_batch(
     iteration_order: Option<Vec<usize>>,
     statuses: Vec<TransactionProcessResult>,
     balances: TransactionBalancesSet,
-    invoked_instructions: Vec<InvokedInstructionsList>,
+    invoked_instructions: Vec<Option<InvokedInstructionsList>>,
     transaction_status_sender: TransactionStatusSender,
 ) {
     let slot = bank.slot();
@@ -2922,9 +2924,12 @@ pub mod tests {
             },
             _balances,
             _invoked_instructions,
-        ) = batch
-            .bank()
-            .load_execute_and_commit_transactions(&batch, MAX_PROCESSING_AGE, false);
+        ) = batch.bank().load_execute_and_commit_transactions(
+            &batch,
+            MAX_PROCESSING_AGE,
+            false,
+            false,
+        );
         let (err, signature) = get_first_error(&batch, fee_collection_results).unwrap();
         // First error found should be for the 2nd transaction, due to iteration_order
         assert_eq!(err.unwrap_err(), TransactionError::AccountNotFound);

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -16,7 +16,7 @@ use solana_metrics::{datapoint_error, inc_new_counter_debug};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::{
     bank::{
-        Bank, InvokedInstructionsList, TransactionBalancesSet, TransactionProcessResult,
+        Bank, InnerInstructionsList, TransactionBalancesSet, TransactionProcessResult,
         TransactionResults,
     },
     bank_forks::BankForks,
@@ -103,7 +103,7 @@ fn execute_batch(
     transaction_status_sender: Option<TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
 ) -> Result<()> {
-    let (tx_results, balances, invoked_instructions) =
+    let (tx_results, balances, inner_instructions) =
         batch.bank().load_execute_and_commit_transactions(
             batch,
             MAX_PROCESSING_AGE,
@@ -126,7 +126,7 @@ fn execute_batch(
             batch.iteration_order_vec(),
             processing_results,
             balances,
-            invoked_instructions,
+            inner_instructions,
             sender,
         );
     }
@@ -1054,7 +1054,7 @@ pub struct TransactionStatusBatch {
     pub iteration_order: Option<Vec<usize>>,
     pub statuses: Vec<TransactionProcessResult>,
     pub balances: TransactionBalancesSet,
-    pub invoked_instructions: Vec<Option<InvokedInstructionsList>>,
+    pub inner_instructions: Vec<Option<InnerInstructionsList>>,
 }
 
 pub type TransactionStatusSender = Sender<TransactionStatusBatch>;
@@ -1065,7 +1065,7 @@ pub fn send_transaction_status_batch(
     iteration_order: Option<Vec<usize>>,
     statuses: Vec<TransactionProcessResult>,
     balances: TransactionBalancesSet,
-    invoked_instructions: Vec<Option<InvokedInstructionsList>>,
+    inner_instructions: Vec<Option<InnerInstructionsList>>,
     transaction_status_sender: TransactionStatusSender,
 ) {
     let slot = bank.slot();
@@ -1075,7 +1075,7 @@ pub fn send_transaction_status_batch(
         iteration_order,
         statuses,
         balances,
-        invoked_instructions,
+        inner_instructions,
     }) {
         trace!(
             "Slot {} transaction_status send batch failed: {:?}",
@@ -2923,7 +2923,7 @@ pub mod tests {
                 ..
             },
             _balances,
-            _invoked_instructions,
+            _inner_instructions,
         ) = batch.bank().load_execute_and_commit_transactions(
             &batch,
             MAX_PROCESSING_AGE,

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -227,7 +227,7 @@ impl InvokeContext for MockInvokeContext {
     fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         None
     }
-    fn record_instruction(&self, _instruction: Instruction) {}
+    fn record_instruction(&self, _instruction: &Instruction) {}
 }
 #[derive(Debug, Default, Clone)]
 pub struct MockLogger {

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -227,6 +227,7 @@ impl InvokeContext for MockInvokeContext {
     fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         None
     }
+    fn record_instruction(&self, _instruction: Instruction) {}
 }
 #[derive(Debug, Default, Clone)]
 pub struct MockLogger {

--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -251,9 +251,9 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_assert(SUCCESS ==
                sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
 
+    // Signer privilege escalation will always fail the whole transaction
     instruction.accounts[0].is_signer = true;
-    sol_assert(SUCCESS !=
-               sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
+    sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
     break;
   }
   case TEST_PRIVILEGE_ESCALATION_WRITABLE: {
@@ -267,9 +267,9 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_assert(SUCCESS ==
                sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
 
+    // Writable privilege escalation will always fail the whole transaction
     instruction.accounts[0].is_writable = true;
-    sol_assert(SUCCESS !=
-               sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
+    sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
     break;
   }
   default:

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -239,6 +239,7 @@ fn process_instruction(
             );
             invoke(&invoked_instruction, accounts)?;
 
+            // Signer privilege escalation will always fail the whole transaction
             invoked_instruction.accounts[0].is_signer = true;
             assert_eq!(
                 invoke(&invoked_instruction, accounts),
@@ -254,6 +255,7 @@ fn process_instruction(
             );
             invoke(&invoked_instruction, accounts)?;
 
+            // Writable privilege escalation will always fail the whole transaction
             invoked_instruction.accounts[0].is_writable = true;
             assert_eq!(
                 invoke(&invoked_instruction, accounts),

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -18,7 +18,7 @@ use solana_sdk::{
     account::{Account, KeyedAccount},
     bpf_loader, bpf_loader_deprecated,
     client::SyncClient,
-    clock::DEFAULT_SLOTS_PER_EPOCH,
+    clock::{DEFAULT_SLOTS_PER_EPOCH, MAX_PROCESSING_AGE},
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
     entrypoint_native::{
         ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
@@ -28,7 +28,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, Signer},
     sysvar::{clock, fees, rent, rewards, slot_hashes, stake_history},
-    transaction::TransactionError,
+    transaction::{Transaction, TransactionError},
 };
 use std::{cell::RefCell, env, fs::File, io::Read, path::PathBuf, rc::Rc, sync::Arc};
 
@@ -96,6 +96,23 @@ fn run_program(
     );
     deserialize_parameters(&bpf_loader::id(), parameter_accounts, &parameter_bytes).unwrap();
     Ok(vm.get_total_instruction_count())
+}
+
+fn process_transaction_and_record_invoked(
+    bank: &Bank,
+    tx: Transaction,
+) -> (Result<(), TransactionError>, Vec<Vec<CompiledInstruction>>) {
+    let signature = tx.signatures.get(0).unwrap().clone();
+    let txs = vec![tx];
+    let tx_batch = bank.prepare_batch(&txs, None);
+    let (mut results, _, mut invoked) =
+        bank.load_execute_and_commit_transactions(&tx_batch, MAX_PROCESSING_AGE, false);
+    let invoked_instructions = invoked.swap_remove(0);
+    let result = results
+        .fee_collection_results
+        .swap_remove(0)
+        .and_then(|_| bank.get_signature_status(&signature).unwrap());
+    (result, invoked_instructions)
 }
 
 #[test]
@@ -482,61 +499,91 @@ fn test_program_bpf_invoke() {
             account_metas.clone(),
         );
         let message = Message::new(&[instruction], Some(&mint_pubkey));
-        assert!(bank_client
-            .send_and_confirm_message(
-                &[
-                    &mint_keypair,
-                    &argument_keypair,
-                    &invoked_argument_keypair,
-                    &from_keypair
-                ],
-                message,
-            )
-            .is_ok());
+        let tx = Transaction::new(
+            &[
+                &mint_keypair,
+                &argument_keypair,
+                &invoked_argument_keypair,
+                &from_keypair,
+            ],
+            message.clone(),
+            bank.last_blockhash(),
+        );
+        let (result, invoked_instructions) = process_transaction_and_record_invoked(&bank, tx);
+        assert!(result.is_ok());
+        let invoked_programs: Vec<Pubkey> = invoked_instructions[0]
+            .iter()
+            .map(|ix| message.account_keys[ix.program_id_index as usize].clone())
+            .collect();
+        assert_eq!(
+            invoked_programs,
+            vec![
+                solana_sdk::system_program::id(),
+                solana_sdk::system_program::id(),
+                invoked_program_id.clone(),
+                invoked_program_id.clone(),
+                invoked_program_id.clone(),
+                invoked_program_id.clone(),
+                invoked_program_id.clone(),
+                invoked_program_id.clone(),
+                invoked_program_id.clone(),
+            ]
+        );
 
         // failure cases
 
         let instruction = Instruction::new(
             invoke_program_id,
-            &TEST_PRIVILEGE_ESCALATION_SIGNER,
+            &[TEST_PRIVILEGE_ESCALATION_SIGNER, nonce1, nonce2, nonce3],
             account_metas.clone(),
         );
         let message = Message::new(&[instruction], Some(&mint_pubkey));
+        let tx = Transaction::new(
+            &[
+                &mint_keypair,
+                &argument_keypair,
+                &invoked_argument_keypair,
+                &from_keypair,
+            ],
+            message.clone(),
+            bank.last_blockhash(),
+        );
+
+        let (result, invoked_instructions) = process_transaction_and_record_invoked(&bank, tx);
+        let invoked_programs: Vec<Pubkey> = invoked_instructions[0]
+            .iter()
+            .map(|ix| message.account_keys[ix.program_id_index as usize].clone())
+            .collect();
+        assert_eq!(invoked_programs, vec![invoked_program_id.clone()]);
         assert_eq!(
-            bank_client
-                .send_and_confirm_message(
-                    &[
-                        &mint_keypair,
-                        &argument_keypair,
-                        &invoked_argument_keypair,
-                        &from_keypair
-                    ],
-                    message,
-                )
-                .unwrap_err()
-                .unwrap(),
+            result.unwrap_err(),
             TransactionError::InstructionError(0, InstructionError::Custom(194969602))
         );
 
         let instruction = Instruction::new(
             invoke_program_id,
-            &TEST_PRIVILEGE_ESCALATION_WRITABLE,
+            &[TEST_PRIVILEGE_ESCALATION_WRITABLE, nonce1, nonce2, nonce3],
             account_metas.clone(),
         );
         let message = Message::new(&[instruction], Some(&mint_pubkey));
+        let tx = Transaction::new(
+            &[
+                &mint_keypair,
+                &argument_keypair,
+                &invoked_argument_keypair,
+                &from_keypair,
+            ],
+            message.clone(),
+            bank.last_blockhash(),
+        );
+        let (result, invoked_instructions) = process_transaction_and_record_invoked(&bank, tx);
+        let invoked_programs: Vec<Pubkey> = invoked_instructions[0]
+            .iter()
+            .map(|ix| message.account_keys[ix.program_id_index as usize].clone())
+            .collect();
+        assert_eq!(invoked_programs, vec![invoked_program_id.clone()]);
         assert_eq!(
-            bank_client
-                .send_and_confirm_message(
-                    &[
-                        &mint_keypair,
-                        &argument_keypair,
-                        &invoked_argument_keypair,
-                        &from_keypair
-                    ],
-                    message,
-                )
-                .unwrap_err()
-                .unwrap(),
+            result.unwrap_err(),
             TransactionError::InstructionError(0, InstructionError::Custom(194969602))
         );
 
@@ -639,6 +686,7 @@ impl InvokeContext for MockInvokeContext {
     fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         None
     }
+    fn record_instruction(&self, _instruction: Instruction) {}
 }
 
 #[derive(Debug, Default, Clone)]

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -106,13 +106,16 @@ fn process_transaction_and_record_invoked(
     let txs = vec![tx];
     let tx_batch = bank.prepare_batch(&txs, None);
     let (mut results, _, mut invoked) =
-        bank.load_execute_and_commit_transactions(&tx_batch, MAX_PROCESSING_AGE, false);
+        bank.load_execute_and_commit_transactions(&tx_batch, MAX_PROCESSING_AGE, false, true);
     let invoked_instructions = invoked.swap_remove(0);
     let result = results
         .fee_collection_results
         .swap_remove(0)
         .and_then(|_| bank.get_signature_status(&signature).unwrap());
-    (result, invoked_instructions)
+    (
+        result,
+        invoked_instructions.expect("cpi recording should be enabled"),
+    )
 }
 
 #[test]
@@ -686,7 +689,7 @@ impl InvokeContext for MockInvokeContext {
     fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         None
     }
-    fn record_instruction(&self, _instruction: Instruction) {}
+    fn record_instruction(&self, _instruction: &Instruction) {}
 }
 
 #[derive(Debug, Default, Clone)]

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -270,11 +270,15 @@ impl Executor for BPFExecutor {
 mod tests {
     use super::*;
     use rand::Rng;
-    use solana_runtime::message_processor::{Executors, ThisInvokeContext};
+    use solana_runtime::{
+        instruction_recorder::InstructionRecorder,
+        message_processor::{Executors, ThisInvokeContext},
+    };
     use solana_sdk::{
         account::Account,
         entrypoint_native::{ComputeBudget, Logger, ProcessInstruction},
         instruction::CompiledInstruction,
+        instruction::Instruction,
         message::Message,
         rent::Rent,
     };
@@ -360,6 +364,7 @@ mod tests {
         fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
             None
         }
+        fn record_instruction(&self, _instruction: Instruction) {}
     }
 
     struct TestInstructionMeter {
@@ -587,6 +592,7 @@ mod tests {
                 max_invoke_depth: 2,
             },
             Rc::new(RefCell::new(Executors::default())),
+            InstructionRecorder::default(),
         );
         assert_eq!(
             Err(InstructionError::Custom(194969602)),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -270,10 +270,7 @@ impl Executor for BPFExecutor {
 mod tests {
     use super::*;
     use rand::Rng;
-    use solana_runtime::{
-        instruction_recorder::InstructionRecorder,
-        message_processor::{Executors, ThisInvokeContext},
-    };
+    use solana_runtime::message_processor::{Executors, ThisInvokeContext};
     use solana_sdk::{
         account::Account,
         entrypoint_native::{ComputeBudget, Logger, ProcessInstruction},
@@ -364,7 +361,7 @@ mod tests {
         fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
             None
         }
-        fn record_instruction(&self, _instruction: Instruction) {}
+        fn record_instruction(&self, _instruction: &Instruction) {}
     }
 
     struct TestInstructionMeter {
@@ -592,7 +589,7 @@ mod tests {
                 max_invoke_depth: 2,
             },
             Rc::new(RefCell::new(Executors::default())),
-            InstructionRecorder::default(),
+            None,
         );
         assert_eq!(
             Err(InstructionError::Custom(194969602)),

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1020,7 +1020,7 @@ fn call<'a>(
         ro_regions,
     )?;
     verify_instruction(syscall, &instruction, &signers)?;
-    invoke_context.record_instruction(instruction.clone());
+    invoke_context.record_instruction(&instruction);
     let message = Message::new(&[instruction], None);
     let callee_program_id_index = message.instructions[0].program_id_index as usize;
     let callee_program_id = message.account_keys[callee_program_id_index];

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1020,6 +1020,7 @@ fn call<'a>(
         ro_regions,
     )?;
     verify_instruction(syscall, &instruction, &signers)?;
+    invoke_context.record_instruction(instruction.clone());
     let message = Message::new(&[instruction], None);
     let callee_program_id_index = message.instructions[0].program_id_index as usize;
     let callee_program_id = message.account_keys[callee_program_id_index];

--- a/runtime/src/instruction_recorder.rs
+++ b/runtime/src/instruction_recorder.rs
@@ -1,0 +1,26 @@
+use std::{cell::RefCell, rc::Rc};
+
+use solana_sdk::{
+    instruction::{CompiledInstruction, Instruction},
+    message::Message,
+};
+
+/// Records and compiles cross-program invoked instructions
+#[derive(Clone, Default)]
+pub struct InstructionRecorder {
+    inner: Rc<RefCell<Vec<Instruction>>>,
+}
+
+impl InstructionRecorder {
+    pub fn compile_instructions(&self, message: &Message) -> Vec<CompiledInstruction> {
+        self.inner
+            .borrow()
+            .iter()
+            .map(|ix| message.compile_instruction(ix))
+            .collect()
+    }
+
+    pub fn record_instruction(&self, instruction: Instruction) {
+        self.inner.borrow_mut().push(instruction);
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,6 +14,7 @@ pub mod commitment;
 pub mod epoch_stakes;
 pub mod genesis_utils;
 pub mod hardened_unpack;
+pub mod instruction_recorder;
 pub mod loader_utils;
 pub mod log_collector;
 pub mod message_processor;

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1,5 +1,6 @@
 use crate::{
-    log_collector::LogCollector, native_loader::NativeLoader, rent_collector::RentCollector,
+    instruction_recorder::InstructionRecorder, log_collector::LogCollector,
+    native_loader::NativeLoader, rent_collector::RentCollector,
 };
 use log::*;
 use serde::{Deserialize, Serialize};
@@ -11,7 +12,7 @@ use solana_sdk::{
         Executor, InvokeContext, Logger, ProcessInstruction, ProcessInstructionWithContext,
     },
     genesis_config::ClusterType,
-    instruction::{CompiledInstruction, InstructionError},
+    instruction::{CompiledInstruction, Instruction, InstructionError},
     message::Message,
     native_loader,
     pubkey::Pubkey,
@@ -206,6 +207,7 @@ pub struct ThisInvokeContext {
     compute_budget: ComputeBudget,
     compute_meter: Rc<RefCell<dyn ComputeMeter>>,
     executors: Rc<RefCell<Executors>>,
+    instruction_recorder: InstructionRecorder,
 }
 impl ThisInvokeContext {
     pub fn new(
@@ -217,6 +219,7 @@ impl ThisInvokeContext {
         is_cross_program_supported: bool,
         compute_budget: ComputeBudget,
         executors: Rc<RefCell<Executors>>,
+        instruction_recorder: InstructionRecorder,
     ) -> Self {
         let mut program_ids = Vec::with_capacity(compute_budget.max_invoke_depth);
         program_ids.push(*program_id);
@@ -232,6 +235,7 @@ impl ThisInvokeContext {
                 remaining: compute_budget.max_units,
             })),
             executors,
+            instruction_recorder,
         }
     }
 }
@@ -293,6 +297,9 @@ impl InvokeContext for ThisInvokeContext {
     }
     fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         self.executors.borrow().get(&pubkey)
+    }
+    fn record_instruction(&self, instruction: Instruction) {
+        self.instruction_recorder.record_instruction(instruction);
     }
 }
 pub struct ThisLogger {
@@ -667,6 +674,7 @@ impl MessageProcessor {
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
         executors: Rc<RefCell<Executors>>,
+        instruction_recorder: InstructionRecorder,
         instruction_index: usize,
         cluster_type: ClusterType,
         epoch: Epoch,
@@ -696,6 +704,7 @@ impl MessageProcessor {
             self.is_cross_program_supported,
             self.compute_budget,
             executors,
+            instruction_recorder,
         );
         let keyed_accounts =
             Self::create_keyed_accounts(message, instruction, executable_accounts, accounts)?;
@@ -714,6 +723,7 @@ impl MessageProcessor {
     /// Process a message.
     /// This method calls each instruction in the message over the set of loaded Accounts
     /// The accounts are committed back to the bank only if every instruction succeeds
+    #[allow(clippy::too_many_arguments)]
     pub fn process_message(
         &self,
         message: &Message,
@@ -722,10 +732,13 @@ impl MessageProcessor {
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
         executors: Rc<RefCell<Executors>>,
+        instruction_recorders: &mut Vec<InstructionRecorder>,
         cluster_type: ClusterType,
         epoch: Epoch,
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
+            let instruction_recorder = InstructionRecorder::default();
+            instruction_recorders.push(instruction_recorder.clone());
             self.execute_instruction(
                 message,
                 instruction,
@@ -734,6 +747,7 @@ impl MessageProcessor {
                 rent_collector,
                 log_collector.clone(),
                 executors.clone(),
+                instruction_recorder,
                 instruction_index,
                 cluster_type,
                 epoch,
@@ -794,6 +808,7 @@ mod tests {
             true,
             ComputeBudget::default(),
             Rc::new(RefCell::new(Executors::default())),
+            InstructionRecorder::default(),
         );
 
         // Check call depth increases and has a limit
@@ -1329,6 +1344,7 @@ mod tests {
             &rent_collector,
             None,
             executors.clone(),
+            &mut vec![],
             ClusterType::Development,
             0,
         );
@@ -1352,6 +1368,7 @@ mod tests {
             &rent_collector,
             None,
             executors.clone(),
+            &mut vec![],
             ClusterType::Development,
             0,
         );
@@ -1379,6 +1396,7 @@ mod tests {
             &rent_collector,
             None,
             executors,
+            &mut vec![],
             ClusterType::Development,
             0,
         );
@@ -1489,6 +1507,7 @@ mod tests {
             &rent_collector,
             None,
             executors.clone(),
+            &mut vec![],
             ClusterType::Development,
             0,
         );
@@ -1516,6 +1535,7 @@ mod tests {
             &rent_collector,
             None,
             executors.clone(),
+            &mut vec![],
             ClusterType::Development,
             0,
         );
@@ -1540,6 +1560,7 @@ mod tests {
             &rent_collector,
             None,
             executors,
+            &mut vec![],
             ClusterType::Development,
             0,
         );
@@ -1618,6 +1639,7 @@ mod tests {
             true,
             ComputeBudget::default(),
             Rc::new(RefCell::new(Executors::default())),
+            InstructionRecorder::default(),
         );
         let metas = vec![
             AccountMeta::new(owned_key, false),

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -3,8 +3,10 @@
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 use crate::abi_example::AbiExample;
 use crate::{
-    account::Account, account::KeyedAccount, instruction::CompiledInstruction,
-    instruction::InstructionError, message::Message, pubkey::Pubkey,
+    account::{Account, KeyedAccount},
+    instruction::{CompiledInstruction, Instruction, InstructionError},
+    message::Message,
+    pubkey::Pubkey,
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
@@ -225,6 +227,8 @@ pub trait InvokeContext {
     fn add_executor(&mut self, pubkey: &Pubkey, executor: Arc<dyn Executor>);
     /// Get the completed loader work that can be re-used across executions
     fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>>;
+    /// Record invoked instruction
+    fn record_instruction(&self, instruction: Instruction);
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -228,7 +228,7 @@ pub trait InvokeContext {
     /// Get the completed loader work that can be re-used across executions
     fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>>;
     /// Record invoked instruction
-    fn record_instruction(&self, instruction: Instruction);
+    fn record_instruction(&self, instruction: &Instruction);
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -272,6 +272,10 @@ impl Message {
         Self::new(&instructions, payer)
     }
 
+    pub fn compile_instruction(&self, ix: &Instruction) -> CompiledInstruction {
+        compile_instruction(ix, &self.account_keys)
+    }
+
     pub fn serialize(&self) -> Vec<u8> {
         bincode::serialize(self).unwrap()
     }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -9,7 +9,7 @@ use solana_sdk::{
 };
 use solana_transaction_status::{
     ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature,
-    InvokedInstructions, Rewards, TransactionStatus, TransactionStatusMeta,
+    InnerInstructions, Rewards, TransactionStatus, TransactionStatusMeta,
     TransactionWithStatusMeta,
 };
 use std::collections::HashMap;
@@ -162,7 +162,7 @@ struct StoredConfirmedBlockTransactionStatusMeta {
     fee: u64,
     pre_balances: Vec<u64>,
     post_balances: Vec<u64>,
-    invoked: Option<Vec<InvokedInstructions>>,
+    inner_instructions: Option<Vec<InnerInstructions>>,
 }
 
 impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
@@ -172,7 +172,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             fee,
             pre_balances,
             post_balances,
-            invoked,
+            inner_instructions,
         } = value;
         let status = match &err {
             None => Ok(()),
@@ -183,7 +183,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             fee,
             pre_balances,
             post_balances,
-            invoked,
+            inner_instructions,
         }
     }
 }
@@ -195,7 +195,7 @@ impl From<TransactionStatusMeta> for StoredConfirmedBlockTransactionStatusMeta {
             fee,
             pre_balances,
             post_balances,
-            invoked,
+            inner_instructions,
             ..
         } = value;
         Self {
@@ -203,7 +203,7 @@ impl From<TransactionStatusMeta> for StoredConfirmedBlockTransactionStatusMeta {
             fee,
             pre_balances,
             post_balances,
-            invoked,
+            inner_instructions,
         }
     }
 }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -8,8 +8,9 @@ use solana_sdk::{
     transaction::{Transaction, TransactionError},
 };
 use solana_transaction_status::{
-    ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature, Rewards,
-    TransactionStatus, TransactionStatusMeta, TransactionWithStatusMeta,
+    ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature,
+    InvokedInstructions, Rewards, TransactionStatus, TransactionStatusMeta,
+    TransactionWithStatusMeta,
 };
 use std::collections::HashMap;
 use thiserror::Error;
@@ -161,6 +162,7 @@ struct StoredConfirmedBlockTransactionStatusMeta {
     fee: u64,
     pre_balances: Vec<u64>,
     post_balances: Vec<u64>,
+    invoked: Option<Vec<InvokedInstructions>>,
 }
 
 impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
@@ -170,6 +172,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             fee,
             pre_balances,
             post_balances,
+            invoked,
         } = value;
         let status = match &err {
             None => Ok(()),
@@ -180,6 +183,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             fee,
             pre_balances,
             post_balances,
+            invoked,
         }
     }
 }
@@ -191,6 +195,7 @@ impl From<TransactionStatusMeta> for StoredConfirmedBlockTransactionStatusMeta {
             fee,
             pre_balances,
             post_balances,
+            invoked,
             ..
         } = value;
         Self {
@@ -198,6 +203,7 @@ impl From<TransactionStatusMeta> for StoredConfirmedBlockTransactionStatusMeta {
             fee,
             pre_balances,
             post_balances,
+            invoked,
         }
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -15,7 +15,7 @@ use solana_sdk::{
     clock::{Slot, UnixTimestamp},
     commitment_config::CommitmentConfig,
     instruction::CompiledInstruction,
-    message::MessageHeader,
+    message::{Message, MessageHeader},
     pubkey::Pubkey,
     signature::Signature,
     transaction::{Result, Transaction, TransactionError},
@@ -34,6 +34,19 @@ pub enum UiInstruction {
 pub enum UiParsedInstruction {
     Parsed(ParsedInstruction),
     PartiallyDecoded(UiPartiallyDecodedInstruction),
+}
+
+impl UiInstruction {
+    fn parse(instruction: &CompiledInstruction, message: &Message) -> Self {
+        let program_id = instruction.program_id(&message.account_keys);
+        if let Ok(parsed_instruction) = parse(program_id, instruction, &message.account_keys) {
+            UiInstruction::Parsed(UiParsedInstruction::Parsed(parsed_instruction))
+        } else {
+            UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(
+                UiPartiallyDecodedInstruction::from(instruction, &message.account_keys),
+            ))
+        }
+    }
 }
 
 /// A duplicate representation of a CompiledInstruction for pretty JSON serialization
@@ -79,12 +92,56 @@ impl UiPartiallyDecodedInstruction {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct InvokedInstructions {
+    /// Transaction instruction index
+    pub index: u8,
+    /// List of invoked instructions
+    pub instructions: Vec<CompiledInstruction>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiInvokedInstructions {
+    /// Transaction instruction index
+    pub index: u8,
+    /// List of invoked instructions
+    pub instructions: Vec<UiInstruction>,
+}
+
+impl UiInvokedInstructions {
+    fn parse(invoked: InvokedInstructions, message: &Message) -> Self {
+        Self {
+            index: invoked.index,
+            instructions: invoked
+                .instructions
+                .iter()
+                .map(|ix| UiInstruction::parse(ix, message))
+                .collect(),
+        }
+    }
+}
+
+impl From<InvokedInstructions> for UiInvokedInstructions {
+    fn from(invoked: InvokedInstructions) -> Self {
+        Self {
+            index: invoked.index,
+            instructions: invoked
+                .instructions
+                .iter()
+                .map(|ix| UiInstruction::Compiled(ix.into()))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionStatusMeta {
     pub status: Result<()>,
     pub fee: u64,
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
+    pub invoked: Option<Vec<InvokedInstructions>>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -94,6 +151,7 @@ impl Default for TransactionStatusMeta {
             fee: 0,
             pre_balances: vec![],
             post_balances: vec![],
+            invoked: None,
         }
     }
 }
@@ -107,6 +165,24 @@ pub struct UiTransactionStatusMeta {
     pub fee: u64,
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
+    pub invoked: Option<Vec<UiInvokedInstructions>>,
+}
+
+impl UiTransactionStatusMeta {
+    fn parse(meta: TransactionStatusMeta, message: &Message) -> Self {
+        Self {
+            err: meta.status.clone().err(),
+            status: meta.status,
+            fee: meta.fee,
+            pre_balances: meta.pre_balances,
+            post_balances: meta.post_balances,
+            invoked: meta.invoked.map(|ixs| {
+                ixs.into_iter()
+                    .map(|ix| UiInvokedInstructions::parse(ix, message))
+                    .collect()
+            }),
+        }
+    }
 }
 
 impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
@@ -117,6 +193,9 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
             fee: meta.fee,
             pre_balances: meta.pre_balances,
             post_balances: meta.post_balances,
+            invoked: meta
+                .invoked
+                .map(|ixs| ixs.into_iter().map(|ix| ix.into()).collect()),
         }
     }
 }
@@ -261,9 +340,11 @@ pub struct TransactionWithStatusMeta {
 
 impl TransactionWithStatusMeta {
     fn encode(self, encoding: UiTransactionEncoding) -> EncodedTransactionWithStatusMeta {
+        let message = self.transaction.message();
+        let meta = self.meta.map(|meta| meta.encode(encoding, message));
         EncodedTransactionWithStatusMeta {
             transaction: EncodedTransaction::encode(self.transaction, encoding),
-            meta: self.meta.map(|meta| meta.into()),
+            meta,
         }
     }
 }
@@ -273,6 +354,15 @@ impl TransactionWithStatusMeta {
 pub struct EncodedTransactionWithStatusMeta {
     pub transaction: EncodedTransaction,
     pub meta: Option<UiTransactionStatusMeta>,
+}
+
+impl TransactionStatusMeta {
+    fn encode(self, encoding: UiTransactionEncoding, message: &Message) -> UiTransactionStatusMeta {
+        match encoding {
+            UiTransactionEncoding::JsonParsed => UiTransactionStatusMeta::parse(self, message),
+            _ => self.into(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
@@ -334,24 +424,7 @@ impl EncodedTransaction {
                             .instructions
                             .iter()
                             .map(|instruction| {
-                                let program_id =
-                                    instruction.program_id(&transaction.message.account_keys);
-                                if let Ok(parsed_instruction) = parse(
-                                    program_id,
-                                    instruction,
-                                    &transaction.message.account_keys,
-                                ) {
-                                    UiInstruction::Parsed(UiParsedInstruction::Parsed(
-                                        parsed_instruction,
-                                    ))
-                                } else {
-                                    UiInstruction::Parsed(UiParsedInstruction::PartiallyDecoded(
-                                        UiPartiallyDecodedInstruction::from(
-                                            instruction,
-                                            &transaction.message.account_keys,
-                                        ),
-                                    ))
-                                }
+                                UiInstruction::parse(instruction, &transaction.message)
                             })
                             .collect(),
                     })

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -92,27 +92,27 @@ impl UiPartiallyDecodedInstruction {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct InvokedInstructions {
+pub struct InnerInstructions {
     /// Transaction instruction index
     pub index: u8,
-    /// List of invoked instructions
+    /// List of inner instructions
     pub instructions: Vec<CompiledInstruction>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct UiInvokedInstructions {
+pub struct UiInnerInstructions {
     /// Transaction instruction index
     pub index: u8,
-    /// List of invoked instructions
+    /// List of inner instructions
     pub instructions: Vec<UiInstruction>,
 }
 
-impl UiInvokedInstructions {
-    fn parse(invoked: InvokedInstructions, message: &Message) -> Self {
+impl UiInnerInstructions {
+    fn parse(inner_instructions: InnerInstructions, message: &Message) -> Self {
         Self {
-            index: invoked.index,
-            instructions: invoked
+            index: inner_instructions.index,
+            instructions: inner_instructions
                 .instructions
                 .iter()
                 .map(|ix| UiInstruction::parse(ix, message))
@@ -121,11 +121,11 @@ impl UiInvokedInstructions {
     }
 }
 
-impl From<InvokedInstructions> for UiInvokedInstructions {
-    fn from(invoked: InvokedInstructions) -> Self {
+impl From<InnerInstructions> for UiInnerInstructions {
+    fn from(inner_instructions: InnerInstructions) -> Self {
         Self {
-            index: invoked.index,
-            instructions: invoked
+            index: inner_instructions.index,
+            instructions: inner_instructions
                 .instructions
                 .iter()
                 .map(|ix| UiInstruction::Compiled(ix.into()))
@@ -141,7 +141,7 @@ pub struct TransactionStatusMeta {
     pub fee: u64,
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
-    pub invoked: Option<Vec<InvokedInstructions>>,
+    pub inner_instructions: Option<Vec<InnerInstructions>>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -151,7 +151,7 @@ impl Default for TransactionStatusMeta {
             fee: 0,
             pre_balances: vec![],
             post_balances: vec![],
-            invoked: None,
+            inner_instructions: None,
         }
     }
 }
@@ -165,7 +165,7 @@ pub struct UiTransactionStatusMeta {
     pub fee: u64,
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
-    pub invoked: Option<Vec<UiInvokedInstructions>>,
+    pub inner_instructions: Option<Vec<UiInnerInstructions>>,
 }
 
 impl UiTransactionStatusMeta {
@@ -176,9 +176,9 @@ impl UiTransactionStatusMeta {
             fee: meta.fee,
             pre_balances: meta.pre_balances,
             post_balances: meta.post_balances,
-            invoked: meta.invoked.map(|ixs| {
+            inner_instructions: meta.inner_instructions.map(|ixs| {
                 ixs.into_iter()
-                    .map(|ix| UiInvokedInstructions::parse(ix, message))
+                    .map(|ix| UiInnerInstructions::parse(ix, message))
                     .collect()
             }),
         }
@@ -193,8 +193,8 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
             fee: meta.fee,
             pre_balances: meta.pre_balances,
             post_balances: meta.post_balances,
-            invoked: meta
-                .invoked
+            inner_instructions: meta
+                .inner_instructions
                 .map(|ixs| ixs.into_iter().map(|ix| ix.into()).collect()),
         }
     }


### PR DESCRIPTION
#### Problem
It's not possible to determine which CPI's were run during transaction execution. This is because we do not currently do not track this info outside of the message processor and do not store that information in RocksDB / BigTable.

#### Summary of Changes
- Record each invoked instruction when `--enable-cpi-instruction-recording` flag is present
- Store compiled invoked instructions in transaction meta in rocksdb and bigtable
- Use `Option` to denote the difference between 0 invoked instructions and missing info

Fixes https://github.com/solana-labs/solana/issues/11753
