### PR TITLE
fix: use Node.js https agent when endpoint uses https

### DIFF
--- a/web3.js/rollup.config.js
+++ b/web3.js/rollup.config.js
@@ -98,6 +98,8 @@ function generateConfig(configType) {
         'bs58',
         'buffer-layout',
         'crypto-hash',
+        'http',
+        'https',
         'jayson/lib/client/browser',
         'node-fetch',
         'rpc-websockets',

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -505,8 +505,8 @@ type ConfirmedBlock = {
   }>,
 };
 
-function createRpcRequest(url): RpcRequest {
-  const agentManager = new AgentManager();
+function createRpcRequest(url: string, useHttps: boolean): RpcRequest {
+  const agentManager = new AgentManager(useHttps);
   const server = jayson(async (request, callback) => {
     const agent = agentManager.requestStart();
     const options = {
@@ -1453,8 +1453,9 @@ export class Connection {
    */
   constructor(endpoint: string, commitment: ?Commitment) {
     let url = urlParse(endpoint);
+    const useHttps = url.protocol === 'https:';
 
-    this._rpcRequest = createRpcRequest(url.href);
+    this._rpcRequest = createRpcRequest(url.href, useHttps);
     this._commitment = commitment;
     this._blockhashInfo = {
       recentBlockhash: null,
@@ -1463,7 +1464,7 @@ export class Connection {
       simulatedSignatures: [],
     };
 
-    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    url.protocol = useHttps ? 'wss:' : 'ws:';
     url.host = '';
     // Only shift the port by +1 as a convention for ws(s) only if given endpoint
     // is explictly specifying the endpoint port (HTTP-based RPC), assuming

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -2515,3 +2515,14 @@ test('root notification', async () => {
   expect(roots[1]).toBeGreaterThan(roots[0]);
   await connection.removeRootChangeListener(subscriptionId);
 });
+
+test('https request', async () => {
+  if (mockRpcEnabled) {
+    console.log('non-live test skipped');
+    return;
+  }
+
+  const connection = new Connection('https://devnet.solana.com');
+  const version = await connection.getVersion();
+  expect(version['solana-core']).toBeTruthy();
+});


### PR DESCRIPTION
#### Problem
Cannot use `http.Agent` for https fetch requests in Node.js

```
    TypeError: Protocol "https:" not supported. Expected "http:"TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
```

#### Summary of Changes
- Check the endpoint protocol to determine which agent to use
- Add https test against devnet api to prevent this in the future :/
- Silence rollup dependency warnings

Fixes #
