### PR TITLE
Include post balance information for rewards

### DIFF
--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -1,5 +1,6 @@
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use solana_ledger::blockstore::Blockstore;
+use solana_runtime::bank::RewardInfo;
 use solana_sdk::{clock::Slot, pubkey::Pubkey};
 use solana_transaction_status::Reward;
 use std::{
@@ -11,8 +12,8 @@ use std::{
     time::Duration,
 };
 
-pub type RewardsRecorderReceiver = Receiver<(Slot, Vec<(Pubkey, i64)>)>;
-pub type RewardsRecorderSender = Sender<(Slot, Vec<(Pubkey, i64)>)>;
+pub type RewardsRecorderReceiver = Receiver<(Slot, Vec<(Pubkey, RewardInfo)>)>;
+pub type RewardsRecorderSender = Sender<(Slot, Vec<(Pubkey, RewardInfo)>)>;
 
 pub struct RewardsRecorderService {
     thread_hdl: JoinHandle<()>,
@@ -49,9 +50,9 @@ impl RewardsRecorderService {
         let (slot, rewards) = rewards_receiver.recv_timeout(Duration::from_secs(1))?;
         let rpc_rewards = rewards
             .into_iter()
-            .map(|(pubkey, lamports)| Reward {
+            .map(|(pubkey, reward_info)| Reward {
                 pubkey: pubkey.to_string(),
-                lamports,
+                lamports: reward_info.lamports,
             })
             .collect();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -480,6 +480,12 @@ pub(crate) struct BankFieldsToSerialize<'a> {
     pub(crate) is_delta: bool,
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize, AbiExample, Default, Clone, Copy)]
+pub struct RewardInfo {
+    pub lamports: i64,     // Reward amount
+    pub post_balance: u64, // Account balance in lamports after `lamports` was applied
+}
+
 /// Manager for the state of all accounts and programs after processing its entries.
 /// AbiExample is needed even without Serialize/Deserialize; actual (de-)serialization
 /// are implemented elsewhere for versioning
@@ -595,7 +601,7 @@ pub struct Bank {
     pub last_vote_sync: AtomicU64,
 
     /// Rewards that were paid out immediately after this bank was created
-    pub rewards: Option<Vec<(Pubkey, i64)>>,
+    pub rewards: Option<Vec<(Pubkey, RewardInfo)>>,
 
     pub skip_drop: AtomicBool,
 
@@ -1145,7 +1151,13 @@ impl Bank {
         if let Some(rewards) = self.rewards.as_ref() {
             assert_eq!(
                 validator_rewards_paid,
-                u64::try_from(rewards.iter().map(|(_pubkey, reward)| reward).sum::<i64>()).unwrap()
+                u64::try_from(
+                    rewards
+                        .iter()
+                        .map(|(_pubkey, reward_info)| reward_info.lamports)
+                        .sum::<i64>()
+                )
+                .unwrap()
             );
         }
 
@@ -1241,11 +1253,18 @@ impl Bank {
                     vote_account_changed = true;
 
                     if voters_reward > 0 {
-                        *rewards.entry(*vote_pubkey).or_insert(0i64) += voters_reward as i64;
+                        let reward_info =
+                            rewards.entry(*vote_pubkey).or_insert(RewardInfo::default());
+                        reward_info.lamports += voters_reward as i64;
+                        reward_info.post_balance = vote_account.lamports;
                     }
 
                     if stakers_reward > 0 {
-                        *rewards.entry(*stake_pubkey).or_insert(0i64) += stakers_reward as i64;
+                        let reward_info = rewards
+                            .entry(*stake_pubkey)
+                            .or_insert(RewardInfo::default());
+                        reward_info.lamports += stakers_reward as i64;
+                        reward_info.post_balance = stake_account.lamports;
                     }
                 } else {
                     debug!(
@@ -5547,7 +5566,10 @@ mod tests {
             bank1.rewards,
             Some(vec![(
                 stake_id,
-                (rewards.validator_point_value * validator_points as f64) as i64
+                RewardInfo {
+                    lamports: (rewards.validator_point_value * validator_points as f64) as i64,
+                    post_balance: bank1.get_balance(&stake_id),
+                }
             )])
         );
         bank1.freeze();

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -226,9 +226,11 @@ pub struct ConfirmedTransactionStatusWithSignature {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Reward {
     pub pubkey: String,
     pub lamports: i64,
+    //pub post_balance: u64; // Account balance in lamports after `lamports` was applied
 }
 
 pub type Rewards = Vec<Reward>;


### PR DESCRIPTION
The rewards information surfaced in RPC `getConfirmedBlock` currently doesn't include the account balance before or after the reward was credited.   This makes it impossible to easily answer the simple question, "What's the % staking rewards my account received in previous epochs".

This draft PR adds a `post_balance` field to the `Rewards` struct that comes out of the Bank.  The plumbing into Blockstore/Bigtable/RPC is TBD.