### PR TITLE
Fix multisig signed instruction formatting on explorer

### DIFF
--- a/explorer/src/components/instruction/token/TokenDetailsCard.tsx
+++ b/explorer/src/components/instruction/token/TokenDetailsCard.tsx
@@ -132,6 +132,24 @@ function TokenInstruction(props: InfoProps) {
     let value = props.info[key];
     if (value === undefined) continue;
 
+    // Flatten lists of public keys
+    if (Array.isArray(value) && value.every((v) => v instanceof PublicKey)) {
+      for (let i = 0; i < value.length; i++) {
+        let publicKey = value[i];
+        let label = `${key.charAt(0).toUpperCase() + key.slice(1)} - #${i + 1}`;
+
+        attributes.push(
+          <tr key={key + i}>
+            <td>{label}</td>
+            <td className="text-lg-right">
+              <Address pubkey={publicKey} alignRight link />
+            </td>
+          </tr>
+        );
+      }
+      continue;
+    }
+
     if (key === "tokenAmount") {
       key = "amount";
       value = (value as TokenAmountUi).amount;


### PR DESCRIPTION
#### Problem
Explorer crashes when trying to display a token instruction which uses a multisig authority

#### Summary of Changes
Flatten and properly display multisig signers:
<img width="1176" alt="Screen Shot 2020-09-24 at 1 10 53 PM" src="https://user-images.githubusercontent.com/1076145/94103480-618df000-fe67-11ea-983a-3f1cec3235c9.png">

Fixes #
