### PR TITLE
Update Current Leader query

### DIFF
--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -136,7 +136,7 @@
           "hide": false,
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT MODE(last) FROM ( SELECT last(\"leader\") FROM \"$testnet\".\"autogen\".\"replay_stage-new_leader\" WHERE $timeFilter GROUP BY host_id )\n",
+          "query": "SELECT last(\"leader\") FROM \"$testnet\".\"autogen\".\"replay_stage-new_leader\" WHERE $timeFilter ORDER BY \"time\" desc \n",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "table",


### PR DESCRIPTION
#### Problem
The current-leader datapoint submitted by all nodes (added in https://github.com/solana-labs/solana/pull/5291) was removed more than a year ago. The dashboard Current Leader query has been broken since then, and always returns the lowest host_id in `replay_stage-new_leader`

#### Summary of Changes
Fix query
