### PR TITLE
improves threads' utilization in processing gossip packets

### DIFF
--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -273,9 +273,9 @@ impl EntryVerificationState {
                             .zip(entries)
                             .all(|((hash, tx_hash), answer)| {
                                 if answer.num_hashes == 0 {
-                                    *hash == answer.hash
+                                    hash == answer.hash
                                 } else {
-                                    let mut poh = Poh::new(*hash, None);
+                                    let mut poh = Poh::new(hash, None);
                                     if let Some(mixin) = tx_hash {
                                         poh.record(*mixin).unwrap().hash == answer.hash
                                     } else {


### PR DESCRIPTION
#### Problem
ClusterInfo::process_packets handles incoming packets in a thread_pool:
https://github.com/solana-labs/solana/blob/87311cce7/core/src/cluster_info.rs#L2118-L2134

However, profiling runtime shows that threads are not well utilized and
a lot of the processing is done sequentially.

#### Summary of Changes
This commit redistributes the work done in parallel. Testing on a gce
cluster shows 20%+ improvement in processing gossip packets with much
smaller variations.