### PR TITLE
Moar rolling upgrade

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -93,7 +93,6 @@ ledger_dir="$SOLANA_CONFIG_DIR"/bootstrap-validator
 args+=(
   --enable-rpc-exit
   --enable-rpc-set-log-filter
-  --require-tower
   --ledger "$ledger_dir"
   --rpc-port 8899
   --snapshot-interval-slots 200

--- a/multinode-demo/setup.sh
+++ b/multinode-demo/setup.sh
@@ -4,7 +4,7 @@ here=$(dirname "$0")
 # shellcheck source=multinode-demo/common.sh
 source "$here"/common.sh
 
-set -e
+set -ex
 
 rm -rf "$SOLANA_CONFIG_DIR"/bootstrap-validator
 mkdir -p "$SOLANA_CONFIG_DIR"/bootstrap-validator
@@ -48,4 +48,5 @@ default_arg --faucet-lamports 500000000000000000
 default_arg --hashes-per-tick auto
 default_arg --cluster-type development
 
+echo "genesis args: ${args[@]}"
 $solana_genesis "${args[@]}"

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -228,7 +228,6 @@ default_arg --ledger "$ledger_dir"
 default_arg --log -
 default_arg --enable-rpc-exit
 default_arg --enable-rpc-set-log-filter
-default_arg --require-tower
 
 if [[ -n $SOLANA_CUDA ]]; then
   program=$solana_validator_cuda

--- a/net/net.sh
+++ b/net/net.sh
@@ -289,6 +289,7 @@ startBootstrapLeader() {
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
          \"$extraPrimordialStakes\" \
+         > ~/solana/remote-node.log
       "
 
   ) >> "$logFile" 2>&1 || {
@@ -360,6 +361,7 @@ startNode() {
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
          \"$extraPrimordialStakes\" \
+         > ~/solana/remote-node.log
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!

--- a/net/net.sh
+++ b/net/net.sh
@@ -204,7 +204,8 @@ build() {
       else
         git reset --hard "FETCH_HEAD"
       fi
-      export CI_COMMIT=$(git rev-parse HEAD)
+      CI_COMMIT=$(git rev-parse HEAD)
+      export CI_COMMIT
     fi
 
     cargo_error_code=

--- a/net/net.sh
+++ b/net/net.sh
@@ -204,7 +204,7 @@ build() {
       else
         git reset --hard "FETCH_HEAD"
       fi
-      CI_COMMIT=$(git rev-parse HEAD)
+      export CI_COMMIT=$(git rev-parse HEAD)
     fi
 
     cargo_error_code=

--- a/net/net.sh
+++ b/net/net.sh
@@ -204,6 +204,7 @@ build() {
       else
         git reset --hard "FETCH_HEAD"
       fi
+      CI_COMMIT=$(git rev-parse HEAD)
     fi
 
     cargo_error_code=

--- a/run.sh
+++ b/run.sh
@@ -104,7 +104,6 @@ args=(
   --enable-rpc-exit
   --enable-rpc-transaction-history
   --init-complete-file "$dataDir"/init-completed
-  --require-tower
 )
 solana-validator "${args[@]}" &
 validator=$!

--- a/system-test/rolling-upgrade/rolling_upgrade.sh
+++ b/system-test/rolling-upgrade/rolling_upgrade.sh
@@ -34,21 +34,20 @@ check_sanity() {
 (
   declare -g sw_version_args
   get_net_launch_software_version_launch_args "$UPGRADE_CHANNEL" "upgrade-release" sw_version_args
-  if [[ $UPGRADE_CHANNEL == "local" ]]; then
-    if [[ -n $LOCAL_BUILD_BRANCH || -n $LOCAL_BUILD_REVISION ]]; then
-      unset LOCAL_BUILD_BRANCH
-      unset LOCAL_BUILD_REVISION
-    fi
-    if [[ -n $UPGRADE_LOCAL_BUILD_BRANCH ]]; then
-      export LOCAL_BUILD_BRANCH="$UPGRADE_LOCAL_BUILD_BRANCH"
-    fi
-    if [[ -n $UPGRADE_LOCAL_BUILD_REVISION ]]; then
-      export LOCAL_BUILD_REVISION="$UPGRADE_LOCAL_BUILD_REVISION"
-    fi
-  else
-    if [[ -n $LOCAL_BUILD_BRANCH || -n $LOCAL_BUILD_REVISION ]]; then
+
+  # Override LOCAL_BUILD_* to build custom version to upgrade
+  if [[ -n $LOCAL_BUILD_BRANCH || -n $LOCAL_BUILD_REVISION ]]; then
+    unset LOCAL_BUILD_BRANCH
+    unset LOCAL_BUILD_REVISION
+    if [[ $UPGRADE_CHANNEL != "local" ]]; then
       echo "Conflicting options: $UPGRADE_CHANNEL, $LOCAL_BUILD_BRANCH, $LOCAL_BUILD_REVISION"
     fi
+  fi
+  if [[ -n $UPGRADE_LOCAL_BUILD_BRANCH ]]; then
+    export LOCAL_BUILD_BRANCH="$UPGRADE_LOCAL_BUILD_BRANCH"
+  fi
+  if [[ -n $UPGRADE_LOCAL_BUILD_REVISION ]]; then
+    export LOCAL_BUILD_REVISION="$UPGRADE_LOCAL_BUILD_REVISION"
   fi
 
   # shellcheck disable=2086 # $sw_version_args holds two args. Don't quote!

--- a/system-test/rolling-upgrade/rolling_upgrade.sh
+++ b/system-test/rolling-upgrade/rolling_upgrade.sh
@@ -30,19 +30,25 @@ check_sanity() {
   )
 }
 
-# Fetch new software and upload it to the bootstrap validator
+# Fetch or build new software and upload it to the bootstrap validator
 (
   declare -g sw_version_args
   get_net_launch_software_version_launch_args "$UPGRADE_CHANNEL" "upgrade-release" sw_version_args
-  if [[ -n $LOCAL_BUILD_BRANCH || -n $LOCAL_BUILD_REVISION ]]; then
-    unset LOCAL_BUILD_BRANCH
-    unset LOCAL_BUILD_REVISION
-  fi
-  if [[ -n $UPGRADE_LOCAL_BUILD_BRANCH ]]; then
-    export LOCAL_BUILD_BRANCH="$UPGRADE_LOCAL_BUILD_BRANCH"
-  fi
-  if [[ -n $UPGRADE_LOCAL_BUILD_REVISION ]]; then
-    export LOCAL_BUILD_REVISION="$UPGRADE_LOCAL_BUILD_REVISION"
+  if [[ $UPGRADE_CHANNEL == "local" ]]; then
+    if [[ -n $LOCAL_BUILD_BRANCH || -n $LOCAL_BUILD_REVISION ]]; then
+      unset LOCAL_BUILD_BRANCH
+      unset LOCAL_BUILD_REVISION
+    fi
+    if [[ -n $UPGRADE_LOCAL_BUILD_BRANCH ]]; then
+      export LOCAL_BUILD_BRANCH="$UPGRADE_LOCAL_BUILD_BRANCH"
+    fi
+    if [[ -n $UPGRADE_LOCAL_BUILD_REVISION ]]; then
+      export LOCAL_BUILD_REVISION="$UPGRADE_LOCAL_BUILD_REVISION"
+    fi
+  else
+    if [[ -n $LOCAL_BUILD_BRANCH || -n $LOCAL_BUILD_REVISION ]]; then
+      echo "Conflicting options: $UPGRADE_CHANNEL, $LOCAL_BUILD_BRANCH, $LOCAL_BUILD_REVISION"
+    fi
   fi
 
   # shellcheck disable=2086 # $sw_version_args holds two args. Don't quote!

--- a/system-test/rolling-upgrade/rolling_upgrade.sh
+++ b/system-test/rolling-upgrade/rolling_upgrade.sh
@@ -23,6 +23,13 @@ sleep_if_positive() {
   fi
 }
 
+check_sanity() {
+  (
+    set -e
+    "$NET_SH" sanity
+  )
+}
+
 # Fetch new software and upload it to the bootstrap validator
 declare -g sw_version_args
 get_net_launch_software_version_launch_args "$UPGRADE_CHANNEL" "upgrade-release" sw_version_args
@@ -33,7 +40,7 @@ get_net_launch_software_version_launch_args "$UPGRADE_CHANNEL" "upgrade-release"
 sleep_if_positive "$UPGRADE_INITIAL_DELAY"
 
 if [[ "$UPGRADE_INITIAL_DELAY" -gt 0 ]]; then
-  "$NET_SH" sanity
+  check_sanity
 fi
 
 # Restart validators one by one
@@ -52,11 +59,11 @@ for i in "${!validatorIpList[@]}"; do
   # This could be replaced with something based on `solana catchup`
   sleep_if_positive "$UPGRADE_INTERVALIDATOR_DELAY"
 
-  "$NET_SH" sanity
+  check_sanity
 done
 
 sleep_if_positive "$UPGRADE_POST_TEST_DELAY"
 
 if [[ "$UPGRADE_POST_TEST_DELAY" -gt 0 ]]; then
-  "$NET_SH" sanity
+  check_sanity
 fi

--- a/system-test/rolling-upgrade/rolling_upgrade.sh
+++ b/system-test/rolling-upgrade/rolling_upgrade.sh
@@ -31,10 +31,23 @@ check_sanity() {
 }
 
 # Fetch new software and upload it to the bootstrap validator
-declare -g sw_version_args
-get_net_launch_software_version_launch_args "$UPGRADE_CHANNEL" "upgrade-release" sw_version_args
-# shellcheck disable=2086 # $sw_version_args holds two args. Don't quote!
-"$NET_SH" upgrade $sw_version_args
+(
+  declare -g sw_version_args
+  get_net_launch_software_version_launch_args "$UPGRADE_CHANNEL" "upgrade-release" sw_version_args
+  if [[ -n $LOCAL_BUILD_BRANCH || -n $LOCAL_BUILD_REVISION ]]; then
+    unset LOCAL_BUILD_BRANCH
+    unset LOCAL_BUILD_REVISION
+  fi
+  if [[ -n $UPGRADE_LOCAL_BUILD_BRANCH ]]; then
+    export LOCAL_BUILD_BRANCH="$UPGRADE_LOCAL_BUILD_BRANCH"
+  fi
+  if [[ -n $UPGRADE_LOCAL_BUILD_REVISION ]]; then
+    export LOCAL_BUILD_REVISION="$UPGRADE_LOCAL_BUILD_REVISION"
+  fi
+
+  # shellcheck disable=2086 # $sw_version_args holds two args. Don't quote!
+  "$NET_SH" upgrade $sw_version_args
+)
 
 # Wait initial delay, if any
 sleep_if_positive "$UPGRADE_INITIAL_DELAY"

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+NDEBUG="${NDEBUG-1}"
+export NDEBUG
+
 # shellcheck disable=SC1090
 # shellcheck disable=SC1091
 source "$(dirname "$0")"/automation_utils.sh
@@ -124,6 +127,10 @@ function launch_testnet() {
   declare -g version_args
   get_net_launch_software_version_launch_args "$CHANNEL" "solana-release" version_args
 
+  if [[ -z $NDEBUG ]]; then
+    maybeDebug=--debug
+  fi
+
   declare maybeWarpSlot
   if [[ -n "$WARP_SLOT" ]]; then
     maybeWarpSlot="--warp-slot $WARP_SLOT"
@@ -141,7 +148,7 @@ function launch_testnet() {
 
   # shellcheck disable=SC2068
   # shellcheck disable=SC2086
-  "${REPO_ROOT}"/net/net.sh start $version_args \
+  "${REPO_ROOT}"/net/net.sh start $version_args $maybeDebug \
     -c idle=$NUMBER_OF_CLIENT_NODES $maybeStartAllowBootFailures \
     --gpu-mode $startGpuMode $maybeWarpSlot $maybeAsyncNodeInit $maybeExtraPrimordialStakes \
     $GENESIS_OPTIONS

--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -143,7 +143,8 @@ function launch_testnet() {
   # shellcheck disable=SC2086
   "${REPO_ROOT}"/net/net.sh start $version_args \
     -c idle=$NUMBER_OF_CLIENT_NODES $maybeStartAllowBootFailures \
-    --gpu-mode $startGpuMode $maybeWarpSlot $maybeAsyncNodeInit $maybeExtraPrimordialStakes
+    --gpu-mode $startGpuMode $maybeWarpSlot $maybeAsyncNodeInit $maybeExtraPrimordialStakes \
+    $GENESIS_OPTIONS
 
   execution_step "Waiting for bootstrap validator's stake to fall below ${BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD}%"
   wait_for_bootstrap_validator_stake_drop "$BOOTSTRAP_VALIDATOR_MAX_STAKE_THRESHOLD"
@@ -326,6 +327,7 @@ TEST_PARAMS_TO_DISPLAY=(CLOUD_PROVIDER \
                         PARTITION_ITERATION_COUNT \
                         TEST_TYPE \
                         CUSTOM_SCRIPT \
+                        GENESIS_OPTIONS \
                         )
 
 TEST_CONFIGURATION=


### PR DESCRIPTION
#### Problem

testing upgrade version test is hard and required local patches to be merged into stable and beta release channels
and supporting the combination of newer `net/*.sh` and older validator seems tedious and basically unmaintained.

#### Summary of Changes

basic idea is like this

1. git reset --hard `$HEAD_OF_STABLE_OR_WHATEVER_PR_ON_STABLE_BRANCH`
1. build locally
1. scp binaries
1. ./net/start.sh ...
1. git reset --hard `$HEAD_OF_BETA_OR_WHATEVER_PR_ON_STABLE_BRANCH`
1. build locally
1. scp binaries
1. ./net/start.sh ...

This is reboot of #9212 op top of #12337 . #9212 originally [closed without merging because building local version is supported without that pr](https://github.com/solana-labs/solana/pull/9212#issuecomment-607015733). But now we want to support to building multiple versions locally. So I think this justifies the need of this pr.

Fixes #
