### PR TITLE
Add inflation_kill_switch feature

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3757,6 +3757,12 @@ impl Bank {
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 
+        if new_feature_activations.contains(&feature_set::inflation_kill_switch::id()) {
+            *self.inflation.write().unwrap() = Inflation::new_disabled();
+            self.fee_rate_governor.burn_percent = 100; // 100% fee burn
+            self.rent_collector.rent.burn_percent = 100; // 100% rent burn
+        }
+
         if new_feature_activations.contains(&feature_set::spl_token_v2_multisig_fix::id()) {
             self.apply_spl_token_v2_multisig_fix();
         }

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -21,6 +21,10 @@ pub mod pico_inflation {
     solana_sdk::declare_id!("GaBtBJvmS4Arjj5W1NmFcyvPjsHN38UGYDq2MDwbs9Qu");
 }
 
+pub mod inflation_kill_switch {
+    solana_sdk::declare_id!("SECCKV5UVUsr8sTVSVAzULjdm87r7mLPaqH2FGZjevR");
+}
+
 pub mod spl_token_v2_multisig_fix {
     solana_sdk::declare_id!("E5JiFDQCwyC6QfT9REFyMpfK2mHcmv1GUDySU1Ue7TYv");
 }
@@ -52,6 +56,7 @@ lazy_static! {
         (secp256k1_program_enabled::id(), "secp256k1 program"),
         (consistent_recent_blockhashes_sysvar::id(), "consistent recentblockhashes sysvar"),
         (pico_inflation::id(), "pico-inflation"),
+        (inflation_kill_switch::id(), "inflation kill switch"),
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),
         (bpf_loader2_program::id(), "bpf_loader2 program"),
         (compute_budget_config2::id(), "1ms compute budget"),


### PR DESCRIPTION
When the `pico-inflation` feature is enabled it'll be nice to have a mechanism for the Foundation to halt inflation if any anomalies occur during the first couple months of monitoring.
