### PR TITLE
introduce RpcPerfSample and modify getPerformanceSamples output

### DIFF
--- a/client/src/rpc_response.rs
+++ b/client/src/rpc_response.rs
@@ -275,6 +275,15 @@ pub struct RpcConfirmedTransactionStatusWithSignature {
     pub memo: Option<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcPerfSample {
+    pub slot: Slot,
+    pub num_transactions: u64,
+    pub num_slots: u64,
+    pub sample_period_secs: u16,
+}
+
 impl From<ConfirmedTransactionStatusWithSignature> for RpcConfirmedTransactionStatusWithSignature {
     fn from(value: ConfirmedTransactionStatusWithSignature) -> Self {
         let ConfirmedTransactionStatusWithSignature {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -33,10 +33,7 @@ use solana_client::{
     rpc_response::*,
 };
 use solana_faucet::faucet::request_airdrop_transaction;
-use solana_ledger::{
-    blockstore::Blockstore, blockstore_db::BlockstoreError, blockstore_meta::PerfSample,
-    get_tmp_ledger_path,
-};
+use solana_ledger::{blockstore::Blockstore, blockstore_db::BlockstoreError, get_tmp_ledger_path};
 use solana_perf::packet::PACKET_DATA_SIZE;
 use solana_runtime::{
     accounts::AccountAddressFilter,
@@ -1505,7 +1502,7 @@ pub trait RpcSol {
         &self,
         meta: Self::Metadata,
         limit: Option<usize>,
-    ) -> Result<Vec<(Slot, PerfSample)>>;
+    ) -> Result<Vec<RpcPerfSample>>;
 
     #[rpc(meta, name = "getEpochInfo")]
     fn get_epoch_info(
@@ -1900,7 +1897,7 @@ impl RpcSol for RpcSolImpl {
         &self,
         meta: Self::Metadata,
         limit: Option<usize>,
-    ) -> Result<Vec<(Slot, PerfSample)>> {
+    ) -> Result<Vec<RpcPerfSample>> {
         debug!("get_recent_performance_samples request received");
 
         let limit = limit.unwrap_or(PERFORMANCE_SAMPLES_LIMIT);
@@ -1912,12 +1909,21 @@ impl RpcSol for RpcSolImpl {
             )));
         }
 
-        meta.blockstore
+        Ok(meta
+            .blockstore
             .get_recent_perf_samples(limit)
             .map_err(|err| {
                 warn!("get_recent_performance_samples failed: {:?}", err);
                 Error::invalid_request()
+            })?
+            .iter()
+            .map(|(slot, sample)| RpcPerfSample {
+                slot: *slot,
+                num_transactions: sample.num_transactions,
+                num_slots: sample.num_slots,
+                sample_period_secs: sample.sample_period_secs,
             })
+            .collect())
     }
 
     fn get_cluster_nodes(&self, meta: Self::Metadata) -> Result<Vec<RpcContactInfo>> {
@@ -2546,6 +2552,7 @@ pub mod tests {
     use solana_client::rpc_filter::{Memcmp, MemcmpEncodedBytes};
     use solana_ledger::{
         blockstore::entries_to_test_shreds,
+        blockstore_meta::PerfSample,
         blockstore_processor::fill_blockstore_slot_with_ticks,
         entry::next_entry_mut,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -2858,14 +2865,12 @@ pub mod tests {
             "jsonrpc": "2.0",
             "id": 1,
             "result": [
-                [
-                    0,
-                    {
-                        "num_slots": 1,
-                        "num_transactions": 4,
-                        "sample_period_secs": 60
-                    }
-                ]
+                {
+                    "slot": 0,
+                    "num_slots": 1,
+                    "num_transactions": 4,
+                    "sample_period_secs": 60
+                }
             ],
         });
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2867,9 +2867,9 @@ pub mod tests {
             "result": [
                 {
                     "slot": 0,
-                    "num_slots": 1,
-                    "num_transactions": 4,
-                    "sample_period_secs": 60
+                    "numSlots": 1,
+                    "numTransactions": 4,
+                    "samplePeriodSecs": 60
                 }
             ],
         });


### PR DESCRIPTION
#### Problem
`getRecentPerformanceSamples` currently outputs a vector of ordered pairs `(slot, PerfSample)`. This isn't a common pattern in the rpc api, and it would be better if the results were flattened (i.e. a list of objects).

#### Summary of Changes
Move slot number into RpcPerfSample.