### PR TITLE
Explorer: MintToChecked: mint authority optional

### DIFF
--- a/explorer/src/components/instruction/token/types.ts
+++ b/explorer/src/components/instruction/token/types.ts
@@ -148,7 +148,7 @@ const ApproveChecked = object({
 const MintToChecked = object({
   account: Pubkey,
   mint: Pubkey,
-  mintAuthority: Pubkey,
+  mintAuthority: optional(Pubkey),
   multisigMintAuthority: optional(Pubkey),
   signers: optional(array(Pubkey)),
   tokenAmount: TokenAmountUi,


### PR DESCRIPTION
#### Problem
mintAuthority is optional on MintToChecked instruction.

#### Summary of Changes
Make mintAuthority optional.
