### PR TITLE
Omit workspace Cargo.toml when incrementing version

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -31,7 +31,7 @@ readCargoVariable() {
 }
 
 # shellcheck disable=2207
-Cargo_tomls=($(find . -name Cargo.toml -not -path './web3.js/examples/*'))
+Cargo_tomls=($(find . -mindepth 2 -name Cargo.toml -not -path './web3.js/examples/*'))
 # shellcheck disable=2207
 markdownFiles=($(find . -name "*.md"))
 


### PR DESCRIPTION
#### Problem

The version incrementing script can attempt to read the current version from the workspace Cargo.toml, which does not contain it.

#### Summary of Changes

Omit the workspace Cargo.toml from consideration