### PR TITLE
RPC: Transaction deser can be quite slow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3614,6 +3620,7 @@ name = "solana-client"
 version = "1.4.0"
 dependencies = [
  "assert_matches",
+ "base64 0.13.0",
  "bincode",
  "bs58",
  "clap",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+base64 = "0.13.0"
 bincode = "1.3.1"
 bs58 = "0.3.1"
 clap = "2.33.0"

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -4,6 +4,7 @@ use solana_sdk::{
     clock::Epoch,
     commitment_config::{CommitmentConfig, CommitmentLevel},
 };
+use solana_transaction_status::UiTransactionEncoding;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,6 +18,7 @@ pub struct RpcSendTransactionConfig {
     #[serde(default)]
     pub skip_preflight: bool,
     pub preflight_commitment: Option<CommitmentLevel>,
+    pub encoding: Option<UiTransactionEncoding>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
@@ -26,6 +28,7 @@ pub struct RpcSimulateTransactionConfig {
     pub sig_verify: bool,
     #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
+    pub encoding: Option<UiTransactionEncoding>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 codecov = { repository = "solana-labs/solana", branch = "master", service = "github" }
 
 [dependencies]
+base64 = "0.12.3"
 bincode = "1.3.1"
 bv = { version = "0.11.1", features = ["serde"] }
 bs58 = "0.3.1"
@@ -78,7 +79,6 @@ solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "1.4.0" }
 trees = "0.2.1"
 
 [dev-dependencies]
-base64 = "0.12.3"
 matches = "0.1.6"
 reqwest = { version = "0.10.6", default-features = false, features = ["blocking", "rustls-tls", "json"] }
 serial_test = "0.4.0"

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -1470,10 +1470,11 @@ Before submitting, the following preflight checks are performed:
 
 #### Parameters:
 
-- `<string>` - fully-signed Transaction, as base-58 encoded string
+- `<string>` - fully-signed Transaction, as encoded string
 - `<object>` - (optional) Configuration object containing the following field:
   - `skipPreflight: <bool>` - if true, skip the preflight transaction checks (default: false)
   - `preflightCommitment: <string>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to use for preflight (default: `"max"`).
+  - `encoding: <string>` - (optional) Encoding used for the transaction data. Either `"base58"` (*slow*, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
 
 #### Results:
 
@@ -1495,10 +1496,11 @@ Simulate sending a transaction
 
 #### Parameters:
 
-- `<string>` - Transaction, as base-58 encoded string. The transaction must have a valid blockhash, but is not required to be signed.
+- `<string>` - Transaction, as an encoded string. The transaction must have a valid blockhash, but is not required to be signed.
 - `<object>` - (optional) Configuration object containing the following field:
   - `sigVerify: <bool>` - if true the transaction signatures will be verified (default: false)
   - `commitment: <string>` - (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment) level to simulate the transaction at (default: `"max"`).
+  - `encoding: <string>` - (optional) Encoding used for the transaction data. Either `"base58"` (*slow*, **DEPRECATED**), or `"base64"`. (default: `"base58"`).
 
 #### Results:
 

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -21,6 +21,7 @@ use solana_sdk::{
     signature::Signature,
     transaction::{Result, Transaction, TransactionError},
 };
+use std::fmt;
 
 /// A duplicate representation of an Instruction for pretty JSON serialization
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -378,6 +379,14 @@ pub enum UiTransactionEncoding {
     Base58,
     Json,
     JsonParsed,
+}
+
+impl fmt::Display for UiTransactionEncoding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let v = serde_json::to_value(self).map_err(|_| fmt::Error)?;
+        let s = v.as_str().ok_or(fmt::Error)?;
+        write!(f, "{}", s)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
#### Problem

RPC accepts large (sometimes too) base58-encoded TXs.  Base58 is slow.

#### Summary of Changes

- Check encoded TX size before decoding
- Support submitting base64-encoded TXs (default to base58 for compat)

cc/ @jstarry for web3js support