### PR TITLE
add token type on token instructions + symbol on amount

### DIFF
--- a/explorer/src/components/instruction/token/TokenDetailsCard.tsx
+++ b/explorer/src/components/instruction/token/TokenDetailsCard.tsx
@@ -19,6 +19,8 @@ import {
 } from "providers/accounts";
 import { normalizeTokenAmount } from "utils";
 import { reportError } from "utils/sentry";
+import { useCluster } from "providers/cluster";
+import { TokenRegistry } from "tokenRegistry";
 
 type DetailsProps = {
   tx: ParsedTransaction;
@@ -81,6 +83,7 @@ function TokenInstruction(props: InfoProps) {
   const tokenInfo = useTokenAccountInfo(tokenAddress);
   const mintAddress = infoMintAddress || tokenInfo?.mint.toBase58();
   const mintInfo = useMintAccountInfo(mintAddress);
+  const { cluster } = useCluster();
   const fetchAccountInfo = useFetchAccountInfo();
 
   React.useEffect(() => {
@@ -97,6 +100,26 @@ function TokenInstruction(props: InfoProps) {
 
   const decimals = mintInfo?.decimals;
   const attributes = [];
+
+  let tokenSymbol = "";
+
+  if (mintAddress) {
+    const tokenDetails = TokenRegistry.get(mintAddress, cluster);
+
+    if (tokenDetails && "symbol" in tokenDetails) {
+      tokenSymbol = tokenDetails.symbol;
+    }
+
+    attributes.push(
+      <tr key={mintAddress}>
+        <td>Token</td>
+        <td className="text-lg-right">
+          <Address pubkey={new PublicKey(mintAddress)} alignRight link />
+        </td>
+      </tr>
+    );
+  }
+
   for (let key in props.info) {
     const value = props.info[key];
     if (value === undefined) continue;
@@ -116,7 +139,11 @@ function TokenInstruction(props: InfoProps) {
           maximumFractionDigits: decimals,
         }).format(normalizeTokenAmount(value, decimals));
       }
-      tag = <>{amount}</>;
+      tag = (
+        <>
+          {amount} {tokenSymbol}
+        </>
+      );
     } else {
       tag = <>{value}</>;
     }


### PR DESCRIPTION
#### Problem
When viewing a transaction involving a token transfer, it's difficult to know which token is being transferred because SPL Token "Transfer" instructions don't include the mint address ("Transfer2" does). 

Example:

The following transaction displays an instruction which transfers wrapped ETH:
https://explorer.solana.com/tx/afPaFtbXfK8iE5D6P3F2KiPC917EfCq8yA6awT9q73iCo3MU8kn6UNd8sy3K77wZda7S9twvbMrPL5BUL2ARNNV
We know that because we can inspect the source account:
https://explorer.solana.com/address/EgrroRsUDmwDLeWFd1zZ4Yej7Jhu6yYqUEwT2RLgTdQW

#### Proposed Solution
Display which token is being transferred and include the token unit.

Fixes https://github.com/solana-labs/solana/issues/12273