### PR TITLE
cli: Improve error message when .config/solana/id.json is not found

### DIFF
--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -78,7 +78,7 @@ pub fn signer_from_path(
         KeypairUrl::Filepath(path) => match read_keypair_file(&path) {
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("could not find keypair file: {} error: {}", path, e),
+                format!("could not read keypair file \"{}\". Run \"solana-keygen new\" to create a keypair file: {}", path, e),
             )
             .into()),
             Ok(file) => Ok(Box::new(file)),
@@ -149,7 +149,7 @@ pub fn resolve_signer_from_path(
         KeypairUrl::Filepath(path) => match read_keypair_file(&path) {
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("could not find keypair file: {} error: {}", path, e),
+                format!("could not read keypair file \"{}\". Run \"solana-keygen new\" to create a keypair file: {}", path, e),
             )
             .into()),
             Ok(_) => Ok(Some(path.to_string())),


### PR DESCRIPTION
The `error: could not find keypair file: ~/.config/solana/id.json error: No such file or directory (os error 2)` error message that appears when the user hasn't yet run `solana-keygen new` is pretty harsh for a newbie.

Rework the error message to include a hint of what to do next:
```
Error: could not read keypair file "~/.config/solana/id.json". Run "solana-keygen new" to create a keypair file: No such file or directory (os error 2)
```
