### PR TITLE
Update get-block method in get_confirmed_transaction

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -342,9 +342,7 @@ impl LedgerStorage {
             .await?;
 
         // Load the block and return the transaction
-        let block = bigtable
-            .get_bincode_cell::<StoredConfirmedBlock>("blocks", slot_to_key(slot))
-            .await?;
+        let block = self.get_confirmed_block(slot).await?;
         match block.transactions.into_iter().nth(index as usize) {
             None => {
                 warn!("Transaction info for {} is corrupt", signature);

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -358,7 +358,7 @@ impl LedgerStorage {
                 } else {
                     Ok(Some(ConfirmedTransaction {
                         slot,
-                        transaction: bucket_block_transaction.into(),
+                        transaction: bucket_block_transaction,
                     }))
                 }
             }


### PR DESCRIPTION
#### Problem
Some transactions are showing up in explorer without details. These are older transactions that have been pruned from Blockstore, but new enough that their containing block was encoded for bigtable using protobuf.

The bigtable `get_confirmed_transaction` method is erroneously assuming that all blocks will use bincode encoding, so loading the full block fails for protobuf blocks.

#### Summary of Changes
Use `get_confirmed_block` instead, as it correctly handles loading protobuf or bincode blocks.

Fixes #12908 
