### PR TITLE
genesis-programs/: Remove legacy inflation activation code

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -464,13 +464,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let native_instruction_processors =
         solana_genesis_programs::get_native_programs_for_genesis(cluster_type);
-    let inflation = solana_genesis_programs::get_inflation(cluster_type, 0).unwrap();
 
     let mut genesis_config = GenesisConfig {
         native_instruction_processors,
         ticks_per_slot,
         epoch_schedule,
-        inflation,
         fee_rate_governor,
         rent,
         poh_config,

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -179,9 +179,6 @@ impl LocalCluster {
             _ => (),
         }
 
-        genesis_config.inflation =
-            solana_genesis_programs::get_inflation(genesis_config.cluster_type, 0).unwrap();
-
         genesis_config
             .native_instruction_processors
             .extend_from_slice(&config.native_instruction_processors);


### PR DESCRIPTION
#### Problem
1. Inflation activation is not a "genesis-program" 
2. This code is all dead now.
3. Future inflation adjustments can be done directly in the Bank with the framework at #12376 

#### Summary of Changes
🚮 
