### PR TITLE
sdk: add "everything" feature

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -79,7 +79,9 @@ _ scripts/cargo-for-all-lock-files.sh +"$rust_stable" audit "${cargo_audit_ignor
       cd "$project"
       _ cargo +"$rust_stable" fmt -- --check
       _ cargo +"$rust_nightly" test
-      _ cargo +"$rust_nightly" clippy -- --deny=warnings --allow=clippy::missing_safety_doc
+      _ cargo +"$rust_nightly" clippy -- --deny=warnings \
+        --allow=clippy::missing_safety_doc \
+        --allow=clippy::stable_sort_primitive
     )
   done
 }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,12 +11,14 @@ edition = "2018"
 [features]
 # On-chain program specific dependencies
 program = []
-# Dependencies that are not compatible or needed for on-chain programs
+# Everything includes functionality that is not compatible or needed for on-chain programs
 default = [
+  "everything"
+]
+everything = [
     "assert_matches",
     "byteorder",
     "chrono",
-    "curve25519-dalek",
     "generic-array",
     "memmap",
     "rand",
@@ -65,6 +67,9 @@ rustversion = "1.0.3"
 libsecp256k1 = { version = "0.3.5", optional = true }
 sha3 = { version = "0.9.1", optional = true }
 digest = { version = "0.9.0", optional = true }
+
+[target.'cfg(not(target_arch = "bpf"))'.dependencies]
+curve25519-dalek = { version = "2.1.0" }
 
 [dev-dependencies]
 curve25519-dalek = "2.1.0"

--- a/sdk/src/abi_example.rs
+++ b/sdk/src/abi_example.rs
@@ -213,9 +213,9 @@ atomic_example_impls! { AtomicI64 }
 atomic_example_impls! { AtomicIsize }
 atomic_example_impls! { AtomicBool }
 
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 use generic_array::{ArrayLength, GenericArray};
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 impl<T: Default, U: ArrayLength<T>> AbiExample for GenericArray<T, U> {
     fn example() -> Self {
         Self::default()
@@ -413,14 +413,14 @@ impl<T: std::cmp::Ord + AbiExample> AbiExample for BTreeSet<T> {
     }
 }
 
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 impl AbiExample for memmap::MmapMut {
     fn example() -> Self {
         memmap::MmapMut::map_anon(1).expect("failed to map the data file")
     }
 }
 
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 impl AbiExample for std::path::PathBuf {
     fn example() -> Self {
         std::path::PathBuf::from(String::example())

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -90,7 +90,7 @@ impl Hash {
     }
 
     /// New random hash value for tests and benchmarks.
-    #[cfg(not(feature = "program"))]
+    #[cfg(feature = "everything")]
     pub fn new_rand<R: ?Sized>(rng: &mut R) -> Self
     where
         R: rand::Rng,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -104,25 +104,25 @@ macro_rules! program_stubs {
 pub mod serialize_utils;
 
 // Modules not usable by on-chain programs
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod client;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod genesis_config;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod hard_forks;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod secp256k1;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod shred_version;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod signature;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod signers;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod system_transaction;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod transaction;
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub mod transport;
 
 #[macro_use]

--- a/sdk/src/nonce/account.rs
+++ b/sdk/src/nonce/account.rs
@@ -170,7 +170,7 @@ pub fn create_account(lamports: u64) -> RefCell<account::Account> {
 }
 
 /// Convenience function for working with keyed accounts in tests
-#[cfg(not(feature = "program"))]
+#[cfg(feature = "everything")]
 pub fn with_test_keyed_account<F>(lamports: u64, signer: bool, f: F)
 where
     F: Fn(&KeyedAccount),

--- a/sdk/src/program_error.rs
+++ b/sdk/src/program_error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[cfg(feature = "program")]
 use crate::info;
-#[cfg(not(feature = "program"))]
+#[cfg(all(feature = "everything", not(feature = "program")))]
 use log::info;
 
 /// Reasons the program may fail

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -1,11 +1,5 @@
-#[cfg(all(feature = "program", target_arch = "bpf"))]
-use crate::entrypoint::SUCCESS;
-#[cfg(not(all(feature = "program", target_arch = "bpf")))]
-use crate::hash::Hasher;
 use crate::{decode_error::DecodeError, hash::hashv};
 use num_derive::{FromPrimitive, ToPrimitive};
-#[cfg(not(feature = "program"))]
-use std::error;
 use std::{convert::TryFrom, fmt, mem, str::FromStr};
 use thiserror::Error;
 
@@ -130,7 +124,7 @@ impl Pubkey {
         // not supported
         #[cfg(not(all(feature = "program", target_arch = "bpf")))]
         {
-            let mut hasher = Hasher::default();
+            let mut hasher = crate::hash::Hasher::default();
             for seed in seeds.iter() {
                 if seed.len() > MAX_SEED_LEN {
                     return Err(PubkeyError::MaxSeedLengthExceeded);
@@ -170,7 +164,7 @@ impl Pubkey {
                 )
             };
             match result {
-                SUCCESS => Ok(Pubkey::new(&bytes)),
+                crate::entrypoint::SUCCESS => Ok(Pubkey::new(&bytes)),
                 _ => Err(result.into()),
             }
         }
@@ -194,7 +188,7 @@ impl Pubkey {
         panic!("Unable to find a viable program address bump seed");
     }
 
-    #[cfg(not(feature = "program"))]
+    #[cfg(feature = "everything")]
     pub fn new_rand() -> Self {
         Self::new(&rand::random::<[u8; 32]>())
     }
@@ -236,8 +230,8 @@ impl fmt::Display for Pubkey {
     }
 }
 
-#[cfg(not(feature = "program"))]
-pub fn write_pubkey_file(outfile: &str, pubkey: Pubkey) -> Result<(), Box<dyn error::Error>> {
+#[cfg(feature = "everything")]
+pub fn write_pubkey_file(outfile: &str, pubkey: Pubkey) -> Result<(), Box<dyn std::error::Error>> {
     use std::io::Write;
 
     let printable = format!("{}", pubkey);
@@ -252,8 +246,8 @@ pub fn write_pubkey_file(outfile: &str, pubkey: Pubkey) -> Result<(), Box<dyn er
     Ok(())
 }
 
-#[cfg(not(feature = "program"))]
-pub fn read_pubkey_file(infile: &str) -> Result<Pubkey, Box<dyn error::Error>> {
+#[cfg(feature = "everything")]
+pub fn read_pubkey_file(infile: &str) -> Result<Pubkey, Box<dyn std::error::Error>> {
     let f = std::fs::File::open(infile.to_string())?;
     let printable: String = serde_json::from_reader(f)?;
     Ok(Pubkey::from_str(&printable)?)
@@ -434,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_write_pubkey() -> Result<(), Box<dyn error::Error>> {
+    fn test_read_write_pubkey() -> Result<(), Box<dyn std::error::Error>> {
         let filename = "test_pubkey.json";
         let pubkey = Pubkey::new_rand();
         write_pubkey_file(filename, pubkey)?;


### PR DESCRIPTION
Cargo features are intended to be additive.  Once the "program" feature is added there's no way to get back to the feature set of solana-sdk that includes everything.   To avoid this add an explicit "everything" feature (enabled by default).  