### PR TITLE
RpcClient: Encode TXs as base64 by default

### DIFF
--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -112,7 +112,7 @@ impl RpcSender for MockSender {
                     Signature::new(&[8; 64]).to_string()
                 } else {
                     let tx_str = params.as_array().unwrap()[0].as_str().unwrap().to_string();
-                    let data = bs58::decode(tx_str).into_vec().unwrap();
+                    let data = base64::decode(tx_str).unwrap();
                     let tx: Transaction = bincode::deserialize(&data).unwrap();
                     tx.signatures[0].to_string()
                 };

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -133,7 +133,11 @@ impl RpcClient {
         transaction: &Transaction,
         config: RpcSendTransactionConfig,
     ) -> ClientResult<Signature> {
-        let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
+        let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base64);
+        let config = RpcSendTransactionConfig {
+            encoding: Some(encoding),
+            ..config
+        };
         let serialized_encoded = serialize_encode_transaction(transaction, encoding)?;
         let signature_base58_str: String = self.send(
             RpcRequest::SendTransaction,
@@ -170,7 +174,11 @@ impl RpcClient {
         transaction: &Transaction,
         config: RpcSimulateTransactionConfig,
     ) -> RpcResult<RpcSimulateTransactionResult> {
-        let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
+        let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base64);
+        let config = RpcSimulateTransactionConfig {
+            encoding: Some(encoding),
+            ..config
+        };
         let serialized_encoded = serialize_encode_transaction(transaction, encoding)?;
         self.send(
             RpcRequest::SimulateTransaction,


### PR DESCRIPTION
#### Problem

`RpcClient` encodes transactions as `base58` despite it being slow and servers supporting `base64`

#### Summary of Changes

Switch `RpcClient` default transaction encoding to `base64`

Towards #12700 
