### PR TITLE
CLI: Drop unused runtime dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,7 +3555,6 @@ dependencies = [
  "solana-logger 1.4.0",
  "solana-net-utils",
  "solana-remote-wallet",
- "solana-runtime",
  "solana-sdk 1.4.0",
  "solana-stake-program",
  "solana-transaction-status",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,6 @@ solana-faucet = { path = "../faucet", version = "1.4.0" }
 solana-logger = { path = "../logger", version = "1.4.0" }
 solana-net-utils = { path = "../net-utils", version = "1.4.0" }
 solana-remote-wallet = { path = "../remote-wallet", version = "1.4.0" }
-solana-runtime = { path = "../runtime", version = "1.4.0" }
 solana-sdk = { path = "../sdk", version = "1.4.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.4.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.4.0" }


### PR DESCRIPTION
#### Problem

CLI unnecessarily depends on runtime.

Looks like this originally came in to access `epoch_schedule`, which we now query over RPC

#### Summary of Changes

Remove runtime from Cargo.toml