### PR TITLE
Fix zero-len slice translations

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -114,6 +114,18 @@ extern uint64_t entrypoint(const uint8_t *input) {
                  sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
     }
 
+    sol_log("Test no instruction data");
+    {
+      SolAccountMeta arguments[] = {{accounts[ARGUMENT_INDEX].key, true, true}};
+      uint8_t data[] = {};
+      const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+                                          arguments, SOL_ARRAY_SIZE(arguments),
+                                          data, SOL_ARRAY_SIZE(data)};
+
+      sol_assert(SUCCESS ==
+                 sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
+    }
+
     sol_log("Test return error");
     {
       SolAccountMeta arguments[] = {{accounts[ARGUMENT_INDEX].key, true, true}};

--- a/programs/bpf/c/src/invoked/invoked.c
+++ b/programs/bpf/c/src/invoked/invoked.c
@@ -12,6 +12,10 @@ extern uint64_t entrypoint(const uint8_t *input) {
     return ERROR_INVALID_ARGUMENT;
   }
 
+  if (params.data_len == 0) {
+    return SUCCESS;
+  }
+
   switch (params.data[0]) {
   case TEST_VERIFY_TRANSLATIONS: {
     sol_log("verify data translations");

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -116,6 +116,16 @@ fn process_instruction(
                 invoke(&instruction, accounts)?;
             }
 
+            info!("Test no instruction data");
+            {
+                let instruction = create_instruction(
+                    *accounts[INVOKED_PROGRAM_INDEX].key,
+                    &[(accounts[ARGUMENT_INDEX].key, true, true)],
+                    vec![],
+                );
+                invoke(&instruction, accounts)?;
+            }
+
             info!("Test return error");
             {
                 let instruction = create_instruction(

--- a/programs/bpf/rust/invoked/src/lib.rs
+++ b/programs/bpf/rust/invoked/src/lib.rs
@@ -21,6 +21,10 @@ fn process_instruction(
 ) -> ProgramResult {
     info!("Invoked program");
 
+    if instruction_data.is_empty() {
+        return Ok(());
+    }
+
     match instruction_data[0] {
         TEST_VERIFY_TRANSLATIONS => {
             info!("verify data translations");

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -535,6 +535,7 @@ fn test_program_bpf_invoke() {
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
+                invoked_program_id.clone(),
             ]
         );
 
@@ -632,12 +633,12 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_128bit", 543),
             ("solana_bpf_rust_alloc", 19082),
             ("solana_bpf_rust_dep_crate", 2),
-            ("solana_bpf_rust_external_spend", 477),
+            ("solana_bpf_rust_external_spend", 485),
             ("solana_bpf_rust_iter", 723),
             ("solana_bpf_rust_many_args", 231),
-            ("solana_bpf_rust_noop", 451),
+            ("solana_bpf_rust_noop", 459),
             ("solana_bpf_rust_param_passing", 54),
-            ("solana_bpf_rust_sanity", 2215),
+            ("solana_bpf_rust_sanity", 2223),
         ]);
     }
 

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -227,6 +227,8 @@ macro_rules! translate_slice_mut {
             && ($vm_addr as u64 as *mut $t).align_offset(align_of::<$t>()) != 0
         {
             Err(SyscallError::UnalignedPointer.into())
+        } else if $len == 0 {
+            Ok(unsafe { from_raw_parts_mut(0x1 as *mut $t, $len as usize) })
         } else {
             match translate_addr::<BPFError>(
                 $vm_addr as u64,
@@ -1227,6 +1229,21 @@ mod tests {
 
     #[test]
     fn test_translate_slice() {
+        // zero len
+        let good_data = vec![1u8, 2, 3, 4, 5];
+        let data: Vec<u8> = vec![];
+        assert_eq!(0x1 as *const u8, data.as_ptr());
+        let addr = good_data.as_ptr() as *const _ as u64;
+        let regions = vec![MemoryRegion {
+            addr_host: addr,
+            addr_vm: 100,
+            len: good_data.len() as u64,
+        }];
+        let translated_data =
+            translate_slice!(u8, data.as_ptr(), data.len(), &regions, &bpf_loader::id()).unwrap();
+        assert_eq!(data, translated_data);
+        assert_eq!(0, translated_data.len());
+
         // u8
         let mut data = vec![1u8, 2, 3, 4, 5];
         let addr = data.as_ptr() as *const _ as u64;


### PR DESCRIPTION
#### Problem

Zero-length vectors have not been allocated yet so calling as_ptr() returns address 0x1 which is not in the translation map and thus fails with an access violation

#### Summary of Changes

If translating a zero-length vector then don't attempt to translate

Fixes #
