### PR TITLE
client: simulate_transaction_with_config() now passes full config to server

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -161,26 +161,20 @@ impl RpcClient {
     pub fn simulate_transaction(
         &self,
         transaction: &Transaction,
-        sig_verify: bool,
     ) -> RpcResult<RpcSimulateTransactionResult> {
-        self.simulate_transaction_with_config(
-            transaction,
-            sig_verify,
-            RpcSimulateTransactionConfig::default(),
-        )
+        self.simulate_transaction_with_config(transaction, RpcSimulateTransactionConfig::default())
     }
 
     pub fn simulate_transaction_with_config(
         &self,
         transaction: &Transaction,
-        sig_verify: bool,
         config: RpcSimulateTransactionConfig,
     ) -> RpcResult<RpcSimulateTransactionResult> {
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
         let serialized_encoded = serialize_encode_transaction(transaction, encoding)?;
         self.send(
             RpcRequest::SimulateTransaction,
-            json!([serialized_encoded, { "sigVerify": sig_verify }]),
+            json!([serialized_encoded, config]),
         )
     }
 

--- a/stake-o-matic/src/main.rs
+++ b/stake-o-matic/src/main.rs
@@ -6,8 +6,8 @@ use solana_clap_utils::{
 };
 use solana_cli_output::display::format_labeled_address;
 use solana_client::{
-    client_error, rpc_client::RpcClient, rpc_request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
-    rpc_response::RpcVoteAccountInfo,
+    client_error, rpc_client::RpcClient, rpc_config::RpcSimulateTransactionConfig,
+    rpc_request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS, rpc_response::RpcVoteAccountInfo,
 };
 use solana_metrics::datapoint_info;
 use solana_notifier::Notifier;
@@ -394,7 +394,13 @@ fn simulate_transactions(
     for (mut transaction, memo) in candidate_transactions {
         transaction.message.recent_blockhash = blockhash;
 
-        let sim_result = rpc_client.simulate_transaction(&transaction, false)?;
+        let sim_result = rpc_client.simulate_transaction_with_config(
+            &transaction,
+            RpcSimulateTransactionConfig {
+                sig_verify: false,
+                ..RpcSimulateTransactionConfig::default()
+            },
+        )?;
         if sim_result.value.err.is_some() {
             trace!(
                 "filtering out transaction due to simulation failure: {:?}: {}",


### PR DESCRIPTION
Fixes #12795

@armaniferrante - would you mind confirming this PR works for you instead of https://github.com/project-serum/serum-dex/blob/89ac8ea77b2f0310156578e1ec52add3a7e03e79/common/src/client/rpc.rs#L201?