### PR TITLE
Revert "CLI: Put `deploy` ephemeral keypair behind a flag"

### DIFF
--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -64,7 +64,6 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: None,
         use_deprecated_loader: false,
-        random_address: true,
     };
 
     let response = process_command(&config);
@@ -99,7 +98,6 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
-        random_address: false,
     };
     process_command(&config).unwrap();
     let account1 = rpc_client


### PR DESCRIPTION
This reverts commit 5a5b7f39c1d6b46f98d15d5cec017c6c178efcaa.

#### Problem
We want to reconsider this fix to avoid a breaking change to solana-cli
