### PR TITLE
CI: Warn when setting up a buildkite agent with no SSH authorized_keys

### DIFF
--- a/ci/setup-new-buildkite-agent/setup-new-machine.sh
+++ b/ci/setup-new-buildkite-agent/setup-new-machine.sh
@@ -7,6 +7,7 @@ SOLANA_ROOT="$HERE"/../..
 source "$HERE"/utils.sh
 
 ensure_env || exit 1
+check_ssh_authorized_keys || exit 1
 
 set -ex
 

--- a/ci/setup-new-buildkite-agent/setup-ssh.sh
+++ b/ci/setup-new-buildkite-agent/setup-ssh.sh
@@ -6,6 +6,11 @@ HERE="$(dirname "$0")"
 source "$HERE"/utils.sh
 
 ensure_env || exit 1
+# This is a last ditch effort to prevent the caller from locking themselves
+# out of the machine. Exiting here will likely leave the system in some
+# half-configured state. To prevent this, duplicate the next line at the top
+# of the entrypoint script.
+check_ssh_authorized_keys || exit 1
 
 set -xe
 # Setup sshd

--- a/ci/setup-new-buildkite-agent/utils.sh
+++ b/ci/setup-new-buildkite-agent/utils.sh
@@ -14,3 +14,33 @@ ensure_env() {
   $RC
 }
 
+# Some scripts disable SSH password logins. If no one hash setup authorized_keys
+# this will result in the machine being remotely inaccessible. Check that the
+# user running this script has setup their keys
+check_ssh_authorized_keys() {
+  declare rc=false
+  declare user_home=
+  if [[ -n "$SUDO_USER" ]]; then
+    declare user uid gid home
+    declare passwd_entry
+    passwd_entry="$(grep "$SUDO_USER:[^:]*:$SUDO_UID:$SUDO_GID" /etc/passwd)"
+    IFS=: read -r user _ uid gid _ home _ <<<"$passwd_entry"
+    if [[ "$user" == "$SUDO_USER" && "$uid" == "$SUDO_UID" && "$gid" == "$SUDO_GID" ]]; then
+      user_home="$home"
+    fi
+  else
+    user_home="$HOME"
+  fi
+  declare authorized_keys="${user_home}/.ssh/authorized_keys"
+  if [[ -n "$user_home" ]]; then
+    [[ -s "$authorized_keys" ]] && rc=true
+  fi
+  if ! $rc; then
+    echo "ERROR! This script will disable SSH password logins and you don't"
+    echo "appear to have set up any authorized keys.  Please add you SSH"
+    echo "public key to ${authorized_keys} before continuing!"
+  fi
+  $rc
+}
+
+check_ssh_authorized_keys


### PR DESCRIPTION
#### Problem

The buildkite agent setup scripts disable SSH password logins, but don't check that the calling user has `authorized_keys` set up, leading to lockout.

#### Summary of Changes

Check for a non-empty `~/.ssh/authorized_keys` and bail if not