### PR TITLE
fix: createProgramAddress now throws on an invalid seed length

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -3,6 +3,7 @@ declare module '@solana/web3.js' {
   import * as BufferLayout from 'buffer-layout';
 
   // === src/publickey.js ===
+  export const MAX_SEED_LENGTH: number;
   export type PublicKeyNonce = [PublicKey, number];
   export class PublicKey {
     constructor(value: number | string | Buffer | Uint8Array | Array<number>);

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -16,6 +16,7 @@ import {PublicKey} from './src/publickey';
 
 declare module '@solana/web3.js' {
   // === src/publickey.js ===
+  declare export var MAX_SEED_LENGTH: number;
   declare export type PublicKeyNonce = [PublicKey, number];
   declare export class PublicKey {
     constructor(

--- a/web3.js/src/index.js
+++ b/web3.js/src/index.js
@@ -6,7 +6,7 @@ export {Connection} from './connection';
 export {Loader} from './loader';
 export {Message} from './message';
 export {NonceAccount, NONCE_ACCOUNT_LENGTH} from './nonce-account';
-export {PublicKey} from './publickey';
+export {MAX_SEED_LENGTH, PublicKey} from './publickey';
 export {
   STAKE_CONFIG_ID,
   Authorized,

--- a/web3.js/src/publickey.js
+++ b/web3.js/src/publickey.js
@@ -11,6 +11,11 @@ let naclLowLevel = nacl.lowlevel;
 type PublicKeyNonce = [PublicKey, number]; // This type exists to workaround an esdoc parse error
 
 /**
+ * Maximum length of derived pubkey seed
+ */
+export const MAX_SEED_LENGTH = 32;
+
+/**
  * A public key
  */
 export class PublicKey {
@@ -97,6 +102,9 @@ export class PublicKey {
   ): Promise<PublicKey> {
     let buffer = Buffer.alloc(0);
     seeds.forEach(function (seed) {
+      if (seed.length > MAX_SEED_LENGTH) {
+        throw new Error(`Max seed length exceeded`);
+      }
       buffer = Buffer.concat([buffer, Buffer.from(seed)]);
     });
     buffer = Buffer.concat([

--- a/web3.js/test/publickey.test.js
+++ b/web3.js/test/publickey.test.js
@@ -1,7 +1,7 @@
 // @flow
 import BN from 'bn.js';
 
-import {PublicKey} from '../src/publickey';
+import {PublicKey, MAX_SEED_LENGTH} from '../src/publickey';
 
 test('invalid', () => {
   expect(() => {
@@ -278,6 +278,13 @@ test('createProgramAddress', async () => {
     programId,
   );
   expect(programAddress.equals(programAddress2)).toBe(false);
+
+  await expect(
+    PublicKey.createProgramAddress(
+      [Buffer.alloc(MAX_SEED_LENGTH + 1)],
+      programId,
+    ),
+  ).rejects.toThrow('Max seed length exceeded');
 
   // https://github.com/solana-labs/solana/issues/11950
   {


### PR DESCRIPTION
solana-web3.js's `createProgramAddress` now throws like `Pubkey::create_program_address` does when the input seed is too long.