### PR TITLE
Fix fee mismatch on snapshot deserialize

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -156,7 +156,7 @@ mod tests {
             .get(&deserialized_bank.slot())
             .unwrap()
             .clone();
-        bank.compare_bank(&deserialized_bank);
+        assert!(*bank == deserialized_bank);
 
         let slot_snapshot_paths = snapshot_utils::get_snapshot_paths(&snapshot_path);
 

--- a/explorer/wasm/src/stake_account.rs
+++ b/explorer/wasm/src/stake_account.rs
@@ -164,7 +164,7 @@ impl Stake {
 }
 
 #[wasm_bindgen]
-#[derive(Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Serialize, Debug, Deserialize, PartialEq, Clone, Copy)]
 pub struct Delegation {
     /// to whom the stake is delegated
     voter_pubkey: Pubkey,

--- a/explorer/wasm/src/stake_account.rs
+++ b/explorer/wasm/src/stake_account.rs
@@ -113,7 +113,7 @@ pub type Epoch = u64;
 
 #[wasm_bindgen]
 #[repr(transparent)]
-#[derive(Serialize, Deserialize, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Serialize, Debug, Deserialize, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Pubkey([u8; 32]);
 
 #[wasm_bindgen]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -878,7 +878,11 @@ impl Bank {
         );
         assert_eq!(bank.epoch_schedule, genesis_config.epoch_schedule);
         assert_eq!(bank.epoch, bank.epoch_schedule.get_epoch(bank.slot));
-
+        bank.fee_rate_governor.lamports_per_signature = bank.fee_calculator.lamports_per_signature;
+        assert_eq!(
+            bank.fee_rate_governor.create_fee_calculator(),
+            bank.fee_calculator
+        );
         bank
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -71,6 +71,7 @@ use std::{
     mem,
     ops::RangeInclusive,
     path::PathBuf,
+    ptr,
     rc::Rc,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering::Relaxed},
@@ -477,8 +478,12 @@ pub(crate) struct BankFieldsToSerialize<'a> {
     pub(crate) is_delta: bool,
 }
 
+// Can't derive PartialEq because RwLock doesn't implement PartialEq
 impl PartialEq for Bank {
     fn eq(&self, other: &Self) -> bool {
+        if ptr::eq(self, other) {
+            return true;
+        }
         *self.blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
             && self.ancestors == other.ancestors
             && *self.hash.read().unwrap() == *other.hash.read().unwrap()

--- a/runtime/src/blockhash_queue.rs
+++ b/runtime/src/blockhash_queue.rs
@@ -13,7 +13,7 @@ struct HashAge {
 
 /// Low memory overhead, so can be cloned for every checkpoint
 #[frozen_abi(digest = "EwaoLA34VN18E95GvjmkeStUpWqTeBd7FGpd7mppLmEw")]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, AbiExample)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, AbiExample)]
 pub struct BlockhashQueue {
     /// updated whenever an hash is registered
     hash_height: u64,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -7,13 +7,13 @@ use std::{collections::HashMap, sync::Arc};
 pub type NodeIdToVoteAccounts = HashMap<Pubkey, NodeVoteAccounts>;
 pub type EpochAuthorizedVoters = HashMap<Pubkey, Pubkey>;
 
-#[derive(Clone, Serialize, Debug, Deserialize, Default, PartialEq, AbiExample)]
+#[derive(Clone, Serialize, Debug, Deserialize, Default, PartialEq, Eq, AbiExample)]
 pub struct NodeVoteAccounts {
     pub vote_accounts: Vec<Pubkey>,
     pub total_stake: u64,
 }
 
-#[derive(Clone, Serialize, Deserialize, AbiExample)]
+#[derive(Clone, Debug, Serialize, Deserialize, AbiExample, PartialEq)]
 pub struct EpochStakes {
     stakes: Arc<Stakes>,
     total_stake: u64,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -219,7 +219,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
     assert_eq!(dbank.get_balance(&key1.pubkey()), 0);
     assert_eq!(dbank.get_balance(&key2.pubkey()), 10);
     assert_eq!(dbank.get_balance(&key3.pubkey()), 0);
-    bank2.compare_bank(&dbank);
+    assert!(bank2 == dbank);
 }
 
 #[cfg(test)]

--- a/sdk/src/fee_calculator.rs
+++ b/sdk/src/fee_calculator.rs
@@ -68,7 +68,7 @@ pub struct FeeRateGovernor {
     // The current cost of a signature  This amount may increase/decrease over time based on
     // cluster processing load.
     #[serde(skip)]
-    lamports_per_signature: u64,
+    pub lamports_per_signature: u64,
 
     // The target cost of a signature when the cluster is operating around target_signatures_per_slot
     // signatures

--- a/sdk/src/hard_forks.rs
+++ b/sdk/src/hard_forks.rs
@@ -4,7 +4,7 @@
 use byteorder::{ByteOrder, LittleEndian};
 use solana_sdk::clock::Slot;
 
-#[derive(Default, Clone, Deserialize, Serialize, AbiExample)]
+#[derive(Default, Clone, Debug, Deserialize, Serialize, AbiExample, PartialEq, Eq)]
 pub struct HardForks {
     hard_forks: Vec<(Slot, usize)>,
 }

--- a/sdk/src/stake_history.rs
+++ b/sdk/src/stake_history.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Default, Clone, AbiExample)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
 pub struct StakeHistoryEntry {
     pub effective: u64,    // effective stake at this epoch
     pub activating: u64,   // sum of portion of stakes not fully warmed up
@@ -16,7 +16,7 @@ pub struct StakeHistoryEntry {
 }
 
 #[repr(C)]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Default, Clone, AbiExample)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone, AbiExample)]
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
 
 impl StakeHistory {


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/12670#issuecomment-704064936

#### Summary of Changes
As I see it, two options:

1) Proper fix: Serialize `lamports_per_signature` field and add gating to roll this out
2) Just take the `lamports_per_signature` value from the fee calculator on deserialize

Fixes #
