### PR TITLE
Port fix_recent_blockhashes_sysvar_delay to FeatureSet

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3651,14 +3651,12 @@ impl Bank {
     }
 
     fn fix_recent_blockhashes_sysvar_delay(&self) -> bool {
-        let activation_slot = match self.cluster_type() {
-            ClusterType::Development => 0,
-            ClusterType::Devnet => 0,
-            ClusterType::Testnet => 27_740_256, // Epoch 76
-            ClusterType::MainnetBeta => Slot::MAX / 2,
-        };
-
-        self.slot() >= activation_slot
+        match self.cluster_type() {
+            ClusterType::Development | ClusterType::Devnet | ClusterType::Testnet => true,
+            ClusterType::MainnetBeta => self
+                .feature_set
+                .is_active(&feature_set::consistent_recent_blockhashes_sysvar::id()),
+        }
     }
 
     // only used for testing

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -13,11 +13,16 @@ pub mod secp256k1_program_enabled {
     solana_sdk::declare_id!("E3PHP7w8kB7np3CTQ1qQ2tW3KCtjRSXBQgW9vM2mWv2Y");
 }
 
+pub mod consistent_recent_blockhashes_sysvar {
+    solana_sdk::declare_id!("3h1BQWPDS5veRsq6mDBWruEpgPxRJkfwGexg5iiQ9mYg");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
         (instructions_sysvar_enabled::id(), "instructions sysvar"),
-        (secp256k1_program_enabled::id(), "secp256k1 program")
+        (secp256k1_program_enabled::id(), "secp256k1 program"),
+        (consistent_recent_blockhashes_sysvar::id(), "consistent recentblockhashes sysvar"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
We still need to activate the RecentBlockhashes one tick delay fix on mainnet-beta (https://github.com/solana-labs/solana/issues/11053).   Port it to FeatureSet to make this easier.

<s>NOTE: This PR is currently based on #12376.  Ignore all but the top commit in here.  `noCI` label until #12376 lands as well to keep CI load down</s>