### PR TITLE
Add transaction log messages to |solana confirm -v| output

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -197,6 +197,15 @@ pub fn write_transaction<W: io::Write>(
                 )?;
             }
         }
+
+        if let Some(log_messages) = &transaction_status.log_messages {
+            if !log_messages.is_empty() {
+                writeln!(w, "{}Log Messages:", prefix,)?;
+                for log_message in log_messages {
+                    writeln!(w, "{}  {}", prefix, log_message,)?;
+                }
+            }
+        }
     } else {
         writeln!(w, "{}Status: Unavailable", prefix)?;
     }


### PR DESCRIPTION
Example:
```
$ solana confirm -v 5FLpQfciuG1ug7CsT239Qg7xvn3jsdooAbWYedHx9ntwRbbyg5LdMhtw6Lz1wsM1AXQAv44tyeB7huCocPgSSdTv
RPC URL: http://api.mainnet-beta.solana.com
Default Signer Path: /Users/mvines/.config/solana/id.json

Transaction executed in slot 41187129:
  Recent Blockhash: EYtRZZPXMjuT81CQqywg1KAMwrASSTysFd4yWHBDJsJT
.
.
.
  Log Messages:
    Call BPF program EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o
    BPF program EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o success
    Call BPF program EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o
    Call BPF program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
    Program log: Instruction: Transfer
    BPF program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
    BPF program EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o success
    Call BPF program EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o
    BPF program EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o success

Confirmed
```