### PR TITLE
Add pico-inflation feature

### DIFF
--- a/programs/bpf/rust/sysval/src/lib.rs
+++ b/programs/bpf/rust/sysval/src/lib.rs
@@ -11,7 +11,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     rent,
     sysvar::{
-        self, clock::Clock, fees::Fees, rent::Rent, rewards::Rewards, slot_hashes::SlotHashes,
+        self, clock::Clock, fees::Fees, rent::Rent, slot_hashes::SlotHashes,
         stake_history::StakeHistory, Sysvar,
     },
 };
@@ -35,24 +35,19 @@ fn process_instruction(
     let fee_calculator = fees.fee_calculator;
     assert_eq!(fee_calculator.lamports_per_signature, 0);
 
-    // Rewards
-    info!("Rewards identifier:");
-    sysvar::rewards::id().log();
-    let _rewards = Rewards::from_account_info(&accounts[4]).expect("rewards");
-
     // Slot Hashes
     info!("SlotHashes identifier:");
     sysvar::slot_hashes::id().log();
-    let slot_hashes = SlotHashes::from_account_info(&accounts[5]).expect("slot_hashes");
+    let slot_hashes = SlotHashes::from_account_info(&accounts[4]).expect("slot_hashes");
     assert!(slot_hashes.len() >= 1);
 
     // Stake History
     info!("StakeHistory identifier:");
     sysvar::stake_history::id().log();
-    let stake_history = StakeHistory::from_account_info(&accounts[6]).expect("stake_history");
+    let stake_history = StakeHistory::from_account_info(&accounts[5]).expect("stake_history");
     assert!(stake_history.len() >= 1);
 
-    let rent = Rent::from_account_info(&accounts[7]).unwrap();
+    let rent = Rent::from_account_info(&accounts[6]).unwrap();
     assert_eq!(
         rent.due(
             rent::DEFAULT_LAMPORTS_PER_BYTE_YEAR * rent::DEFAULT_EXEMPTION_THRESHOLD as u64,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -27,7 +27,7 @@ use solana_sdk::{
     message::Message,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
-    sysvar::{clock, fees, rent, rewards, slot_hashes, stake_history},
+    sysvar::{clock, fees, rent, slot_hashes, stake_history},
     transaction::{Transaction, TransactionError},
 };
 use std::{cell::RefCell, env, fs::File, io::Read, path::PathBuf, rc::Rc, sync::Arc};
@@ -182,7 +182,6 @@ fn test_program_bpf_sanity() {
             AccountMeta::new(Keypair::new().pubkey(), false),
             AccountMeta::new(clock::id(), false),
             AccountMeta::new(fees::id(), false),
-            AccountMeta::new(rewards::id(), false),
             AccountMeta::new(slot_hashes::id(), false),
             AccountMeta::new(stake_history::id(), false),
             AccountMeta::new(rent::id(), false),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1041,13 +1041,18 @@ impl Bank {
 
         let validator_point_value = self.pay_validator_rewards(validator_rewards);
 
-        // this sysvar could be retired...
-        self.update_sysvar_account(&sysvar::rewards::id(), |account| {
-            sysvar::rewards::create_account(
-                self.inherit_sysvar_account_balance(account),
-                validator_point_value,
-            )
-        });
+        if !self
+            .feature_set
+            .is_active(&feature_set::pico_inflation::id())
+        {
+            // this sysvar can be retired once `pico_inflation` is enabled on all clusters
+            self.update_sysvar_account(&sysvar::rewards::id(), |account| {
+                sysvar::rewards::create_account(
+                    self.inherit_sysvar_account_balance(account),
+                    validator_point_value,
+                )
+            });
+        }
 
         let validator_rewards_paid =
             self.stakes.read().unwrap().vote_balance_and_staked() - vote_balance_and_staked;
@@ -3490,6 +3495,13 @@ impl Bank {
     // The entire code path herein must be idempotent
     fn apply_feature_activations(&mut self, init_finish_or_warp: bool, initiate_callback: bool) {
         let new_feature_activations = self.compute_active_feature_set(!init_finish_or_warp);
+
+        if new_feature_activations.contains(&feature_set::pico_inflation::id()) {
+            *self.inflation.write().unwrap() = Inflation::new_fixed(0.0001); // 0.01% inflation
+            self.fee_rate_governor.burn_percent = 50; // 50% fee burn
+            self.rent_collector.rent.burn_percent = 50; // 50% rent burn
+        }
+
         self.ensure_builtins(init_finish_or_warp, &new_feature_activations);
         self.reinvoke_entered_epoch_callback(initiate_callback);
         self.recheck_cross_program_support();

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -17,12 +17,17 @@ pub mod consistent_recent_blockhashes_sysvar {
     solana_sdk::declare_id!("3h1BQWPDS5veRsq6mDBWruEpgPxRJkfwGexg5iiQ9mYg");
 }
 
+pub mod pico_inflation {
+    solana_sdk::declare_id!("GaBtBJvmS4Arjj5W1NmFcyvPjsHN38UGYDq2MDwbs9Qu");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
         (instructions_sysvar_enabled::id(), "instructions sysvar"),
         (secp256k1_program_enabled::id(), "secp256k1 program"),
         (consistent_recent_blockhashes_sysvar::id(), "consistent recentblockhashes sysvar"),
+        (pico_inflation::id(), "pico-inflation"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -261,7 +261,7 @@ mod test_bank_serialize {
 
     // These some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "FaZaic5p7bvdsKDxGJmaPVyp12AbAmURyYoGiUdx1Ksu")]
+    #[frozen_abi(digest = "5rd8RyVSLH3hm12xJDVCJWgc1gyqb4Ukt2hJLJNfsB5v")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperFuture {
         #[serde(serialize_with = "wrapper_future")]

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -59,7 +59,7 @@ impl FromStr for ClusterType {
     }
 }
 
-#[frozen_abi(digest = "AM75NxYJj5s45rtkFV5S1RCHg2kNMgACjTu5HPfEt4Fp")]
+#[frozen_abi(digest = "DEg4N5ps9EdEBL2H2ahU54SCcw3QphtPjh48H413fvNq")]
 #[derive(Serialize, Deserialize, Debug, Clone, AbiExample)]
 pub struct GenesisConfig {
     /// when the network (bootstrap validator) was started relative to the UNIX Epoch

--- a/sdk/src/sysvar/rewards.rs
+++ b/sdk/src/sysvar/rewards.rs
@@ -1,4 +1,4 @@
-//! This account contains the current cluster rewards point values
+//! DEPRECATED: This sysvar can be removed once the pico-inflation feature is enabled
 //!
 use crate::{account::Account, sysvar::Sysvar};
 


### PR DESCRIPTION
Add feature to enable minimal inflation:
* 0.01% for vote/stake rewards
* 50% rent burn
* 50% fee burn