### PR TITLE
feat: add Secp256k1 support to solana-web3.js

### DIFF
--- a/web3.js/flow-typed/keccak.js
+++ b/web3.js/flow-typed/keccak.js
@@ -1,0 +1,4 @@
+declare module 'keccak' {
+  // TODO: Fill in types
+  declare module.exports: any;
+}

--- a/web3.js/flow-typed/secp256k1.js
+++ b/web3.js/flow-typed/secp256k1.js
@@ -1,0 +1,4 @@
+declare module 'secp256k1' {
+  // TODO: Fill in types
+  declare module.exports: any;
+}

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -531,6 +531,7 @@ declare module '@solana/web3.js' {
   export const SYSVAR_RENT_PUBKEY: PublicKey;
   export const SYSVAR_REWARDS_PUBKEY: PublicKey;
   export const SYSVAR_STAKE_HISTORY_PUBKEY: PublicKey;
+  export const SYSVAR_INSTRUCTIONS_PUBKEY: PublicKey;
 
   // === src/vote-account.js ===
   export const VOTE_PROGRAM_ID: PublicKey;

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -966,6 +966,54 @@ declare module '@solana/web3.js' {
     ): AuthorizeNonceParams;
   }
 
+  // === src/secp256k1-program.js ===
+  export type CreateSecp256k1InstructionWithPublicKeyParams = {
+    publicKey: Buffer | Uint8Array | Array<number>;
+    message: Buffer | Uint8Array | Array<number>;
+    signature: Buffer | Uint8Array | Array<number>;
+    recoveryId: number;
+  };
+
+  export type CreateSecp256k1InstructionWithPrivateKeyParams = {
+    privateKey: Buffer | Uint8Array | Array<number>;
+    message: Buffer | Uint8Array | Array<number>;
+  };
+
+  export type DecodedSecp256k1Instruction = {
+    numSignatures: number;
+    signatureOffset: number;
+    signatureInstructionOffset: number;
+    ethAddressOffset: number;
+    ethAddressInstructionIndex: number;
+    messageDataOffset: number;
+    messageDataSize: number;
+    messageInstructionIndex: number;
+    signature: Buffer;
+    ethPublicKey: Buffer;
+    recoveryId: number;
+    message: Buffer;
+  };
+
+  export class Secp256k1Instruction {
+    static decodeInstruction(
+      instruction: TransactionInstruction,
+    ): DecodedSecp256k1Instruction;
+
+    static checkProgramId(programId: PublicKey): void;
+  }
+
+  export class Secp256k1Program {
+    static get programId(): PublicKey;
+
+    static createInstructionWithPublicKey(
+      params: CreateSecp256k1InstructionWithPublicKeyParams,
+    ): TransactionInstruction;
+
+    static createInstructionWithPrivateKey(
+      params: CreateSecp256k1InstructionWithPrivateKeyParams,
+    ): TransactionInstruction;
+  }
+
   // === src/loader.js ===
   export class Loader {
     static getMinNumSignatures(dataLength: number): number;

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -980,29 +980,6 @@ declare module '@solana/web3.js' {
     message: Buffer | Uint8Array | Array<number>;
   };
 
-  export type DecodedSecp256k1Instruction = {
-    numSignatures: number;
-    signatureOffset: number;
-    signatureInstructionOffset: number;
-    ethAddressOffset: number;
-    ethAddressInstructionIndex: number;
-    messageDataOffset: number;
-    messageDataSize: number;
-    messageInstructionIndex: number;
-    signature: Buffer;
-    ethPublicKey: Buffer;
-    recoveryId: number;
-    message: Buffer;
-  };
-
-  export class Secp256k1Instruction {
-    static decodeInstruction(
-      instruction: TransactionInstruction,
-    ): DecodedSecp256k1Instruction;
-
-    static checkProgramId(programId: PublicKey): void;
-  }
-
   export class Secp256k1Program {
     static get programId(): PublicKey;
 

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -536,6 +536,7 @@ declare module '@solana/web3.js' {
   declare export var SYSVAR_RENT_PUBKEY;
   declare export var SYSVAR_REWARDS_PUBKEY;
   declare export var SYSVAR_STAKE_HISTORY_PUBKEY;
+  declare export var SYSVAR_INSTRUCTIONS_PUBKEY;
 
   // === src/vote-account.js ===
   declare export var VOTE_PROGRAM_ID;

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -973,6 +973,54 @@ declare module '@solana/web3.js' {
     ): AuthorizeNonceParams;
   }
 
+  // === src/secp256k1-program.js ===
+  declare export type CreateSecp256k1InstructionWithPublicKeyParams = {|
+    publicKey: Buffer | Uint8Array | Array<number>,
+    message: Buffer | Uint8Array | Array<number>,
+    signature: Buffer | Uint8Array | Array<number>,
+    recoveryId: number,
+  |};
+
+  declare export type CreateSecp256k1InstructionWithPrivateKeyParams = {|
+    privateKey: Buffer | Uint8Array | Array<number>,
+    message: Buffer | Uint8Array | Array<number>,
+  |};
+
+  declare export type DecodedSecp256k1Instruction = {|
+    numSignatures: number,
+    signatureOffset: number,
+    signatureInstructionOffset: number,
+    ethAddressOffset: number,
+    ethAddressInstructionIndex: number,
+    messageDataOffset: number,
+    messageDataSize: number,
+    messageInstructionIndex: number,
+    signature: Buffer,
+    ethPublicKey: Buffer,
+    recoveryId: number,
+    message: Buffer,
+  |};
+
+  declare export class Secp256k1Instruction {
+    static decodeInstruction(
+      instruction: TransactionInstruction,
+    ): DecodedSecp256k1Instruction;
+
+    static checkProgramId(programId: PublicKey): void;
+  }
+
+  declare export class Secp256k1Program {
+    static get programId(): PublicKey;
+
+    static createInstructionWithPublicKey(
+      params: CreateSecp256k1InstructionWithPublicKeyParams,
+    ): TransactionInstruction;
+
+    static createInstructionWithPrivateKey(
+      params: CreateSecp256k1InstructionWithPrivateKeyParams,
+    ): TransactionInstruction;
+  }
+
   // === src/loader.js ===
   declare export class Loader {
     static getMinNumSignatures(dataLength: number): number;

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -987,29 +987,6 @@ declare module '@solana/web3.js' {
     message: Buffer | Uint8Array | Array<number>,
   |};
 
-  declare export type DecodedSecp256k1Instruction = {|
-    numSignatures: number,
-    signatureOffset: number,
-    signatureInstructionOffset: number,
-    ethAddressOffset: number,
-    ethAddressInstructionIndex: number,
-    messageDataOffset: number,
-    messageDataSize: number,
-    messageInstructionIndex: number,
-    signature: Buffer,
-    ethPublicKey: Buffer,
-    recoveryId: number,
-    message: Buffer,
-  |};
-
-  declare export class Secp256k1Instruction {
-    static decodeInstruction(
-      instruction: TransactionInstruction,
-    ): DecodedSecp256k1Instruction;
-
-    static checkProgramId(programId: PublicKey): void;
-  }
-
   declare export class Secp256k1Program {
     static get programId(): PublicKey;
 

--- a/web3.js/package-lock.json
+++ b/web3.js/package-lock.json
@@ -7163,8 +7163,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -11357,7 +11356,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -11380,7 +11378,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -14453,6 +14450,22 @@
         "verror": "1.10.0"
       }
     },
+    "keccak": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "requires": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        }
+      }
+    },
     "keypather": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
@@ -15461,14 +15474,12 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -15605,6 +15616,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -21326,6 +21342,42 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
+      }
+    },
+    "secp256k1": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "requires": {
+        "elliptic": "^6.5.2",
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "elliptic": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        }
       }
     },
     "semantic-release": {

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -81,10 +81,12 @@
     "crypto-hash": "^1.2.2",
     "esdoc-inject-style-plugin": "^1.0.0",
     "jayson": "^3.0.1",
+    "keccak": "^3.0.1",
     "mz": "^2.7.0",
     "node-fetch": "^2.2.0",
     "npm-run-all": "^4.1.5",
     "rpc-websockets": "^7.4.2",
+    "secp256k1": "^4.0.2",
     "superstruct": "^0.8.3",
     "tweetnacl": "^1.0.0",
     "ws": "^7.0.0"

--- a/web3.js/rollup.config.js
+++ b/web3.js/rollup.config.js
@@ -106,6 +106,8 @@ function generateConfig(configType) {
         'superstruct',
         'tweetnacl',
         'url',
+        'secp256k1',
+        'keccak',
       ];
       break;
     default:

--- a/web3.js/src/index.js
+++ b/web3.js/src/index.js
@@ -21,6 +21,7 @@ export {
   SystemProgram,
   SYSTEM_INSTRUCTION_LAYOUTS,
 } from './system-program';
+export {Secp256k1Instruction, Secp256k1Program} from './secp256k1-program';
 export {Transaction, TransactionInstruction} from './transaction';
 export {VALIDATOR_INFO_KEY, ValidatorInfo} from './validator-info';
 export {VOTE_PROGRAM_ID, VoteAccount} from './vote-account';
@@ -29,6 +30,7 @@ export {
   SYSVAR_RENT_PUBKEY,
   SYSVAR_REWARDS_PUBKEY,
   SYSVAR_STAKE_HISTORY_PUBKEY,
+  SYSVAR_INSTRUCTIONS_PUBKEY,
 } from './sysvar';
 export {sendAndConfirmTransaction} from './util/send-and-confirm-transaction';
 export {sendAndConfirmRawTransaction} from './util/send-and-confirm-raw-transaction';

--- a/web3.js/src/index.js
+++ b/web3.js/src/index.js
@@ -21,7 +21,7 @@ export {
   SystemProgram,
   SYSTEM_INSTRUCTION_LAYOUTS,
 } from './system-program';
-export {Secp256k1Instruction, Secp256k1Program} from './secp256k1-program';
+export {Secp256k1Program} from './secp256k1-program';
 export {Transaction, TransactionInstruction} from './transaction';
 export {VALIDATOR_INFO_KEY, ValidatorInfo} from './validator-info';
 export {VOTE_PROGRAM_ID, VoteAccount} from './vote-account';

--- a/web3.js/src/secp256k1-program.js
+++ b/web3.js/src/secp256k1-program.js
@@ -81,7 +81,9 @@ export class Secp256k1Instruction {
   /**
    * Decode a secp256k1 instruction
    */
-  static decodeInstruction(instruction: TransactionInstruction) {
+  static decodeInstruction(
+    instruction: TransactionInstruction,
+  ): DecodedSecp256k1Instruction {
     const decoded = SECP256K1_INSTRUCTION_LAYOUT.decode(instruction.data);
     const message = instruction.data.slice(SECP256K1_INSTRUCTION_LAYOUT.span);
     return {
@@ -111,7 +113,7 @@ export class Secp256k1Program {
   /**
    * Create a secp256k1 instruction with public key
    */
-  createInstructionWithPublicKey(
+  static createInstructionWithPublicKey(
     params: CreateSecp256k1InstructionWithPublicKeyParams,
   ): TransactionInstruction {
     const {publicKey, message, signature, recoveryId} = params;
@@ -167,7 +169,7 @@ export class Secp256k1Program {
   /**
    * Create a secp256k1 instruction with private key
    */
-  createInstructionWithPrivateKey(
+  static createInstructionWithPrivateKey(
     params: CreateSecp256k1InstructionWithPrivateKeyParams,
   ): TransactionInstruction {
     const {privateKey, message} = params;
@@ -196,7 +198,7 @@ export class Secp256k1Program {
   }
 }
 
-export function constructEthPubkey(
+function constructEthPubkey(
   publicKey: Buffer | Uint8Array | Array<number>,
 ): Buffer {
   return createKeccakHash('keccak256')

--- a/web3.js/src/secp256k1-program.js
+++ b/web3.js/src/secp256k1-program.js
@@ -84,7 +84,7 @@ export class Secp256k1Instruction {
    * @private
    */
   static checkProgramId(programId: PublicKey) {
-    if (!programId.equals(Secp256kProgram.programId)) {
+    if (!programId.equals(Secp256k1Program.programId)) {
       throw new Error('invalid instruction; programId is not Secp256kProgram');
     }
   }
@@ -141,7 +141,7 @@ export class Secp256k1Program {
 
     return new TransactionInstruction({
       keys: [],
-      programId: Secp256kProgram.programId,
+      programId: Secp256k1Program.programId,
       data: toBuffer(instructionData),
     });
   }

--- a/web3.js/src/secp256k1-program.js
+++ b/web3.js/src/secp256k1-program.js
@@ -16,13 +16,13 @@ const SIGNATURE_OFFSETS_SERIALIZED_SIZE = 11;
 
 /**
  * Create a secp256k1 instruction using a public key params
- * @typedef {Object} CreateSecpInstructionWithPublicKeyParams
+ * @typedef {Object} CreateSecp256k1InstructionWithPublicKeyParams
  * @property {Buffer | Uint8Array | Array<number>} publicKey
  * @property {Buffer | Uint8Array | Array<number>} message
  * @property {Buffer | Uint8Array | Array<number>} signature
  * @property {number} recoveryId
  */
-export type CreateSecpInstructionWithPublicKeyParams = {|
+export type CreateSecp256k1InstructionWithPublicKeyParams = {|
   publicKey: Buffer | Uint8Array | Array<number>,
   message: Buffer | Uint8Array | Array<number>,
   signature: Buffer | Uint8Array | Array<number>,
@@ -31,24 +31,24 @@ export type CreateSecpInstructionWithPublicKeyParams = {|
 
 /**
  * Create a secp256k1 instruction using a private key params
- * @typedef {Object} CreateSecpInstructionWithPrivateKeyParams
+ * @typedef {Object} CreateSecp256k1InstructionWithPrivateKeyParams
  * @property {Buffer | Uint8Array | Array<number>} privateKey
  * @property {Buffer | Uint8Array | Array<number>} message
  */
-export type CreateSecpInstructionWithPrivateKeyParams = {|
+export type CreateSecp256k1InstructionWithPrivateKeyParams = {|
   privateKey: Buffer | Uint8Array | Array<number>,
   message: Buffer | Uint8Array | Array<number>,
 |};
 
 /**
  * A decoded Secp256k instruction
- * @typedef {Object} DecodedSecp256kInstruction
+ * @typedef {Object} DecodedSecp256k1Instruction
  * @property {Buffer} signature
  * @property {Buffer} ethPublicKey
  * @property {Buffer} message
  * @property {number} recoveryId
  */
-export type DecodedSecp256kInstruction = {|
+export type DecodedSecp256k1Instruction = {|
   numSignatures: number,
   signatureOffset: number,
   signatureInstructionOffset: number,
@@ -112,7 +112,7 @@ export class Secp256k1Program {
    * Create a secp256k1 instruction with public key
    */
   createInstructionWithPublicKey(
-    params: CreateSecpInstructionWithPublicKeyParams,
+    params: CreateSecp256k1InstructionWithPublicKeyParams,
   ): TransactionInstruction {
     const {publicKey, message, signature, recoveryId} = params;
 
@@ -168,7 +168,7 @@ export class Secp256k1Program {
    * Create a secp256k1 instruction with private key
    */
   createInstructionWithPrivateKey(
-    params: CreateSecpInstructionWithPrivateKeyParams,
+    params: CreateSecp256k1InstructionWithPrivateKeyParams,
   ): TransactionInstruction {
     const {privateKey, message} = params;
 

--- a/web3.js/src/secp256k1-program.js
+++ b/web3.js/src/secp256k1-program.js
@@ -42,33 +42,10 @@ export type CreateSecp256k1InstructionWithPrivateKeyParams = {|
   message: Buffer | Uint8Array | Array<number>,
 |};
 
-/**
- * A decoded Secp256k1 instruction
- * @typedef {Object} DecodedSecp256k1Instruction
- * @property {Buffer} signature
- * @property {Buffer} ethPublicKey
- * @property {Buffer} message
- * @property {number} recoveryId
- */
-export type DecodedSecp256k1Instruction = {|
-  numSignatures: number,
-  signatureOffset: number,
-  signatureInstructionOffset: number,
-  ethAddressOffset: number,
-  ethAddressInstructionIndex: number,
-  messageDataOffset: number,
-  messageDataSize: number,
-  messageInstructionIndex: number,
-  signature: Buffer,
-  ethPublicKey: Buffer,
-  recoveryId: number,
-  message: Buffer,
-|};
-
 const SECP256K1_INSTRUCTION_LAYOUT = BufferLayout.struct([
   BufferLayout.u8('numSignatures'),
   BufferLayout.u16('signatureOffset'),
-  BufferLayout.u8('signatureInstructionOffset'),
+  BufferLayout.u8('signatureInstructionIndex'),
   BufferLayout.u16('ethAddressOffset'),
   BufferLayout.u8('ethAddressInstructionIndex'),
   BufferLayout.u16('messageDataOffset'),
@@ -78,31 +55,6 @@ const SECP256K1_INSTRUCTION_LAYOUT = BufferLayout.struct([
   BufferLayout.blob(64, 'signature'),
   BufferLayout.u8('recoveryId'),
 ]);
-
-export class Secp256k1Instruction {
-  /**
-   * Decode a Secp256k1 instruction
-   */
-  static decodeInstruction(
-    instruction: TransactionInstruction,
-  ): DecodedSecp256k1Instruction {
-    const decoded = SECP256K1_INSTRUCTION_LAYOUT.decode(instruction.data);
-    const message = instruction.data.slice(SECP256K1_INSTRUCTION_LAYOUT.span);
-    return {
-      ...decoded,
-      message,
-    };
-  }
-
-  /**
-   * @private
-   */
-  static checkProgramId(programId: PublicKey) {
-    if (!programId.equals(Secp256k1Program.programId)) {
-      throw new Error('invalid instruction; programId is not Secp256k1Program');
-    }
-  }
-}
 
 export class Secp256k1Program {
   /**
@@ -146,7 +98,7 @@ export class Secp256k1Program {
       {
         numSignatures: numSignatures,
         signatureOffset: signatureOffset,
-        signatureInstructionOffset: 0,
+        signatureInstructionIndex: 0,
         ethAddressOffset: ethAddressOffset,
         ethAddressInstructionIndex: 0,
         messageDataOffset: messageDataOffset,

--- a/web3.js/src/secp256k1-program.js
+++ b/web3.js/src/secp256k1-program.js
@@ -1,13 +1,15 @@
 // @flow
 
 import * as BufferLayout from 'buffer-layout';
-import {publicKeyCreate, ecdsaSign, publicKeyConvert} from 'secp256k1';
+import secp256k1 from 'secp256k1';
 import createKeccakHash from 'keccak';
-import {PublicKey} from './publickey';
-import {Transaction, TransactionInstruction} from './transaction';
-import {toBuffer} from './util/to-buffer';
 import assert from 'assert';
-import {encodeData, decodeData} from './instruction';
+
+import {PublicKey} from './publickey';
+import {TransactionInstruction} from './transaction';
+import {toBuffer} from './util/to-buffer';
+
+const {publicKeyCreate, ecdsaSign} = secp256k1;
 
 const PRIVATE_KEY_BYTES = 32;
 const PUBLIC_KEY_BYTES = 65;
@@ -157,12 +159,12 @@ export class Secp256k1Program {
       instructionData,
     );
 
-    instructionData.fill(message, SECP256K1_INSTRUCTION_LAYOUT.span);
+    instructionData.fill(toBuffer(message), SECP256K1_INSTRUCTION_LAYOUT.span);
 
     return new TransactionInstruction({
       keys: [],
       programId: Secp256k1Program.programId,
-      data: toBuffer(instructionData),
+      data: instructionData,
     });
   }
 
@@ -198,7 +200,7 @@ export class Secp256k1Program {
   }
 }
 
-function constructEthPubkey(
+export function constructEthPubkey(
   publicKey: Buffer | Uint8Array | Array<number>,
 ): Buffer {
   return createKeccakHash('keccak256')

--- a/web3.js/src/secp256k1-program.js
+++ b/web3.js/src/secp256k1-program.js
@@ -17,7 +17,7 @@ const HASHED_PUBKEY_SERIALIZED_SIZE = 20;
 const SIGNATURE_OFFSETS_SERIALIZED_SIZE = 11;
 
 /**
- * Create a secp256k1 instruction using a public key params
+ * Create a Secp256k1 instruction using a public key params
  * @typedef {Object} CreateSecp256k1InstructionWithPublicKeyParams
  * @property {Buffer | Uint8Array | Array<number>} publicKey
  * @property {Buffer | Uint8Array | Array<number>} message
@@ -32,7 +32,7 @@ export type CreateSecp256k1InstructionWithPublicKeyParams = {|
 |};
 
 /**
- * Create a secp256k1 instruction using a private key params
+ * Create a Secp256k1 instruction using a private key params
  * @typedef {Object} CreateSecp256k1InstructionWithPrivateKeyParams
  * @property {Buffer | Uint8Array | Array<number>} privateKey
  * @property {Buffer | Uint8Array | Array<number>} message
@@ -43,7 +43,7 @@ export type CreateSecp256k1InstructionWithPrivateKeyParams = {|
 |};
 
 /**
- * A decoded Secp256k instruction
+ * A decoded Secp256k1 instruction
  * @typedef {Object} DecodedSecp256k1Instruction
  * @property {Buffer} signature
  * @property {Buffer} ethPublicKey
@@ -81,7 +81,7 @@ const SECP256K1_INSTRUCTION_LAYOUT = BufferLayout.struct([
 
 export class Secp256k1Instruction {
   /**
-   * Decode a secp256k1 instruction
+   * Decode a Secp256k1 instruction
    */
   static decodeInstruction(
     instruction: TransactionInstruction,
@@ -99,7 +99,7 @@ export class Secp256k1Instruction {
    */
   static checkProgramId(programId: PublicKey) {
     if (!programId.equals(Secp256k1Program.programId)) {
-      throw new Error('invalid instruction; programId is not Secp256kProgram');
+      throw new Error('invalid instruction; programId is not Secp256k1Program');
     }
   }
 }

--- a/web3.js/src/secp256k1-program.js
+++ b/web3.js/src/secp256k1-program.js
@@ -1,0 +1,207 @@
+// @flow
+
+import * as BufferLayout from 'buffer-layout';
+import {publicKeyCreate, ecdsaSign, publicKeyConvert} from 'secp256k1';
+import createKeccakHash from 'keccak';
+import {PublicKey} from './publickey';
+import {Transaction, TransactionInstruction} from './transaction';
+import {toBuffer} from './util/to-buffer';
+import assert from 'assert';
+import {encodeData, decodeData} from './instruction';
+
+const PRIVATE_KEY_BYTES = 32;
+const PUBLIC_KEY_BYTES = 65;
+const HASHED_PUBKEY_SERIALIZED_SIZE = 20;
+const SIGNATURE_OFFSETS_SERIALIZED_SIZE = 11;
+
+/**
+ * Create a secp256k1 instruction using a public key params
+ * @typedef {Object} CreateSecpInstructionWithPublicKeyParams
+ * @property {Buffer | Uint8Array | Array<number>} publicKey
+ * @property {Buffer | Uint8Array | Array<number>} message
+ * @property {Buffer | Uint8Array | Array<number>} signature
+ * @property {number} recoveryId
+ */
+export type CreateSecpInstructionWithPublicKeyParams = {|
+  publicKey: Buffer | Uint8Array | Array<number>,
+  message: Buffer | Uint8Array | Array<number>,
+  signature: Buffer | Uint8Array | Array<number>,
+  recoveryId: number,
+|};
+
+/**
+ * Create a secp256k1 instruction using a private key params
+ * @typedef {Object} CreateSecpInstructionWithPrivateKeyParams
+ * @property {Buffer | Uint8Array | Array<number>} privateKey
+ * @property {Buffer | Uint8Array | Array<number>} message
+ */
+export type CreateSecpInstructionWithPrivateKeyParams = {|
+  privateKey: Buffer | Uint8Array | Array<number>,
+  message: Buffer | Uint8Array | Array<number>,
+|};
+
+/**
+ * A decoded Secp256k instruction
+ * @typedef {Object} DecodedSecp256kInstruction
+ * @property {Buffer} signature
+ * @property {Buffer} ethPublicKey
+ * @property {Buffer} message
+ * @property {number} recoveryId
+ */
+export type DecodedSecp256kInstruction = {|
+  signature: Buffer,
+  ethPublicKey: Buffer,
+  message: Buffer,
+  recoveryId: number,
+|};
+
+export class Secp256k1Instruction {
+  /**
+   * Decode a secp256k1 instruction
+   */
+  static decodeInstruction(instruction: TransactionInstruction) {
+    const layout = BufferLayout.struct([
+      BufferLayout.blob(12, 'offsetData'),
+      BufferLayout.blob(20, 'ethPublicKey'),
+      BufferLayout.blob(64, 'signature'),
+      BufferLayout.u8('recoveryId'),
+    ]);
+
+    const {signature, ethPublicKey, recoveryId} = layout.decode(
+      instruction.data,
+    );
+    const message = instruction.data.slice(97);
+
+    return {
+      signature,
+      ethPublicKey,
+      recoveryId,
+      message,
+    };
+  }
+
+  /**
+   * @private
+   */
+  static checkProgramId(programId: PublicKey) {
+    if (!programId.equals(Secp256kProgram.programId)) {
+      throw new Error('invalid instruction; programId is not Secp256kProgram');
+    }
+  }
+}
+
+export class Secp256k1Program {
+  /**
+   * Public key that identifies the Secp256k program
+   */
+  static get programId(): PublicKey {
+    return new PublicKey('KeccakSecp256k11111111111111111111111111111');
+  }
+
+  /**
+   * Create a secp256k1 instruction with public key
+   */
+  createSecpInstructionWithPublicKey(
+    params: CreateSecpInstructionWithPublicKeyParams,
+  ): TransactionInstruction {
+    const {publicKey, message, signature, recoveryId} = params;
+
+    assert(
+      publicKey.length === PUBLIC_KEY_BYTES,
+      `Public key must be ${PUBLIC_KEY_BYTES} bytes`,
+    );
+
+    let ethPublicKey;
+    try {
+      ethPublicKey = constructEthPubkey(publicKey);
+    } catch (error) {
+      throw new Error(`Error constructing ethereum public key: ${error}`);
+    }
+
+    const dataStart = 1 + SIGNATURE_OFFSETS_SERIALIZED_SIZE;
+    const ethAddressOffset = dataStart;
+    const signatureOffset = dataStart + ethPublicKey.length;
+    const messageDataOffset = signatureOffset + signature.length + 1;
+    const numSignatures = 1;
+
+    const instructionData = buildU8intArray([
+      new Uint8Array([numSignatures]),
+      buildUint8ArrayFromUint16Array([signatureOffset]),
+      new Uint8Array([0]),
+      buildUint8ArrayFromUint16Array([ethAddressOffset]),
+      new Uint8Array([0]),
+      buildUint8ArrayFromUint16Array([messageDataOffset]),
+      buildUint8ArrayFromUint16Array([message.length]),
+      new Uint8Array([0]),
+      ethPublicKey,
+      signature,
+      new Uint8Array([recoveryId]),
+      message,
+    ]);
+
+    return new TransactionInstruction({
+      keys: [],
+      programId: Secp256kProgram.programId,
+      data: toBuffer(instructionData),
+    });
+  }
+
+  /**
+   * Create a secp256k1 instruction with private key
+   */
+  createSecpInstructionWithPrivateKey(
+    params: CreateSecpInstructionWithPrivateKeyParams,
+  ): TransactionInstruction {
+    const {privateKey, message} = params;
+
+    assert(
+      privateKey.length === PRIVATE_KEY_BYTES,
+      `Private key must be ${PRIVATE_KEY_BYTES} bytes`,
+    );
+
+    try {
+      const publicKey = publicKeyCreate(privateKey, false);
+      const messageHash = createKeccakHash('keccak256')
+        .update(toBuffer(message))
+        .digest();
+      const {signature, recid: recoveryId} = ecdsaSign(messageHash, privateKey);
+
+      return this.createSecpInstructionWithPublicKey({
+        publicKey,
+        message,
+        signature,
+        recoveryId,
+      });
+    } catch (error) {
+      throw new Error(`Error creating instruction; ${error}`);
+    }
+  }
+}
+
+export function constructEthPubkey(
+  publicKey: Buffer | Uint8Array | Array<number>,
+): Buffer {
+  return createKeccakHash('keccak256')
+    .update(toBuffer(publicKey.slice(1))) // throw away leading byte
+    .digest()
+    .slice(-HASHED_PUBKEY_SERIALIZED_SIZE);
+}
+
+function buildU8intArray(dataArrays): Uint8Array {
+  const size = dataArrays.reduce((acc, cur) => acc + cur.length, 0);
+
+  const final = new Uint8Array(size);
+
+  let pos = 0;
+  dataArrays.forEach(item => {
+    final.set(item, pos);
+    pos += item.length;
+  });
+
+  return final;
+}
+
+function buildUint8ArrayFromUint16Array(array: Array<number>): Uint8Array {
+  const uint16 = new Uint16Array(array);
+  return new Uint8Array(uint16.buffer, uint16.byteOffset, uint16.byteLength);
+}

--- a/web3.js/src/sysvar.js
+++ b/web3.js/src/sysvar.js
@@ -20,3 +20,7 @@ export const SYSVAR_REWARDS_PUBKEY = new PublicKey(
 export const SYSVAR_STAKE_HISTORY_PUBKEY = new PublicKey(
   'SysvarStakeHistory1111111111111111111111111',
 );
+
+export const SYSVAR_INSTRUCTIONS_PUBKEY = new PublicKey(
+  'Sysvar1nstructions1111111111111111111111111',
+);

--- a/web3.js/test/secp256k1-program.test.js
+++ b/web3.js/test/secp256k1-program.test.js
@@ -1,3 +1,4 @@
+// @flow
 import {
   Secp256k1Program,
   Secp256k1Instruction,
@@ -29,18 +30,33 @@ test('decode secp256k1 instruction', () => {
     privateKey = randomBytes(32);
   } while (!privateKeyVerify(privateKey));
 
-  const instruction = program.createSecpInstructionWithPrivateKey({
+  const instruction = program.createInstructionWithPrivateKey({
     privateKey,
     message: Buffer.from('Test message'),
   });
 
   let {
+    numSignatures,
+    signatureOffset,
+    signatureInstructionOffset,
+    ethAddressOffset,
+    ethAddressInstructionIndex,
+    messageDataOffset,
+    messageDataSize,
+    messageInstructionIndex,
     signature,
     ethPublicKey,
     recoveryId,
     message,
   } = Secp256k1Instruction.decodeInstruction(instruction);
 
+  expect(numSignatures).toEqual(1);
+  expect(signatureOffset).toEqual(32);
+  expect(signatureInstructionOffset).toEqual(0);
+  expect(ethAddressOffset).toEqual(12);
+  expect(messageDataOffset).toEqual(97);
+  expect(messageDataSize).toEqual('Test message'.length);
+  expect(messageInstructionIndex).toEqual(0);
   expect(recoveryId > -1).toEqual(true);
   expect(signature.length).toEqual(64);
   expect(ethPublicKey.length).toEqual(20);
@@ -65,7 +81,7 @@ test('live create secp256k1 instruction with public key', async () => {
   const messageHash = createKeccakHash('keccak256').update(message).digest();
   const {signature, recid: recoveryId} = ecdsaSign(messageHash, privateKey);
 
-  const instruction = program.createSecpInstructionWithPublicKey({
+  const instruction = program.createInstructionWithPublicKey({
     publicKey,
     message,
     signature,
@@ -105,7 +121,7 @@ test('live create secp256k1 instruction with private key', async () => {
     privateKey = randomBytes(32);
   } while (!privateKeyVerify(privateKey));
 
-  const instruction = program.createSecpInstructionWithPrivateKey({
+  const instruction = program.createInstructionWithPrivateKey({
     privateKey,
     message: Buffer.from('Test 123'),
   });

--- a/web3.js/test/secp256k1-program.test.js
+++ b/web3.js/test/secp256k1-program.test.js
@@ -1,15 +1,12 @@
 // @flow
-import {
-  Secp256k1Program,
-  Secp256k1Instruction,
-  constructEthPubkey,
-} from '../src/secp256k1-program';
-import {privateKeyVerify, ecdsaSign, publicKeyCreate} from 'secp256k1';
+
 import createKeccakHash from 'keccak';
+import secp256k1 from 'secp256k1';
 import {randomBytes} from 'crypto';
+
+import {Secp256k1Program, Secp256k1Instruction} from '../src/secp256k1-program';
 import {mockRpcEnabled} from './__mocks__/node-fetch';
 import {url} from './url';
-
 import {
   Connection,
   Account,
@@ -17,6 +14,8 @@ import {
   LAMPORTS_PER_SOL,
   Transaction,
 } from '../src';
+
+const {privateKeyVerify, ecdsaSign, publicKeyCreate} = secp256k1;
 
 if (!mockRpcEnabled) {
   jest.setTimeout(20000);
@@ -52,6 +51,7 @@ test('decode secp256k1 instruction', () => {
   expect(signatureOffset).toEqual(32);
   expect(signatureInstructionOffset).toEqual(0);
   expect(ethAddressOffset).toEqual(12);
+  expect(ethAddressInstructionIndex).toEqual(0);
   expect(messageDataOffset).toEqual(97);
   expect(messageDataSize).toEqual('Test message'.length);
   expect(messageInstructionIndex).toEqual(0);

--- a/web3.js/test/secp256k1-program.test.js
+++ b/web3.js/test/secp256k1-program.test.js
@@ -4,7 +4,7 @@ import createKeccakHash from 'keccak';
 import secp256k1 from 'secp256k1';
 import {randomBytes} from 'crypto';
 
-import {Secp256k1Program, Secp256k1Instruction} from '../src/secp256k1-program';
+import {Secp256k1Program} from '../src/secp256k1-program';
 import {mockRpcEnabled} from './__mocks__/node-fetch';
 import {url} from './url';
 import {
@@ -20,46 +20,6 @@ const {privateKeyVerify, ecdsaSign, publicKeyCreate} = secp256k1;
 if (!mockRpcEnabled) {
   jest.setTimeout(20000);
 }
-
-test('decode secp256k1 instruction', () => {
-  let privateKey;
-  do {
-    privateKey = randomBytes(32);
-  } while (!privateKeyVerify(privateKey));
-
-  const instruction = Secp256k1Program.createInstructionWithPrivateKey({
-    privateKey,
-    message: Buffer.from('Test message'),
-  });
-
-  let {
-    numSignatures,
-    signatureOffset,
-    signatureInstructionOffset,
-    ethAddressOffset,
-    ethAddressInstructionIndex,
-    messageDataOffset,
-    messageDataSize,
-    messageInstructionIndex,
-    signature,
-    ethPublicKey,
-    recoveryId,
-    message,
-  } = Secp256k1Instruction.decodeInstruction(instruction);
-
-  expect(numSignatures).toEqual(1);
-  expect(signatureOffset).toEqual(32);
-  expect(signatureInstructionOffset).toEqual(0);
-  expect(ethAddressOffset).toEqual(12);
-  expect(ethAddressInstructionIndex).toEqual(0);
-  expect(messageDataOffset).toEqual(97);
-  expect(messageDataSize).toEqual(Buffer.from('Test message').length);
-  expect(messageInstructionIndex).toEqual(0);
-  expect(recoveryId > -1).toEqual(true);
-  expect(signature.length).toEqual(64);
-  expect(ethPublicKey.length).toEqual(20);
-  expect(message.toString('utf8')).toEqual('Test message');
-});
 
 test('live create secp256k1 instruction with public key', async () => {
   if (mockRpcEnabled) {

--- a/web3.js/test/secp256k1-program.test.js
+++ b/web3.js/test/secp256k1-program.test.js
@@ -23,14 +23,12 @@ if (!mockRpcEnabled) {
 }
 
 test('decode secp256k1 instruction', () => {
-  const program = new Secp256k1Program();
-
   let privateKey;
   do {
     privateKey = randomBytes(32);
   } while (!privateKeyVerify(privateKey));
 
-  const instruction = program.createInstructionWithPrivateKey({
+  const instruction = Secp256k1Program.createInstructionWithPrivateKey({
     privateKey,
     message: Buffer.from('Test message'),
   });
@@ -69,7 +67,6 @@ test('live create secp256k1 instruction with public key', async () => {
     return;
   }
 
-  const program = new Secp256k1Program();
   const message = Buffer.from('This is a message');
 
   let privateKey;
@@ -81,7 +78,7 @@ test('live create secp256k1 instruction with public key', async () => {
   const messageHash = createKeccakHash('keccak256').update(message).digest();
   const {signature, recid: recoveryId} = ecdsaSign(messageHash, privateKey);
 
-  const instruction = program.createInstructionWithPublicKey({
+  const instruction = Secp256k1Program.createInstructionWithPublicKey({
     publicKey,
     message,
     signature,
@@ -114,14 +111,12 @@ test('live create secp256k1 instruction with private key', async () => {
     return;
   }
 
-  const program = new Secp256k1Program();
-
   let privateKey;
   do {
     privateKey = randomBytes(32);
   } while (!privateKeyVerify(privateKey));
 
-  const instruction = program.createInstructionWithPrivateKey({
+  const instruction = Secp256k1Program.createInstructionWithPrivateKey({
     privateKey,
     message: Buffer.from('Test 123'),
   });

--- a/web3.js/test/secp256k1-program.test.js
+++ b/web3.js/test/secp256k1-program.test.js
@@ -1,0 +1,131 @@
+import {
+  Secp256k1Program,
+  Secp256k1Instruction,
+  constructEthPubkey,
+} from '../src/secp256k1-program';
+import {privateKeyVerify, ecdsaSign, publicKeyCreate} from 'secp256k1';
+import createKeccakHash from 'keccak';
+import {randomBytes} from 'crypto';
+import {mockRpcEnabled} from './__mocks__/node-fetch';
+import {url} from './url';
+
+import {
+  Connection,
+  Account,
+  sendAndConfirmTransaction,
+  LAMPORTS_PER_SOL,
+  Transaction,
+} from '../src';
+
+if (!mockRpcEnabled) {
+  jest.setTimeout(20000);
+}
+
+test('decode secp256k1 instruction', () => {
+  const program = new Secp256k1Program();
+
+  let privateKey;
+  do {
+    privateKey = randomBytes(32);
+  } while (!privateKeyVerify(privateKey));
+
+  const instruction = program.createSecpInstructionWithPrivateKey({
+    privateKey,
+    message: Buffer.from('Test message'),
+  });
+
+  let {
+    signature,
+    ethPublicKey,
+    recoveryId,
+    message,
+  } = Secp256k1Instruction.decodeInstruction(instruction);
+
+  expect(recoveryId > -1).toEqual(true);
+  expect(signature.length).toEqual(64);
+  expect(ethPublicKey.length).toEqual(20);
+  expect(message.toString('utf8')).toEqual('Test message');
+});
+
+test('live create secp256k1 instruction with public key', async () => {
+  if (mockRpcEnabled) {
+    console.log('non-live test skipped');
+    return;
+  }
+
+  const program = new Secp256k1Program();
+  const message = Buffer.from('This is a message');
+
+  let privateKey;
+  do {
+    privateKey = randomBytes(32);
+  } while (!privateKeyVerify(privateKey));
+
+  const publicKey = publicKeyCreate(privateKey, false);
+  const messageHash = createKeccakHash('keccak256').update(message).digest();
+  const {signature, recid: recoveryId} = ecdsaSign(messageHash, privateKey);
+
+  const instruction = program.createSecpInstructionWithPublicKey({
+    publicKey,
+    message,
+    signature,
+    recoveryId,
+  });
+
+  const transaction = new Transaction();
+  transaction.add(instruction);
+
+  const connection = new Connection(url, 'recent');
+  const from = new Account();
+  await connection.requestAirdrop(from.publicKey, 2 * LAMPORTS_PER_SOL);
+
+  const transactionSignature = await sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [from],
+    {
+      commitment: 'single',
+      skipPreflight: true,
+    },
+  );
+
+  expect(transactionSignature.length > 0).toEqual(true);
+});
+
+test('live create secp256k1 instruction with private key', async () => {
+  if (mockRpcEnabled) {
+    console.log('non-live test skipped');
+    return;
+  }
+
+  const program = new Secp256k1Program();
+
+  let privateKey;
+  do {
+    privateKey = randomBytes(32);
+  } while (!privateKeyVerify(privateKey));
+
+  const instruction = program.createSecpInstructionWithPrivateKey({
+    privateKey,
+    message: Buffer.from('Test 123'),
+  });
+
+  const transaction = new Transaction();
+  transaction.add(instruction);
+
+  const connection = new Connection(url, 'recent');
+  const from = new Account();
+  await connection.requestAirdrop(from.publicKey, 2 * LAMPORTS_PER_SOL);
+
+  const signature = await sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [from],
+    {
+      commitment: 'single',
+      skipPreflight: true,
+    },
+  );
+
+  expect(signature.length > 0).toEqual(true);
+});

--- a/web3.js/test/secp256k1-program.test.js
+++ b/web3.js/test/secp256k1-program.test.js
@@ -53,7 +53,7 @@ test('decode secp256k1 instruction', () => {
   expect(ethAddressOffset).toEqual(12);
   expect(ethAddressInstructionIndex).toEqual(0);
   expect(messageDataOffset).toEqual(97);
-  expect(messageDataSize).toEqual('Test message'.length);
+  expect(messageDataSize).toEqual(Buffer.from('Test message').length);
   expect(messageInstructionIndex).toEqual(0);
   expect(recoveryId > -1).toEqual(true);
   expect(signature.length).toEqual(64);
@@ -92,17 +92,10 @@ test('live create secp256k1 instruction with public key', async () => {
   const from = new Account();
   await connection.requestAirdrop(from.publicKey, 2 * LAMPORTS_PER_SOL);
 
-  const transactionSignature = await sendAndConfirmTransaction(
-    connection,
-    transaction,
-    [from],
-    {
-      commitment: 'single',
-      skipPreflight: true,
-    },
-  );
-
-  expect(transactionSignature.length > 0).toEqual(true);
+  await sendAndConfirmTransaction(connection, transaction, [from], {
+    commitment: 'single',
+    skipPreflight: true,
+  });
 });
 
 test('live create secp256k1 instruction with private key', async () => {
@@ -128,15 +121,8 @@ test('live create secp256k1 instruction with private key', async () => {
   const from = new Account();
   await connection.requestAirdrop(from.publicKey, 2 * LAMPORTS_PER_SOL);
 
-  const signature = await sendAndConfirmTransaction(
-    connection,
-    transaction,
-    [from],
-    {
-      commitment: 'single',
-      skipPreflight: true,
-    },
-  );
-
-  expect(signature.length > 0).toEqual(true);
+  await sendAndConfirmTransaction(connection, transaction, [from], {
+    commitment: 'single',
+    skipPreflight: true,
+  });
 });


### PR DESCRIPTION
#### Problem
The newly added Secp256k1 program/instruction is not yet exposed in solana-web3.js. It should be easy to create this Instruction in web3.js.

#### Summary of Changes
- Create Secp256k1 program and instruction classes
- Allow creating instruction with private key + message or public key + signature + message (support Ren use case)

Fixes #12672 
