### PR TITLE
Docs: Unbreak 'Listening for Deposits' section

### DIFF
--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -130,77 +130,6 @@ greater security. If so, you will need to move SOL to hot accounts using our
 When a user wants to deposit SOL into your exchange, instruct them to send a
 transfer to the appropriate deposit address.
 
-## Validating User-supplied Account Addresses for Withdrawals in SOL
-
-As withdrawals are irreversible, it may be a good practice to validate the
-account address before authorizing withdrawals into user-supplied accounts
-to prevent accidental user's fund loss.
-
-For a normal account in Solana, its address is simply a Base58-encoded
-actual 256-bit public key of ed25519. Because not all bit pattern is a valid
-public key for the ed25519, it's possible to make sure user-supplied
-account addresses are at least something that may be a correct ed25519 public
-key.
-
-### Java
-
-You can check Solana's normal account address validity by first decoding
-Base58 string and ensuring the decoded bytes are valid ed25519 public keys
-like this:
-
-The following code sample assumes you're using the Maven.
-
-`pom.xml`:
-
-```xml
-<repositories>
-  ...
-  <repository>
-    <id>spring</id>
-    <url>https://repo.spring.io/libs-release/</url>
-  </repository>
-</repositories>
-
-...
-
-<dependencies>
-  ...
-  <dependency>
-      <groupId>io.github.novacrypto</groupId>
-      <artifactId>Base58</artifactId>
-      <version>0.1.3</version>
-  </dependency>
-  <dependency>
-      <groupId>cafe.cryptography</groupId>
-      <artifactId>curve25519-elisabeth</artifactId>
-      <version>0.1.0</version>
-  </dependency>
-<dependencies>
-```
-
-```java
-import io.github.novacrypto.base58.Base58;
-import cafe.cryptography.curve25519.CompressedEdwardsY;
-
-public class PubkeyValidator
-{
-    public static boolean verifyPubkey(String userProvidedPubkey)
-    {
-        try {
-            return _verifyPubkeyInternal(userProvidedPubkey);
-        } catch (Exception e) {
-            return false;
-        }
-    }
-
-    public static boolean _verifyPubkeyInternal(String maybePubkey) throws Exception
-    {
-        byte[] bytes = Base58.base58Decode(maybePubkey);
-        return !(new CompressedEdwardsY(bytes)).decompress().isSmallOrder();
-    }
-}
-```
-
 ### Poll for Blocks
 
 The easiest way to track all the deposit accounts for your exchange is to poll
@@ -487,6 +416,75 @@ You can also doublecheck whether a particular blockhash is still valid by sendin
 [`getFeeCalculatorForBlockhash`](../apps/jsonrpc-api.md#getfeecalculatorforblockhash)
 request with the blockhash as a parameter. If the response value is null, the
 blockhash is expired, and the withdrawal transaction should never succeed.
+
+### Validating User-supplied Account Addresses for Withdrawals
+
+As withdrawals are irreversible, it may be a good practice to validate a
+user-supplied account address before authorizing a withdrawal in order to
+prevent accidental loss of user funds.
+
+The address of a normal account in Solana is a Base58-encoded string of a
+256-bit ed25519 public key. Not all bit patterns are valid public keys for the
+ed25519 curve, so it is possible to ensure user-supplied account addresses are
+at least correct ed25519 public keys.
+
+#### Java
+
+Here is a Java example of validating a user-supplied address as a valid ed25519
+public key:
+
+The following code sample assumes you're using the Maven.
+
+`pom.xml`:
+
+```xml
+<repositories>
+  ...
+  <repository>
+    <id>spring</id>
+    <url>https://repo.spring.io/libs-release/</url>
+  </repository>
+</repositories>
+
+...
+
+<dependencies>
+  ...
+  <dependency>
+      <groupId>io.github.novacrypto</groupId>
+      <artifactId>Base58</artifactId>
+      <version>0.1.3</version>
+  </dependency>
+  <dependency>
+      <groupId>cafe.cryptography</groupId>
+      <artifactId>curve25519-elisabeth</artifactId>
+      <version>0.1.0</version>
+  </dependency>
+<dependencies>
+```
+
+```java
+import io.github.novacrypto.base58.Base58;
+import cafe.cryptography.curve25519.CompressedEdwardsY;
+
+public class PubkeyValidator
+{
+    public static boolean verifyPubkey(String userProvidedPubkey)
+    {
+        try {
+            return _verifyPubkeyInternal(userProvidedPubkey);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public static boolean _verifyPubkeyInternal(String maybePubkey) throws Exception
+    {
+        byte[] bytes = Base58.base58Decode(maybePubkey);
+        return !(new CompressedEdwardsY(bytes)).decompress().isSmallOrder();
+    }
+}
+```
 
 ## Testing the Integration
 


### PR DESCRIPTION
#### Problem
The `Validating User-supplied Account Addresses for Withdrawals in SOL` section got added on top of `Listening for Deposits`, breaking the heading hierarchy and order.

#### Summary of Changes
Move it to inside the `Sending Withdrawals` section, and demote the heading levels by 1
Also change the name of the heading, since we will be referring to it for withdrawals of spl-tokens too