### PR TITLE
Store program logs in blockstore / bigtable (TransactionWithStatusMeta)

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -534,13 +534,13 @@ impl BankingStage {
             mut loaded_accounts,
             results,
             inner_instructions,
+            transaction_logs,
             mut retryable_txs,
             tx_count,
             signature_count,
         ) = bank.load_and_execute_transactions(
             batch,
             MAX_PROCESSING_AGE,
-            None,
             transaction_status_sender.is_some(),
         );
         load_execute_time.stop();
@@ -580,6 +580,7 @@ impl BankingStage {
                     tx_results.processing_results,
                     TransactionBalancesSet::new(pre_balances, post_balances),
                     inner_instructions,
+                    transaction_logs,
                     sender,
                 );
             }

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -542,6 +542,7 @@ impl BankingStage {
             batch,
             MAX_PROCESSING_AGE,
             transaction_status_sender.is_some(),
+            transaction_status_sender.is_some(),
         );
         load_execute_time.stop();
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5680,6 +5680,7 @@ pub mod tests {
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
                             inner_instructions: Some(vec![]),
+                            log_messages: Some(vec![]),
                         },
                     )
                     .unwrap();
@@ -5693,6 +5694,7 @@ pub mod tests {
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
                             inner_instructions: Some(vec![]),
+                            log_messages: Some(vec![]),
                         },
                     )
                     .unwrap();
@@ -5704,6 +5706,7 @@ pub mod tests {
                         pre_balances,
                         post_balances,
                         inner_instructions: Some(vec![]),
+                        log_messages: Some(vec![]),
                     }),
                 }
             })
@@ -6000,6 +6003,7 @@ pub mod tests {
                 index: 0,
                 instructions: vec![CompiledInstruction::new(1, &(), vec![0])],
             }];
+            let log_messages_vec = vec![String::from("Test message\n")];
 
             // result not found
             assert!(transaction_status_cf
@@ -6019,6 +6023,7 @@ pub mod tests {
                         pre_balances: pre_balances_vec.clone(),
                         post_balances: post_balances_vec.clone(),
                         inner_instructions: Some(inner_instructions_vec.clone()),
+                        log_messages: Some(log_messages_vec.clone()),
                     },
                 )
                 .is_ok());
@@ -6030,6 +6035,7 @@ pub mod tests {
                 pre_balances,
                 post_balances,
                 inner_instructions,
+                log_messages,
             } = transaction_status_cf
                 .get((0, Signature::default(), 0))
                 .unwrap()
@@ -6039,6 +6045,7 @@ pub mod tests {
             assert_eq!(pre_balances, pre_balances_vec);
             assert_eq!(post_balances, post_balances_vec);
             assert_eq!(inner_instructions.unwrap(), inner_instructions_vec);
+            assert_eq!(log_messages.unwrap(), log_messages_vec);
 
             // insert value
             assert!(transaction_status_cf
@@ -6050,6 +6057,7 @@ pub mod tests {
                         pre_balances: pre_balances_vec.clone(),
                         post_balances: post_balances_vec.clone(),
                         inner_instructions: Some(inner_instructions_vec.clone()),
+                        log_messages: Some(log_messages_vec.clone()),
                     },
                 )
                 .is_ok());
@@ -6061,6 +6069,7 @@ pub mod tests {
                 pre_balances,
                 post_balances,
                 inner_instructions,
+                log_messages,
             } = transaction_status_cf
                 .get((0, Signature::new(&[2u8; 64]), 9))
                 .unwrap()
@@ -6072,6 +6081,7 @@ pub mod tests {
             assert_eq!(pre_balances, pre_balances_vec);
             assert_eq!(post_balances, post_balances_vec);
             assert_eq!(inner_instructions.unwrap(), inner_instructions_vec);
+            assert_eq!(log_messages.unwrap(), log_messages_vec);
         }
         Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
     }
@@ -6299,6 +6309,7 @@ pub mod tests {
                 pre_balances: pre_balances_vec,
                 post_balances: post_balances_vec,
                 inner_instructions: Some(vec![]),
+                log_messages: Some(vec![]),
             };
 
             let signature1 = Signature::new(&[1u8; 64]);
@@ -6432,6 +6443,7 @@ pub mod tests {
                     index: 0,
                     instructions: vec![CompiledInstruction::new(1, &(), vec![0])],
                 }]);
+                let log_messages = Some(vec![String::from("Test message\n")]);
                 let signature = transaction.signatures[0];
                 blockstore
                     .transaction_status_cf
@@ -6443,6 +6455,7 @@ pub mod tests {
                             pre_balances: pre_balances.clone(),
                             post_balances: post_balances.clone(),
                             inner_instructions: inner_instructions.clone(),
+                            log_messages: log_messages.clone(),
                         },
                     )
                     .unwrap();
@@ -6454,6 +6467,7 @@ pub mod tests {
                         pre_balances,
                         post_balances,
                         inner_instructions,
+                        log_messages,
                     }),
                 }
             })
@@ -6894,6 +6908,7 @@ pub mod tests {
                             pre_balances: vec![],
                             post_balances: vec![],
                             inner_instructions: Some(vec![]),
+                            log_messages: Some(vec![]),
                         },
                     )
                     .unwrap();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -109,6 +109,7 @@ fn execute_batch(
             MAX_PROCESSING_AGE,
             transaction_status_sender.is_some(),
             transaction_status_sender.is_some(),
+            transaction_status_sender.is_some(),
         );
 
     bank_utils::find_and_send_votes(batch.transactions(), &tx_results, replay_vote_sender);
@@ -2899,6 +2900,7 @@ pub mod tests {
         ) = batch.bank().load_execute_and_commit_transactions(
             &batch,
             MAX_PROCESSING_AGE,
+            false,
             false,
             false,
         );

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -16,8 +16,8 @@ use solana_metrics::{datapoint_error, inc_new_counter_debug};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::{
     bank::{
-        Bank, Builtins, InnerInstructionsList, TransactionBalancesSet, TransactionProcessResult,
-        TransactionResults,
+        Bank, Builtins, InnerInstructionsList, TransactionBalancesSet, TransactionLogMessages,
+        TransactionProcessResult, TransactionResults,
     },
     bank_forks::BankForks,
     bank_utils,
@@ -103,7 +103,7 @@ fn execute_batch(
     transaction_status_sender: Option<TransactionStatusSender>,
     replay_vote_sender: Option<&ReplayVoteSender>,
 ) -> Result<()> {
-    let (tx_results, balances, inner_instructions) =
+    let (tx_results, balances, inner_instructions, transaction_logs) =
         batch.bank().load_execute_and_commit_transactions(
             batch,
             MAX_PROCESSING_AGE,
@@ -127,6 +127,7 @@ fn execute_batch(
             processing_results,
             balances,
             inner_instructions,
+            transaction_logs,
             sender,
         );
     }
@@ -1031,6 +1032,7 @@ pub struct TransactionStatusBatch {
     pub statuses: Vec<TransactionProcessResult>,
     pub balances: TransactionBalancesSet,
     pub inner_instructions: Vec<Option<InnerInstructionsList>>,
+    pub transaction_logs: Vec<TransactionLogMessages>,
 }
 
 pub type TransactionStatusSender = Sender<TransactionStatusBatch>;
@@ -1042,6 +1044,7 @@ pub fn send_transaction_status_batch(
     statuses: Vec<TransactionProcessResult>,
     balances: TransactionBalancesSet,
     inner_instructions: Vec<Option<InnerInstructionsList>>,
+    transaction_logs: Vec<TransactionLogMessages>,
     transaction_status_sender: TransactionStatusSender,
 ) {
     let slot = bank.slot();
@@ -1052,6 +1055,7 @@ pub fn send_transaction_status_batch(
         statuses,
         balances,
         inner_instructions,
+        transaction_logs,
     }) {
         trace!(
             "Slot {} transaction_status send batch failed: {:?}",
@@ -2891,6 +2895,7 @@ pub mod tests {
             },
             _balances,
             _inner_instructions,
+            _log_messages,
         ) = batch.bank().load_execute_and_commit_transactions(
             &batch,
             MAX_PROCESSING_AGE,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -105,8 +105,8 @@ fn process_transaction_and_record_inner(
     let signature = tx.signatures.get(0).unwrap().clone();
     let txs = vec![tx];
     let tx_batch = bank.prepare_batch(&txs, None);
-    let (mut results, _, mut inner) =
-        bank.load_execute_and_commit_transactions(&tx_batch, MAX_PROCESSING_AGE, false, true);
+    let (mut results, _, mut inner, _transaction_logs) =
+        bank.load_execute_and_commit_transactions(&tx_batch, MAX_PROCESSING_AGE, false, true, false);
     let inner_instructions = inner.swap_remove(0);
     let result = results
         .fee_collection_results

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8152,8 +8152,12 @@ mod tests {
                 false,
             );
 
+        assert_eq!(inner_instructions.len(), 2);
         assert!(inner_instructions[0].iter().all(|ix| ix.is_empty()));
-        assert!(transaction_logs.is_empty());
+
+        assert_eq!(transaction_logs.len(), 2);
+        assert!(transaction_logs[0].is_empty(), 2);
+
         assert_eq!(transaction_balances_set.pre_balances.len(), 3);
         assert_eq!(transaction_balances_set.post_balances.len(), 3);
 

--- a/runtime/src/log_collector.rs
+++ b/runtime/src/log_collector.rs
@@ -10,6 +10,7 @@ impl LogCollector {
         self.messages.borrow_mut().push(message.to_string())
     }
 }
+
 impl Into<Vec<String>> for LogCollector {
     fn into(self) -> Vec<String> {
         self.messages.into_inner()

--- a/storage-bigtable/proto/solana.bigtable.confirmed_block.rs
+++ b/storage-bigtable/proto/solana.bigtable.confirmed_block.rs
@@ -59,6 +59,8 @@ pub struct TransactionStatusMeta {
     pub post_balances: ::std::vec::Vec<u64>,
     #[prost(message, repeated, tag = "5")]
     pub inner_instructions: ::std::vec::Vec<InnerInstructions>,
+    #[prost(message, repeated, tag = "6")]
+    pub log_messages: ::std::vec::Vec<String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionError {

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -654,6 +654,7 @@ mod tests {
                 pre_balances: vec![43, 0, 1],
                 post_balances: vec![0, 42, 1],
                 inner_instructions: Some(vec![]),
+                log_messages: Some(vec![]),
             }),
         };
         let block = ConfirmedBlock {

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -702,7 +702,8 @@ mod tests {
         if let CellData::Bincode(bincode_block) = deserialized {
             let mut block = block;
             if let Some(meta) = &mut block.transactions[0].meta {
-                meta.inner_instructions = None; // Legacy bincode implementation does not suport inner_instructions
+                meta.inner_instructions = None; // Legacy bincode implementation does not support inner_instructions
+                meta.log_messages = None; // Legacy bincode implementation does not support log_messages
             }
             assert_eq!(block, bincode_block.into());
         } else {

--- a/storage-bigtable/src/convert.rs
+++ b/storage-bigtable/src/convert.rs
@@ -201,6 +201,7 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             pre_balances,
             post_balances,
             inner_instructions,
+            log_messages,
         } = value;
         let err = match status {
             Ok(()) => None,
@@ -213,12 +214,14 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             .into_iter()
             .map(|ii| ii.into())
             .collect();
+        let log_messages = log_messages.unwrap_or_default();
         Self {
             err,
             fee,
             pre_balances,
             post_balances,
             inner_instructions,
+            log_messages,
         }
     }
 }
@@ -233,6 +236,7 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
             pre_balances,
             post_balances,
             inner_instructions,
+            log_messages,
         } = value;
         let status = match &err {
             None => Ok(()),
@@ -244,12 +248,14 @@ impl TryFrom<generated::TransactionStatusMeta> for TransactionStatusMeta {
                 .map(|inner| inner.into())
                 .collect(),
         );
+        let log_messages = Some(log_messages);
         Ok(Self {
             status,
             fee,
             pre_balances,
             post_balances,
             inner_instructions,
+            log_messages,
         })
     }
 }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -184,6 +184,7 @@ impl From<StoredConfirmedBlockTransactionStatusMeta> for TransactionStatusMeta {
             pre_balances,
             post_balances,
             inner_instructions: None,
+            log_messages: None,
         }
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -144,6 +144,8 @@ pub struct TransactionStatusMeta {
     pub post_balances: Vec<u64>,
     #[serde(deserialize_with = "default_on_eof")]
     pub inner_instructions: Option<Vec<InnerInstructions>>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub log_messages: Option<Vec<String>>,
 }
 
 impl Default for TransactionStatusMeta {
@@ -154,6 +156,7 @@ impl Default for TransactionStatusMeta {
             pre_balances: vec![],
             post_balances: vec![],
             inner_instructions: None,
+            log_messages: None,
         }
     }
 }
@@ -168,6 +171,7 @@ pub struct UiTransactionStatusMeta {
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
     pub inner_instructions: Option<Vec<UiInnerInstructions>>,
+    pub log_messages: Option<Vec<String>>,
 }
 
 impl UiTransactionStatusMeta {
@@ -183,6 +187,7 @@ impl UiTransactionStatusMeta {
                     .map(|ix| UiInnerInstructions::parse(ix, message))
                     .collect()
             }),
+            log_messages: meta.log_messages,
         }
     }
 }
@@ -198,6 +203,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
             inner_instructions: meta
                 .inner_instructions
                 .map(|ixs| ixs.into_iter().map(|ix| ix.into()).collect()),
+            log_messages: meta.log_messages,
         }
     }
 }


### PR DESCRIPTION
#### Problem
Transaction instruction logs are not easy to view, and not at all from the explorer. This would be a great debug tool for program developers. 

#### Summary of Changes
- Collects logging from transaction batches
- Stores log messages in TransactionWithStatusMeta
- Stores as Option for backwards deserialization compatibility 

Fixes https://github.com/solana-labs/solana/issues/12209
