### PR TITLE
Rpc -> proper optimistic confirmation

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -611,7 +611,6 @@ impl ClusterInfoVoteListener {
                                 warn!("bank_notification_sender failed: {:?}", err)
                             });
                     }
-                    subscriptions.notify_gossip_subscribers(*slot);
                 }
 
                 if !is_new && !is_gossip_vote {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod ledger_cleanup_service;
 pub mod local_vote_signer_service;
 pub mod non_circulating_supply;
 pub mod optimistic_confirmation_verifier;
+pub mod optimistically_confirmed_bank_tracker;
 pub mod poh_recorder;
 pub mod poh_service;
 pub mod progress_map;

--- a/core/src/optimistically_confirmed_bank_tracker.rs
+++ b/core/src/optimistically_confirmed_bank_tracker.rs
@@ -1,0 +1,275 @@
+//! The `optimistically_confirmed_bank_tracker` module implements a threaded service to track the
+//! most recent optimistically confirmed bank for use in rpc services, and triggers gossip
+//! subscription notifications
+
+use crate::rpc_subscriptions::RpcSubscriptions;
+use solana_runtime::{bank::Bank, bank_forks::BankForks};
+use solana_sdk::clock::Slot;
+use std::{
+    collections::HashSet,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{Receiver, RecvTimeoutError},
+        Arc, RwLock,
+    },
+    thread::{self, Builder, JoinHandle},
+    time::Duration,
+};
+
+pub struct OptimisticallyConfirmedBank {
+    pub bank: Arc<Bank>,
+}
+
+impl OptimisticallyConfirmedBank {
+    pub fn locked_from_bank_forks_root(bank_forks: &Arc<RwLock<BankForks>>) -> Arc<RwLock<Self>> {
+        Arc::new(RwLock::new(Self {
+            bank: bank_forks.read().unwrap().root_bank().clone(),
+        }))
+    }
+}
+
+pub enum BankNotification {
+    OptimisticallyConfirmed(Slot),
+    Frozen(Arc<Bank>),
+    Root(Arc<Bank>),
+}
+
+impl std::fmt::Debug for BankNotification {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            BankNotification::OptimisticallyConfirmed(slot) => {
+                write!(f, "OptimisticallyConfirmed({:?})", slot)
+            }
+            BankNotification::Frozen(bank) => write!(f, "Frozen({})", bank.slot()),
+            BankNotification::Root(bank) => write!(f, "Root({})", bank.slot()),
+        }
+    }
+}
+
+pub struct OptimisticallyConfirmedBankTracker {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl OptimisticallyConfirmedBankTracker {
+    pub fn new(
+        receiver: Receiver<BankNotification>,
+        exit: &Arc<AtomicBool>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
+        subscriptions: Arc<RpcSubscriptions>,
+    ) -> Self {
+        let exit_ = exit.clone();
+        let mut pending_optimistically_confirmed_banks = HashSet::new();
+        let thread_hdl = Builder::new()
+            .name("solana-optimistic-bank-tracker".to_string())
+            .spawn(move || loop {
+                if exit_.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                if let Err(RecvTimeoutError::Disconnected) = Self::recv_notification(
+                    &receiver,
+                    &bank_forks,
+                    &optimistically_confirmed_bank,
+                    &subscriptions,
+                    &mut pending_optimistically_confirmed_banks,
+                ) {
+                    break;
+                }
+            })
+            .unwrap();
+        Self { thread_hdl }
+    }
+
+    fn recv_notification(
+        receiver: &Receiver<BankNotification>,
+        bank_forks: &Arc<RwLock<BankForks>>,
+        optimistically_confirmed_bank: &Arc<RwLock<OptimisticallyConfirmedBank>>,
+        subscriptions: &Arc<RpcSubscriptions>,
+        mut pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
+    ) -> Result<(), RecvTimeoutError> {
+        let notification = receiver.recv_timeout(Duration::from_secs(1))?;
+        Self::process_notification(
+            notification,
+            bank_forks,
+            optimistically_confirmed_bank,
+            subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        Ok(())
+    }
+
+    fn process_notification(
+        notification: BankNotification,
+        bank_forks: &Arc<RwLock<BankForks>>,
+        optimistically_confirmed_bank: &Arc<RwLock<OptimisticallyConfirmedBank>>,
+        subscriptions: &Arc<RpcSubscriptions>,
+        pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
+    ) {
+        debug!("received bank notification: {:?}", notification);
+        match notification {
+            BankNotification::OptimisticallyConfirmed(slot) => {
+                if let Some(bank) = bank_forks
+                    .read()
+                    .unwrap()
+                    .get(slot)
+                    .filter(|b| b.is_frozen())
+                {
+                    let mut w_optimistically_confirmed_bank =
+                        optimistically_confirmed_bank.write().unwrap();
+                    if bank.slot() > w_optimistically_confirmed_bank.bank.slot() {
+                        w_optimistically_confirmed_bank.bank = bank.clone();
+                    }
+                    drop(w_optimistically_confirmed_bank);
+                    subscriptions.notify_gossip_subscribers(slot);
+                } else {
+                    pending_optimistically_confirmed_banks.insert(slot);
+                }
+            }
+            BankNotification::Frozen(bank) => {
+                let frozen_slot = bank.slot();
+                if pending_optimistically_confirmed_banks.remove(&bank.slot()) {
+                    let mut w_optimistically_confirmed_bank =
+                        optimistically_confirmed_bank.write().unwrap();
+                    if frozen_slot > w_optimistically_confirmed_bank.bank.slot() {
+                        w_optimistically_confirmed_bank.bank = bank;
+                    }
+                    drop(w_optimistically_confirmed_bank);
+                    subscriptions.notify_gossip_subscribers(frozen_slot);
+                }
+            }
+            BankNotification::Root(bank) => {
+                let root_slot = bank.slot();
+                let mut w_optimistically_confirmed_bank =
+                    optimistically_confirmed_bank.write().unwrap();
+                if root_slot > w_optimistically_confirmed_bank.bank.slot() {
+                    w_optimistically_confirmed_bank.bank = bank;
+                }
+                drop(w_optimistically_confirmed_bank);
+                *pending_optimistically_confirmed_banks = pending_optimistically_confirmed_banks
+                    .iter()
+                    .cloned()
+                    .filter(|&s| s > root_slot)
+                    .collect();
+            }
+        }
+    }
+
+    pub fn close(self) -> thread::Result<()> {
+        self.join()
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
+    use solana_runtime::commitment::BlockCommitmentCache;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_process_notification() {
+        let exit = Arc::new(AtomicBool::new(false));
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
+        let bank = Bank::new(&genesis_config);
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        bank_forks.write().unwrap().insert(bank1);
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        bank_forks.write().unwrap().insert(bank2);
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+        bank_forks.write().unwrap().insert(bank3);
+
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let subscriptions = Arc::new(RpcSubscriptions::new(
+            &exit,
+            bank_forks.clone(),
+            block_commitment_cache,
+        ));
+
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let mut pending_optimistically_confirmed_banks = HashSet::new();
+
+        assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 0);
+
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(2),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
+
+        // Test max optimistically confirmed bank remains in the cache
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(1),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
+
+        // Test bank will only be cached when frozen
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        // assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
+        assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
+        assert_eq!(pending_optimistically_confirmed_banks.contains(&3), true);
+
+        // Test bank will only be cached when frozen
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::Frozen(bank3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 3);
+
+        // Test higher root will be cached and clear pending_optimistically_confirmed_banks
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+        let bank4 = Bank::new_from_parent(&bank3, &Pubkey::default(), 4);
+        bank_forks.write().unwrap().insert(bank4);
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(4),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 3);
+        assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
+        assert_eq!(pending_optimistically_confirmed_banks.contains(&4), true);
+
+        let bank4 = bank_forks.read().unwrap().get(4).unwrap().clone();
+        let bank5 = Bank::new_from_parent(&bank4, &Pubkey::default(), 5);
+        bank_forks.write().unwrap().insert(bank5);
+        let bank5 = bank_forks.read().unwrap().get(5).unwrap().clone();
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::Root(bank5),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 5);
+        assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
+        assert_eq!(pending_optimistically_confirmed_banks.contains(&4), false);
+    }
+}

--- a/core/src/optimistically_confirmed_bank_tracker.rs
+++ b/core/src/optimistically_confirmed_bank_tracker.rs
@@ -102,7 +102,7 @@ impl OptimisticallyConfirmedBankTracker {
         Ok(())
     }
 
-    fn process_notification(
+    pub(crate) fn process_notification(
         notification: BankNotification,
         bank_forks: &Arc<RwLock<BankForks>>,
         optimistically_confirmed_bank: &Arc<RwLock<OptimisticallyConfirmedBank>>,

--- a/core/src/optimistically_confirmed_bank_tracker.rs
+++ b/core/src/optimistically_confirmed_bank_tracker.rs
@@ -3,13 +3,13 @@
 //! subscription notifications
 
 use crate::rpc_subscriptions::RpcSubscriptions;
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use solana_runtime::{bank::Bank, bank_forks::BankForks};
 use solana_sdk::clock::Slot;
 use std::{
     collections::HashSet,
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc::{Receiver, RecvTimeoutError, Sender},
         Arc, RwLock,
     },
     thread::{self, Builder, JoinHandle},

--- a/core/src/optimistically_confirmed_bank_tracker.rs
+++ b/core/src/optimistically_confirmed_bank_tracker.rs
@@ -9,7 +9,7 @@ use std::{
     collections::HashSet,
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc::{Receiver, RecvTimeoutError},
+        mpsc::{Receiver, RecvTimeoutError, Sender},
         Arc, RwLock,
     },
     thread::{self, Builder, JoinHandle},
@@ -46,13 +46,16 @@ impl std::fmt::Debug for BankNotification {
     }
 }
 
+pub type BankNotificationReceiver = Receiver<BankNotification>;
+pub type BankNotificationSender = Sender<BankNotification>;
+
 pub struct OptimisticallyConfirmedBankTracker {
     thread_hdl: JoinHandle<()>,
 }
 
 impl OptimisticallyConfirmedBankTracker {
     pub fn new(
-        receiver: Receiver<BankNotification>,
+        receiver: BankNotificationReceiver,
         exit: &Arc<AtomicBool>,
         bank_forks: Arc<RwLock<BankForks>>,
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1975,6 +1975,7 @@ pub(crate) mod tests {
     use crate::{
         consensus::test::{initialize_state, VoteSimulator},
         consensus::Tower,
+        optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         progress_map::ValidatorStakeInfo,
         replay_stage::ReplayStage,
         transaction_status_service::TransactionStatusService,
@@ -2087,11 +2088,14 @@ pub(crate) mod tests {
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
 
         // RpcSubscriptions
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let exit = Arc::new(AtomicBool::new(false));
         let rpc_subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,
             bank_forks.clone(),
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
+            optimistically_confirmed_bank,
         ));
 
         ReplayBlockstoreComponents {
@@ -2582,6 +2586,7 @@ pub(crate) mod tests {
             &exit,
             bank_forks.clone(),
             block_commitment_cache.clone(),
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         ));
         let (lockouts_sender, _) =
             AggregateCommitmentService::new(&exit, block_commitment_cache.clone(), subscriptions);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -311,7 +311,6 @@ impl ReplayStage {
                         transaction_status_sender.clone(),
                         &verify_recyclers,
                         &mut heaviest_subtree_fork_choice,
-                        &subscriptions,
                         &replay_vote_sender,
                         &bank_notification_sender,
                     );
@@ -1264,7 +1263,6 @@ impl ReplayStage {
         transaction_status_sender: Option<TransactionStatusSender>,
         verify_recyclers: &VerifyRecyclers,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
-        subscriptions: &Arc<RpcSubscriptions>,
         replay_vote_sender: &ReplayVoteSender,
         bank_notification_sender: &Option<BankNotificationSender>,
     ) -> bool {
@@ -1337,7 +1335,6 @@ impl ReplayStage {
                 bank.freeze();
                 heaviest_subtree_fork_choice
                     .add_new_leaf_slot(bank.slot(), Some(bank.parent_slot()));
-                subscriptions.notify_frozen(bank.slot());
                 if let Some(sender) = bank_notification_sender {
                     sender
                         .send(BankNotification::Frozen(bank.clone()))

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -4096,31 +4096,13 @@ pub mod tests {
 
     #[test]
     fn test_rpc_send_bad_tx() {
-        let exit = Arc::new(AtomicBool::new(false));
-        let validator_exit = create_validator_exit(&exit);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
-        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let genesis = create_genesis_config(100);
+        let bank = Arc::new(Bank::new(&genesis.genesis_config));
+        let meta = JsonRpcRequestProcessor::new_from_bank(&bank);
 
         let mut io = MetaIoHandler::default();
         let rpc = RpcSolImpl;
         io.extend_with(rpc.to_delegate());
-        let cluster_info = Arc::new(ClusterInfo::default());
-        let tpu_address = cluster_info.my_contact_info().tpu;
-        let bank_forks = new_bank_forks().0;
-        let (meta, receiver) = JsonRpcRequestProcessor::new(
-            JsonRpcConfig::default(),
-            new_bank_forks().0,
-            block_commitment_cache,
-            blockstore,
-            validator_exit,
-            RpcHealth::stub(),
-            cluster_info,
-            Hash::default(),
-            &runtime::Runtime::new().unwrap(),
-            None,
-        );
-        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"sendTransaction","params":["37u9WtQpcm6ULa3Vmu7ySnANv"]}"#;
         let res = io.handle_request_sync(req, meta);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -5568,6 +5568,7 @@ pub mod tests {
             &exit,
             bank_forks.clone(),
             block_commitment_cache.clone(),
+            optimistically_confirmed_bank.clone(),
         ));
 
         let (meta, _receiver) = JsonRpcRequestProcessor::new(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -4,6 +4,7 @@ use crate::{
     cluster_info::ClusterInfo,
     contact_info::ContactInfo,
     non_circulating_supply::calculate_non_circulating_supply,
+    optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
     rpc_error::RpcCustomError,
     rpc_health::*,
     send_transaction_service::{SendTransactionService, TransactionInfo},
@@ -121,6 +122,7 @@ pub struct JsonRpcRequestProcessor {
     transaction_sender: Arc<Mutex<Sender<TransactionInfo>>>,
     runtime_handle: runtime::Handle,
     bigtable_ledger_storage: Option<solana_storage_bigtable::LedgerStorage>,
+    optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
 }
 impl Metadata for JsonRpcRequestProcessor {}
 
@@ -133,6 +135,17 @@ impl JsonRpcRequestProcessor {
             None => CommitmentLevel::Max,
             Some(config) => config.commitment,
         };
+
+        if commitment_level == CommitmentLevel::SingleGossip {
+            let bank = self
+                .optimistically_confirmed_bank
+                .read()
+                .unwrap()
+                .bank
+                .clone();
+            debug!("RPC using optimistically confirmed slot: {:?}", bank.slot());
+            return bank;
+        }
 
         let slot = self
             .block_commitment_cache
@@ -147,12 +160,13 @@ impl JsonRpcRequestProcessor {
             CommitmentLevel::Root => {
                 debug!("RPC using node root: {:?}", slot);
             }
-            CommitmentLevel::Single | CommitmentLevel::SingleGossip => {
+            CommitmentLevel::Single => {
                 debug!("RPC using confirmed slot: {:?}", slot);
             }
             CommitmentLevel::Max => {
                 debug!("RPC using block: {:?}", slot);
             }
+            CommitmentLevel::SingleGossip => unreachable!(),
         };
 
         r_bank_forks.get(slot).cloned().unwrap_or_else(|| {
@@ -187,6 +201,7 @@ impl JsonRpcRequestProcessor {
         genesis_hash: Hash,
         runtime: &runtime::Runtime,
         bigtable_ledger_storage: Option<solana_storage_bigtable::LedgerStorage>,
+        optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
     ) -> (Self, Receiver<TransactionInfo>) {
         let (sender, receiver) = channel();
         (
@@ -202,6 +217,7 @@ impl JsonRpcRequestProcessor {
                 transaction_sender: Arc::new(Mutex::new(sender)),
                 runtime_handle: runtime.handle().clone(),
                 bigtable_ledger_storage,
+                optimistically_confirmed_bank,
             },
             receiver,
         )
@@ -237,6 +253,9 @@ impl JsonRpcRequestProcessor {
             transaction_sender: Arc::new(Mutex::new(sender)),
             runtime_handle: runtime::Runtime::new().unwrap().handle().clone(),
             bigtable_ledger_storage: None,
+            optimistically_confirmed_bank: Arc::new(RwLock::new(OptimisticallyConfirmedBank {
+                bank: bank.clone(),
+            })),
         }
     }
 
@@ -2553,8 +2572,13 @@ pub(crate) fn create_validator_exit(exit: &Arc<AtomicBool>) -> Arc<RwLock<Option
 pub mod tests {
     use super::*;
     use crate::{
-        contact_info::ContactInfo, non_circulating_supply::non_circulating_accounts,
+        contact_info::ContactInfo,
+        non_circulating_supply::non_circulating_accounts,
+        optimistically_confirmed_bank_tracker::{
+            BankNotification, OptimisticallyConfirmedBankTracker,
+        },
         replay_stage::tests::create_test_transactions_and_populate_blockstore,
+        rpc_subscriptions::RpcSubscriptions,
     };
     use bincode::deserialize;
     use jsonrpc_core::{
@@ -2752,6 +2776,7 @@ pub mod tests {
             Hash::default(),
             &runtime::Runtime::new().unwrap(),
             None,
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
@@ -4142,6 +4167,7 @@ pub mod tests {
             Hash::default(),
             &runtime::Runtime::new().unwrap(),
             None,
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
@@ -4324,6 +4350,7 @@ pub mod tests {
             Hash::default(),
             &runtime::Runtime::new().unwrap(),
             None,
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
         assert_eq!(request_processor.validator_exit(), false);
@@ -4353,6 +4380,7 @@ pub mod tests {
             Hash::default(),
             &runtime::Runtime::new().unwrap(),
             None,
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
         assert_eq!(request_processor.validator_exit(), true);
@@ -4441,6 +4469,7 @@ pub mod tests {
             Hash::default(),
             &runtime::Runtime::new().unwrap(),
             None,
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
         assert_eq!(
@@ -5506,5 +5535,118 @@ pub mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn test_rpc_single_gossip() {
+        let exit = Arc::new(AtomicBool::new(false));
+        let validator_exit = create_validator_exit(&exit);
+        let ledger_path = get_tmp_ledger_path!();
+        let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
+        let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
+        let cluster_info = Arc::new(ClusterInfo::default());
+
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
+        let bank = Bank::new(&genesis_config);
+
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap().clone();
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        bank_forks.write().unwrap().insert(bank1);
+        let bank1 = bank_forks.read().unwrap().get(1).unwrap().clone();
+        let bank2 = Bank::new_from_parent(&bank1, &Pubkey::default(), 2);
+        bank_forks.write().unwrap().insert(bank2);
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap().clone();
+        let bank3 = Bank::new_from_parent(&bank2, &Pubkey::default(), 3);
+        bank_forks.write().unwrap().insert(bank3);
+
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let mut pending_optimistically_confirmed_banks = HashSet::new();
+
+        let subscriptions = Arc::new(RpcSubscriptions::new(
+            &exit,
+            bank_forks.clone(),
+            block_commitment_cache.clone(),
+        ));
+
+        let (meta, _receiver) = JsonRpcRequestProcessor::new(
+            JsonRpcConfig::default(),
+            bank_forks.clone(),
+            block_commitment_cache,
+            blockstore,
+            validator_exit,
+            RpcHealth::stub(),
+            cluster_info,
+            Hash::default(),
+            &runtime::Runtime::new().unwrap(),
+            None,
+            optimistically_confirmed_bank.clone(),
+        );
+
+        let mut io = MetaIoHandler::default();
+        io.extend_with(RpcSolImpl.to_delegate());
+
+        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment":"singleGossip"}]}"#;
+        let res = io.handle_request_sync(req, meta.clone());
+        let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
+        assert_eq!(slot, 0);
+
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(2),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "singleGossip"}]}"#;
+        let res = io.handle_request_sync(&req, meta.clone());
+        let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
+        assert_eq!(slot, 2);
+
+        // Test rollback does not appear to happen, even if slots are notified out of order
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(1),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "singleGossip"}]}"#;
+        let res = io.handle_request_sync(&req, meta.clone());
+        let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
+        assert_eq!(slot, 2);
+
+        // Test bank will only be cached when frozen
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::OptimisticallyConfirmed(3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "singleGossip"}]}"#;
+        let res = io.handle_request_sync(&req, meta.clone());
+        let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
+        assert_eq!(slot, 2);
+
+        // Test freezing an optimistically confirmed bank will update cache
+        let bank3 = bank_forks.read().unwrap().get(3).unwrap().clone();
+        OptimisticallyConfirmedBankTracker::process_notification(
+            BankNotification::Frozen(bank3),
+            &bank_forks,
+            &optimistically_confirmed_bank,
+            &subscriptions,
+            &mut pending_optimistically_confirmed_banks,
+        );
+        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "singleGossip"}]}"#;
+        let res = io.handle_request_sync(&req, meta);
+        let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
+        assert_eq!(slot, 3);
     }
 }

--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -73,6 +73,7 @@ impl PubSubService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank;
     use solana_runtime::{
         bank::Bank,
         bank_forks::BankForks,
@@ -91,10 +92,13 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,
             bank_forks,
             Arc::new(RwLock::new(BlockCommitmentCache::new_for_tests())),
+            optimistically_confirmed_bank,
         ));
         let pubsub_service = PubSubService::new(&subscriptions, pubsub_addr, &exit);
         let thread = pubsub_service.thread_hdl.thread();

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -7,6 +7,7 @@ use crate::{
     cluster_info::ClusterInfo,
     cluster_info_vote_listener::{ClusterInfoVoteListener, VerifiedVoteSender, VoteTracker},
     fetch_stage::FetchStage,
+    optimistically_confirmed_bank_tracker::BankNotificationSender,
     poh_recorder::{PohRecorder, WorkingBankEntry},
     rpc_subscriptions::RpcSubscriptions,
     sigverify::TransactionSigVerifier,
@@ -57,6 +58,7 @@ impl Tpu {
         verified_vote_sender: VerifiedVoteSender,
         replay_vote_receiver: ReplayVoteReceiver,
         replay_vote_sender: ReplayVoteSender,
+        bank_notification_sender: Option<BankNotificationSender>,
     ) -> Self {
         let (packet_sender, packet_receiver) = channel();
         let fetch_stage = FetchStage::new_with_sender(
@@ -85,6 +87,7 @@ impl Tpu {
             verified_vote_sender,
             replay_vote_receiver,
             blockstore.clone(),
+            bank_notification_sender,
         );
 
         let banking_stage = BankingStage::new(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -258,6 +258,7 @@ pub mod tests {
     use crate::{
         banking_stage::create_test_recorder,
         cluster_info::{ClusterInfo, Node},
+        optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
     };
     use serial_test_derive::serial;
     use solana_ledger::{
@@ -327,6 +328,7 @@ pub mod tests {
                 &exit,
                 bank_forks.clone(),
                 block_commitment_cache.clone(),
+                OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
             )),
             &poh_recorder,
             tower,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -12,6 +12,7 @@ use crate::{
     completed_data_sets_service::CompletedDataSetsSender,
     consensus::Tower,
     ledger_cleanup_service::LedgerCleanupService,
+    optimistically_confirmed_bank_tracker::BankNotificationSender,
     poh_recorder::PohRecorder,
     replay_stage::{ReplayStage, ReplayStageConfig},
     retransmit_stage::RetransmitStage,
@@ -106,6 +107,7 @@ impl Tvu {
         verified_vote_receiver: VerifiedVoteReceiver,
         replay_vote_sender: ReplayVoteSender,
         completed_data_sets_sender: CompletedDataSetsSender,
+        bank_notification_sender: Option<BankNotificationSender>,
         tvu_config: TvuConfig,
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info.keypair.clone();
@@ -196,6 +198,7 @@ impl Tvu {
             transaction_status_sender,
             rewards_recorder_sender,
             cache_block_time_sender,
+            bank_notification_sender,
         };
 
         let replay_stage = ReplayStage::new(
@@ -341,6 +344,7 @@ pub mod tests {
             verified_vote_receiver,
             replay_vote_sender,
             completed_data_sets_sender,
+            None,
             TvuConfig::default(),
         );
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -411,7 +411,7 @@ impl Validator {
                     assert!(!ContactInfo::is_valid_address(&node.info.rpc_pubsub));
                 }
                 let tpu_address = cluster_info.my_contact_info().tpu;
-                let (bank_notification_sender, bank_notification_receiver) = channel();
+                let (bank_notification_sender, bank_notification_receiver) = unbounded();
                 let optimistically_confirmed_bank =
                     OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
                 (

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -338,10 +338,14 @@ impl Validator {
         block_commitment_cache.initialize_slots(bank.slot());
         let block_commitment_cache = Arc::new(RwLock::new(block_commitment_cache));
 
+        let optimistically_confirmed_bank =
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+
         let subscriptions = Arc::new(RpcSubscriptions::new(
             &exit,
             bank_forks.clone(),
             block_commitment_cache.clone(),
+            optimistically_confirmed_bank.clone(),
         ));
 
         let (completed_data_sets_sender, completed_data_sets_receiver) =
@@ -412,8 +416,6 @@ impl Validator {
                 }
                 let tpu_address = cluster_info.my_contact_info().tpu;
                 let (bank_notification_sender, bank_notification_receiver) = unbounded();
-                let optimistically_confirmed_bank =
-                    OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
                 (
                     Some(RpcServices {
                         json_rpc_service: JsonRpcService::new(

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -1,5 +1,6 @@
 use solana_client::{pubsub_client::PubsubClient, rpc_client::RpcClient, rpc_response::SlotInfo};
 use solana_core::{
+    optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
     rpc_pubsub_service::PubSubService, rpc_subscriptions::RpcSubscriptions,
     test_validator::TestValidator,
 };
@@ -91,10 +92,13 @@ fn test_slot_subscription() {
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new(&genesis_config);
     let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+    let optimistically_confirmed_bank =
+        OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
     let subscriptions = Arc::new(RpcSubscriptions::new(
         &exit,
         bank_forks,
         Arc::new(RwLock::new(BlockCommitmentCache::default())),
+        optimistically_confirmed_bank,
     ));
     let pubsub_service = PubSubService::new(&subscriptions, pubsub_addr, &exit);
     std::thread::sleep(Duration::from_millis(400));

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -104,8 +104,8 @@ impl BlockCommitmentCache {
     }
 
     pub fn highest_gossip_confirmed_slot(&self) -> Slot {
-        // TODO: see solana_core::RpcSubscriptions:
-        //self.last_checked_slots.get(&CommitmentLevel::SingleGossip).unwrap_or(&0)
+        // TODO: combine bank caches
+        // Currently, this information is provided by OptimisticallyConfirmedBank::bank.slot()
         self.highest_confirmed_slot()
     }
 


### PR DESCRIPTION
#### Problem
Rpc uses the same bank for `Single` and `SingleGossip` commitment levels.

#### Summary of Changes
- Add service to track optimistically confirmed banks (currently being done inside RpcSubscriptions)
- Remove tracking from RpcSubscriptions
- Use service to update OptimisticallyConfirmedBank, which caches a reference to the Bank
- Use OptimisticallyConfirmedBank in Rpc
