### PR TITLE
Correct Bank timestamp drift every slot

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -33,6 +33,7 @@ use solana_sdk::{
     program_utils::limited_deserialize,
     pubkey::Pubkey,
     signature::{Keypair, Signature, Signer},
+    stake_weighted_timestamp::{calculate_stake_weighted_timestamp, TIMESTAMP_SLOT_RANGE},
     timing::timestamp,
     transaction::Transaction,
 };
@@ -77,7 +78,6 @@ thread_local!(static PAR_THREAD_POOL_ALL_CPUS: RefCell<ThreadPool> = RefCell::ne
 pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
 pub const MAX_TURBINE_PROPAGATION_IN_MS: u64 = 100;
 pub const MAX_TURBINE_DELAY_IN_TICKS: u64 = MAX_TURBINE_PROPAGATION_IN_MS / MS_PER_TICK;
-const TIMESTAMP_SLOT_RANGE: usize = 16;
 
 // An upper bound on maximum number of data shreds we can handle in a slot
 // 32K shreds would allow ~320K peak TPS
@@ -3130,33 +3130,6 @@ fn slot_has_updates(slot_meta: &SlotMeta, slot_meta_backup: &Option<SlotMeta>) -
         (slot_meta_backup.is_some() && slot_meta_backup.as_ref().unwrap().consumed != slot_meta.consumed))
 }
 
-fn calculate_stake_weighted_timestamp(
-    unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)>,
-    stakes: &HashMap<Pubkey, (u64, Account)>,
-    slot: Slot,
-    slot_duration: Duration,
-) -> Option<UnixTimestamp> {
-    let (stake_weighted_timestamps_sum, total_stake) = unique_timestamps
-        .into_iter()
-        .filter_map(|(vote_pubkey, (timestamp_slot, timestamp))| {
-            let offset = (slot - timestamp_slot) as u32 * slot_duration;
-            stakes.get(&vote_pubkey).map(|(stake, _account)| {
-                (
-                    (timestamp as u128 + offset.as_secs() as u128) * *stake as u128,
-                    stake,
-                )
-            })
-        })
-        .fold((0, 0), |(timestamps, stakes), (timestamp, stake)| {
-            (timestamps + timestamp, stakes + *stake as u128)
-        });
-    if total_stake > 0 {
-        Some((stake_weighted_timestamps_sum / total_stake) as i64)
-    } else {
-        None
-    }
-}
-
 // Creates a new ledger with slot 0 full of ticks (and only ticks).
 //
 // Returns the blockhash that can be used to append entries with.
@@ -3478,7 +3451,6 @@ pub mod tests {
         hash::{self, hash, Hash},
         instruction::CompiledInstruction,
         message::Message,
-        native_token::sol_to_lamports,
         packet::PACKET_DATA_SIZE,
         pubkey::Pubkey,
         signature::Signature,
@@ -5887,113 +5859,6 @@ pub mod tests {
                 .is_err());
             assert_eq!(blockstore.get_block_time(*slot).unwrap(), None);
         }
-    }
-
-    #[test]
-    fn test_calculate_stake_weighted_timestamp() {
-        let recent_timestamp: UnixTimestamp = 1_578_909_061;
-        let slot = 5;
-        let slot_duration = Duration::from_millis(400);
-        let expected_offset = (slot * slot_duration).as_secs();
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
-        let pubkey3 = Pubkey::new_rand();
-        let unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)> = [
-            (pubkey0, (0, recent_timestamp)),
-            (pubkey1, (0, recent_timestamp)),
-            (pubkey2, (0, recent_timestamp)),
-            (pubkey3, (0, recent_timestamp)),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-
-        let stakes: HashMap<Pubkey, (u64, Account)> = [
-            (
-                pubkey0,
-                (
-                    sol_to_lamports(4_500_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey1,
-                (
-                    sol_to_lamports(4_500_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey2,
-                (
-                    sol_to_lamports(4_500_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey3,
-                (
-                    sol_to_lamports(4_500_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-        assert_eq!(
-            calculate_stake_weighted_timestamp(
-                unique_timestamps.clone(),
-                &stakes,
-                slot as Slot,
-                slot_duration
-            ),
-            Some(recent_timestamp + expected_offset as i64)
-        );
-
-        let stakes: HashMap<Pubkey, (u64, Account)> = [
-            (
-                pubkey0,
-                (
-                    sol_to_lamports(15_000_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey1,
-                (
-                    sol_to_lamports(1_000_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey2,
-                (
-                    sol_to_lamports(1_000_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-            (
-                pubkey3,
-                (
-                    sol_to_lamports(1_000_000_000.0),
-                    Account::new(1, 0, &Pubkey::default()),
-                ),
-            ),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-        assert_eq!(
-            calculate_stake_weighted_timestamp(
-                unique_timestamps,
-                &stakes,
-                slot as Slot,
-                slot_duration
-            ),
-            Some(recent_timestamp + expected_offset as i64)
-        );
     }
 
     #[test]

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1630,7 +1630,7 @@ impl Blockstore {
 
         let mut calculate_timestamp = Measure::start("calculate_timestamp");
         let stake_weighted_timestamp =
-            calculate_stake_weighted_timestamp(unique_timestamps, stakes, slot, slot_duration)
+            calculate_stake_weighted_timestamp(&unique_timestamps, stakes, slot, slot_duration)
                 .ok_or(BlockstoreError::EmptyEpochStakes)?;
         calculate_timestamp.stop();
         datapoint_info!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -57,6 +57,7 @@ use solana_sdk::{
     signature::{Keypair, Signature},
     slot_hashes::SlotHashes,
     slot_history::SlotHistory,
+    stake_weighted_timestamp::{calculate_stake_weighted_timestamp, TIMESTAMP_SLOT_RANGE},
     system_transaction,
     sysvar::{self, Sysvar},
     timing::years_as_slots,
@@ -77,6 +78,7 @@ use std::{
         atomic::{AtomicBool, AtomicU64, Ordering::Relaxed},
         LockResult, RwLockWriteGuard, {Arc, RwLock, RwLockReadGuard},
     },
+    time::Duration,
 };
 
 // Partial SPL Token v2.0.x declarations inlined to avoid an external dependency on the spl-token crate
@@ -1359,6 +1361,47 @@ impl Bank {
     pub fn update_recent_blockhashes(&self) {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         self.update_recent_blockhashes_locked(&blockhash_queue);
+    }
+
+    fn get_timestamp_estimate(&self) -> Option<UnixTimestamp> {
+        let mut get_timestamp_estimate_time = Measure::start("get_timestamp_estimate");
+        let recent_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)> = self
+            .vote_accounts()
+            .into_iter()
+            .filter_map(|(pubkey, (_, account))| {
+                VoteState::from(&account).and_then(|state| {
+                    let timestamp_slot = state.last_timestamp.slot;
+                    if self.slot().checked_sub(timestamp_slot)? <= TIMESTAMP_SLOT_RANGE as u64 {
+                        Some((
+                            pubkey,
+                            (state.last_timestamp.slot, state.last_timestamp.timestamp),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+        let slot_duration = Duration::from_nanos(self.ns_per_slot as u64);
+        let epoch = self.epoch_schedule().get_epoch(self.slot());
+        let stakes = HashMap::new();
+        let stakes = self.epoch_vote_accounts(epoch).unwrap_or(&stakes);
+        let stake_weighted_timestamp = calculate_stake_weighted_timestamp(
+            recent_timestamps,
+            stakes,
+            self.slot(),
+            slot_duration,
+        );
+        get_timestamp_estimate_time.stop();
+        datapoint_info!(
+            "bank-timestamp",
+            (
+                "get_timestamp_estimate_us",
+                get_timestamp_estimate_time.as_us(),
+                i64
+            ),
+        );
+        stake_weighted_timestamp
     }
 
     // Distribute collected transaction fees for this slot to collector_id (= current leader).
@@ -3951,7 +3994,8 @@ mod tests {
     use crate::{
         accounts_index::{AccountMap, Ancestors},
         genesis_utils::{
-            create_genesis_config_with_leader, GenesisConfigInfo, BOOTSTRAP_VALIDATOR_LAMPORTS,
+            create_genesis_config_with_leader, create_genesis_config_with_vote_accounts,
+            GenesisConfigInfo, ValidatorVoteKeypairs, BOOTSTRAP_VALIDATOR_LAMPORTS,
         },
         process_instruction::InvokeContext,
         status_cache::MAX_CACHE_ENTRIES,
@@ -3980,7 +4024,7 @@ mod tests {
     use solana_vote_program::vote_state::VoteStateVersions;
     use solana_vote_program::{
         vote_instruction,
-        vote_state::{self, Vote, VoteInit, VoteState, MAX_LOCKOUT_HISTORY},
+        vote_state::{self, BlockTimestamp, Vote, VoteInit, VoteState, MAX_LOCKOUT_HISTORY},
     };
     use std::{result, time::Duration};
 
@@ -9383,6 +9427,70 @@ mod tests {
         // Account is now empty, and the account lamports were burnt
         assert_eq!(bank.get_balance(&inline_spl_token_v2_0::id()), 0);
         assert_eq!(bank.capitalization(), original_capitalization - 100);
+    }
+
+    fn update_vote_account_timestamp(timestamp: BlockTimestamp, bank: &Bank, vote_pubkey: &Pubkey) {
+        let mut vote_account = bank.get_account(vote_pubkey).unwrap_or_default();
+        let mut vote_state = VoteState::from(&vote_account).unwrap_or_default();
+        vote_state.last_timestamp = timestamp;
+        let versioned = VoteStateVersions::Current(Box::new(vote_state));
+        VoteState::to(&versioned, &mut vote_account).unwrap();
+        bank.store_account(vote_pubkey, &vote_account);
+    }
+
+    #[test]
+    fn test_get_timestamp_estimate() {
+        let validator_vote_keypairs0 = ValidatorVoteKeypairs::new_rand();
+        let validator_vote_keypairs1 = ValidatorVoteKeypairs::new_rand();
+        let validator_keypairs = vec![&validator_vote_keypairs0, &validator_vote_keypairs1];
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair: _,
+            voting_keypair: _,
+        } = create_genesis_config_with_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![10_000; 2],
+        );
+        let mut bank = Bank::new(&genesis_config);
+        assert_eq!(bank.get_timestamp_estimate(), Some(0));
+
+        let recent_timestamp: UnixTimestamp = bank.unix_timestamp();
+        update_vote_account_timestamp(
+            BlockTimestamp {
+                slot: bank.slot(),
+                timestamp: recent_timestamp,
+            },
+            &bank,
+            &validator_vote_keypairs0.vote_keypair.pubkey(),
+        );
+        let additional_secs = 2;
+        update_vote_account_timestamp(
+            BlockTimestamp {
+                slot: bank.slot(),
+                timestamp: recent_timestamp + additional_secs,
+            },
+            &bank,
+            &validator_vote_keypairs1.vote_keypair.pubkey(),
+        );
+        assert_eq!(
+            bank.get_timestamp_estimate(),
+            Some(recent_timestamp + additional_secs / 2)
+        );
+
+        for _ in 0..10 {
+            bank = new_from_parent(&Arc::new(bank));
+        }
+        let adjustment = (bank.ns_per_slot as u64 * bank.slot()) / 1_000_000_000;
+        assert_eq!(
+            bank.get_timestamp_estimate(),
+            Some(recent_timestamp + adjustment as i64 + additional_secs / 2)
+        );
+
+        for _ in 0..7 {
+            bank = new_from_parent(&Arc::new(bank));
+        }
+        assert_eq!(bank.get_timestamp_estimate(), None);
     }
 
     fn setup_bank_with_removable_zero_lamport_account() -> Arc<Bank> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1037,19 +1037,22 @@ impl Bank {
     }
 
     pub fn clock(&self) -> sysvar::clock::Clock {
-        sysvar::clock::Clock {
+        sysvar::clock::Clock::from_account(
+            &self.get_account(&sysvar::clock::id()).unwrap_or_default(),
+        )
+        .unwrap_or_default()
+    }
+
+    fn update_clock(&self) {
+        let clock = sysvar::clock::Clock {
             slot: self.slot,
             unused: Self::get_unused_from_slot(self.slot, self.unused),
             epoch: self.epoch_schedule.get_epoch(self.slot),
             leader_schedule_epoch: self.epoch_schedule.get_leader_schedule_epoch(self.slot),
             unix_timestamp: self.unix_timestamp(),
-        }
-    }
-
-    fn update_clock(&self) {
+        };
         self.update_sysvar_account(&sysvar::clock::id(), |account| {
-            self.clock()
-                .create_account(self.inherit_sysvar_account_balance(account))
+            clock.create_account(self.inherit_sysvar_account_balance(account))
         });
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1398,10 +1398,9 @@ impl Bank {
             .collect();
         let slot_duration = Duration::from_nanos(self.ns_per_slot as u64);
         let epoch = self.epoch_schedule().get_epoch(self.slot());
-        let stakes = HashMap::new();
-        let stakes = self.epoch_vote_accounts(epoch).unwrap_or(&stakes);
+        let stakes = self.epoch_vote_accounts(epoch)?;
         let stake_weighted_timestamp = calculate_stake_weighted_timestamp(
-            recent_timestamps,
+            &recent_timestamps,
             stakes,
             self.slot(),
             slot_duration,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1051,6 +1051,11 @@ impl Bank {
         {
             if let Some(timestamp_estimate) = self.get_timestamp_estimate() {
                 if timestamp_estimate > unix_timestamp {
+                    datapoint_info!(
+                        "bank-timestamp-correction",
+                        ("from_genesis", unix_timestamp, i64),
+                        ("corrected", timestamp_estimate, i64),
+                    );
                     unix_timestamp = timestamp_estimate
                 }
             }

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -57,6 +57,10 @@ pub mod max_program_call_depth_64 {
     solana_sdk::declare_id!("YCKSgA6XmjtkQrHBQjpyNrX6EMhJPcYcLWMVgWn36iv");
 }
 
+pub mod timestamp_correction {
+    solana_sdk::declare_id!("3zydSLUwuqqsV3wL5wBsaVgyvMox3XTHx7zLEuQf1U2Z");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -72,7 +76,8 @@ lazy_static! {
         (no_overflow_rent_distribution::id(), "no overflow rent distribution"),
         (ristretto_mul_syscall_enabled::id(), "ristretto multiply syscall"),
         (max_invoke_depth_4::id(), "max invoke call depth 4"),
-        (max_program_call_depth_64::id(), "max program call depth 64")
+        (max_program_call_depth_64::id(), "max program call depth 64"),
+        (timestamp_correction::id(), "correct bank timestamps"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -45,6 +45,7 @@ pub mod short_vec;
 pub mod slot_hashes;
 pub mod slot_history;
 pub mod stake_history;
+pub mod stake_weighted_timestamp;
 pub mod system_instruction;
 pub mod system_program;
 pub mod sysvar;

--- a/sdk/src/stake_weighted_timestamp.rs
+++ b/sdk/src/stake_weighted_timestamp.rs
@@ -10,18 +10,18 @@ use std::{collections::HashMap, time::Duration};
 pub const TIMESTAMP_SLOT_RANGE: usize = 16;
 
 pub fn calculate_stake_weighted_timestamp(
-    unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)>,
+    unique_timestamps: &HashMap<Pubkey, (Slot, UnixTimestamp)>,
     stakes: &HashMap<Pubkey, (u64, Account)>,
     slot: Slot,
     slot_duration: Duration,
 ) -> Option<UnixTimestamp> {
     let (stake_weighted_timestamps_sum, total_stake) = unique_timestamps
-        .into_iter()
+        .iter()
         .filter_map(|(vote_pubkey, (timestamp_slot, timestamp))| {
             let offset = (slot - timestamp_slot) as u32 * slot_duration;
             stakes.get(&vote_pubkey).map(|(stake, _account)| {
                 (
-                    (timestamp as u128 + offset.as_secs() as u128) * *stake as u128,
+                    (*timestamp as u128 + offset.as_secs() as u128) * *stake as u128,
                     stake,
                 )
             })
@@ -96,7 +96,7 @@ pub mod tests {
         .collect();
         assert_eq!(
             calculate_stake_weighted_timestamp(
-                unique_timestamps.clone(),
+                &unique_timestamps,
                 &stakes,
                 slot as Slot,
                 slot_duration
@@ -139,7 +139,7 @@ pub mod tests {
         .collect();
         assert_eq!(
             calculate_stake_weighted_timestamp(
-                unique_timestamps,
+                &unique_timestamps,
                 &stakes,
                 slot as Slot,
                 slot_duration

--- a/sdk/src/stake_weighted_timestamp.rs
+++ b/sdk/src/stake_weighted_timestamp.rs
@@ -1,0 +1,150 @@
+/// A helper for calculating a stake-weighted timestamp estimate from a set of timestamps and epoch
+/// stake.
+use solana_sdk::{
+    account::Account,
+    clock::{Slot, UnixTimestamp},
+    pubkey::Pubkey,
+};
+use std::{collections::HashMap, time::Duration};
+
+pub const TIMESTAMP_SLOT_RANGE: usize = 16;
+
+pub fn calculate_stake_weighted_timestamp(
+    unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)>,
+    stakes: &HashMap<Pubkey, (u64, Account)>,
+    slot: Slot,
+    slot_duration: Duration,
+) -> Option<UnixTimestamp> {
+    let (stake_weighted_timestamps_sum, total_stake) = unique_timestamps
+        .into_iter()
+        .filter_map(|(vote_pubkey, (timestamp_slot, timestamp))| {
+            let offset = (slot - timestamp_slot) as u32 * slot_duration;
+            stakes.get(&vote_pubkey).map(|(stake, _account)| {
+                (
+                    (timestamp as u128 + offset.as_secs() as u128) * *stake as u128,
+                    stake,
+                )
+            })
+        })
+        .fold((0, 0), |(timestamps, stakes), (timestamp, stake)| {
+            (timestamps + timestamp, stakes + *stake as u128)
+        });
+    if total_stake > 0 {
+        Some((stake_weighted_timestamps_sum / total_stake) as i64)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use solana_sdk::native_token::sol_to_lamports;
+
+    #[test]
+    fn test_calculate_stake_weighted_timestamp() {
+        let recent_timestamp: UnixTimestamp = 1_578_909_061;
+        let slot = 5;
+        let slot_duration = Duration::from_millis(400);
+        let expected_offset = (slot * slot_duration).as_secs();
+        let pubkey0 = Pubkey::new_rand();
+        let pubkey1 = Pubkey::new_rand();
+        let pubkey2 = Pubkey::new_rand();
+        let pubkey3 = Pubkey::new_rand();
+        let unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)> = [
+            (pubkey0, (0, recent_timestamp)),
+            (pubkey1, (0, recent_timestamp)),
+            (pubkey2, (0, recent_timestamp)),
+            (pubkey3, (0, recent_timestamp)),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        let stakes: HashMap<Pubkey, (u64, Account)> = [
+            (
+                pubkey0,
+                (
+                    sol_to_lamports(4_500_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey1,
+                (
+                    sol_to_lamports(4_500_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey2,
+                (
+                    sol_to_lamports(4_500_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey3,
+                (
+                    sol_to_lamports(4_500_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert_eq!(
+            calculate_stake_weighted_timestamp(
+                unique_timestamps.clone(),
+                &stakes,
+                slot as Slot,
+                slot_duration
+            ),
+            Some(recent_timestamp + expected_offset as i64)
+        );
+
+        let stakes: HashMap<Pubkey, (u64, Account)> = [
+            (
+                pubkey0,
+                (
+                    sol_to_lamports(15_000_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey1,
+                (
+                    sol_to_lamports(1_000_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey2,
+                (
+                    sol_to_lamports(1_000_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+            (
+                pubkey3,
+                (
+                    sol_to_lamports(1_000_000_000.0),
+                    Account::new(1, 0, &Pubkey::default()),
+                ),
+            ),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+        assert_eq!(
+            calculate_stake_weighted_timestamp(
+                unique_timestamps,
+                &stakes,
+                slot as Slot,
+                slot_duration
+            ),
+            Some(recent_timestamp + expected_offset as i64)
+        );
+    }
+}


### PR DESCRIPTION
#### Problem
The timestamp returned by `Bank::unix_timestamp()` ends up in the clock sysvar and is used to assess time-based stake account lockouts. However it's based on a theoretical slots-per-second instead of reality, so it's quite inaccurate. This will pose a problem for lockups, since the accounts will not register as lockup-free on (or anytime near) the date the lockup is set to expire.

Block times are estimated using a validator timestamp oracle; this data provides an opportunity to align the bank timestamp more closely with real-world time.

#### Summary of Changes
- Adjust `Bank::update_clock` to set the Clock sysvar timestamp to the stake-weighted timestamp estimate if it is greater than the unix_timestamp from genesis; feature-gated

This adds 50us to each `Bank::new_from_parent()`, which was not distinguishable in confirmation-time or other metrics on a testnet under moderate TPS load.

Fixes #9874 
Toward #10093 (but requires some additional handling to update Bank::slots_per_year)
