### PR TITLE
Fix TransactionStatusMeta breakage in blockstore

### DIFF
--- a/sdk/src/deserialize_utils.rs
+++ b/sdk/src/deserialize_utils.rs
@@ -1,0 +1,91 @@
+use serde::{Deserialize, Deserializer};
+
+pub fn default_on_eof<'de, T, D>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    let result = T::deserialize(d);
+    match result {
+        Err(err) if err.to_string() == "io error: unexpected end of file" => Ok(T::default()),
+        result => result,
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use bincode::deserialize;
+
+    #[test]
+    fn test_default_on_eof() {
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct Foo {
+            bar: u16,
+            #[serde(deserialize_with = "default_on_eof")]
+            baz: Option<u16>,
+            #[serde(deserialize_with = "default_on_eof")]
+            quz: String,
+        }
+
+        let data = vec![1, 0];
+        assert_eq!(
+            Foo {
+                bar: 1,
+                baz: None,
+                quz: "".to_string(),
+            },
+            deserialize(&data).unwrap()
+        );
+
+        let data = vec![1, 0, 0];
+        assert_eq!(
+            Foo {
+                bar: 1,
+                baz: None,
+                quz: "".to_string(),
+            },
+            deserialize(&data).unwrap()
+        );
+
+        let data = vec![1, 0, 1];
+        assert_eq!(
+            Foo {
+                bar: 1,
+                baz: None,
+                quz: "".to_string(),
+            },
+            deserialize(&data).unwrap()
+        );
+
+        let data = vec![1, 0, 1, 0];
+        assert_eq!(
+            Foo {
+                bar: 1,
+                baz: None,
+                quz: "".to_string(),
+            },
+            deserialize(&data).unwrap()
+        );
+
+        let data = vec![1, 0, 1, 0, 0, 1];
+        assert_eq!(
+            Foo {
+                bar: 1,
+                baz: Some(0),
+                quz: "".to_string(),
+            },
+            deserialize(&data).unwrap()
+        );
+
+        let data = vec![1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 116];
+        assert_eq!(
+            Foo {
+                bar: 1,
+                baz: Some(0),
+                quz: "t".to_string(),
+            },
+            deserialize(&data).unwrap()
+        );
+    }
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -17,6 +17,7 @@ pub mod builtins;
 pub mod clock;
 pub mod commitment_config;
 pub mod decode_error;
+pub mod deserialize_utils;
 pub mod entrypoint_native;
 pub mod epoch_info;
 pub mod epoch_schedule;

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -14,6 +14,7 @@ use crate::{
 use solana_sdk::{
     clock::{Slot, UnixTimestamp},
     commitment_config::CommitmentConfig,
+    deserialize_utils::default_on_eof,
     instruction::CompiledInstruction,
     message::{Message, MessageHeader},
     pubkey::Pubkey,
@@ -141,6 +142,7 @@ pub struct TransactionStatusMeta {
     pub fee: u64,
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
+    #[serde(deserialize_with = "default_on_eof")]
     pub inner_instructions: Option<Vec<InnerInstructions>>,
 }
 


### PR DESCRIPTION
#### Problem
As of https://github.com/solana-labs/solana/pull/12311 (and the v1.3 backport), nodes running on current code cannot deserialize legacy TransactionStatusMeta data.

#### Summary of Changes
- Add a deserialization helper function that sets remaining fields to default on end of file error. This enables extending structs by adding new optional fields to the end.

cc #12494 
