### PR TITLE
Tighten docs publishing flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ jobs:
           - ~/.npm
 
       before_install:
+        - .travis/channel_restriction.sh edge beta || travis_terminate 0
         - .travis/affects.sh docs/ .travis || travis_terminate 0
         - cd docs/
         - source .travis/before_install.sh

--- a/.travis/channel_restriction.sh
+++ b/.travis/channel_restriction.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Only proceed if we are on one of the channels passed in when calling this file
+#
+
+set -ex
+
+eval "$(ci/channel-info.sh)"
+
+for acceptable_channel in "$@"; do
+  if [[ "$CHANNEL" == "$acceptable_channel" ]]; then
+    exit 0
+  fi
+done
+
+echo "Not running from one of the following channels: $@"
+exit 1

--- a/.travis/channel_restriction.sh
+++ b/.travis/channel_restriction.sh
@@ -13,5 +13,5 @@ for acceptable_channel in "$@"; do
   fi
 done
 
-echo "Not running from one of the following channels: $@"
+echo "Not running from one of the following channels: $*"
 exit 1

--- a/docs/set-solana-release-tag.sh
+++ b/docs/set-solana-release-tag.sh
@@ -3,25 +3,9 @@ set -e
 
 cd "$(dirname "$0")"
 
-if [[ -n $CI_TAG ]]; then
-  LATEST_SOLANA_RELEASE_VERSION=$CI_TAG
-elif [[ -z $CI_PULL_REQUEST ]]; then
-  LATEST_SOLANA_RELEASE_VERSION=$(\
-    curl -sSfL https://api.github.com/repos/solana-labs/solana/releases/latest \
-    | grep -m 1 tag_name \
-    | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p' \
-  )
-else
-  # Don't bother the `api.github.com` on pull requests to avoid getting rate
-  # limited
-  LATEST_SOLANA_RELEASE_VERSION=unknown-version
-fi
+eval "$(../ci/channel-info.sh)"
 
-if [[ -z "$LATEST_SOLANA_RELEASE_VERSION" ]]; then
-  echo Error: release version not defined
-  exit 1
-fi
-
+LATEST_SOLANA_RELEASE_VERSION=$BETA_CHANNEL_LATEST_TAG
 VERSION_FOR_DOCS_RS="${LATEST_SOLANA_RELEASE_VERSION:1}"
 
 set -x


### PR DESCRIPTION
#### Problem
 - We are substituting in a release tag into the docs content based on the latest-in-time release on any branch.  We should only sub in tags from the latest tag on the beta branch.
- Docs publishing to docs.solana.com occurs when a tag is made on any branch, but this should only update docs.solana.com when a tag is made on beta branch.

#### Summary of Changes
 - Use `ci/channel-info.sh` to get latest beta tag, rather than querying github API.
 - Add a check to `.travis.yml` not to proceed with docs publishing if we are not on `beta` or `edge` channels.

Fixes #11505
Fixes #11387
