### PR TITLE
fix: return correct number of signatures needed to load programs

### DIFF
--- a/web3.js/src/loader.js
+++ b/web3.js/src/loader.js
@@ -34,7 +34,12 @@ export class Loader {
    * Can be used to calculate transaction fees
    */
   static getMinNumSignatures(dataLength: number): number {
-    return Math.ceil(dataLength / Loader.chunkSize);
+    return (
+      2 * // Every transaction requires two signatures (payer + program)
+      (Math.ceil(dataLength / Loader.chunkSize) +
+        1 + // Add one for Create transaction
+        1) // Add one for Finalize transaction
+    );
   }
 
   /**


### PR DESCRIPTION
#### Problem
`Loader.getMinNumSignatures` does not return the correct number of signatures needed to load a program. It doesn't take into the Create and Finalize transactions and also doesn't take into account that each transaction requires 2 signatures (payer and program)

#### Summary of Changes
- Return correct number of signatures
- Remove "NUM_RETRIES" logic from tests since it isn't needed and was concealing the fact that `getMinNumSignatures` was broken

Fixes #
