### PR TITLE
Fix cargo-audit error on v1.2

### DIFF
--- a/ci/buildkite.yml
+++ b/ci/buildkite.yml
@@ -15,6 +15,12 @@ steps:
 
   - wait
 
+  - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_audit_docker_image ci/test-audit.sh"
+    name: "audit"
+    timeout_in_minutes: 20
+
+  - wait
+
   - command: ". ci/rust-version.sh; ci/docker-run.sh $$rust_nightly_docker_image ci/test-checks.sh"
     name: "checks"
     timeout_in_minutes: 20

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -34,6 +34,9 @@ export rust_stable_docker_image=solanalabs/rust:"$stable_version"
 export rust_nightly=nightly-"$nightly_version"
 export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
 
+export rust_audit="1.46.0"
+export rust_audit_docker_image=solanalabs/rust-nightly:2020-08-17
+
 [[ -z $1 ]] || (
 
   rustup_install() {
@@ -47,6 +50,9 @@ export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
   set -e
   cd "$(dirname "${BASH_SOURCE[0]}")"
   case $1 in
+  audit)
+     rustup_install "$rust_audit"
+     ;;
   stable)
      rustup_install "$rust_stable"
      ;;
@@ -56,6 +62,7 @@ export rust_nightly_docker_image=solanalabs/rust-nightly:"$nightly_version"
   all)
      rustup_install "$rust_stable"
      rustup_install "$rust_nightly"
+     rustup_install "$rust_audit"
     ;;
   *)
     echo "Note: ignoring unknown argument: $1"

--- a/ci/test-audit.sh
+++ b/ci/test-audit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+source ci/_
+source ci/rust-version.sh audit
+
+export RUST_BACKTRACE=1
+export RUSTFLAGS="-D warnings"
+
+_ cargo +"$rust_audit" audit --version
+_ scripts/cargo-for-all-lock-files.sh +"$rust_audit" audit --ignore RUSTSEC-2020-0002 --ignore RUSTSEC-2020-0008

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -35,7 +35,6 @@ _ ci/order-crates-for-publishing.py
 
 {
   cd programs/bpf
-  _ cargo +"$rust_stable" audit
   for project in rust/*/ ; do
     echo "+++ do_bpf_checks $project"
     (

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -31,8 +31,6 @@ _ cargo +"$rust_stable" fmt --all -- --check
 _ cargo +"$rust_stable" clippy --version
 _ cargo +"$rust_stable" clippy --workspace -- --deny=warnings
 
-_ cargo +"$rust_stable" audit --version
-_ scripts/cargo-for-all-lock-files.sh +"$rust_stable" audit --ignore RUSTSEC-2020-0002 --ignore RUSTSEC-2020-0008
 _ ci/order-crates-for-publishing.py
 
 {


### PR DESCRIPTION
#### Problem

v1.2 docker image contains a `cargo-audit` version that does not support the recently deployed v3 advisory format, breaking CI.

#### Changes

Split `cargo-audit` to its own buildkite job, run with a newer docker image and rust version