### PR TITLE
passes through feature-set to gossip requests handling

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -52,6 +52,7 @@ use solana_perf::packet::{
 };
 use solana_rayon_threadlimit::get_thread_count;
 use solana_runtime::bank_forks::BankForks;
+use solana_runtime::feature_set::{self, FeatureSet};
 use solana_sdk::hash::Hash;
 use solana_sdk::{
     clock::{Slot, DEFAULT_MS_PER_SLOT, DEFAULT_SLOTS_PER_EPOCH},
@@ -1651,6 +1652,7 @@ impl ClusterInfo {
         stakes: &HashMap<Pubkey, u64>,
         packets: Packets,
         response_sender: &PacketSender,
+        feature_set: Option<&FeatureSet>,
         epoch_time_ms: u64,
     ) {
         // iter over the packets, collect pulls separately and process everything else
@@ -1781,7 +1783,7 @@ impl ClusterInfo {
             self.stats
                 .pull_requests_count
                 .add_relaxed(gossip_pull_data.len() as u64);
-            let rsp = self.handle_pull_requests(recycler, gossip_pull_data, stakes);
+            let rsp = self.handle_pull_requests(recycler, gossip_pull_data, stakes, feature_set);
             if let Some(rsp) = rsp {
                 let _ignore_disconnect = response_sender.send(rsp);
             }
@@ -1809,7 +1811,13 @@ impl ClusterInfo {
         recycler: &PacketsRecycler,
         requests: Vec<PullData>,
         stakes: &HashMap<Pubkey, u64>,
+        feature_set: Option<&FeatureSet>,
     ) -> Option<Packets> {
+        if matches!(feature_set, Some(feature_set) if
+                    feature_set.is_active(&feature_set::pull_request_ping_pong_check::id()))
+        {
+            // TODO: add ping-pong check on pull-request addresses.
+        }
         // split the requests into addrs and filters
         let mut caller_and_filters = vec![];
         let mut addrs = vec![];
@@ -2114,12 +2122,13 @@ impl ClusterInfo {
         recycler: &PacketsRecycler,
         response_sender: &PacketSender,
         stakes: HashMap<Pubkey, u64>,
+        feature_set: Option<&FeatureSet>,
         epoch_time_ms: u64,
     ) {
         let sender = response_sender.clone();
         thread_pool.install(|| {
             requests.into_par_iter().for_each_with(sender, |s, reqs| {
-                self.handle_packets(&recycler, &stakes, reqs, s, epoch_time_ms)
+                self.handle_packets(&recycler, &stakes, reqs, s, feature_set, epoch_time_ms)
             });
         });
     }
@@ -2153,13 +2162,22 @@ impl ClusterInfo {
         }
 
         let (stakes, epoch_time_ms) = Self::get_stakes_and_epoch_time(bank_forks);
-
+        let feature_set = bank_forks.map(|bank_forks| {
+            bank_forks
+                .read()
+                .unwrap()
+                .working_bank()
+                .deref()
+                .feature_set
+                .clone()
+        });
         self.process_packets(
             requests,
             thread_pool,
             recycler,
             response_sender,
             stakes,
+            feature_set.as_deref(),
             epoch_time_ms,
         );
 

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2162,11 +2162,14 @@ impl ClusterInfo {
         }
 
         let (stakes, epoch_time_ms) = Self::get_stakes_and_epoch_time(bank_forks);
+        // Using root_bank instead of working_bank here so that an enbaled
+        // feature does not roll back (if the feature happens to get enabled in
+        // a minority fork).
         let feature_set = bank_forks.map(|bank_forks| {
             bank_forks
                 .read()
                 .unwrap()
-                .working_bank()
+                .root_bank()
                 .deref()
                 .feature_set
                 .clone()

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -69,6 +69,10 @@ pub mod pubkey_log_syscall_enabled {
     solana_sdk::declare_id!("MoqiU1vryuCGQSxFKA1SZ316JdLEFFhoAu6cKUNk7dN");
 }
 
+pub mod pull_request_ping_pong_check {
+    solana_sdk::declare_id!("5RzEHTnf6D7JPZCvwEzjM19kzBsyjSU3HoMfXaQmVgnZ");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -88,6 +92,7 @@ lazy_static! {
         (timestamp_correction::id(), "correct bank timestamps"),
         (cumulative_rent_related_fixes::id(), "rent fixes (#10206, #10468, #11342)"),
         (pubkey_log_syscall_enabled::id(), "pubkey log syscall"),
+        (pull_request_ping_pong_check::id(), "ping-pong packet check #12794"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
For https://github.com/solana-labs/solana/pull/12794 we want to activate ping/pong check of addresses dynamically once super majority of nodes have updated to the new code. see: https://github.com/solana-labs/solana/pull/12794#discussion_r503683449

#### Summary of Changes
The commit adds a new feature id for ping/pong check and passes through the feature-set construct down to request handler.
