### PR TITLE
`solana vote-account`/`solana stake-account` now works with RPC servers without `--enable-rpc-transaction-history`

### DIFF
--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -50,10 +50,10 @@ impl Into<TransportError> for ClientErrorKind {
 #[derive(Error, Debug)]
 #[error("{kind}")]
 pub struct ClientError {
-    request: Option<rpc_request::RpcRequest>,
+    pub request: Option<rpc_request::RpcRequest>,
 
     #[source]
-    kind: ClientErrorKind,
+    pub kind: ClientErrorKind,
 }
 
 impl ClientError {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -10,6 +10,7 @@ pub mod perf_utils;
 pub mod pubsub_client;
 pub mod rpc_client;
 pub mod rpc_config;
+pub mod rpc_custom_error;
 pub mod rpc_filter;
 pub mod rpc_request;
 pub mod rpc_response;

--- a/client/src/rpc_custom_error.rs
+++ b/client/src/rpc_custom_error.rs
@@ -4,12 +4,12 @@ use crate::rpc_response::RpcSimulateTransactionResult;
 use jsonrpc_core::{Error, ErrorCode};
 use solana_sdk::clock::Slot;
 
-const JSON_RPC_SERVER_ERROR_1: i64 = -32001;
-const JSON_RPC_SERVER_ERROR_2: i64 = -32002;
-const JSON_RPC_SERVER_ERROR_3: i64 = -32003;
-const JSON_RPC_SERVER_ERROR_4: i64 = -32004;
-const JSON_RPC_SERVER_ERROR_5: i64 = -32005;
-const JSON_RPC_SERVER_ERROR_6: i64 = -32006;
+pub const JSON_RPC_SERVER_ERROR_BLOCK_CLEANED_UP: i64 = -32001;
+pub const JSON_RPC_SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE: i64 = -32002;
+pub const JSON_RPC_SERVER_ERROR_TRANSACTION_SIGNATURE_VERIFICATION_FAILURE: i64 = -32003;
+pub const JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE: i64 = -32004;
+pub const JSON_RPC_SERVER_ERROR_NODE_UNHEALTHLY: i64 = -32005;
+pub const JSON_RPC_SERVER_ERROR_TRANSACTION_PRECOMPILE_VERIFICATION_FAILURE: i64 = -32006;
 
 pub enum RpcCustomError {
     BlockCleanedUp {
@@ -35,7 +35,7 @@ impl From<RpcCustomError> for Error {
                 slot,
                 first_available_block,
             } => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_1),
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_BLOCK_CLEANED_UP),
                 message: format!(
                     "Block {} cleaned up, does not exist on node. First available block: {}",
                     slot, first_available_block,
@@ -43,27 +43,33 @@ impl From<RpcCustomError> for Error {
                 data: None,
             },
             RpcCustomError::SendTransactionPreflightFailure { message, result } => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_2),
+                code: ErrorCode::ServerError(
+                    JSON_RPC_SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+                ),
                 message,
                 data: Some(serde_json::json!(result)),
             },
             RpcCustomError::TransactionSignatureVerificationFailure => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_3),
+                code: ErrorCode::ServerError(
+                    JSON_RPC_SERVER_ERROR_TRANSACTION_SIGNATURE_VERIFICATION_FAILURE,
+                ),
                 message: "Transaction signature verification failure".to_string(),
                 data: None,
             },
             RpcCustomError::BlockNotAvailable { slot } => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_4),
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE),
                 message: format!("Block not available for slot {}", slot),
                 data: None,
             },
             RpcCustomError::RpcNodeUnhealthy => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_5),
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_NODE_UNHEALTHLY),
                 message: "RPC node is unhealthy".to_string(),
                 data: None,
             },
             RpcCustomError::TransactionPrecompileVerificationFailure(e) => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_6),
+                code: ErrorCode::ServerError(
+                    JSON_RPC_SERVER_ERROR_TRANSACTION_SIGNATURE_VERIFICATION_FAILURE,
+                ),
                 message: format!("Transaction precompile verification failure {:?}", e),
                 data: None,
             },

--- a/client/src/rpc_custom_error.rs
+++ b/client/src/rpc_custom_error.rs
@@ -1,5 +1,7 @@
+//! Implementation defined RPC server errors
+
+use crate::rpc_response::RpcSimulateTransactionResult;
 use jsonrpc_core::{Error, ErrorCode};
-use solana_client::rpc_response::RpcSimulateTransactionResult;
 use solana_sdk::clock::Slot;
 
 const JSON_RPC_SERVER_ERROR_1: i64 = -32001;

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -140,8 +140,10 @@ impl RpcRequest {
 
 #[derive(Debug, Error)]
 pub enum RpcError {
-    #[error("rpc request error: {0}")]
+    #[error("RPC request error: {0}")]
     RpcRequestError(String),
+    #[error("RPC response error {code}: {message}")]
+    RpcResponseError { code: i64, message: String },
     #[error("parse error: expected {0}")]
     ParseError(String), /* "expected" */
     // Anything in a `ForUser` needs to die.  The caller should be

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -55,7 +55,6 @@ mod result;
 pub mod retransmit_stage;
 pub mod rewards_recorder_service;
 pub mod rpc;
-pub mod rpc_error;
 pub mod rpc_health;
 pub mod rpc_pubsub;
 pub mod rpc_pubsub_service;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -5,7 +5,6 @@ use crate::{
     contact_info::ContactInfo,
     non_circulating_supply::calculate_non_circulating_supply,
     optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
-    rpc_error::RpcCustomError,
     rpc_health::*,
     send_transaction_service::{SendTransactionService, TransactionInfo},
     validator::ValidatorExit,
@@ -23,6 +22,7 @@ use solana_account_decoder::{
 };
 use solana_client::{
     rpc_config::*,
+    rpc_custom_error::RpcCustomError,
     rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
     rpc_request::{
         TokenAccountsFilter, DELINQUENT_VALIDATOR_SLOT_DISTANCE, MAX_GET_CONFIRMED_BLOCKS_RANGE,


### PR DESCRIPTION
Vote/stake epoch rewards are only fetchable from RPC servers with `--enable-rpc-transaction-history` enabled.  Cleanly handle when this is not the case

Partial fix for #12843 (the cli failure)