### PR TITLE
Add rand dependency test

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1897,6 +1897,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-rand"
+version = "1.4.0"
+dependencies = [
+ "getrandom",
+ "rand",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-bpf-rust-sanity"
 version = "1.4.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "rust/panic",
     "rust/param_passing",
     "rust/param_passing_dep",
+    "rust/rand",
     "rust/sanity",
     "rust/sysval",
 ]

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -80,6 +80,7 @@ fn main() {
             "noop",
             "panic",
             "param_passing",
+            "rand",
             "sanity",
             "sysval",
         ];

--- a/programs/bpf/rust/rand/Cargo.toml
+++ b/programs/bpf/rust/rand/Cargo.toml
@@ -1,0 +1,28 @@
+
+# Note: This crate must be built using do.sh
+
+[package]
+name = "solana-bpf-rust-rand"
+version = "1.4.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+getrandom = { version = "0.1.14", features = ["dummy"] }
+rand = "0.7"
+solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = false }
+
+[features]
+program = ["solana-sdk/program"]
+default = ["program", "solana-sdk/default"]
+
+[lib]
+name = "solana_bpf_rust_rand"
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/rand/Xargo.toml
+++ b/programs/bpf/rust/rand/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/bpf/rust/rand/src/lib.rs
+++ b/programs/bpf/rust/rand/src/lib.rs
@@ -13,5 +13,6 @@ fn process_instruction(
     _accounts: &[AccountInfo],
     _instruction_data: &[u8],
 ) -> ProgramResult {
+    info!("rand");
     Ok(())
 }

--- a/programs/bpf/rust/rand/src/lib.rs
+++ b/programs/bpf/rust/rand/src/lib.rs
@@ -1,0 +1,17 @@
+//! @brief Example Rust-based BPF program that tests rand behavior
+
+#![allow(unreachable_code)]
+
+extern crate solana_sdk;
+use solana_sdk::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, info, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    Ok(())
+}

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -23,7 +23,6 @@ use solana_sdk::{
     client::SyncClient,
     clock::{DEFAULT_SLOTS_PER_EPOCH, MAX_PROCESSING_AGE},
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
-
     instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
     message::Message,
     pubkey::Pubkey,
@@ -153,6 +152,7 @@ fn test_program_bpf_sanity() {
             ("solana_bpf_rust_noop", true),
             ("solana_bpf_rust_panic", false),
             ("solana_bpf_rust_param_passing", true),
+            ("solana_bpf_rust_rand", true),
             ("solana_bpf_rust_sanity", true),
             ("solana_bpf_rust_sysval", true),
         ]);


### PR DESCRIPTION
#### Problem

No test to verify building a BPF program with the `get_random` workaround works

#### Summary of Changes

Test it

Fixes #
