### PR TITLE
clap-utils: Allow nonce/offline args to be global

### DIFF
--- a/clap-utils/src/nonce.rs
+++ b/clap-utils/src/nonce.rs
@@ -36,12 +36,15 @@ pub fn nonce_authority_arg<'a, 'b>() -> Arg<'a, 'b> {
 }
 
 pub trait NonceArgs {
-    fn nonce_args(self) -> Self;
+    fn nonce_args(self, global: bool) -> Self;
 }
 
 impl NonceArgs for App<'_, '_> {
-    fn nonce_args(self) -> Self {
-        self.arg(nonce_arg())
-            .arg(nonce_authority_arg().requires(NONCE_ARG.name))
+    fn nonce_args(self, global: bool) -> Self {
+        self.arg(nonce_arg().global(global)).arg(
+            nonce_authority_arg()
+                .requires(NONCE_ARG.name)
+                .global(global),
+        )
     }
 }

--- a/clap-utils/src/offline.rs
+++ b/clap-utils/src/offline.rs
@@ -48,13 +48,13 @@ fn signer_arg<'a, 'b>() -> Arg<'a, 'b> {
 }
 
 pub trait OfflineArgs {
-    fn offline_args(self) -> Self;
+    fn offline_args(self, global: bool) -> Self;
 }
 
 impl OfflineArgs for App<'_, '_> {
-    fn offline_args(self) -> Self {
-        self.arg(blockhash_arg())
-            .arg(sign_only_arg())
-            .arg(signer_arg())
+    fn offline_args(self, global: bool) -> Self {
+        self.arg(blockhash_arg().global(global))
+            .arg(sign_only_arg().global(global))
+            .arg(signer_arg().global(global))
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2124,8 +2124,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .required(true)
                         .help("The amount to send, in SOL; accepts keyword ALL"),
                 )
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
         )
         .subcommand(
             SubCommand::with_name("resolve-signer")
@@ -2171,8 +2171,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(false)
                         .help("Return signature immediately after submitting the transaction, instead of waiting for confirmations"),
                 )
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg()),
         )
         .subcommand(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -154,8 +154,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Source account of funds [default: cli config keypair]"),
                 )
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg())
         )
         .subcommand(
@@ -183,8 +183,8 @@ impl StakeSubCommands for App<'_, '_> {
                         "The vote account to which the stake will be delegated")
                 )
                 .arg(stake_authority_arg())
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg())
         )
         .subcommand(
@@ -213,8 +213,8 @@ impl StakeSubCommands for App<'_, '_> {
                 )
                 .arg(stake_authority_arg())
                 .arg(withdraw_authority_arg())
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg())
         )
         .subcommand(
@@ -228,8 +228,8 @@ impl StakeSubCommands for App<'_, '_> {
                         "Stake account to be deactivated. ")
                 )
                 .arg(stake_authority_arg())
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg())
         )
         .subcommand(
@@ -268,8 +268,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("Seed for address generation; if specified, the resulting account will be at a derived address of the SPLIT STAKE ACCOUNT pubkey")
                 )
                 .arg(stake_authority_arg())
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg())
         )
         .subcommand(
@@ -290,8 +290,8 @@ impl StakeSubCommands for App<'_, '_> {
                         "Source stake account for the merge.  If successful, this stake account will no longer exist after the merge")
                 )
                 .arg(stake_authority_arg())
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg())
         )
         .subcommand(
@@ -321,8 +321,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .help("The amount to withdraw from the stake account, in SOL")
                 )
                 .arg(withdraw_authority_arg())
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(
                     Arg::with_name("custodian")
@@ -376,8 +376,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Keypair of the existing custodian [default: cli config pubkey]")
                 )
-                .offline_args()
-                .nonce_args()
+                .offline_args(false)
+                .nonce_args(false)
                 .arg(fee_payer_arg())
         )
         .subcommand(

--- a/client/src/blockhash_query.rs
+++ b/client/src/blockhash_query.rs
@@ -177,7 +177,9 @@ mod tests {
 
     #[test]
     fn test_blockhash_query_new_from_matches_ok() {
-        let test_commands = App::new("blockhash_query_test").nonce_args().offline_args();
+        let test_commands = App::new("blockhash_query_test")
+            .nonce_args(false)
+            .offline_args(false);
         let blockhash = hash(&[1u8]);
         let blockhash_string = blockhash.to_string();
 


### PR DESCRIPTION
#### Problem

clap helpers for setting up offline/nonce args have no way to make them global

#### Summary of Changes

Plumb one