### PR TITLE
Move process_instruction defs to runtime

### DIFF
--- a/genesis-programs/.gitignore
+++ b/genesis-programs/.gitignore
@@ -1,2 +1,0 @@
-/target/
-/farf/

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -14,15 +14,15 @@ use solana_runtime::{
     bank_client::BankClient,
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
     loader_utils::load_program,
+    process_instruction::{
+        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
+    },
 };
 use solana_sdk::{
     account::Account,
     bpf_loader,
     client::SyncClient,
     entrypoint::SUCCESS,
-    entrypoint_native::{
-        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
-    },
     instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
     message::Message,
     pubkey::Pubkey,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -13,6 +13,9 @@ use solana_runtime::{
     bank_client::BankClient,
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
     loader_utils::load_program,
+    process_instruction::{
+        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
+    },
 };
 use solana_sdk::{
     account::{Account, KeyedAccount},
@@ -20,9 +23,7 @@ use solana_sdk::{
     client::SyncClient,
     clock::{DEFAULT_SLOTS_PER_EPOCH, MAX_PROCESSING_AGE},
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
-    entrypoint_native::{
-        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
-    },
+
     instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
     message::Message,
     pubkey::Pubkey,
@@ -629,12 +630,12 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_128bit", 543),
             ("solana_bpf_rust_alloc", 19082),
             ("solana_bpf_rust_dep_crate", 2),
-            ("solana_bpf_rust_external_spend", 473),
+            ("solana_bpf_rust_external_spend", 477),
             ("solana_bpf_rust_iter", 723),
             ("solana_bpf_rust_many_args", 231),
-            ("solana_bpf_rust_noop", 447),
+            ("solana_bpf_rust_noop", 451),
             ("solana_bpf_rust_param_passing", 54),
-            ("solana_bpf_rust_sanity", 2211),
+            ("solana_bpf_rust_sanity", 2215),
         ]);
     }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -16,12 +16,12 @@ use solana_rbpf::{
     memory_region::MemoryRegion,
     vm::{EbpfVm, Executable, InstructionMeter},
 };
+use solana_runtime::process_instruction::{ComputeMeter, Executor, InvokeContext};
 use solana_sdk::{
     account::{is_executable, next_keyed_account, KeyedAccount},
     bpf_loader, bpf_loader_deprecated,
     decode_error::DecodeError,
     entrypoint::SUCCESS,
-    entrypoint_native::{ComputeMeter, Executor, InvokeContext},
     instruction::InstructionError,
     loader_instruction::LoaderInstruction,
     program_utils::limited_deserialize,
@@ -270,14 +270,13 @@ impl Executor for BPFExecutor {
 mod tests {
     use super::*;
     use rand::Rng;
-    use solana_runtime::message_processor::{Executors, ThisInvokeContext};
+    use solana_runtime::{
+        message_processor::{Executors, ThisInvokeContext},
+        process_instruction::{ComputeBudget, Logger, ProcessInstruction},
+    };
     use solana_sdk::{
-        account::Account,
-        entrypoint_native::{ComputeBudget, Logger, ProcessInstruction},
-        instruction::CompiledInstruction,
-        instruction::Instruction,
-        message::Message,
-        rent::Rent,
+        account::Account, instruction::CompiledInstruction, instruction::Instruction,
+        message::Message, rent::Rent,
     };
     use std::{cell::RefCell, fs::File, io::Read, ops::Range, rc::Rc};
 

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -6,14 +6,16 @@ use solana_rbpf::{
     memory_region::{translate_addr, MemoryRegion},
     vm::{EbpfVm, SyscallObject},
 };
-use solana_runtime::message_processor::MessageProcessor;
+use solana_runtime::{
+    message_processor::MessageProcessor,
+    process_instruction::{ComputeMeter, InvokeContext, Logger},
+};
 use solana_sdk::{
     account::Account,
     account::KeyedAccount,
     account_info::AccountInfo,
     bpf_loader, bpf_loader_deprecated,
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
-    entrypoint_native::{ComputeMeter, InvokeContext, Logger},
     instruction::{AccountMeta, Instruction, InstructionError},
     message::Message,
     program_error::ProgramError,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -18,6 +18,9 @@ use crate::{
     log_collector::LogCollector,
     message_processor::{Executors, MessageProcessor},
     nonce_utils,
+    process_instruction::{
+        ComputeBudget, Executor, ProcessInstruction, ProcessInstructionWithContext,
+    },
     rent_collector::RentCollector,
     stakes::Stakes,
     status_cache::{SlotDelta, StatusCache},
@@ -37,9 +40,6 @@ use solana_sdk::{
     clock::{
         Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, DEFAULT_TICKS_PER_SECOND,
         MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES, SECONDS_PER_DAY,
-    },
-    entrypoint_native::{
-        ComputeBudget, Executor, ProcessInstruction, ProcessInstructionWithContext,
     },
     epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
@@ -3805,13 +3805,13 @@ mod tests {
         genesis_utils::{
             create_genesis_config_with_leader, GenesisConfigInfo, BOOTSTRAP_VALIDATOR_LAMPORTS,
         },
+        process_instruction::InvokeContext,
         status_cache::MAX_CACHE_ENTRIES,
     };
     use solana_sdk::{
         account::KeyedAccount,
         account_utils::StateMut,
         clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
-        entrypoint_native::InvokeContext,
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         genesis_config::create_genesis_config,
         instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
@@ -8740,7 +8740,7 @@ mod tests {
             _pubkey: &Pubkey,
             _ka: &[KeyedAccount],
             _data: &[u8],
-            _context: &mut dyn solana_sdk::entrypoint_native::InvokeContext,
+            _context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Ok(())
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -211,7 +211,6 @@ pub struct Builtins {
 const MAX_CACHED_EXECUTORS: usize = 100; // 10 MB assuming programs are around 100k
 
 /// LFU Cache of executors
-#[derive(AbiExample)]
 struct CachedExecutors {
     max: usize,
     executors: HashMap<Pubkey, (AtomicU64, Arc<dyn Executor>)>,
@@ -224,6 +223,17 @@ impl Default for CachedExecutors {
         }
     }
 }
+
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
+impl AbiExample for CachedExecutors {
+    fn example() -> Self {
+        // Delegate AbiExample impl to Default before going deep and stuck with
+        // not easily impl-able Arc<dyn Executor> due to rust's coherence issue
+        // This is safe because CachedExecutors isn't serializable by definition.
+        Self::default()
+    }
+}
+
 impl Clone for CachedExecutors {
     fn clone(&self) -> Self {
         let mut executors = HashMap::new();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -22,6 +22,7 @@ pub mod log_collector;
 pub mod message_processor;
 mod native_loader;
 pub mod nonce_utils;
+pub mod process_instruction;
 pub mod rent_collector;
 pub mod serde_snapshot;
 pub mod snapshot_package;

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -3,6 +3,10 @@ use crate::{
     instruction_recorder::InstructionRecorder,
     log_collector::LogCollector,
     native_loader::NativeLoader,
+    process_instruction::{
+        ComputeBudget, ComputeMeter, ErasedProcessInstruction, ErasedProcessInstructionWithContext,
+        Executor, InvokeContext, Logger, ProcessInstruction, ProcessInstructionWithContext,
+    },
     rent_collector::RentCollector,
 };
 use log::*;
@@ -10,10 +14,6 @@ use serde::{Deserialize, Serialize};
 use solana_sdk::{
     account::{create_keyed_readonly_accounts, Account, KeyedAccount},
     clock::Epoch,
-    entrypoint_native::{
-        ComputeBudget, ComputeMeter, ErasedProcessInstruction, ErasedProcessInstructionWithContext,
-        Executor, InvokeContext, Logger, ProcessInstruction, ProcessInstructionWithContext,
-    },
     instruction::{CompiledInstruction, Instruction, InstructionError},
     message::Message,
     native_loader,
@@ -1694,7 +1694,7 @@ mod tests {
             _pubkey: &Pubkey,
             _ka: &[KeyedAccount],
             _data: &[u8],
-            _context: &mut dyn solana_sdk::entrypoint_native::InvokeContext,
+            _context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             Ok(())
         }

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -1,4 +1,5 @@
 //! Native loader
+use crate::process_instruction::{InvokeContext, LoaderEntrypoint};
 #[cfg(unix)]
 use libloading::os::unix::*;
 #[cfg(windows)]
@@ -8,7 +9,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use solana_sdk::{
     account::{next_keyed_account, KeyedAccount},
     decode_error::DecodeError,
-    entrypoint_native::{InvokeContext, LoaderEntrypoint, ProgramEntrypoint},
+    entrypoint_native::ProgramEntrypoint,
     instruction::InstructionError,
     pubkey::Pubkey,
 };

--- a/runtime/src/process_instruction.rs
+++ b/runtime/src/process_instruction.rs
@@ -1,5 +1,3 @@
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
-use solana_sdk::abi_example::AbiExample;
 use solana_sdk::{
     account::{Account, KeyedAccount},
     instruction::{CompiledInstruction, Instruction, InstructionError},
@@ -129,22 +127,4 @@ pub trait Executor: Send + Sync {
         instruction_data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError>;
-}
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
-impl AbiExample for Arc<dyn Executor> {
-    fn example() -> Self {
-        struct ExampleExecutor {}
-        impl Executor for ExampleExecutor {
-            fn execute(
-                &self,
-                _program_id: &Pubkey,
-                _keyed_accounts: &[KeyedAccount],
-                _instruction_data: &[u8],
-                _invoke_context: &mut dyn InvokeContext,
-            ) -> std::result::Result<(), InstructionError> {
-                Ok(())
-            }
-        }
-        Arc::new(ExampleExecutor {})
-    }
 }

--- a/runtime/src/process_instruction.rs
+++ b/runtime/src/process_instruction.rs
@@ -1,0 +1,150 @@
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
+use solana_sdk::abi_example::AbiExample;
+use solana_sdk::{
+    account::{Account, KeyedAccount},
+    instruction::{CompiledInstruction, Instruction, InstructionError},
+    message::Message,
+    pubkey::Pubkey,
+};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+// Prototype of a native loader entry point
+///
+/// program_id: Program ID of the currently executing program
+/// keyed_accounts: Accounts passed as part of the instruction
+/// instruction_data: Instruction data
+/// invoke_context: Invocation context
+pub type LoaderEntrypoint = unsafe extern "C" fn(
+    program_id: &Pubkey,
+    keyed_accounts: &[KeyedAccount],
+    instruction_data: &[u8],
+    invoke_context: &dyn InvokeContext,
+) -> Result<(), InstructionError>;
+
+pub type ProcessInstruction = fn(&Pubkey, &[KeyedAccount], &[u8]) -> Result<(), InstructionError>;
+pub type ProcessInstructionWithContext =
+    fn(&Pubkey, &[KeyedAccount], &[u8], &mut dyn InvokeContext) -> Result<(), InstructionError>;
+
+// These are just type aliases for work around of Debug-ing above function pointers
+pub type ErasedProcessInstructionWithContext = fn(
+    &'static Pubkey,
+    &'static [KeyedAccount<'static>],
+    &'static [u8],
+    &'static mut dyn InvokeContext,
+) -> Result<(), InstructionError>;
+
+pub type ErasedProcessInstruction = fn(
+    &'static Pubkey,
+    &'static [KeyedAccount<'static>],
+    &'static [u8],
+) -> Result<(), InstructionError>;
+
+/// Invocation context passed to loaders
+pub trait InvokeContext {
+    /// Push a program ID on to the invocation stack
+    fn push(&mut self, key: &Pubkey) -> Result<(), InstructionError>;
+    /// Pop a program ID off of the invocation stack
+    fn pop(&mut self);
+    /// Verify and update PreAccount state based on program execution
+    fn verify_and_update(
+        &mut self,
+        message: &Message,
+        instruction: &CompiledInstruction,
+        accounts: &[Rc<RefCell<Account>>],
+    ) -> Result<(), InstructionError>;
+    /// Get the program ID of the currently executing program
+    fn get_caller(&self) -> Result<&Pubkey, InstructionError>;
+    /// Get a list of built-in programs
+    fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)];
+    /// Get this invocation's logger
+    fn get_logger(&self) -> Rc<RefCell<dyn Logger>>;
+    /// Are cross program invocations supported
+    fn is_cross_program_supported(&self) -> bool;
+    /// Get this invocation's compute budget
+    fn get_compute_budget(&self) -> ComputeBudget;
+    /// Get this invocation's compute meter
+    fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>>;
+    /// Loaders may need to do work in order to execute a program.  Cache
+    /// the work that can be re-used across executions
+    fn add_executor(&mut self, pubkey: &Pubkey, executor: Arc<dyn Executor>);
+    /// Get the completed loader work that can be re-used across executions
+    fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>>;
+    /// Record invoked instruction
+    fn record_instruction(&self, instruction: &Instruction);
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ComputeBudget {
+    /// Number of compute units that an instruction is allowed.  Compute units
+    /// are consumed by program execution, resources they use, etc...
+    pub max_units: u64,
+    /// Number of compute units consumed by a log call
+    pub log_units: u64,
+    /// Number of compute units consumed by a log_u64 call
+    pub log_64_units: u64,
+    /// Number of compute units consumed by a create_program_address call
+    pub create_program_address_units: u64,
+    /// Number of compute units consumed by an invoke call (not including the cost incured by
+    /// the called program)
+    pub invoke_units: u64,
+    /// Maximum cross-program invocation depth allowed including the orignal caller
+    pub max_invoke_depth: usize,
+}
+impl Default for ComputeBudget {
+    fn default() -> Self {
+        // Tuned for ~1ms
+        ComputeBudget {
+            max_units: 200_000,
+            log_units: 100,
+            log_64_units: 100,
+            create_program_address_units: 1500,
+            invoke_units: 1000,
+            max_invoke_depth: 2,
+        }
+    }
+}
+
+/// Compute meter
+pub trait ComputeMeter {
+    /// Consume compute units
+    fn consume(&mut self, amount: u64) -> Result<(), InstructionError>;
+    /// Get the number of remaining compute units
+    fn get_remaining(&self) -> u64;
+}
+
+/// Log messages
+pub trait Logger {
+    fn log_enabled(&self) -> bool;
+    /// Log a message
+    fn log(&mut self, message: &str);
+}
+
+/// Program executor
+pub trait Executor: Send + Sync {
+    /// Execute the program
+    fn execute(
+        &self,
+        program_id: &Pubkey,
+        keyed_accounts: &[KeyedAccount],
+        instruction_data: &[u8],
+        invoke_context: &mut dyn InvokeContext,
+    ) -> Result<(), InstructionError>;
+}
+#[cfg(RUSTC_WITH_SPECIALIZATION)]
+impl AbiExample for Arc<dyn Executor> {
+    fn example() -> Self {
+        struct ExampleExecutor {}
+        impl Executor for ExampleExecutor {
+            fn execute(
+                &self,
+                _program_id: &Pubkey,
+                _keyed_accounts: &[KeyedAccount],
+                _instruction_data: &[u8],
+                _invoke_context: &mut dyn InvokeContext,
+            ) -> std::result::Result<(), InstructionError> {
+                Ok(())
+            }
+        }
+        Arc::new(ExampleExecutor {})
+    }
+}

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -1,7 +1,5 @@
 //! @brief Solana Native program entry point
 
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
-use crate::abi_example::AbiExample;
 use crate::{account::KeyedAccount, instruction::InstructionError, pubkey::Pubkey};
 
 // Prototype of a native program entry point

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -2,13 +2,7 @@
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 use crate::abi_example::AbiExample;
-use crate::{
-    account::{Account, KeyedAccount},
-    instruction::{CompiledInstruction, Instruction, InstructionError},
-    message::Message,
-    pubkey::Pubkey,
-};
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use crate::{account::KeyedAccount, instruction::InstructionError, pubkey::Pubkey};
 
 // Prototype of a native program entry point
 ///
@@ -19,19 +13,6 @@ pub type ProgramEntrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
-) -> Result<(), InstructionError>;
-
-// Prototype of a native loader entry point
-///
-/// program_id: Program ID of the currently executing program
-/// keyed_accounts: Accounts passed as part of the instruction
-/// instruction_data: Instruction data
-/// invoke_context: Invocation context
-pub type LoaderEntrypoint = unsafe extern "C" fn(
-    program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
-    instruction_data: &[u8],
-    invoke_context: &dyn InvokeContext,
 ) -> Result<(), InstructionError>;
 
 #[rustversion::since(1.46.0)]
@@ -178,131 +159,3 @@ macro_rules! declare_program(
         }
     )
 );
-
-pub type ProcessInstruction = fn(&Pubkey, &[KeyedAccount], &[u8]) -> Result<(), InstructionError>;
-pub type ProcessInstructionWithContext =
-    fn(&Pubkey, &[KeyedAccount], &[u8], &mut dyn InvokeContext) -> Result<(), InstructionError>;
-
-// These are just type aliases for work around of Debug-ing above function pointers
-pub type ErasedProcessInstructionWithContext = fn(
-    &'static Pubkey,
-    &'static [KeyedAccount<'static>],
-    &'static [u8],
-    &'static mut dyn InvokeContext,
-) -> Result<(), InstructionError>;
-
-pub type ErasedProcessInstruction = fn(
-    &'static Pubkey,
-    &'static [KeyedAccount<'static>],
-    &'static [u8],
-) -> Result<(), InstructionError>;
-
-/// Invocation context passed to loaders
-pub trait InvokeContext {
-    /// Push a program ID on to the invocation stack
-    fn push(&mut self, key: &Pubkey) -> Result<(), InstructionError>;
-    /// Pop a program ID off of the invocation stack
-    fn pop(&mut self);
-    /// Verify and update PreAccount state based on program execution
-    fn verify_and_update(
-        &mut self,
-        message: &Message,
-        instruction: &CompiledInstruction,
-        accounts: &[Rc<RefCell<Account>>],
-    ) -> Result<(), InstructionError>;
-    /// Get the program ID of the currently executing program
-    fn get_caller(&self) -> Result<&Pubkey, InstructionError>;
-    /// Get a list of built-in programs
-    fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)];
-    /// Get this invocation's logger
-    fn get_logger(&self) -> Rc<RefCell<dyn Logger>>;
-    /// Are cross program invocations supported
-    fn is_cross_program_supported(&self) -> bool;
-    /// Get this invocation's compute budget
-    fn get_compute_budget(&self) -> ComputeBudget;
-    /// Get this invocation's compute meter
-    fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>>;
-    /// Loaders may need to do work in order to execute a program.  Cache
-    /// the work that can be re-used across executions
-    fn add_executor(&mut self, pubkey: &Pubkey, executor: Arc<dyn Executor>);
-    /// Get the completed loader work that can be re-used across executions
-    fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>>;
-    /// Record invoked instruction
-    fn record_instruction(&self, instruction: &Instruction);
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct ComputeBudget {
-    /// Number of compute units that an instruction is allowed.  Compute units
-    /// are consumed by program execution, resources they use, etc...
-    pub max_units: u64,
-    /// Number of compute units consumed by a log call
-    pub log_units: u64,
-    /// Number of compute units consumed by a log_u64 call
-    pub log_64_units: u64,
-    /// Number of compute units consumed by a create_program_address call
-    pub create_program_address_units: u64,
-    /// Number of compute units consumed by an invoke call (not including the cost incured by
-    /// the called program)
-    pub invoke_units: u64,
-    /// Maximum cross-program invocation depth allowed including the orignal caller
-    pub max_invoke_depth: usize,
-}
-impl Default for ComputeBudget {
-    fn default() -> Self {
-        // Tuned for ~1ms
-        ComputeBudget {
-            max_units: 200_000,
-            log_units: 100,
-            log_64_units: 100,
-            create_program_address_units: 1500,
-            invoke_units: 1000,
-            max_invoke_depth: 2,
-        }
-    }
-}
-
-/// Compute meter
-pub trait ComputeMeter {
-    /// Consume compute units
-    fn consume(&mut self, amount: u64) -> Result<(), InstructionError>;
-    /// Get the number of remaining compute units
-    fn get_remaining(&self) -> u64;
-}
-
-/// Log messages
-pub trait Logger {
-    fn log_enabled(&self) -> bool;
-    /// Log a message
-    fn log(&mut self, message: &str);
-}
-
-/// Program executor
-pub trait Executor: Send + Sync {
-    /// Execute the program
-    fn execute(
-        &self,
-        program_id: &Pubkey,
-        keyed_accounts: &[KeyedAccount],
-        instruction_data: &[u8],
-        invoke_context: &mut dyn InvokeContext,
-    ) -> Result<(), InstructionError>;
-}
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
-impl AbiExample for Arc<dyn Executor> {
-    fn example() -> Self {
-        struct ExampleExecutor {}
-        impl Executor for ExampleExecutor {
-            fn execute(
-                &self,
-                _program_id: &Pubkey,
-                _keyed_accounts: &[KeyedAccount],
-                _instruction_data: &[u8],
-                _invoke_context: &mut dyn InvokeContext,
-            ) -> std::result::Result<(), InstructionError> {
-                Ok(())
-            }
-        }
-        Arc::new(ExampleExecutor {})
-    }
-}


### PR DESCRIPTION
#### Problem

- Bunch of definitions that don't need to be in the sdk
- We are going to need to pipe `FeatureSet` into `InvokeContext` but `FeatureSet` is local to runtime

#### Summary of Changes

These definitions don't need to be in the SDK and moving them into runtime brings them in with their users and allows us to leave `FeatureSet` where it is.

Fixes #
