### PR TITLE
terminology update, nonce to bump seed

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -31,9 +31,9 @@ extern uint64_t entrypoint(const uint8_t *input) {
     return ERROR_INVALID_ARGUMENT;
   }
 
-  uint8_t nonce1 = params.data[1];
-  uint8_t nonce2 = params.data[2];
-  uint8_t nonce3 = params.data[3];
+  uint8_t bump_seed1 = params.data[1];
+  uint8_t bump_seed2 = params.data[2];
+  uint8_t bump_seed3 = params.data[3];
 
   switch (params.data[0]) {
   case TEST_SUCCESS: {
@@ -54,7 +54,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
       uint8_t seed1[] = {'Y', 'o', 'u', ' ', 'p', 'a', 's', 's',
                          ' ', 'b', 'u', 't', 't', 'e', 'r'};
       const SolSignerSeed seeds1[] = {{seed1, SOL_ARRAY_SIZE(seed1)},
-                                      {&nonce1, 1}};
+                                      {&bump_seed1, 1}};
       const SolSignerSeeds signers_seeds[] = {{seeds1, SOL_ARRAY_SIZE(seeds1)}};
       sol_assert(SUCCESS == sol_invoke_signed(&instruction, accounts,
                                               SOL_ARRAY_SIZE(accounts),
@@ -144,7 +144,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
       uint8_t seed1[] = {'Y', 'o', 'u', ' ', 'p', 'a', 's', 's',
                          ' ', 'b', 'u', 't', 't', 'e', 'r'};
       const SolSignerSeed seeds1[] = {{seed1, SOL_ARRAY_SIZE(seed1)},
-                                      {&nonce1, 1}};
+                                      {&bump_seed1, 1}};
       SolPubkey address;
       sol_assert(SUCCESS ==
                  sol_create_program_address(seeds1, SOL_ARRAY_SIZE(seeds1),
@@ -163,14 +163,14 @@ extern uint64_t entrypoint(const uint8_t *input) {
           {accounts[DERIVED_KEY1_INDEX].key, true, true},
           {accounts[DERIVED_KEY2_INDEX].key, true, false},
           {accounts[DERIVED_KEY3_INDEX].key, false, false}};
-      uint8_t data[] = {TEST_DERIVED_SIGNERS, nonce2, nonce3};
+      uint8_t data[] = {TEST_DERIVED_SIGNERS, bump_seed2, bump_seed3};
       const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                           arguments, SOL_ARRAY_SIZE(arguments),
                                           data, SOL_ARRAY_SIZE(data)};
       uint8_t seed1[] = {'Y', 'o', 'u', ' ', 'p', 'a', 's', 's',
                          ' ', 'b', 'u', 't', 't', 'e', 'r'};
       const SolSignerSeed seeds1[] = {{seed1, SOL_ARRAY_SIZE(seed1)},
-                                      {&nonce1, 1}};
+                                      {&bump_seed1, 1}};
       const SolSignerSeeds signers_seeds[] = {{seeds1, SOL_ARRAY_SIZE(seeds1)}};
       sol_assert(SUCCESS == sol_invoke_signed(&instruction, accounts,
                                               SOL_ARRAY_SIZE(accounts),

--- a/programs/bpf/c/src/invoked/invoked.c
+++ b/programs/bpf/c/src/invoked/invoked.c
@@ -101,8 +101,8 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_assert(!accounts[DERIVED_KEY2_INDEX].is_signer);
     sol_assert(!accounts[DERIVED_KEY2_INDEX].is_signer);
 
-    uint8_t nonce2 = params.data[1];
-    uint8_t nonce3 = params.data[2];
+    uint8_t bump_seed2 = params.data[1];
+    uint8_t bump_seed3 = params.data[2];
 
     SolAccountMeta arguments[] = {
         {accounts[DERIVED_KEY1_INDEX].key, true, false},
@@ -116,10 +116,10 @@ extern uint64_t entrypoint(const uint8_t *input) {
     uint8_t seed2[] = {'B', 'i', 't', 's'};
     const SolSignerSeed seeds1[] = {{seed1, SOL_ARRAY_SIZE(seed1)},
                                     {seed2, SOL_ARRAY_SIZE(seed2)},
-                                    {&nonce2, 1}};
+                                    {&bump_seed2, 1}};
     const SolSignerSeed seeds2[] = {
         {(uint8_t *)accounts[DERIVED_KEY2_INDEX].key, SIZE_PUBKEY},
-        {&nonce3, 1}};
+        {&bump_seed3, 1}};
     const SolSignerSeeds signers_seeds[] = {{seeds1, SOL_ARRAY_SIZE(seeds1)},
                                             {seeds2, SOL_ARRAY_SIZE(seeds2)}};
 

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -41,9 +41,9 @@ fn process_instruction(
 ) -> ProgramResult {
     info!("invoke Rust program");
 
-    let nonce1 = instruction_data[1];
-    let nonce2 = instruction_data[2];
-    let nonce3 = instruction_data[3];
+    let bump_seed1 = instruction_data[1];
+    let bump_seed2 = instruction_data[2];
+    let bump_seed3 = instruction_data[3];
 
     match instruction_data[0] {
         TEST_SUCCESS => {
@@ -63,7 +63,11 @@ fn process_instruction(
                     MAX_PERMITTED_DATA_INCREASE as u64,
                     program_id,
                 );
-                invoke_signed(&instruction, accounts, &[&[b"You pass butter", &[nonce1]]])?;
+                invoke_signed(
+                    &instruction,
+                    accounts,
+                    &[&[b"You pass butter", &[bump_seed1]]],
+                )?;
 
                 assert_eq!(accounts[FROM_INDEX].lamports(), from_lamports - 42);
                 assert_eq!(accounts[DERIVED_KEY1_INDEX].lamports(), to_lamports + 42);
@@ -143,7 +147,10 @@ fn process_instruction(
             info!("Test create_program_address");
             {
                 assert_eq!(
-                    &Pubkey::create_program_address(&[b"You pass butter", &[nonce1]], program_id)?,
+                    &Pubkey::create_program_address(
+                        &[b"You pass butter", &[bump_seed1]],
+                        program_id
+                    )?,
                     accounts[DERIVED_KEY1_INDEX].key
                 );
                 assert_eq!(
@@ -167,12 +174,12 @@ fn process_instruction(
                         (accounts[DERIVED_KEY2_INDEX].key, true, false),
                         (accounts[DERIVED_KEY3_INDEX].key, false, false),
                     ],
-                    vec![TEST_DERIVED_SIGNERS, nonce2, nonce3],
+                    vec![TEST_DERIVED_SIGNERS, bump_seed2, bump_seed3],
                 );
                 invoke_signed(
                     &invoked_instruction,
                     accounts,
-                    &[&[b"You pass butter", &[nonce1]]],
+                    &[&[b"You pass butter", &[bump_seed1]]],
                 )?;
             }
 

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -118,8 +118,8 @@ fn process_instruction(
             assert!(!accounts[DERIVED_KEY2_INDEX].is_signer);
             assert!(!accounts[DERIVED_KEY3_INDEX].is_signer);
 
-            let nonce2 = instruction_data[1];
-            let nonce3 = instruction_data[2];
+            let bump_seed2 = instruction_data[1];
+            let bump_seed3 = instruction_data[2];
             let invoked_instruction = create_instruction(
                 *accounts[INVOKED_PROGRAM_INDEX].key,
                 &[
@@ -133,8 +133,8 @@ fn process_instruction(
                 &invoked_instruction,
                 accounts,
                 &[
-                    &[b"Lil'", b"Bits", &[nonce2]],
-                    &[accounts[DERIVED_KEY2_INDEX].key.as_ref(), &[nonce3]],
+                    &[b"Lil'", b"Bits", &[bump_seed2]],
+                    &[accounts[DERIVED_KEY2_INDEX].key.as_ref(), &[bump_seed3]],
                 ],
             )?;
         }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -480,11 +480,11 @@ fn test_program_bpf_invoke() {
         let account = Account::new(84, 0, &solana_sdk::system_program::id());
         bank.store_account(&from_keypair.pubkey(), &account);
 
-        let (derived_key1, nonce1) =
+        let (derived_key1, bump_seed1) =
             Pubkey::find_program_address(&[b"You pass butter"], &invoke_program_id);
-        let (derived_key2, nonce2) =
+        let (derived_key2, bump_seed2) =
             Pubkey::find_program_address(&[b"Lil'", b"Bits"], &invoked_program_id);
-        let (derived_key3, nonce3) =
+        let (derived_key3, bump_seed3) =
             Pubkey::find_program_address(&[derived_key2.as_ref()], &invoked_program_id);
 
         let mint_pubkey = mint_keypair.pubkey();
@@ -506,7 +506,7 @@ fn test_program_bpf_invoke() {
 
         let instruction = Instruction::new(
             invoke_program_id,
-            &[TEST_SUCCESS, nonce1, nonce2, nonce3],
+            &[TEST_SUCCESS, bump_seed1, bump_seed2, bump_seed3],
             account_metas.clone(),
         );
         let message = Message::new(&[instruction], Some(&mint_pubkey));
@@ -548,7 +548,7 @@ fn test_program_bpf_invoke() {
 
         let instruction = Instruction::new(
             invoke_program_id,
-            &[TEST_PRIVILEGE_ESCALATION_SIGNER, nonce1, nonce2, nonce3],
+            &[TEST_PRIVILEGE_ESCALATION_SIGNER, bump_seed1, bump_seed2, bump_seed3],
             account_metas.clone(),
         );
         let message = Message::new(&[instruction], Some(&mint_pubkey));
@@ -576,7 +576,7 @@ fn test_program_bpf_invoke() {
 
         let instruction = Instruction::new(
             invoke_program_id,
-            &[TEST_PRIVILEGE_ESCALATION_WRITABLE, nonce1, nonce2, nonce3],
+            &[TEST_PRIVILEGE_ESCALATION_WRITABLE, bump_seed1, bump_seed2, bump_seed3],
             account_metas.clone(),
         );
         let message = Message::new(&[instruction], Some(&mint_pubkey));
@@ -603,7 +603,7 @@ fn test_program_bpf_invoke() {
 
         let instruction = Instruction::new(
             invoke_program_id,
-            &[TEST_PPROGRAM_NOT_EXECUTABLE, nonce1, nonce2, nonce3],
+            &[TEST_PPROGRAM_NOT_EXECUTABLE, bump_seed1, bump_seed2, bump_seed3],
             account_metas.clone(),
         );
         let message = Message::new(&[instruction], Some(&mint_pubkey));


### PR DESCRIPTION
#### Problem

When deriving program addresses an extra seed may be required to push the address off the curve.  The extra seed is called a "nonce" but it's used more than once.

#### Summary of Changes

Call it a "bump seed" instead

Fixes #
