### PR TITLE
cli: Add inflation subcommand

### DIFF
--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -19,7 +19,6 @@ use solana_sdk::{
 use std::{collections::HashMap, fmt, sync::Arc};
 
 #[derive(Debug, PartialEq)]
-#[allow(clippy::large_enum_variant)]
 pub enum FeatureCliCommand {
     Status { features: Vec<Pubkey> },
     Activate { feature: Pubkey },
@@ -242,7 +241,7 @@ fn feature_activation_allowed(rpc_client: &RpcClient) -> Result<bool, ClientErro
         .unwrap_or(false);
 
     if !feature_activation_allowed {
-        println!("\n{}", style("Stake By Feature Id:").bold());
+        println!("\n{}", style("Stake By Feature Set:").bold());
         for (feature_set, percentage) in active_stake_by_feature_set.iter() {
             if *feature_set == 0 {
                 println!("unknown - {}%", percentage);
@@ -252,7 +251,7 @@ fn feature_activation_allowed(rpc_client: &RpcClient) -> Result<bool, ClientErro
                     feature_set,
                     percentage,
                     if *feature_set == my_feature_set {
-                        " <-- current"
+                        " <-- me"
                     } else {
                         ""
                     }

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -1,0 +1,89 @@
+use crate::cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult};
+use clap::{App, ArgMatches, SubCommand};
+use console::style;
+use solana_clap_utils::keypair::*;
+use solana_client::rpc_client::RpcClient;
+use solana_remote_wallet::remote_wallet::RemoteWalletManager;
+use std::sync::Arc;
+
+#[derive(Debug, PartialEq)]
+pub enum InflationCliCommand {
+    Show,
+}
+
+pub trait InflationSubCommands {
+    fn inflation_subcommands(self) -> Self;
+}
+
+impl InflationSubCommands for App<'_, '_> {
+    fn inflation_subcommands(self) -> Self {
+        self.subcommand(SubCommand::with_name("inflation").about("Show inflation information"))
+    }
+}
+
+pub fn parse_inflation_subcommand(
+    _matches: &ArgMatches<'_>,
+    _default_signer: &DefaultSigner,
+    _wallet_manager: &mut Option<Arc<RemoteWalletManager>>,
+) -> Result<CliCommandInfo, CliError> {
+    Ok(CliCommandInfo {
+        command: CliCommand::Inflation(InflationCliCommand::Show),
+        signers: vec![],
+    })
+}
+
+pub fn process_inflation_subcommand(
+    rpc_client: &RpcClient,
+    _config: &CliConfig,
+    inflation_subcommand: &InflationCliCommand,
+) -> ProcessResult {
+    assert_eq!(*inflation_subcommand, InflationCliCommand::Show);
+
+    let governor = rpc_client.get_inflation_governor()?;
+    let current_inflation_rate = rpc_client.get_inflation_rate()?;
+
+    println!("{}", style("Inflation Governor:").bold());
+    if (governor.initial - governor.terminal).abs() < f64::EPSILON {
+        println!(
+            "Fixed APR:               {:>5.2}%",
+            governor.terminal * 100.
+        );
+    } else {
+        println!("Initial APR:             {:>5.2}%", governor.initial * 100.);
+        println!(
+            "Terminal APR:            {:>5.2}%",
+            governor.terminal * 100.
+        );
+        println!("Rate reduction per year: {:>5.2}%", governor.taper * 100.);
+    }
+    if governor.foundation_term > 0. {
+        println!("Foundation percentage:   {:>5.2}%", governor.foundation);
+        println!(
+            "Foundation term:         {:.1} years",
+            governor.foundation_term
+        );
+    }
+
+    println!(
+        "\n{}",
+        style(format!(
+            "Inflation for Epoch {}:",
+            current_inflation_rate.epoch
+        ))
+        .bold()
+    );
+    println!(
+        "Total APR:               {:>5.2}%",
+        current_inflation_rate.total * 100.
+    );
+    println!(
+        "Staking APR:             {:>5.2}%",
+        current_inflation_rate.validator * 100.
+    );
+    println!(
+        "Foundation APR:          {:>5.2}%",
+        current_inflation_rate.foundation * 100.
+    );
+
+    Ok("".to_string())
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -24,6 +24,7 @@ pub mod checks;
 pub mod cli;
 pub mod cluster_query;
 pub mod feature;
+pub mod inflation;
 pub mod nonce;
 pub mod spend_utils;
 pub mod stake;


### PR DESCRIPTION
#### devnet
pico-inflation is active:
```
$ solana inflation
Inflation Governor:
Fixed APR:                0.01%

Inflation for Epoch 14:
Total APR:                0.01%
Staking APR:              0.01%
Foundation APR:           0.00%
```

#### testnet
hard-coded inflation defaults (but pico-inflation will be enabled soon):
```
$ solana inflation
Inflation Governor:
Initial APR:             15.00%
Terminal APR:             1.50%
Rate reduction per year: 15.00%
Foundation percentage:    0.05%
Foundation term:         7.0 years

Inflation for Epoch 103:
Total APR:               13.83%
Staking APR:             13.14%
Foundation APR:           0.69%
```

#### mainnet-beta
inflation disabled:
```
$ solana inflation
Inflation Governor:
Fixed APR:                0.00%

Inflation for Epoch 89:
Total APR:                0.00%
Staking APR:              0.00%
Foundation APR:           0.00%
```