### PR TITLE
Add convenience script for working in stability branches

### DIFF
--- a/cargo
+++ b/cargo
@@ -3,7 +3,7 @@
 # shellcheck source=ci/rust-version.sh
 here=$(dirname "$0")
 
-source "${here}"/../ci/rust-version.sh all
+source "${here}"/ci/rust-version.sh all
 
 toolchain=
 case "$1" in

--- a/scripts/curgo.sh
+++ b/scripts/curgo.sh
@@ -24,4 +24,4 @@ case "$1" in
 esac
 
 set -x
-cargo "+${toolchain}" "${@}"
+exec cargo "+${toolchain}" "${@}"

--- a/scripts/curgo.sh
+++ b/scripts/curgo.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# shellcheck source=ci/rust-version.sh
+here=$(dirname "$0")
+
+source "${here}"/../ci/rust-version.sh all
+
+toolchain=
+case "$1" in
+  stable)
+    # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
+    toolchain="$rust_stable"
+    shift
+    ;;
+  nightly)
+    # shellcheck disable=SC2054 # rust_nightly is sourced from rust-version.sh
+    toolchain="$rust_nightly"
+    shift
+    ;;
+  *)
+    # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
+    toolchain="$rust_stable"
+    ;;
+esac
+
+set -x
+cargo "+${toolchain}" "${@}"


### PR DESCRIPTION
#### Problem

It's inconvenient to work in stability branches with their toolchains pinned to older versions than are likely to be default in the dev env.  This leads to unintentional `Cargo.lock`, clippy and fmt changes

#### Summary of Changes

Add a convenience script that wraps `cargo`, injecting toolchains as specified in `ci/rust-version.sh`

Alternative naming suggestions welcome :wink: 