### PR TITLE
Fix ref-count for multiple stores to the same pubkey in a slot, fixes zero lamport purge detection

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4243,23 +4243,27 @@ pub mod tests {
         accounts.store(current_slot, &[(&pubkey1, &account2)]);
         accounts.store(current_slot, &[(&pubkey1, &account2)]);
         assert_eq!(1, accounts.alive_account_count_in_store(current_slot));
-        assert_eq!(3, accounts.ref_count_for_pubkey(&pubkey1));
+        // Stores to same pubkey, same slot only count once towards the
+        // ref count
+        assert_eq!(2, accounts.ref_count_for_pubkey(&pubkey1));
         accounts.add_root(current_slot);
 
         // C: Yet more update to trigger lazy clean of step A
         current_slot += 1;
-        assert_eq!(3, accounts.ref_count_for_pubkey(&pubkey1));
+        assert_eq!(2, accounts.ref_count_for_pubkey(&pubkey1));
         accounts.store(current_slot, &[(&pubkey1, &account3)]);
-        assert_eq!(4, accounts.ref_count_for_pubkey(&pubkey1));
+        assert_eq!(3, accounts.ref_count_for_pubkey(&pubkey1));
         accounts.add_root(current_slot);
 
         // D: Make pubkey1 0-lamport; also triggers clean of step B
         current_slot += 1;
-        assert_eq!(4, accounts.ref_count_for_pubkey(&pubkey1));
+        assert_eq!(3, accounts.ref_count_for_pubkey(&pubkey1));
         accounts.store(current_slot, &[(&pubkey1, &zero_lamport_account)]);
         accounts.process_dead_slots(None);
         assert_eq!(
-            3, /* == 4 - 2 + 1 */
+            // Removed one reference from the dead slot (reference only counted once
+            // even though there were two stores to the pubkey in that slot)
+            3, /* == 3 - 1 + 1 */
             accounts.ref_count_for_pubkey(&pubkey1)
         );
         accounts.add_root(current_slot);

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -161,12 +161,12 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
         if let Some(lock) = self.account_maps.get(pubkey) {
             let list = &mut lock.1.write().unwrap();
             // filter out other dirty entries from the same slot
-            let mut same_slot_previous_updates: Vec<(usize, (Slot, T))> = list
+            let mut same_slot_previous_updates: Vec<(usize, (Slot, &T))> = list
                 .iter()
                 .enumerate()
-                .filter_map(|(i, (f, value))| {
-                    if *f == slot {
-                        Some((i, (*f, value.clone())))
+                .filter_map(|(i, (s, value))| {
+                    if *s == slot {
+                        Some((i, (*s, value)))
                     } else {
                         None
                     }
@@ -174,8 +174,9 @@ impl<'a, T: 'a + Clone> AccountsIndex<T> {
                 .collect();
             assert!(same_slot_previous_updates.len() <= 1);
 
-            if let Some((list_index, previous_update)) = same_slot_previous_updates.pop() {
-                reclaims.push(previous_update);
+            if let Some((list_index, (s, previous_update_value))) = same_slot_previous_updates.pop()
+            {
+                reclaims.push((s, previous_update_value.clone()));
                 list.remove(list_index);
             } else {
                 // Only increment ref count if the account was not prevously updated in this slot


### PR DESCRIPTION
#### Problem
Storing to the same key multiple times in a slot only keeps one entry alive for that (pubkey, slot)  pair in the AccountsIndex, but increments the ref count multiple times. This means the zero-lamport purge logic will not accurately detect if an account can be purged

#### Summary of Changes
Only increment ref count once per store per pubkey/slot.

Fixes #
