### PR TITLE
Revert "CLI: Put `deploy` ephemeral keypair behind a flag (#12941)"

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -193,7 +193,6 @@ pub enum CliCommand {
         program_location: String,
         address: Option<SignerIndex>,
         use_deprecated_loader: bool,
-        random_address: bool,
     },
     // Stake Commands
     CreateStakeAccount {
@@ -630,14 +629,12 @@ pub fn parse_command(
                 1
             });
             let use_deprecated_loader = matches.is_present("use_deprecated_loader");
-            let random_address = matches.is_present("random_address");
 
             Ok(CliCommandInfo {
                 command: CliCommand::Deploy {
                     program_location: matches.value_of("program_location").unwrap().to_string(),
                     address,
                     use_deprecated_loader,
-                    random_address,
                 },
                 signers,
             })
@@ -1242,16 +1239,12 @@ fn process_deploy(
     program_location: &str,
     address: Option<SignerIndex>,
     use_deprecated_loader: bool,
-    random_address: bool,
 ) -> ProcessResult {
     let new_keypair = Keypair::new(); // Create ephemeral keypair to use for program address, if not provided
     let program_id = if let Some(i) = address {
         config.signers[i]
-    } else if random_address {
-        &new_keypair
     } else {
-        // Clap will enforce one of the previous two conditions
-        unreachable!();
+        &new_keypair
     };
     let mut file = File::open(program_location).map_err(|err| {
         CliError::DynamicProgramError(format!("Unable to open program file: {}", err))
@@ -1955,14 +1948,12 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             program_location,
             address,
             use_deprecated_loader,
-            random_address,
         } => process_deploy(
             &rpc_client,
             config,
             program_location,
             *address,
             *use_deprecated_loader,
-            *random_address,
         ),
 
         // Stake Commands
@@ -2626,17 +2617,10 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("address_signer")
                         .index(2)
-                        .value_name("ADDRESS_KEYPAIR")
+                        .value_name("SIGNER_KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
-                        .required_unless("random_address")
-                        .help("The signer for the desired program address. See also: --random-address")
-                )
-                .arg(
-                    Arg::with_name("random_address")
-                        .long("random-address")
-                        .takes_value(false)
-                        .help("Deploy at a random address. WARNING: Deployment cannot be retried!")
+                        .help("The signer for the desired address of the program [default: new random address]")
                 )
                 .arg(
                     Arg::with_name("use_deprecated_loader")
@@ -3093,12 +3077,10 @@ mod tests {
         );
 
         // Test Deploy Subcommand
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "deploy",
-            "/Users/test/program.o",
-            "--random-address",
-        ]);
+        let test_deploy =
+            test_commands
+                .clone()
+                .get_matches_from(vec!["test", "deploy", "/Users/test/program.o"]);
         assert_eq!(
             parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
             CliCommandInfo {
@@ -3106,7 +3088,6 @@ mod tests {
                     program_location: "/Users/test/program.o".to_string(),
                     address: None,
                     use_deprecated_loader: false,
-                    random_address: true,
                 },
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
             }
@@ -3128,7 +3109,6 @@ mod tests {
                     program_location: "/Users/test/program.o".to_string(),
                     address: Some(1),
                     use_deprecated_loader: false,
-                    random_address: false,
                 },
                 signers: vec![
                     read_keypair_file(&keypair_file).unwrap().into(),
@@ -3857,7 +3837,6 @@ mod tests {
             program_location: pathbuf.to_str().unwrap().to_string(),
             address: None,
             use_deprecated_loader: false,
-            random_address: true,
         };
         let result = process_command(&config);
         let json: Value = serde_json::from_str(&result.unwrap()).unwrap();
@@ -3876,7 +3855,6 @@ mod tests {
             program_location: "bad/file/location.so".to_string(),
             address: None,
             use_deprecated_loader: false,
-            random_address: true,
         };
         assert!(process_command(&config).is_err());
     }

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -64,7 +64,6 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: None,
         use_deprecated_loader: false,
-        random_address: true,
     };
 
     let response = process_command(&config);
@@ -99,7 +98,6 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
-        random_address: false,
     };
     process_command(&config).unwrap();
     let account1 = rpc_client


### PR DESCRIPTION
This reverts commit c2806aa2f92c52b2ef7f6f732411db09c65bf1a1.

#### Problem
We want to reconsider this fix to avoid a breaking change to solana-cli

