### PR TITLE
implements drain_filter for crds table

### DIFF
--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -424,18 +424,20 @@ impl CrdsValue {
     }
 
     /// Return all the possible labels for a record identified by Pubkey.
-    pub fn record_labels(key: &Pubkey) -> Vec<CrdsValueLabel> {
-        let mut labels = vec![
-            CrdsValueLabel::ContactInfo(*key),
-            CrdsValueLabel::LowestSlot(*key),
-            CrdsValueLabel::SnapshotHashes(*key),
-            CrdsValueLabel::AccountsHashes(*key),
-            CrdsValueLabel::LegacyVersion(*key),
-            CrdsValueLabel::Version(*key),
+    pub fn record_labels(key: Pubkey) -> impl Iterator<Item = CrdsValueLabel> {
+        const CRDS_VALUE_LABEL_STUBS: [fn(Pubkey) -> CrdsValueLabel; 6] = [
+            CrdsValueLabel::ContactInfo,
+            CrdsValueLabel::LowestSlot,
+            CrdsValueLabel::SnapshotHashes,
+            CrdsValueLabel::AccountsHashes,
+            CrdsValueLabel::LegacyVersion,
+            CrdsValueLabel::Version,
         ];
-        labels.extend((0..MAX_VOTES).map(|ix| CrdsValueLabel::Vote(ix, *key)));
-        labels.extend((0..MAX_EPOCH_SLOTS).map(|ix| CrdsValueLabel::EpochSlots(ix, *key)));
-        labels
+        CRDS_VALUE_LABEL_STUBS
+            .iter()
+            .map(move |f| (f)(key))
+            .chain((0..MAX_VOTES).map(move |ix| CrdsValueLabel::Vote(ix, key)))
+            .chain((0..MAX_EPOCH_SLOTS).map(move |ix| CrdsValueLabel::EpochSlots(ix, key)))
     }
 
     /// Returns the size (in bytes) of a CrdsValue
@@ -484,8 +486,8 @@ mod test {
     fn test_labels() {
         let mut hits = [false; 6 + MAX_VOTES as usize + MAX_EPOCH_SLOTS as usize];
         // this method should cover all the possible labels
-        for v in &CrdsValue::record_labels(&Pubkey::default()) {
-            match v {
+        for v in CrdsValue::record_labels(Pubkey::default()) {
+            match &v {
                 CrdsValueLabel::ContactInfo(_) => hits[0] = true,
                 CrdsValueLabel::LowestSlot(_) => hits[1] = true,
                 CrdsValueLabel::SnapshotHashes(_) => hits[2] = true,


### PR DESCRIPTION
#### Problem
Crds::find_old_labels clones and re-allocates all the outdated crds
labels on the heap:
https://github.com/solana-labs/solana/blob/0d5258b6d/core/src/crds.rs#L181-L203
CrdsGossipPull::purge_active then looks up the values again from the
crds table and removes them:
https://github.com/solana-labs/solana/blob/0d5258b6d/core/src/crds_gossip_pull.rs#L485-L507
The heap allocation and the 2nd lookup are redundant and unnecessary.

Similarly CrdsValue::record_labels allocates ~300 CrdsValueLabel on the
heap by buffering into a vector, whereas an iterator will suffice at the
call-site.
https://github.com/solana-labs/solana/blob/0d5258b6d/core/src/crds_value.rs#L426-L439

#### Summary of Changes
The commit implements a drain_filter method, similar to
Vec::drain_filter:
https://doc.rust-lang.org/std/vec/struct.Vec.html#method.drain_filter
to remove values more efficiently without buffering into a vector and
redundant second lookup.

Also, updated Crds::find_old_labels to return an iterator.