### PR TITLE
Explorer: The length of history doesn't change after Refresh.

### DIFF
--- a/explorer/src/providers/accounts/history.tsx
+++ b/explorer/src/providers/accounts/history.tsx
@@ -166,7 +166,9 @@ export function useFetchAccountHistory() {
           limit: 25,
         });
       } else {
-        fetchAccountHistory(dispatch, pubkey, cluster, url, { limit: 25 });
+        fetchAccountHistory(dispatch, pubkey, cluster, url, { 
+          limit: before?.data?.fetched.length || 25 
+        });
       }
     },
     [state, dispatch, cluster, url]


### PR DESCRIPTION
It's simple solution to fix #11934
If your click "Load more" 3 times, then after refreshing your will see 100 detail rows of history (25 - from page load + 25 * 3 from 'load more')