### PR TITLE
Remove unnecessary skip-no-mangle feature from sdk

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,8 +11,6 @@ edition = "2018"
 [features]
 # On-chain program specific dependencies
 program = []
-# Program elements to optionally skip
-skip-no-mangle = []
 # Dependencies that are not compatible or needed for on-chain programs
 default = [
     "assert_matches",


### PR DESCRIPTION
#### Problem

The sdk feature `skip-no-mangle` isn't actually used in the sdk, just by the callers of the entrypoint macro.

#### Summary of Changes

Remove the feature from the sdk

Fixes #
