### PR TITLE
Expose all rewards (fees, rent, voting and staking) in RPC getConfirmedBlock and the cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4659,6 +4659,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "solana-account-decoder",
+ "solana-runtime",
  "solana-sdk 1.5.0",
  "solana-stake-program",
  "solana-vote-program",

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -98,7 +98,7 @@ pub enum CliCommand {
     Fees,
     FirstAvailableBlock,
     GetBlock {
-        slot: Slot,
+        slot: Option<Slot>,
     },
     GetBlockTime {
         slot: Option<Slot>,

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -73,8 +73,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .validator(is_slot)
                         .value_name("SLOT")
                         .takes_value(true)
-                        .index(1)
-                        .required(true),
+                        .index(1),
                 ),
         )
         .subcommand(
@@ -363,7 +362,7 @@ pub fn parse_cluster_ping(
 }
 
 pub fn parse_get_block(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
-    let slot = value_t_or_exit!(matches, "slot", Slot);
+    let slot = value_of(matches, "slot");
     Ok(CliCommandInfo {
         command: CliCommand::GetBlock { slot },
         signers: vec![],
@@ -700,7 +699,17 @@ pub fn process_leader_schedule(rpc_client: &RpcClient) -> ProcessResult {
     Ok("".to_string())
 }
 
-pub fn process_get_block(rpc_client: &RpcClient, _config: &CliConfig, slot: Slot) -> ProcessResult {
+pub fn process_get_block(
+    rpc_client: &RpcClient,
+    _config: &CliConfig,
+    slot: Option<Slot>,
+) -> ProcessResult {
+    let slot = if let Some(slot) = slot {
+        slot
+    } else {
+        rpc_client.get_slot()?
+    };
+
     let mut block =
         rpc_client.get_confirmed_block_with_encoding(slot, UiTransactionEncoding::Base64)?;
 
@@ -716,18 +725,23 @@ pub fn process_get_block(rpc_client: &RpcClient, _config: &CliConfig, slot: Slot
         let mut total_rewards = 0;
         println!("Rewards:",);
         println!(
-            "  {:<44}  {:<15}  {:<13}  {:>14}",
-            "Address", "Amount", "New Balance", "Percent Change"
+            "  {:<44}  {:^15}  {:<15}  {:<20}  {:>14}",
+            "Address", "Type", "Amount", "New Balance", "Percent Change"
         );
         for reward in block.rewards {
             let sign = if reward.lamports < 0 { "-" } else { "" };
 
             total_rewards += reward.lamports;
             println!(
-                "  {:<44}  {:>15}  {}",
+                "  {:<44}  {:^15}  {:>15}  {}",
                 reward.pubkey,
+                if let Some(reward_type) = reward.reward_type {
+                    format!("{}", reward_type)
+                } else {
+                    "-".to_string()
+                },
                 format!(
-                    "{}◎{:<14.4}",
+                    "{}◎{:<14.9}",
                     sign,
                     lamports_to_sol(reward.lamports.abs() as u64)
                 ),
@@ -735,7 +749,7 @@ pub fn process_get_block(rpc_client: &RpcClient, _config: &CliConfig, slot: Slot
                     "          -                 -".to_string()
                 } else {
                     format!(
-                        "◎{:<12.4}  {:>13.9}%",
+                        "◎{:<19.9}  {:>13.9}%",
                         lamports_to_sol(reward.post_balance),
                         reward.lamports.abs() as f64
                             / (reward.post_balance as f64 - reward.lamports as f64)
@@ -746,7 +760,7 @@ pub fn process_get_block(rpc_client: &RpcClient, _config: &CliConfig, slot: Slot
 
         let sign = if total_rewards < 0 { "-" } else { "" };
         println!(
-            "Total Rewards: {}◎{:12.9}",
+            "Total Rewards: {}◎{:<12.9}",
             sign,
             lamports_to_sol(total_rewards.abs() as u64)
         );

--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -54,6 +54,7 @@ impl RewardsRecorderService {
                 pubkey: pubkey.to_string(),
                 lamports: reward_info.lamports,
                 post_balance: reward_info.post_balance,
+                reward_type: Some(reward_info.reward_type),
             })
             .collect();
 

--- a/docs/src/apps/jsonrpc-api.md
+++ b/docs/src/apps/jsonrpc-api.md
@@ -342,6 +342,7 @@ The result field will be an object with the following fields:
     - `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
     - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
     - `postBalance: <u64>` - account balance in lamports after the reward was applied
+    - `rewardType: <string|undefined>` - type of reward: "fee", "rent", "voting", "staking"
   - `blockTime: <i64 | null>` - estimated production time, as Unix timestamp (seconds since the Unix epoch). null if not available
 
 #### Example:

--- a/storage-bigtable/proto/solana.bigtable.confirmed_block.rs
+++ b/storage-bigtable/proto/solana.bigtable.confirmed_block.rs
@@ -91,9 +91,20 @@ pub struct Reward {
     pub lamports: i64,
     #[prost(uint64, tag = "3")]
     pub post_balance: u64,
+    #[prost(enumeration = "RewardType", tag = "4")]
+    pub reward_type: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnixTimestamp {
     #[prost(int64, tag = "1")]
     pub timestamp: i64,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum RewardType {
+    Unspecified = 0,
+    Fee = 1,
+    Rent = 2,
+    Staking = 3,
+    Voting = 4,
 }

--- a/storage-bigtable/src/confirmed_block.proto
+++ b/storage-bigtable/src/confirmed_block.proto
@@ -57,10 +57,19 @@ message CompiledInstruction {
     bytes data = 3;
 }
 
+enum RewardType {
+    Unspecified = 0;
+    Fee = 1;
+    Rent = 2;
+    Staking = 3;
+    Voting = 4;
+}
+
 message Reward {
     string pubkey = 1;
     int64 lamports = 2;
     uint64 post_balance = 3;
+    RewardType reward_type = 4;
 }
 
 message UnixTimestamp {

--- a/storage-bigtable/src/convert.rs
+++ b/storage-bigtable/src/convert.rs
@@ -7,7 +7,8 @@ use solana_sdk::{
     transaction::Transaction,
 };
 use solana_transaction_status::{
-    ConfirmedBlock, InnerInstructions, Reward, TransactionStatusMeta, TransactionWithStatusMeta,
+    ConfirmedBlock, InnerInstructions, Reward, RewardType, TransactionStatusMeta,
+    TransactionWithStatusMeta,
 };
 use std::convert::{TryFrom, TryInto};
 
@@ -24,6 +25,13 @@ impl From<Reward> for generated::Reward {
             pubkey: reward.pubkey,
             lamports: reward.lamports,
             post_balance: reward.post_balance,
+            reward_type: match reward.reward_type {
+                None => generated::RewardType::Unspecified,
+                Some(RewardType::Fee) => generated::RewardType::Fee,
+                Some(RewardType::Rent) => generated::RewardType::Rent,
+                Some(RewardType::Staking) => generated::RewardType::Staking,
+                Some(RewardType::Voting) => generated::RewardType::Voting,
+            } as i32,
         }
     }
 }
@@ -34,6 +42,14 @@ impl From<generated::Reward> for Reward {
             pubkey: reward.pubkey,
             lamports: reward.lamports,
             post_balance: reward.post_balance,
+            reward_type: match reward.reward_type {
+                0 => None,
+                1 => Some(RewardType::Fee),
+                2 => Some(RewardType::Rent),
+                3 => Some(RewardType::Voting),
+                4 => Some(RewardType::Staking),
+                _ => None,
+            },
         }
     }
 }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -222,6 +222,7 @@ impl From<StoredConfirmedBlockReward> for Reward {
             pubkey,
             lamports,
             post_balance: 0,
+            reward_type: None,
         }
     }
 }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -19,6 +19,7 @@ serde_derive = "1.0.103"
 serde_json = "1.0.56"
 solana-account-decoder = { path = "../account-decoder", version = "1.5.0" }
 solana-sdk = { path = "../sdk", version = "1.5.0" }
+solana-runtime = { path = "../runtime", version = "1.5.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.5.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.5.0" }
 spl-memo-v1-0 = { package = "spl-memo", version = "=1.0.7", features = ["skip-no-mangle"] }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -11,6 +11,7 @@ use crate::{
     parse_accounts::{parse_accounts, ParsedAccount},
     parse_instruction::{parse, ParsedInstruction},
 };
+pub use solana_runtime::bank::RewardType;
 use solana_sdk::{
     clock::{Slot, UnixTimestamp},
     commitment_config::CommitmentConfig,
@@ -241,6 +242,8 @@ pub struct Reward {
     pub lamports: i64,
     #[serde(deserialize_with = "default_on_eof")]
     pub post_balance: u64, // Account balance in lamports after `lamports` was applied
+    #[serde(default, deserialize_with = "default_on_eof")]
+    pub reward_type: Option<RewardType>,
 }
 
 pub type Rewards = Vec<Reward>;

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -502,6 +502,8 @@ type ConfirmedBlock = {
   rewards: Array<{
     pubkey: string,
     lamports: number,
+    postBalance: number | null,
+    rewardType: string | null,
   }>,
 };
 
@@ -1152,6 +1154,8 @@ export const GetConfirmedBlockRpcResult = jsonRpcResult(
           struct({
             pubkey: 'string',
             lamports: 'number',
+            postBalance: struct.union(['number', 'undefined']),
+            rewardType: struct.union(['string', 'undefined']),
           }),
         ]),
       ]),


### PR DESCRIPTION
The rewards array in `getConfirmedBlock` has a couple limitations that this PR addresses:
1. No indication of the type of reward -- was it for voting and staking?  This can be inferred by looking at the type of account of course but that's clumsy
2. Transaction fees and rent distributions are not surfaced

With this PR `getConfirmedBlock` will now report at minimum one reward per block, the transaction fees paid to the leader.  