### PR TITLE
Add nop feature set for upcoming ported rent fixes

### DIFF
--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -61,6 +61,10 @@ pub mod timestamp_correction {
     solana_sdk::declare_id!("3zydSLUwuqqsV3wL5wBsaVgyvMox3XTHx7zLEuQf1U2Z");
 }
 
+pub mod cumulative_rent_related_fixes {
+    solana_sdk::declare_id!("FtjnuAtJTWwX3Kx9m24LduNEhzaGuuPfDW6e14SX2Fy5");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -78,6 +82,7 @@ lazy_static! {
         (max_invoke_depth_4::id(), "max invoke call depth 4"),
         (max_program_call_depth_64::id(), "max program call depth 64"),
         (timestamp_correction::id(), "correct bank timestamps"),
+        (cumulative_rent_related_fixes::id(), "rent fixes (#10206, #10468, #11342)"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

we can't simply port halfly-enabled cluster-type based gating to runtime feature

#### Summary of Changes

Firstly populate the feature account on devnet and testnet.

#### release flow

1. release a new version with this pr merged
1. enable the feature on devnet and testnet
1. wait an epoch
1. merge the next pr (#12842), which actually port the various rent fixes.
1. enable the feature on mainnet-beta.

Prepare for #11682, #11545, #10810.
