### PR TITLE
Include count in doc for example grind command

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -150,7 +150,7 @@ See [Paper Wallet Usage](../paper-wallet/paper-wallet-usage.md) for more info.
 You can generate a custom vanity keypair using solana-keygen. For instance:
 
 ```bash
-solana-keygen grind --starts-with e1v1s
+solana-keygen grind --starts-with e1v1s:1
 ```
 
 Depending on the string requested, it may take days to find a match...


### PR DESCRIPTION
#### Problem

The example keygen grind command in documentation does not include the required count parameter on `starts-with`, making it invalid.

#### Summary of Changes

Add a count to make the command valid.

Fixes #
