### PR TITLE
Support arbitrary toolchains with cargo wrapper script

### DIFF
--- a/cargo
+++ b/cargo
@@ -17,6 +17,10 @@ case "$1" in
     toolchain="$rust_nightly"
     shift
     ;;
+  +*)
+    toolchain="${1#+}"
+    shift
+    ;;
   *)
     # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
     toolchain="$rust_stable"


### PR DESCRIPTION
#### Problem

`cargo` wrapper script is _limited_ to the pinned toolchains, which isn't very ergonomic

#### Summary of Changes

Support the usual `+toolchain` syntax in `$1`