### PR TITLE
Port various rent fixes to runtime feature

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -144,6 +144,8 @@ impl Accounts {
             let mut payer_index = None;
             let mut tx_rent: TransactionRent = 0;
             let mut accounts = Vec::with_capacity(message.account_keys.len());
+            let fix_rent = feature_set.rent_fix_enabled();
+
             for (i, key) in message.account_keys.iter().enumerate() {
                 let account = if Self::is_non_loader_key(message, key, i) {
                     if payer_index.is_none() {
@@ -163,7 +165,11 @@ impl Accounts {
                                 .map(|(mut account, _)| {
                                     if message.is_writable(i) {
                                         let rent_due = rent_collector
-                                            .collect_from_existing_account(&key, &mut account);
+                                            .collect_from_existing_account(
+                                                &key,
+                                                &mut account,
+                                                fix_rent,
+                                            );
                                         (account, rent_due)
                                     } else {
                                         (account, 0)
@@ -720,6 +726,8 @@ impl Accounts {
     }
 
     /// Store the accounts into the DB
+    // allow(clippy) needed for various gating flags
+    #[allow(clippy::too_many_arguments)]
     pub fn store_accounts(
         &self,
         slot: Slot,
@@ -730,6 +738,7 @@ impl Accounts {
         rent_collector: &RentCollector,
         last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
         fix_recent_blockhashes_sysvar_delay: bool,
+        fix_rent: bool,
     ) {
         let accounts_to_store = self.collect_accounts_to_store(
             txs,
@@ -739,6 +748,7 @@ impl Accounts {
             rent_collector,
             last_blockhash_with_fee_calculator,
             fix_recent_blockhashes_sysvar_delay,
+            fix_rent,
         );
         self.accounts_db.store(slot, &accounts_to_store);
     }
@@ -766,6 +776,7 @@ impl Accounts {
         rent_collector: &RentCollector,
         last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
         fix_recent_blockhashes_sysvar_delay: bool,
+        fix_rent: bool,
     ) -> Vec<(&'a Pubkey, &'a Account)> {
         let mut accounts = Vec::with_capacity(loaded.len());
         for (i, ((raccs, _hash_age_kind), (_, tx))) in loaded
@@ -806,7 +817,8 @@ impl Accounts {
                 );
                 if message.is_writable(i) {
                     if account.rent_epoch == 0 {
-                        acc.2 += rent_collector.collect_from_created_account(&key, account);
+                        acc.2 +=
+                            rent_collector.collect_from_created_account(&key, account, fix_rent);
                     }
                     accounts.push((key, &*account));
                 }
@@ -1122,7 +1134,6 @@ mod tests {
                 lamports_per_byte_year: 42,
                 ..Rent::default()
             },
-            ClusterType::Development,
         );
         let min_balance = rent_collector.rent.minimum_balance(nonce::State::size());
         let fee_calculator = FeeCalculator::new(min_balance);
@@ -1798,6 +1809,7 @@ mod tests {
             &mut loaded,
             &rent_collector,
             &(Hash::default(), FeeCalculator::default()),
+            true,
             true,
         );
         assert_eq!(collected_accounts.len(), 2);

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -131,7 +131,7 @@ impl FeatureSet {
         self.active.contains(feature_id)
     }
 
-    pub fn rent_fix_enabled(&self) -> bool {
+    pub fn cumulative_rent_related_fixes_enabled(&self) -> bool {
         self.is_active(&cumulative_rent_related_fixes::id())
     }
 

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -130,6 +130,11 @@ impl FeatureSet {
     pub fn is_active(&self, feature_id: &Pubkey) -> bool {
         self.active.contains(feature_id)
     }
+
+    pub fn rent_fix_enabled(&self) -> bool {
+        self.is_active(&cumulative_rent_related_fixes::id())
+    }
+
     /// All features enabled, useful for testing
     pub fn all_enabled() -> Self {
         Self {

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -54,7 +54,7 @@ impl RentCollector {
         &self,
         address: &Pubkey,
         account: &mut Account,
-        enable_new_behavior: bool,
+        rent_fix_enabled: bool,
     ) -> u64 {
         if account.executable
             || account.rent_epoch > self.epoch
@@ -81,7 +81,7 @@ impl RentCollector {
             if exempt || rent_due != 0 {
                 if account.lamports > rent_due {
                     account.rent_epoch = self.epoch
-                        + if enable_new_behavior && exempt {
+                        + if rent_fix_enabled && exempt {
                             // Rent isn't collected for the next epoch
                             // Make sure to check exempt status later in curent epoch again
                             0

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -1,13 +1,7 @@
 //! calculate and collect rent from Accounts
 use solana_sdk::{
-    account::Account,
-    clock::Epoch,
-    epoch_schedule::EpochSchedule,
-    genesis_config::{ClusterType, GenesisConfig},
-    incinerator,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar,
+    account::Account, clock::Epoch, epoch_schedule::EpochSchedule, genesis_config::GenesisConfig,
+    incinerator, pubkey::Pubkey, rent::Rent, sysvar,
 };
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, AbiExample)]
@@ -16,11 +10,6 @@ pub struct RentCollector {
     pub epoch_schedule: EpochSchedule,
     pub slots_per_year: f64,
     pub rent: Rent,
-    // serde(skip) is needed not to break abi
-    // Also, wrap this with Option so that we can spot any uninitialized codepath (like
-    // snapshot restore)
-    #[serde(skip)]
-    pub cluster_type: Option<ClusterType>,
 }
 
 impl Default for RentCollector {
@@ -31,7 +20,6 @@ impl Default for RentCollector {
             // derive default value using GenesisConfig::default()
             slots_per_year: GenesisConfig::default().slots_per_year(),
             rent: Rent::default(),
-            cluster_type: Option::default(),
         }
     }
 }
@@ -42,31 +30,19 @@ impl RentCollector {
         epoch_schedule: &EpochSchedule,
         slots_per_year: f64,
         rent: &Rent,
-        cluster_type: ClusterType,
     ) -> Self {
         Self {
             epoch,
             epoch_schedule: *epoch_schedule,
             slots_per_year,
             rent: *rent,
-            cluster_type: Some(cluster_type),
         }
     }
 
-    pub fn clone_with_epoch(&self, epoch: Epoch, cluster_type: ClusterType) -> Self {
+    pub fn clone_with_epoch(&self, epoch: Epoch) -> Self {
         Self {
             epoch,
-            cluster_type: Some(cluster_type),
             ..self.clone()
-        }
-    }
-
-    fn enable_new_behavior(&self) -> bool {
-        match self.cluster_type.unwrap() {
-            ClusterType::Development => true,
-            ClusterType::Devnet => true,
-            ClusterType::Testnet => self.epoch >= 97,
-            ClusterType::MainnetBeta => self.epoch >= Epoch::max_value(),
         }
     }
 
@@ -74,7 +50,12 @@ impl RentCollector {
     //  the account rent collected, if any
     //
     #[must_use = "add to Bank::collected_rent"]
-    pub fn collect_from_existing_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
+    pub fn collect_from_existing_account(
+        &self,
+        address: &Pubkey,
+        account: &mut Account,
+        enable_new_behavior: bool,
+    ) -> u64 {
         if account.executable
             || account.rent_epoch > self.epoch
             || sysvar::check_id(&account.owner)
@@ -100,7 +81,7 @@ impl RentCollector {
             if exempt || rent_due != 0 {
                 if account.lamports > rent_due {
                     account.rent_epoch = self.epoch
-                        + if self.enable_new_behavior() && exempt {
+                        + if enable_new_behavior && exempt {
                             // Rent isn't collected for the next epoch
                             // Make sure to check exempt status later in curent epoch again
                             0
@@ -123,10 +104,15 @@ impl RentCollector {
     }
 
     #[must_use = "add to Bank::collected_rent"]
-    pub fn collect_from_created_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
+    pub fn collect_from_created_account(
+        &self,
+        address: &Pubkey,
+        account: &mut Account,
+        enable_new_behavior: bool,
+    ) -> u64 {
         // initialize rent_epoch as created at this epoch
         account.rent_epoch = self.epoch;
-        self.collect_from_existing_account(address, account)
+        self.collect_from_existing_account(address, account, enable_new_behavior)
     }
 }
 
@@ -148,19 +134,24 @@ mod tests {
             (account.clone(), account)
         };
 
-        let rent_collector =
-            RentCollector::default().clone_with_epoch(new_epoch, ClusterType::Development);
+        let rent_collector = RentCollector::default().clone_with_epoch(new_epoch);
 
         // collect rent on a newly-created account
-        let collected =
-            rent_collector.collect_from_created_account(&Pubkey::new_rand(), &mut created_account);
+        let collected = rent_collector.collect_from_created_account(
+            &Pubkey::new_rand(),
+            &mut created_account,
+            true,
+        );
         assert!(created_account.lamports < old_lamports);
         assert_eq!(created_account.lamports + collected, old_lamports);
         assert_ne!(created_account.rent_epoch, old_epoch);
 
         // collect rent on a already-existing account
-        let collected = rent_collector
-            .collect_from_existing_account(&Pubkey::new_rand(), &mut existing_account);
+        let collected = rent_collector.collect_from_existing_account(
+            &Pubkey::new_rand(),
+            &mut existing_account,
+            true,
+        );
         assert!(existing_account.lamports < old_lamports);
         assert_eq!(existing_account.lamports + collected, old_lamports);
         assert_ne!(existing_account.rent_epoch, old_epoch);
@@ -183,11 +174,10 @@ mod tests {
         assert_eq!(account.rent_epoch, 0);
 
         // create a tested rent collector
-        let rent_collector =
-            RentCollector::default().clone_with_epoch(epoch, ClusterType::Development);
+        let rent_collector = RentCollector::default().clone_with_epoch(epoch);
 
         // first mark account as being collected while being rent-exempt
-        collected = rent_collector.collect_from_existing_account(&pubkey, &mut account);
+        collected = rent_collector.collect_from_existing_account(&pubkey, &mut account, true);
         assert_eq!(account.lamports, huge_lamports);
         assert_eq!(collected, 0);
 
@@ -195,7 +185,7 @@ mod tests {
         account.lamports = tiny_lamports;
 
         // ... and trigger another rent collection on the same epoch and check that rent is working
-        collected = rent_collector.collect_from_existing_account(&pubkey, &mut account);
+        collected = rent_collector.collect_from_existing_account(&pubkey, &mut account, true);
         assert_eq!(account.lamports, tiny_lamports - collected);
         assert_ne!(collected, 0);
     }


### PR DESCRIPTION
#### Problem

low priority various rent fixes still uses obsolete cluster type based gating.

#### Summary of Changes

port it to runtime feature.

because these fixes are active or inactive depending on clusters, we have to be careful to transition.... so #12841 must go first as a prior version update.

Fixes #11682, fixes #11545, fixes #10810.