### PR TITLE
Inflation cli fix and parameter update

### DIFF
--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -57,7 +57,7 @@ pub fn process_inflation_subcommand(
         println!("Rate reduction per year: {:>5.2}%", governor.taper * 100.);
     }
     if governor.foundation_term > 0. {
-        println!("Foundation percentage:   {:>5.2}%", governor.foundation);
+        println!("Foundation percentage:   {:>5.2}%", governor.foundation * 100.);
         println!(
             "Foundation term:         {:.1} years",
             governor.foundation_term

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -57,7 +57,7 @@ pub fn process_inflation_subcommand(
         println!("Rate reduction per year: {:>5.2}%", governor.taper * 100.);
     }
     if governor.foundation_term > 0. {
-        println!("Foundation percentage:   {:>5.2}%", governor.foundation * 100.);
+        println!("Foundation percentage:   {:>5.2}%", governor.foundation);
         println!(
             "Foundation term:         {:.1} years",
             governor.foundation_term

--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -22,7 +22,7 @@ pub struct Inflation {
     __unused: f64,
 }
 
-const DEFAULT_INITIAL: f64 = 0.15;
+const DEFAULT_INITIAL: f64 = 0.08;
 const DEFAULT_TERMINAL: f64 = 0.015;
 const DEFAULT_TAPER: f64 = 0.15;
 const DEFAULT_FOUNDATION: f64 = 0.05;


### PR DESCRIPTION
#### Problem
`solana inflation` printed fractional Foundation allocation rather than %.
Initial inflation rate governor default didn't match current design (15% rather than 8%)

#### Summary of Changes
Fixed & updated

Fixes #
