### PR TITLE
adds an atomic variant of the bloom filter

### DIFF
--- a/runtime/benches/bloom.rs
+++ b/runtime/benches/bloom.rs
@@ -3,7 +3,8 @@
 extern crate test;
 use bv::BitVec;
 use fnv::FnvHasher;
-use solana_runtime::bloom::{Bloom, BloomHashIndex};
+use rand::Rng;
+use solana_runtime::bloom::{AtomicBloom, Bloom, BloomHashIndex};
 use solana_sdk::{
     hash::{hash, Hash},
     signature::Signature,
@@ -96,4 +97,49 @@ fn bench_sigs_hashmap(bencher: &mut Bencher) {
         iterations += 1;
     });
     assert_eq!(falses, 0);
+}
+
+#[bench]
+fn bench_add_hash(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let hash_values: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        .take(1200)
+        .collect();
+    let mut fail = 0;
+    bencher.iter(|| {
+        let mut bloom = Bloom::random(1287, 0.1, 7424);
+        for hash_value in &hash_values {
+            bloom.add(hash_value);
+        }
+        let index = rng.gen_range(0, hash_values.len());
+        if !bloom.contains(&hash_values[index]) {
+            fail += 1;
+        }
+    });
+    assert_eq!(fail, 0);
+}
+
+#[bench]
+fn bench_add_hash_atomic(bencher: &mut Bencher) {
+    let mut rng = rand::thread_rng();
+    let hash_values: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        .take(1200)
+        .collect();
+    let mut fail = 0;
+    bencher.iter(|| {
+        let bloom: AtomicBloom<_> = Bloom::random(1287, 0.1, 7424).into();
+        // Intentionally not using parallelism here, so that this and above
+        // benchmark only compare the bit-vector ops.
+        // For benchmarking the parallel code, change bellow for loop to:
+        //     hash_values.par_iter().for_each(|v| bloom.add(v));
+        for hash_value in &hash_values {
+            bloom.add(hash_value);
+        }
+        let bloom: Bloom<_> = bloom.into();
+        let index = rng.gen_range(0, hash_values.len());
+        if !bloom.contains(&hash_values[index]) {
+            fail += 1;
+        }
+    });
+    assert_eq!(fail, 0);
 }

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -88,6 +88,17 @@ impl Hash {
     pub fn to_bytes(self) -> [u8; HASH_BYTES] {
         self.0
     }
+
+    /// New random hash value for tests and benchmarks.
+    #[cfg(not(feature = "program"))]
+    pub fn new_rand<R: ?Sized>(rng: &mut R) -> Self
+    where
+        R: rand::Rng,
+    {
+        let mut buf = [0u8; HASH_BYTES];
+        rng.fill(&mut buf);
+        Hash::new(&buf)
+    }
 }
 
 /// Return a Sha256 hash for the given data.


### PR DESCRIPTION
#### Problem
For crds_gossip_pull, we want to parallelize build_crds_filters, which
requires concurrent writes to bloom filters.

#### Summary of Changes
This commit implements a variant of the bloom filter which uses atomics
for its bits vector, and so is thread-safe.