### PR TITLE
cluster docs: Advise setting `--wal-recovery-mode`, and using `--private-rpc` for mainnet-beta

### DIFF
--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -45,6 +45,7 @@ $ solana-validator \
     --dynamic-port-range 8000-8010 \
     --entrypoint entrypoint.devnet.solana.com:8001 \
     --expected-genesis-hash EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG \
+    --wal-recovery-mode skip_any_corrupted_record \
     --limit-ledger-size
 ```
 
@@ -88,6 +89,7 @@ $ solana-validator \
     --dynamic-port-range 8000-8010 \
     --entrypoint entrypoint.testnet.solana.com:8001 \
     --expected-genesis-hash 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY \
+    --wal-recovery-mode skip_any_corrupted_record \
     --limit-ledger-size
 ```
 
@@ -131,9 +133,11 @@ $ solana-validator \
     --no-untrusted-rpc \
     --ledger ~/validator-ledger \
     --rpc-port 8899 \
+    --private-rpc \
     --dynamic-port-range 8000-8010 \
     --entrypoint mainnet-beta.solana.com:8001 \
     --expected-genesis-hash 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d \
+    --wal-recovery-mode skip_any_corrupted_record \
     --limit-ledger-size
 ```
 


### PR DESCRIPTION
Advise users add `--wal-recovery-mode skip_any_corrupted_record` to avoid #11629.
Also default to `--private-rpc` in the mainnet-beta example.


Fixes #11629 