### PR TITLE
Pipe FeatureSet though InvokeContext

### DIFF
--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -218,7 +218,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         "Tuner must consume the whole budget"
     );
     println!(
-        "{:?} Consumed compute budget took {:?} us ({:?} instructions)",
+        "{:?} compute units took {:?} us ({:?} instructions)",
         BUDGET - instruction_meter.get_remaining(),
         measure.as_us(),
         vm.get_total_instruction_count(),

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -229,6 +229,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
 pub struct MockInvokeContext {
     key: Pubkey,
     logger: MockLogger,
+    compute_budget: ComputeBudget,
     compute_meter: Rc<RefCell<MockComputeMeter>>,
 }
 impl InvokeContext for MockInvokeContext {
@@ -253,11 +254,8 @@ impl InvokeContext for MockInvokeContext {
     fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
         Rc::new(RefCell::new(self.logger.clone()))
     }
-    fn is_cross_program_supported(&self) -> bool {
-        true
-    }
-    fn get_compute_budget(&self) -> ComputeBudget {
-        ComputeBudget::default()
+    fn get_compute_budget(&self) -> &ComputeBudget {
+        &self.compute_budget
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         self.compute_meter.clone()
@@ -267,6 +265,9 @@ impl InvokeContext for MockInvokeContext {
         None
     }
     fn record_instruction(&self, _instruction: &Instruction) {}
+    fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
+        true
+    }
 }
 #[derive(Debug, Default, Clone)]
 pub struct MockLogger {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -23,7 +23,6 @@ use solana_sdk::{
     client::SyncClient,
     clock::{DEFAULT_SLOTS_PER_EPOCH, MAX_PROCESSING_AGE},
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
-
     instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
     message::Message,
     pubkey::Pubkey,
@@ -657,6 +656,7 @@ fn assert_instruction_count() {
 struct MockInvokeContext {
     pub key: Pubkey,
     pub logger: MockLogger,
+    pub compute_budget: ComputeBudget,
     pub compute_meter: MockComputeMeter,
 }
 impl InvokeContext for MockInvokeContext {
@@ -681,11 +681,8 @@ impl InvokeContext for MockInvokeContext {
     fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
         Rc::new(RefCell::new(self.logger.clone()))
     }
-    fn is_cross_program_supported(&self) -> bool {
-        true
-    }
-    fn get_compute_budget(&self) -> ComputeBudget {
-        ComputeBudget::default()
+    fn get_compute_budget(&self) -> &ComputeBudget {
+        &self.compute_budget
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         Rc::new(RefCell::new(self.compute_meter.clone()))
@@ -695,6 +692,9 @@ impl InvokeContext for MockInvokeContext {
         None
     }
     fn record_instruction(&self, _instruction: &Instruction) {}
+    fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/programs/bpf_loader/src/bpf_verifier.rs
+++ b/programs/bpf_loader/src/bpf_verifier.rs
@@ -54,12 +54,14 @@ pub enum VerifierError {
     InvalidRegister(usize),
 }
 
-fn check_prog_len(prog: &[u8]) -> Result<(), BPFError> {
+fn check_prog_len(prog: &[u8], is_program_size_cap: bool) -> Result<(), BPFError> {
     if prog.len() % ebpf::INSN_SIZE != 0 {
         return Err(VerifierError::ProgramLengthNotMultiple.into());
     }
-    if prog.len() > ebpf::PROG_MAX_SIZE {
-        return Err(VerifierError::ProgramTooLarge(prog.len() / ebpf::INSN_SIZE).into());
+    if is_program_size_cap {
+        if prog.len() > ebpf::PROG_MAX_SIZE {
+            return Err(VerifierError::ProgramTooLarge(prog.len() / ebpf::INSN_SIZE).into());
+        }
     }
 
     if prog.is_empty() {
@@ -139,8 +141,8 @@ fn check_imm_register(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), Verifier
 }
 
 #[rustfmt::skip]
-pub fn check(prog: &[u8]) -> Result<(), BPFError> {
-    check_prog_len(prog)?;
+pub fn check(prog: &[u8], is_program_size_cap: bool) -> Result<(), BPFError> {
+    check_prog_len(prog, is_program_size_cap)?;
 
     let mut insn_ptr: usize = 0;
     while insn_ptr * ebpf::INSN_SIZE < prog.len() {

--- a/programs/bpf_loader/src/bpf_verifier.rs
+++ b/programs/bpf_loader/src/bpf_verifier.rs
@@ -58,10 +58,8 @@ fn check_prog_len(prog: &[u8], is_program_size_cap: bool) -> Result<(), BPFError
     if prog.len() % ebpf::INSN_SIZE != 0 {
         return Err(VerifierError::ProgramLengthNotMultiple.into());
     }
-    if is_program_size_cap {
-        if prog.len() > ebpf::PROG_MAX_SIZE {
-            return Err(VerifierError::ProgramTooLarge(prog.len() / ebpf::INSN_SIZE).into());
-        }
+    if is_program_size_cap && prog.len() > ebpf::PROG_MAX_SIZE {
+        return Err(VerifierError::ProgramTooLarge(prog.len() / ebpf::INSN_SIZE).into());
     }
 
     if prog.is_empty() {

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -42,7 +42,7 @@ lazy_static! {
         (pico_inflation::id(), "pico-inflation"),
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),
         (bpf_loader2_program::id(), "bpf_loader2 program"),
-        (compute_budget_config2::id(), "compute budget configuration 2"),
+        (compute_budget_config2::id(), "1ms compute budget"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -29,6 +29,10 @@ pub mod bpf_loader2_program {
     solana_sdk::declare_id!("DFBnrgThdzH4W6wZ12uGPoWcMnvfZj11EHnxHcVxLPhD");
 }
 
+pub mod compute_budget_config2 {
+    solana_sdk::declare_id!("HxvjqDSiF5sYdSYuCXsUnS8UeAoWsMT9iGoFP8pgV1mB");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -38,6 +42,7 @@ lazy_static! {
         (pico_inflation::id(), "pico-inflation"),
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),
         (bpf_loader2_program::id(), "bpf_loader2 program"),
+        (compute_budget_config2::id(), "compute budget configuration 2"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()
@@ -75,15 +80,6 @@ impl Default for FeatureSet {
         Self {
             active: HashSet::new(),
             inactive: FEATURE_NAMES.keys().cloned().collect(),
-        }
-    }
-}
-
-impl FeatureSet {
-    pub fn enabled() -> Self {
-        Self {
-            active: FEATURE_NAMES.keys().cloned().collect(),
-            inactive: HashSet::new(),
         }
     }
 }

--- a/runtime/src/process_instruction.rs
+++ b/runtime/src/process_instruction.rs
@@ -56,10 +56,8 @@ pub trait InvokeContext {
     fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)];
     /// Get this invocation's logger
     fn get_logger(&self) -> Rc<RefCell<dyn Logger>>;
-    /// Are cross program invocations supported
-    fn is_cross_program_supported(&self) -> bool;
     /// Get this invocation's compute budget
-    fn get_compute_budget(&self) -> ComputeBudget;
+    fn get_compute_budget(&self) -> &ComputeBudget;
     /// Get this invocation's compute meter
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>>;
     /// Loaders may need to do work in order to execute a program.  Cache
@@ -69,6 +67,8 @@ pub trait InvokeContext {
     fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>>;
     /// Record invoked instruction
     fn record_instruction(&self, instruction: &Instruction);
+    /// Get the bank's active feature set
+    fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
#### Problem

Runtime and the loader have no access to bank's feature set

#### Summary of Changes

- Pipe the bank's feature set through InvokeContext
- Remove the cross-program invocation feature, already enabled in all networks
- Add a feature to update the compute budget and move the compute budget into MessageProcessor
- Remove cap on maximum program size, not hittable now but could be when the new compute budget configuration feature is enabled.

Fixes #
