### PR TITLE
Give the duplicate send_transaction_service a different thread name

### DIFF
--- a/core/src/send_transaction_service.rs
+++ b/core/src/send_transaction_service.rs
@@ -116,7 +116,7 @@ impl SendTransactionService {
         }
 
         Builder::new()
-            .name("send-tx-svc".to_string())
+            .name("send-tx-sv2".to_string())
             .spawn(move || loop {
                 if exit.load(Ordering::Relaxed) {
                     break;


### PR DESCRIPTION
There are two SendTransactionServices (🤕) and they both use the name thread name, so we can't tell which one (both?!) is misbehaving at https://github.com/solana-labs/solana/issues/12317