### PR TITLE
sdk: Add SyscallStubs to enable syscall interception when building programs for non-BPF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,6 +4440,7 @@ dependencies = [
  "hex",
  "hmac",
  "itertools 0.9.0",
+ "lazy_static",
  "libsecp256k1",
  "log 0.4.8",
  "memmap",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2121,6 +2121,7 @@ dependencies = [
  "hex",
  "hmac",
  "itertools",
+ "lazy_static",
  "libsecp256k1",
  "log",
  "memmap",

--- a/programs/bpf/rust/128bit/src/lib.rs
+++ b/programs/bpf/rust/128bit/src/lib.rs
@@ -53,8 +53,6 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/alloc/src/lib.rs
+++ b/programs/bpf/rust/alloc/src/lib.rs
@@ -85,8 +85,6 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/dep_crate/src/lib.rs
+++ b/programs/bpf/rust/dep_crate/src/lib.rs
@@ -20,8 +20,6 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/deprecated_loader/src/lib.rs
+++ b/programs/bpf/rust/deprecated_loader/src/lib.rs
@@ -67,8 +67,6 @@ fn process_instruction(
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_return_sstruct() {

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -365,8 +365,6 @@ fn process_instruction(
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn create_program_address_is_defined() {

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -194,6 +194,3 @@ fn process_instruction(
 
     Ok(())
 }
-
-// Pull in syscall stubs when building for non-BPF targets
-solana_sdk::program_stubs!();

--- a/programs/bpf/rust/iter/src/lib.rs
+++ b/programs/bpf/rust/iter/src/lib.rs
@@ -21,8 +21,6 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/many_args/src/lib.rs
+++ b/programs/bpf/rust/many_args/src/lib.rs
@@ -29,8 +29,6 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/many_args_dep/src/lib.rs
+++ b/programs/bpf/rust/many_args_dep/src/lib.rs
@@ -51,8 +51,6 @@ pub fn many_args_sret(
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_many_args() {

--- a/programs/bpf/rust/param_passing/src/lib.rs
+++ b/programs/bpf/rust/param_passing/src/lib.rs
@@ -26,8 +26,6 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_entrypoint() {

--- a/programs/bpf/rust/param_passing_dep/src/lib.rs
+++ b/programs/bpf/rust/param_passing_dep/src/lib.rs
@@ -27,8 +27,6 @@ impl<'a> TestDep {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_dep() {

--- a/programs/bpf/rust/ristretto/src/lib.rs
+++ b/programs/bpf/rust/ristretto/src/lib.rs
@@ -38,8 +38,6 @@ fn process_instruction(
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_ristretto() {

--- a/programs/bpf/rust/sanity/src/lib.rs
+++ b/programs/bpf/rust/sanity/src/lib.rs
@@ -67,8 +67,6 @@ fn process_instruction(
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_return_sstruct() {

--- a/programs/bpf/rust/sha256/src/lib.rs
+++ b/programs/bpf/rust/sha256/src/lib.rs
@@ -25,8 +25,6 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    // Pull in syscall stubs when building for non-BPF targets
-    solana_sdk::program_stubs!();
 
     #[test]
     fn test_sha256() {

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -42,6 +42,7 @@ generic-array = { version = "0.14.3", default-features = false, features = ["ser
 hex = "0.4.2"
 hmac = "0.7.0"
 itertools = { version = "0.9.0" }
+lazy_static = "1.4.0"
 log = { version = "0.4.8" }
 memmap = { version = "0.7.0", optional = true }
 num-derive = { version = "0.3" }

--- a/sdk/src/decode_error.rs
+++ b/sdk/src/decode_error.rs
@@ -1,6 +1,6 @@
 use num_traits::FromPrimitive;
 
-/// Allows customer errors to be decoded back to their original enum
+/// Allows custom errors to be decoded back to their original enum
 pub trait DecodeError<E> {
     fn decode_custom_error_to_enum(custom: u32) -> Option<E>
     where

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -84,7 +84,23 @@ pub mod entrypoint_deprecated;
 pub mod log;
 pub mod program;
 pub mod program_error;
+
+#[cfg(all(feature = "program", not(target_arch = "bpf")))]
+extern crate lazy_static;
+
+#[cfg(all(feature = "program", not(target_arch = "bpf")))]
 pub mod program_stubs;
+
+// Unused `solana_sdk::program_stubs!()` macro retained for source backwards compatibility with v1.3.x programs
+#[macro_export]
+#[deprecated(
+    since = "1.4.2",
+    note = "program_stubs macro is obsolete and can be safely removed"
+)]
+macro_rules! program_stubs {
+    () => {};
+}
+
 pub mod serialize_utils;
 
 // Modules not usable by on-chain programs

--- a/sdk/src/log.rs
+++ b/sdk/src/log.rs
@@ -31,10 +31,16 @@ macro_rules! info {
 /// @param message - Message to print
 #[inline]
 pub fn sol_log(message: &str) {
+    #[cfg(target_arch = "bpf")]
     unsafe {
         sol_log_(message.as_ptr(), message.len() as u64);
     }
+
+    #[cfg(not(target_arch = "bpf"))]
+    crate::program_stubs::sol_log(message);
 }
+
+#[cfg(target_arch = "bpf")]
 extern "C" {
     fn sol_log_(message: *const u8, len: u64);
 }
@@ -45,10 +51,16 @@ extern "C" {
 
 #[inline]
 pub fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+    #[cfg(target_arch = "bpf")]
     unsafe {
         sol_log_64_(arg1, arg2, arg3, arg4, arg5);
     }
+
+    #[cfg(not(target_arch = "bpf"))]
+    crate::program_stubs::sol_log_64(arg1, arg2, arg3, arg4, arg5);
 }
+
+#[cfg(target_arch = "bpf")]
 extern "C" {
     fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64);
 }

--- a/sdk/src/program_stubs.rs
+++ b/sdk/src/program_stubs.rs
@@ -1,36 +1,54 @@
-//! @brief Syscall stubs when building for non-BPF targets
+//! @brief Syscall stubs when building for programs for non-BPF targets
 
-#[cfg(not(target_arch = "bpf"))]
-#[no_mangle]
-/// # Safety
-pub unsafe fn sol_log_(message: *const u8, length: u64) {
-    let slice = std::slice::from_raw_parts(message, length as usize);
-    let string = std::str::from_utf8(&slice).unwrap();
-    println!("{}", string);
+use crate::{
+    account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
+    program_error::ProgramError,
+};
+use std::sync::{Arc, RwLock};
+
+lazy_static::lazy_static! {
+    static ref SYSCALL_STUBS: Arc<RwLock<Box<dyn SyscallStubs>>> = Arc::new(RwLock::new(Box::new(DefaultSyscallStubs {})));
 }
 
-#[cfg(not(target_arch = "bpf"))]
-#[no_mangle]
-pub fn sol_log_64_(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
-    println!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5);
+// The default syscall stubs don't do much, but `set_syscalls()` can be used to swap in
+// alternatives
+pub fn set_syscall_stubs(syscall_stubs: Box<dyn SyscallStubs>) -> Box<dyn SyscallStubs> {
+    std::mem::replace(&mut SYSCALL_STUBS.write().unwrap(), syscall_stubs)
 }
 
-#[cfg(not(target_arch = "bpf"))]
-#[no_mangle]
-pub fn sol_invoke_signed_rust() {
-    println!("sol_invoke_signed_rust()");
+pub trait SyscallStubs: Sync + Send {
+    fn sol_log(&self, message: &str) {
+        println!("{}", message);
+    }
+    fn sol_invoke_signed(
+        &self,
+        _instruction: &Instruction,
+        _account_infos: &[AccountInfo],
+        _signers_seeds: &[&[&[u8]]],
+    ) -> ProgramResult {
+        sol_log("SyscallStubs: sol_invoke_signed() not available");
+        Err(ProgramError::InvalidArgument)
+    }
 }
 
-#[macro_export]
-macro_rules! program_stubs {
-    () => {
-        #[cfg(not(target_arch = "bpf"))]
-        #[test]
-        fn pull_in_externs() {
-            use solana_sdk::program_stubs::{sol_invoke_signed_rust, sol_log_, sol_log_64_};
-            unsafe { sol_log_("sol_log_".as_ptr(), 8) };
-            sol_log_64_(1, 2, 3, 4, 5);
-            sol_invoke_signed_rust();
-        }
-    };
+struct DefaultSyscallStubs {}
+impl SyscallStubs for DefaultSyscallStubs {}
+
+pub(crate) fn sol_log(message: &str) {
+    SYSCALL_STUBS.read().unwrap().sol_log(message);
+}
+
+pub(crate) fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
+    sol_log(&format!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5));
+}
+
+pub(crate) fn sol_invoke_signed(
+    instruction: &Instruction,
+    account_infos: &[AccountInfo],
+    signers_seeds: &[&[&[u8]]],
+) -> ProgramResult {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_invoke_signed(instruction, account_infos, signers_seeds)
 }

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -204,12 +204,17 @@ impl Pubkey {
     }
 
     /// Log a `Pubkey` from a program
-    #[cfg(feature = "program")]
     pub fn log(&self) {
-        extern "C" {
-            fn sol_log_pubkey(pubkey_addr: *const u8);
-        };
-        unsafe { sol_log_pubkey(self.as_ref() as *const _ as *const u8) };
+        #[cfg(all(feature = "program", target_arch = "bpf"))]
+        {
+            extern "C" {
+                fn sol_log_pubkey(pubkey_addr: *const u8);
+            };
+            unsafe { sol_log_pubkey(self.as_ref() as *const _ as *const u8) };
+        }
+
+        #[cfg(all(feature = "program", not(target_arch = "bpf")))]
+        crate::program_stubs::sol_log(&self.to_string());
     }
 }
 


### PR DESCRIPTION
There's no way to override `sol_invoke_signed()` from a program unit-test environment, resulting in unsightly program-specific stubs.

With this PR, program unit tests can use `set_syscall_stubs()` to swap in their own `sol_invoke_signed()`, which would allow for code like [this](https://github.com/solana-labs/solana-program-library/blob/0e8c4fb5bf13229c3d23a5b5d0b09d4d24bfc306/token-swap/program/src/processor.rs#L534-L568) to live  under `#[cfg(test)]`.

Note there's still a ton of boilerplate that's required to supply an implementation of `SyscallStubs::sol_invoke_signed()`.  This'll be worked on as (multiple) follow-up PRs.   Generate thought is that `runtime/` supplies a `SyscallStubs` implementation with a full-blown `InvokeContext` 
