### PR TITLE
Don't report RewardType::Fee when none was awarded

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1484,14 +1484,16 @@ impl Bank {
             );
 
             let post_balance = self.deposit(&self.collector_id, unburned);
-            self.rewards.write().unwrap().push((
-                self.collector_id,
-                RewardInfo {
-                    reward_type: RewardType::Fee,
-                    lamports: unburned as i64,
-                    post_balance,
-                },
-            ));
+            if unburned != 0 {
+                self.rewards.write().unwrap().push((
+                    self.collector_id,
+                    RewardInfo {
+                        reward_type: RewardType::Fee,
+                        lamports: unburned as i64,
+                        post_balance,
+                    },
+                ));
+            }
             self.capitalization.fetch_sub(burned, Relaxed);
         }
     }


### PR DESCRIPTION
`solana block` on mainnet-beta is reporting unhelpful rewards such as:
```
Rewards:
  Address                                            Type        Amount           New Balance           Percent Change
  Awes4Tr6TX8JDzEhCZY2QVNimT6iD1zWHzf1vNyGvpLM        fee        ◎0.000000000     ◎314.357516520          0.000000000%
```
If there's no unburned fee, skip posting the fee reward