### PR TITLE
validator: Add --require-tower stub arg

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1061,6 +1061,12 @@ pub fn main() {
                 .help("Use CUDA"),
         )
         .arg(
+            Arg::with_name("require_tower")
+                .long("require-tower")
+                .takes_value(false)
+                .hidden(true)
+        )
+        .arg(
             Arg::with_name("expected_genesis_hash")
                 .long("expected-genesis-hash")
                 .value_name("HASH")


### PR DESCRIPTION
#### Problem

master/HEAD scripts pass `--require-tower`, which v1.3 validator bins don't know about

#### Summary of Changes

Add a stub arg