### PR TITLE
Add precompile verification to preflight

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2210,6 +2210,10 @@ impl RpcSol for RpcSolImpl {
                 return Err(RpcCustomError::TransactionSignatureVerificationFailure.into());
             }
 
+            if let Err(e) = transaction.verify_precompiles() {
+                return Err(RpcCustomError::TransactionPrecompileVerificationFailure(e).into());
+            }
+
             if meta.health.check() != RpcHealthStatus::Ok {
                 return Err(RpcCustomError::RpcNodeUnhealthy.into());
             }

--- a/core/src/rpc_error.rs
+++ b/core/src/rpc_error.rs
@@ -7,6 +7,7 @@ const JSON_RPC_SERVER_ERROR_2: i64 = -32002;
 const JSON_RPC_SERVER_ERROR_3: i64 = -32003;
 const JSON_RPC_SERVER_ERROR_4: i64 = -32004;
 const JSON_RPC_SERVER_ERROR_5: i64 = -32005;
+const JSON_RPC_SERVER_ERROR_6: i64 = -32006;
 
 pub enum RpcCustomError {
     BlockCleanedUp {
@@ -22,6 +23,7 @@ pub enum RpcCustomError {
         slot: Slot,
     },
     RpcNodeUnhealthy,
+    TransactionPrecompileVerificationFailure(solana_sdk::transaction::TransactionError),
 }
 
 impl From<RpcCustomError> for Error {
@@ -56,6 +58,11 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::RpcNodeUnhealthy => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_5),
                 message: "RPC node is unhealthy".to_string(),
+                data: None,
+            },
+            RpcCustomError::TransactionPrecompileVerificationFailure(e) => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_6),
+                message: format!("Transaction precompile verification failure {:?}", e),
                 data: None,
             },
         }


### PR DESCRIPTION
#### Problem

No precompile checks for transaction preflight makes it hard to debug transaction failures.

#### Summary of Changes

Add precompile checks to preflight.

Fixes #
