### PR TITLE
Make bpf instruction tuner slower

### DIFF
--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -210,7 +210,26 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     let instruction_meter = MockInstructionMeter { compute_meter };
 
     let mut measure = Measure::start("tune");
-    let _ = vm.execute_program_metered(&mut [0], &[], &[], instruction_meter.clone());
+
+    let accounts = [RefCell::new(Account::new(1, 10000001, &Pubkey::new_rand()))];
+    let keys = [Pubkey::new_rand()];
+    let keyed_accounts: Vec<_> = keys
+        .iter()
+        .zip(&accounts)
+        .map(|(key, account)| solana_sdk::account::KeyedAccount::new(&key, false, &account))
+        .collect();
+    let instruction_data = vec![0u8];
+
+    // Serialize account data
+    let mut serialized = solana_bpf_loader_program::serialization::serialize_parameters(
+        &bpf_loader::id(),
+        &Pubkey::new_rand(),
+        &keyed_accounts,
+        &instruction_data,
+    )
+    .unwrap();
+
+    let r = vm.execute_program_metered(&mut serialized, &[], &[], instruction_meter.clone());
     measure.stop();
     assert_eq!(
         0,

--- a/programs/bpf/c/src/tuner/tuner.c
+++ b/programs/bpf/c/src/tuner/tuner.c
@@ -8,15 +8,22 @@
 
 #include <solana_sdk.h>
 
+#define NUM_KA 1
+
 extern uint64_t entrypoint(const uint8_t *input) {
-  uint8_t *val = (uint8_t *)input;
+  SolAccountInfo ka[NUM_KA];
+  SolParameters params = (SolParameters) { .ka = ka };
+  if (!sol_deserialize(input, &params, SOL_ARRAY_SIZE(ka))) {
+      return ERROR_INVALID_ARGUMENT;
+  }
+  uint8_t *val = (uint8_t *)ka[0].data;
+  size_t current = 1;
   for (uint64_t i = 0; i < UINT64_MAX; i++) {
 
     // Uncomment for raw compute
     {
-      if (*val != 0) {
-        *val = *val + 1;
-      }
+      *val ^= val[current % 10000001] + 13181312;
+      current *= 12345678;
     }
 
     // // Uncomment for SHA256 syscall


### PR DESCRIPTION
#### Problem

BPF instruction tuner `tuner.c` is very fast because it touches the same cached memory location each iteration.

#### Summary of Changes

Create a larger ~10mb size input account and randomly sample from it.

Fixes #
