### PR TITLE
Fix solana-tokens check_payer_balances for distribute-stake

### DIFF
--- a/tokens/.gitignore
+++ b/tokens/.gitignore
@@ -1,2 +1,3 @@
 target/
 *.csv
+/farf/

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -156,9 +156,9 @@ where
                         .help("Stake Account Address"),
                 )
                 .arg(
-                    Arg::with_name("sol_for_fees")
+                    Arg::with_name("unlocked_sol")
                         .default_value("1.0")
-                        .long("sol-for-fees")
+                        .long("unlocked-sol")
                         .takes_value(true)
                         .value_name("SOL_AMOUNT")
                         .help("Amount of SOL to put in system account to pay for fees"),
@@ -327,7 +327,7 @@ fn parse_distribute_stake_args(
 
     let stake_args = StakeArgs {
         stake_account_address,
-        sol_for_fees: value_t_or_exit!(matches, "sol_for_fees", f64),
+        unlocked_sol: value_t_or_exit!(matches, "unlocked_sol", f64),
         stake_authority,
         withdraw_authority,
         lockup_authority,

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -208,7 +208,7 @@ where
                         .required(true)
                         .takes_value(true)
                         .value_name("FILE")
-                        .help("Bids CSV file"),
+                        .help("Allocations CSV file"),
                 ),
         )
         .subcommand(

--- a/tokens/src/args.rs
+++ b/tokens/src/args.rs
@@ -12,7 +12,7 @@ pub struct DistributeTokensArgs {
 }
 
 pub struct StakeArgs {
-    pub sol_for_fees: f64,
+    pub unlocked_sol: f64,
     pub stake_account_address: Pubkey,
     pub stake_authority: Box<dyn Signer>,
     pub withdraw_authority: Box<dyn Signer>,

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -230,29 +230,29 @@ async fn distribute_allocations(
     allocations: &[Allocation],
     args: &DistributeTokensArgs,
 ) -> Result<(), Error> {
-    let (messages, stake_extras): (Vec<Message>, Vec<(Keypair, Option<DateTime<Utc>>)>) =
-        allocations
-            .iter()
-            .map(|allocation| {
-                let new_stake_account_keypair = Keypair::new();
-                let lockup_date = if allocation.lockup_date == "" {
-                    None
-                } else {
-                    Some(allocation.lockup_date.parse::<DateTime<Utc>>().unwrap())
-                };
+    type StakeExtras = Vec<(Keypair, Option<DateTime<Utc>>)>;
+    let (messages, stake_extras): (Vec<Message>, StakeExtras) = allocations
+        .iter()
+        .map(|allocation| {
+            let new_stake_account_keypair = Keypair::new();
+            let lockup_date = if allocation.lockup_date == "" {
+                None
+            } else {
+                Some(allocation.lockup_date.parse::<DateTime<Utc>>().unwrap())
+            };
 
-                println!("{:<44}  {:>24.9}", allocation.recipient, allocation.amount);
-                let instructions = distribution_instructions(
-                    allocation,
-                    &new_stake_account_keypair.pubkey(),
-                    args,
-                    lockup_date,
-                );
-                let fee_payer_pubkey = args.fee_payer.pubkey();
-                let message = Message::new(&instructions, Some(&fee_payer_pubkey));
-                (message, (new_stake_account_keypair, lockup_date))
-            })
-            .unzip();
+            println!("{:<44}  {:>24.9}", allocation.recipient, allocation.amount);
+            let instructions = distribution_instructions(
+                allocation,
+                &new_stake_account_keypair.pubkey(),
+                args,
+                lockup_date,
+            );
+            let fee_payer_pubkey = args.fee_payer.pubkey();
+            let message = Message::new(&instructions, Some(&fee_payer_pubkey));
+            (message, (new_stake_account_keypair, lockup_date))
+        })
+        .unzip();
 
     let num_signatures = messages
         .iter()

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -29,12 +29,6 @@ use std::{
 };
 use tokio::time::delay_for;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct Bid {
-    accepted_amount_dollars: f64,
-    primary_address: String,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Allocation {
     recipient: String,

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -266,9 +266,7 @@ async fn distribute_allocations(
             }
         };
     }
-    if args.dry_run {
-        check_payer_balances(num_signatures, allocations, client, args).await?;
-    }
+    check_payer_balances(num_signatures, allocations, client, args).await?;
     Ok(())
 }
 


### PR DESCRIPTION
#### Problem
The `check_payer_balances` method was making assumptions about distribution and fees amounts and payers that were true for the `distribute-tokens` subcommand, but not for `distribute-stakes`. As a result, it was returning erroneous errors for `distribute-stakes` on dry-run.

#### Summary of Changes
- Add proper handling for distribute-stakes when `args.stake_args.is_some()`


