### PR TITLE
Fix token history fetching and broken display of inner spl token instructions

### DIFF
--- a/explorer/src/providers/transactions/details.tsx
+++ b/explorer/src/providers/transactions/details.tsx
@@ -104,3 +104,18 @@ export function useTransactionDetails(
 
   return context.entries[signature];
 }
+
+export type TransactionDetailsCache = {
+  [key: string]: Cache.CacheEntry<Details>;
+};
+export function useTransactionDetailsCache(): TransactionDetailsCache {
+  const context = React.useContext(StateContext);
+
+  if (!context) {
+    throw new Error(
+      `useTransactionDetailsCache must be used within a TransactionsProvider`
+    );
+  }
+
+  return context.entries;
+}


### PR DESCRIPTION
#### Problem
Token history is spread out across many token accounts and some of those accounts may have a lot more history than others. This means that relatively old transactions could be fetched for one token account while another has many recent transactions. This is an issue because the history list shows all fetched transactions making it appear that all transactions up to an old slot have been fetched.

#### Summary of Changes
- Only display transactions for slots that we know we have already fetched full history for with no holes.
- Display transactions with inner SPL Token instructions as "Unknown (Inner)" for now
- Optimize rendering of history rows

![Screen Shot 2020-09-28 at 10 33 11 AM](https://user-images.githubusercontent.com/1076145/94384797-0402e780-0176-11eb-8a32-5dcd7c5b3cb7.png)

Related to: https://github.com/solana-labs/solana/issues/11935