### PR TITLE
Pre-construct cpi instruction recorders before message processing

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2009,11 +2009,15 @@ impl Bank {
                     let (account_refcells, loader_refcells) =
                         Self::accounts_to_refcells(accounts, loaders);
 
-                    let mut instruction_recorders = if enable_cpi_recording {
-                        Some(Vec::new())
+                    let instruction_recorders = if enable_cpi_recording {
+                        Some(vec![
+                            InstructionRecorder::default();
+                            tx.message.instructions.len()
+                        ])
                     } else {
                         None
                     };
+
                     let process_result = self.message_processor.process_message(
                         tx.message(),
                         &loader_refcells,
@@ -2021,7 +2025,7 @@ impl Bank {
                         &self.rent_collector,
                         log_collector.clone(),
                         executors.clone(),
-                        instruction_recorders.as_mut(),
+                        instruction_recorders.as_deref(),
                         self.cluster_type(),
                         self.epoch(),
                     );

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -734,16 +734,14 @@ impl MessageProcessor {
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
         executors: Rc<RefCell<Executors>>,
-        mut instruction_recorders: Option<&mut Vec<InstructionRecorder>>,
+        instruction_recorders: Option<&[InstructionRecorder]>,
         cluster_type: ClusterType,
         epoch: Epoch,
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
-            let instruction_recorder = instruction_recorders.as_mut().map(|recorders| {
-                let instruction_recorder = InstructionRecorder::default();
-                recorders.push(instruction_recorder.clone());
-                instruction_recorder
-            });
+            let instruction_recorder = instruction_recorders
+                .as_ref()
+                .map(|recorders| recorders[instruction_index].clone());
             self.execute_instruction(
                 message,
                 instruction,


### PR DESCRIPTION
#### Problem
Lingering feedback from PR https://github.com/solana-labs/solana/pull/12311

> could these be constructed as a single shot earlier (in the bank) and then looked up here via `instruction_index`?

_Originally posted by @jackcmay in https://github.com/solana-labs/solana/pull/12311#r494638929_

#### Summary of Changes
Pre-allocate the instruction recorder vector when cpi recording is enabled

Fixes #
