### PR TITLE
cli: Simplify cli node version output, display semver only by default

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1489,7 +1489,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             follow,
         } => process_catchup(&rpc_client, config, node_pubkey, node_json_rpc_url, *follow),
         CliCommand::ClusterDate => process_cluster_date(&rpc_client, config),
-        CliCommand::ClusterVersion => process_cluster_version(&rpc_client),
+        CliCommand::ClusterVersion => process_cluster_version(&rpc_client, config),
         CliCommand::CreateAddressWithSeed {
             from_pubkey,
             seed,

--- a/cli/src/cli_output.rs
+++ b/cli/src/cli_output.rs
@@ -300,7 +300,7 @@ impl fmt::Display for CliValidators {
 
             writeln!(
                 f,
-                "{} {:<44}  {:<44}  {:>3}%   {:>8}  {:>10}  {:>10}  {:>17}  {}",
+                "{} {:<44}  {:<44}  {:>3}%   {:>8}  {:>10}  {:>10}  {:>8}  {}",
                 if delinquent {
                     WARNING.to_string()
                 } else {
@@ -359,7 +359,7 @@ impl fmt::Display for CliValidators {
         for (version, info) in self.stake_by_version.iter() {
             writeln!(
                 f,
-                "{:<16} - {:3} current validators ({:>5.2}%){}",
+                "{:<8} - {:3} current validators ({:>5.2}%){}",
                 version,
                 info.current_validators,
                 100. * info.current_active_stake as f64 / self.total_active_stake as f64,
@@ -380,7 +380,7 @@ impl fmt::Display for CliValidators {
             f,
             "{}",
             style(format!(
-                "  {:<44}  {:<38}  {}  {}  {}  {:>10}  {:^17}  {}",
+                "  {:<44}  {:<38}  {}  {}  {}  {:>10}  {:^8}  {}",
                 "Identity Pubkey",
                 "Vote Account Pubkey",
                 "Commission",

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -15,7 +15,7 @@ use solana_client::{
     pubsub_client::PubsubClient,
     rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient},
     rpc_config::{RpcLargestAccountsConfig, RpcLargestAccountsFilter},
-    rpc_response::SlotInfo,
+    rpc_response::{RpcVersionInfo, SlotInfo},
 };
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
@@ -622,9 +622,14 @@ pub fn process_cluster_date(rpc_client: &RpcClient, config: &CliConfig) -> Proce
     }
 }
 
-pub fn process_cluster_version(rpc_client: &RpcClient) -> ProcessResult {
+pub fn process_cluster_version(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
     let remote_version = rpc_client.get_version()?;
-    Ok(remote_version.solana_core)
+
+    if config.verbose {
+        Ok(format!("{:?}", remote_version))
+    } else {
+        Ok(remote_version.to_string())
+    }
 }
 
 pub fn process_fees(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
@@ -1312,9 +1317,12 @@ pub fn process_show_validators(
     for contact_info in rpc_client.get_cluster_nodes()? {
         node_version.insert(
             contact_info.pubkey,
-            contact_info
-                .version
-                .unwrap_or_else(|| unknown_version.clone()),
+            RpcVersionInfo {
+                solana_core: contact_info
+                    .version
+                    .unwrap_or_else(|| unknown_version.clone()),
+            }
+            .to_string(),
         );
     }
 

--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -7,7 +7,7 @@ use solana_sdk::{
     transaction::{Result, TransactionError},
 };
 use solana_transaction_status::ConfirmedTransactionStatusWithSignature;
-use std::{collections::HashMap, net::SocketAddr};
+use std::{collections::HashMap, fmt, net::SocketAddr};
 
 pub type RpcResult<T> = client_error::Result<Response<T>>;
 
@@ -137,11 +137,28 @@ pub struct RpcContactInfo {
 /// Map of leader base58 identity pubkeys to the slot indices relative to the first epoch slot
 pub type RpcLeaderSchedule = HashMap<String, Vec<usize>>;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct RpcVersionInfo {
     /// The current version of solana-core
     pub solana_core: String,
+}
+
+impl fmt::Debug for RpcVersionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.solana_core)
+    }
+}
+
+impl fmt::Display for RpcVersionInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(version) = self.solana_core.split_whitespace().next() {
+            // Display just the semver if possible
+            write!(f, "{}", version)
+        } else {
+            write!(f, "{}", self.solana_core)
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
`solana cluster-version` and `solana validators` display more than just the semver by default.   This starts to become too much information with https://github.com/solana-labs/solana/pull/12376 as additional feature set information is added to the version string.

Use `solana cluster-version --verbose` to display the additional version information.
