### PR TITLE
Remove transaction encoding from storage layer

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -35,7 +35,7 @@ use solana_sdk::{
     transaction::{self, Transaction},
 };
 use solana_transaction_status::{
-    ConfirmedBlock, ConfirmedTransaction, TransactionStatus, UiTransactionEncoding,
+    EncodedConfirmedBlock, EncodedConfirmedTransaction, TransactionStatus, UiTransactionEncoding,
 };
 use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::{
@@ -248,7 +248,7 @@ impl RpcClient {
         self.send(RpcRequest::GetClusterNodes, Value::Null)
     }
 
-    pub fn get_confirmed_block(&self, slot: Slot) -> ClientResult<ConfirmedBlock> {
+    pub fn get_confirmed_block(&self, slot: Slot) -> ClientResult<EncodedConfirmedBlock> {
         self.get_confirmed_block_with_encoding(slot, UiTransactionEncoding::Json)
     }
 
@@ -256,7 +256,7 @@ impl RpcClient {
         &self,
         slot: Slot,
         encoding: UiTransactionEncoding,
-    ) -> ClientResult<ConfirmedBlock> {
+    ) -> ClientResult<EncodedConfirmedBlock> {
         self.send(RpcRequest::GetConfirmedBlock, json!([slot, encoding]))
     }
 
@@ -326,7 +326,7 @@ impl RpcClient {
         &self,
         signature: &Signature,
         encoding: UiTransactionEncoding,
-    ) -> ClientResult<ConfirmedTransaction> {
+    ) -> ClientResult<EncodedConfirmedTransaction> {
         self.send(
             RpcRequest::GetConfirmedTransaction,
             json!([signature.to_string(), encoding]),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1992,7 +1992,7 @@ pub(crate) mod tests {
         system_transaction,
         transaction::TransactionError,
     };
-    use solana_transaction_status::{EncodedTransaction, TransactionWithStatusMeta};
+    use solana_transaction_status::TransactionWithStatusMeta;
     use solana_vote_program::{
         vote_state::{VoteState, VoteStateVersions},
         vote_transaction,
@@ -2732,36 +2732,26 @@ pub(crate) mod tests {
                 blockstore.clone(),
             );
 
-            let confirmed_block = blockstore.get_confirmed_block(slot, None).unwrap();
+            let confirmed_block = blockstore.get_confirmed_block(slot).unwrap();
             assert_eq!(confirmed_block.transactions.len(), 3);
 
             for TransactionWithStatusMeta { transaction, meta } in
                 confirmed_block.transactions.into_iter()
             {
-                if let EncodedTransaction::Json(transaction) = transaction {
-                    if transaction.signatures[0] == signatures[0].to_string() {
-                        let meta = meta.unwrap();
-                        assert_eq!(meta.err, None);
-                        assert_eq!(meta.status, Ok(()));
-                    } else if transaction.signatures[0] == signatures[1].to_string() {
-                        let meta = meta.unwrap();
-                        assert_eq!(
-                            meta.err,
-                            Some(TransactionError::InstructionError(
-                                0,
-                                InstructionError::Custom(1)
-                            ))
-                        );
-                        assert_eq!(
-                            meta.status,
-                            Err(TransactionError::InstructionError(
-                                0,
-                                InstructionError::Custom(1)
-                            ))
-                        );
-                    } else {
-                        assert_eq!(meta, None);
-                    }
+                if transaction.signatures[0] == signatures[0] {
+                    let meta = meta.unwrap();
+                    assert_eq!(meta.status, Ok(()));
+                } else if transaction.signatures[0] == signatures[1] {
+                    let meta = meta.unwrap();
+                    assert_eq!(
+                        meta.status,
+                        Err(TransactionError::InstructionError(
+                            0,
+                            InstructionError::Custom(1)
+                        ))
+                    );
+                } else {
+                    assert_eq!(meta, None);
                 }
             }
         }

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -7,7 +7,7 @@ use solana_clap_utils::{
 use solana_cli::display::println_transaction;
 use solana_ledger::{blockstore::Blockstore, blockstore_db::AccessType};
 use solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature};
-use solana_transaction_status::UiTransactionEncoding;
+use solana_transaction_status::ConfirmedBlock;
 use std::{
     path::Path,
     process::exit,
@@ -51,9 +51,7 @@ async fn block(slot: Slot) -> Result<(), Box<dyn std::error::Error>> {
         .await
         .map_err(|err| format!("Failed to connect to storage: {:?}", err))?;
 
-    let block = bigtable
-        .get_confirmed_block(slot, UiTransactionEncoding::Base64)
-        .await?;
+    let block = bigtable.get_confirmed_block(slot).await?;
 
     println!("Slot: {}", slot);
     println!("Parent Slot: {}", block.parent_slot);
@@ -65,11 +63,11 @@ async fn block(slot: Slot) -> Result<(), Box<dyn std::error::Error>> {
     if !block.rewards.is_empty() {
         println!("Rewards: {:?}", block.rewards);
     }
-    for (index, transaction_with_meta) in block.transactions.iter().enumerate() {
+    for (index, transaction_with_meta) in block.transactions.into_iter().enumerate() {
         println!("Transaction {}:", index);
         println_transaction(
-            &transaction_with_meta.transaction.decode().unwrap(),
-            &transaction_with_meta.meta,
+            &transaction_with_meta.transaction,
+            &transaction_with_meta.meta.map(|meta| meta.into()),
             "  ",
         );
     }
@@ -96,22 +94,15 @@ async fn confirm(signature: &Signature, verbose: bool) -> Result<(), Box<dyn std
     let transaction_status = bigtable.get_signature_status(signature).await?;
 
     if verbose {
-        match bigtable
-            .get_confirmed_transaction(signature, UiTransactionEncoding::Base64)
-            .await
-        {
+        match bigtable.get_confirmed_transaction(signature).await {
             Ok(Some(confirmed_transaction)) => {
                 println!(
                     "\nTransaction executed in slot {}:",
                     confirmed_transaction.slot
                 );
                 println_transaction(
-                    &confirmed_transaction
-                        .transaction
-                        .transaction
-                        .decode()
-                        .expect("Successful decode"),
-                    &confirmed_transaction.transaction.meta,
+                    &confirmed_transaction.transaction.transaction,
+                    &confirmed_transaction.transaction.meta.map(|m| m.into()),
                     "  ",
                 );
             }
@@ -138,7 +129,7 @@ pub async fn transaction_history(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bigtable = solana_storage_bigtable::LedgerStorage::new(true).await?;
 
-    let mut loaded_block: Option<(Slot, solana_transaction_status::ConfirmedBlock)> = None;
+    let mut loaded_block: Option<(Slot, ConfirmedBlock)> = None;
     while limit > 0 {
         let results = bigtable
             .get_confirmed_signatures_for_address(
@@ -188,11 +179,8 @@ pub async fn transaction_history(
                                 }
                                 Some(transaction_with_meta) => {
                                     println_transaction(
-                                        &transaction_with_meta
-                                            .transaction
-                                            .decode()
-                                            .expect("Successful decode"),
-                                        &transaction_with_meta.meta,
+                                        &transaction_with_meta.transaction,
+                                        &transaction_with_meta.meta.clone().map(|m| m.into()),
                                         "  ",
                                     );
                                 }
@@ -200,10 +188,7 @@ pub async fn transaction_history(
                             break;
                         }
                     }
-                    match bigtable
-                        .get_confirmed_block(result.slot, UiTransactionEncoding::Base64)
-                        .await
-                    {
+                    match bigtable.get_confirmed_block(result.slot).await {
                         Err(err) => {
                             println!("  Unable to get confirmed transaction details: {}", err);
                             break;

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -135,10 +135,7 @@ pub async fn upload_confirmed_blocks(
                         break;
                     }
 
-                    let _ = match blockstore.get_confirmed_block(
-                        *slot,
-                        Some(solana_transaction_status::UiTransactionEncoding::Base64),
-                    ) {
+                    let _ = match blockstore.get_confirmed_block(*slot) {
                         Ok(confirmed_block) => sender.send((*slot, Some(confirmed_block))),
                         Err(err) => {
                             warn!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -37,9 +37,8 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_transaction_status::{
-    ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature,
-    EncodedTransaction, Rewards, TransactionStatusMeta, TransactionWithStatusMeta,
-    UiTransactionEncoding, UiTransactionStatusMeta,
+    ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature, Rewards,
+    TransactionStatusMeta, TransactionWithStatusMeta,
 };
 use solana_vote_program::vote_instruction::VoteInstruction;
 use std::{
@@ -1643,11 +1642,7 @@ impl Blockstore {
         Ok(root_iterator.next().unwrap_or_default())
     }
 
-    pub fn get_confirmed_block(
-        &self,
-        slot: Slot,
-        encoding: Option<UiTransactionEncoding>,
-    ) -> Result<ConfirmedBlock> {
+    pub fn get_confirmed_block(&self, slot: Slot) -> Result<ConfirmedBlock> {
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_confirmed_block".to_string(), String)
@@ -1658,7 +1653,6 @@ impl Blockstore {
         if *lowest_cleanup_slot > 0 && *lowest_cleanup_slot >= slot {
             return Err(BlockstoreError::SlotCleanedUp);
         }
-        let encoding = encoding.unwrap_or(UiTransactionEncoding::Json);
         if self.is_root(slot) {
             let slot_meta_cf = self.db.column::<cf::SlotMeta>();
             let slot_meta = match slot_meta_cf.get(slot)? {
@@ -1694,11 +1688,8 @@ impl Blockstore {
                     previous_blockhash: previous_blockhash.to_string(),
                     blockhash: blockhash.to_string(),
                     parent_slot: slot_meta.parent_slot,
-                    transactions: self.map_transactions_to_statuses(
-                        slot,
-                        encoding,
-                        slot_transaction_iterator,
-                    ),
+                    transactions: self
+                        .map_transactions_to_statuses(slot, slot_transaction_iterator),
                     rewards,
                     block_time,
                 };
@@ -1711,19 +1702,16 @@ impl Blockstore {
     fn map_transactions_to_statuses<'a>(
         &self,
         slot: Slot,
-        encoding: UiTransactionEncoding,
         iterator: impl Iterator<Item = Transaction> + 'a,
     ) -> Vec<TransactionWithStatusMeta> {
         iterator
             .map(|transaction| {
                 let signature = transaction.signatures[0];
-                let encoded_transaction = EncodedTransaction::encode(transaction, encoding);
                 TransactionWithStatusMeta {
-                    transaction: encoded_transaction,
+                    transaction,
                     meta: self
                         .read_transaction_status((signature, slot))
-                        .expect("Expect database get to succeed")
-                        .map(UiTransactionStatusMeta::from),
+                        .expect("Expect database get to succeed"),
                 }
             })
             .collect()
@@ -1899,7 +1887,6 @@ impl Blockstore {
     pub fn get_confirmed_transaction(
         &self,
         signature: Signature,
-        encoding: Option<UiTransactionEncoding>,
     ) -> Result<Option<ConfirmedTransaction>> {
         datapoint_info!(
             "blockstore-rpc-api",
@@ -1909,13 +1896,11 @@ impl Blockstore {
             let transaction = self
                 .find_transaction_in_slot(slot, signature)?
                 .ok_or(BlockstoreError::TransactionStatusSlotMismatch)?; // Should not happen
-            let encoding = encoding.unwrap_or(UiTransactionEncoding::Json);
-            let encoded_transaction = EncodedTransaction::encode(transaction, encoding);
             Ok(Some(ConfirmedTransaction {
                 slot,
                 transaction: TransactionWithStatusMeta {
-                    transaction: encoded_transaction,
-                    meta: Some(status.into()),
+                    transaction,
+                    meta: Some(status),
                 },
             }))
         } else {
@@ -2016,27 +2001,23 @@ impl Blockstore {
                 match transaction_status {
                     None => return Ok(vec![]),
                     Some((slot, _)) => {
-                        let confirmed_block = self
-                            .get_confirmed_block(slot, Some(UiTransactionEncoding::Base64))
-                            .map_err(|err| {
-                                BlockstoreError::IO(IOError::new(
-                                    ErrorKind::Other,
-                                    format!("Unable to get confirmed block: {}", err),
-                                ))
-                            })?;
+                        let confirmed_block = self.get_confirmed_block(slot).map_err(|err| {
+                            BlockstoreError::IO(IOError::new(
+                                ErrorKind::Other,
+                                format!("Unable to get confirmed block: {}", err),
+                            ))
+                        })?;
 
                         // Load all signatures for the block
                         let mut slot_signatures: Vec<_> = confirmed_block
                             .transactions
-                            .iter()
+                            .into_iter()
                             .filter_map(|transaction_with_meta| {
-                                if let Some(transaction) =
-                                    transaction_with_meta.transaction.decode()
-                                {
-                                    transaction.signatures.into_iter().next()
-                                } else {
-                                    None
-                                }
+                                transaction_with_meta
+                                    .transaction
+                                    .signatures
+                                    .into_iter()
+                                    .next()
                             })
                             .collect();
 
@@ -2070,27 +2051,23 @@ impl Blockstore {
                 match transaction_status {
                     None => (0, HashSet::new()),
                     Some((slot, _)) => {
-                        let confirmed_block = self
-                            .get_confirmed_block(slot, Some(UiTransactionEncoding::Base64))
-                            .map_err(|err| {
-                                BlockstoreError::IO(IOError::new(
-                                    ErrorKind::Other,
-                                    format!("Unable to get confirmed block: {}", err),
-                                ))
-                            })?;
+                        let confirmed_block = self.get_confirmed_block(slot).map_err(|err| {
+                            BlockstoreError::IO(IOError::new(
+                                ErrorKind::Other,
+                                format!("Unable to get confirmed block: {}", err),
+                            ))
+                        })?;
 
                         // Load all signatures for the block
                         let mut slot_signatures: Vec<_> = confirmed_block
                             .transactions
-                            .iter()
+                            .into_iter()
                             .filter_map(|transaction_with_meta| {
-                                if let Some(transaction) =
-                                    transaction_with_meta.transaction.decode()
-                                {
-                                    transaction.signatures.into_iter().next()
-                                } else {
-                                    None
-                                }
+                                transaction_with_meta
+                                    .transaction
+                                    .signatures
+                                    .into_iter()
+                                    .next()
                             })
                             .collect();
 
@@ -5653,7 +5630,7 @@ pub mod tests {
             .put_meta_bytes(slot - 1, &serialize(&parent_meta).unwrap())
             .unwrap();
 
-        let expected_transactions: Vec<(Transaction, Option<UiTransactionStatusMeta>)> = entries
+        let expected_transactions: Vec<TransactionWithStatusMeta> = entries
             .iter()
             .cloned()
             .filter(|entry| !entry.is_tick())
@@ -5690,37 +5667,27 @@ pub mod tests {
                         },
                     )
                     .unwrap();
-                (
+                TransactionWithStatusMeta {
                     transaction,
-                    Some(
-                        TransactionStatusMeta {
-                            status: Ok(()),
-                            fee: 42,
-                            pre_balances,
-                            post_balances,
-                        }
-                        .into(),
-                    ),
-                )
+                    meta: Some(TransactionStatusMeta {
+                        status: Ok(()),
+                        fee: 42,
+                        pre_balances,
+                        post_balances,
+                    }),
+                }
             })
             .collect();
 
         // Even if marked as root, a slot that is empty of entries should return an error
-        let confirmed_block_err = ledger.get_confirmed_block(slot - 1, None).unwrap_err();
+        let confirmed_block_err = ledger.get_confirmed_block(slot - 1).unwrap_err();
         assert_matches!(confirmed_block_err, BlockstoreError::SlotNotRooted);
 
-        let confirmed_block = ledger.get_confirmed_block(slot, None).unwrap();
+        let confirmed_block = ledger.get_confirmed_block(slot).unwrap();
         assert_eq!(confirmed_block.transactions.len(), 100);
 
         let expected_block = ConfirmedBlock {
-            transactions: expected_transactions
-                .iter()
-                .cloned()
-                .map(|(tx, meta)| TransactionWithStatusMeta {
-                    transaction: EncodedTransaction::encode(tx, UiTransactionEncoding::Json),
-                    meta,
-                })
-                .collect(),
+            transactions: expected_transactions.clone(),
             parent_slot: slot - 1,
             blockhash: blockhash.to_string(),
             previous_blockhash: Hash::default().to_string(),
@@ -5731,18 +5698,11 @@ pub mod tests {
         // root, but empty of entries. This is special handling for snapshot root slots.
         assert_eq!(confirmed_block, expected_block);
 
-        let confirmed_block = ledger.get_confirmed_block(slot + 1, None).unwrap();
+        let confirmed_block = ledger.get_confirmed_block(slot + 1).unwrap();
         assert_eq!(confirmed_block.transactions.len(), 100);
 
         let mut expected_block = ConfirmedBlock {
-            transactions: expected_transactions
-                .iter()
-                .cloned()
-                .map(|(tx, meta)| TransactionWithStatusMeta {
-                    transaction: EncodedTransaction::encode(tx, UiTransactionEncoding::Json),
-                    meta,
-                })
-                .collect(),
+            transactions: expected_transactions,
             parent_slot: slot,
             blockhash: blockhash.to_string(),
             previous_blockhash: blockhash.to_string(),
@@ -5751,7 +5711,7 @@ pub mod tests {
         };
         assert_eq!(confirmed_block, expected_block);
 
-        let not_root = ledger.get_confirmed_block(slot + 2, None).unwrap_err();
+        let not_root = ledger.get_confirmed_block(slot + 2).unwrap_err();
         assert_matches!(not_root, BlockstoreError::SlotNotRooted);
 
         // Test block_time returns, if available
@@ -5759,7 +5719,7 @@ pub mod tests {
         ledger.blocktime_cf.put(slot + 1, &timestamp).unwrap();
         expected_block.block_time = Some(timestamp);
 
-        let confirmed_block = ledger.get_confirmed_block(slot + 1, None).unwrap();
+        let confirmed_block = ledger.get_confirmed_block(slot + 1).unwrap();
         assert_eq!(confirmed_block, expected_block);
 
         drop(ledger);
@@ -6415,7 +6375,7 @@ pub mod tests {
         blockstore.insert_shreds(shreds, None, false).unwrap();
         blockstore.set_roots(&[slot - 1, slot]).unwrap();
 
-        let expected_transactions: Vec<(Transaction, Option<UiTransactionStatusMeta>)> = entries
+        let expected_transactions: Vec<TransactionWithStatusMeta> = entries
             .iter()
             .cloned()
             .filter(|entry| !entry.is_tick())
@@ -6440,48 +6400,32 @@ pub mod tests {
                         },
                     )
                     .unwrap();
-                (
+                TransactionWithStatusMeta {
                     transaction,
-                    Some(
-                        TransactionStatusMeta {
-                            status: Ok(()),
-                            fee: 42,
-                            pre_balances,
-                            post_balances,
-                        }
-                        .into(),
-                    ),
-                )
+                    meta: Some(TransactionStatusMeta {
+                        status: Ok(()),
+                        fee: 42,
+                        pre_balances,
+                        post_balances,
+                    }),
+                }
             })
             .collect();
 
-        for (transaction, status) in expected_transactions.clone() {
-            let signature = transaction.signatures[0];
-            let encoded_transaction =
-                EncodedTransaction::encode(transaction, UiTransactionEncoding::Json);
-            let expected_transaction = ConfirmedTransaction {
-                slot,
-                transaction: TransactionWithStatusMeta {
-                    transaction: encoded_transaction,
-                    meta: status,
-                },
-            };
+        for transaction in expected_transactions.clone() {
+            let signature = transaction.transaction.signatures[0];
             assert_eq!(
-                blockstore
-                    .get_confirmed_transaction(signature, None)
-                    .unwrap(),
-                Some(expected_transaction)
+                blockstore.get_confirmed_transaction(signature).unwrap(),
+                Some(ConfirmedTransaction { slot, transaction })
             );
         }
 
         blockstore.run_purge(0, 2, PurgeType::PrimaryIndex).unwrap();
         *blockstore.lowest_cleanup_slot.write().unwrap() = slot;
-        for (transaction, _) in expected_transactions {
+        for TransactionWithStatusMeta { transaction, .. } in expected_transactions {
             let signature = transaction.signatures[0];
             assert_eq!(
-                blockstore
-                    .get_confirmed_transaction(signature, None)
-                    .unwrap(),
+                blockstore.get_confirmed_transaction(signature).unwrap(),
                 None,
             );
         }
@@ -6494,7 +6438,7 @@ pub mod tests {
         blockstore.set_roots(&[0]).unwrap();
         assert_eq!(
             blockstore
-                .get_confirmed_transaction(Signature::default(), None)
+                .get_confirmed_transaction(Signature::default())
                 .unwrap(),
             None
         );
@@ -6916,11 +6860,7 @@ pub mod tests {
                 vec![CompiledInstruction::new(1, &(), vec![0])],
             ));
 
-            let map = blockstore.map_transactions_to_statuses(
-                slot,
-                UiTransactionEncoding::Json,
-                transactions.into_iter(),
-            );
+            let map = blockstore.map_transactions_to_statuses(slot, transactions.into_iter());
             assert_eq!(map.len(), 5);
             for (x, m) in map.iter().take(4).enumerate() {
                 assert_eq!(m.meta.as_ref().unwrap().fee, x as u64);

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -7,7 +7,9 @@ use solana_sdk::{
     pubkey::Pubkey, signature::Signature, transaction::Transaction,
 };
 use solana_stake_program::{stake_instruction::StakeInstruction, stake_state::Lockup};
-use solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding, UiTransactionStatusMeta};
+use solana_transaction_status::{
+    EncodedConfirmedBlock, UiTransactionEncoding, UiTransactionStatusMeta,
+};
 use std::{collections::HashMap, thread::sleep, time::Duration};
 
 pub type PubkeyString = String;
@@ -244,7 +246,7 @@ fn process_transaction(
 
 fn process_confirmed_block(
     slot: Slot,
-    confirmed_block: ConfirmedBlock,
+    confirmed_block: EncodedConfirmedBlock,
     accounts: &mut HashMap<PubkeyString, AccountInfo>,
 ) {
     for rpc_transaction in confirmed_block.transactions {
@@ -281,7 +283,7 @@ fn load_blocks(
     rpc_client: &RpcClient,
     start_slot: Slot,
     end_slot: Slot,
-) -> ClientResult<Vec<(Slot, ConfirmedBlock)>> {
+) -> ClientResult<Vec<(Slot, EncodedConfirmedBlock)>> {
     info!(
         "Loading confirmed blocks between slots: {} - {}",
         start_slot, end_slot

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -16,7 +16,7 @@ use solana_sdk::{
     clock::Slot, hash::Hash, native_token::lamports_to_sol, program_utils::limited_deserialize,
     pubkey::Pubkey,
 };
-use solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding};
+use solana_transaction_status::{EncodedConfirmedBlock, UiTransactionEncoding};
 use solana_vote_program::vote_instruction::VoteInstruction;
 use std::{
     collections::HashMap,
@@ -157,7 +157,11 @@ fn get_config() -> Config {
     config
 }
 
-fn process_confirmed_block(notifier: &Notifier, slot: Slot, confirmed_block: ConfirmedBlock) {
+fn process_confirmed_block(
+    notifier: &Notifier,
+    slot: Slot,
+    confirmed_block: EncodedConfirmedBlock,
+) {
     let break_program_id = "BrEAK7zGZ6dM71zUDACDqJnekihmwF15noTddWTsknjC"
         .parse::<Pubkey>()
         .unwrap();
@@ -215,7 +219,7 @@ fn load_blocks(
     rpc_client: &RpcClient,
     start_slot: Slot,
     end_slot: Slot,
-) -> ClientResult<Vec<(Slot, ConfirmedBlock)>> {
+) -> ClientResult<Vec<(Slot, EncodedConfirmedBlock)>> {
     info!(
         "Loading confirmed blocks between slots: {} - {}",
         start_slot, end_slot


### PR DESCRIPTION
#### Problem
Transaction encoding is done in the storage layer (bigtable / blockstore) when it really only needs to be done at the api layer (RPC). The current implementation couples the storage types with "UI"/"Encoded" types which adds extra data conversion overhead that isn't necessary. It also does unnecessary transaction serialization

Context: This makes it easier to separate API invoked instruction types from storage invoked instruction types here: https://github.com/solana-labs/solana/pull/12311

#### Summary of Changes
- Introduce new `Encoded..` flavors of `ConfirmedBlock`, `ConfirmedTransaction`, etc.
- Remove all encoding logic from blockstore and bigtable libraries

Fixes #
