### PR TITLE
Support multiple connected HW wallets configured with the same seed phrase

### DIFF
--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -525,13 +525,16 @@ pub fn get_ledger_from_info(
     }
     let mut matches: Vec<(String, String)> = matches
         .filter(|&device_info| device_info.error.is_none())
-        .map(|device_info| (device_info.host_device_path.clone(), device_info.get_pretty_path()))
+        .map(|device_info| {
+            let query_item = format!("{} ({})", device_info.get_pretty_path(), device_info.model,);
+            (device_info.host_device_path.clone(), query_item)
+        })
         .collect();
     if matches.is_empty() {
         return Err(RemoteWalletError::NoDeviceFound);
     }
     matches.sort_by(|a, b| a.1.cmp(&b.1));
-    let (host_device_paths, device_paths): (Vec<Pubkey>, Vec<String>) = matches.into_iter().unzip();
+    let (host_device_paths, items): (Vec<String>, Vec<String>) = matches.into_iter().unzip();
 
     let wallet_host_device_path = if host_device_paths.len() > 1 {
         let selection = Select::with_theme(&ColorfulTheme::default())
@@ -540,7 +543,7 @@ pub fn get_ledger_from_info(
                 keypair_name
             ))
             .default(0)
-            .items(&device_paths[..])
+            .items(&items[..])
             .interact()
             .unwrap();
         &host_device_paths[selection]

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -152,11 +152,14 @@ impl RemoteWalletManager {
 
     /// Get a particular wallet
     #[allow(unreachable_patterns)]
-    pub fn get_ledger(&self, pubkey: &Pubkey) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
+    pub fn get_ledger(
+        &self,
+        host_device_path: &str,
+    ) -> Result<Arc<LedgerWallet>, RemoteWalletError> {
         self.devices
             .read()
             .iter()
-            .find(|device| &device.info.pubkey == pubkey)
+            .find(|device| device.info.host_device_path == host_device_path)
             .ok_or(RemoteWalletError::PubkeyNotFound)
             .and_then(|device| match &device.wallet_type {
                 RemoteWalletType::Ledger(ledger) => Ok(ledger.clone()),
@@ -237,6 +240,8 @@ pub struct RemoteWalletInfo {
     pub manufacturer: String,
     /// RemoteWallet device serial number
     pub serial: String,
+    /// RemoteWallet host device path
+    pub host_device_path: String,
     /// Base pubkey of device at Solana derivation path
     pub pubkey: Pubkey,
     /// Initial read error
@@ -449,6 +454,7 @@ mod tests {
             model: "nano-s".to_string(),
             manufacturer: "ledger".to_string(),
             serial: "".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey,
             error: None,
         }));
@@ -465,6 +471,7 @@ mod tests {
             model: "nano-s".to_string(),
             manufacturer: "ledger".to_string(),
             serial: "".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey,
             error: None,
         }));
@@ -481,6 +488,7 @@ mod tests {
             model: "nano-s".to_string(),
             manufacturer: "ledger".to_string(),
             serial: "".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey,
             error: None,
         }));
@@ -497,6 +505,7 @@ mod tests {
             model: "nano-s".to_string(),
             manufacturer: "ledger".to_string(),
             serial: "".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey,
             error: None,
         }));
@@ -513,6 +522,7 @@ mod tests {
             model: "nano-s".to_string(),
             manufacturer: "ledger".to_string(),
             serial: "".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey,
             error: None,
         }));
@@ -531,6 +541,7 @@ mod tests {
             model: "nano-s".to_string(),
             manufacturer: "ledger".to_string(),
             serial: "".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey: Pubkey::default(),
             error: None,
         }));
@@ -547,6 +558,7 @@ mod tests {
             model: "".to_string(),
             manufacturer: "ledger".to_string(),
             serial: "".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey: Pubkey::default(),
             error: None,
         }));
@@ -581,6 +593,7 @@ mod tests {
             manufacturer: "Ledger".to_string(),
             model: "Nano S".to_string(),
             serial: "0001".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey,
             error: None,
         };
@@ -592,6 +605,8 @@ mod tests {
         test_info.model = "Other".to_string();
         assert!(info.matches(&test_info));
         test_info.model = "Nano S".to_string();
+        assert!(info.matches(&test_info));
+        test_info.host_device_path = "/host/device/path".to_string();
         assert!(info.matches(&test_info));
         let another_pubkey = Pubkey::new_rand();
         test_info.pubkey = another_pubkey;
@@ -608,6 +623,7 @@ mod tests {
             model: "nano-s".to_string(),
             manufacturer: "ledger".to_string(),
             serial: "".to_string(),
+            host_device_path: "/host/device/path".to_string(),
             pubkey,
             error: None,
         };


### PR DESCRIPTION
#### Problem

When multiple hardware wallets are connected to the same system, if they are configured with the same seed phrase, it is impossible to choose any but the first.  This is because selection happens based on the device's root pubkey, which in this situation is not a unique identifier

#### Summary of Changes

- Use host device path as unique identifer
- Append the wallet "name" to entries in the multi-wallet selector