### PR TITLE
builds crds filters in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,7 @@ checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
 dependencies = [
  "autocfg 1.0.0",
  "hashbrown",
+ "rayon",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ crossbeam-channel = "0.4"
 ed25519-dalek = "=1.0.0-pre.4"
 fs_extra = "1.1.0"
 flate2 = "1.0"
-indexmap = "1.5"
+indexmap = { version = "1.5", features = ["rayon"] }
 itertools = "0.9.0"
 jsonrpc-core = "15.0.0"
 jsonrpc-core-client = { version = "15.0.0", features = ["ws"] }

--- a/core/benches/crds_gossip_pull.rs
+++ b/core/benches/crds_gossip_pull.rs
@@ -3,24 +3,51 @@
 extern crate test;
 
 use rand::{thread_rng, Rng};
-use solana_core::crds_gossip_pull::CrdsFilter;
-use solana_sdk::hash::{Hash, HASH_BYTES};
+use rayon::ThreadPoolBuilder;
+use solana_core::cluster_info::MAX_BLOOM_SIZE;
+use solana_core::crds::Crds;
+use solana_core::crds_gossip_pull::{CrdsFilter, CrdsGossipPull};
+use solana_core::crds_value::CrdsValue;
+use solana_sdk::hash::Hash;
 use test::Bencher;
 
 #[bench]
 fn bench_hash_as_u64(bencher: &mut Bencher) {
     let mut rng = thread_rng();
-    let hashes: Vec<_> = (0..1000)
-        .map(|_| {
-            let mut buf = [0u8; HASH_BYTES];
-            rng.fill(&mut buf);
-            Hash::new(&buf)
-        })
+    let hashes: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        .take(1000)
         .collect();
     bencher.iter(|| {
         hashes
             .iter()
             .map(CrdsFilter::hash_as_u64)
             .collect::<Vec<_>>()
+    });
+}
+
+#[bench]
+fn bench_build_crds_filters(bencher: &mut Bencher) {
+    let thread_pool = ThreadPoolBuilder::new().build().unwrap();
+    let mut rng = thread_rng();
+    let mut crds_gossip_pull = CrdsGossipPull::default();
+    let mut crds = Crds::default();
+    for _ in 0..50_000 {
+        crds_gossip_pull
+            .purged_values
+            .push_back((Hash::new_rand(&mut rng), rng.gen()));
+    }
+    let mut num_inserts = 0;
+    for _ in 0..90_000 {
+        if crds
+            .insert(CrdsValue::new_rand(&mut rng), rng.gen())
+            .is_ok()
+        {
+            num_inserts += 1;
+        }
+    }
+    assert_eq!(num_inserts, 90_000);
+    bencher.iter(|| {
+        let filters = crds_gossip_pull.build_crds_filters(&thread_pool, &crds, MAX_BLOOM_SIZE);
+        assert_eq!(filters.len(), 128);
     });
 }

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -10,6 +10,7 @@ use crate::{
     crds_gossip_push::{CrdsGossipPush, CRDS_GOSSIP_NUM_ACTIVE},
     crds_value::{CrdsValue, CrdsValueLabel},
 };
+use rayon::ThreadPool;
 use solana_sdk::pubkey::Pubkey;
 use std::collections::{HashMap, HashSet};
 
@@ -134,12 +135,14 @@ impl CrdsGossip {
     /// generate a random request
     pub fn new_pull_request(
         &self,
+        thread_pool: &ThreadPool,
         now: u64,
         gossip_validators: Option<&HashSet<Pubkey>>,
         stakes: &HashMap<Pubkey, u64>,
         bloom_size: usize,
     ) -> Result<(Pubkey, Vec<CrdsFilter>, CrdsValue), CrdsGossipError> {
         self.pull.new_pull_request(
+            thread_pool,
             &self.crds,
             &self.id,
             self.shred_version,


### PR DESCRIPTION
#### Problem
Based on run-time profiles, the majority time of new_pull_requests is
spent building bloom filters, in hashing and bit-vec ops.

#### Summary of Changes
This commit builds crds filters in parallel using rayon constructs. The
added benchmark shows ~5x speedup (4-core machine, 8 threads).