### PR TITLE
Correct Bank timestamp drift

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -33,6 +33,7 @@ use solana_sdk::{
     program_utils::limited_deserialize,
     pubkey::Pubkey,
     signature::{Keypair, Signature, Signer},
+    stake_weighted_timestamp::{calculate_stake_weighted_timestamp, TIMESTAMP_SLOT_RANGE},
     timing::timestamp,
     transaction::Transaction,
 };
@@ -77,7 +78,6 @@ thread_local!(static PAR_THREAD_POOL_ALL_CPUS: RefCell<ThreadPool> = RefCell::ne
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
 pub const MAX_TURBINE_PROPAGATION_IN_MS: u64 = 100;
 pub const MAX_TURBINE_DELAY_IN_TICKS: u64 = MAX_TURBINE_PROPAGATION_IN_MS / MS_PER_TICK;
-const TIMESTAMP_SLOT_RANGE: usize = 16;
 
 // An upper bound on maximum number of data shreds we can handle in a slot
 // 32K shreds would allow ~320K peak TPS
@@ -3124,33 +3124,6 @@ fn slot_has_updates(slot_meta: &SlotMeta, slot_meta_backup: &Option<SlotMeta>) -
         (slot_meta_backup.is_some() && slot_meta_backup.as_ref().unwrap().consumed != slot_meta.consumed))
 }
 
-fn calculate_stake_weighted_timestamp(
-    unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)>,
-    stakes: &HashMap<Pubkey, (u64, Account)>,
-    slot: Slot,
-    slot_duration: Duration,
-) -> Option<UnixTimestamp> {
-    let (stake_weighted_timestamps_sum, total_stake) = unique_timestamps
-        .into_iter()
-        .filter_map(|(vote_pubkey, (timestamp_slot, timestamp))| {
-            let offset = (slot - timestamp_slot) as u32 * slot_duration;
-            stakes.get(&vote_pubkey).map(|(stake, _account)| {
-                (
-                    (timestamp as u128 + offset.as_secs() as u128) * *stake as u128,
-                    stake,
-                )
-            })
-        })
-        .fold((0, 0), |(timestamps, stakes), (timestamp, stake)| {
-            (timestamps + timestamp, stakes + *stake as u128)
-        });
-    if total_stake > 0 {
-        Some((stake_weighted_timestamps_sum / total_stake) as i64)
-    } else {
-        None
-    }
-}
-
 // Creates a new ledger with slot 0 full of ticks (and only ticks).
 //
 // Returns the blockhash that can be used to append entries with.
@@ -3472,7 +3445,6 @@ pub mod tests {
         hash::{self, hash, Hash},
         instruction::CompiledInstruction,
         message::Message,
-        native_token::sol_to_lamports,
         packet::PACKET_DATA_SIZE,
         pubkey::Pubkey,
         signature::Signature,
@@ -5878,113 +5850,6 @@ pub mod tests {
                 .is_err());
             assert_eq!(blockstore.get_block_time(*slot).unwrap(), None);
         }
-    }
-
-    #[test]
-    fn test_calculate_stake_weighted_timestamp() {
-        let recent_timestamp: UnixTimestamp = 1_578_909_061;
-        let slot = 5;
-        let slot_duration = Duration::from_millis(400);
-        let expected_offset = (slot * slot_duration).as_secs();
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
-        let pubkey3 = Pubkey::new_rand();
-        let unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)> = [
-            (pubkey0, (0, recent_timestamp)),
-            (pubkey1, (0, recent_timestamp)),
-            (pubkey2, (0, recent_timestamp)),
-            (pubkey3, (0, recent_timestamp)),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-
-        let stakes: HashMap<Pubkey, (u64, Account)> = [
-            (
-                pubkey0,
-                (
-                    sol_to_lamports(4_500_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey1,
-                (
-                    sol_to_lamports(4_500_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey2,
-                (
-                    sol_to_lamports(4_500_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey3,
-                (
-                    sol_to_lamports(4_500_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-        assert_eq!(
-            calculate_stake_weighted_timestamp(
-                unique_timestamps.clone(),
-                &stakes,
-                slot as Slot,
-                slot_duration
-            ),
-            Some(recent_timestamp + expected_offset as i64)
-        );
-
-        let stakes: HashMap<Pubkey, (u64, Account)> = [
-            (
-                pubkey0,
-                (
-                    sol_to_lamports(15_000_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey1,
-                (
-                    sol_to_lamports(1_000_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey2,
-                (
-                    sol_to_lamports(1_000_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey3,
-                (
-                    sol_to_lamports(1_000_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-        assert_eq!(
-            calculate_stake_weighted_timestamp(
-                unique_timestamps,
-                &stakes,
-                slot as Slot,
-                slot_duration
-            ),
-            Some(recent_timestamp + expected_offset as i64)
-        );
     }
 
     #[test]

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -45,6 +45,10 @@ pub mod ristretto_mul_syscall_enabled {
     solana_sdk::declare_id!("HRe7A6aoxgjKzdjbBv6HTy7tJ4YWqE6tVmYCGho6S9Aq");
 }
 
+pub mod epoch_timestamps {
+    solana_sdk::declare_id!("3zydSLUwuqqsV3wL5wBsaVgyvMox3XTHx7zLEuQf1U2Z");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -58,6 +62,7 @@ lazy_static! {
         (sha256_syscall_enabled::id(), "sha256 syscall"),
         (no_overflow_rent_distribution::id(), "no overflow rent distribution"),
         (ristretto_mul_syscall_enabled::id(), "ristretto multiply syscall"),
+        (epoch_timestamps::id(), "bank timestamp relative to epoch boundary"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -45,6 +45,7 @@ pub mod short_vec;
 pub mod slot_hashes;
 pub mod slot_history;
 pub mod stake_history;
+pub mod stake_weighted_timestamp;
 pub mod system_instruction;
 pub mod system_program;
 pub mod sysvar;

--- a/sdk/src/stake_weighted_timestamp.rs
+++ b/sdk/src/stake_weighted_timestamp.rs
@@ -1,0 +1,150 @@
+/// A helper for calculating a stake-weighted timestamp estimate from a set of timestamps and epoch
+/// stake.
+use solana_sdk::{
+    account::Account,
+    clock::{Slot, UnixTimestamp},
+    pubkey::Pubkey,
+};
+use std::{collections::HashMap, time::Duration};
+
+pub const TIMESTAMP_SLOT_RANGE: usize = 16;
+
+pub fn calculate_stake_weighted_timestamp(
+    unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)>,
+    stakes: &HashMap<Pubkey, (u64, Account)>,
+    slot: Slot,
+    slot_duration: Duration,
+) -> Option<UnixTimestamp> {
+    let (stake_weighted_timestamps_sum, total_stake) = unique_timestamps
+        .into_iter()
+        .filter_map(|(vote_pubkey, (timestamp_slot, timestamp))| {
+            let offset = (slot - timestamp_slot) as u32 * slot_duration;
+            stakes.get(&vote_pubkey).map(|(stake, _account)| {
+                (
+                    (timestamp as u128 + offset.as_secs() as u128) * *stake as u128,
+                    stake,
+                )
+            })
+        })
+        .fold((0, 0), |(timestamps, stakes), (timestamp, stake)| {
+            (timestamps + timestamp, stakes + *stake as u128)
+        });
+    if total_stake > 0 {
+        Some((stake_weighted_timestamps_sum / total_stake) as i64)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use solana_sdk::native_token::sol_to_lamports;
+
+    #[test]
+    fn test_calculate_stake_weighted_timestamp() {
+        let recent_timestamp: UnixTimestamp = 1_578_909_061;
+        let slot = 5;
+        let slot_duration = Duration::from_millis(400);
+        let expected_offset = (slot * slot_duration).as_secs();
+        let pubkey0 = Pubkey::new_rand();
+        let pubkey1 = Pubkey::new_rand();
+        let pubkey2 = Pubkey::new_rand();
+        let pubkey3 = Pubkey::new_rand();
+        let unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)> = [
+            (pubkey0, (0, recent_timestamp)),
+            (pubkey1, (0, recent_timestamp)),
+            (pubkey2, (0, recent_timestamp)),
+            (pubkey3, (0, recent_timestamp)),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        let stakes: HashMap<Pubkey, (u64, Account)> = [
+            (
+                pubkey0,
+                (
+                    sol_to_lamports(4_500_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey1,
+                (
+                    sol_to_lamports(4_500_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey2,
+                (
+                    sol_to_lamports(4_500_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey3,
+                (
+                    sol_to_lamports(4_500_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert_eq!(
+            calculate_stake_weighted_timestamp(
+                unique_timestamps.clone(),
+                &stakes,
+                slot as Slot,
+                slot_duration
+            ),
+            Some(recent_timestamp + expected_offset as i64)
+        );
+
+        let stakes: HashMap<Pubkey, (u64, Account)> = [
+            (
+                pubkey0,
+                (
+                    sol_to_lamports(15_000_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey1,
+                (
+                    sol_to_lamports(1_000_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey2,
+                (
+                    sol_to_lamports(1_000_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey3,
+                (
+                    sol_to_lamports(1_000_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert_eq!(
+            calculate_stake_weighted_timestamp(
+                unique_timestamps,
+                &stakes,
+                slot as Slot,
+                slot_duration
+            ),
+            Some(recent_timestamp + expected_offset as i64)
+        );
+    }
+}

--- a/sdk/src/stake_weighted_timestamp.rs
+++ b/sdk/src/stake_weighted_timestamp.rs
@@ -36,6 +36,57 @@ pub fn calculate_stake_weighted_timestamp(
     }
 }
 
+/// Calculates an estimated slot timestamp based on the epoch start timestamp and a set of samples;
+/// populated sample length must be >= 1, and the difference between the slot and the epoch start
+/// slot must be < u32::MAX
+pub fn calculate_timestamp_from_samples(
+    samples: &HashMap<Slot, Option<UnixTimestamp>>,
+    slot: Slot,
+    epoch_start_timestamp: (Slot, UnixTimestamp),
+) -> Option<UnixTimestamp> {
+    let slot_delta = slot.checked_sub(epoch_start_timestamp.0)?;
+    if slot_delta > std::u32::MAX as u64 {
+        return None;
+    }
+    let mut sample_tuples: Vec<_> = samples
+        .iter()
+        .filter_map(|(slot, maybe_timestamp)| {
+            maybe_timestamp.map(|timestamp| (*slot, timestamp as u64))
+        })
+        .collect();
+    if sample_tuples.is_empty() {
+        return None;
+    }
+    sample_tuples.insert(0, (epoch_start_timestamp.0, epoch_start_timestamp.1 as u64));
+    sample_tuples.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+    let average_slot_duration = calculate_average_slot_duration(sample_tuples)?;
+    Some((slot_delta as u32 * average_slot_duration).as_secs() as i64 + epoch_start_timestamp.1)
+}
+
+/// Calculates the mean slot duration of a monotonically increasing set of samples. First calculates
+/// the mean slot duration between each pair of samples, and returns the mean of those means. Sample
+/// length must be >= 2.
+fn calculate_average_slot_duration(samples: Vec<(u64, u64)>) -> Option<Duration> {
+    let mut slot_duration: Vec<Duration> = vec![];
+    let gaps = samples.len().checked_sub(1)?;
+    for x in 0..gaps {
+        let (old_slot, old_timestamp) = samples[x];
+        let (new_slot, new_timestamp) = samples[x + 1];
+        let timestamp_delta = new_timestamp.checked_sub(old_timestamp)?;
+        if timestamp_delta == 0 {
+            return None;
+        }
+        let duration = Duration::from_secs(timestamp_delta);
+        slot_duration.push(duration.checked_div((new_slot.checked_sub(old_slot)?) as u32)?);
+    }
+    Some(
+        slot_duration
+            .iter()
+            .sum::<Duration>()
+            .checked_div(gaps as u32)?,
+    )
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -145,6 +196,79 @@ pub mod tests {
                 slot_duration
             ),
             Some(recent_timestamp + expected_offset as i64)
+        );
+    }
+
+    #[test]
+    fn test_calculate_average_slot_duration() {
+        let recent_timestamp: u64 = 1_578_909_000;
+
+        let samples = vec![];
+        assert_eq!(calculate_average_slot_duration(samples), None);
+
+        let samples = vec![(0, recent_timestamp)];
+        assert_eq!(calculate_average_slot_duration(samples), None);
+
+        let samples = vec![(0, recent_timestamp), (1, recent_timestamp)];
+        assert_eq!(calculate_average_slot_duration(samples), None);
+
+        let samples = vec![(0, recent_timestamp), (0, recent_timestamp + 1)];
+        assert_eq!(calculate_average_slot_duration(samples), None);
+
+        let samples = vec![(0, recent_timestamp), (2, recent_timestamp + 2)];
+        assert_eq!(
+            calculate_average_slot_duration(samples),
+            Some(Duration::from_secs(1))
+        );
+
+        let samples = vec![
+            (0, recent_timestamp),
+            (2, recent_timestamp + 2),
+            (4, recent_timestamp + 3),
+        ];
+        assert_eq!(
+            calculate_average_slot_duration(samples),
+            Some(Duration::from_millis(750))
+        );
+    }
+
+    #[test]
+    fn test_calculate_timestamp_from_samples() {
+        let recent_timestamp: UnixTimestamp = 1_578_909_000;
+        let slot = 12;
+        let epoch_starting_timestamp = (0, recent_timestamp);
+        let mut samples = HashMap::new();
+        assert_eq!(
+            calculate_timestamp_from_samples(&samples, slot, epoch_starting_timestamp),
+            None
+        );
+
+        // Insert some empty samples
+        samples.insert(1, None);
+        samples.insert(6, None);
+        assert_eq!(
+            calculate_timestamp_from_samples(&samples, slot, epoch_starting_timestamp),
+            None
+        );
+
+        // Insert some populated samples, assert estimate changes as expected
+        samples.insert(4, Some(recent_timestamp + 2)); // Mean slot duration is 0.5s
+        assert_eq!(
+            calculate_timestamp_from_samples(&samples, slot, epoch_starting_timestamp),
+            Some(recent_timestamp + 6)
+        );
+        samples.insert(8, Some(recent_timestamp + 6)); // Mean slot duration is now 0.75s
+        assert_eq!(
+            calculate_timestamp_from_samples(&samples, slot, epoch_starting_timestamp),
+            Some(recent_timestamp + 9)
+        );
+
+        // Ensure absence of empty samples has no effect
+        samples.remove(&1).unwrap();
+        samples.remove(&6).unwrap();
+        assert_eq!(
+            calculate_timestamp_from_samples(&samples, slot, epoch_starting_timestamp),
+            Some(recent_timestamp + 9)
         );
     }
 }

--- a/sdk/src/sysvar/epoch_timestamps.rs
+++ b/sdk/src/sysvar/epoch_timestamps.rs
@@ -1,0 +1,32 @@
+//! This account contains epoch timestamp information
+//!
+use crate::{
+    account::Account,
+    clock::{Slot, UnixTimestamp},
+    sysvar::Sysvar,
+};
+use std::collections::HashMap;
+
+crate::declare_sysvar_id!(
+    "SysvarEpochTimestamps1111111111111111111111",
+    EpochTimestamps
+);
+
+#[repr(C)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+pub struct EpochTimestamps {
+    pub first_slot: Slot,
+    pub timestamp: UnixTimestamp,
+    pub samples: HashMap<Slot, Option<UnixTimestamp>>,
+}
+
+impl Sysvar for EpochTimestamps {}
+
+pub fn create_account(lamports: u64, first_slot: Slot, timestamp: UnixTimestamp) -> Account {
+    EpochTimestamps {
+        first_slot,
+        timestamp,
+        ..EpochTimestamps::default()
+    }
+    .create_account(lamports)
+}

--- a/sdk/src/sysvar/mod.rs
+++ b/sdk/src/sysvar/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 
 pub mod clock;
 pub mod epoch_schedule;
+pub mod epoch_timestamps;
 pub mod fees;
 pub mod instructions;
 pub mod recent_blockhashes;
@@ -22,6 +23,7 @@ pub mod stake_history;
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
     clock::check_id(id)
         || epoch_schedule::check_id(id)
+        || epoch_timestamps::check_id(id)
         || fees::check_id(id)
         || recent_blockhashes::check_id(id)
         || rent::check_id(id)


### PR DESCRIPTION
#### Problem
The timestamp returned by `Bank::unix_timestamp()` ends up in the clock sysvar and is used to assess time-based stake account lockouts. However it's based on a theoretical slots-per-second instead of reality, so it's quite inaccurate. This will pose a problem for lockups, since the accounts will not register as lockup-free on (or anytime near) the date the lockup is set to expire.

Block times are estimated using a validator timestamp oracle; this data provides an opportunity to align the bank timestamp more closely with real-world time. 

#### Summary of Changes
- Add feature-gated EpochTimestamps sysvar that stores:
  1. The timestamp at the beginning of the epoch. Use it for updates to the clock sysvar, so that drift only happens from the beginning of the epoch. (`Bank::unix_timestamp_from_epoch`)
  2. A selection of slots in the upcoming epoch to sample.
- Add Bank method to get a bank's stake-weighted timestamp estimate using epoch vote accounts `last_timestamp`.
- Add `Bank::update_epoch_timestamps`:
  1. On `Bank::new_from_parent`, check the expected timestamp sample slots, and if one has passed, populate the sample with the stake-weighted timestamp.
  2. On epoch boundary, use populated sample timestamps to set a new epoch base timestamp in EpochTimestamps sysvar. Right now, all timestamp samples receive equal weight, regardless of when in the epoch they occurred. (TODO: Set sample slots for the upcoming epoch)

Right now, even with the feature activated this code is a no-op for the timestamp in the clock sysvar. Because the expected samples map is never populated, the timestamp at the epoch boundary defaults to the `Bank::unix_timestamp_from_genesis()`.

TODO:
- [ ] Propose a method of selecting sampling slots
- [ ] Implement that method in `Bank::update_epoch_timestamps`

Fixes #9874 
Toward #10093 (but requires some additional consideration of inflation timing)
