### PR TITLE
SendTransactionServices now exit their thread on channel drop instead of by a flag

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -25,7 +25,6 @@ use std::{
     io,
     net::{Ipv4Addr, SocketAddr},
     sync::{
-        atomic::AtomicBool,
         mpsc::{channel, Receiver, Sender},
         Arc, RwLock,
     },
@@ -250,14 +249,8 @@ pub async fn start_tcp_server(
         // the generated Banks trait.
         .map(move |chan| {
             let (sender, receiver) = channel();
-            let exit_send_transaction_service = Arc::new(AtomicBool::new(false));
 
-            SendTransactionService::new(
-                tpu_addr,
-                &bank_forks,
-                &exit_send_transaction_service,
-                receiver,
-            );
+            SendTransactionService::new(tpu_addr, &bank_forks, receiver);
 
             let server =
                 BanksServer::new(bank_forks.clone(), block_commitment_cache.clone(), sender);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -218,7 +218,7 @@ impl JsonRpcRequestProcessor {
         let cluster_info = Arc::new(ClusterInfo::default());
         let tpu_address = cluster_info.my_contact_info().tpu;
         let (sender, receiver) = channel();
-        SendTransactionService::new(tpu_address, &bank_forks, None, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
         Self {
             config: JsonRpcConfig::default(),
@@ -2686,7 +2686,7 @@ pub mod tests {
             &runtime::Runtime::new().unwrap(),
             None,
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
         cluster_info.insert_info(ContactInfo::new_with_pubkey_socketaddr(
             &leader_pubkey,
@@ -3998,7 +3998,7 @@ pub mod tests {
             &runtime::Runtime::new().unwrap(),
             None,
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["37u9WtQpcm6ULa3Vmu7ySnANv"]}"#;
         let res = io.handle_request_sync(req, meta);
@@ -4039,7 +4039,7 @@ pub mod tests {
             &runtime::Runtime::new().unwrap(),
             None,
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
         let mut bad_transaction =
             system_transaction::transfer(&mint_keypair, &Pubkey::new_rand(), 42, Hash::default());
@@ -4221,7 +4221,7 @@ pub mod tests {
             &runtime::Runtime::new().unwrap(),
             None,
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
         assert_eq!(request_processor.validator_exit(), false);
         assert_eq!(exit.load(Ordering::Relaxed), false);
     }
@@ -4250,7 +4250,7 @@ pub mod tests {
             &runtime::Runtime::new().unwrap(),
             None,
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
         assert_eq!(request_processor.validator_exit(), true);
         assert_eq!(exit.load(Ordering::Relaxed), true);
     }
@@ -4336,7 +4336,7 @@ pub mod tests {
             &runtime::Runtime::new().unwrap(),
             None,
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, &exit, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
         assert_eq!(
             request_processor.get_block_commitment(0),
             RpcBlockCommitment {

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -313,14 +313,12 @@ impl JsonRpcService {
             bigtable_ledger_storage,
         );
 
-        let exit_send_transaction_service = Arc::new(AtomicBool::new(false));
         let leader_info =
             poh_recorder.map(|recorder| LeaderInfo::new(cluster_info.clone(), recorder));
         let _send_transaction_service = Arc::new(SendTransactionService::new(
             tpu_address,
             &bank_forks,
             leader_info,
-            &exit_send_transaction_service,
             receiver,
         ));
 
@@ -369,7 +367,6 @@ impl JsonRpcService {
                 let server = server.unwrap();
                 close_handle_sender.send(server.close_handle()).unwrap();
                 server.wait();
-                exit_send_transaction_service.store(true, Ordering::Relaxed);
                 exit_bigtable_ledger_upload_service.store(true, Ordering::Relaxed);
             })
             .unwrap();

--- a/core/src/send_transaction_service.rs
+++ b/core/src/send_transaction_service.rs
@@ -116,7 +116,7 @@ impl SendTransactionService {
         }
 
         Builder::new()
-            .name("send-tx-svc".to_string())
+            .name("send-tx-sv2".to_string())
             .spawn(move || loop {
                 if exit.load(Ordering::Relaxed) {
                     break;


### PR DESCRIPTION
BanksServer was not properly exiting its SendTransactionService as it wasn't setting the exit flag.  Rework both SendTransactionServices to remove the exit flag and just exit on channel drop instead.  Less error prone, we need to exit in this case anyway, and also fixes #12317.
