### PR TITLE
Add ristretto multiply syscall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle 2.2.2",
+ "zeroize",
+]
+
+[[package]]
 name = "derivative"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,7 +864,7 @@ version = "1.0.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "ed25519",
  "rand 0.7.3",
  "serde",
@@ -3491,6 +3504,7 @@ version = "1.4.0"
 dependencies = [
  "bincode",
  "byteorder",
+ "curve25519-dalek 3.0.0",
  "num-derive",
  "num-traits",
  "rand 0.7.3",
@@ -3735,7 +3749,7 @@ dependencies = [
  "backtrace",
  "bytes 0.4.12",
  "cc",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "ed25519-dalek",
  "either",
  "failure",
@@ -3758,7 +3772,7 @@ dependencies = [
  "backtrace",
  "bytes 0.4.12",
  "cc",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "ed25519-dalek",
  "either",
  "failure",
@@ -4184,7 +4198,7 @@ name = "solana-perf"
 version = "1.4.0"
 dependencies = [
  "bincode",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "dlopen",
  "dlopen_derive",
  "lazy_static",
@@ -4333,7 +4347,7 @@ dependencies = [
  "bv",
  "byteorder",
  "chrono",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "ed25519-dalek",
  "generic-array 0.14.3",
  "hex",
@@ -4370,7 +4384,7 @@ dependencies = [
  "bv",
  "byteorder",
  "chrono",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "digest 0.9.0",
  "ed25519-dalek",
  "generic-array 0.14.3",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -396,6 +396,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder 1.3.4",
+ "digest 0.9.0",
+ "rand_core",
+ "subtle 2.2.2",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,7 +457,7 @@ version = "1.0.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "ed25519",
  "rand",
  "serde",
@@ -1738,6 +1751,7 @@ version = "1.4.0"
 dependencies = [
  "bincode",
  "byteorder 1.3.4",
+ "curve25519-dalek 3.0.0",
  "num-derive 0.3.0",
  "num-traits",
  "solana-runtime",
@@ -1913,6 +1927,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-ristretto"
+version = "1.4.0"
+dependencies = [
+ "curve25519-dalek 3.0.0",
+ "getrandom",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-bpf-rust-sanity"
 version = "1.4.0"
 dependencies = [
@@ -1952,7 +1975,7 @@ dependencies = [
  "backtrace",
  "bytes 0.4.12",
  "cc",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "ed25519-dalek",
  "either",
  "failure",
@@ -2064,7 +2087,7 @@ dependencies = [
  "bv",
  "byteorder 1.3.4",
  "chrono",
- "curve25519-dalek",
+ "curve25519-dalek 2.1.0",
  "digest 0.9.0",
  "ed25519-dalek",
  "generic-array 0.14.3",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "rust/param_passing",
     "rust/param_passing_dep",
     "rust/rand",
+    "rust/ristretto",
     "rust/sanity",
     "rust/sha256",
     "rust/sysval",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -82,6 +82,7 @@ fn main() {
             "panic",
             "param_passing",
             "rand",
+            "ristretto",
             "sanity",
             "sha256",
             "sysval",

--- a/programs/bpf/rust/ristretto/Cargo.toml
+++ b/programs/bpf/rust/ristretto/Cargo.toml
@@ -1,0 +1,28 @@
+
+# Note: This crate must be built using do.sh
+
+[package]
+name = "solana-bpf-rust-ristretto"
+version = "1.4.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+curve25519-dalek = "3"
+getrandom = { version = "0.1.14", features = ["dummy"] }
+solana-sdk = { path = "../../../../sdk/", version = "1.4.0", default-features = false }
+
+[features]
+program = ["solana-sdk/program"]
+default = ["program", "solana-sdk/default"]
+
+[lib]
+name = "solana_bpf_rust_ristretto"
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/ristretto/Xargo.toml
+++ b/programs/bpf/rust/ristretto/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/bpf/rust/ristretto/src/lib.rs
+++ b/programs/bpf/rust/ristretto/src/lib.rs
@@ -1,0 +1,46 @@
+//! @brief Example Rust-based BPF program that performs a ristretto multiply
+
+pub mod ristretto;
+
+extern crate solana_sdk;
+use crate::ristretto::ristretto_mul;
+use curve25519_dalek::{
+    constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint, scalar::Scalar,
+    traits::Identity,
+};
+use solana_sdk::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, info, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    info!("Ristretto multiply");
+
+    let point = RISTRETTO_BASEPOINT_POINT;
+    let scalar = Scalar::zero();
+    let result = ristretto_mul(&point, &scalar)?;
+    assert_ne!(point, result);
+
+    let point = RISTRETTO_BASEPOINT_POINT;
+    let scalar = Scalar::one();
+    let result = ristretto_mul(&point, &scalar)?;
+    assert_eq!(point, result);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    // Pull in syscall stubs when building for non-BPF targets
+    solana_sdk::program_stubs!();
+
+    #[test]
+    fn test_return_sstruct() {
+        assert_eq!(SStruct { x: 1, y: 2, z: 3 }, return_sstruct());
+    }
+}

--- a/programs/bpf/rust/ristretto/src/lib.rs
+++ b/programs/bpf/rust/ristretto/src/lib.rs
@@ -32,15 +32,3 @@ fn process_instruction(
 
     Ok(())
 }
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
-
-    #[test]
-    fn test_return_sstruct() {
-        assert_eq!(SStruct { x: 1, y: 2, z: 3 }, return_sstruct());
-    }
-}

--- a/programs/bpf/rust/ristretto/src/lib.rs
+++ b/programs/bpf/rust/ristretto/src/lib.rs
@@ -4,10 +4,7 @@ pub mod ristretto;
 
 extern crate solana_sdk;
 use crate::ristretto::ristretto_mul;
-use curve25519_dalek::{
-    constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint, scalar::Scalar,
-    traits::Identity,
-};
+use curve25519_dalek::{constants::RISTRETTO_BASEPOINT_POINT, scalar::Scalar};
 use solana_sdk::{
     account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, info, pubkey::Pubkey,
 };

--- a/programs/bpf/rust/ristretto/src/ristretto.rs
+++ b/programs/bpf/rust/ristretto/src/ristretto.rs
@@ -1,0 +1,31 @@
+use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
+use solana_sdk::{entrypoint::SUCCESS, program_error::ProgramError};
+
+/// Prints a string to stdout
+///
+/// @param message - Message to print
+#[inline]
+pub fn ristretto_mul(
+    point: &RistrettoPoint,
+    scalar: &Scalar,
+) -> Result<RistrettoPoint, ProgramError> {
+    let mut result = RistrettoPoint::default();
+    let status = unsafe {
+        sol_ristretto_mul(
+            point as *const _ as *const u8,
+            scalar as *const _ as *const u8,
+            &mut result as *const _ as *mut u8,
+        )
+    };
+    match status {
+        SUCCESS => Ok(result),
+        _ => Err(status.into()),
+    }
+}
+extern "C" {
+    fn sol_ristretto_mul(
+        point_addr: *const u8,
+        scalar_addr: *const u8,
+        result_addr: *mut u8,
+    ) -> u64;
+}

--- a/programs/bpf/rust/ristretto/src/ristretto.rs
+++ b/programs/bpf/rust/ristretto/src/ristretto.rs
@@ -1,9 +1,11 @@
 use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 use solana_sdk::{entrypoint::SUCCESS, program_error::ProgramError};
 
-/// Prints a string to stdout
+/// Multiply a ristretto point with a scalar
 ///
-/// @param message - Message to print
+/// @param point - Ristretto point
+/// @param scalar - Scalar to mulitply against
+/// @return - result of the multiplication
 #[inline]
 pub fn ristretto_mul(
     point: &RistrettoPoint,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -155,6 +155,7 @@ fn test_program_bpf_sanity() {
             ("solana_bpf_rust_panic", false),
             ("solana_bpf_rust_param_passing", true),
             ("solana_bpf_rust_rand", true),
+            ("solana_bpf_rust_ristretto", true),
             ("solana_bpf_rust_sanity", true),
             ("solana_bpf_rust_sha256", true),
             ("solana_bpf_rust_sysval", true),
@@ -667,9 +668,10 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_external_spend", 538),
             ("solana_bpf_rust_iter", 723),
             ("solana_bpf_rust_many_args", 231),
-            ("solana_bpf_rust_noop", 512),
+            ("solana_bpf_rust_noop", 488),
             ("solana_bpf_rust_param_passing", 46),
-            ("solana_bpf_rust_sanity", 1989),
+            ("solana_bpf_rust_ristretto", 19399),
+            ("solana_bpf_rust_sanity", 1965),
         ]);
     }
 

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.3.1"
 byteorder = "1.3.4"
+curve25519-dalek = "3"
 num-derive = "0.3"
 num-traits = "0.2"
 solana-runtime = { path = "../../runtime", version = "1.4.0" }

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -41,6 +41,10 @@ pub mod no_overflow_rent_distribution {
     solana_sdk::declare_id!("4kpdyrcj5jS47CZb2oJGfVxjYbsMm2Kx97gFyZrxxwXz");
 }
 
+pub mod ristretto_mul_syscall_enabled {
+    solana_sdk::declare_id!("HRe7A6aoxgjKzdjbBv6HTy7tJ4YWqE6tVmYCGho6S9Aq");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -53,6 +57,7 @@ lazy_static! {
         (compute_budget_config2::id(), "1ms compute budget"),
         (sha256_syscall_enabled::id(), "sha256 syscall"),
         (no_overflow_rent_distribution::id(), "no overflow rent distribution"),
+        (ristretto_mul_syscall_enabled::id(), "ristretto multiply syscall"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Multiplying curve25519 Ristretto points with a scalar is very expensive if not using lookup tables.  The lookup tables are too large to store and use in a BPF program.

#### Summary of Changes

Add a syscall to do that work.

Fixes #
