### PR TITLE
Re-use accounts stores

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4535,6 +4535,19 @@ pub mod tests {
     }
 
     #[test]
+    fn test_storage_finder() {
+        solana_logger::setup();
+        let db = AccountsDB::new_sized(Vec::new(), 16 * 1024);
+        let key = Pubkey::new_rand();
+        let lamports = 100;
+        let data_len = 8190;
+        let account = Account::new(lamports, data_len, &Pubkey::new_rand());
+        // pre-populate with a smaller empty store
+        db.create_and_insert_store(1, 8192);
+        db.store(1, &[(&key, &account)]);
+    }
+
+    #[test]
     fn test_get_snapshot_storages_empty() {
         let db = AccountsDB::new(Vec::new(), &ClusterType::Development);
         assert!(db.get_snapshot_storages(0).is_empty());

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1445,7 +1445,7 @@ impl AccountsDB {
             let mut found_store = None;
             let mut recycle_stores = self.recycle_stores.write().unwrap();
             for (i, store) in recycle_stores.iter().enumerate() {
-                if store.accounts.capacity() > size as u64 {
+                if Arc::strong_count(store) == 1 && store.accounts.capacity() > size as u64 {
                     found_store = Some(recycle_stores.swap_remove(i));
                     break;
                 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7732,6 +7732,7 @@ mod tests {
 
     #[test]
     fn test_status_cache_ancestors() {
+        solana_logger::setup();
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
         let parent = Arc::new(Bank::new(&genesis_config));
         let bank1 = Arc::new(new_from_parent(&parent));

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -275,8 +275,8 @@ where
         for (slot, entries) in storage.into_iter() {
             let sub_map = map.entry(slot).or_insert_with(HashMap::new);
             for entry in entries.into_iter() {
-                let mut entry: AccountStorageEntry = entry.into();
-                entry.slot = slot;
+                let entry: AccountStorageEntry = entry.into();
+                entry.slot.store(slot, Ordering::Relaxed);
                 sub_map.insert(entry.id, Arc::new(entry));
             }
         }

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -277,7 +277,7 @@ where
             for entry in entries.into_iter() {
                 let entry: AccountStorageEntry = entry.into();
                 entry.slot.store(slot, Ordering::Relaxed);
-                sub_map.insert(entry.id, Arc::new(entry));
+                sub_map.insert(entry.append_vec_id(), Arc::new(entry));
             }
         }
         map
@@ -306,7 +306,8 @@ where
 
                 // Move the corresponding AppendVec from the snapshot into the directory pointed
                 // at by `local_dir`
-                let append_vec_relative_path = AppendVec::new_relative_path(slot, storage_entry.id);
+                let append_vec_relative_path =
+                    AppendVec::new_relative_path(slot, storage_entry.append_vec_id());
                 let append_vec_abs_path = stream_append_vecs_path
                     .as_ref()
                     .join(&append_vec_relative_path);

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -235,7 +235,7 @@ impl<'a> TypeContext<'a> for Context {
             serialize_iter_as_map(serializable_db.account_storage_entries.iter().map(|x| {
                 *entry_count.borrow_mut() += x.len();
                 (
-                    x.first().unwrap().slot,
+                    x.first().unwrap().slot(),
                     serialize_iter_as_seq(
                         x.iter()
                             .map(|x| Self::SerializableAccountStorageEntry::from(x.as_ref())),

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -18,7 +18,7 @@ impl solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableAccountStora
 impl From<&AccountStorageEntry> for SerializableAccountStorageEntry {
     fn from(rhs: &AccountStorageEntry) -> Self {
         Self {
-            id: rhs.id,
+            id: rhs.append_vec_id(),
             accounts_current_len: rhs.accounts.len(),
         }
     }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -27,11 +27,9 @@ fn copy_append_vecs<P: AsRef<Path>>(
     let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value());
     for storage in storage_entries.iter().flatten() {
         let storage_path = storage.get_path();
-        let output_path = output_dir.as_ref().join(
-            storage_path
-                .file_name()
-                .expect("Invalid AppendVec file path"),
-        );
+        let output_path = output_dir
+            .as_ref()
+            .join(AppendVec::new_relative_path(storage.slot(), storage.id));
 
         std::fs::copy(storage_path, output_path)?;
     }

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -27,9 +27,10 @@ fn copy_append_vecs<P: AsRef<Path>>(
     let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value());
     for storage in storage_entries.iter().flatten() {
         let storage_path = storage.get_path();
-        let output_path = output_dir
-            .as_ref()
-            .join(AppendVec::new_relative_path(storage.slot(), storage.id));
+        let output_path = output_dir.as_ref().join(AppendVec::new_relative_path(
+            storage.slot(),
+            storage.append_vec_id(),
+        ));
 
         std::fs::copy(storage_path, output_path)?;
     }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -251,9 +251,7 @@ pub fn archive_snapshot_package(snapshot_package: &AccountsPackage) -> Result<()
         storage.flush()?;
         let storage_path = storage.get_path();
         let output_path = staging_accounts_dir.join(
-            storage_path
-                .file_name()
-                .expect("Invalid AppendVec file path"),
+            crate::append_vec::AppendVec::new_relative_path(storage.slot(), storage.id),
         );
 
         // `storage_path` - The file path where the AppendVec itself is located

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -250,9 +250,11 @@ pub fn archive_snapshot_package(snapshot_package: &AccountsPackage) -> Result<()
     for storage in snapshot_package.storages.iter().flatten() {
         storage.flush()?;
         let storage_path = storage.get_path();
-        let output_path = staging_accounts_dir.join(
-            crate::append_vec::AppendVec::new_relative_path(storage.slot(), storage.id),
-        );
+        let output_path =
+            staging_accounts_dir.join(crate::append_vec::AppendVec::new_relative_path(
+                storage.slot(),
+                storage.append_vec_id(),
+            ));
 
         // `storage_path` - The file path where the AppendVec itself is located
         // `output_path` - The directory where the AppendVec will be placed in the staging directory.


### PR DESCRIPTION
#### Problem

File/mmap creation can be expensive (100s of ms) and mmap deletion causes a flush to disk which increases unnecessary writes to disk when that data is not actually needed.

#### Summary of Changes

Save stores for re-use later.

Fixes #
