### PR TITLE
CLI: Put `deploy` ephemeral keypair behind a flag

### DIFF
--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -64,6 +64,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: None,
         use_deprecated_loader: false,
+        random_address: true,
     };
 
     let response = process_command(&config);
@@ -98,6 +99,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
+        random_address: false,
     };
     process_command(&config).unwrap();
     let account1 = rpc_client


### PR DESCRIPTION
#### Problem

`solana deploy` falls back to an ephemeral address keypair if the user doesn't supply one.  Since the user doesn't have the keypair, failed deploys can't be retried, leading to bricked accounts

#### Summary of Changes

Gate ephemeral keypair fallback behind a flag (`--random-address`)

Fixes #12938 
