### PR TITLE
Improve solana deploy

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1158,7 +1158,8 @@ fn process_deploy(
         if account.executable {
             return Err(CliError::DynamicProgramError(
                 "Program account is already executable".to_string(),
-            ));
+            )
+            .into());
         }
         if account.data.is_empty() {
             instructions.push(system_instruction::allocate(
@@ -1186,7 +1187,7 @@ fn process_deploy(
             &loader_id,
         )]
     };
-    let initial_message = if initial_instructions.len() > 0 {
+    let initial_message = if !initial_instructions.is_empty() {
         Some(Message::new(
             &initial_instructions,
             Some(&config.signers[0].pubkey()),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2286,7 +2286,12 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
 mod tests {
     use super::*;
     use serde_json::Value;
-    use solana_client::{blockhash_query, mock_sender::SIGNATURE};
+    use solana_client::{
+        blockhash_query,
+        mock_sender::SIGNATURE,
+        rpc_request::RpcRequest,
+        rpc_response::{Response, RpcResponseContext},
+    };
     use solana_sdk::{
         pubkey::Pubkey,
         signature::{keypair_from_seed, read_keypair_file, write_keypair_file, Presigner},
@@ -2858,7 +2863,15 @@ mod tests {
 
         // Success case
         let mut config = CliConfig::default();
-        config.rpc_client = Some(RpcClient::new_mock("deploy_succeeds".to_string()));
+        let account_info_response = json!(Response {
+            context: RpcResponseContext { slot: 1 },
+            value: Value::Null,
+        });
+        let mut mocks = HashMap::new();
+        mocks.insert(RpcRequest::GetAccountInfo, account_info_response);
+        let rpc_client = RpcClient::new_mock_with_mocks("".to_string(), mocks);
+
+        config.rpc_client = Some(rpc_client);
         let default_keypair = Keypair::new();
         config.signers = vec![&default_keypair];
 

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -94,9 +94,15 @@ impl RpcSender for MockSender {
                         err,
                     })
                 };
+                let statuses: Vec<Option<TransactionStatus>> = params.as_array().unwrap()[0]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|_| status.clone())
+                    .collect();
                 serde_json::to_value(Response {
                     context: RpcResponseContext { slot: 1 },
-                    value: vec![status],
+                    value: statuses,
                 })?
             }
             RpcRequest::GetTransactionCount => Value::Number(Number::from(1234)),

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -164,6 +164,19 @@ impl RpcClient {
         self.send(RpcRequest::GetSignatureStatuses, json!([signatures]))
     }
 
+    pub fn get_signature_statuses_with_history(
+        &self,
+        signatures: &[Signature],
+    ) -> RpcResult<Vec<Option<TransactionStatus>>> {
+        let signatures: Vec<_> = signatures.iter().map(|s| s.to_string()).collect();
+        self.send(
+            RpcRequest::GetSignatureStatuses,
+            json!([signatures, {
+                "searchTransactionHistory": true
+            }]),
+        )
+    }
+
     pub fn get_signature_status_with_commitment(
         &self,
         signature: &Signature,


### PR DESCRIPTION
#### Problem
`solana deploy` includes a transaction that creates the new account for the program. After a failed attempt, the account has  usually already been created, so running the command a second time fails when it attempts to create an account that already exists. This is frustrating; `solana deploy` should be recoverable.

Also: deploying a program of reasonable size to one of the solana clusters via a public api node takes an extremely long time, and frequently fails. The slowness is in large part due to the api-node rate limiting, but it exposes some issues in the deploy script that result in the failures
- The signature status check does not include the config paramter to search pre-status-cache history (blockstore and bigtable) -- with a large program, the statuses are gone before the script finishes sending the transactions, meaning they never appear confirmed. This kicks the script back to resend them all.
- The deploy script continues to retry status checks 15 times, even though transactions that have not landed by the time the blockhash expires will never land.

#### Summary of Changes
- Mirroring https://github.com/solana-labs/solana/pull/12163:
  - Check if program account already exists
  - If a program already exists, check if it is setup with the correct allocation, owner, and balance
  - If program exists and is setup correctly, proceed directly to loading instructions
  - If a program already exists and is executable, exit early
- Use last_valid_slot to time out status-check loop iteration
- Update `RpcClient::get_signature_statuses()` to search transaction history
- Borrow some niceties from stake-o-matic `transact()`, including batch signature status checks.

Using this PR, `solana deploy spl_token.so --url http://devnet.solana.com` ultimately succeeds. (Process never terminates without, and only approximately 200 chunks of the program land without.)

