### PR TITLE
feat: introduce getRecentPerformanceSamples rpc

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -155,6 +155,13 @@ declare module '@solana/web3.js' {
     }>;
   };
 
+  export type PerfSample = {
+    slot: number,
+    numTransactions: number,
+    numSlots: number,
+    samplePeriodSecs: number,
+  };
+
   export type ConfirmedTransaction = {
     slot: number;
     transaction: Transaction;
@@ -421,6 +428,9 @@ declare module '@solana/web3.js' {
     getRecentBlockhashAndContext(
       commitment?: Commitment,
     ): Promise<RpcResponseAndContext<BlockhashAndFeeCalculator>>;
+    getRecentPerformanceSamples(
+      limit?: number,
+    ): Promise<Array<PerfSample>>;
     getFeeCalculatorForBlockhash(
       blockhash: Blockhash,
       commitment?: Commitment,

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -156,10 +156,10 @@ declare module '@solana/web3.js' {
   };
 
   export type PerfSample = {
-    slot: number,
-    numTransactions: number,
-    numSlots: number,
-    samplePeriodSecs: number,
+    slot: number;
+    numTransactions: number;
+    numSlots: number;
+    samplePeriodSecs: number;
   };
 
   export type ConfirmedTransaction = {
@@ -428,9 +428,7 @@ declare module '@solana/web3.js' {
     getRecentBlockhashAndContext(
       commitment?: Commitment,
     ): Promise<RpcResponseAndContext<BlockhashAndFeeCalculator>>;
-    getRecentPerformanceSamples(
-      limit?: number,
-    ): Promise<Array<PerfSample>>;
+    getRecentPerformanceSamples(limit?: number): Promise<Array<PerfSample>>;
     getFeeCalculatorForBlockhash(
       blockhash: Blockhash,
       commitment?: Commitment,

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -433,9 +433,7 @@ declare module '@solana/web3.js' {
     getRecentBlockhashAndContext(
       commitment: ?Commitment,
     ): Promise<RpcResponseAndContext<BlockhashAndFeeCalculator>>;
-    getRecentPerformanceSamples(
-      limit: ?Number,
-    ): Promise<Array<PerfSample>>;
+    getRecentPerformanceSamples(limit: ?number): Promise<Array<PerfSample>>;
     getFeeCalculatorForBlockhash(
       blockhash: Blockhash,
       commitment: ?Commitment,

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -169,6 +169,13 @@ declare module '@solana/web3.js' {
     }>,
   };
 
+  declare export type PerfSample = {
+    slot: number,
+    numTransactions: number,
+    numSlots: number,
+    samplePeriodSecs: number,
+  };
+
   declare export type ConfirmedTransaction = {
     slot: number,
     transaction: Transaction,
@@ -426,6 +433,9 @@ declare module '@solana/web3.js' {
     getRecentBlockhashAndContext(
       commitment: ?Commitment,
     ): Promise<RpcResponseAndContext<BlockhashAndFeeCalculator>>;
+    getRecentPerformanceSamples(
+      limit: ?Number,
+    ): Promise<Array<PerfSample>>;
     getFeeCalculatorForBlockhash(
       blockhash: Blockhash,
       commitment: ?Commitment,

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -506,7 +506,7 @@ type ConfirmedBlock = {
 };
 
 /**
- * A PerfSample (performance sample)
+ * A performance sample
  *
  * @typedef {Object} PerfSample
  * @property {number} slot Slot number of sample
@@ -2361,9 +2361,9 @@ export class Connection {
    * @return {Promise<Array<PerfSample>>}
    */
   async getRecentPerformanceSamples(
-    limit: ?Number,
+    limit: ?number,
   ): Promise<Array<PerfSample>> {
-    const args = this._buildArgs([limit]);
+    const args = this._buildArgs(limit ? [limit] : []);
     const unsafeRes = await this._rpcRequest(
       'getRecentPerformanceSamples',
       args,

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -505,8 +505,25 @@ type ConfirmedBlock = {
   }>,
 };
 
+/**
+ * A PerfSample (performance sample)
+ *
+ * @typedef {Object} PerfSample
+ * @property {number} slot Slot number of sample
+ * @property {number} numTransactions Number of transactions in a sample window
+ * @property {number} numSlots Number of slots in a sample window
+ * @property {number} samplePeriodSecs Sample window in seconds
+ */
+type PerfSample = {
+  slot: number,
+  numTransactions: number,
+  numSlots: number,
+  samplePeriodSecs: number,
+};
+
 function createRpcRequest(url: string, useHttps: boolean): RpcRequest {
   const agentManager = new AgentManager(useHttps);
+
   const server = jayson(async (request, callback) => {
     const agent = agentManager.requestStart();
     const options = {
@@ -1180,6 +1197,20 @@ const GetRecentBlockhashAndContextRpcResult = jsonRpcResultAndContext(
       lamportsPerSignature: 'number',
     }),
   }),
+);
+
+/*
+ * Expected JSON RPC response for "getRecentPerformanceSamples" message
+ */
+const GetRecentPerformanceSamplesRpcResult = jsonRpcResult(
+  struct.array([
+    struct.object({
+      slot: 'number',
+      numTransactions: 'number',
+      numSlots: 'number',
+      samplePeriodSecs: 'number',
+    }),
+  ]),
 );
 
 /**
@@ -2321,6 +2352,30 @@ export class Connection {
     if (res.error) {
       throw new Error('failed to get recent blockhash: ' + res.error.message);
     }
+    assert(typeof res.result !== 'undefined');
+    return res.result;
+  }
+
+  /**
+   * Fetch recent performance samples
+   * @return {Promise<Array<PerfSample>>}
+   */
+  async getRecentPerformanceSamples(
+    limit: ?Number,
+  ): Promise<Array<PerfSample>> {
+    const args = this._buildArgs([limit]);
+    const unsafeRes = await this._rpcRequest(
+      'getRecentPerformanceSamples',
+      args,
+    );
+
+    const res = GetRecentPerformanceSamplesRpcResult(unsafeRes);
+    if (res.error) {
+      throw new Error(
+        'failed to get recent performance samples: ' + res.error.message,
+      );
+    }
+
     assert(typeof res.result !== 'undefined');
     return res.result;
   }

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1204,7 +1204,7 @@ const GetRecentBlockhashAndContextRpcResult = jsonRpcResultAndContext(
  */
 const GetRecentPerformanceSamplesRpcResult = jsonRpcResult(
   struct.array([
-    struct.object({
+    struct.pick({
       slot: 'number',
       numTransactions: 'number',
       numSlots: 'number',

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1280,6 +1280,11 @@ test('get supply', async () => {
 });
 
 test('get performance samples', async () => {
+  if (!mockRpcEnabled) {
+    console.log('live test skipped');
+    return;
+  }
+
   const connection = new Connection(url);
 
   mockRpc.push([
@@ -1310,6 +1315,11 @@ test('get performance samples', async () => {
 });
 
 test('get performance samples limit too high', async () => {
+  if (!mockRpcEnabled) {
+    console.log('live test skipped');
+    return;
+  }
+
   const connection = new Connection(url);
 
   mockRpc.push([

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1279,6 +1279,59 @@ test('get supply', async () => {
   expect(supply.nonCirculatingAccounts.length).toBeGreaterThan(0);
 });
 
+test('get performance samples', async () => {
+  const connection = new Connection(url);
+
+  mockRpc.push([
+    url,
+    {
+      method: 'getRecentPerformanceSamples',
+      params: [],
+    },
+    {
+      error: null,
+      result: [
+        {
+          slot: 1234,
+          numTransactions: 1000,
+          numSlots: 60,
+          samplePeriodSecs: 60,
+        },
+      ],
+    },
+  ]);
+
+  const perfSamples = await connection.getRecentPerformanceSamples();
+  expect(perfSamples.length).toBeGreaterThan(0);
+  expect(perfSamples[0].slot).toBeGreaterThan(0);
+  expect(perfSamples[0].numTransactions).toBeGreaterThan(0);
+  expect(perfSamples[0].numSlots).toBeGreaterThan(0);
+  expect(perfSamples[0].samplePeriodSecs).toBeGreaterThan(0);
+});
+
+test('get performance samples limit too high', async () => {
+  const connection = new Connection(url);
+
+  mockRpc.push([
+    url,
+    {
+      method: 'getRecentPerformanceSamples',
+      params: [100000],
+    },
+    {
+      error: {
+        code: -32602,
+        message: 'Invalid limit; max 720',
+      },
+      result: null,
+    },
+  ]);
+
+  await expect(
+    connection.getRecentPerformanceSamples(100000),
+  ).rejects.toThrow();
+});
+
 const TOKEN_PROGRAM_ID = new PublicKey(
   'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
 );

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1280,62 +1280,59 @@ test('get supply', async () => {
 });
 
 test('get performance samples', async () => {
-  if (!mockRpcEnabled) {
-    console.log('live test skipped');
-    return;
-  }
-
   const connection = new Connection(url);
 
-  mockRpc.push([
-    url,
-    {
-      method: 'getRecentPerformanceSamples',
-      params: [],
-    },
-    {
-      error: null,
-      result: [
-        {
-          slot: 1234,
-          numTransactions: 1000,
-          numSlots: 60,
-          samplePeriodSecs: 60,
-        },
-      ],
-    },
-  ]);
+  if (mockRpcEnabled) {
+    mockRpc.push([
+      url,
+      {
+        method: 'getRecentPerformanceSamples',
+        params: [],
+      },
+      {
+        error: null,
+        result: [
+          {
+            slot: 1234,
+            numTransactions: 1000,
+            numSlots: 60,
+            samplePeriodSecs: 60,
+          },
+        ],
+      },
+    ]);
+  }
 
   const perfSamples = await connection.getRecentPerformanceSamples();
-  expect(perfSamples.length).toBeGreaterThan(0);
-  expect(perfSamples[0].slot).toBeGreaterThan(0);
-  expect(perfSamples[0].numTransactions).toBeGreaterThan(0);
-  expect(perfSamples[0].numSlots).toBeGreaterThan(0);
-  expect(perfSamples[0].samplePeriodSecs).toBeGreaterThan(0);
+  expect(Array.isArray(perfSamples)).toBe(true);
+
+  if (perfSamples.length > 0) {
+    expect(perfSamples[0].slot).toBeGreaterThan(0);
+    expect(perfSamples[0].numTransactions).toBeGreaterThan(0);
+    expect(perfSamples[0].numSlots).toBeGreaterThan(0);
+    expect(perfSamples[0].samplePeriodSecs).toBeGreaterThan(0);
+  }
 });
 
 test('get performance samples limit too high', async () => {
-  if (!mockRpcEnabled) {
-    console.log('live test skipped');
-    return;
-  }
-
   const connection = new Connection(url);
 
-  mockRpc.push([
-    url,
-    {
-      method: 'getRecentPerformanceSamples',
-      params: [100000],
-    },
-    {
-      error: {
-        code: -32602,
-        message: 'Invalid limit; max 720',
+  if (mockRpcEnabled) {
+    mockRpc.push([
+      url,
+      {
+        method: 'getRecentPerformanceSamples',
+        params: [100000],
       },
-      result: null,
-    },
-  ]);
+      {
+        error: {
+          code: -32602,
+          message: 'Invalid limit; max 720',
+        },
+        result: null,
+      },
+    ]);
+  }
 
   await expect(
     connection.getRecentPerformanceSamples(100000),


### PR DESCRIPTION
#### Problem
The `getRecentPerformanceSamples` rpc was introduced in 1.3 and needs an associated call in solana-web3.js. 

#### Proposed Solution
Implement `getRecentPerformanceSamples` in solana-web3.js.

Fixes https://github.com/solana-labs/solana/issues/12419
