### PR TITLE
Add blocktime column to blockstore

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -136,6 +136,7 @@ pub struct Blockstore {
     transaction_status_index_cf: LedgerColumn<cf::TransactionStatusIndex>,
     active_transaction_status_index: RwLock<u64>,
     rewards_cf: LedgerColumn<cf::Rewards>,
+    _blocktime_cf: LedgerColumn<cf::Blocktime>,
     last_root: Arc<RwLock<Slot>>,
     insert_shreds_lock: Arc<Mutex<()>>,
     pub new_shreds_signals: Vec<SyncSender<bool>>,
@@ -291,6 +292,9 @@ impl Blockstore {
         let address_signatures_cf = db.column();
         let transaction_status_index_cf = db.column();
         let rewards_cf = db.column();
+        // This column is created (but never populated) in order to maintain compatibility with
+        // newer versions of Blockstore.
+        let _blocktime_cf = db.column();
 
         let db = Arc::new(db);
 
@@ -335,6 +339,7 @@ impl Blockstore {
             transaction_status_index_cf,
             active_transaction_status_index: RwLock::new(active_transaction_status_index),
             rewards_cf,
+            _blocktime_cf,
             new_shreds_signals: vec![],
             completed_slots_senders: vec![],
             insert_shreds_lock: Arc::new(Mutex::new(())),

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -133,6 +133,10 @@ impl Blockstore {
             & self
                 .db
                 .delete_range_cf::<cf::Rewards>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
+                .delete_range_cf::<cf::Blocktime>(&mut write_batch, from_slot, to_slot)
                 .is_ok();
         let mut w_active_transaction_status_index =
             self.active_transaction_status_index.write().unwrap();
@@ -222,6 +226,10 @@ impl Blockstore {
                 .unwrap_or(false)
             && self
                 .rewards_cf
+                .compact_range(from_slot, to_slot)
+                .unwrap_or(false)
+            && self
+                ._blocktime_cf
                 .compact_range(from_slot, to_slot)
                 .unwrap_or(false);
         compact_timer.stop();

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -10,7 +10,11 @@ use rocksdb::{
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use solana_runtime::hardened_unpack::UnpackError;
-use solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature};
+use solana_sdk::{
+    clock::{Slot, UnixTimestamp},
+    pubkey::Pubkey,
+    signature::Signature,
+};
 use solana_transaction_status::{Rewards, TransactionStatusMeta};
 use std::{collections::HashMap, fs, marker::PhantomData, path::Path, sync::Arc};
 use thiserror::Error;
@@ -46,6 +50,8 @@ const ADDRESS_SIGNATURES_CF: &str = "address_signatures";
 const TRANSACTION_STATUS_INDEX_CF: &str = "transaction_status_index";
 /// Column family for Rewards
 const REWARDS_CF: &str = "rewards";
+/// Column family for Blocktime
+const BLOCKTIME_CF: &str = "blocktime";
 
 #[derive(Error, Debug)]
 pub enum BlockstoreError {
@@ -128,6 +134,10 @@ pub mod columns {
     #[derive(Debug)]
     /// The rewards column
     pub struct Rewards;
+
+    #[derive(Debug)]
+    /// The blocktime column
+    pub struct Blocktime;
 }
 
 pub enum AccessType {
@@ -187,8 +197,9 @@ impl Rocks {
         recovery_mode: Option<BlockstoreRecoveryMode>,
     ) -> Result<Rocks> {
         use columns::{
-            AddressSignatures, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans, Rewards,
-            Root, ShredCode, ShredData, SlotMeta, TransactionStatus, TransactionStatusIndex,
+            AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
+            Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
+            TransactionStatusIndex,
         };
 
         fs::create_dir_all(&path)?;
@@ -221,6 +232,8 @@ impl Rocks {
         let transaction_status_index_cf_descriptor =
             ColumnFamilyDescriptor::new(TransactionStatusIndex::NAME, get_cf_options());
         let rewards_cf_descriptor = ColumnFamilyDescriptor::new(Rewards::NAME, get_cf_options());
+        let blocktime_cf_descriptor =
+            ColumnFamilyDescriptor::new(Blocktime::NAME, get_cf_options());
 
         let cfs = vec![
             (SlotMeta::NAME, meta_cf_descriptor),
@@ -239,6 +252,7 @@ impl Rocks {
                 transaction_status_index_cf_descriptor,
             ),
             (Rewards::NAME, rewards_cf_descriptor),
+            (Blocktime::NAME, blocktime_cf_descriptor),
         ];
 
         // Open the database
@@ -276,8 +290,9 @@ impl Rocks {
 
     fn columns(&self) -> Vec<&'static str> {
         use columns::{
-            AddressSignatures, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans, Rewards,
-            Root, ShredCode, ShredData, SlotMeta, TransactionStatus, TransactionStatusIndex,
+            AddressSignatures, Blocktime, DeadSlots, DuplicateSlots, ErasureMeta, Index, Orphans,
+            Rewards, Root, ShredCode, ShredData, SlotMeta, TransactionStatus,
+            TransactionStatusIndex,
         };
 
         vec![
@@ -294,6 +309,7 @@ impl Rocks {
             AddressSignatures::NAME,
             TransactionStatusIndex::NAME,
             Rewards::NAME,
+            Blocktime::NAME,
         ]
     }
 
@@ -517,6 +533,14 @@ impl ColumnName for columns::Rewards {
 }
 impl TypedColumn for columns::Rewards {
     type Type = Rewards;
+}
+
+impl SlotColumn for columns::Blocktime {}
+impl ColumnName for columns::Blocktime {
+    const NAME: &'static str = BLOCKTIME_CF;
+}
+impl TypedColumn for columns::Blocktime {
+    type Type = UnixTimestamp;
 }
 
 impl Column for columns::ShredCode {


### PR DESCRIPTION
#### Problem
v1.3 cannot currently open ledgers built off of the tip of master due to the addition of the blockstore_db Blocktime column. Rocksdb cannot open databases that contain extra columns.

#### Summary of Changes
Add the Blocktime column to blockstore_db, including purge and compaction logic.
