### PR TITLE
Default to 50% rent burn

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -51,7 +51,8 @@ fn test_accounts_create(bencher: &mut Bencher) {
 
 #[bench]
 fn test_accounts_squash(bencher: &mut Bencher) {
-    let (genesis_config, _) = create_genesis_config(100_000);
+    let (mut genesis_config, _) = create_genesis_config(100_000);
+    genesis_config.rent.burn_percent = 100; // Avoid triggering an assert in Bank::distribute_rent_to_validators()
     let bank1 = Arc::new(Bank::new_with_paths(
         &genesis_config,
         vec![PathBuf::from("bench_a1")],

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8743,6 +8743,7 @@ mod tests {
         );
         genesis_config.creation_time = 0;
         genesis_config.cluster_type = ClusterType::MainnetBeta;
+        genesis_config.rent.burn_percent = 100;
         let mut bank = Arc::new(Bank::new(&genesis_config));
         // Check a few slots, cross an epoch boundary
         assert_eq!(bank.get_slots_in_epoch(0), 32);

--- a/sdk/src/rent.rs
+++ b/sdk/src/rent.rs
@@ -24,7 +24,7 @@ pub const DEFAULT_LAMPORTS_PER_BYTE_YEAR: u64 = 1_000_000_000 / 100 * 365 / (102
 pub const DEFAULT_EXEMPTION_THRESHOLD: f64 = 2.0;
 
 /// default percentage of rent to burn (Valid values are 0 to 100)
-pub const DEFAULT_BURN_PERCENT: u8 = 100;
+pub const DEFAULT_BURN_PERCENT: u8 = 50;
 
 /// account storage overhead for calculation of base rent
 pub const ACCOUNT_STORAGE_OVERHEAD: u64 = 128;


### PR DESCRIPTION
When a new dev cluster is created, it's more helpful to have less than 100% rent burn to exercise more code paths