### PR TITLE
Use publish=false for benches

### DIFF
--- a/accounts-bench/Cargo.toml
+++ b/accounts-bench/Cargo.toml
@@ -6,6 +6,7 @@ version = "1.4.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
+publish = false
 
 [dependencies]
 log = "0.4.6"

--- a/banking-bench/Cargo.toml
+++ b/banking-bench/Cargo.toml
@@ -6,6 +6,7 @@ version = "1.4.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
+publish = false
 
 [dependencies]
 clap = "2.33.1"

--- a/bench-streamer/Cargo.toml
+++ b/bench-streamer/Cargo.toml
@@ -6,6 +6,7 @@ version = "1.4.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
+publish = false
 
 [dependencies]
 clap = "2.33.1"

--- a/bench-tps/Cargo.toml
+++ b/bench-tps/Cargo.toml
@@ -6,6 +6,7 @@ version = "1.4.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
+publish = false
 
 [dependencies]
 bincode = "1.3.1"

--- a/dos/Cargo.toml
+++ b/dos/Cargo.toml
@@ -6,6 +6,7 @@ version = "1.4.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
+publish = false
 
 [dependencies]
 bincode = "1.3.1"


### PR DESCRIPTION
#### Problem
Benches don't need to be published to crates.io. In some cases, this happens indirectly because the Cargo.toml does not include a description. But `publish = false` is more clear. Also, it sames 1-2min in solana-secondary CI per crate.

#### Summary of Changes
Use `publish = false` for all benches
