### PR TITLE
fix: permit getConfirmedTransaction log messages field to be null

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1128,7 +1128,7 @@ const ConfirmedTransactionMetaResult = struct.union([
     fee: 'number',
     preBalances: struct.array(['number']),
     postBalances: struct.array(['number']),
-    logMessages: struct.union([struct.array(['string']), 'undefined']),
+    logMessages: struct.union([struct.array(['string']), 'null', 'undefined']),
   }),
 ]);
 


### PR DESCRIPTION
Transaction details aren't fetching in the explorer because the ConfirmedTransactionMetaResult superstruct verification doesn't permit `logMessages: null`.  This can occur for older transactions that executed before log message support was enabled.