### PR TITLE
Check CPI program is executable

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -7,6 +7,7 @@
 static const uint8_t TEST_SUCCESS = 1;
 static const uint8_t TEST_PRIVILEGE_ESCALATION_SIGNER = 2;
 static const uint8_t TEST_PRIVILEGE_ESCALATION_WRITABLE = 3;
+static const uint8_t TEST_PPROGRAM_NOT_EXECUTABLE = 4;
 
 static const int MINT_INDEX = 0;
 static const int ARGUMENT_INDEX = 1;
@@ -271,6 +272,16 @@ extern uint64_t entrypoint(const uint8_t *input) {
     instruction.accounts[0].is_writable = true;
     sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
     break;
+  }
+  case TEST_PPROGRAM_NOT_EXECUTABLE: {
+    sol_log("Test program not executable");
+    SolAccountMeta arguments[] = {
+        {accounts[DERIVED_KEY3_INDEX].key, false, false}};
+    uint8_t data[] = {TEST_VERIFY_PRIVILEGE_ESCALATION};
+    const SolInstruction instruction = {accounts[ARGUMENT_INDEX].key, arguments,
+                                        SOL_ARRAY_SIZE(arguments), data,
+                                        SOL_ARRAY_SIZE(data)};
+    return sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
   }
   default:
     sol_panic();

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1088,6 +1088,9 @@ fn call<'a>(
     // Process instruction
 
     let program_account = (*accounts[callee_program_id_index]).clone();
+    if !program_account.borrow().executable {
+        return Err(SyscallError::InstructionError(InstructionError::AccountNotExecutable).into());
+    }
     let executable_accounts = vec![(callee_program_id, program_account)];
     let mut message_processor = MessageProcessor::default();
     for (program_id, process_instruction) in invoke_context.get_programs().iter() {

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -457,7 +457,6 @@ impl MessageProcessor {
             })
             .collect();
         keyed_accounts.append(&mut keyed_accounts2);
-        assert!(keyed_accounts[0].executable()?, "account not executable");
         Ok(keyed_accounts)
     }
 


### PR DESCRIPTION
#### Problem

cross-program invocation's don't enforce that the program be executable

#### Summary of Changes

- Enforce that programs are executable (mirrors this check: https://github.com/solana-labs/solana/blob/42aeead6b4e97663c8941ea5761b03b56eaa4be0/runtime/src/accounts.rs#L250)
- Remove long-standing `assert`

Fixes #