### PR TITLE
Increase rpc pubsub max payload to unblock large account notifications

### DIFF
--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -1,7 +1,6 @@
 //! The `pubsub` module implements a threaded subscription service on client RPC request
 
 use crate::{
-    rpc::MAX_REQUEST_PAYLOAD_SIZE,
     rpc_pubsub::{RpcSolPubSub, RpcSolPubSubImpl},
     rpc_subscriptions::RpcSubscriptions,
 };
@@ -45,7 +44,7 @@ impl PubSubService {
                         session
                 })
                 .max_connections(1000) // Arbitrary, default of 100 is too low
-                .max_payload(MAX_REQUEST_PAYLOAD_SIZE)
+                .max_payload(10 * 1024 * 1024 + 1024) // max account size (10MB) + extra (1K)
                 .start(&pubsub_addr);
 
                 if let Err(e) = server {


### PR DESCRIPTION
#### Problem
The `max_payload(..)` method now affects the ws server max output buffer capacity as of jsonrpc v15 which means that account notifications over 50KB in size will be dropped. Since account notifications can be up to 10MB, we need to bump this value until we can set output buffer capacity separate from payload size: https://github.com/paritytech/jsonrpc/issues/590

#### Summary of Changes
- Revert max payload size from 50KB to 10MB + change

Fixes #
