### PR TITLE
Add ComputeBudget tuner

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "elf",
  "solana-bpf-loader-program",
  "solana-logger",
+ "solana-measure",
  "solana-runtime",
  "solana-sdk",
  "solana_rbpf",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -24,6 +24,7 @@ byteorder = "1.3.2"
 elf = "0.0.10"
 solana-bpf-loader-program = { path = "../bpf_loader", version = "1.4.0" }
 solana-logger = { path = "../../logger", version = "1.4.0" }
+solana-measure = { path = "../../measure", version = "1.4.0" }
 solana-runtime = { path = "../../runtime", version = "1.4.0" }
 solana-sdk = { path = "../../sdk", version = "1.4.0" }
 solana_rbpf = "=0.1.31"

--- a/programs/bpf/c/src/sanity++/sanity++.cc
+++ b/programs/bpf/c/src/sanity++/sanity++.cc
@@ -1,0 +1,27 @@
+/**
+ * @brief Example C++-based BPF program that prints out the parameters
+ * passed to it
+ */
+#include <solana_sdk.h>
+
+/**
+ * Custom error for when input serialization fails
+ */
+#define INVALID_INPUT 1
+
+extern uint64_t entrypoint(const uint8_t *input) {
+  SolAccountInfo ka[1];
+  SolParameters params = (SolParameters) { .ka = ka };
+
+  sol_log(__FILE__);
+
+  if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {
+    return ERROR_INVALID_ARGUMENT;
+  }
+
+  // Log the provided input parameters.  In the case of  the no-op
+  // program, no account keys or input data are expected but real
+  // programs will have specific requirements so they can do their work.
+  sol_log_params(&params);
+  return SUCCESS;
+}

--- a/programs/bpf/c/src/tuner/tuner.c
+++ b/programs/bpf/c/src/tuner/tuner.c
@@ -1,0 +1,23 @@
+/**
+ * @brief Compute budget tuner program.  Spins in a loop consuming the entire
+ * budget, used by the tuner bench test to tune the compute budget costs.
+ *
+ * Care should be taken because the compiler might optimize out the mechanism
+ * you are trying to tune.
+ */
+
+#include <solana_sdk.h>
+
+extern uint64_t entrypoint(const uint8_t *input) {
+  uint8_t *val = (uint8_t *)input;
+  for (uint64_t i = 0; i < UINT64_MAX; i++) {
+
+    // Uncomment for raw compute
+    {
+      if (*val != 0) {
+        *val = *val + 1;
+      }
+    }
+  }
+  return *val;
+}

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -134,6 +134,8 @@ fn test_program_bpf_sanity() {
             ("noop++", true),
             ("panic", false),
             ("relative_call", true),
+            ("sanity", true),
+            ("sanity++", true),
             ("struct_pass", true),
             ("struct_ret", true),
         ]);
@@ -150,6 +152,7 @@ fn test_program_bpf_sanity() {
             ("solana_bpf_rust_noop", true),
             ("solana_bpf_rust_panic", false),
             ("solana_bpf_rust_param_passing", true),
+            ("solana_bpf_rust_sanity", true),
             ("solana_bpf_rust_sysval", true),
         ]);
     }


### PR DESCRIPTION
#### Problem

No way to tune the compute budget

#### Summary of Changes

Add a bench that runs different scenarios and reports on the time taken given a specific compute budget.  Can be used to tune the compute budget costs.

Also, add missing test

Fixes #
