### PR TITLE
Add RPC notify and banking keys debug

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -98,6 +98,7 @@ pub struct ValidatorConfig {
     pub poh_verify: bool, // Perform PoH verification during blockstore processing at boo
     pub cuda: bool,
     pub require_tower: bool,
+    pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
 }
 
 impl Default for ValidatorConfig {
@@ -131,6 +132,7 @@ impl Default for ValidatorConfig {
             poh_verify: true,
             cuda: false,
             require_tower: false,
+            debug_keys: None,
         }
     }
 }
@@ -770,6 +772,7 @@ fn new_banks_from_ledger(
         dev_halt_at_slot: config.dev_halt_at_slot,
         new_hard_forks: config.new_hard_forks.clone(),
         frozen_accounts: config.frozen_accounts.clone(),
+        debug_keys: config.debug_keys.clone(),
         ..blockstore_processor::ProcessOptions::default()
     };
 

--- a/core/tests/bank_forks.rs
+++ b/core/tests/bank_forks.rs
@@ -88,6 +88,7 @@ mod tests {
                 &genesis_config_info.genesis_config,
                 vec![accounts_dir.path().to_path_buf()],
                 &[],
+                None,
             );
             bank0.freeze();
             let mut bank_forks = BankForks::new(bank0);
@@ -141,6 +142,7 @@ mod tests {
             ),
             CompressionType::Bzip2,
             old_genesis_config,
+            None,
         )
         .unwrap();
 

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -65,6 +65,7 @@ pub fn load(
                     &archive_filename,
                     compression,
                     genesis_config,
+                    process_options.debug_keys.clone(),
                 )
                 .expect("Load from snapshot failed");
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -36,7 +36,7 @@ use solana_sdk::{
 use solana_vote_program::vote_state::VoteState;
 use std::{
     cell::RefCell,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::PathBuf,
     result,
     sync::Arc,
@@ -311,6 +311,7 @@ pub struct ProcessOptions {
     pub override_num_threads: Option<usize>,
     pub new_hard_forks: Option<Vec<Slot>>,
     pub frozen_accounts: Vec<Pubkey>,
+    pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
 }
 
 fn initiate_callback(mut bank: &mut Arc<Bank>, genesis_config: &GenesisConfig) {
@@ -341,6 +342,7 @@ pub fn process_blockstore(
         &genesis_config,
         account_paths,
         &opts.frozen_accounts,
+        opts.debug_keys.clone(),
     ));
     initiate_callback(&mut bank0, genesis_config);
     info!("processing ledger for slot 0...");
@@ -2846,7 +2848,7 @@ pub mod tests {
         genesis_config: &GenesisConfig,
         account_paths: Vec<PathBuf>,
     ) -> EpochSchedule {
-        let bank = Bank::new_with_paths(&genesis_config, account_paths, &[]);
+        let bank = Bank::new_with_paths(&genesis_config, account_paths, &[], None);
         *bank.epoch_schedule()
     }
 

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -36,7 +36,7 @@ fn bench_has_duplicates(bencher: &mut Bencher) {
 #[bench]
 fn test_accounts_create(bencher: &mut Bencher) {
     let (genesis_config, _) = create_genesis_config(10_000);
-    let bank0 = Bank::new_with_paths(&genesis_config, vec![PathBuf::from("bench_a0")], &[]);
+    let bank0 = Bank::new_with_paths(&genesis_config, vec![PathBuf::from("bench_a0")], &[], None);
     bencher.iter(|| {
         let mut pubkeys: Vec<Pubkey> = vec![];
         deposit_many(&bank0, &mut pubkeys, 1000);
@@ -50,6 +50,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
         &genesis_config,
         vec![PathBuf::from("bench_a1")],
         &[],
+        None,
     ));
     let mut pubkeys: Vec<Pubkey> = vec![];
     deposit_many(&bank1, &mut pubkeys, 250_000);

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -29,7 +29,7 @@ use {
         pubkey::Pubkey,
     },
     std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         io::{BufReader, BufWriter, Read, Write},
         path::{Path, PathBuf},
         result::Result,
@@ -124,6 +124,7 @@ pub(crate) fn bank_from_stream<R, P>(
     account_paths: &[PathBuf],
     genesis_config: &GenesisConfig,
     frozen_account_pubkeys: &[Pubkey],
+    debug_keys: Option<Arc<HashSet<Pubkey>>>,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -140,6 +141,7 @@ where
                 frozen_account_pubkeys,
                 account_paths,
                 append_vecs_path,
+                debug_keys,
             )?;
             Ok(bank)
         }};
@@ -224,6 +226,7 @@ fn reconstruct_bank_from_fields<E, P>(
     frozen_account_pubkeys: &[Pubkey],
     account_paths: &[PathBuf],
     append_vecs_path: P,
+    debug_keys: Option<Arc<HashSet<Pubkey>>>,
 ) -> Result<Bank, Error>
 where
     E: Into<AccountStorageEntry>,
@@ -238,7 +241,7 @@ where
     accounts_db.freeze_accounts(&bank_fields.ancestors, frozen_account_pubkeys);
 
     let bank_rc = BankRc::new(Accounts::new_empty(accounts_db), bank_fields.slot);
-    let bank = Bank::new_from_fields(bank_rc, genesis_config, bank_fields);
+    let bank = Bank::new_from_fields(bank_rc, genesis_config, bank_fields, debug_keys);
 
     Ok(bank)
 }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -211,6 +211,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         &dbank_paths,
         &genesis_config,
         &[],
+        None,
     )
     .unwrap();
     dbank.src = ref_sc;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -20,6 +20,8 @@ use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
 };
+use std::collections::HashSet;
+use std::sync::Arc;
 use std::{
     cmp::Ordering,
     fmt,
@@ -571,6 +573,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     snapshot_tar: P,
     compression: CompressionType,
     genesis_config: &GenesisConfig,
+    debug_keys: Option<Arc<HashSet<Pubkey>>>,
 ) -> Result<Bank> {
     // Untar the snapshot into a temp directory under `snapshot_config.snapshot_path()`
     let unpack_dir = tempfile::tempdir_in(snapshot_path)?;
@@ -591,6 +594,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
         &unpacked_snapshots_dir,
         unpacked_accounts_dir,
         genesis_config,
+        debug_keys,
     )?;
 
     if !bank.verify_snapshot_bank() {
@@ -748,6 +752,7 @@ fn rebuild_bank_from_snapshots<P>(
     unpacked_snapshots_dir: &PathBuf,
     append_vecs_path: P,
     genesis_config: &GenesisConfig,
+    debug_keys: Option<Arc<HashSet<Pubkey>>>,
 ) -> Result<Bank>
 where
     P: AsRef<Path>,
@@ -779,6 +784,7 @@ where
                 account_paths,
                 genesis_config,
                 frozen_account_pubkeys,
+                debug_keys,
             ),
         }?)
     })?;

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1128,6 +1128,15 @@ pub fn main() {
                        May be specified multiple times. If unspecified any snapshot hash will be accepted"),
         )
         .arg(
+            Arg::with_name("debug_key")
+                .long("debug-key")
+                .validator(is_pubkey)
+                .value_name("PUBKEY")
+                .multiple(true)
+                .takes_value(true)
+                .help("Log when transactions are processed which reference a given key."),
+        )
+        .arg(
             Arg::with_name("no_untrusted_rpc")
                 .long("no-untrusted-rpc")
                 .takes_value(false)
@@ -1264,6 +1273,16 @@ pub fn main() {
         exit(1);
     });
 
+    let debug_keys: Option<Arc<HashSet<_>>> = if matches.is_present("debug_key") {
+        Some(Arc::new(
+            values_t_or_exit!(matches, "debug_key", Pubkey)
+                .into_iter()
+                .collect(),
+        ))
+    } else {
+        None
+    };
+
     let trusted_validators = validators_set(
         &identity_keypair.pubkey(),
         &matches,
@@ -1339,6 +1358,7 @@ pub fn main() {
         no_rocksdb_compaction,
         wal_recovery_mode,
         poh_verify: !matches.is_present("skip_poh_verify"),
+        debug_keys,
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

No way to enable debug for notifications or transaction processing.

#### Summary of Changes

Add a `--debug-key` feature to allow the operator to print all transactions which touch certain keys and also to when RPC subscriptions are notified. This can help debug latency issues by passing a flag and enabling a debug mask.

Fixes #
