### PR TITLE
Disable rent in flaky test

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2396,6 +2396,14 @@ impl AccountsDB {
             }
         }
     }
+
+    #[cfg(test)]
+    pub fn get_append_vec_id(&self, pubkey: &Pubkey, slot: Slot) -> Option<AppendVecId> {
+        let ancestors = vec![(slot, 1)].into_iter().collect();
+        let accounts_index = self.accounts_index.read().unwrap();
+        let result = accounts_index.get(&pubkey, Some(&ancestors), None);
+        result.map(|(list, index)| list[index].1.store_id)
+    }
 }
 
 #[cfg(test)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -9351,7 +9351,7 @@ mod tests {
         // Make sure rent collection doesn't overwrite `large_account_pubkey`, which
         // keeps slot 1 alive in the accounts database. Otherwise, slot 1 and it's bank
         // hash would be removed from accounts, preventing `rehash()` from succeeding
-        bank1.lazy_rent_collection.store(false, Relaxed);
+        bank1.lazy_rent_collection.store(true, Relaxed);
         bank1.freeze();
         let bank1_hash = bank1.hash();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -9333,7 +9333,25 @@ mod tests {
                 &Pubkey::default(),
             ),
         );
+        assert_ne!(
+            bank1
+                .rc
+                .accounts
+                .accounts_db
+                .get_append_vec_id(&large_account_pubkey, 1)
+                .unwrap(),
+            bank1
+                .rc
+                .accounts
+                .accounts_db
+                .get_append_vec_id(&zero_lamport_pubkey, 1)
+                .unwrap()
+        );
 
+        // Make sure rent collection doesn't overwrite `large_account_pubkey`, which
+        // keeps slot 1 alive in the accounts database. Otherwise, slot 1 and it's bank
+        // hash would be removed from accounts, preventing `rehash()` from succeeding
+        bank1.lazy_rent_collection.store(false, Relaxed);
         bank1.freeze();
         let bank1_hash = bank1.hash();
 


### PR DESCRIPTION
#### Problem
`test_clean_zero_lamport_account_different_hash()` is flaky because of rent collection

#### Summary of Changes
Disable rent, add comment explaining why

Fixes #
