### PR TITLE
Calculate accounts hash async in accounts background service

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -51,6 +51,10 @@ impl SnapshotRequestHandler {
                     status_cache_slot_deltas,
                 } = snapshot_request;
 
+                let mut hash_time = Measure::start("hash_time");
+                snapshot_root_bank.update_accounts_hash();
+                hash_time.stop();
+
                 let mut shrink_time = Measure::start("shrink_time");
                 snapshot_root_bank.process_stale_slot_with_budget(0, SHRUNKEN_ACCOUNT_PER_INTERVAL);
                 shrink_time.stop();
@@ -97,7 +101,8 @@ impl SnapshotRequestHandler {
                         "purge_old_snapshots_time",
                         purge_old_snapshots_time.as_us(),
                         i64
-                    )
+                    ),
+                    ("hash_time", hash_time.as_us(), i64),
                 );
                 snapshot_root_bank.block_height()
             })

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1929,6 +1929,7 @@ impl AccountsDB {
 
     fn calculate_accounts_hash(
         &self,
+        slot: Slot,
         ancestors: &Ancestors,
         check_hash: bool,
     ) -> Result<(Hash, u64), BankHashVerificationError> {
@@ -1941,7 +1942,8 @@ impl AccountsDB {
         let hashes: Vec<_> = keys
             .par_iter()
             .filter_map(|pubkey| {
-                if let Some((list, index)) = accounts_index.get(pubkey, Some(ancestors), None) {
+                if let Some((list, index)) = accounts_index.get(pubkey, Some(ancestors), Some(slot))
+                {
                     let (slot, account_info) = &list[index];
                     if account_info.lamports != 0 {
                         storage
@@ -2011,7 +2013,9 @@ impl AccountsDB {
     }
 
     pub fn update_accounts_hash(&self, slot: Slot, ancestors: &Ancestors) -> (Hash, u64) {
-        let (hash, total_lamports) = self.calculate_accounts_hash(ancestors, false).unwrap();
+        let (hash, total_lamports) = self
+            .calculate_accounts_hash(slot, ancestors, false)
+            .unwrap();
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
         bank_hash_info.snapshot_hash = hash;
@@ -2027,7 +2031,7 @@ impl AccountsDB {
         use BankHashVerificationError::*;
 
         let (calculated_hash, calculated_lamports) =
-            self.calculate_accounts_hash(ancestors, true)?;
+            self.calculate_accounts_hash(slot, ancestors, true)?;
 
         if calculated_lamports != total_lamports {
             warn!(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -216,8 +216,6 @@ impl BankForks {
                 bank.squash();
                 is_root_bank_squashed = bank_slot == root;
 
-                bank.update_accounts_hash();
-
                 if self.snapshot_config.is_some() && snapshot_request_sender.is_some() {
                     let snapshot_root_bank = self.root_bank().clone();
                     let root_slot = snapshot_root_bank.slot();


### PR DESCRIPTION
#### Problem

Full accounts hash is computed synchronously in bank_forks::set_root which blocks other replay processing and voting.

#### Summary of Changes

Calculate hash async in accounts background service. Use the max_root parameter such that a potential future root doesn't affect the result of the calculation.

Fixes #
