### PR TITLE
Add env variable for rayon thread counts

### DIFF
--- a/rayon-threadlimit/src/lib.rs
+++ b/rayon-threadlimit/src/lib.rs
@@ -1,12 +1,16 @@
 #[macro_use]
 extern crate lazy_static;
 
+use std::env;
 //TODO remove this hack when rayon fixes itself
 
 lazy_static! {
     // reduce the number of threads each pool is allowed to half the cpu core count, to avoid rayon
     // hogging cpu
-    static ref MAX_RAYON_THREADS: usize = num_cpus::get() as usize / 2;
+    static ref MAX_RAYON_THREADS: usize =
+            env::var("SOLANA_RAYON_THREADS")
+                .map(|x| x.parse().unwrap_or(num_cpus::get() as usize / 2))
+                .unwrap_or(num_cpus::get() as usize / 2);
 }
 
 pub fn get_thread_count() -> usize {


### PR DESCRIPTION
#### Problem

Default rayon threadcount as threads/2 is not ideal for all use-cases like when hyperthreading is disabled.

#### Summary of Changes

Add environment variable `SOLANA_RAYON_THREADS` knob to adjust.

Fixes #
