### PR TITLE
Fix tower/blockstore unsync due to external causes

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -554,8 +554,8 @@ impl Tower {
                     // validator SEGV, OS/HW crash, or plain No Free Space FS error.
 
                     // When we're in this clause, it basically means validator is badly running
-                    // with a future tower and RE-CREATING a block for one of past slots as the leader
-                    // of the slot, especially problematic is last_voted_slot.
+                    // with a future tower while replaying past slots, especially problematic is
+                    // last_voted_slot.
                     // So, don't re-vote on it by returning pseudo FailedSwitchThreshold, otherwise
                     // there would be slashing because of double vote on one of last_vote_ancestors.
                     // (Well, needless to say, re-creating the duplicate block must be handled properly
@@ -563,10 +563,9 @@ impl Tower {
                     //
                     // To be specific, the replay stage is tricked into a false perception where
                     // last_vote_ancestors is AVAILABLE for descendant-of-`switch_slot`,  stale, and
-                    // stray slots (which should always be empty_ancestors). This is caused by the banking
-                    // stage's incorrectly creating new duplicate block.
+                    // stray slots (which should always be empty_ancestors).
                     //
-                    // This is covered by test_future_tower in local_cluster
+                    // This is covered by test_future_tower_* in local_cluster
                     SwitchForkDecision::FailedSwitchThreshold(0, total_stake)
                 };
 
@@ -903,10 +902,11 @@ impl Tower {
                 self.initialize_root(replayed_root);
             } else {
                 // This should never occur under normal operation.
-                // If this validator has leader slots while voting suspended this way,
+                // While this validator's voting is suspended this way,
                 // suspended_decision_due_to_major_unsynced_ledger() will be also touched.
                 let message = format!(
-                    "For some reason, we're REPROCESSING already voted and ROOTED slots; \
+                    "For some reason, we're REPROCESSING slots which has already been \
+                     voted and ROOTED by us; \
                      VOTING will be SUSPENDED UNTIL {}!",
                     last_voted_slot,
                 );

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -547,7 +547,7 @@ impl Tower {
                     &empty_ancestors
                 };
 
-                let suspended_decision_due_to_major_unsynced_ledger = |total_stake| {
+                let suspended_decision_due_to_major_unsynced_ledger = || {
                     // This peculiar corner handling is needed mainly for a tower which is newer than
                     // blockstore. (Yeah, we tolerate it for ease of maintaining validator by operators)
                     // This condition could be introduced by manual ledger mishandling,
@@ -604,7 +604,7 @@ impl Tower {
                             last_voted_slot
                         );
                     } else {
-                        return suspended_decision_due_to_major_unsynced_ledger(total_stake);
+                        return suspended_decision_due_to_major_unsynced_ledger();
                     }
                 }
 

--- a/sdk/program/src/slot_history.rs
+++ b/sdk/program/src/slot_history.rs
@@ -6,7 +6,7 @@ use bv::BitVec;
 use bv::BitsMut;
 
 #[repr(C)]
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct SlotHistory {
     pub bits: BitVec<u64>,
     pub next_slot: Slot,


### PR DESCRIPTION
#### Problem

there are various persisted tower assertions which shouldn't be triggered (thanks for reporting, @sakridge )

All of them is related to flushing timing issue or unintended ledger manual manipulation:

|FKFE8cSNZ5AzTNq4VsC7y6wEeoYWbzVRfxuzc36Sqr5y | validator | solana-replay-stage | panicked at 'assertion failed: !last_vote_ancestors.contains(&switch_slot)', core/src/consensus.rs:540:17
-- | -- | -- | --

|twP716sMjTFynrZRSCKkHhoeHaQEXnR2bzqDEzuxP81 |	validator	|main	|panicked at 'at least 1 parent slot must be found', core/src/consensus.rs:1094:13
-- | -- | -- | --



#### Summary of Changes

Adjust those assertions to accomodate any kind of incomplete unsync between tower <=> blockstore. Also, support a future tower which is descendant of ledger root.

Fixes #13128

context: #10718