### PR TITLE
Remove skip-no-mangle entirely

### DIFF
--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -22,7 +22,7 @@ solana-config-program = { path = "../programs/config", version = "1.4.0" }
 solana-sdk = { path = "../sdk", version = "1.4.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.4.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.4.0" }
-spl-token-v2-0 = { package = "spl-token", version = "2.0.6", features = ["skip-no-mangle"] }
+spl-token-v2-0 = { package = "spl-token", version = "=2.0.6", features = ["skip-no-mangle"] }
 thiserror = "1.0"
 
 [package.metadata.docs.rs]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -68,7 +68,7 @@ solana-transaction-status = { path = "../transaction-status", version = "1.4.0" 
 solana-version = { path = "../version", version = "1.4.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.4.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.4.0" }
-spl-token-v2-0 = { package = "spl-token", version = "2.0.6", features = ["skip-no-mangle"] }
+spl-token-v2-0 = { package = "spl-token", version = "=2.0.6", features = ["skip-no-mangle"] }
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "0.2.22", features = ["full"] }

--- a/sdk/src/entrypoint.rs
+++ b/sdk/src/entrypoint.rs
@@ -53,7 +53,6 @@ macro_rules! entrypoint {
         };
 
         /// # Safety
-        #[cfg(not(feature = "skip-no-mangle"))]
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
             let (program_id, accounts, instruction_data) =

--- a/sdk/src/entrypoint_deprecated.rs
+++ b/sdk/src/entrypoint_deprecated.rs
@@ -37,7 +37,6 @@ pub const SUCCESS: u64 = 0;
 macro_rules! entrypoint_deprecated {
     ($process_instruction:ident) => {
         /// # Safety
-        #[cfg(not(feature = "skip-no-mangle"))]
         #[no_mangle]
         pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
             let (program_id, accounts, instruction_data) =

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -21,8 +21,8 @@ solana-account-decoder = { path = "../account-decoder", version = "1.4.0" }
 solana-sdk = { path = "../sdk", version = "1.4.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.4.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.4.0" }
-spl-memo-v1-0 = { package = "spl-memo", version = "1.0.7", features = ["skip-no-mangle"] }
-spl-token-v2-0 = { package = "spl-token", version = "2.0.6", features = ["skip-no-mangle"] }
+spl-memo-v1-0 = { package = "spl-memo", version = "=1.0.7", features = ["skip-no-mangle"] }
+spl-token-v2-0 = { package = "spl-token", version = "=2.0.6", features = ["skip-no-mangle"] }
 thiserror = "1.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
#### Problem

Programs now use other features to decide if the program's entrypoint should be pulled in or not.

#### Summary of Changes

Remove this feature usage from the `entrypoint` macro

Fixes #
