### PR TITLE
Fix banks RPC port

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -71,6 +71,14 @@ pub trait BanksClientExt {
     /// are said to be finalized. The cluster will not fork to a higher slot height.
     async fn get_root_slot(&mut self) -> io::Result<Slot>;
 
+    /// Return the account at the given address at the slot corresponding to the given
+    /// commitment level. If the account is not found, None is returned.
+    async fn get_account_with_commitment(
+        &mut self,
+        address: Pubkey,
+        commitment: CommitmentLevel,
+    ) -> io::Result<Option<Account>>;
+
     /// Return the account at the given address at the time of the most recent root slot.
     /// If the account is not found, None is returned.
     async fn get_account(&mut self, address: Pubkey) -> io::Result<Option<Account>>;
@@ -130,13 +138,18 @@ impl BanksClientExt for BanksClient {
             .await
     }
 
+    async fn get_account_with_commitment(
+        &mut self,
+        address: Pubkey,
+        commitment: CommitmentLevel,
+    ) -> io::Result<Option<Account>> {
+        self.get_account_with_commitment_and_context(context::current(), address, commitment)
+            .await
+    }
+
     async fn get_account(&mut self, address: Pubkey) -> io::Result<Option<Account>> {
-        self.get_account_with_commitment_and_context(
-            context::current(),
-            address,
-            CommitmentLevel::default(),
-        )
-        .await
+        self.get_account_with_commitment(address, CommitmentLevel::default())
+            .await
     }
 
     async fn get_balance_with_commitment(

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -82,7 +82,7 @@ impl Config {
             return "".to_string();
         }
         let mut url = json_rpc_url.unwrap();
-        let port = url.port_or_known_default().unwrap_or(80);
+        let port = url.port().unwrap_or(8899);
         url.set_port(Some(port + 3)).expect("unable to set port");
         url.to_string()
     }
@@ -138,12 +138,12 @@ mod test {
     fn compute_rpc_banks_url() {
         assert_eq!(
             Config::compute_rpc_banks_url(&"http://devnet.solana.com"),
-            "http://devnet.solana.com:83/".to_string()
+            "http://devnet.solana.com:8902/".to_string()
         );
 
         assert_eq!(
             Config::compute_rpc_banks_url(&"https://devnet.solana.com"),
-            "https://devnet.solana.com:446/".to_string()
+            "https://devnet.solana.com:8902/".to_string()
         );
 
         assert_eq!(


### PR DESCRIPTION
#### Problem

The BanksServer port is calculated as 3 above the RPC port.  If no RPC port is provided, it uses 80 (or 443) instead of 8899.

#### Summary of Changes

* Default to 8899
* Also add `BanksClientExt::get_account_with_commitment` while in the neighborhood

cc: @CriesofCarrots @mvines 