### PR TITLE
Support new checked parsed token instructions

### DIFF
--- a/explorer/src/components/instruction/token/types.ts
+++ b/explorer/src/components/instruction/token/types.ts
@@ -181,6 +181,10 @@ export const TokenInstructionType = enums([
   "approve2",
   "mintTo2",
   "burn2",
+  "transferChecked",
+  "approveChecked",
+  "mintToChecked",
+  "burnChecked",
 ]);
 
 export const IX_STRUCTS = {
@@ -200,6 +204,10 @@ export const IX_STRUCTS = {
   approve2: ApproveChecked,
   mintTo2: MintToChecked,
   burn2: BurnChecked,
+  transferChecked: TransferChecked,
+  approveChecked: ApproveChecked,
+  mintToChecked: MintToChecked,
+  burnChecked: BurnChecked,
 };
 
 export const IX_TITLES = {
@@ -219,4 +227,8 @@ export const IX_TITLES = {
   approve2: "Approve (Checked)",
   mintTo2: "Mint To (Checked)",
   burn2: "Burn (Checked)",
+  transferChecked: "Transfer (Checked)",
+  approveChecked: "Approve (Checked)",
+  mintToChecked: "Mint To (Checked)",
+  burnChecked: "Burn (Checked)",
 };


### PR DESCRIPTION
#### Problem
Some token instructions have been renamed from "instruction2" to "instructionChecked" e.g. transfer2 to transferChecked.

#### Summary of Changes
Introduced support for both naming styles, until the previous naming style is no longer in production.
