### PR TITLE
rpc_client: Switch get_program_accounts to use base64

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -572,8 +572,16 @@ impl RpcClient {
     }
 
     pub fn get_program_accounts(&self, pubkey: &Pubkey) -> ClientResult<Vec<(Pubkey, Account)>> {
-        let accounts: Vec<RpcKeyedAccount> =
-            self.send(RpcRequest::GetProgramAccounts, json!([pubkey.to_string()]))?;
+        let config = RpcAccountInfoConfig {
+            encoding: Some(UiAccountEncoding::Base64),
+            commitment: None,
+            data_slice: None,
+        };
+
+        let accounts: Vec<RpcKeyedAccount> = self.send(
+            RpcRequest::GetProgramAccounts,
+            json!([pubkey.to_string(), config]),
+        )?;
         parse_keyed_accounts(accounts, RpcRequest::GetProgramAccounts)
     }
 


### PR DESCRIPTION
#### Problem
`solana stakes` times out on mainnet-beta

#### Summary of Changes
The underlying RpcClient:: get_program_accounts() RPC call was still using the very slow "Binary" (base-58) encoding scheme.  Switch to base64 for a free speed boost.