### PR TITLE
Faucet request limiter can overflow

### DIFF
--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -87,7 +87,10 @@ impl Faucet {
     }
 
     pub fn check_time_request_limit(&mut self, request_amount: u64) -> bool {
-        (self.request_current + request_amount) <= self.per_time_cap
+        self.request_current
+            .checked_add(request_amount)
+            .map(|s| s <= self.per_time_cap)
+            .unwrap_or(false)
     }
 
     pub fn clear_request_count(&mut self) {
@@ -122,7 +125,7 @@ impl Faucet {
                     }
                 }
                 if self.check_time_request_limit(lamports) {
-                    self.request_current += lamports;
+                    self.request_current = self.request_current.saturating_add(lamports);
                     datapoint_info!(
                         "faucet-airdrop",
                         ("request_amount", lamports, i64),

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -324,6 +324,8 @@ mod tests {
         assert!(faucet.check_time_request_limit(1));
         faucet.request_current = 3;
         assert!(!faucet.check_time_request_limit(1));
+        faucet.request_current = 1;
+        assert!(!faucet.check_time_request_limit(u64::MAX));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Faucet uses unchecked math in request limiter

#### Summary of Changes

Add failing test
Use checked math