### PR TITLE
Only fetch snapshot if it's newer than local

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -180,7 +180,7 @@ fn get_rpc_node(
             "Searching for an RPC service with shred version {}{}...",
             shred_version,
             retry_reason
-                .clone()
+                .as_ref()
                 .map(|s| format!(" (Retrying: {})", s))
                 .unwrap_or_default()
         );

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -148,8 +148,9 @@ fn get_rpc_node(
     snapshot_not_required: bool,
     no_untrusted_rpc: bool,
     ledger_path: &std::path::Path,
-) -> (ContactInfo, Option<(Slot, Hash)>) {
+) -> Option<(ContactInfo, Option<(Slot, Hash)>)> {
     let mut blacklist_timeout = Instant::now();
+    let mut newer_cluster_snapshot_timeout = None;
     let mut retry_reason = None;
     loop {
         sleep(Duration::from_secs(1));
@@ -270,6 +271,15 @@ fn get_rpc_node(
                 }
                 Some(highest_snapshot_hash) => {
                     if eligible_rpc_peers.is_empty() {
+                        match newer_cluster_snapshot_timeout {
+                            None => newer_cluster_snapshot_timeout = Some(Instant::now()),
+                            Some(newer_cluster_snapshot_timeout) => {
+                                if newer_cluster_snapshot_timeout.elapsed().as_secs() > 180 {
+                                    warn!("giving up newer snapshot from the cluster");
+                                    return None;
+                                }
+                            }
+                        }
                         retry_reason = Some(format!(
                             "Wait for newer snapshot than local: {:?}",
                             highest_snapshot_hash
@@ -299,7 +309,7 @@ fn get_rpc_node(
         if !eligible_rpc_peers.is_empty() {
             let contact_info =
                 &eligible_rpc_peers[thread_rng().gen_range(0, eligible_rpc_peers.len())];
-            return (contact_info.clone(), highest_snapshot_hash);
+            return Some((contact_info.clone(), highest_snapshot_hash));
         } else {
             retry_reason = Some("No snapshots available".to_owned());
         }
@@ -649,7 +659,7 @@ fn rpc_bootstrap(
             ));
         }
 
-        let (rpc_contact_info, snapshot_hash) = get_rpc_node(
+        let rpc_node_details = get_rpc_node(
             &gossip.as_ref().unwrap().0,
             &cluster_entrypoint.gossip,
             &validator_config,
@@ -658,6 +668,11 @@ fn rpc_bootstrap(
             bootstrap_config.no_untrusted_rpc,
             ledger_path,
         );
+        if rpc_node_details.is_none() {
+            return;
+        }
+        let (rpc_contact_info, snapshot_hash) = rpc_node_details.unwrap();
+
         info!(
             "Using RPC service from node {}: {:?}",
             rpc_contact_info.id, rpc_contact_info.rpc

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -211,14 +211,14 @@ fn get_rpc_node(
         );
 
         if rpc_peers_blacklisted == rpc_peers_total {
-            if blacklist_timeout.elapsed().as_secs() > 60 {
+            retry_reason = if blacklist_timeout.elapsed().as_secs() > 60 {
                 // If all nodes are blacklisted and no additional nodes are discovered after 60 seconds,
                 // remove the blacklist and try them all again
-                retry_reason = Some("Blacklist timeout expired".to_owned());
                 blacklisted_rpc_nodes.clear();
+                Some("Blacklist timeout expired".to_owned())
             } else {
-                retry_reason = Some("Wait for trusted rpc peers".to_owned());
-            }
+                Some("Wait for trusted rpc peers".to_owned())
+            };
             continue;
         }
         blacklist_timeout = Instant::now();


### PR DESCRIPTION
#### Problem

When a booting validator is fetching snapshot from the cluster, it's possible to fetch older snapshot than local...
Depending on gossip status, it's possible...

If that's the case, the persisted tower ultimately vomits a panic because it now can detect root got warped to the past.

#### Summary of Changes

Don't ever download older snapshot.

Fixes #12591 
