### PR TITLE
Add log_messages to proto file

### DIFF
--- a/storage-bigtable/proto/solana.bigtable.confirmed_block.rs
+++ b/storage-bigtable/proto/solana.bigtable.confirmed_block.rs
@@ -59,8 +59,8 @@ pub struct TransactionStatusMeta {
     pub post_balances: ::std::vec::Vec<u64>,
     #[prost(message, repeated, tag = "5")]
     pub inner_instructions: ::std::vec::Vec<InnerInstructions>,
-    #[prost(message, repeated, tag = "6")]
-    pub log_messages: ::std::vec::Vec<String>,
+    #[prost(string, repeated, tag = "6")]
+    pub log_messages: ::std::vec::Vec<std::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionError {

--- a/storage-bigtable/src/confirmed_block.proto
+++ b/storage-bigtable/src/confirmed_block.proto
@@ -40,6 +40,7 @@ message TransactionStatusMeta {
     repeated uint64 pre_balances = 3;
     repeated uint64 post_balances = 4;
     repeated InnerInstructions inner_instructions = 5;
+    repeated string log_messages = 6;
 }
 
 message TransactionError {


### PR DESCRIPTION
#### Problem
Rebuilding `storage-bigtable/src/confirmed_block.proto` breaks `generated::TransactionStatusMeta` because it is regenerated without the `log_messages` field. `log_messages` was added into proto/solana.bigtable.confirmed_block.rs by hand. 

#### Summary of Changes
Add `log_messages` to confirmed_block.proto
