### PR TITLE
Release: Use pinned cargo version to install spl-token-cli

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -112,7 +112,8 @@ mkdir -p "$installDir/bin"
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
   $cargo $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
-  $cargo install spl-token-cli --root "$installDir"
+  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
+  $cargo $maybeRustVersion install spl-token-cli --root "$installDir"
 )
 
 for bin in "${BINS[@]}"; do


### PR DESCRIPTION
#### Problem

When adding `spl-token-cli` to the release tarball, we us the default cargo version, which may lead to build errors upon new Rust releases

#### Summary of Changes

Use pinned cargo instead

cc/ @ryoqun 