### PR TITLE
Add CI env to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ jobs:
           - ~/.npm
 
       before_install:
+        - source ci/env.sh
         - .travis/channel_restriction.sh edge beta || travis_terminate 0
         - .travis/affects.sh docs/ .travis || travis_terminate 0
         - cd docs/


### PR DESCRIPTION
#### Problem
Channel name checks don't work if you don't source the channel environment variables.

#### Summary of Changes
Make it so

Fixes `amateur_hour`
