### PR TITLE
Include post balance information for rewards

### DIFF
--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -53,6 +53,7 @@ impl RewardsRecorderService {
             .map(|(pubkey, reward_info)| Reward {
                 pubkey: pubkey.to_string(),
                 lamports: reward_info.lamports,
+                post_balance: reward_info.post_balance,
             })
             .collect();
 

--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -1,5 +1,6 @@
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use solana_ledger::blockstore::Blockstore;
+use solana_runtime::bank::RewardInfo;
 use solana_sdk::{clock::Slot, pubkey::Pubkey};
 use solana_transaction_status::Reward;
 use std::{
@@ -11,8 +12,8 @@ use std::{
     time::Duration,
 };
 
-pub type RewardsRecorderReceiver = Receiver<(Slot, Vec<(Pubkey, i64)>)>;
-pub type RewardsRecorderSender = Sender<(Slot, Vec<(Pubkey, i64)>)>;
+pub type RewardsRecorderReceiver = Receiver<(Slot, Vec<(Pubkey, RewardInfo)>)>;
+pub type RewardsRecorderSender = Sender<(Slot, Vec<(Pubkey, RewardInfo)>)>;
 
 pub struct RewardsRecorderService {
     thread_hdl: JoinHandle<()>,
@@ -49,9 +50,9 @@ impl RewardsRecorderService {
         let (slot, rewards) = rewards_receiver.recv_timeout(Duration::from_secs(1))?;
         let rpc_rewards = rewards
             .into_iter()
-            .map(|(pubkey, lamports)| Reward {
+            .map(|(pubkey, reward_info)| Reward {
                 pubkey: pubkey.to_string(),
-                lamports,
+                lamports: reward_info.lamports,
             })
             .collect();
 

--- a/storage-bigtable/proto/solana.bigtable.confirmed_block.rs
+++ b/storage-bigtable/proto/solana.bigtable.confirmed_block.rs
@@ -87,6 +87,8 @@ pub struct Reward {
     pub pubkey: std::string::String,
     #[prost(int64, tag = "2")]
     pub lamports: i64,
+    #[prost(uint64, tag = "3")]
+    pub post_balance: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnixTimestamp {

--- a/storage-bigtable/src/confirmed_block.proto
+++ b/storage-bigtable/src/confirmed_block.proto
@@ -60,6 +60,7 @@ message CompiledInstruction {
 message Reward {
     string pubkey = 1;
     int64 lamports = 2;
+    uint64 post_balance = 3;
 }
 
 message UnixTimestamp {

--- a/storage-bigtable/src/convert.rs
+++ b/storage-bigtable/src/convert.rs
@@ -23,6 +23,7 @@ impl From<Reward> for generated::Reward {
         Self {
             pubkey: reward.pubkey,
             lamports: reward.lamports,
+            post_balance: reward.post_balance,
         }
     }
 }
@@ -32,6 +33,7 @@ impl From<generated::Reward> for Reward {
         Self {
             pubkey: reward.pubkey,
             lamports: reward.lamports,
+            post_balance: reward.post_balance,
         }
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -228,9 +228,12 @@ pub struct ConfirmedTransactionStatusWithSignature {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Reward {
     pub pubkey: String,
     pub lamports: i64,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub post_balance: u64, // Account balance in lamports after `lamports` was applied
 }
 
 pub type Rewards = Vec<Reward>;


### PR DESCRIPTION
The rewards information surfaced in RPC getConfirmedBlock currently doesn't include the account balance before or after the reward was credited. This makes it impossible to easily answer the simple question, "What's the % staking rewards my account received in previous epochs".

This PR adds a post_balance field to the Rewards struct that comes out of the Bank, and adds handling for Blockstore and Bigtable such that legacy Rewards without that field will still be deserialized properly. Post-balance is set to 0 if not available.

Closes #12561 