### PR TITLE
Move no-0-rent rent dist. behavior under feature

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2676,7 +2676,7 @@ impl Bank {
                 } else {
                     rent_share
                 };
-                if rent_to_be_paid > 0 {
+                if !enforce_fix || rent_to_be_paid > 0 {
                     let mut account = self.get_account(&pubkey).unwrap_or_default();
                     account.lamports += rent_to_be_paid;
                     self.store_account(&pubkey, &account);


### PR DESCRIPTION
#### Problem

#12791 introduces differing behavior.

#### Summary of Changes

Properly gate it. Fortunately, we have still not enabled runtime feature (`no_overflow_rent_distribution`); let's free-ride on it

Fixes #12791 
