### PR TITLE
Update docs to show support for Nano X

### DIFF
--- a/docs/src/staking.md
+++ b/docs/src/staking.md
@@ -66,12 +66,12 @@ description is below.
 #### Supported Wallets
 Staking operations are supported by the following wallet solutions:
 
- - SolFlare.com in conjunction with a keystore file or a Ledger Nano S or Nano X.
+ - SolFlare.com in conjunction with a keystore file or a Ledger Nano.
 Check out our [guide to using SolFlare](wallet-guide/solflare.md) for details.
 
  - Solana command line tools can perform all stake operations in conjunction
  with a CLI-generated keypair file wallet, a paper wallet, or with a connected
- Ledger Nano S or Nano X.
+ Ledger Nano.
  [Staking commands using the Solana Command Line Tools](cli/delegate-stake.md).
 
 #### Create a Stake Account

--- a/docs/src/staking.md
+++ b/docs/src/staking.md
@@ -66,12 +66,12 @@ description is below.
 #### Supported Wallets
 Staking operations are supported by the following wallet solutions:
 
- - SolFlare.com in conjunction with a keystore file or a Ledger Nano S.  Check
- out our [guide to using SolFlare](wallet-guide/solflare.md) for details.
+ - SolFlare.com in conjunction with a keystore file or a Ledger Nano S or Nano X.
+Check out our [guide to using SolFlare](wallet-guide/solflare.md) for details.
 
  - Solana command line tools can perform all stake operations in conjunction
  with a CLI-generated keypair file wallet, a paper wallet, or with a connected
- Ledger Nano S.
+ Ledger Nano S or Nano X.
  [Staking commands using the Solana Command Line Tools](cli/delegate-stake.md).
 
 #### Create a Stake Account

--- a/docs/src/wallet-guide/apps.md
+++ b/docs/src/wallet-guide/apps.md
@@ -35,19 +35,18 @@ viewed at any later time in the app by following these steps:
 
 [Trust Wallet](trust-wallet.md)
 
-## Ledger Live with Ledger Nano S
+## Ledger Live with Nano S or Nano X
 
 [Ledger Live](https://www.ledger.com/ledger-live) is available as free desktop
 software and as a free app for iOS and Android. It is used to manage apps and
 crypto accounts on a Ledger _hardware wallet_, which must be purchased
 separately and connected to the device running Ledger Live.
 
-[Ledger Nano S](https://shop.ledger.com/products/ledger-nano-s) is a
-hardware wallet which stores the wallet's private keys on a secure device that
+[Ledger Nano S](https://shop.ledger.com/products/ledger-nano-s) and the
+[Ledger Nano X](https://shop.ledger.com/pages/ledger-nano-x) are
+hardware wallets which stores the wallet's private keys on a secure device that
 is physically separate from the computer, and connects via USB cable.
 This provides an extra level of security but requires the user to purchase and
 keep track of the hardware device.
-
-Solana does not support the Ledger Nano **X** at this time.
 
 [Ledger Live](ledger-live.md)

--- a/docs/src/wallet-guide/hardware-wallets.md
+++ b/docs/src/wallet-guide/hardware-wallets.md
@@ -19,7 +19,7 @@ hardware wallet.
 
 The Solana CLI supports the following hardware wallets:
 
-- [Ledger Nano S](hardware-wallets/ledger.md)
+- [Ledger Nano S and Ledger Nano X](hardware-wallets/ledger.md)
 
 ## Specify a Keypair URL
 

--- a/docs/src/wallet-guide/hardware-wallets/ledger.md
+++ b/docs/src/wallet-guide/hardware-wallets/ledger.md
@@ -2,20 +2,20 @@
 title: Ledger Hardware Wallet
 ---
 
-The Ledger Nano hardware wallet offers secure storage of your Solana private
-keys. The Solana Ledger app enables derivation of essentially infinite keys, and
-secure transaction signing.
+This page describes how to use a Ledger Nano S or Nano X to interact with Solana
+using the command line tools.  To see other solutions to interact with Solana with
+your Nano, [click here](../ledger-live.md#interact-with-the-solana-network).
 
 ## Before You Begin
 
-- [Set up a Ledger Nano with the Solana App](../ledger-live.md)
+- [Set up a Nano with the Solana App](../ledger-live.md)
 - [Install the Solana command-line tools](../../cli/install-solana-cli-tools.md)
 
-## Use Ledger Nano S or Nano X with Solana CLI
+## Use Ledger Nano with Solana CLI
 
 1. Ensure the Ledger Live application is closed
-2. Plug your Ledger device into your computer's USB port
-3. Enter your pin and start the Solana app on the Ledger device
+2. Plug your Nano into your computer's USB port
+3. Enter your pin and start the Solana app on the Nano
 4. Ensure the screen reads "Application is ready"
 
 ### View your Wallet ID
@@ -28,7 +28,7 @@ solana-keygen pubkey usb://ledger
 
 This confirms your Ledger device is connected properly and in the correct state
 to interact with the Solana CLI. The command returns your Ledger's unique
-_wallet ID_. When you have multiple Nano S or X devices connected to the same
+_wallet ID_. When you have multiple Nano devices connected to the same
 computer, you can use your wallet ID to specify which Ledger hardware wallet
 you want to use. If you only plan to use a single Nano on your computer
 at a time, you don't need to include the wallet ID. For information on
@@ -37,7 +37,7 @@ using the wallet ID to use a specific Ledger, see
 
 ### View your Wallet Addresses
 
-Your Nano S and X supports an arbitrary number of valid wallet addresses and signers.
+Your Nano supports an arbitrary number of valid wallet addresses and signers.
 To view any address, use the `solana-keygen pubkey` command, as shown below,
 followed by a valid [keypair URL](../hardware-wallets.md#specify-a-keypair-url).
 
@@ -58,7 +58,7 @@ solana-keygen pubkey usb://ledger?key=2
 You can use other values for the number after `key=` as well.
 Any of the addresses displayed by these commands are valid Solana wallet
 addresses. The private portion associated with each address is stored securely
-on the Nano device, and is used to sign transactions from this address.
+on the Nano, and is used to sign transactions from this address.
 Just make a note of which keypair URL you used to derive any address you will be
 using to receive tokens.
 
@@ -99,7 +99,7 @@ Ledger, will show as "Not Found" in the explorer. Empty accounts and non-existen
 accounts are treated the same in Solana. This will change when your account
 address has some SOL in it.
 
-### Send SOL from a Ledger Nano
+### Send SOL from a Nano
 
 To send some tokens from an address controlled by your Nano, you will
 need to use the device to sign a transaction, using the same keypair URL you
@@ -159,7 +159,7 @@ choose which wallet to use for each signature.
 
 Instead of using the interactive prompts, you can generate fully qualified
 URLs using the Solana CLI `resolve-signer` command. For example, try
-connecting a Ledger Nano to USB, unlock it with your pin, and running the
+connecting a Nano to USB, unlock it with your pin, and running the
 following command:
 
 ```text

--- a/docs/src/wallet-guide/hardware-wallets/ledger.md
+++ b/docs/src/wallet-guide/hardware-wallets/ledger.md
@@ -2,22 +2,21 @@
 title: Ledger Hardware Wallet
 ---
 
-The Ledger Nano S hardware wallet offers secure storage of your Solana private
+The Ledger Nano hardware wallet offers secure storage of your Solana private
 keys. The Solana Ledger app enables derivation of essentially infinite keys, and
 secure transaction signing.
 
 ## Before You Begin
 
-- [Set up a Ledger Nano S with the Solana App](../ledger-live.md)
+- [Set up a Ledger Nano with the Solana App](../ledger-live.md)
 - [Install the Solana command-line tools](../../cli/install-solana-cli-tools.md)
 
-## Use Ledger Nano S with Solana CLI
+## Use Ledger Nano S or Nano X with Solana CLI
 
 1. Ensure the Ledger Live application is closed
 2. Plug your Ledger device into your computer's USB port
 3. Enter your pin and start the Solana app on the Ledger device
-4. Press both buttons to advance past the "Pending Ledger review" screen
-5. Ensure the screen reads "Application is ready"
+4. Ensure the screen reads "Application is ready"
 
 ### View your Wallet ID
 
@@ -29,16 +28,16 @@ solana-keygen pubkey usb://ledger
 
 This confirms your Ledger device is connected properly and in the correct state
 to interact with the Solana CLI. The command returns your Ledger's unique
-_wallet ID_. When you have multiple Nano S devices connected to the same
+_wallet ID_. When you have multiple Nano S or X devices connected to the same
 computer, you can use your wallet ID to specify which Ledger hardware wallet
-you want to use. If you only plan to use a single Nano S on your computer
+you want to use. If you only plan to use a single Nano on your computer
 at a time, you don't need to include the wallet ID. For information on
 using the wallet ID to use a specific Ledger, see
 [Manage Multiple Hardware Wallets](#manage-multiple-hardware-wallets).
 
 ### View your Wallet Addresses
 
-Your Nano S supports an arbitrary number of valid wallet addresses and signers.
+Your Nano S and X supports an arbitrary number of valid wallet addresses and signers.
 To view any address, use the `solana-keygen pubkey` command, as shown below,
 followed by a valid [keypair URL](../hardware-wallets.md#specify-a-keypair-url).
 
@@ -59,7 +58,7 @@ solana-keygen pubkey usb://ledger?key=2
 You can use other values for the number after `key=` as well.
 Any of the addresses displayed by these commands are valid Solana wallet
 addresses. The private portion associated with each address is stored securely
-on the Nano S device, and is used to sign transactions from this address.
+on the Nano device, and is used to sign transactions from this address.
 Just make a note of which keypair URL you used to derive any address you will be
 using to receive tokens.
 
@@ -100,11 +99,11 @@ Ledger, will show as "Not Found" in the explorer. Empty accounts and non-existen
 accounts are treated the same in Solana. This will change when your account
 address has some SOL in it.
 
-### Send SOL from a Ledger Nano S
+### Send SOL from a Ledger Nano
 
-To send some tokens from an address controlled by your Nano S device, you will
+To send some tokens from an address controlled by your Nano, you will
 need to use the device to sign a transaction, using the same keypair URL you
-used to derive the address. To do this, make sure your Nano S is plugged in,
+used to derive the address. To do this, make sure your Nano is plugged in,
 unlocked with the PIN, Ledger Live is not running, and the Solana App is open
 on the device, showing "Application is Ready".
 
@@ -160,7 +159,7 @@ choose which wallet to use for each signature.
 
 Instead of using the interactive prompts, you can generate fully qualified
 URLs using the Solana CLI `resolve-signer` command. For example, try
-connecting a Ledger Nano-S to USB, unlock it with your pin, and running the
+connecting a Ledger Nano to USB, unlock it with your pin, and running the
 following command:
 
 ```text

--- a/docs/src/wallet-guide/ledger-live.md
+++ b/docs/src/wallet-guide/ledger-live.md
@@ -20,13 +20,13 @@ on your Nano device, users have several options of how to
 - Install [Ledger Live desktop software](https://www.ledger.com/ledger-live/)
   - If you already have Ledger Live installed, please update to the latest
   version of Ledger Live, which enables the newest firmware and app updates.
-- Connect your Nano S or X to your computer and follow the on-screen instructions.
+- Connect your Nano to your computer and follow the on-screen instructions.
 - Update the firmware on your new Nano.  This is needed to ensure you are able
 to install the latest version of the Solana App.
   - [Update Nano S Firmware](https://support.ledger.com/hc/en-us/articles/360002731113-Update-Ledger-Nano-S-firmware)
   - [Update Nano X Firmware](https://support.ledger.com/hc/en-us/articles/360013349800)
 
-## Install the Solana App on your Ledger Nano
+## Install the Solana App on your Nano
 
 - Open Ledger Live
 - Click on "Manager" in the left pane on the app and search for "Solana" in the
@@ -59,12 +59,18 @@ Solana:
 - [SolFlare.com](https://solflare.com/) is a non-custodial web wallet built
 specifically for Solana and supports basic transfers and staking operations
 with the Ledger device.
-Check out our guide for [using a Ledger Nano with SolFlare](solflare.md).
+Check out our guide for [using a Nano with SolFlare](solflare.md).
 
 - Developers and advanced users may
-[use a Ledger Nano with the Solana command line tools](hardware-wallets/ledger.md).
+[use a Nano with the Solana command line tools](hardware-wallets/ledger.md).
 New wallet features are almost always supported in the native command line tools
 before being supported by third-party wallets.
+
+## Known Issues
+
+- Nano X sometimes cannot connect to web wallets using the Windows operating
+system. This is likely to affect any browser-based wallets that use WebUSB.
+The Ledger team is working to resolve this.
 
 ## Support
 

--- a/docs/src/wallet-guide/ledger-live.md
+++ b/docs/src/wallet-guide/ledger-live.md
@@ -1,73 +1,68 @@
 ---
-title: Ledger Live and Ledger Nano S
+title: Set up a Ledger Nano S or Nano X
 ---
 
 This document describes how to set up a
-[Ledger Nano S hardware wallet](https://shop.ledger.com/products/ledger-nano-s)
+[Ledger Nano S](https://shop.ledger.com/products/ledger-nano-s) or
+[Ledger Nano X](https://shop.ledger.com/pages/ledger-nano-x)
 with the [Ledger Live](https://www.ledger.com/ledger-live) software.
 
 Once the setup steps shown below are complete and the Solana app is installed
-on your Nano S device, users have several options of how to
-[use the Nano S to interact with the Solana Network](#interact-with-the-solana-network)
+on your Nano device, users have several options of how to
+[use the Nano to interact with the Solana Network](#interact-with-the-solana-network)
 
-## Set up a Ledger Nano S
+## Getting Started
 
-- Order a [Nano S from Ledger](https://shop.ledger.com/products/ledger-nano-s)
+- Order a [Nano S](https://shop.ledger.com/products/ledger-nano-s) or
+[Nano X](https://shop.ledger.com/pages/ledger-nano-x) from Ledger.
 - Follow the instructions for device setup included in the package,
   or [Ledger's Start page](https://www.ledger.com/start/)
-- [Install the latest device firmware](https://support.ledgerwallet.com/hc/en-us/articles/360002731113-Update-Ledger-Nano-S-firmware)
+- Install [Ledger Live desktop software](https://www.ledger.com/ledger-live/)
+  - If you already have Ledger Live installed, please update to the latest
+  version of Ledger Live, which enables the newest firmware and app updates.
+- Connect your Nano S or X to your computer and follow the on-screen instructions.
+- Update the firmware on your new Nano.  This is needed to ensure you are able
+to install the latest version of the Solana App.
+  - [Update Nano S Firmware](https://support.ledger.com/hc/en-us/articles/360002731113-Update-Ledger-Nano-S-firmware)
+  - [Update Nano X Firmware](https://support.ledger.com/hc/en-us/articles/360013349800)
 
-## Install Ledger Live
-
-- Install [Ledger Live desktop software](https://www.ledger.com/ledger-live/),
-  or
-- Install the [Ledger Live app for iOS](https://apps.apple.com/app/id1361671700)
-  or [Ledger Live for Android](https://play.google.com/store/apps/details?id=com.ledger.live).
-  - Requires iOS 9.1 or later. Compatible with iPhone, iPad, and iPod touch.
-  - Requires Android 7.0 or later.
-- Connect your Nano S to your device and follow the instructions
-
-## Install the Solana App on your Nano S
+## Install the Solana App on your Ledger Nano
 
 - Open Ledger Live
-- Go to Manager in the app and find "Solana" in the App Catalog and
-  click Install
+- Click on "Manager" in the left pane on the app and search for "Solana" in the
+App Catalog, then click "Install".
   - Make sure your device is plugged in via USB and is unlocked with its PIN
-- You may be prompted on the Nano S to confirm the install of Solana App
+- You may be prompted on the Nano to confirm the install of Solana App
 - "Solana" should now show as "Installed" in the Ledger Live Manager
-
-![Installed Solana App in Manager](/img/ledger-live-latest-version-installed.png)
 
 ## Upgrade to the latest version of the Solana App
 
 To make sure you have the latest functionality, if you are using an older version
-of the Solana App, please upgrade to version v0.2.2 by following these steps.
+of the Solana App, please upgrade to version `v1.0.1` by following these steps.
 
-- Connect your Nano S to your computer an unlock it by entering your PIN on the
-  device
-- Open Ledger Live and click on "Manager" in the left pane
-- On your Nano S, click both buttons when prompted to "Allow Manager"
-- Click the "Update All" button to update the Solana app to the latest version
-  (v.0.2.2)
-
-![Upgrade All button in Manager](/img/ledger-live-update-available-v0.2.2.png)
-
-- Once the upgrade is finished, confirm v0.2.2 is installed under "Apps Installed"
-
-![Upgrade complete](/img/ledger-live-latest-version-installed.png)
+- Make sure you have Ledger Live version 2.10.0 or later.
+  - To check your version of Ledger Live, click on the Settings button in the
+ upper-right corner, then click "About".  If a newer version of Ledger Live is
+ available, you should see a banner prompting you to upgrade when you first open
+ Ledger Live.
+- Update the firmware on your Nano
+  - [Update Nano S Firmware](https://support.ledger.com/hc/en-us/articles/360002731113-Update-Ledger-Nano-S-firmware)
+  - [Update Nano X Firmware](https://support.ledger.com/hc/en-us/articles/360013349800)
+-  After a successful firmware update, the Solana app should automatically get
+re-installed with the latest version of the app.
 
 ## Interact with the Solana network
 
-Users can use any of the following options to sign and submit transactions with
-the Ledger Nano S to interact with the Solana network:
+Users can use any of the following options to use their Nano to interact with
+Solana:
 
 - [SolFlare.com](https://solflare.com/) is a non-custodial web wallet built
 specifically for Solana and supports basic transfers and staking operations
 with the Ledger device.
-Check out our guide for [using a Ledger Nano S with SolFlare](solflare.md).
+Check out our guide for [using a Ledger Nano with SolFlare](solflare.md).
 
 - Developers and advanced users may
-[use a Ledger Nano S with the Solana command line tools](hardware-wallets/ledger.md).
+[use a Ledger Nano with the Solana command line tools](hardware-wallets/ledger.md).
 New wallet features are almost always supported in the native command line tools
 before being supported by third-party wallets.
 

--- a/docs/src/wallet-guide/solflare.md
+++ b/docs/src/wallet-guide/solflare.md
@@ -50,9 +50,8 @@ then you will be taken to the wallet interface main page.
 
 ### Using a Ledger Nano hardware wallet
 
-*NOTE: SolFlare and Solana supports both Ledger Nano S and Nano X.
-There is a known issue in which a Nano X sometimes cannot connect using the
-Windows operating system. The Ledger team is working to resolve this.*
+*NOTE: Please see [known issues](ledger-live.md#known-issues) for any current
+limitations in using the Nano.*
 
 #### Initial Device Setup
 To use a Ledger Nano with SolFlare, first ensure you have
@@ -178,7 +177,7 @@ If you accessed your wallet using a Keystore file, you will be prompted to enter
 your password any time the key is needed to sign a transaction.
 
 ### Using a Ledger Nano
-If you accessed your wallet with a Ledger Nano S or X, you will be prompted to
+If you accessed your wallet with a Ledger Nano, you will be prompted to
 confirm the pending transaction details on your device whenever the key is needed
 to sign. On the Nano, use the left and right buttons to view and confirm all of the
 transaction details.  If everything looks correct, keep clicking the right button

--- a/docs/src/wallet-guide/solflare.md
+++ b/docs/src/wallet-guide/solflare.md
@@ -13,7 +13,7 @@ SolFlare also supports staking of SOL tokens.
 As a _non-custodial_ wallet, your private keys are not stored by the SolFlare
 site itself, but rather they are stored in an encrypted
 [Keystore File](#using-a-keystore-file) or on a
-[Ledger Nano S hardware wallet](#using-a-ledger-nano-s-hardware-wallet).
+[Ledger Nano S or X hardware wallet](#using-a-ledger-nano-hardware-wallet).
 
 This guide describes how to set up a wallet using SolFlare, how to send and
 receive SOL tokens, and how to create and manage a stake account.
@@ -22,7 +22,7 @@ receive SOL tokens, and how to create and manage a stake account.
 
 Go to https://www.solflare.com in a supported browser.  Most popular web browsers
 should work when interacting with a Keystore File, but currently only
-Chrome and Brave are supported when interacting with a Ledger Nano S.
+Chrome and Brave are supported when interacting with a Ledger Nano.
 
 ### Using a Keystore File
 
@@ -48,21 +48,24 @@ Keystore file, you will be taken to the Access page directly.
 You will be prompted to enter the password and upload your Keystore file,
 then you will be taken to the wallet interface main page.
 
-### Using a Ledger Nano S hardware wallet
+### Using a Ledger Nano hardware wallet
+
+*NOTE: SolFlare and Solana supports both Ledger Nano S and Nano X.
+There is a known issue in which a Nano X sometimes cannot connect using the
+Windows operating system. The Ledger team is working to resolve this.*
 
 #### Initial Device Setup
-To use a Ledger Nano S with SolFlare, first ensure you have
-[set up your Nano S](ledger-live.md) and have [installed the latest version of
+To use a Ledger Nano with SolFlare, first ensure you have
+[set up your Nano](ledger-live.md) and have [installed the latest version of
 the Solana app](ledger-live.md#upgrade-to-the-latest-version-of-the-solana-app)
 on your device.
 
 #### Select a Ledger address to access
-Plug in your Nano S and open the Solana app.  Acknowledge a message of "Pending
-Ledger Review" by tapping both buttons at once so the device screen displays
+Plug in your Nano and open the Solana app so the device screen displays
 "Application is Ready".
 
 From the SolFlare home page, click "Access a Wallet" then select "Using Ledger
-Nano S".  Under "Select derivation path", select the only option:
+Nano S | Ledger Nano X".  Under "Select derivation path", select the only option:
 
 ```Solana - 44`/501`/```
 
@@ -174,10 +177,10 @@ it will be accepted by the network.
 If you accessed your wallet using a Keystore file, you will be prompted to enter
 your password any time the key is needed to sign a transaction.
 
-### Using a Ledger Nano S
-If you accessed your wallet with a Ledger Nano S, you will be prompted to confirm
-the pending transaction details on your device whenever the key is needed to sign.
-On the Nano S, use the left and right buttons to view and confirm all of the
+### Using a Ledger Nano
+If you accessed your wallet with a Ledger Nano S or X, you will be prompted to
+confirm the pending transaction details on your device whenever the key is needed
+to sign. On the Nano, use the left and right buttons to view and confirm all of the
 transaction details.  If everything looks correct, keep clicking the right button
 until the screen shows "Approve".  Click both buttons to approve the transaction.
 If something looks incorrect, press the right button once more so the screen shows


### PR DESCRIPTION
#### Problem
- Instructions for installing and using Solana App still reflect the app being in development mode. 
- We now support Nano X, but docs only reflect support for Nano S

#### Summary of Changes
Update Ledger Live setup instructions and update to latest minimum versions to get v1.0.1
Add Nano X