### PR TITLE
Follow up to persistent tower with tests and API cleaning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,6 +4083,7 @@ name = "solana-local-cluster"
 version = "1.5.0"
 dependencies = [
  "assert_matches",
+ "fs_extra",
  "gag",
  "itertools 0.9.0",
  "log 0.4.8",

--- a/core/src/bank_weight_fork_choice.rs
+++ b/core/src/bank_weight_fork_choice.rs
@@ -60,7 +60,7 @@ impl ForkChoice for BankWeightForkChoice {
         trace!("frozen_banks {}", frozen_banks.len());
         let num_old_banks = frozen_banks
             .iter()
-            .filter(|b| b.slot() < tower.root().unwrap_or(0))
+            .filter(|b| b.slot() < tower.root())
             .count();
 
         let last_voted_slot = tower.last_voted_slot();

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1174,15 +1174,12 @@ pub fn reconcile_blockstore_roots_with_tower(
                 ),
             })
             .collect();
-        // or check last_root or 0?
-        //assert!(
-        //    !new_roots.is_empty(),
-        //    "at least 1 parent slot must be found"
-        //);
+        assert!(
+            !new_roots.is_empty(),
+            "at least 1 parent slot must be found"
+        );
 
-        if !new_roots.is_empty() {
-            blockstore.set_roots(&new_roots)?
-        }
+        blockstore.set_roots(&new_roots)?
     }
     Ok(())
 }
@@ -2704,7 +2701,6 @@ pub mod test {
     }
 
     #[test]
-    #[ignore]
     #[should_panic(expected = "at least 1 parent slot must be found")]
     fn test_reconcile_blockstore_roots_with_tower_panic_no_parent() {
         solana_logger::setup();

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -387,17 +387,14 @@ impl Tower {
     pub fn record_bank_vote(&mut self, vote: Vote) -> Option<Slot> {
         let slot = vote.last_voted_slot().unwrap_or(0);
         trace!("{} record_vote for {}", self.node_pubkey, slot);
-        let root_slot = self.root();
+        let old_root = self.root();
         self.lockouts.process_vote_unchecked(&vote);
         self.last_vote = vote;
+        let new_root = self.root();
 
-        datapoint_info!(
-            "tower-vote",
-            ("latest", slot, i64),
-            ("root", self.root(), i64)
-        );
-        if root_slot != self.root() {
-            Some(self.root())
+        datapoint_info!("tower-vote", ("latest", slot, i64), ("root", new_root, i64));
+        if old_root != new_root {
+            Some(new_root)
         } else {
             None
         }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -2704,6 +2704,7 @@ pub mod test {
     }
 
     #[test]
+    #[ignore]
     #[should_panic(expected = "at least 1 parent slot must be found")]
     fn test_reconcile_blockstore_roots_with_tower_panic_no_parent() {
         solana_logger::setup();

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -450,10 +450,6 @@ impl Tower {
         self.lockouts.root_slot.unwrap()
     }
 
-    pub fn node_pubkey(&self) -> Pubkey {
-        self.node_pubkey
-    }
-
     // a slot is recent if it's newer than the last vote we have
     pub fn is_recent(&self, slot: Slot) -> bool {
         if let Some(last_voted_slot) = self.lockouts.last_voted_slot() {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -450,6 +450,10 @@ impl Tower {
         self.lockouts.root_slot.unwrap()
     }
 
+    pub fn node_pubkey(&self) -> Pubkey {
+        self.node_pubkey
+    }
+
     // a slot is recent if it's newer than the last vote we have
     pub fn is_recent(&self, slot: Slot) -> bool {
         if let Some(last_voted_slot) = self.lockouts.last_voted_slot() {

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://solana.com/"
 [dependencies]
 itertools = "0.9.0"
 gag = "0.1.10"
+fs_extra = "1.1.0"
 log = "0.4.8"
 rand = "0.7.0"
 solana-config-program = { path = "../programs/config", version = "1.5.0" }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -370,6 +370,15 @@ impl LocalCluster {
         validator_pubkey
     }
 
+    pub fn ledger_path(&self, validator_pubkey: &Pubkey) -> std::path::PathBuf {
+        self.validators
+            .get(validator_pubkey)
+            .unwrap()
+            .info
+            .ledger_path
+            .clone()
+    }
+
     fn close(&mut self) {
         self.close_preserve_ledgers();
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1723,6 +1723,7 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
     let (mut validator_a_finished, mut validator_b_finished) = (false, false);
     while !(validator_a_finished && validator_b_finished) {
         sleep(Duration::from_millis(100));
+
         if let Some(last_vote) = last_vote_in_tower(&val_a_ledger_path, &validator_a_pubkey) {
             if !validator_a_finished && last_vote >= next_slot_on_a {
                 validator_a_finished = true;
@@ -1783,19 +1784,15 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
     for _ in 0..100 {
         sleep(Duration::from_millis(100));
 
-        let last_vote = last_vote_in_tower(&val_c_ledger_path, &validator_c_pubkey);
-        match last_vote {
-            None => continue,
-            Some(last_vote) => {
-                if last_vote != base_slot {
-                    votes_on_c_fork.insert(last_vote);
-                    // Collect 4 votes
-                    if votes_on_c_fork.len() >= 4 {
-                        break;
-                    }
+        if let Some(last_vote) = last_vote_in_tower(&val_c_ledger_path, &validator_c_pubkey) {
+            if last_vote != base_slot {
+                votes_on_c_fork.insert(last_vote);
+                // Collect 4 votes
+                if votes_on_c_fork.len() >= 4 {
+                    break;
                 }
             }
-        };
+        }
     }
     assert!(!votes_on_c_fork.is_empty());
     info!("collected validator C's votes: {:?}", votes_on_c_fork);
@@ -1810,14 +1807,10 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
     for _ in 0..100 {
         sleep(Duration::from_millis(100));
 
-        let last_vote = last_vote_in_tower(&val_a_ledger_path, &validator_a_pubkey);
-        match last_vote {
-            None => continue,
-            Some(last_vote) => {
-                if votes_on_c_fork.contains(&last_vote) {
-                    bad_vote_detected = true;
-                    break;
-                }
+        if let Some(last_vote) = last_vote_in_tower(&val_a_ledger_path, &validator_a_pubkey) {
+            if votes_on_c_fork.contains(&last_vote) {
+                bad_vote_detected = true;
+                break;
             }
         }
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1431,12 +1431,6 @@ fn test_optimistic_confirmation_violation_with_no_tower() {
             prev_voted_slot
         );
         blockstore.set_dead_slot(prev_voted_slot).unwrap();
-
-        std::fs::remove_file(Tower::get_filename(
-            &exited_validator_info.info.ledger_path,
-            &entry_point_id,
-        ))
-        .unwrap();
     }
     cluster.restart_node(&entry_point_id, exited_validator_info);
 
@@ -1473,6 +1467,7 @@ fn test_optimistic_confirmation_violation_with_no_tower() {
 #[serial]
 #[ignore]
 fn test_no_optimistic_confirmation_violation_with_tower() {
+    // rewrite this test scenario!
     solana_logger::setup();
     let mut buf = BufferRedirect::stderr().unwrap();
 
@@ -1597,7 +1592,7 @@ fn test_validator_saves_tower() {
     let validator_info = cluster.exit_node(&validator_id);
     let tower1 = Tower::restore(&ledger_path, &validator_id).unwrap();
     trace!("tower1: {:?}", tower1);
-    assert_eq!(tower1.root(), Some(0));
+    assert_eq!(tower1.root(), 0);
 
     // Restart the validator and wait for a new root
     cluster.restart_node(&validator_id, validator_info);
@@ -1622,7 +1617,7 @@ fn test_validator_saves_tower() {
     let validator_info = cluster.exit_node(&validator_id);
     let tower2 = Tower::restore(&ledger_path, &validator_id).unwrap();
     trace!("tower2: {:?}", tower2);
-    assert_eq!(tower2.root(), Some(last_replayed_root));
+    assert_eq!(tower2.root(), last_replayed_root);
     last_replayed_root = recent_slot;
 
     // Rollback saved tower to `tower1` to simulate a validator starting from a newer snapshot
@@ -1651,7 +1646,7 @@ fn test_validator_saves_tower() {
     let mut validator_info = cluster.exit_node(&validator_id);
     let tower3 = Tower::restore(&ledger_path, &validator_id).unwrap();
     trace!("tower3: {:?}", tower3);
-    assert!(tower3.root().unwrap() > last_replayed_root);
+    assert!(tower3.root() > last_replayed_root);
 
     // Remove the tower file entirely and allow the validator to start without a tower.  It will
     // rebuild tower from its vote account contents
@@ -1680,7 +1675,7 @@ fn test_validator_saves_tower() {
     let tower4 = Tower::restore(&ledger_path, &validator_id).unwrap();
     trace!("tower4: {:?}", tower4);
     // should tower4 advance 1 slot compared to tower3????
-    assert_eq!(tower4.root(), tower3.root().map(|s| s + 1));
+    assert_eq!(tower4.root(), tower3.root() + 1);
 }
 
 fn wait_for_next_snapshot(

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1372,9 +1372,14 @@ fn test_optimistic_confirmation_violation_with_no_tower() {
     // First set up the cluster with 2 nodes
     let slots_per_epoch = 2048;
     let node_stakes = vec![51, 50];
-    let validator_keys: Vec<_> = iter::repeat_with(|| (Arc::new(Keypair::new()), true))
-        .take(node_stakes.len())
-        .collect();
+    let validator_keys: Vec<_> = vec![
+        "4qhhXNTbKD1a5vxDDLZcHKj7ELNeiivtUBxn3wUK1F5VRsQVP89VUhfXqSfgiFB14GfuBgtrQ96n9NvWQADVkcCg",
+        "3kHBzVwie5vTEaY6nFCPeFT8qDpoXzn7dCEioGRNBTnUDpvwnG85w8Wq63gVWpVTP8k2a8cgcWRjSXyUkEygpXWS",
+    ]
+    .iter()
+    .map(|s| (Arc::new(Keypair::from_base58_string(s)), true))
+    .take(node_stakes.len())
+    .collect();
     let config = ClusterConfig {
         cluster_lamports: 100_000,
         node_stakes: node_stakes.clone(),
@@ -1474,9 +1479,14 @@ fn test_no_optimistic_confirmation_violation_with_tower() {
     // First set up the cluster with 2 nodes
     let slots_per_epoch = 2048;
     let node_stakes = vec![51, 50];
-    let validator_keys: Vec<_> = iter::repeat_with(|| (Arc::new(Keypair::new()), true))
-        .take(node_stakes.len())
-        .collect();
+    let validator_keys: Vec<_> = vec![
+        "4qhhXNTbKD1a5vxDDLZcHKj7ELNeiivtUBxn3wUK1F5VRsQVP89VUhfXqSfgiFB14GfuBgtrQ96n9NvWQADVkcCg",
+        "3kHBzVwie5vTEaY6nFCPeFT8qDpoXzn7dCEioGRNBTnUDpvwnG85w8Wq63gVWpVTP8k2a8cgcWRjSXyUkEygpXWS",
+    ]
+    .iter()
+    .map(|s| (Arc::new(Keypair::from_base58_string(s)), true))
+    .take(node_stakes.len())
+    .collect();
     let config = ClusterConfig {
         cluster_lamports: 100_000,
         node_stakes: node_stakes.clone(),

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -43,6 +43,14 @@ impl Keypair {
         self.0.to_bytes()
     }
 
+    pub fn from_base58_string(s: &str) -> Self {
+        Self::from_bytes(&bs58::decode(s).into_vec().unwrap()).unwrap()
+    }
+
+    pub fn to_base58_string(&self) -> String {
+        bs58::encode(&self.0.to_bytes()).into_string()
+    }
+
     pub fn secret(&self) -> &ed25519_dalek::SecretKey {
         &self.0.secret
     }

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -48,7 +48,8 @@ impl Keypair {
     }
 
     pub fn to_base58_string(&self) -> String {
-        bs58::encode(&self.0.to_bytes()).into_string()
+        // Remove .iter() once we're rust 1.47+
+        bs58::encode(&self.0.to_bytes().iter()).into_string()
     }
 
     pub fn secret(&self) -> &ed25519_dalek::SecretKey {


### PR DESCRIPTION
#### Problem

Tower::root() can get away of `Option<_>`.

#### Summary of Changes

Let's simplify code and reduce combinatorial complexes for humans.

And some minor follow up fixes.

Also, adds long-awaited interesting test: https://github.com/solana-labs/solana/pull/10718#discussion_r491253093

There should be no functional change.

#### Context

follow up #10718 
