### PR TITLE
Query BigTable for block time if does not exist in blockstore

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -711,6 +711,15 @@ impl JsonRpcRequestProcessor {
                 .highest_confirmed_root()
         {
             let result = self.blockstore.get_block_time(slot);
+            if result.is_err() {
+                if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
+                    return Ok(self
+                        .runtime_handle
+                        .block_on(bigtable_ledger_storage.get_confirmed_block(slot))
+                        .ok()
+                        .and_then(|confirmed_block| confirmed_block.block_time));
+                }
+            }
             self.check_slot_cleaned_up(&result, slot)?;
             Ok(result.ok().unwrap_or(None))
         } else {


### PR DESCRIPTION
#### Problem
Once mainnet-beta upgrades to v1.3, our BigTable store will start logging block times for all stored blocks. These will be returned as part of `getConfirmedBlock` responses, but `getBlockTime` queries are currently limited to the slots in blockstore.

#### Summary of Changes
- If `blockstore.get_block_time` returns an error (block-time slot has been cleaned up), query BigTable block store and return stored block time if it exists. (Unless we reprocess the ledger, block times will only exist in BigTable for blocks after the v1.3 upgrade.)
