### PR TITLE
Add replacements for Pubkey::new_rand()/Hash::new_rand()

### DIFF
--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -111,8 +111,8 @@ mod test {
 
     #[test]
     fn test_parse_account_data() {
-        let account_pubkey = Pubkey::new_rand();
-        let other_program = Pubkey::new_rand();
+        let account_pubkey = solana_sdk::pubkey::new_rand();
+        let other_program = solana_sdk::pubkey::new_rand();
         let data = vec![0; 4];
         assert!(parse_account_data(&account_pubkey, &other_program, &data, None).is_err());
 

--- a/account-decoder/src/parse_config.rs
+++ b/account-decoder/src/parse_config.rs
@@ -117,7 +117,7 @@ mod test {
             }))
             .unwrap(),
         };
-        let info_pubkey = Pubkey::new_rand();
+        let info_pubkey = solana_sdk::pubkey::new_rand();
         let validator_info_config_account = create_config_account(
             vec![(validator_info::id(), false), (info_pubkey, true)],
             &validator_info,

--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -134,7 +134,6 @@ impl From<Delegation> for UiDelegation {
 mod test {
     use super::*;
     use bincode::serialize;
-    use solana_sdk::pubkey::Pubkey;
 
     #[test]
     fn test_parse_stake() {

--- a/account-decoder/src/parse_stake.rs
+++ b/account-decoder/src/parse_stake.rs
@@ -145,8 +145,8 @@ mod test {
             StakeAccountType::Uninitialized
         );
 
-        let pubkey = Pubkey::new_rand();
-        let custodian = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
         let authorized = Authorized::auto(&pubkey);
         let lockup = Lockup {
             unix_timestamp: 0,
@@ -180,7 +180,7 @@ mod test {
             })
         );
 
-        let voter_pubkey = Pubkey::new_rand();
+        let voter_pubkey = solana_sdk::pubkey::new_rand();
         let stake = Stake {
             delegation: Delegation {
                 voter_pubkey,

--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -319,7 +319,7 @@ mod test {
             }]),
         );
 
-        let bad_pubkey = Pubkey::new_rand();
+        let bad_pubkey = solana_sdk::pubkey::new_rand();
         assert!(parse_sysvar(&stake_history_sysvar.data, &bad_pubkey).is_err());
 
         let bad_data = vec![0; 4];

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -69,7 +69,7 @@ fn make_accounts_txs(
     hash: Hash,
     same_payer: bool,
 ) -> Vec<Transaction> {
-    let to_pubkey = Pubkey::new_rand();
+    let to_pubkey = solana_sdk::pubkey::new_rand();
     let payer_key = Keypair::new();
     let dummy = system_transaction::transfer(&payer_key, &to_pubkey, 1, hash);
     (0..total_num_transactions)
@@ -78,9 +78,9 @@ fn make_accounts_txs(
             let mut new = dummy.clone();
             let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
             if !same_payer {
-                new.message.account_keys[0] = Pubkey::new_rand();
+                new.message.account_keys[0] = solana_sdk::pubkey::new_rand();
             }
-            new.message.account_keys[1] = Pubkey::new_rand();
+            new.message.account_keys[1] = solana_sdk::pubkey::new_rand();
             new.signatures = vec![Signature::new(&sig[0..64])];
             new
         })
@@ -241,7 +241,7 @@ fn main() {
         let base_tx_count = bank.transaction_count();
         let mut txs_processed = 0;
         let mut root = 1;
-        let collector = Pubkey::new_rand();
+        let collector = solana_sdk::pubkey::new_rand();
         let config = Config {
             packets_per_batch: packets_per_chunk,
             chunk_len,

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -20,7 +20,6 @@ use solana_perf::packet::to_packets_chunked;
 use solana_runtime::{bank::Bank, bank_forks::BankForks};
 use solana_sdk::{
     hash::Hash,
-    pubkey::Pubkey,
     signature::Keypair,
     signature::Signature,
     system_transaction,

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -213,7 +213,7 @@ mod tests {
     use super::*;
     use solana_banks_server::banks_server::start_local_server;
     use solana_runtime::{bank::Bank, bank_forks::BankForks, genesis_utils::create_genesis_config};
-    use solana_sdk::{message::Message, pubkey::Pubkey, signature::Signer, system_instruction};
+    use solana_sdk::{message::Message, signature::Signer, system_instruction};
     use std::sync::{Arc, RwLock};
     use tarpc::transport;
     use tokio::{runtime::Runtime, time::delay_for};

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -235,7 +235,7 @@ mod tests {
             &genesis.genesis_config,
         ))));
 
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let mint_pubkey = genesis.mint_keypair.pubkey();
         let instruction = system_instruction::transfer(&mint_pubkey, &bob_pubkey, 1);
         let message = Message::new(&[instruction], Some(&mint_pubkey));
@@ -265,7 +265,7 @@ mod tests {
         ))));
 
         let mint_pubkey = &genesis.mint_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let instruction = system_instruction::transfer(&mint_pubkey, &bob_pubkey, 1);
         let message = Message::new(&[instruction], Some(&mint_pubkey));
 

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -228,8 +228,8 @@ mod tests {
         assert_eq!(values_of(&matches, "multiple"), Some(vec![50, 39]));
         assert_eq!(values_of::<u64>(&matches, "single"), None);
 
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let matches = app().clone().get_matches_from(vec![
             "test",
             "--multiple",
@@ -251,7 +251,7 @@ mod tests {
         assert_eq!(value_of(&matches, "single"), Some(50));
         assert_eq!(value_of::<u64>(&matches, "multiple"), None);
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let matches = app()
             .clone()
             .get_matches_from(vec!["test", "--single", &pubkey.to_string()]);
@@ -331,8 +331,8 @@ mod tests {
 
     #[test]
     fn test_pubkeys_sigs_of() {
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
         let sig1 = Keypair::new().sign_message(&[0u8]);
         let sig2 = Keypair::new().sign_message(&[1u8]);
         let signer1 = format!("{}={}", key1, sig1);

--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -161,7 +161,7 @@ mod tests {
             context: RpcResponseContext { slot: 1 },
             value: json!(account_balance),
         });
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let fee_calculator = FeeCalculator::new(1);
 
         let pubkey0 = Pubkey::new(&[0; 32]);
@@ -221,7 +221,7 @@ mod tests {
             context: RpcResponseContext { slot: 1 },
             value: json!(account_balance),
         });
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let mut mocks = HashMap::new();
         mocks.insert(RpcRequest::GetBalance, account_balance_response);
@@ -267,9 +267,9 @@ mod tests {
 
     #[test]
     fn test_check_unique_pubkeys() {
-        let pubkey0 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
         let pubkey_clone = pubkey0;
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
 
         check_unique_pubkeys((&pubkey0, "foo".to_string()), (&pubkey1, "bar".to_string()))
             .expect("unexpected result");

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2409,7 +2409,7 @@ mod tests {
             .unwrap();
         assert_eq!(signer_info.signers.len(), 1);
         assert_eq!(signer_info.index_of(None), Some(0));
-        assert_eq!(signer_info.index_of(Some(Pubkey::new_rand())), None);
+        assert_eq!(signer_info.index_of(Some(solana_sdk::pubkey::new_rand())), None);
 
         let keypair0 = keypair_from_seed(&[1u8; 32]).unwrap();
         let keypair0_pubkey = keypair0.pubkey();
@@ -2465,7 +2465,7 @@ mod tests {
     fn test_cli_parse_command() {
         let test_commands = app("test", "desc", "version");
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let pubkey_string = format!("{}", pubkey);
 
         let default_keypair = Keypair::new();
@@ -2561,7 +2561,7 @@ mod tests {
         assert!(parse_command(&test_bad_signature, &default_signer, &mut None).is_err());
 
         // Test CreateAddressWithSeed
-        let from_pubkey = Some(Pubkey::new_rand());
+        let from_pubkey = Some(solana_sdk::pubkey::new_rand());
         let from_str = from_pubkey.unwrap().to_string();
         for (name, program_id) in &[
             ("STAKE", solana_stake_program::id()),
@@ -2718,7 +2718,7 @@ mod tests {
         let result = process_command(&config);
         assert!(result.is_ok());
 
-        let new_authorized_pubkey = Pubkey::new_rand();
+        let new_authorized_pubkey = solana_sdk::pubkey::new_rand();
         config.signers = vec![&bob_keypair];
         config.command = CliCommand::VoteAuthorize {
             vote_account_pubkey: bob_pubkey,
@@ -2740,7 +2740,7 @@ mod tests {
 
         let bob_keypair = Keypair::new();
         let bob_pubkey = bob_keypair.pubkey();
-        let custodian = Pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
         config.command = CliCommand::CreateStakeAccount {
             stake_account: 1,
             seed: None,
@@ -2763,8 +2763,8 @@ mod tests {
         let result = process_command(&config);
         assert!(result.is_ok());
 
-        let stake_account_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let stake_account_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
         config.command = CliCommand::WithdrawStake {
             stake_account_pubkey,
             destination_account_pubkey: to_pubkey,
@@ -2781,7 +2781,7 @@ mod tests {
         let result = process_command(&config);
         assert!(result.is_ok());
 
-        let stake_account_pubkey = Pubkey::new_rand();
+        let stake_account_pubkey = solana_sdk::pubkey::new_rand();
         config.command = CliCommand::DeactivateStake {
             stake_account_pubkey,
             stake_authority: 0,
@@ -2794,7 +2794,7 @@ mod tests {
         let result = process_command(&config);
         assert!(result.is_ok());
 
-        let stake_account_pubkey = Pubkey::new_rand();
+        let stake_account_pubkey = solana_sdk::pubkey::new_rand();
         let split_stake_account = Keypair::new();
         config.command = CliCommand::SplitStake {
             stake_account_pubkey,
@@ -2812,8 +2812,8 @@ mod tests {
         let result = process_command(&config);
         assert!(result.is_ok());
 
-        let stake_account_pubkey = Pubkey::new_rand();
-        let source_stake_account_pubkey = Pubkey::new_rand();
+        let stake_account_pubkey = solana_sdk::pubkey::new_rand();
+        let source_stake_account_pubkey = solana_sdk::pubkey::new_rand();
         let merge_stake_account = Keypair::new();
         config.command = CliCommand::MergeStake {
             stake_account_pubkey,
@@ -2836,7 +2836,7 @@ mod tests {
         assert_eq!(process_command(&config).unwrap(), "1234");
 
         // CreateAddressWithSeed
-        let from_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
         config.signers = vec![];
         config.command = CliCommand::CreateAddressWithSeed {
             from_pubkey: Some(from_pubkey),
@@ -2849,7 +2849,7 @@ mod tests {
         assert_eq!(address.unwrap(), expected_address.to_string());
 
         // Need airdrop cases
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         config.signers = vec![&keypair];
         config.command = CliCommand::Airdrop {
             faucet_host: None,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2409,7 +2409,10 @@ mod tests {
             .unwrap();
         assert_eq!(signer_info.signers.len(), 1);
         assert_eq!(signer_info.index_of(None), Some(0));
-        assert_eq!(signer_info.index_of(Some(solana_sdk::pubkey::new_rand())), None);
+        assert_eq!(
+            signer_info.index_of(Some(solana_sdk::pubkey::new_rand())),
+            None
+        );
 
         let keypair0 = keypair_from_seed(&[1u8; 32]).unwrap();
         let keypair0_pubkey = keypair0.pubkey();

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -833,7 +833,7 @@ mod tests {
     #[test]
     fn test_check_nonce_account() {
         let blockhash = Hash::default();
-        let nonce_pubkey = Pubkey::new_rand();
+        let nonce_pubkey = solana_sdk::pubkey::new_rand();
         let data = Versions::new_current(State::Initialized(nonce::state::Data {
             authority: nonce_pubkey,
             blockhash,
@@ -869,7 +869,7 @@ mod tests {
         }
 
         let data = Versions::new_current(State::Initialized(nonce::state::Data {
-            authority: Pubkey::new_rand(),
+            authority: solana_sdk::pubkey::new_rand(),
             blockhash,
             fee_calculator: FeeCalculator::default(),
         }));

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2426,9 +2426,9 @@ mod tests {
         );
 
         // Test CreateStakeAccount SubCommand
-        let custodian = Pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
         let custodian_string = format!("{}", custodian);
-        let authorized = Pubkey::new_rand();
+        let authorized = solana_sdk::pubkey::new_rand();
         let authorized_string = format!("{}", authorized);
         let test_create_stake_account = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2566,7 +2566,7 @@ mod tests {
         );
 
         // Test DelegateStake Subcommand
-        let vote_account_pubkey = Pubkey::new_rand();
+        let vote_account_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account_string = vote_account_pubkey.to_string();
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2593,7 +2593,7 @@ mod tests {
         );
 
         // Test DelegateStake Subcommand w/ authority
-        let vote_account_pubkey = Pubkey::new_rand();
+        let vote_account_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account_string = vote_account_pubkey.to_string();
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
             "test",
@@ -2712,7 +2712,7 @@ mod tests {
         );
 
         // Test Delegate Subcommand w/ absent fee payer
-        let key1 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
         let sig1 = Keypair::new().sign_message(&[0u8]);
         let signer1 = format!("{}={}", key1, sig1);
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
@@ -2752,7 +2752,7 @@ mod tests {
         );
 
         // Test Delegate Subcommand w/ absent fee payer and absent nonce authority
-        let key2 = Pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
         let sig2 = Keypair::new().sign_message(&[0u8]);
         let signer2 = format!("{}={}", key2, sig2);
         let test_delegate_stake = test_commands.clone().get_matches_from(vec![
@@ -3080,7 +3080,7 @@ mod tests {
         );
 
         // Test Deactivate Subcommand w/ absent fee payer
-        let key1 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
         let sig1 = Keypair::new().sign_message(&[0u8]);
         let signer1 = format!("{}={}", key1, sig1);
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
@@ -3117,7 +3117,7 @@ mod tests {
         );
 
         // Test Deactivate Subcommand w/ absent fee payer and nonce authority
-        let key2 = Pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
         let sig2 = Keypair::new().sign_message(&[0u8]);
         let signer2 = format!("{}={}", key2, sig2);
         let test_deactivate_stake = test_commands.clone().get_matches_from(vec![
@@ -3296,7 +3296,7 @@ mod tests {
         let stake_account_keypair = Keypair::new();
         write_keypair(&stake_account_keypair, tmp_file.as_file_mut()).unwrap();
 
-        let source_stake_account_pubkey = Pubkey::new_rand();
+        let source_stake_account_pubkey = solana_sdk::pubkey::new_rand();
         let test_merge_stake_account = test_commands.clone().get_matches_from(vec![
             "test",
             "merge-stake",

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn test_parse_validator_info() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let keys = vec![(validator_info::id(), false), (pubkey, true)];
         let config = ConfigKeys { keys };
 

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -915,7 +915,7 @@ mod tests {
         );
 
         // test init with an authed voter
-        let authed = Pubkey::new_rand();
+        let authed = solana_sdk::pubkey::new_rand();
         let (keypair_file, mut tmp_file) = make_tmp_file();
         let keypair = Keypair::new();
         write_keypair(&keypair, tmp_file.as_file_mut()).unwrap();

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -172,7 +172,7 @@ fn full_battery_tests(
     assert_ne!(first_nonce, third_nonce);
 
     // Withdraw from nonce account
-    let payee_pubkey = Pubkey::new_rand();
+    let payee_pubkey = solana_sdk::pubkey::new_rand();
     config_payer.signers = authorized_signers;
     config_payer.command = CliCommand::WithdrawFromNonceAccount {
         nonce_account,

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -110,7 +110,7 @@ fn test_vote_authorize_and_withdraw() {
     assert_eq!(authorized_withdrawer, withdraw_authority.pubkey());
 
     // Withdraw from vote account
-    let destination_account = Pubkey::new_rand(); // Send withdrawal to new account to make balance check easy
+    let destination_account = solana_sdk::pubkey::new_rand(); // Send withdrawal to new account to make balance check easy
     config.signers = vec![&default_signer, &withdraw_authority];
     config.command = CliCommand::WithdrawFromVoteAccount {
         vote_account_pubkey,

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -12,7 +12,6 @@ use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
     account_utils::StateMut,
     commitment_config::CommitmentConfig,
-    pubkey::Pubkey,
     signature::{Keypair, Signer},
 };
 use solana_vote_program::vote_state::{VoteAuthorize, VoteState, VoteStateVersions};

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1456,7 +1456,7 @@ mod tests {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
 
         let key = Keypair::new();
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let blockhash = Hash::default();
         let tx = system_transaction::transfer(&key, &to, 50, blockhash);
 
@@ -1509,7 +1509,7 @@ mod tests {
         let rpc_client = RpcClient::new_mock("succeeds".to_string());
 
         let key = Keypair::new();
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let blockhash = Hash::default();
         let tx = system_transaction::transfer(&key, &to, 50, blockhash);
         let result = rpc_client.send_and_confirm_transaction(&tx);

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -228,7 +228,7 @@ mod tests {
 
         // Test request with CommitmentConfig and params
         let test_request = RpcRequest::GetTokenAccountsByOwner;
-        let mint = Pubkey::new_rand();
+        let mint = solana_sdk::pubkey::new_rand();
         let token_account_filter = RpcTokenAccountsFilter::Mint(mint.to_string());
         let request = test_request
             .build_request_json(1, json!([addr, token_account_filter, commitment_config]));

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -56,7 +56,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
     let bank = Arc::new(Bank::new(&genesis_config));
     let ledger_path = get_tmp_ledger_path!();
-    let my_pubkey = Pubkey::new_rand();
+    let my_pubkey = solana_sdk::pubkey::new_rand();
     {
         let blockstore = Arc::new(
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
@@ -94,15 +94,15 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
 }
 
 fn make_accounts_txs(txes: usize, mint_keypair: &Keypair, hash: Hash) -> Vec<Transaction> {
-    let to_pubkey = Pubkey::new_rand();
+    let to_pubkey = solana_sdk::pubkey::new_rand();
     let dummy = system_transaction::transfer(mint_keypair, &to_pubkey, 1, hash);
     (0..txes)
         .into_par_iter()
         .map(|_| {
             let mut new = dummy.clone();
             let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
-            new.message.account_keys[0] = Pubkey::new_rand();
-            new.message.account_keys[1] = Pubkey::new_rand();
+            new.message.account_keys[0] = solana_sdk::pubkey::new_rand();
+            new.message.account_keys[1] = solana_sdk::pubkey::new_rand();
             new.signatures = vec![Signature::new(&sig[0..64])];
             new
         })
@@ -117,7 +117,7 @@ fn make_programs_txs(txes: usize, hash: Hash) -> Vec<Transaction> {
             let mut instructions = vec![];
             let from_key = Keypair::new();
             for _ in 1..progs {
-                let to_key = Pubkey::new_rand();
+                let to_key = solana_sdk::pubkey::new_rand();
                 instructions.push(system_instruction::transfer(&from_key.pubkey(), &to_key, 1));
             }
             let message = Message::new(&instructions, Some(&from_key.pubkey()));

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -20,7 +20,7 @@ use solana_runtime::bank::Bank;
 use solana_sdk::genesis_config::GenesisConfig;
 use solana_sdk::hash::Hash;
 use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signature::Signature;
 use solana_sdk::signature::Signer;
@@ -56,7 +56,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
     let bank = Arc::new(Bank::new(&genesis_config));
     let ledger_path = get_tmp_ledger_path!();
-    let my_pubkey = solana_sdk::pubkey::new_rand();
+    let my_pubkey = pubkey::new_rand();
     {
         let blockstore = Arc::new(
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
@@ -94,15 +94,15 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
 }
 
 fn make_accounts_txs(txes: usize, mint_keypair: &Keypair, hash: Hash) -> Vec<Transaction> {
-    let to_pubkey = solana_sdk::pubkey::new_rand();
+    let to_pubkey = pubkey::new_rand();
     let dummy = system_transaction::transfer(mint_keypair, &to_pubkey, 1, hash);
     (0..txes)
         .into_par_iter()
         .map(|_| {
             let mut new = dummy.clone();
             let sig: Vec<u8> = (0..64).map(|_| thread_rng().gen()).collect();
-            new.message.account_keys[0] = solana_sdk::pubkey::new_rand();
-            new.message.account_keys[1] = solana_sdk::pubkey::new_rand();
+            new.message.account_keys[0] = pubkey::new_rand();
+            new.message.account_keys[1] = pubkey::new_rand();
             new.signatures = vec![Signature::new(&sig[0..64])];
             new
         })
@@ -117,7 +117,7 @@ fn make_programs_txs(txes: usize, hash: Hash) -> Vec<Transaction> {
             let mut instructions = vec![];
             let from_key = Keypair::new();
             for _ in 1..progs {
-                let to_key = solana_sdk::pubkey::new_rand();
+                let to_key = pubkey::new_rand();
                 instructions.push(system_instruction::transfer(&from_key.pubkey(), &to_key, 1));
             }
             let message = Message::new(&instructions, Some(&from_key.pubkey()));

--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -8,7 +8,7 @@ use solana_core::broadcast_stage::{broadcast_shreds, get_broadcast_peers};
 use solana_core::cluster_info::{ClusterInfo, Node};
 use solana_core::contact_info::ContactInfo;
 use solana_ledger::shred::Shred;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::pubkey;
 use solana_sdk::timing::timestamp;
 use std::{
     collections::HashMap,
@@ -20,7 +20,7 @@ use test::Bencher;
 #[bench]
 fn broadcast_shreds_bench(bencher: &mut Bencher) {
     solana_logger::setup();
-    let leader_pubkey = solana_sdk::pubkey::new_rand();
+    let leader_pubkey = pubkey::new_rand();
     let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
     let cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info);
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
@@ -30,7 +30,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     let mut stakes = HashMap::new();
     const NUM_PEERS: usize = 200;
     for _ in 0..NUM_PEERS {
-        let id = solana_sdk::pubkey::new_rand();
+        let id = pubkey::new_rand();
         let contact_info = ContactInfo::new_localhost(&id, timestamp());
         cluster_info.insert_info(contact_info);
         stakes.insert(id, thread_rng().gen_range(1, NUM_PEERS) as u64);

--- a/core/benches/cluster_info.rs
+++ b/core/benches/cluster_info.rs
@@ -20,7 +20,7 @@ use test::Bencher;
 #[bench]
 fn broadcast_shreds_bench(bencher: &mut Bencher) {
     solana_logger::setup();
-    let leader_pubkey = Pubkey::new_rand();
+    let leader_pubkey = solana_sdk::pubkey::new_rand();
     let leader_info = Node::new_localhost_with_pubkey(&leader_pubkey);
     let cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.info);
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
@@ -30,7 +30,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     let mut stakes = HashMap::new();
     const NUM_PEERS: usize = 200;
     for _ in 0..NUM_PEERS {
-        let id = Pubkey::new_rand();
+        let id = solana_sdk::pubkey::new_rand();
         let contact_info = ContactInfo::new_localhost(&id, timestamp());
         cluster_info.insert_info(contact_info);
         stakes.insert(id, thread_rng().gen_range(1, NUM_PEERS) as u64);

--- a/core/benches/crds_gossip_pull.rs
+++ b/core/benches/crds_gossip_pull.rs
@@ -8,13 +8,13 @@ use solana_core::cluster_info::MAX_BLOOM_SIZE;
 use solana_core::crds::Crds;
 use solana_core::crds_gossip_pull::{CrdsFilter, CrdsGossipPull};
 use solana_core::crds_value::CrdsValue;
-use solana_sdk::hash::Hash;
+use solana_sdk::hash;
 use test::Bencher;
 
 #[bench]
 fn bench_hash_as_u64(bencher: &mut Bencher) {
     let mut rng = thread_rng();
-    let hashes: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
+    let hashes: Vec<_> = std::iter::repeat_with(|| hash::new_rand(&mut rng))
         .take(1000)
         .collect();
     bencher.iter(|| {

--- a/core/benches/crds_gossip_pull.rs
+++ b/core/benches/crds_gossip_pull.rs
@@ -14,7 +14,7 @@ use test::Bencher;
 #[bench]
 fn bench_hash_as_u64(bencher: &mut Bencher) {
     let mut rng = thread_rng();
-    let hashes: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+    let hashes: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
         .take(1000)
         .collect();
     bencher.iter(|| {
@@ -34,7 +34,7 @@ fn bench_build_crds_filters(bencher: &mut Bencher) {
     for _ in 0..50_000 {
         crds_gossip_pull
             .purged_values
-            .push_back((Hash::new_rand(&mut rng), rng.gen()));
+            .push_back((solana_sdk::hash::new_rand(&mut rng), rng.gen()));
     }
     let mut num_inserts = 0;
     for _ in 0..90_000 {

--- a/core/benches/crds_shards.rs
+++ b/core/benches/crds_shards.rs
@@ -7,14 +7,14 @@ use solana_core::contact_info::ContactInfo;
 use solana_core::crds::VersionedCrdsValue;
 use solana_core::crds_shards::CrdsShards;
 use solana_core::crds_value::{CrdsData, CrdsValue};
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::pubkey;
 use solana_sdk::timing::timestamp;
 use test::Bencher;
 
 const CRDS_SHARDS_BITS: u32 = 8;
 
 fn new_test_crds_value() -> VersionedCrdsValue {
-    let data = CrdsData::ContactInfo(ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp()));
+    let data = CrdsData::ContactInfo(ContactInfo::new_localhost(&pubkey::new_rand(), timestamp()));
     VersionedCrdsValue::new(timestamp(), CrdsValue::new_unsigned(data))
 }
 

--- a/core/benches/crds_shards.rs
+++ b/core/benches/crds_shards.rs
@@ -14,7 +14,7 @@ use test::Bencher;
 const CRDS_SHARDS_BITS: u32 = 8;
 
 fn new_test_crds_value() -> VersionedCrdsValue {
-    let data = CrdsData::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp()));
+    let data = CrdsData::ContactInfo(ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp()));
     VersionedCrdsValue::new(timestamp(), CrdsValue::new_unsigned(data))
 }
 

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -34,7 +34,7 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     const NUM_PEERS: usize = 4;
     let mut peer_sockets = Vec::new();
     for _ in 0..NUM_PEERS {
-        let id = Pubkey::new_rand();
+        let id = solana_sdk::pubkey::new_rand();
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let mut contact_info = ContactInfo::new_localhost(&id, timestamp());
         contact_info.tvu = socket.local_addr().unwrap();

--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -14,7 +14,7 @@ use solana_perf::packet::to_packets_chunked;
 use solana_perf::test_tx::test_tx;
 use solana_runtime::bank::Bank;
 use solana_runtime::bank_forks::BankForks;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::pubkey;
 use solana_sdk::timing::timestamp;
 use std::net::UdpSocket;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -34,7 +34,7 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     const NUM_PEERS: usize = 4;
     let mut peer_sockets = Vec::new();
     for _ in 0..NUM_PEERS {
-        let id = solana_sdk::pubkey::new_rand();
+        let id = pubkey::new_rand();
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let mut contact_info = ContactInfo::new_localhost(&id, timestamp());
         contact_info.tvu = socket.local_addr().unwrap();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1246,16 +1246,16 @@ mod tests {
             bank.process_transaction(&fund_tx).unwrap();
 
             // good tx
-            let to = Pubkey::new_rand();
+            let to = solana_sdk::pubkey::new_rand();
             let tx = system_transaction::transfer(&mint_keypair, &to, 1, start_hash);
 
             // good tx, but no verify
-            let to2 = Pubkey::new_rand();
+            let to2 = solana_sdk::pubkey::new_rand();
             let tx_no_ver = system_transaction::transfer(&keypair, &to2, 2, start_hash);
 
             // bad tx, AccountNotFound
             let keypair = Keypair::new();
-            let to3 = Pubkey::new_rand();
+            let to3 = solana_sdk::pubkey::new_rand();
             let tx_anf = system_transaction::transfer(&keypair, &to3, 1, start_hash);
 
             // send 'em over
@@ -1448,9 +1448,9 @@ mod tests {
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
-            let pubkey = Pubkey::new_rand();
+            let pubkey = solana_sdk::pubkey::new_rand();
             let keypair2 = Keypair::new();
-            let pubkey2 = Pubkey::new_rand();
+            let pubkey2 = solana_sdk::pubkey::new_rand();
 
             let transactions = vec![
                 system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash()),
@@ -1528,7 +1528,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let transactions = vec![
             None,
@@ -1609,7 +1609,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let transactions = vec![
             system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash()),
@@ -1680,8 +1680,8 @@ mod tests {
 
     #[test]
     fn test_should_process_or_forward_packets() {
-        let my_pubkey = Pubkey::new_rand();
-        let my_pubkey1 = Pubkey::new_rand();
+        let my_pubkey = solana_sdk::pubkey::new_rand();
+        let my_pubkey1 = solana_sdk::pubkey::new_rand();
 
         assert_eq!(
             BankingStage::consume_or_forward_packets(&my_pubkey, None, true, false,),
@@ -1727,7 +1727,7 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let transactions = vec![system_transaction::transfer(
             &mint_keypair,
@@ -1824,8 +1824,8 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let pubkey = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
 
         let transactions = vec![
             system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash()),
@@ -1920,7 +1920,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new(&genesis_config));
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let transactions =
             vec![
@@ -1938,7 +1938,7 @@ mod tests {
                 bank.slot(),
                 Some((4, 4)),
                 bank.ticks_per_slot(),
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
@@ -1978,8 +1978,8 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let pubkey = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let keypair1 = Keypair::new();
 
         let success_tx =

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -140,7 +140,6 @@ impl BroadcastRun for BroadcastFakeShredsRun {
 mod tests {
     use super::*;
     use crate::contact_info::ContactInfo;
-    use solana_sdk::pubkey::Pubkey;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     #[test]

--- a/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
+++ b/core/src/broadcast_stage/broadcast_fake_shreds_run.rs
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn test_tvu_peers_ordering() {
         let cluster = ClusterInfo::new_with_invalid_keypair(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         ));
         cluster.insert_info(ContactInfo::new_with_socketaddr(&SocketAddr::new(

--- a/core/src/broadcast_stage/broadcast_utils.rs
+++ b/core/src/broadcast_stage/broadcast_utils.rs
@@ -92,7 +92,7 @@ mod tests {
         let bank0 = Arc::new(Bank::new(&genesis_config));
         let tx = system_transaction::transfer(
             &mint_keypair,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             1,
             genesis_config.hash(),
         );

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2570,7 +2570,7 @@ pub struct Node {
 
 impl Node {
     pub fn new_localhost() -> Self {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         Self::new_localhost_with_pubkey(&pubkey)
     }
     pub fn new_localhost_with_pubkey(pubkey: &Pubkey) -> Self {
@@ -2734,10 +2734,10 @@ mod tests {
     #[test]
     fn test_gossip_node() {
         //check that a gossip nodes always show up as spies
-        let (node, _, _) = ClusterInfo::spy_node(&Pubkey::new_rand(), 0);
+        let (node, _, _) = ClusterInfo::spy_node(&solana_sdk::pubkey::new_rand(), 0);
         assert!(ClusterInfo::is_spy_node(&node));
         let (node, _, _) =
-            ClusterInfo::gossip_node(&Pubkey::new_rand(), &"1.1.1.1:1111".parse().unwrap(), 0);
+            ClusterInfo::gossip_node(&solana_sdk::pubkey::new_rand(), &"1.1.1.1:1111".parse().unwrap(), 0);
         assert!(ClusterInfo::is_spy_node(&node));
     }
 
@@ -2747,7 +2747,7 @@ mod tests {
         let node = Node::new_localhost();
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(node.info));
 
-        let entrypoint_pubkey = Pubkey::new_rand();
+        let entrypoint_pubkey = solana_sdk::pubkey::new_rand();
         let data = test_crds_values(entrypoint_pubkey);
         let timeouts = HashMap::new();
         assert_eq!(
@@ -2760,7 +2760,7 @@ mod tests {
             )
         );
 
-        let entrypoint_pubkey2 = Pubkey::new_rand();
+        let entrypoint_pubkey2 = solana_sdk::pubkey::new_rand();
         assert_eq!(
             (1, 0, 0),
             ClusterInfo::handle_pull_response(&cluster_info, &entrypoint_pubkey2, data, &timeouts)
@@ -2775,7 +2775,7 @@ mod tests {
 
     #[test]
     fn test_filter_shred_version() {
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let my_shred_version = 1;
         let other_shred_version = 1;
 
@@ -2810,7 +2810,7 @@ mod tests {
         assert_eq!(values.len(), 1);
 
         let snapshot_hash_data = CrdsValue::new_unsigned(CrdsData::SnapshotHashes(SnapshotHash {
-            from: Pubkey::new_rand(),
+            from: solana_sdk::pubkey::new_rand(),
             hashes: vec![],
             wallclock: 0,
         }));
@@ -2831,7 +2831,7 @@ mod tests {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         //check that gossip doesn't try to push to invalid addresses
         let node = Node::new_localhost();
-        let (spy, _, _) = ClusterInfo::spy_node(&Pubkey::new_rand(), 0);
+        let (spy, _, _) = ClusterInfo::spy_node(&solana_sdk::pubkey::new_rand(), 0);
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(node.info));
         cluster_info.insert_info(spy);
         cluster_info
@@ -2851,16 +2851,16 @@ mod tests {
 
     #[test]
     fn test_cluster_info_new() {
-        let d = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let d = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         let cluster_info = ClusterInfo::new_with_invalid_keypair(d.clone());
         assert_eq!(d.id, cluster_info.id());
     }
 
     #[test]
     fn insert_info_test() {
-        let d = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let d = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         let cluster_info = ClusterInfo::new_with_invalid_keypair(d);
-        let d = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let d = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         let label = CrdsValueLabel::ContactInfo(d.id);
         cluster_info.insert_info(d);
         assert!(cluster_info
@@ -2874,7 +2874,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_update_contact_info() {
-        let d = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let d = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         let cluster_info = ClusterInfo::new_with_invalid_keypair(d);
         let entry_label = CrdsValueLabel::ContactInfo(cluster_info.id());
         assert!(cluster_info
@@ -2903,7 +2903,7 @@ mod tests {
 
         // Inserting Contactinfo with different pubkey should panic,
         // and update should fail
-        cluster_info.update_contact_info(|ci| ci.id = Pubkey::new_rand())
+        cluster_info.update_contact_info(|ci| ci.id = solana_sdk::pubkey::new_rand())
     }
 
     fn assert_in_range(x: u16, range: (u16, u16)) {
@@ -2938,7 +2938,7 @@ mod tests {
     fn new_with_external_ip_test_random() {
         let ip = Ipv4Addr::from(0);
         let node = Node::new_with_external_ip(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             &socketaddr!(ip, 0),
             VALIDATOR_PORT_RANGE,
             IpAddr::V4(ip),
@@ -2956,7 +2956,7 @@ mod tests {
         let ip = IpAddr::V4(Ipv4Addr::from(0));
         let port = bind_in_range(ip, port_range).expect("Failed to bind").0;
         let node =
-            Node::new_with_external_ip(&Pubkey::new_rand(), &socketaddr!(0, port), port_range, ip);
+            Node::new_with_external_ip(&solana_sdk::pubkey::new_rand(), &socketaddr!(0, port), port_range, ip);
 
         check_node_sockets(&node, ip, port_range);
 
@@ -3221,7 +3221,7 @@ mod tests {
             ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
             node_keypair,
         );
-        let entrypoint_pubkey = Pubkey::new_rand();
+        let entrypoint_pubkey = solana_sdk::pubkey::new_rand();
         let entrypoint = ContactInfo::new_localhost(&entrypoint_pubkey, timestamp());
         cluster_info.set_entrypoint(entrypoint.clone());
         let pulls = cluster_info.new_pull_requests(&thread_pool, None, &HashMap::new());
@@ -3380,14 +3380,14 @@ mod tests {
             ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
             node_keypair,
         );
-        let entrypoint_pubkey = Pubkey::new_rand();
+        let entrypoint_pubkey = solana_sdk::pubkey::new_rand();
         let mut entrypoint = ContactInfo::new_localhost(&entrypoint_pubkey, timestamp());
         entrypoint.gossip = socketaddr!("127.0.0.2:1234");
         cluster_info.set_entrypoint(entrypoint.clone());
 
         let mut stakes = HashMap::new();
 
-        let other_node_pubkey = Pubkey::new_rand();
+        let other_node_pubkey = solana_sdk::pubkey::new_rand();
         let other_node = ContactInfo::new_localhost(&other_node_pubkey, timestamp());
         assert_ne!(other_node.gossip, entrypoint.gossip);
         cluster_info.insert_info(other_node.clone());
@@ -3430,7 +3430,7 @@ mod tests {
         for i in 0..10 {
             // make these invalid for the upcoming repair request
             let peer_lowest = if i >= 5 { 10 } else { 0 };
-            let other_node_pubkey = Pubkey::new_rand();
+            let other_node_pubkey = solana_sdk::pubkey::new_rand();
             let other_node = ContactInfo::new_localhost(&other_node_pubkey, timestamp());
             cluster_info.insert_info(other_node.clone());
             let value = CrdsValue::new_unsigned(CrdsData::LowestSlot(
@@ -3581,7 +3581,7 @@ mod tests {
 
         // Simulate getting entrypoint ContactInfo from gossip
         let mut gossiped_entrypoint_info =
-            ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+            ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         gossiped_entrypoint_info.gossip = entrypoint_gossip_addr;
         gossiped_entrypoint_info.shred_version = 1;
         cluster_info.insert_info(gossiped_entrypoint_info.clone());

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2736,8 +2736,11 @@ mod tests {
         //check that a gossip nodes always show up as spies
         let (node, _, _) = ClusterInfo::spy_node(&solana_sdk::pubkey::new_rand(), 0);
         assert!(ClusterInfo::is_spy_node(&node));
-        let (node, _, _) =
-            ClusterInfo::gossip_node(&solana_sdk::pubkey::new_rand(), &"1.1.1.1:1111".parse().unwrap(), 0);
+        let (node, _, _) = ClusterInfo::gossip_node(
+            &solana_sdk::pubkey::new_rand(),
+            &"1.1.1.1:1111".parse().unwrap(),
+            0,
+        );
         assert!(ClusterInfo::is_spy_node(&node));
     }
 
@@ -2955,8 +2958,12 @@ mod tests {
 
         let ip = IpAddr::V4(Ipv4Addr::from(0));
         let port = bind_in_range(ip, port_range).expect("Failed to bind").0;
-        let node =
-            Node::new_with_external_ip(&solana_sdk::pubkey::new_rand(), &socketaddr!(0, port), port_range, ip);
+        let node = Node::new_with_external_ip(
+            &solana_sdk::pubkey::new_rand(),
+            &socketaddr!(0, port),
+            port_range,
+            ip,
+        );
 
         check_node_sockets(&node, ip, port_range);
 

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -898,7 +898,7 @@ mod tests {
         let (vote_tracker, bank, _, _) = setup();
 
         // Check outdated slots are purged with new root
-        let new_voter = Arc::new(Pubkey::new_rand());
+        let new_voter = Arc::new(solana_sdk::pubkey::new_rand());
         // Make separate copy so the original doesn't count toward
         // the ref count, which would prevent cleanup
         let new_voter_ = Arc::new(*new_voter);
@@ -1681,7 +1681,7 @@ mod tests {
     fn run_test_verify_votes_1_pass(hash: Option<Hash>) {
         let vote_tx = test_vote_tx(hash);
         let votes = vec![vote_tx];
-        let labels = vec![CrdsValueLabel::Vote(0, Pubkey::new_rand())];
+        let labels = vec![CrdsValueLabel::Vote(0, solana_sdk::pubkey::new_rand())];
         let (vote_txs, packets) = ClusterInfoVoteListener::verify_votes(votes, labels);
         assert_eq!(vote_txs.len(), 1);
         verify_packets_len(&packets, 1);
@@ -1698,7 +1698,7 @@ mod tests {
         let mut bad_vote = vote_tx.clone();
         bad_vote.signatures[0] = Signature::default();
         let votes = vec![vote_tx.clone(), bad_vote, vote_tx];
-        let label = CrdsValueLabel::Vote(0, Pubkey::new_rand());
+        let label = CrdsValueLabel::Vote(0, solana_sdk::pubkey::new_rand());
         let labels: Vec<_> = (0..votes.len()).map(|_| label.clone()).collect();
         let (vote_txs, packets) = ClusterInfoVoteListener::verify_votes(votes, labels);
         assert_eq!(vote_txs.len(), 2);

--- a/core/src/cluster_slots.rs
+++ b/core/src/cluster_slots.rs
@@ -237,8 +237,8 @@ mod tests {
         let mut c1 = ContactInfo::default();
         let mut c2 = ContactInfo::default();
         let mut map = HashMap::new();
-        let k1 = Pubkey::new_rand();
-        let k2 = Pubkey::new_rand();
+        let k1 = solana_sdk::pubkey::new_rand();
+        let k2 = solana_sdk::pubkey::new_rand();
         map.insert(Arc::new(k1), std::u64::MAX / 2);
         map.insert(Arc::new(k2), 0);
         cs.cluster_slots
@@ -259,8 +259,8 @@ mod tests {
         let mut c1 = ContactInfo::default();
         let mut c2 = ContactInfo::default();
         let mut map = HashMap::new();
-        let k1 = Pubkey::new_rand();
-        let k2 = Pubkey::new_rand();
+        let k1 = solana_sdk::pubkey::new_rand();
+        let k2 = solana_sdk::pubkey::new_rand();
         map.insert(Arc::new(k2), 0);
         cs.cluster_slots
             .write()
@@ -290,7 +290,7 @@ mod tests {
         let cs = ClusterSlots::default();
         let mut contact_infos = vec![ContactInfo::default(); 2];
         for ci in contact_infos.iter_mut() {
-            ci.id = Pubkey::new_rand();
+            ci.id = solana_sdk::pubkey::new_rand();
         }
         let slot = 9;
 
@@ -359,7 +359,7 @@ mod tests {
         let mut epoch_slot = EpochSlots::default();
         epoch_slot.fill(&[1], 0);
         cs.update_internal(0, (vec![epoch_slot], None));
-        let self_id = Pubkey::new_rand();
+        let self_id = solana_sdk::pubkey::new_rand();
         assert_eq!(
             cs.generate_repairs_for_missing_slots(&self_id, 0),
             vec![RepairType::HighestShred(1, 0)]

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -375,19 +375,19 @@ mod tests {
 
         let rooted_stake_amount = 40;
 
-        let sk1 = Pubkey::new_rand();
-        let pk1 = Pubkey::new_rand();
-        let mut vote_account1 = vote_state::create_account(&pk1, &Pubkey::new_rand(), 0, 100);
+        let sk1 = solana_sdk::pubkey::new_rand();
+        let pk1 = solana_sdk::pubkey::new_rand();
+        let mut vote_account1 = vote_state::create_account(&pk1, &solana_sdk::pubkey::new_rand(), 0, 100);
         let stake_account1 =
             stake_state::create_account(&sk1, &pk1, &vote_account1, &genesis_config.rent, 100);
-        let sk2 = Pubkey::new_rand();
-        let pk2 = Pubkey::new_rand();
-        let mut vote_account2 = vote_state::create_account(&pk2, &Pubkey::new_rand(), 0, 50);
+        let sk2 = solana_sdk::pubkey::new_rand();
+        let pk2 = solana_sdk::pubkey::new_rand();
+        let mut vote_account2 = vote_state::create_account(&pk2, &solana_sdk::pubkey::new_rand(), 0, 50);
         let stake_account2 =
             stake_state::create_account(&sk2, &pk2, &vote_account2, &genesis_config.rent, 50);
-        let sk3 = Pubkey::new_rand();
-        let pk3 = Pubkey::new_rand();
-        let mut vote_account3 = vote_state::create_account(&pk3, &Pubkey::new_rand(), 0, 1);
+        let sk3 = solana_sdk::pubkey::new_rand();
+        let pk3 = solana_sdk::pubkey::new_rand();
+        let mut vote_account3 = vote_state::create_account(&pk3, &solana_sdk::pubkey::new_rand(), 0, 1);
         let stake_account3 = stake_state::create_account(
             &sk3,
             &pk3,
@@ -395,9 +395,9 @@ mod tests {
             &genesis_config.rent,
             rooted_stake_amount,
         );
-        let sk4 = Pubkey::new_rand();
-        let pk4 = Pubkey::new_rand();
-        let mut vote_account4 = vote_state::create_account(&pk4, &Pubkey::new_rand(), 0, 1);
+        let sk4 = solana_sdk::pubkey::new_rand();
+        let pk4 = solana_sdk::pubkey::new_rand();
+        let mut vote_account4 = vote_state::create_account(&pk4, &solana_sdk::pubkey::new_rand(), 0, 1);
         let stake_account4 = stake_state::create_account(
             &sk4,
             &pk4,

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -377,17 +377,20 @@ mod tests {
 
         let sk1 = solana_sdk::pubkey::new_rand();
         let pk1 = solana_sdk::pubkey::new_rand();
-        let mut vote_account1 = vote_state::create_account(&pk1, &solana_sdk::pubkey::new_rand(), 0, 100);
+        let mut vote_account1 =
+            vote_state::create_account(&pk1, &solana_sdk::pubkey::new_rand(), 0, 100);
         let stake_account1 =
             stake_state::create_account(&sk1, &pk1, &vote_account1, &genesis_config.rent, 100);
         let sk2 = solana_sdk::pubkey::new_rand();
         let pk2 = solana_sdk::pubkey::new_rand();
-        let mut vote_account2 = vote_state::create_account(&pk2, &solana_sdk::pubkey::new_rand(), 0, 50);
+        let mut vote_account2 =
+            vote_state::create_account(&pk2, &solana_sdk::pubkey::new_rand(), 0, 50);
         let stake_account2 =
             stake_state::create_account(&sk2, &pk2, &vote_account2, &genesis_config.rent, 50);
         let sk3 = solana_sdk::pubkey::new_rand();
         let pk3 = solana_sdk::pubkey::new_rand();
-        let mut vote_account3 = vote_state::create_account(&pk3, &solana_sdk::pubkey::new_rand(), 0, 1);
+        let mut vote_account3 =
+            vote_state::create_account(&pk3, &solana_sdk::pubkey::new_rand(), 0, 1);
         let stake_account3 = stake_state::create_account(
             &sk3,
             &pk3,
@@ -397,7 +400,8 @@ mod tests {
         );
         let sk4 = solana_sdk::pubkey::new_rand();
         let pk4 = solana_sdk::pubkey::new_rand();
-        let mut vote_account4 = vote_state::create_account(&pk4, &solana_sdk::pubkey::new_rand(), 0, 1);
+        let mut vote_account4 =
+            vote_state::create_account(&pk4, &solana_sdk::pubkey::new_rand(), 0, 1);
         let stake_account4 = stake_state::create_account(
             &sk4,
             &pk4,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1536,7 +1536,7 @@ pub mod test {
                 &mut account.data,
             )
             .expect("serialize state");
-            stakes.push((Pubkey::new_rand(), (*lamports, account)));
+            stakes.push((solana_sdk::pubkey::new_rand(), (*lamports, account)));
         }
         stakes
     }

--- a/core/src/contact_info.rs
+++ b/core/src/contact_info.rs
@@ -130,7 +130,7 @@ impl ContactInfo {
         let addr = socketaddr!("224.0.1.255:1000");
         assert!(addr.ip().is_multicast());
         Self {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             gossip: addr,
             tvu: addr,
             tvu_forwards: addr,

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -361,7 +361,7 @@ mod test {
         }
 
         let mut crds = Crds::default();
-        let pubkeys: Vec<_> = std::iter::repeat_with(Pubkey::new_rand).take(256).collect();
+        let pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand).take(256).collect();
         let mut rng = thread_rng();
         let mut num_inserts = 0;
         for _ in 0..4096 {
@@ -484,14 +484,14 @@ mod test {
         let v1 = VersionedCrdsValue::new(
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 0,
             ))),
         );
         let v2 = VersionedCrdsValue::new(
             1,
             CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 0,
             ))),
         );

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -361,7 +361,9 @@ mod test {
         }
 
         let mut crds = Crds::default();
-        let pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand).take(256).collect();
+        let pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
+            .take(256)
+            .collect();
         let mut rng = thread_rng();
         let mut num_inserts = 0;
         for _ in 0..4096 {

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -649,13 +649,13 @@ mod test {
         let mut stakes = HashMap::new();
         let node = CrdsGossipPull::default();
         let me = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         crds.insert(me.clone(), 0).unwrap();
         for i in 1..=30 {
             let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 0,
             )));
             let id = entry.label().pubkey();
@@ -682,25 +682,25 @@ mod test {
         let gossip = socketaddr!("127.0.0.1:1234");
 
         let me = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             shred_version: 123,
             gossip,
             ..ContactInfo::default()
         }));
         let spy = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             shred_version: 0,
             gossip,
             ..ContactInfo::default()
         }));
         let node_123 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             shred_version: 123,
             gossip,
             ..ContactInfo::default()
         }));
         let node_456 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             shred_version: 456,
             gossip,
             ..ContactInfo::default()
@@ -741,12 +741,12 @@ mod test {
         let gossip = socketaddr!("127.0.0.1:1234");
 
         let me = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             gossip,
             ..ContactInfo::default()
         }));
         let node_123 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             gossip,
             ..ContactInfo::default()
         }));
@@ -767,7 +767,7 @@ mod test {
         assert!(options.is_empty());
 
         // Unknown pubkey in gossip_validators -- will pull from nobody
-        gossip_validators.insert(Pubkey::new_rand());
+        gossip_validators.insert(solana_sdk::pubkey::new_rand());
         let options = node.pull_options(
             &crds,
             &me.label().pubkey(),
@@ -898,7 +898,7 @@ mod test {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         let id = entry.label().pubkey();
@@ -933,7 +933,7 @@ mod test {
         );
 
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         crds.insert(new.clone(), 0).unwrap();
@@ -957,19 +957,19 @@ mod test {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
         let mut node = CrdsGossipPull::default();
         crds.insert(entry.clone(), 0).unwrap();
         let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         crds.insert(old.clone(), 0).unwrap();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         crds.insert(new.clone(), 0).unwrap();
@@ -1000,14 +1000,14 @@ mod test {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
         let node = CrdsGossipPull::default();
         node_crds.insert(entry, 0).unwrap();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         node_crds.insert(new, 0).unwrap();
@@ -1031,7 +1031,7 @@ mod test {
         assert_eq!(rsp[0].len(), 0);
 
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             CRDS_GOSSIP_PULL_MSG_TIMEOUT_MS,
         )));
         dest_crds
@@ -1047,7 +1047,7 @@ mod test {
         filters.push(filters[0].clone());
         //should return new value since caller is new
         filters[1].0 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             CRDS_GOSSIP_PULL_MSG_TIMEOUT_MS + 1,
         )));
 
@@ -1063,14 +1063,14 @@ mod test {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         let node_pubkey = entry.label().pubkey();
         let node = CrdsGossipPull::default();
         node_crds.insert(entry, 0).unwrap();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         node_crds.insert(new, 0).unwrap();
@@ -1113,7 +1113,7 @@ mod test {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             1,
         )));
         let node_pubkey = entry.label().pubkey();
@@ -1121,14 +1121,14 @@ mod test {
         node_crds.insert(entry, 0).unwrap();
 
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             1,
         )));
         node_crds.insert(new, 0).unwrap();
 
         let mut dest = CrdsGossipPull::default();
         let mut dest_crds = Crds::default();
-        let new_id = Pubkey::new_rand();
+        let new_id = solana_sdk::pubkey::new_rand();
         let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &new_id, 1,
         )));
@@ -1210,7 +1210,7 @@ mod test {
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
         let mut node_crds = Crds::default();
         let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         let node_label = entry.label();
@@ -1218,7 +1218,7 @@ mod test {
         let mut node = CrdsGossipPull::default();
         node_crds.insert(entry, 0).unwrap();
         let old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         node_crds.insert(old.clone(), 0).unwrap();
@@ -1330,7 +1330,7 @@ mod test {
         let mut node_crds = Crds::default();
         let mut node = CrdsGossipPull::default();
 
-        let peer_pubkey = Pubkey::new_rand();
+        let peer_pubkey = solana_sdk::pubkey::new_rand();
         let peer_entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(
             ContactInfo::new_localhost(&peer_pubkey, 0),
         ));

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -626,7 +626,7 @@ mod test {
         }
         let mut rng = thread_rng();
         for _ in 0..100 {
-            let hash = Hash::new_rand(&mut rng);
+            let hash = solana_sdk::hash::new_rand(&mut rng);
             assert_eq!(CrdsFilter::hash_as_u64(&hash), hash_as_u64_bitops(&hash));
         }
     }
@@ -638,7 +638,7 @@ mod test {
         assert_eq!(filter.mask, mask);
         let mut rng = thread_rng();
         for _ in 0..10 {
-            let hash = Hash::new_rand(&mut rng);
+            let hash = solana_sdk::hash::new_rand(&mut rng);
             assert!(filter.test_mask(&hash));
         }
     }
@@ -797,7 +797,7 @@ mod test {
         let mut rng = thread_rng();
         let crds_filter_set =
             CrdsFilterSet::new(/*num_items=*/ 9672788, /*max_bytes=*/ 8196);
-        let hash_values: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        let hash_values: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
             .take(1024)
             .collect();
         for hash_value in &hash_values {
@@ -849,7 +849,7 @@ mod test {
         for _ in 0..10_000 {
             crds_gossip_pull
                 .purged_values
-                .push_back((Hash::new_rand(&mut rng), rng.gen()));
+                .push_back((solana_sdk::hash::new_rand(&mut rng), rng.gen()));
         }
         let mut num_inserts = 0;
         for _ in 0..20_000 {

--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -438,15 +438,15 @@ mod test {
         let mut push = CrdsGossipPush::default();
         let mut stakes = HashMap::new();
 
-        let self_id = Pubkey::new_rand();
-        let origin = Pubkey::new_rand();
+        let self_id = solana_sdk::pubkey::new_rand();
+        let origin = solana_sdk::pubkey::new_rand();
         stakes.insert(self_id, 100);
         stakes.insert(origin, 100);
 
         let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
             &origin, 0,
         )));
-        let low_staked_peers = (0..10).map(|_| Pubkey::new_rand());
+        let low_staked_peers = (0..10).map(|_| solana_sdk::pubkey::new_rand());
         let mut low_staked_set = HashSet::new();
         low_staked_peers.for_each(|p| {
             let _ = push.process_push_message(&mut crds, &p, value.clone(), 0);
@@ -460,7 +460,7 @@ mod test {
             "should not prune if min threshold has not been reached"
         );
 
-        let high_staked_peer = Pubkey::new_rand();
+        let high_staked_peer = solana_sdk::pubkey::new_rand();
         let high_stake = CrdsGossipPush::prune_stake_threshold(100, 100) + 10;
         stakes.insert(high_staked_peer, high_stake);
         let _ = push.process_push_message(&mut crds, &high_staked_peer, value, 0);
@@ -483,7 +483,7 @@ mod test {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
         let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         let label = value.label();
@@ -504,7 +504,7 @@ mod test {
     fn test_process_push_old_version() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         ci.wallclock = 1;
         let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone()));
 
@@ -527,7 +527,7 @@ mod test {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
         let timeout = push.msg_timeout;
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
 
         // push a version to far in the future
         ci.wallclock = timeout + 1;
@@ -549,7 +549,7 @@ mod test {
     fn test_process_push_update() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         ci.wallclock = 0;
         let value_old = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci.clone()));
 
@@ -584,7 +584,7 @@ mod test {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
         let value1 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
 
@@ -593,7 +593,7 @@ mod test {
 
         assert!(push.active_set.get(&value1.label().pubkey()).is_some());
         let value2 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         assert!(push.active_set.get(&value2.label().pubkey()).is_none());
@@ -608,7 +608,7 @@ mod test {
 
         for _ in 0..push.num_active {
             let value2 = CrdsValue::new_unsigned(CrdsData::ContactInfo(
-                ContactInfo::new_localhost(&Pubkey::new_rand(), 0),
+                ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0),
             ));
             assert_eq!(crds.insert(value2.clone(), now), Ok(None));
         }
@@ -624,7 +624,7 @@ mod test {
         let mut stakes = HashMap::new();
         for i in 1..=100 {
             let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 time,
             )));
             let id = peer.label().pubkey();
@@ -652,25 +652,25 @@ mod test {
         let gossip = socketaddr!("127.0.0.1:1234");
 
         let me = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             shred_version: 123,
             gossip,
             ..ContactInfo::default()
         }));
         let spy = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             shred_version: 0,
             gossip,
             ..ContactInfo::default()
         }));
         let node_123 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             shred_version: 123,
             gossip,
             ..ContactInfo::default()
         }));
         let node_456 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             shred_version: 456,
             gossip,
             ..ContactInfo::default()
@@ -709,12 +709,12 @@ mod test {
         let gossip = socketaddr!("127.0.0.1:1234");
 
         let me = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             gossip,
             ..ContactInfo::default()
         }));
         let node_123 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             gossip,
             ..ContactInfo::default()
         }));
@@ -735,7 +735,7 @@ mod test {
         assert!(options.is_empty());
 
         // Unknown pubkey in gossip_validators -- will push to nobody
-        gossip_validators.insert(Pubkey::new_rand());
+        gossip_validators.insert(solana_sdk::pubkey::new_rand());
         let options = node.push_options(
             &crds,
             &me.label().pubkey(),
@@ -765,14 +765,14 @@ mod test {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
         let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer.clone(), now), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), None, &Pubkey::default(), 0, 1, 1);
 
         let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         let mut expected = HashMap::new();
@@ -790,17 +790,17 @@ mod test {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
         let peer_1 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer_1.clone(), now), Ok(None));
         let peer_2 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer_2.clone(), now), Ok(None));
         let peer_3 = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             now,
         )));
         assert_eq!(
@@ -823,17 +823,17 @@ mod test {
     #[test]
     fn test_process_prune() {
         let mut crds = Crds::default();
-        let self_id = Pubkey::new_rand();
+        let self_id = solana_sdk::pubkey::new_rand();
         let mut push = CrdsGossipPush::default();
         let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer.clone(), 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), None, &Pubkey::default(), 0, 1, 1);
 
         let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         let expected = HashMap::new();
@@ -853,13 +853,13 @@ mod test {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
         let peer = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
         )));
         assert_eq!(crds.insert(peer, 0), Ok(None));
         push.refresh_push_active_set(&crds, &HashMap::new(), None, &Pubkey::default(), 0, 1, 1);
 
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         ci.wallclock = 1;
         let new_msg = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
         let expected = HashMap::new();
@@ -875,7 +875,7 @@ mod test {
     fn test_purge_old_received_cache() {
         let mut crds = Crds::default();
         let mut push = CrdsGossipPush::default();
-        let mut ci = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut ci = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         ci.wallclock = 0;
         let value = CrdsValue::new_unsigned(CrdsData::ContactInfo(ci));
         let label = value.label();

--- a/core/src/crds_shards.rs
+++ b/core/src/crds_shards.rs
@@ -142,7 +142,7 @@ mod test {
 
     fn new_test_crds_value() -> VersionedCrdsValue {
         let data =
-            CrdsData::ContactInfo(ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp()));
+            CrdsData::ContactInfo(ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp()));
         VersionedCrdsValue::new(timestamp(), CrdsValue::new_unsigned(data))
     }
 

--- a/core/src/crds_shards.rs
+++ b/core/src/crds_shards.rs
@@ -135,14 +135,15 @@ mod test {
     use crate::contact_info::ContactInfo;
     use crate::crds_value::{CrdsData, CrdsValue};
     use rand::{thread_rng, Rng};
-    use solana_sdk::pubkey::Pubkey;
     use solana_sdk::timing::timestamp;
     use std::collections::HashSet;
     use std::ops::Index;
 
     fn new_test_crds_value() -> VersionedCrdsValue {
-        let data =
-            CrdsData::ContactInfo(ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp()));
+        let data = CrdsData::ContactInfo(ContactInfo::new_localhost(
+            &solana_sdk::pubkey::new_rand(),
+            timestamp(),
+        ));
         VersionedCrdsValue::new(timestamp(), CrdsValue::new_unsigned(data))
     }
 

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -318,7 +318,7 @@ impl CrdsValue {
         R: rand::Rng,
     {
         let now = rng.gen();
-        let contact_info = ContactInfo::new_localhost(&Pubkey::new_rand(), now);
+        let contact_info = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), now);
         Self::new_signed(CrdsData::ContactInfo(contact_info), &Keypair::new())
     }
 

--- a/core/src/gossip_service.rs
+++ b/core/src/gossip_service.rs
@@ -306,8 +306,8 @@ mod tests {
     #[test]
     fn test_gossip_services_spy() {
         let keypair = Keypair::new();
-        let peer0 = Pubkey::new_rand();
-        let peer1 = Pubkey::new_rand();
+        let peer0 = solana_sdk::pubkey::new_rand();
+        let peer1 = solana_sdk::pubkey::new_rand();
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
         let peer0_info = ContactInfo::new_localhost(&peer0, 0);
         let peer1_info = ContactInfo::new_localhost(&peer1, 0);
@@ -335,7 +335,7 @@ mod tests {
             spy_ref.clone(),
             None,
             Some(0),
-            Some(Pubkey::new_rand()),
+            Some(solana_sdk::pubkey::new_rand()),
             None,
         );
         assert_eq!(met_criteria, false);
@@ -349,7 +349,7 @@ mod tests {
             spy_ref.clone(),
             Some(1),
             Some(0),
-            Some(Pubkey::new_rand()),
+            Some(solana_sdk::pubkey::new_rand()),
             None,
         );
         assert_eq!(met_criteria, false);

--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -135,7 +135,7 @@ mod tests {
         let num_genesis_accounts = 10;
         for _ in 0..num_genesis_accounts {
             accounts.insert(
-                Pubkey::new_rand(),
+                solana_sdk::pubkey::new_rand(),
                 Account::new(balance, 0, &Pubkey::default()),
             );
         }
@@ -147,7 +147,7 @@ mod tests {
 
         let num_stake_accounts = 3;
         for _ in 0..num_stake_accounts {
-            let pubkey = Pubkey::new_rand();
+            let pubkey = solana_sdk::pubkey::new_rand();
             let meta = Meta {
                 authorized: Authorized::auto(&pubkey),
                 lockup: Lockup {

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -401,7 +401,7 @@ mod test {
     fn test_add_vote_pubkey() {
         let mut stats = PropagatedStats::default();
         let mut all_pubkeys = PubkeyReferences::default();
-        let mut vote_pubkey = Pubkey::new_rand();
+        let mut vote_pubkey = solana_sdk::pubkey::new_rand();
         all_pubkeys.get_or_insert(&vote_pubkey);
 
         // Add a vote pubkey, the number of references in all_pubkeys
@@ -420,7 +420,7 @@ mod test {
         assert_eq!(stats.propagated_validators_stake, 1);
 
         // Adding another pubkey should succeed
-        vote_pubkey = Pubkey::new_rand();
+        vote_pubkey = solana_sdk::pubkey::new_rand();
         stats.add_vote_pubkey(&vote_pubkey, &mut all_pubkeys, 2);
         assert!(stats.propagated_validators.contains(&vote_pubkey));
         assert_eq!(stats.propagated_validators_stake, 3);
@@ -434,7 +434,7 @@ mod test {
     fn test_add_node_pubkey_internal() {
         let num_vote_accounts = 10;
         let staked_vote_accounts = 5;
-        let vote_account_pubkeys: Vec<_> = std::iter::repeat_with(Pubkey::new_rand)
+        let vote_account_pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
             .take(num_vote_accounts)
             .collect();
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys
@@ -445,7 +445,7 @@ mod test {
 
         let mut stats = PropagatedStats::default();
         let mut all_pubkeys = PubkeyReferences::default();
-        let mut node_pubkey = Pubkey::new_rand();
+        let mut node_pubkey = solana_sdk::pubkey::new_rand();
         all_pubkeys.get_or_insert(&node_pubkey);
 
         // Add a vote pubkey, the number of references in all_pubkeys
@@ -481,7 +481,7 @@ mod test {
 
         // Adding another pubkey with same vote accounts should succeed, but stake
         // shouldn't increase
-        node_pubkey = Pubkey::new_rand();
+        node_pubkey = solana_sdk::pubkey::new_rand();
         stats.add_node_pubkey_internal(
             &node_pubkey,
             &mut all_pubkeys,
@@ -500,8 +500,8 @@ mod test {
 
         // Adding another pubkey with different vote accounts should succeed
         // and increase stake
-        node_pubkey = Pubkey::new_rand();
-        let vote_account_pubkeys: Vec<_> = std::iter::repeat_with(Pubkey::new_rand)
+        node_pubkey = solana_sdk::pubkey::new_rand();
+        let vote_account_pubkeys: Vec<_> = std::iter::repeat_with(solana_sdk::pubkey::new_rand)
             .take(num_vote_accounts)
             .collect();
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2554,7 +2554,7 @@ pub(crate) mod tests {
             bank.store_account(&pubkey, &leader_vote_account);
         }
 
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let leader_lamports = 3;
         let genesis_config_info =
             create_genesis_config_with_leader(50, &leader_pubkey, leader_lamports);
@@ -2596,7 +2596,7 @@ pub(crate) mod tests {
             .is_none());
 
         let bank1 = Bank::new_from_parent(&arc_bank0, &Pubkey::default(), arc_bank0.slot() + 1);
-        let _res = bank1.transfer(10, &genesis_config_info.mint_keypair, &Pubkey::new_rand());
+        let _res = bank1.transfer(10, &genesis_config_info.mint_keypair, &solana_sdk::pubkey::new_rand());
         for _ in 0..genesis_config.ticks_per_slot {
             bank1.register_tick(&Hash::default());
         }
@@ -2612,7 +2612,7 @@ pub(crate) mod tests {
         );
 
         let bank2 = Bank::new_from_parent(&arc_bank1, &Pubkey::default(), arc_bank1.slot() + 1);
-        let _res = bank2.transfer(10, &genesis_config_info.mint_keypair, &Pubkey::new_rand());
+        let _res = bank2.transfer(10, &genesis_config_info.mint_keypair, &solana_sdk::pubkey::new_rand());
         for _ in 0..genesis_config.ticks_per_slot {
             bank2.register_tick(&Hash::default());
         }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2596,7 +2596,11 @@ pub(crate) mod tests {
             .is_none());
 
         let bank1 = Bank::new_from_parent(&arc_bank0, &Pubkey::default(), arc_bank0.slot() + 1);
-        let _res = bank1.transfer(10, &genesis_config_info.mint_keypair, &solana_sdk::pubkey::new_rand());
+        let _res = bank1.transfer(
+            10,
+            &genesis_config_info.mint_keypair,
+            &solana_sdk::pubkey::new_rand(),
+        );
         for _ in 0..genesis_config.ticks_per_slot {
             bank1.register_tick(&Hash::default());
         }
@@ -2612,7 +2616,11 @@ pub(crate) mod tests {
         );
 
         let bank2 = Bank::new_from_parent(&arc_bank1, &Pubkey::default(), arc_bank1.slot() + 1);
-        let _res = bank2.transfer(10, &genesis_config_info.mint_keypair, &solana_sdk::pubkey::new_rand());
+        let _res = bank2.transfer(
+            10,
+            &genesis_config_info.mint_keypair,
+            &solana_sdk::pubkey::new_rand(),
+        );
         for _ in 0..genesis_config.ticks_per_slot {
             bank2.register_tick(&Hash::default());
         }

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -521,7 +521,7 @@ mod tests {
         let leader_schedule_cache = Arc::new(cached_leader_schedule);
         let bank_forks = Arc::new(RwLock::new(bank_forks));
 
-        let mut me = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let mut me = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         let ip_addr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));
         let port = find_available_port_in_range(ip_addr, (8000, 10000)).unwrap();
         let me_retransmit = UdpSocket::bind(format!("127.0.0.1:{}", port)).unwrap();
@@ -533,7 +533,7 @@ mod tests {
             .local_addr()
             .unwrap();
 
-        let other = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+        let other = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(other);
         cluster_info.insert_info(me);
 

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -504,7 +504,6 @@ mod tests {
     use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_net_utils::find_available_port_in_range;
     use solana_perf::packet::{Meta, Packet, Packets};
-    use solana_sdk::pubkey::Pubkey;
     use std::net::{IpAddr, Ipv4Addr};
 
     #[test]

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2904,7 +2904,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_request_processor_new() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let genesis = create_genesis_config(100);
         let bank = Arc::new(Bank::new(&genesis.genesis_config));
         bank.transfer(20, &genesis.mint_keypair, &bob_pubkey)
@@ -2964,7 +2964,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_cluster_nodes() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -2991,7 +2991,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_recent_performance_samples() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getRecentPerformanceSamples"}"#;
@@ -3020,7 +3020,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_recent_performance_samples_invalid_limit() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req =
@@ -3046,7 +3046,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_slot_leader() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -3066,7 +3066,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_tx_count() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let genesis = create_genesis_config(10);
         let bank = Arc::new(Bank::new(&genesis.genesis_config));
         // Add 4 transactions
@@ -3096,7 +3096,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_minimum_ledger_slot() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"minimumLedgerSlot"}"#;
@@ -3111,7 +3111,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_total_supply() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getTotalSupply"}"#;
@@ -3136,7 +3136,7 @@ pub mod tests {
 
     #[test]
     fn test_get_supply() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSupply"}"#;
         let res = io.handle_request_sync(&req, meta);
@@ -3161,7 +3161,7 @@ pub mod tests {
 
     #[test]
     fn test_get_largest_accounts() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io, meta, alice, ..
         } = start_rpc_handler_with_tx(&bob_pubkey);
@@ -3220,7 +3220,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_minimum_balance_for_rent_exemption() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let data_len = 50;
         let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
@@ -3252,7 +3252,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_inflation() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getInflationGovernor"}"#;
@@ -3299,7 +3299,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_epoch_schedule() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getEpochSchedule"}"#;
@@ -3321,7 +3321,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_leader_schedule() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         for req in [
@@ -3377,7 +3377,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_account_info() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = format!(
@@ -3405,7 +3405,7 @@ pub mod tests {
             .expect("actual response deserialization");
         assert_eq!(expected, result);
 
-        let address = Pubkey::new_rand();
+        let address = solana_sdk::pubkey::new_rand();
         let data = vec![1, 2, 3, 4, 5];
         let mut account = Account::new(42, 5, &Pubkey::default());
         account.data = data.clone();
@@ -3459,7 +3459,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_multiple_accounts() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let address = Pubkey::new(&[9; 32]);
@@ -3586,7 +3586,7 @@ pub mod tests {
             ..
         } = start_rpc_handler_with_tx(&bob.pubkey());
 
-        let new_program_id = Pubkey::new_rand();
+        let new_program_id = solana_sdk::pubkey::new_rand();
         let tx = system_transaction::assign(&bob, blockhash, &new_program_id);
         bank.process_transaction(&tx).unwrap();
         let req = format!(
@@ -3633,7 +3633,7 @@ pub mod tests {
         bank.process_transaction(&tx).unwrap();
 
         let nonce_keypair1 = Keypair::new();
-        let authority = Pubkey::new_rand();
+        let authority = solana_sdk::pubkey::new_rand();
         let instruction = system_instruction::create_nonce_account(
             &alice.pubkey(),
             &nonce_keypair1.pubkey(),
@@ -3776,7 +3776,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_simulate_transaction() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -3877,7 +3877,7 @@ pub mod tests {
     #[test]
     #[should_panic]
     fn test_rpc_simulate_transaction_panic_on_unfrozen_bank() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -3903,7 +3903,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_confirm_tx() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -3935,7 +3935,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_signature_status() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -4005,7 +4005,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_signature_statuses() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -4061,7 +4061,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_recent_blockhash() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -4092,7 +4092,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_fees() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -4124,7 +4124,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_fee_calculator_for_blockhash() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let (blockhash, fee_calculator) = bank.last_blockhash_with_fee_calculator();
@@ -4172,7 +4172,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_fee_rate_governor() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getFeeRateGovernor"}"#;
@@ -4201,7 +4201,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_fail_request_airdrop() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         // Expect internal error because no faucet is available
@@ -4272,7 +4272,7 @@ pub mod tests {
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
         let mut bad_transaction =
-            system_transaction::transfer(&mint_keypair, &Pubkey::new_rand(), 42, Hash::default());
+            system_transaction::transfer(&mint_keypair, &solana_sdk::pubkey::new_rand(), 42, Hash::default());
 
         // sendTransaction will fail because the blockhash is invalid
         let req = format!(
@@ -4303,7 +4303,7 @@ pub mod tests {
             )
         );
         let mut bad_transaction =
-            system_transaction::transfer(&mint_keypair, &Pubkey::new_rand(), 42, recent_blockhash);
+            system_transaction::transfer(&mint_keypair, &solana_sdk::pubkey::new_rand(), 42, recent_blockhash);
 
         // sendTransaction will fail due to poor node health
         health.stub_set_health_status(Some(RpcHealthStatus::Behind));
@@ -4386,7 +4386,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_verify_pubkey() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         assert_eq!(verify_pubkey(pubkey.to_string()).unwrap(), pubkey);
         let bad_pubkey = "a1b2c3d4";
         assert_eq!(
@@ -4397,7 +4397,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_verify_signature() {
-        let tx = system_transaction::transfer(&Keypair::new(), &Pubkey::new_rand(), 20, hash(&[0]));
+        let tx = system_transaction::transfer(&Keypair::new(), &solana_sdk::pubkey::new_rand(), 20, hash(&[0]));
         assert_eq!(
             verify_signature(&tx.signatures[0].to_string()).unwrap(),
             tx.signatures[0]
@@ -4489,7 +4489,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_identity() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getIdentity"}"#;
@@ -4510,7 +4510,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_version() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
 
         let req = r#"{"jsonrpc":"2.0","id":1,"method":"getVersion"}"#;
@@ -4597,7 +4597,7 @@ pub mod tests {
 
     #[test]
     fn test_rpc_get_block_commitment() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -4651,7 +4651,7 @@ pub mod tests {
 
     #[test]
     fn test_get_confirmed_block() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let RpcHandler {
             io,
             meta,
@@ -4749,7 +4749,7 @@ pub mod tests {
 
     #[test]
     fn test_get_confirmed_blocks() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let roots = vec![0, 1, 3, 4, 8];
         let RpcHandler {
             io,
@@ -4826,7 +4826,7 @@ pub mod tests {
 
     #[test]
     fn test_get_confirmed_blocks_with_limit() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let roots = vec![0, 1, 3, 4, 8];
         let RpcHandler {
             io,
@@ -4889,7 +4889,7 @@ pub mod tests {
 
     #[test]
     fn test_get_block_time() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let base_timestamp = 1_576_183_541;
         let RpcHandler {
             io,
@@ -4976,7 +4976,7 @@ pub mod tests {
             leader_vote_keypair,
             block_commitment_cache,
             ..
-        } = start_rpc_handler_with_tx(&Pubkey::new_rand());
+        } = start_rpc_handler_with_tx(&solana_sdk::pubkey::new_rand());
 
         assert_eq!(bank.vote_accounts().len(), 1);
 
@@ -5192,7 +5192,7 @@ pub mod tests {
 
     #[test]
     fn test_token_rpcs() {
-        let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&Pubkey::new_rand());
+        let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&solana_sdk::pubkey::new_rand());
 
         let mut account_data = vec![0; TokenAccount::get_packed_len()];
         let mint = SplTokenPubkey::new(&[2; 32]);
@@ -5215,7 +5215,7 @@ pub mod tests {
             owner: spl_token_id_v2_0(),
             ..Account::default()
         };
-        let token_account_pubkey = Pubkey::new_rand();
+        let token_account_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_account_pubkey, &token_account);
 
         // Add the mint
@@ -5253,7 +5253,7 @@ pub mod tests {
         // Test non-existent token account
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenAccountBalance","params":["{}"]}}"#,
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let result: Value = serde_json::from_str(&res.expect("actual response"))
@@ -5278,7 +5278,7 @@ pub mod tests {
         // Test non-existent mint address
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"getTokenSupply","params":["{}"]}}"#,
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let result: Value = serde_json::from_str(&res.expect("actual response"))
@@ -5286,7 +5286,7 @@ pub mod tests {
         assert!(result.get("error").is_some());
 
         // Add another token account with the same owner, delegate, and mint
-        let other_token_account_pubkey = Pubkey::new_rand();
+        let other_token_account_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&other_token_account_pubkey, &token_account);
 
         // Add another token account with the same owner and delegate but different mint
@@ -5309,7 +5309,7 @@ pub mod tests {
             owner: spl_token_id_v2_0(),
             ..Account::default()
         };
-        let token_with_different_mint_pubkey = Pubkey::new_rand();
+        let token_with_different_mint_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_with_different_mint_pubkey, &token_account);
 
         // Test getTokenAccountsByOwner with Token program id returns all accounts, regardless of Mint address
@@ -5390,7 +5390,7 @@ pub mod tests {
                 "params":["{}", {{"programId": "{}"}}]
             }}"#,
             owner,
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let result: Value = serde_json::from_str(&res.expect("actual response"))
@@ -5404,7 +5404,7 @@ pub mod tests {
                 "params":["{}", {{"mint": "{}"}}]
             }}"#,
             owner,
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let result: Value = serde_json::from_str(&res.expect("actual response"))
@@ -5419,7 +5419,7 @@ pub mod tests {
                 "method":"getTokenAccountsByOwner",
                 "params":["{}", {{"programId": "{}"}}]
             }}"#,
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
             spl_token_id_v2_0(),
         );
         let res = io.handle_request_sync(&req, meta.clone());
@@ -5473,7 +5473,7 @@ pub mod tests {
                 "params":["{}", {{"programId": "{}"}}]
             }}"#,
             delegate,
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let result: Value = serde_json::from_str(&res.expect("actual response"))
@@ -5487,7 +5487,7 @@ pub mod tests {
                 "params":["{}", {{"mint": "{}"}}]
             }}"#,
             delegate,
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
         );
         let res = io.handle_request_sync(&req, meta.clone());
         let result: Value = serde_json::from_str(&res.expect("actual response"))
@@ -5502,7 +5502,7 @@ pub mod tests {
                 "method":"getTokenAccountsByDelegate",
                 "params":["{}", {{"programId": "{}"}}]
             }}"#,
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
             spl_token_id_v2_0(),
         );
         let res = io.handle_request_sync(&req, meta.clone());
@@ -5550,7 +5550,7 @@ pub mod tests {
             owner: spl_token_id_v2_0(),
             ..Account::default()
         };
-        let token_with_smaller_balance = Pubkey::new_rand();
+        let token_with_smaller_balance = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_with_smaller_balance, &token_account);
 
         // Test largest token accounts
@@ -5588,7 +5588,7 @@ pub mod tests {
 
     #[test]
     fn test_token_parsing() {
-        let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&Pubkey::new_rand());
+        let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&solana_sdk::pubkey::new_rand());
 
         let mut account_data = vec![0; TokenAccount::get_packed_len()];
         let mint = SplTokenPubkey::new(&[2; 32]);
@@ -5611,7 +5611,7 @@ pub mod tests {
             owner: spl_token_id_v2_0(),
             ..Account::default()
         };
-        let token_account_pubkey = Pubkey::new_rand();
+        let token_account_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_account_pubkey, &token_account);
 
         // Add the mint

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -4271,8 +4271,12 @@ pub mod tests {
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
 
-        let mut bad_transaction =
-            system_transaction::transfer(&mint_keypair, &solana_sdk::pubkey::new_rand(), 42, Hash::default());
+        let mut bad_transaction = system_transaction::transfer(
+            &mint_keypair,
+            &solana_sdk::pubkey::new_rand(),
+            42,
+            Hash::default(),
+        );
 
         // sendTransaction will fail because the blockhash is invalid
         let req = format!(
@@ -4302,8 +4306,12 @@ pub mod tests {
                 r#"{"jsonrpc":"2.0","error":{"code":-32002,"message":"Transaction simulation failed: Transaction failed to sanitize accounts offsets correctly","data":{"err":"SanitizeFailure","logs":[]}},"id":1}"#.to_string(),
             )
         );
-        let mut bad_transaction =
-            system_transaction::transfer(&mint_keypair, &solana_sdk::pubkey::new_rand(), 42, recent_blockhash);
+        let mut bad_transaction = system_transaction::transfer(
+            &mint_keypair,
+            &solana_sdk::pubkey::new_rand(),
+            42,
+            recent_blockhash,
+        );
 
         // sendTransaction will fail due to poor node health
         health.stub_set_health_status(Some(RpcHealthStatus::Behind));
@@ -4397,7 +4405,12 @@ pub mod tests {
 
     #[test]
     fn test_rpc_verify_signature() {
-        let tx = system_transaction::transfer(&Keypair::new(), &solana_sdk::pubkey::new_rand(), 20, hash(&[0]));
+        let tx = system_transaction::transfer(
+            &Keypair::new(),
+            &solana_sdk::pubkey::new_rand(),
+            20,
+            hash(&[0]),
+        );
         assert_eq!(
             verify_signature(&tx.signatures[0].to_string()).unwrap(),
             tx.signatures[0]
@@ -5192,7 +5205,8 @@ pub mod tests {
 
     #[test]
     fn test_token_rpcs() {
-        let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&solana_sdk::pubkey::new_rand());
+        let RpcHandler { io, meta, bank, .. } =
+            start_rpc_handler_with_tx(&solana_sdk::pubkey::new_rand());
 
         let mut account_data = vec![0; TokenAccount::get_packed_len()];
         let mint = SplTokenPubkey::new(&[2; 32]);
@@ -5588,7 +5602,8 @@ pub mod tests {
 
     #[test]
     fn test_token_parsing() {
-        let RpcHandler { io, meta, bank, .. } = start_rpc_handler_with_tx(&solana_sdk::pubkey::new_rand());
+        let RpcHandler { io, meta, bank, .. } =
+            start_rpc_handler_with_tx(&solana_sdk::pubkey::new_rand());
 
         let mut account_data = vec![0; TokenAccount::get_packed_len()];
         let mint = SplTokenPubkey::new(&[2; 32]);

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -505,7 +505,7 @@ mod tests {
             mint_keypair: alice,
             ..
         } = create_genesis_config(10_000);
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let bank = Bank::new(&genesis_config);
         let blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
@@ -551,7 +551,7 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
 
-        let new_stake_authority = Pubkey::new_rand();
+        let new_stake_authority = solana_sdk::pubkey::new_rand();
         let stake_authority = Keypair::new();
         let from = Keypair::new();
         let stake_account = Keypair::new();
@@ -748,7 +748,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_account_unsubscribe() {
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let session = create_session();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::new(&genesis_config))));

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -550,7 +550,11 @@ mod tests {
         let cluster_info = Arc::new(ClusterInfo::default());
         let health_check_slot_distance = 123;
         let override_health_check = Arc::new(AtomicBool::new(false));
-        let trusted_validators = vec![solana_sdk::pubkey::new_rand(), solana_sdk::pubkey::new_rand(), solana_sdk::pubkey::new_rand()];
+        let trusted_validators = vec![
+            solana_sdk::pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
+        ];
 
         let health = Arc::new(RpcHealth::new(
             cluster_info.clone(),

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -550,7 +550,7 @@ mod tests {
         let cluster_info = Arc::new(ClusterInfo::default());
         let health_check_slot_distance = 123;
         let override_health_check = Arc::new(AtomicBool::new(false));
-        let trusted_validators = vec![Pubkey::new_rand(), Pubkey::new_rand(), Pubkey::new_rand()];
+        let trusted_validators = vec![solana_sdk::pubkey::new_rand(), solana_sdk::pubkey::new_rand(), solana_sdk::pubkey::new_rand()];
 
         let health = Arc::new(RpcHealth::new(
             cluster_info.clone(),

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -1250,7 +1250,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let next_bank =
-            Bank::new_from_parent(&bank_forks.banks[&0].clone(), &Pubkey::new_rand(), 1);
+            Bank::new_from_parent(&bank_forks.banks[&0].clone(), &solana_sdk::pubkey::new_rand(), 1);
         bank_forks.insert(next_bank);
 
         bank_forks

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -1249,8 +1249,11 @@ pub(crate) mod tests {
             .process_transaction(&past_bank_tx)
             .unwrap();
 
-        let next_bank =
-            Bank::new_from_parent(&bank_forks.banks[&0].clone(), &solana_sdk::pubkey::new_rand(), 1);
+        let next_bank = Bank::new_from_parent(
+            &bank_forks.banks[&0].clone(),
+            &solana_sdk::pubkey::new_rand(),
+            1,
+        );
         bank_forks.insert(next_bank);
 
         bank_forks

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -971,8 +971,10 @@ mod tests {
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(me.clone()));
 
         // Insert two peers on the network
-        let contact_info2 = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
-        let contact_info3 = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
+        let contact_info2 =
+            ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
+        let contact_info3 =
+            ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         cluster_info.insert_info(contact_info2.clone());
         cluster_info.insert_info(contact_info3.clone());
         let serve_repair = ServeRepair::new(cluster_info);

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -396,7 +396,7 @@ impl ServeRepair {
             cache.insert(slot, (repair_peers, weights));
         }
         let (repair_peers, weights) = cache.get(&slot).unwrap();
-        let n = weighted_best(&weights, Pubkey::new_rand().to_bytes());
+        let n = weighted_best(&weights, solana_sdk::pubkey::new_rand().to_bytes());
         let addr = repair_peers[n].serve_repair; // send the request to the peer's serve_repair port
         let repair_peer_id = repair_peers[n].id;
         let out = self.map_repair_request(
@@ -419,7 +419,7 @@ impl ServeRepair {
             return Err(ClusterInfoError::NoPeers.into());
         }
         let weights = cluster_slots.compute_weights_exclude_noncomplete(slot, &repair_peers);
-        let n = weighted_best(&weights, Pubkey::new_rand().to_bytes());
+        let n = weighted_best(&weights, solana_sdk::pubkey::new_rand().to_bytes());
         Ok((repair_peers[n].id, repair_peers[n].serve_repair))
     }
 
@@ -678,7 +678,7 @@ mod tests {
         {
             let blockstore = Arc::new(Blockstore::open(&ledger_path).unwrap());
             let me = ContactInfo {
-                id: Pubkey::new_rand(),
+                id: solana_sdk::pubkey::new_rand(),
                 gossip: socketaddr!("127.0.0.1:1234"),
                 tvu: socketaddr!("127.0.0.1:1235"),
                 tvu_forwards: socketaddr!("127.0.0.1:1236"),
@@ -748,7 +748,7 @@ mod tests {
     #[test]
     fn window_index_request() {
         let cluster_slots = ClusterSlots::default();
-        let me = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let me = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(me));
         let serve_repair = ServeRepair::new(cluster_info.clone());
         let rv = serve_repair.repair_request(
@@ -762,7 +762,7 @@ mod tests {
 
         let serve_repair_addr = socketaddr!([127, 0, 0, 1], 1243);
         let nxt = ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             gossip: socketaddr!([127, 0, 0, 1], 1234),
             tvu: socketaddr!([127, 0, 0, 1], 1235),
             tvu_forwards: socketaddr!([127, 0, 0, 1], 1236),
@@ -791,7 +791,7 @@ mod tests {
 
         let serve_repair_addr2 = socketaddr!([127, 0, 0, 2], 1243);
         let nxt = ContactInfo {
-            id: Pubkey::new_rand(),
+            id: solana_sdk::pubkey::new_rand(),
             gossip: socketaddr!([127, 0, 0, 1], 1234),
             tvu: socketaddr!([127, 0, 0, 1], 1235),
             tvu_forwards: socketaddr!([127, 0, 0, 1], 1236),
@@ -967,12 +967,12 @@ mod tests {
     #[test]
     fn test_repair_with_repair_validators() {
         let cluster_slots = ClusterSlots::default();
-        let me = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let me = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(me.clone()));
 
         // Insert two peers on the network
-        let contact_info2 = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
-        let contact_info3 = ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp());
+        let contact_info2 = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
+        let contact_info3 = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp());
         cluster_info.insert_info(contact_info2.clone());
         cluster_info.insert_info(contact_info3.clone());
         let serve_repair = ServeRepair::new(cluster_info);
@@ -981,7 +981,7 @@ mod tests {
         // 1) repair validator set doesn't exist in gossip
         // 2) repair validator set only includes our own id
         // then no repairs should be generated
-        for pubkey in &[Pubkey::new_rand(), me.id] {
+        for pubkey in &[solana_sdk::pubkey::new_rand(), me.id] {
             let trusted_validators = Some(vec![*pubkey].into_iter().collect());
             assert!(serve_repair.repair_peers(&trusted_validators, 1).is_empty());
             assert!(serve_repair

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -66,7 +66,7 @@ impl TestValidator {
             mint_lamports,
             &contact_info.id,
             &Keypair::new(),
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             42,
             bootstrap_validator_lamports,
             solana_sdk::genesis_config::ClusterType::Development,

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -59,7 +59,6 @@ mod tests {
     use crate::result::Error;
     use crossbeam_channel::{unbounded, RecvTimeoutError};
     use solana_perf::packet::{Meta, Packet};
-    use solana_sdk::pubkey::Pubkey;
 
     #[test]
     fn test_get_latest_votes() {

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn test_get_latest_votes() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let label1 = CrdsValueLabel::Vote(0 as u8, pubkey);
         let label2 = CrdsValueLabel::Vote(1 as u8, pubkey);
         let mut verified_vote_packets = VerifiedVotePackets(HashMap::new());
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn test_get_and_process_vote_packets() {
         let (s, r) = unbounded();
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let label1 = CrdsValueLabel::Vote(0 as u8, pubkey);
         let label2 = CrdsValueLabel::Vote(1 as u8, pubkey);
         let mut update_version = 0;

--- a/core/src/vote_stake_tracker.rs
+++ b/core/src/vote_stake_tracker.rs
@@ -52,7 +52,7 @@ mod test {
         let total_epoch_stake = 10;
         let mut vote_stake_tracker = VoteStakeTracker::default();
         for i in 0..10 {
-            let pubkey = Arc::new(Pubkey::new_rand());
+            let pubkey = Arc::new(solana_sdk::pubkey::new_rand());
             let (is_confirmed, is_new) =
                 vote_stake_tracker.add_vote_pubkey(pubkey.clone(), 1, total_epoch_stake);
             let stake = vote_stake_tracker.stake();

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -594,7 +594,7 @@ mod test {
 
     #[test]
     fn test_should_retransmit_and_persist() {
-        let me_id = Pubkey::new_rand();
+        let me_id = solana_sdk::pubkey::new_rand();
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
         let bank = Arc::new(Bank::new(

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -38,7 +38,7 @@ fn test_rpc_client() {
         ledger_path,
         ..
     } = TestValidator::run();
-    let bob_pubkey = Pubkey::new_rand();
+    let bob_pubkey = solana_sdk::pubkey::new_rand();
 
     let client = RpcClient::new_socket(leader_data.rpc);
 

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -12,8 +12,7 @@ use solana_runtime::{
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
 };
 use solana_sdk::{
-    commitment_config::CommitmentConfig, pubkey::Pubkey, rpc_port, signature::Signer,
-    system_transaction,
+    commitment_config::CommitmentConfig, rpc_port, signature::Signer, system_transaction,
 };
 use std::{
     fs::remove_dir_all,

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -72,7 +72,7 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
     let timeout = 60 * 5;
 
     // describe the leader
-    let leader_info = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+    let leader_info = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
     let cluster_info = ClusterInfo::new_with_invalid_keypair(leader_info.clone());
 
     // setup staked nodes
@@ -95,7 +95,7 @@ fn run_simulation(stakes: &[u64], fanout: usize) {
         chunk.iter().for_each(|i| {
             //distribute neighbors across threads to maximize parallel compute
             let batch_ix = *i as usize % batches.len();
-            let node = ContactInfo::new_localhost(&Pubkey::new_rand(), 0);
+            let node = ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), 0);
             staked_nodes.insert(node.id, stakes[*i - 1]);
             cluster_info.insert_info(node.clone());
             let (s, r) = channel();

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -77,13 +77,13 @@ fn stakes(network: &Network) -> HashMap<Pubkey, u64> {
 
 fn star_network_create(num: usize) -> Network {
     let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-        &Pubkey::new_rand(),
+        &solana_sdk::pubkey::new_rand(),
         0,
     )));
     let mut network: HashMap<_, _> = (1..num)
         .map(|_| {
             let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 0,
             )));
             let id = new.label().pubkey();
@@ -104,7 +104,7 @@ fn star_network_create(num: usize) -> Network {
 
 fn rstar_network_create(num: usize) -> Network {
     let entry = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-        &Pubkey::new_rand(),
+        &solana_sdk::pubkey::new_rand(),
         0,
     )));
     let mut origin = CrdsGossip::default();
@@ -114,7 +114,7 @@ fn rstar_network_create(num: usize) -> Network {
     let mut network: HashMap<_, _> = (1..num)
         .map(|_| {
             let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 0,
             )));
             let id = new.label().pubkey();
@@ -133,7 +133,7 @@ fn ring_network_create(num: usize) -> Network {
     let mut network: HashMap<_, _> = (0..num)
         .map(|_| {
             let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 0,
             )));
             let id = new.label().pubkey();
@@ -171,7 +171,7 @@ fn connected_staked_network_create(stakes: &[u64]) -> Network {
     let mut network: HashMap<_, _> = (0..num)
         .map(|n| {
             let new = CrdsValue::new_unsigned(CrdsData::ContactInfo(ContactInfo::new_localhost(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 0,
             )));
             let id = new.label().pubkey();

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -63,7 +63,7 @@ fn test_rpc_send_tx() {
         ledger_path,
         ..
     } = TestValidator::run();
-    let bob_pubkey = Pubkey::new_rand();
+    let bob_pubkey = solana_sdk::pubkey::new_rand();
 
     let req = json_req!("getRecentBlockhash", json!([]));
     let json = post_rpc(req, &leader_data);
@@ -128,7 +128,7 @@ fn test_rpc_invalid_requests() {
         ledger_path,
         ..
     } = TestValidator::run();
-    let bob_pubkey = Pubkey::new_rand();
+    let bob_pubkey = solana_sdk::pubkey::new_rand();
 
     // test invalid get_balance request
     let req = json_req!("getBalance", json!(["invalid9999"]));
@@ -173,7 +173,7 @@ fn test_rpc_subscriptions() {
 
     // Create transaction signatures to subscribe to
     let transactions: Vec<Transaction> = (0..1000)
-        .map(|_| system_transaction::transfer(&alice, &Pubkey::new_rand(), 1, genesis_hash))
+        .map(|_| system_transaction::transfer(&alice, &solana_sdk::pubkey::new_rand(), 1, genesis_hash))
         .collect();
     let mut signature_set: HashSet<String> = transactions
         .iter()

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -15,8 +15,8 @@ use solana_client::{
 use solana_core::contact_info::ContactInfo;
 use solana_core::{rpc_pubsub::gen_client::Client as PubsubClient, test_validator::TestValidator};
 use solana_sdk::{
-    commitment_config::CommitmentConfig, hash::Hash, pubkey::Pubkey, signature::Signer,
-    system_transaction, transaction::Transaction,
+    commitment_config::CommitmentConfig, hash::Hash, signature::Signer, system_transaction,
+    transaction::Transaction,
 };
 use std::{
     collections::HashSet,
@@ -173,7 +173,9 @@ fn test_rpc_subscriptions() {
 
     // Create transaction signatures to subscribe to
     let transactions: Vec<Transaction> = (0..1000)
-        .map(|_| system_transaction::transfer(&alice, &solana_sdk::pubkey::new_rand(), 1, genesis_hash))
+        .map(|_| {
+            system_transaction::transfer(&alice, &solana_sdk::pubkey::new_rand(), 1, genesis_hash)
+        })
         .collect();
     let mut signature_set: HashSet<String> = transactions
         .iter()

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -253,7 +253,10 @@ pub mod test {
 
     #[test]
     fn test_dos() {
-        let nodes = [ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp())];
+        let nodes = [ContactInfo::new_localhost(
+            &solana_sdk::pubkey::new_rand(),
+            timestamp(),
+        )];
         let entrypoint_addr = nodes[0].gossip;
         run_dos(
             &nodes,

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -58,7 +58,7 @@ fn run_dos(
     if !nodes.is_empty() {
         let source = thread_rng().gen_range(0, nodes.len());
         let mut contact = nodes[source].clone();
-        contact.id = Pubkey::new_rand();
+        contact.id = solana_sdk::pubkey::new_rand();
         match data_type.as_str() {
             "repair_highest" => {
                 let slot = 100;
@@ -253,7 +253,7 @@ pub mod test {
 
     #[test]
     fn test_dos() {
-        let nodes = [ContactInfo::new_localhost(&Pubkey::new_rand(), timestamp())];
+        let nodes = [ContactInfo::new_localhost(&solana_sdk::pubkey::new_rand(), timestamp())];
         let entrypoint_addr = nodes[0].gossip;
         run_dos(
             &nodes,

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -378,7 +378,7 @@ mod tests {
 
     #[test]
     fn test_faucet_build_airdrop_transaction() {
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let blockhash = Hash::default();
         let request = FaucetRequest::GetAirdrop {
             lamports: 2,
@@ -419,7 +419,7 @@ mod tests {
 
     #[test]
     fn test_process_faucet_request() {
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let blockhash = Hash::new(&to.as_ref());
         let lamports = 50;
         let req = FaucetRequest::GetAirdrop {

--- a/faucet/src/faucet_mock.rs
+++ b/faucet/src/faucet_mock.rs
@@ -16,7 +16,7 @@ pub fn request_airdrop_transaction(
         Err(Error::new(ErrorKind::Other, "Airdrop failed"))
     } else {
         let key = Keypair::new();
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let blockhash = Hash::default();
         let tx = system_transaction::transfer(&key, &to, lamports, blockhash);
         Ok(tx)

--- a/faucet/tests/local-faucet.rs
+++ b/faucet/tests/local-faucet.rs
@@ -12,7 +12,7 @@ use std::sync::mpsc::channel;
 #[test]
 fn test_local_faucet() {
     let keypair = Keypair::new();
-    let to = Pubkey::new_rand();
+    let to = solana_sdk::pubkey::new_rand();
     let lamports = 50;
     let blockhash = Hash::new(&to.as_ref());
     let create_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);

--- a/faucet/tests/local-faucet.rs
+++ b/faucet/tests/local-faucet.rs
@@ -2,7 +2,6 @@ use solana_faucet::faucet::{request_airdrop_transaction, run_local_faucet};
 use solana_sdk::{
     hash::Hash,
     message::Message,
-    pubkey::Pubkey,
     signature::{Keypair, Signer},
     system_instruction,
     transaction::Transaction,

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -630,27 +630,27 @@ mod tests {
 
         let mut genesis_accounts = HashMap::new();
         genesis_accounts.insert(
-            Pubkey::new_rand().to_string(),
+            solana_sdk::pubkey::new_rand().to_string(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 2 as u64,
                 executable: false,
                 data: String::from("aGVsbG8="),
             },
         );
         genesis_accounts.insert(
-            Pubkey::new_rand().to_string(),
+            solana_sdk::pubkey::new_rand().to_string(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 1 as u64,
                 executable: true,
                 data: String::from("aGVsbG8gd29ybGQ="),
             },
         );
         genesis_accounts.insert(
-            Pubkey::new_rand().to_string(),
+            solana_sdk::pubkey::new_rand().to_string(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 3 as u64,
                 executable: true,
                 data: String::from("bWUgaGVsbG8gdG8gd29ybGQ="),
@@ -703,27 +703,27 @@ mod tests {
         // Test more accounts can be appended
         let mut genesis_accounts1 = HashMap::new();
         genesis_accounts1.insert(
-            Pubkey::new_rand().to_string(),
+            solana_sdk::pubkey::new_rand().to_string(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 6 as u64,
                 executable: true,
                 data: String::from("eW91IGFyZQ=="),
             },
         );
         genesis_accounts1.insert(
-            Pubkey::new_rand().to_string(),
+            solana_sdk::pubkey::new_rand().to_string(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 5 as u64,
                 executable: false,
                 data: String::from("bWV0YSBzdHJpbmc="),
             },
         );
         genesis_accounts1.insert(
-            Pubkey::new_rand().to_string(),
+            solana_sdk::pubkey::new_rand().to_string(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 10 as u64,
                 executable: false,
                 data: String::from("YmFzZTY0IHN0cmluZw=="),
@@ -788,7 +788,7 @@ mod tests {
         genesis_accounts2.insert(
             serde_json::to_string(&account_keypairs[0].to_bytes().to_vec()).unwrap(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 20 as u64,
                 executable: true,
                 data: String::from("Y2F0IGRvZw=="),
@@ -797,7 +797,7 @@ mod tests {
         genesis_accounts2.insert(
             serde_json::to_string(&account_keypairs[1].to_bytes().to_vec()).unwrap(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 15 as u64,
                 executable: false,
                 data: String::from("bW9ua2V5IGVsZXBoYW50"),
@@ -806,7 +806,7 @@ mod tests {
         genesis_accounts2.insert(
             serde_json::to_string(&account_keypairs[2].to_bytes().to_vec()).unwrap(),
             Base64Account {
-                owner: Pubkey::new_rand().to_string(),
+                owner: solana_sdk::pubkey::new_rand().to_string(),
                 balance: 30 as u64,
                 executable: true,
                 data: String::from("Y29tYSBtb2Nh"),

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -615,7 +615,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 mod tests {
     use super::*;
     use solana_sdk::genesis_config::GenesisConfig;
-    use solana_sdk::pubkey::Pubkey;
     use std::collections::HashMap;
     use std::fs::remove_file;
     use std::io::Write;

--- a/ledger/benches/protobuf.rs
+++ b/ledger/benches/protobuf.rs
@@ -8,7 +8,7 @@ use solana_ledger::{
     get_tmp_ledger_path,
 };
 use solana_runtime::bank::RewardType;
-use solana_sdk::{clock::Slot, pubkey::Pubkey};
+use solana_sdk::{clock::Slot, pubkey};
 use solana_transaction_status::{Reward, Rewards};
 use std::path::Path;
 use test::Bencher;
@@ -16,7 +16,7 @@ use test::Bencher;
 fn create_rewards() -> Rewards {
     (0..100)
         .map(|i| Reward {
-            pubkey: solana_sdk::pubkey::new_rand().to_string(),
+            pubkey: pubkey::new_rand().to_string(),
             lamports: 42 + i,
             post_balance: std::u64::MAX,
             reward_type: Some(RewardType::Fee),

--- a/ledger/benches/protobuf.rs
+++ b/ledger/benches/protobuf.rs
@@ -16,7 +16,7 @@ use test::Bencher;
 fn create_rewards() -> Rewards {
     (0..100)
         .map(|i| Reward {
-            pubkey: Pubkey::new_rand().to_string(),
+            pubkey: solana_sdk::pubkey::new_rand().to_string(),
             lamports: 42 + i,
             post_balance: std::u64::MAX,
             reward_type: Some(RewardType::Fee),

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3475,9 +3475,9 @@ pub mod tests {
         for x in 0..num_entries {
             let transaction = Transaction::new_with_compiled_instructions(
                 &[&Keypair::new()],
-                &[Pubkey::new_rand()],
+                &[solana_sdk::pubkey::new_rand()],
                 Hash::default(),
-                vec![Pubkey::new_rand()],
+                vec![solana_sdk::pubkey::new_rand()],
                 vec![CompiledInstruction::new(1, &(), vec![0])],
             );
             entries.push(next_entry_mut(&mut Hash::default(), 0, vec![transaction]));
@@ -6391,8 +6391,8 @@ pub mod tests {
         {
             let blockstore = Blockstore::open(&blockstore_path).unwrap();
 
-            let address0 = Pubkey::new_rand();
-            let address1 = Pubkey::new_rand();
+            let address0 = solana_sdk::pubkey::new_rand();
+            let address1 = solana_sdk::pubkey::new_rand();
 
             let slot0 = 10;
             for x in 1..5 {
@@ -6538,7 +6538,7 @@ pub mod tests {
                         &[&Keypair::new()],
                         &[*address],
                         Hash::default(),
-                        vec![Pubkey::new_rand()],
+                        vec![solana_sdk::pubkey::new_rand()],
                         vec![CompiledInstruction::new(1, &(), vec![0])],
                     );
                     entries.push(next_entry_mut(&mut Hash::default(), 0, vec![transaction]));
@@ -6548,8 +6548,8 @@ pub mod tests {
                 entries
             }
 
-            let address0 = Pubkey::new_rand();
-            let address1 = Pubkey::new_rand();
+            let address0 = solana_sdk::pubkey::new_rand();
+            let address1 = solana_sdk::pubkey::new_rand();
 
             for slot in 2..=8 {
                 let entries = make_slot_entries_with_transaction_addresses(&[
@@ -6772,9 +6772,9 @@ pub mod tests {
             for x in 0..4 {
                 let transaction = Transaction::new_with_compiled_instructions(
                     &[&Keypair::new()],
-                    &[Pubkey::new_rand()],
+                    &[solana_sdk::pubkey::new_rand()],
                     Hash::default(),
-                    vec![Pubkey::new_rand()],
+                    vec![solana_sdk::pubkey::new_rand()],
                     vec![CompiledInstruction::new(1, &(), vec![0])],
                 );
                 transaction_status_cf
@@ -6797,9 +6797,9 @@ pub mod tests {
             // Push transaction that will not have matching status, as a test case
             transactions.push(Transaction::new_with_compiled_instructions(
                 &[&Keypair::new()],
-                &[Pubkey::new_rand()],
+                &[solana_sdk::pubkey::new_rand()],
                 Hash::default(),
-                vec![Pubkey::new_rand()],
+                vec![solana_sdk::pubkey::new_rand()],
                 vec![CompiledInstruction::new(1, &(), vec![0])],
             ));
 
@@ -7256,7 +7256,7 @@ pub mod tests {
             let blockstore = Blockstore::open(&blockstore_path).unwrap();
             let rewards: Rewards = (0..100)
                 .map(|i| Reward {
-                    pubkey: Pubkey::new_rand().to_string(),
+                    pubkey: solana_sdk::pubkey::new_rand().to_string(),
                     lamports: 42 + i,
                     post_balance: std::u64::MAX,
                     reward_type: Some(RewardType::Fee),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1805,7 +1805,7 @@ pub mod tests {
     #[test]
     fn test_process_ledger_simple() {
         solana_logger::setup();
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let mint = 100;
         let hashes_per_tick = 10;
         let GenesisConfigInfo {
@@ -2383,7 +2383,7 @@ pub mod tests {
                     bank.last_blockhash(),
                     1,
                     0,
-                    &Pubkey::new_rand(),
+                    &solana_sdk::pubkey::new_rand(),
                 ));
 
                 next_entry_mut(&mut hash, 0, transactions)
@@ -2532,7 +2532,7 @@ pub mod tests {
             ..
         } = create_genesis_config(11_000);
         let bank = Arc::new(Bank::new(&genesis_config));
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.transaction_count(), 1);
         assert_eq!(bank.get_balance(&pubkey), 1_000);
@@ -2738,7 +2738,7 @@ pub mod tests {
                             bank.last_blockhash(),
                             100,
                             100,
-                            &Pubkey::new_rand(),
+                            &solana_sdk::pubkey::new_rand(),
                         ));
                         transactions
                     })
@@ -2873,11 +2873,11 @@ pub mod tests {
 
         // Create array of two transactions which throw different errors
         let account_not_found_tx =
-            system_transaction::transfer(&keypair, &Pubkey::new_rand(), 42, bank.last_blockhash());
+            system_transaction::transfer(&keypair, &solana_sdk::pubkey::new_rand(), 42, bank.last_blockhash());
         let account_not_found_sig = account_not_found_tx.signatures[0];
         let mut account_loaded_twice = system_transaction::transfer(
             &mint_keypair,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             42,
             bank.last_blockhash(),
         );
@@ -2925,7 +2925,7 @@ pub mod tests {
         let bank0 = Arc::new(Bank::new(&genesis_config));
         bank0.freeze();
 
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::new_rand(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 1));
 
         // The new blockhash is going to be the hash of the last tick in the block
         let bank_1_blockhash = bank1.last_blockhash();
@@ -3148,7 +3148,7 @@ pub mod tests {
                             Account::new(1, VoteState::size_of(), &solana_vote_program::id());
                         let versioned = VoteStateVersions::Current(Box::new(vote_state));
                         VoteState::serialize(&versioned, &mut vote_account.data).unwrap();
-                        (Pubkey::new_rand(), (stake, vote_account))
+                        (solana_sdk::pubkey::new_rand(), (stake, vote_account))
                     })
                     .collect_vec()
             };

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2872,8 +2872,12 @@ pub mod tests {
         let keypair = Keypair::new();
 
         // Create array of two transactions which throw different errors
-        let account_not_found_tx =
-            system_transaction::transfer(&keypair, &solana_sdk::pubkey::new_rand(), 42, bank.last_blockhash());
+        let account_not_found_tx = system_transaction::transfer(
+            &keypair,
+            &solana_sdk::pubkey::new_rand(),
+            42,
+            bank.last_blockhash(),
+        );
         let account_not_found_sig = account_not_found_tx.signatures[0];
         let mut account_loaded_twice = system_transaction::transfer(
             &mint_keypair,
@@ -2925,7 +2929,11 @@ pub mod tests {
         let bank0 = Arc::new(Bank::new(&genesis_config));
         bank0.freeze();
 
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(
+            &bank0,
+            &solana_sdk::pubkey::new_rand(),
+            1,
+        ));
 
         // The new blockhash is going to be the hash of the last tick in the block
         let bank_1_blockhash = bank1.last_blockhash();

--- a/ledger/src/genesis_utils.rs
+++ b/ledger/src/genesis_utils.rs
@@ -2,7 +2,6 @@ pub use solana_runtime::genesis_utils::{
     create_genesis_config_with_leader, create_genesis_config_with_leader_ex, GenesisConfigInfo,
     BOOTSTRAP_VALIDATOR_LAMPORTS,
 };
-use solana_sdk::pubkey::Pubkey;
 
 // same as genesis_config::create_genesis_config, but with bootstrap_validator staking logic
 //  for the core crate tests

--- a/ledger/src/genesis_utils.rs
+++ b/ledger/src/genesis_utils.rs
@@ -9,7 +9,7 @@ use solana_sdk::pubkey::Pubkey;
 pub fn create_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {
     create_genesis_config_with_leader(
         mint_lamports,
-        &Pubkey::new_rand(),
+        &solana_sdk::pubkey::new_rand(),
         BOOTSTRAP_VALIDATOR_LAMPORTS,
     )
 }

--- a/ledger/src/leader_schedule.rs
+++ b/ledger/src/leader_schedule.rs
@@ -77,7 +77,9 @@ mod tests {
     #[test]
     fn test_leader_schedule_basic() {
         let num_keys = 10;
-        let stakes: Vec<_> = (0..num_keys).map(|i| (solana_sdk::pubkey::new_rand(), i)).collect();
+        let stakes: Vec<_> = (0..num_keys)
+            .map(|i| (solana_sdk::pubkey::new_rand(), i))
+            .collect();
 
         let seed = solana_sdk::pubkey::new_rand();
         let mut seed_bytes = [0u8; 32];
@@ -93,7 +95,9 @@ mod tests {
     #[test]
     fn test_repeated_leader_schedule() {
         let num_keys = 10;
-        let stakes: Vec<_> = (0..num_keys).map(|i| (solana_sdk::pubkey::new_rand(), i)).collect();
+        let stakes: Vec<_> = (0..num_keys)
+            .map(|i| (solana_sdk::pubkey::new_rand(), i))
+            .collect();
 
         let seed = solana_sdk::pubkey::new_rand();
         let mut seed_bytes = [0u8; 32];

--- a/ledger/src/leader_schedule.rs
+++ b/ledger/src/leader_schedule.rs
@@ -64,8 +64,8 @@ mod tests {
 
     #[test]
     fn test_leader_schedule_index() {
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let leader_schedule = LeaderSchedule {
             slot_leaders: vec![pubkey0, pubkey1],
         };
@@ -77,9 +77,9 @@ mod tests {
     #[test]
     fn test_leader_schedule_basic() {
         let num_keys = 10;
-        let stakes: Vec<_> = (0..num_keys).map(|i| (Pubkey::new_rand(), i)).collect();
+        let stakes: Vec<_> = (0..num_keys).map(|i| (solana_sdk::pubkey::new_rand(), i)).collect();
 
-        let seed = Pubkey::new_rand();
+        let seed = solana_sdk::pubkey::new_rand();
         let mut seed_bytes = [0u8; 32];
         seed_bytes.copy_from_slice(seed.as_ref());
         let len = num_keys * 10;
@@ -93,9 +93,9 @@ mod tests {
     #[test]
     fn test_repeated_leader_schedule() {
         let num_keys = 10;
-        let stakes: Vec<_> = (0..num_keys).map(|i| (Pubkey::new_rand(), i)).collect();
+        let stakes: Vec<_> = (0..num_keys).map(|i| (solana_sdk::pubkey::new_rand(), i)).collect();
 
-        let seed = Pubkey::new_rand();
+        let seed = solana_sdk::pubkey::new_rand();
         let mut seed_bytes = [0u8; 32];
         seed_bytes.copy_from_slice(seed.as_ref());
         let len = num_keys * 10;
@@ -114,8 +114,8 @@ mod tests {
 
     #[test]
     fn test_repeated_leader_schedule_specific() {
-        let alice_pubkey = Pubkey::new_rand();
-        let bob_pubkey = Pubkey::new_rand();
+        let alice_pubkey = solana_sdk::pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let stakes = vec![(alice_pubkey, 2), (bob_pubkey, 1)];
 
         let seed = Pubkey::default();

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -378,7 +378,7 @@ mod tests {
 
     #[test]
     fn test_next_leader_slot() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let mut genesis_config = create_genesis_config_with_leader(
             BOOTSTRAP_VALIDATOR_LAMPORTS,
             &pubkey,
@@ -419,7 +419,7 @@ mod tests {
 
         assert_eq!(
             cache.next_leader_slot(
-                &Pubkey::new_rand(), // not in leader_schedule
+                &solana_sdk::pubkey::new_rand(), // not in leader_schedule
                 0,
                 &bank,
                 None,
@@ -431,7 +431,7 @@ mod tests {
 
     #[test]
     fn test_next_leader_slot_blockstore() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let mut genesis_config = create_genesis_config_with_leader(
             BOOTSTRAP_VALIDATOR_LAMPORTS,
             &pubkey,
@@ -501,7 +501,7 @@ mod tests {
 
             assert_eq!(
                 cache.next_leader_slot(
-                    &Pubkey::new_rand(), // not in leader_schedule
+                    &solana_sdk::pubkey::new_rand(), // not in leader_schedule
                     0,
                     &bank,
                     Some(&blockstore),
@@ -605,7 +605,7 @@ mod tests {
         assert_eq!(bank.get_epoch_and_slot_index(96).0, 2);
         assert!(cache.slot_leader_at(96, Some(&bank)).is_none());
 
-        let bank2 = Bank::new_from_parent(&bank, &Pubkey::new_rand(), 95);
+        let bank2 = Bank::new_from_parent(&bank, &solana_sdk::pubkey::new_rand(), 95);
         assert!(bank2.epoch_vote_accounts(2).is_some());
 
         // Set root for a slot in epoch 1, so that epoch 2 is now confirmed

--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn test_leader_schedule_via_bank() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let genesis_config =
             create_genesis_config_with_leader(0, &pubkey, BOOTSTRAP_VALIDATOR_LAMPORTS)
                 .genesis_config;
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_leader_scheduler1_basic() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let genesis_config = create_genesis_config_with_leader(
             BOOTSTRAP_VALIDATOR_LAMPORTS,
             &pubkey,
@@ -95,8 +95,8 @@ mod tests {
 
     #[test]
     fn test_sort_stakes_basic() {
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let mut stakes = vec![(pubkey0, 1), (pubkey1, 2)];
         sort_stakes(&mut stakes);
         assert_eq!(stakes, vec![(pubkey1, 2), (pubkey0, 1)]);
@@ -104,8 +104,8 @@ mod tests {
 
     #[test]
     fn test_sort_stakes_with_dup() {
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let mut stakes = vec![(pubkey0, 1), (pubkey1, 2), (pubkey0, 1)];
         sort_stakes(&mut stakes);
         assert_eq!(stakes, vec![(pubkey1, 2), (pubkey0, 1)]);
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn test_sort_stakes_with_equal_stakes() {
         let pubkey0 = Pubkey::default();
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let mut stakes = vec![(pubkey0, 1), (pubkey1, 1)];
         sort_stakes(&mut stakes);
         assert_eq!(stakes, vec![(pubkey1, 1), (pubkey0, 1)]);

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -304,7 +304,7 @@ pub(crate) mod tests {
     #[test]
     fn test_to_staked_nodes() {
         let mut stakes = Vec::new();
-        let node1 = Pubkey::new_rand();
+        let node1 = solana_sdk::pubkey::new_rand();
 
         // Node 1 has stake of 3
         for i in 0..3 {
@@ -321,7 +321,7 @@ pub(crate) mod tests {
         }
 
         // Node 1 has stake of 5
-        let node2 = Pubkey::new_rand();
+        let node2 = solana_sdk::pubkey::new_rand();
 
         stakes.push((
             5,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -163,7 +163,7 @@ fn test_local_cluster_signature_subscribe() {
         .unwrap();
 
     let mut transaction =
-        system_transaction::transfer(&cluster.funding_keypair, &Pubkey::new_rand(), 10, blockhash);
+        system_transaction::transfer(&cluster.funding_keypair, &solana_sdk::pubkey::new_rand(), 10, blockhash);
 
     let (mut sig_subscribe_client, receiver) = PubsubClient::signature_subscribe(
         &format!("ws://{}", &non_bootstrap_info.rpc_pubsub.to_string()),
@@ -815,7 +815,7 @@ fn generate_frozen_account_panic(mut cluster: LocalCluster, frozen_account: Arc<
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
         client
-            .async_transfer(1, &frozen_account, &Pubkey::new_rand(), blockhash)
+            .async_transfer(1, &frozen_account, &solana_sdk::pubkey::new_rand(), blockhash)
             .unwrap();
 
         sleep(Duration::from_secs(1));

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -162,8 +162,12 @@ fn test_local_cluster_signature_subscribe() {
         .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
         .unwrap();
 
-    let mut transaction =
-        system_transaction::transfer(&cluster.funding_keypair, &solana_sdk::pubkey::new_rand(), 10, blockhash);
+    let mut transaction = system_transaction::transfer(
+        &cluster.funding_keypair,
+        &solana_sdk::pubkey::new_rand(),
+        10,
+        blockhash,
+    );
 
     let (mut sig_subscribe_client, receiver) = PubsubClient::signature_subscribe(
         &format!("ws://{}", &non_bootstrap_info.rpc_pubsub.to_string()),
@@ -815,7 +819,12 @@ fn generate_frozen_account_panic(mut cluster: LocalCluster, frozen_account: Arc<
             .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
             .unwrap();
         client
-            .async_transfer(1, &frozen_account, &solana_sdk::pubkey::new_rand(), blockhash)
+            .async_transfer(
+                1,
+                &frozen_account,
+                &solana_sdk::pubkey::new_rand(),
+                blockhash,
+            )
             .unwrap();
 
         sleep(Duration::from_secs(1));

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -211,8 +211,8 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
 
     let mut measure = Measure::start("tune");
 
-    let accounts = [RefCell::new(Account::new(1, 10000001, &Pubkey::new_rand()))];
-    let keys = [Pubkey::new_rand()];
+    let accounts = [RefCell::new(Account::new(1, 10000001, &solana_sdk::pubkey::new_rand()))];
+    let keys = [solana_sdk::pubkey::new_rand()];
     let keyed_accounts: Vec<_> = keys
         .iter()
         .zip(&accounts)
@@ -223,7 +223,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     // Serialize account data
     let mut serialized = solana_bpf_loader_program::serialization::serialize_parameters(
         &bpf_loader::id(),
-        &Pubkey::new_rand(),
+        &solana_sdk::pubkey::new_rand(),
         &keyed_accounts,
         &instruction_data,
     )

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -276,11 +276,11 @@ fn test_program_bpf_duplicate_accounts() {
         let bank_client = BankClient::new_shared(&bank);
         let program_id = load_bpf_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
         let payee_account = Account::new(10, 1, &program_id);
-        let payee_pubkey = Pubkey::new_rand();
+        let payee_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&payee_pubkey, &payee_account);
 
         let account = Account::new(10, 1, &program_id);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account_metas = vec![
             AccountMeta::new(mint_keypair.pubkey(), true),
             AccountMeta::new(payee_pubkey, false),
@@ -763,8 +763,8 @@ fn assert_instruction_count() {
 
     for program in programs.iter() {
         println!("Test program: {:?}", program.0);
-        let program_id = Pubkey::new_rand();
-        let key = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
+        let key = solana_sdk::pubkey::new_rand();
         let mut account = RefCell::new(Account::default());
         let parameter_accounts = vec![KeyedAccount::new(&key, false, &mut account)];
         let count = run_program(program.0, &program_id, &parameter_accounts[..], &[]).unwrap();

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -441,8 +441,8 @@ mod tests {
 
     #[test]
     fn test_bpf_loader_write() {
-        let program_id = Pubkey::new_rand();
-        let program_key = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
+        let program_key = solana_sdk::pubkey::new_rand();
         let program_account = Account::new_ref(1, 0, &program_id);
         let keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         let instruction_data = bincode::serialize(&LoaderInstruction::Write {
@@ -508,8 +508,8 @@ mod tests {
 
     #[test]
     fn test_bpf_loader_finalize() {
-        let program_id = Pubkey::new_rand();
-        let program_key = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
+        let program_key = solana_sdk::pubkey::new_rand();
         let mut file = File::open("test_elfs/noop_aligned.so").expect("file open failed");
         let mut elf = Vec::new();
         let rent = Rent::default();
@@ -572,8 +572,8 @@ mod tests {
 
     #[test]
     fn test_bpf_loader_invoke_main() {
-        let program_id = Pubkey::new_rand();
-        let program_key = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
+        let program_key = solana_sdk::pubkey::new_rand();
 
         // Create program account
         let mut file = File::open("test_elfs/noop_aligned.so").expect("file open failed");
@@ -646,7 +646,7 @@ mod tests {
         );
 
         // Case: With duplicate accounts
-        let duplicate_key = Pubkey::new_rand();
+        let duplicate_key = solana_sdk::pubkey::new_rand();
         let parameter_account = Account::new_ref(1, 0, &program_id);
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
@@ -664,8 +664,8 @@ mod tests {
 
     #[test]
     fn test_bpf_loader_serialize_unaligned() {
-        let program_id = Pubkey::new_rand();
-        let program_key = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
+        let program_key = solana_sdk::pubkey::new_rand();
 
         // Create program account
         let mut file = File::open("test_elfs/noop_unaligned.so").expect("file open failed");
@@ -690,7 +690,7 @@ mod tests {
         );
 
         // Case: With duplicate accounts
-        let duplicate_key = Pubkey::new_rand();
+        let duplicate_key = solana_sdk::pubkey::new_rand();
         let parameter_account = Account::new_ref(1, 0, &program_id);
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
@@ -708,8 +708,8 @@ mod tests {
 
     #[test]
     fn test_bpf_loader_serialize_aligned() {
-        let program_id = Pubkey::new_rand();
-        let program_key = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
+        let program_key = solana_sdk::pubkey::new_rand();
 
         // Create program account
         let mut file = File::open("test_elfs/noop_aligned.so").expect("file open failed");
@@ -734,7 +734,7 @@ mod tests {
         );
 
         // Case: With duplicate accounts
-        let duplicate_key = Pubkey::new_rand();
+        let duplicate_key = solana_sdk::pubkey::new_rand();
         let parameter_account = Account::new_ref(1, 0, &program_id);
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
@@ -776,8 +776,8 @@ mod tests {
     #[test]
     #[ignore]
     fn test_fuzz() {
-        let program_id = Pubkey::new_rand();
-        let program_key = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
+        let program_key = solana_sdk::pubkey::new_rand();
 
         // Create program account
         let mut file = File::open("test_elfs/noop_aligned.so").expect("file open failed");

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -264,7 +264,12 @@ mod tests {
     fn test_serialize_parameters() {
         let program_id = solana_sdk::pubkey::new_rand();
         let dup_key = solana_sdk::pubkey::new_rand();
-        let keys = vec![dup_key, dup_key, solana_sdk::pubkey::new_rand(), solana_sdk::pubkey::new_rand()];
+        let keys = vec![
+            dup_key,
+            dup_key,
+            solana_sdk::pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
+        ];
         let accounts = [
             RefCell::new(Account {
                 lamports: 1,

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -262,9 +262,9 @@ mod tests {
 
     #[test]
     fn test_serialize_parameters() {
-        let program_id = Pubkey::new_rand();
-        let dup_key = Pubkey::new_rand();
-        let keys = vec![dup_key, dup_key, Pubkey::new_rand(), Pubkey::new_rand()];
+        let program_id = solana_sdk::pubkey::new_rand();
+        let dup_key = solana_sdk::pubkey::new_rand();
+        let keys = vec![dup_key, dup_key, solana_sdk::pubkey::new_rand(), solana_sdk::pubkey::new_rand()];
         let accounts = [
             RefCell::new(Account {
                 lamports: 1,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1289,7 +1289,7 @@ mod tests {
     #[test]
     fn test_translate_type() {
         // Pubkey
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let addr = &pubkey as *const _ as u64;
         let regions = vec![MemoryRegion {
             addr_host: addr,
@@ -1301,9 +1301,9 @@ mod tests {
 
         // Instruction
         let instruction = Instruction::new(
-            Pubkey::new_rand(),
+            solana_sdk::pubkey::new_rand(),
             &"foobar",
-            vec![AccountMeta::new(Pubkey::new_rand(), false)],
+            vec![AccountMeta::new(solana_sdk::pubkey::new_rand(), false)],
         );
         let addr = &instruction as *const _ as u64;
         let mut regions = vec![MemoryRegion {
@@ -1350,7 +1350,7 @@ mod tests {
         assert_eq!(data, translated_data);
 
         // Pubkeys
-        let mut data = vec![Pubkey::new_rand(); 5];
+        let mut data = vec![solana_sdk::pubkey::new_rand(); 5];
         let addr = data.as_ptr() as *const _ as u64;
         let regions = vec![MemoryRegion {
             addr_host: addr,
@@ -1360,7 +1360,7 @@ mod tests {
         let translated_data =
             translate_slice!(Pubkey, 100, data.len(), &regions, &bpf_loader::id()).unwrap();
         assert_eq!(data, translated_data);
-        data[0] = Pubkey::new_rand(); // Both should point to same place
+        data[0] = solana_sdk::pubkey::new_rand(); // Both should point to same place
         assert_eq!(data, translated_data);
     }
 

--- a/programs/budget/src/budget_expr.rs
+++ b/programs/budget/src/budget_expr.rs
@@ -306,8 +306,8 @@ mod tests {
     #[test]
     fn test_future_payment() {
         let dt = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
-        let from = Pubkey::new_rand();
-        let to = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
 
         let mut expr = BudgetExpr::new_future_payment(dt, &from, 42, &to);
         expr.apply_witness(&Witness::Timestamp(dt), &from);
@@ -319,8 +319,8 @@ mod tests {
         // Ensure timestamp will only be acknowledged if it came from the
         // whitelisted public key.
         let dt = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
-        let from = Pubkey::new_rand();
-        let to = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
 
         let mut expr = BudgetExpr::new_future_payment(dt, &from, 42, &to);
         let orig_expr = expr.clone();
@@ -344,8 +344,8 @@ mod tests {
     }
     #[test]
     fn test_2_2_multisig_payment() {
-        let from0 = Pubkey::new_rand();
-        let from1 = Pubkey::new_rand();
+        let from0 = solana_sdk::pubkey::new_rand();
+        let from1 = solana_sdk::pubkey::new_rand();
         let to = Pubkey::default();
 
         let mut expr = BudgetExpr::new_2_2_multisig_payment(&from0, &from1, 42, &to);
@@ -355,9 +355,9 @@ mod tests {
 
     #[test]
     fn test_multisig_after_sig() {
-        let from0 = Pubkey::new_rand();
-        let from1 = Pubkey::new_rand();
-        let from2 = Pubkey::new_rand();
+        let from0 = solana_sdk::pubkey::new_rand();
+        let from1 = solana_sdk::pubkey::new_rand();
+        let from2 = solana_sdk::pubkey::new_rand();
         let to = Pubkey::default();
 
         let expr = BudgetExpr::new_2_2_multisig_payment(&from0, &from1, 42, &to);
@@ -370,8 +370,8 @@ mod tests {
 
     #[test]
     fn test_multisig_after_ts() {
-        let from0 = Pubkey::new_rand();
-        let from1 = Pubkey::new_rand();
+        let from0 = solana_sdk::pubkey::new_rand();
+        let from1 = solana_sdk::pubkey::new_rand();
         let dt = Utc.ymd(2014, 11, 11).and_hms(7, 7, 7);
         let to = Pubkey::default();
 

--- a/programs/budget/src/budget_instruction.rs
+++ b/programs/budget/src/budget_instruction.rs
@@ -167,18 +167,18 @@ mod tests {
 
     #[test]
     fn test_budget_instruction_verify() {
-        let alice_pubkey = Pubkey::new_rand();
-        let bob_pubkey = Pubkey::new_rand();
-        let budget_pubkey = Pubkey::new_rand();
+        let alice_pubkey = solana_sdk::pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
+        let budget_pubkey = solana_sdk::pubkey::new_rand();
         payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 1); // No panic! indicates success.
     }
 
     #[test]
     #[should_panic]
     fn test_budget_instruction_overspend() {
-        let alice_pubkey = Pubkey::new_rand();
-        let bob_pubkey = Pubkey::new_rand();
-        let budget_pubkey = Pubkey::new_rand();
+        let alice_pubkey = solana_sdk::pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
+        let budget_pubkey = solana_sdk::pubkey::new_rand();
         let expr = BudgetExpr::new_payment(2, &bob_pubkey);
         create_account(&alice_pubkey, &budget_pubkey, 1, expr);
     }
@@ -186,9 +186,9 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_budget_instruction_underspend() {
-        let alice_pubkey = Pubkey::new_rand();
-        let bob_pubkey = Pubkey::new_rand();
-        let budget_pubkey = Pubkey::new_rand();
+        let alice_pubkey = solana_sdk::pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
+        let budget_pubkey = solana_sdk::pubkey::new_rand();
         let expr = BudgetExpr::new_payment(1, &bob_pubkey);
         create_account(&alice_pubkey, &budget_pubkey, 2, expr);
     }

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -250,7 +250,7 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let budget_keypair = Keypair::new();
         let budget_pubkey = budget_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
 
         let mut instructions =
             budget_instruction::payment(&alice_pubkey, &bob_pubkey, &budget_pubkey, 1);
@@ -271,7 +271,7 @@ mod tests {
         let (bank, alice_keypair) = create_bank(10_000);
         let bank_client = BankClient::new(bank);
         let alice_pubkey = alice_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let budget_keypair = Keypair::new();
         let budget_pubkey = budget_keypair.pubkey();
         let instructions =
@@ -292,8 +292,8 @@ mod tests {
         // Initialize BudgetState
         let budget_keypair = Keypair::new();
         let budget_pubkey = budget_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
-        let witness = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
+        let witness = solana_sdk::pubkey::new_rand();
         let instructions = budget_instruction::when_signed(
             &alice_pubkey,
             &bob_pubkey,
@@ -341,7 +341,7 @@ mod tests {
         // Initialize BudgetState
         let budget_keypair = Keypair::new();
         let budget_pubkey = budget_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let dt = Utc::now();
         let instructions = budget_instruction::on_date(
             &alice_pubkey,
@@ -389,8 +389,8 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let budget_keypair = Keypair::new();
         let budget_pubkey = budget_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
-        let mallory_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
+        let mallory_pubkey = solana_sdk::pubkey::new_rand();
         let dt = Utc::now();
 
         let instructions = budget_instruction::on_date(
@@ -460,7 +460,7 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let budget_keypair = Keypair::new();
         let budget_pubkey = budget_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let dt = Utc::now();
 
         let instructions = budget_instruction::on_date(
@@ -518,7 +518,7 @@ mod tests {
     #[test]
     fn test_pay_when_account_data() {
         let (bank, alice_keypair) = create_bank(42);
-        let game_pubkey = Pubkey::new_rand();
+        let game_pubkey = solana_sdk::pubkey::new_rand();
         let game_account = Account {
             lamports: 1,
             data: vec![1, 2, 3],

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -138,7 +138,7 @@ mod tests {
     }
 
     fn create_config_account(keys: Vec<(Pubkey, bool)>) -> (Keypair, RefCell<Account>) {
-        let from_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
         let config_keypair = Keypair::new();
         let config_pubkey = config_keypair.pubkey();
 
@@ -239,9 +239,9 @@ mod tests {
     #[test]
     fn test_process_store_with_additional_signers() {
         solana_logger::setup();
-        let pubkey = Pubkey::new_rand();
-        let signer0_pubkey = Pubkey::new_rand();
-        let signer1_pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let signer0_pubkey = solana_sdk::pubkey::new_rand();
+        let signer1_pubkey = solana_sdk::pubkey::new_rand();
         let keys = vec![
             (pubkey, false),
             (signer0_pubkey, true),
@@ -275,8 +275,8 @@ mod tests {
     #[test]
     fn test_process_store_without_config_signer() {
         solana_logger::setup();
-        let pubkey = Pubkey::new_rand();
-        let signer0_pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let signer0_pubkey = solana_sdk::pubkey::new_rand();
         let keys = vec![(pubkey, false), (signer0_pubkey, true)];
         let (config_keypair, _) = create_config_account(keys.clone());
         let config_pubkey = config_keypair.pubkey();
@@ -295,8 +295,8 @@ mod tests {
     #[test]
     fn test_process_store_with_bad_additional_signer() {
         solana_logger::setup();
-        let signer0_pubkey = Pubkey::new_rand();
-        let signer1_pubkey = Pubkey::new_rand();
+        let signer0_pubkey = solana_sdk::pubkey::new_rand();
+        let signer1_pubkey = solana_sdk::pubkey::new_rand();
         let signer0_account = RefCell::new(Account::default());
         let signer1_account = RefCell::new(Account::default());
         let keys = vec![(signer0_pubkey, true)];
@@ -332,10 +332,10 @@ mod tests {
     #[test]
     fn test_config_updates() {
         solana_logger::setup();
-        let pubkey = Pubkey::new_rand();
-        let signer0_pubkey = Pubkey::new_rand();
-        let signer1_pubkey = Pubkey::new_rand();
-        let signer2_pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let signer0_pubkey = solana_sdk::pubkey::new_rand();
+        let signer1_pubkey = solana_sdk::pubkey::new_rand();
+        let signer2_pubkey = solana_sdk::pubkey::new_rand();
         let signer0_account = RefCell::new(Account::default());
         let signer1_account = RefCell::new(Account::default());
         let signer2_account = RefCell::new(Account::default());
@@ -417,8 +417,8 @@ mod tests {
     #[test]
     fn test_config_updates_requiring_config() {
         solana_logger::setup();
-        let pubkey = Pubkey::new_rand();
-        let signer0_pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let signer0_pubkey = solana_sdk::pubkey::new_rand();
         let signer0_account = RefCell::new(Account::default());
         let keys = vec![
             (pubkey, false),
@@ -479,8 +479,8 @@ mod tests {
 
     #[test]
     fn test_config_initialize_no_panic() {
-        let from_pubkey = Pubkey::new_rand();
-        let config_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let config_pubkey = solana_sdk::pubkey::new_rand();
         let instructions =
             config_instruction::create_account::<MyConfig>(&from_pubkey, &config_pubkey, 1, vec![]);
         let accounts = vec![];

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -11,7 +11,7 @@ use solana_sdk::transaction::TransactionError;
 #[test]
 fn test_program_native_failure() {
     let (genesis_config, alice_keypair) = create_genesis_config(50);
-    let program_id = Pubkey::new_rand();
+    let program_id = solana_sdk::pubkey::new_rand();
     let bank = Bank::new(&genesis_config);
     bank.add_native_program("solana_failure_program", &program_id);
 

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -4,7 +4,6 @@ use solana_runtime::loader_utils::create_invoke_instruction;
 use solana_sdk::client::SyncClient;
 use solana_sdk::genesis_config::create_genesis_config;
 use solana_sdk::instruction::InstructionError;
-use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
 use solana_sdk::transaction::TransactionError;
 

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -151,9 +151,9 @@ mod tests {
 
     #[test]
     fn test_ownable_missing_owner_signature() {
-        let mut account_owner_pubkey = Pubkey::new_rand();
+        let mut account_owner_pubkey = solana_sdk::pubkey::new_rand();
         let owner_pubkey = account_owner_pubkey;
-        let new_owner_pubkey = Pubkey::new_rand();
+        let new_owner_pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new_ref(1, 0, &system_program::id());
         let owner_keyed_account = KeyedAccount::new(&owner_pubkey, false, &account); // <-- Attack! Setting owner without the original owner's signature.
         let err = set_owner(
@@ -167,10 +167,10 @@ mod tests {
 
     #[test]
     fn test_ownable_incorrect_owner() {
-        let mut account_owner_pubkey = Pubkey::new_rand();
-        let new_owner_pubkey = Pubkey::new_rand();
+        let mut account_owner_pubkey = solana_sdk::pubkey::new_rand();
+        let new_owner_pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new_ref(1, 0, &system_program::id());
-        let mallory_pubkey = Pubkey::new_rand(); // <-- Attack! Signing with wrong pubkey
+        let mallory_pubkey = solana_sdk::pubkey::new_rand(); // <-- Attack! Signing with wrong pubkey
         let owner_keyed_account = KeyedAccount::new(&mallory_pubkey, true, &account);
         let err = set_owner(
             &mut account_owner_pubkey,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -623,7 +623,7 @@ mod tests {
             process_instruction(&withdraw(
                 &Pubkey::default(),
                 &Pubkey::default(),
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 100,
                 None,
             )),

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1103,7 +1103,7 @@ mod tests {
 
     #[test]
     fn test_authorized_authorize() {
-        let staker = Pubkey::new_rand();
+        let staker = solana_sdk::pubkey::new_rand();
         let mut authorized = Authorized::auto(&staker);
         let mut signers = HashSet::new();
         assert_eq!(
@@ -1155,7 +1155,7 @@ mod tests {
             ..Clock::default()
         };
 
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         let mut vote_state = VoteState::default();
         for i in 0..1000 {
             vote_state.process_slot_vote_unchecked(i);
@@ -1163,7 +1163,7 @@ mod tests {
 
         let vote_account = RefCell::new(vote_state::create_account(
             &vote_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
             100,
         ));
@@ -1173,7 +1173,7 @@ mod tests {
             .set_state(&VoteStateVersions::Current(Box::new(vote_state)))
             .unwrap();
 
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -1609,14 +1609,14 @@ mod tests {
 
     #[test]
     fn test_stake_initialize() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account =
             Account::new_ref(stake_lamports, std::mem::size_of::<StakeState>(), &id());
 
         // unsigned keyed account
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
-        let custodian = Pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
 
         // not enough balance for rent...
         assert_eq!(
@@ -1673,7 +1673,7 @@ mod tests {
 
     #[test]
     fn test_deactivate() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -1697,10 +1697,10 @@ mod tests {
         );
 
         // Staking
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account = RefCell::new(vote_state::create_account(
             &vote_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
             100,
         ));
@@ -1739,7 +1739,7 @@ mod tests {
 
     #[test]
     fn test_set_lockup() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -1757,7 +1757,7 @@ mod tests {
         );
 
         // initalize the stake
-        let custodian = Pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
         stake_keyed_account
             .initialize(
                 &Authorized::auto(&stake_pubkey),
@@ -1788,10 +1788,10 @@ mod tests {
         );
 
         // delegate stake
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account = RefCell::new(vote_state::create_account(
             &vote_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
             100,
         ));
@@ -1836,7 +1836,7 @@ mod tests {
 
     #[test]
     fn test_optional_lockup() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -1847,7 +1847,7 @@ mod tests {
         .expect("stake_account");
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
 
-        let custodian = Pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
         stake_keyed_account
             .initialize(
                 &Authorized::auto(&stake_pubkey),
@@ -1916,7 +1916,7 @@ mod tests {
             panic!();
         }
 
-        let new_custodian = Pubkey::new_rand();
+        let new_custodian = solana_sdk::pubkey::new_rand();
         assert_eq!(
             stake_keyed_account.set_lockup(
                 &LockupArgs {
@@ -1950,7 +1950,7 @@ mod tests {
 
     #[test]
     fn test_withdraw_stake() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -1962,7 +1962,7 @@ mod tests {
 
         let mut clock = Clock::default();
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
@@ -2001,7 +2001,7 @@ mod tests {
 
         // lockup
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
-        let custodian = Pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
         stake_keyed_account
             .initialize(
                 &Authorized::auto(&stake_pubkey),
@@ -2030,10 +2030,10 @@ mod tests {
         );
 
         // Stake some lamports (available lamports for withdrawals will reduce to zero)
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account = RefCell::new(vote_state::create_account(
             &vote_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
             100,
         ));
@@ -2124,7 +2124,7 @@ mod tests {
 
     #[test]
     fn test_withdraw_stake_before_warmup() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let total_lamports = 100;
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
@@ -2139,17 +2139,17 @@ mod tests {
         let mut future = Clock::default();
         future.epoch += 16;
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
 
         // Stake some lamports (available lamports for withdrawals will reduce)
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account = RefCell::new(vote_state::create_account(
             &vote_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
             100,
         ));
@@ -2195,7 +2195,7 @@ mod tests {
 
     #[test]
     fn test_withdraw_stake_invalid_state() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let total_lamports = 100;
         let stake_account = Account::new_ref_data_with_space(
             total_lamports,
@@ -2205,7 +2205,7 @@ mod tests {
         )
         .expect("stake_account");
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
@@ -2224,8 +2224,8 @@ mod tests {
 
     #[test]
     fn test_withdraw_lockup() {
-        let stake_pubkey = Pubkey::new_rand();
-        let custodian = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
         let total_lamports = 100;
         let stake_account = Account::new_ref_data_with_space(
             total_lamports,
@@ -2242,7 +2242,7 @@ mod tests {
         )
         .expect("stake_account");
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
@@ -2299,7 +2299,7 @@ mod tests {
 
     #[test]
     fn test_withdraw_identical_authorities() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let custodian = stake_pubkey;
         let total_lamports = 100;
         let stake_account = Account::new_ref_data_with_space(
@@ -2317,7 +2317,7 @@ mod tests {
         )
         .expect("stake_account");
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
@@ -2586,7 +2586,7 @@ mod tests {
 
     #[test]
     fn test_authorize_uninit() {
-        let new_authority = Pubkey::new_rand();
+        let new_authority = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -2606,7 +2606,7 @@ mod tests {
 
     #[test]
     fn test_authorize_lockup() {
-        let stake_authority = Pubkey::new_rand();
+        let stake_authority = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -2616,14 +2616,14 @@ mod tests {
         )
         .expect("stake_account");
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
         let clock = Clock::default();
         let stake_keyed_account = KeyedAccount::new(&stake_authority, true, &stake_account);
 
-        let stake_pubkey0 = Pubkey::new_rand();
+        let stake_pubkey0 = solana_sdk::pubkey::new_rand();
         let signers = vec![stake_authority].into_iter().collect();
         assert_eq!(
             stake_keyed_account.authorize(&signers, &stake_pubkey0, StakeAuthorize::Staker),
@@ -2643,7 +2643,7 @@ mod tests {
         }
 
         // A second authorization signed by the stake_keyed_account should fail
-        let stake_pubkey1 = Pubkey::new_rand();
+        let stake_pubkey1 = solana_sdk::pubkey::new_rand();
         assert_eq!(
             stake_keyed_account.authorize(&signers, &stake_pubkey1, StakeAuthorize::Staker),
             Err(InstructionError::MissingRequiredSignature)
@@ -2652,7 +2652,7 @@ mod tests {
         let signers0 = vec![stake_pubkey0].into_iter().collect();
 
         // Test a second authorization by the newly authorized pubkey
-        let stake_pubkey2 = Pubkey::new_rand();
+        let stake_pubkey2 = solana_sdk::pubkey::new_rand();
         assert_eq!(
             stake_keyed_account.authorize(&signers0, &stake_pubkey2, StakeAuthorize::Staker),
             Ok(())
@@ -2705,7 +2705,7 @@ mod tests {
 
     #[test]
     fn test_authorize_with_seed() {
-        let base_pubkey = Pubkey::new_rand();
+        let base_pubkey = solana_sdk::pubkey::new_rand();
         let seed = "42";
         let withdrawer_pubkey = Pubkey::create_with_seed(&base_pubkey, &seed, &id()).unwrap();
         let stake_lamports = 42;
@@ -2722,7 +2722,7 @@ mod tests {
 
         let stake_keyed_account = KeyedAccount::new(&withdrawer_pubkey, true, &stake_account);
 
-        let new_authority = Pubkey::new_rand();
+        let new_authority = solana_sdk::pubkey::new_rand();
 
         // Wrong seed
         assert_eq!(
@@ -2787,7 +2787,7 @@ mod tests {
 
     #[test]
     fn test_authorize_override() {
-        let withdrawer_pubkey = Pubkey::new_rand();
+        let withdrawer_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -2800,7 +2800,7 @@ mod tests {
         let stake_keyed_account = KeyedAccount::new(&withdrawer_pubkey, true, &stake_account);
 
         // Authorize a staker pubkey and move the withdrawer key into cold storage.
-        let new_authority = Pubkey::new_rand();
+        let new_authority = solana_sdk::pubkey::new_rand();
         let signers = vec![withdrawer_pubkey].into_iter().collect();
         assert_eq!(
             stake_keyed_account.authorize(&signers, &new_authority, StakeAuthorize::Staker),
@@ -2808,7 +2808,7 @@ mod tests {
         );
 
         // Attack! The stake key (a hot key) is stolen and used to authorize a new staker.
-        let mallory_pubkey = Pubkey::new_rand();
+        let mallory_pubkey = solana_sdk::pubkey::new_rand();
         let signers = vec![new_authority].into_iter().collect();
         assert_eq!(
             stake_keyed_account.authorize(&signers, &mallory_pubkey, StakeAuthorize::Staker),
@@ -2816,7 +2816,7 @@ mod tests {
         );
 
         // Verify the original staker no longer has access.
-        let new_stake_pubkey = Pubkey::new_rand();
+        let new_stake_pubkey = solana_sdk::pubkey::new_rand();
         assert_eq!(
             stake_keyed_account.authorize(&signers, &new_stake_pubkey, StakeAuthorize::Staker),
             Err(InstructionError::MissingRequiredSignature)
@@ -2839,7 +2839,7 @@ mod tests {
 
     #[test]
     fn test_split_source_uninitialized() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -2849,7 +2849,7 @@ mod tests {
         )
         .expect("stake_account");
 
-        let split_stake_pubkey = Pubkey::new_rand();
+        let split_stake_pubkey = solana_sdk::pubkey::new_rand();
         let split_stake_account = Account::new_ref_data_with_space(
             0,
             &StakeState::Uninitialized,
@@ -2886,7 +2886,7 @@ mod tests {
 
     #[test]
     fn test_split_split_not_uninitialized() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -2896,7 +2896,7 @@ mod tests {
         )
         .expect("stake_account");
 
-        let split_stake_pubkey = Pubkey::new_rand();
+        let split_stake_pubkey = solana_sdk::pubkey::new_rand();
         let split_stake_account = Account::new_ref_data_with_space(
             0,
             &StakeState::Initialized(Meta::auto(&stake_pubkey)),
@@ -2938,7 +2938,7 @@ mod tests {
 
     #[test]
     fn test_split_more_than_staked() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -2951,7 +2951,7 @@ mod tests {
         )
         .expect("stake_account");
 
-        let split_stake_pubkey = Pubkey::new_rand();
+        let split_stake_pubkey = solana_sdk::pubkey::new_rand();
         let split_stake_account = Account::new_ref_data_with_space(
             0,
             &StakeState::Uninitialized,
@@ -2972,8 +2972,8 @@ mod tests {
 
     #[test]
     fn test_split_with_rent() {
-        let stake_pubkey = Pubkey::new_rand();
-        let split_stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
+        let split_stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let rent_exempt_reserve = 10;
         let signers = vec![stake_pubkey].into_iter().collect();
@@ -3073,10 +3073,10 @@ mod tests {
 
     #[test]
     fn test_split() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
 
-        let split_stake_pubkey = Pubkey::new_rand();
+        let split_stake_pubkey = solana_sdk::pubkey::new_rand();
         let signers = vec![stake_pubkey].into_iter().collect();
 
         // test splitting both an Initialized stake and a Staked stake
@@ -3165,11 +3165,11 @@ mod tests {
 
     #[test]
     fn test_split_100_percent_of_source() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let rent_exempt_reserve = 10;
 
-        let split_stake_pubkey = Pubkey::new_rand();
+        let split_stake_pubkey = solana_sdk::pubkey::new_rand();
         let signers = vec![stake_pubkey].into_iter().collect();
 
         let meta = Meta {
@@ -3262,9 +3262,9 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        let stake_pubkey = Pubkey::new_rand();
-        let source_stake_pubkey = Pubkey::new_rand();
-        let authorized_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
+        let source_stake_pubkey = solana_sdk::pubkey::new_rand();
+        let authorized_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
 
         let signers = vec![authorized_pubkey].into_iter().collect();
@@ -3335,10 +3335,10 @@ mod tests {
 
     #[test]
     fn test_merge_incorrect_authorized_staker() {
-        let stake_pubkey = Pubkey::new_rand();
-        let source_stake_pubkey = Pubkey::new_rand();
-        let authorized_pubkey = Pubkey::new_rand();
-        let wrong_authorized_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
+        let source_stake_pubkey = solana_sdk::pubkey::new_rand();
+        let authorized_pubkey = solana_sdk::pubkey::new_rand();
+        let wrong_authorized_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
 
         let signers = vec![authorized_pubkey].into_iter().collect();
@@ -3402,9 +3402,9 @@ mod tests {
 
     #[test]
     fn test_merge_invalid_account_data() {
-        let stake_pubkey = Pubkey::new_rand();
-        let source_stake_pubkey = Pubkey::new_rand();
-        let authorized_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
+        let source_stake_pubkey = solana_sdk::pubkey::new_rand();
+        let authorized_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let signers = vec![authorized_pubkey].into_iter().collect();
 
@@ -3452,9 +3452,9 @@ mod tests {
 
     #[test]
     fn test_merge_active_stake() {
-        let stake_pubkey = Pubkey::new_rand();
-        let source_stake_pubkey = Pubkey::new_rand();
-        let authorized_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
+        let source_stake_pubkey = solana_sdk::pubkey::new_rand();
+        let authorized_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
 
         let signers = vec![authorized_pubkey].into_iter().collect();
@@ -3505,7 +3505,7 @@ mod tests {
 
     #[test]
     fn test_lockup_is_expired() {
-        let custodian = Pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
         let lockup = Lockup {
             epoch: 1,
             unix_timestamp: 1,
@@ -3587,7 +3587,7 @@ mod tests {
 
     #[test]
     fn test_authorize_delegated_stake() {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account = Account::new_ref_data_with_space(
             stake_lamports,
@@ -3599,10 +3599,10 @@ mod tests {
 
         let clock = Clock::default();
 
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account = RefCell::new(vote_state::create_account(
             &vote_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
             100,
         ));
@@ -3623,7 +3623,7 @@ mod tests {
         // deactivate, so we can re-delegate
         stake_keyed_account.deactivate(&clock, &signers).unwrap();
 
-        let new_staker_pubkey = Pubkey::new_rand();
+        let new_staker_pubkey = solana_sdk::pubkey::new_rand();
         assert_eq!(
             stake_keyed_account.authorize(&signers, &new_staker_pubkey, StakeAuthorize::Staker),
             Ok(())
@@ -3632,17 +3632,17 @@ mod tests {
             StakeState::authorized_from(&stake_keyed_account.try_account_ref().unwrap()).unwrap();
         assert_eq!(authorized.staker, new_staker_pubkey);
 
-        let other_pubkey = Pubkey::new_rand();
+        let other_pubkey = solana_sdk::pubkey::new_rand();
         let other_signers = vec![other_pubkey].into_iter().collect();
 
         // Use unsigned stake_keyed_account to test other signers
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
 
-        let new_voter_pubkey = Pubkey::new_rand();
+        let new_voter_pubkey = solana_sdk::pubkey::new_rand();
         let vote_state = VoteState::default();
         let new_vote_account = RefCell::new(vote_state::create_account(
             &new_voter_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             0,
             100,
         ));

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -260,11 +260,11 @@ mod tests {
     #[test]
     fn test_verify_account_unauthorized() {
         // Ensure client can't sneak in with an untrusted date account.
-        let date_pubkey = Pubkey::new_rand();
+        let date_pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new_ref(1, 0, &solana_config_program::id());
         let keyed_account = KeyedAccount::new(&date_pubkey, false, &account);
 
-        let mallory_pubkey = Pubkey::new_rand(); // <-- Attack! Not the expected account.
+        let mallory_pubkey = solana_sdk::pubkey::new_rand(); // <-- Attack! Not the expected account.
         assert_eq!(
             verify_account(&keyed_account, &mallory_pubkey).unwrap_err(),
             VestError::Unauthorized.into()
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn test_verify_signed_account_missing_signature() {
         // Ensure client can't sneak in with an unsigned account.
-        let date_pubkey = Pubkey::new_rand();
+        let date_pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new_ref(1, 0, &solana_config_program::id());
         let keyed_account = KeyedAccount::new(&date_pubkey, false, &account); // <-- Attack! Unsigned transaction.
 
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     fn test_verify_date_account_incorrect_program_id() {
         // Ensure client can't sneak in with a non-Config account.
-        let date_pubkey = Pubkey::new_rand();
+        let date_pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new_ref(1, 0, &id()); // <-- Attack! Pass Vest account where Config account is expected.
         let keyed_account = KeyedAccount::new(&date_pubkey, false, &account);
         assert_eq!(
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn test_verify_date_account_uninitialized_config() {
         // Ensure no panic when `get_config_data()` returns an error.
-        let date_pubkey = Pubkey::new_rand();
+        let date_pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new_ref(1, 0, &solana_config_program::id()); // <-- Attack! Zero space.
         let keyed_account = KeyedAccount::new(&date_pubkey, false, &account);
         assert_eq!(
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     fn test_verify_date_account_invalid_date_config() {
         // Ensure no panic when `deserialize::<DateConfig>()` returns an error.
-        let date_pubkey = Pubkey::new_rand();
+        let date_pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new_ref(1, 1, &solana_config_program::id()); // Attack! 1 byte, enough to sneak by `get_config_data()`, but not DateConfig deserialize.
         let keyed_account = KeyedAccount::new(&date_pubkey, false, &account);
         assert_eq!(
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn test_verify_date_account_deserialize() {
         // Ensure no panic when `deserialize::<DateConfig>()` returns an error.
-        let date_pubkey = Pubkey::new_rand();
+        let date_pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new_ref(1, 1, &solana_config_program::id()); // Attack! 1 byte, enough to sneak by `get_config_data()`, but not DateConfig deserialize.
         let keyed_account = KeyedAccount::new(&date_pubkey, false, &account);
         assert_eq!(
@@ -340,11 +340,11 @@ mod tests {
 
         let mut instructions = vest_instruction::create_account(
             &alice_keypair.pubkey(),
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             &contract_keypair.pubkey(),
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             Utc::now().date(),
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             1,
         );
         instructions[1].accounts = vec![]; // <!-- Attack! Prevent accounts from being passed into processor.
@@ -362,7 +362,7 @@ mod tests {
     fn test_set_payee_and_terminator() {
         let (bank_client, alice_keypair) = create_bank_client(39);
         let alice_pubkey = alice_keypair.pubkey();
-        let date_pubkey = Pubkey::new_rand();
+        let date_pubkey = solana_sdk::pubkey::new_rand();
         let contract_keypair = Keypair::new();
         let contract_pubkey = contract_keypair.pubkey();
         let bob_keypair = Keypair::new();
@@ -381,7 +381,7 @@ mod tests {
         )
         .unwrap();
 
-        let new_bob_pubkey = Pubkey::new_rand();
+        let new_bob_pubkey = solana_sdk::pubkey::new_rand();
 
         // Ensure some rando can't change the payee.
         // Transfer bob a token to pay the transaction fee.
@@ -410,7 +410,7 @@ mod tests {
         .unwrap();
 
         // Ensure the rando can't change the terminator either.
-        let new_alice_pubkey = Pubkey::new_rand();
+        let new_alice_pubkey = solana_sdk::pubkey::new_rand();
         send_set_terminator(
             &bank_client,
             &contract_pubkey,
@@ -433,7 +433,7 @@ mod tests {
     fn test_set_payee() {
         let (bank_client, alice_keypair) = create_bank_client(38);
         let alice_pubkey = alice_keypair.pubkey();
-        let date_pubkey = Pubkey::new_rand();
+        let date_pubkey = solana_sdk::pubkey::new_rand();
         let contract_keypair = Keypair::new();
         let contract_pubkey = contract_keypair.pubkey();
         let bob_keypair = Keypair::new();
@@ -452,7 +452,7 @@ mod tests {
         )
         .unwrap();
 
-        let new_bob_pubkey = Pubkey::new_rand();
+        let new_bob_pubkey = solana_sdk::pubkey::new_rand();
 
         // Ensure some rando can't change the payee.
         // Transfer bob a token to pay the transaction fee.
@@ -496,7 +496,7 @@ mod tests {
 
         let contract_keypair = Keypair::new();
         let contract_pubkey = contract_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let start_date = Utc.ymd(2018, 1, 1);
 
         create_vest_account(
@@ -558,7 +558,7 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let contract_keypair = Keypair::new();
         let contract_pubkey = contract_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let start_date = Utc::now().date();
 
         let date_keypair = Keypair::new();
@@ -602,7 +602,7 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let contract_keypair = Keypair::new();
         let contract_pubkey = contract_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let start_date = Utc::now().date();
 
         let date_keypair = Keypair::new();
@@ -626,7 +626,7 @@ mod tests {
         assert_eq!(bank_client.get_balance(&contract_pubkey).unwrap(), 1);
 
         // Now, terminate the transaction. carol gets the funds.
-        let carol_pubkey = Pubkey::new_rand();
+        let carol_pubkey = solana_sdk::pubkey::new_rand();
         let instruction =
             vest_instruction::terminate(&contract_pubkey, &alice_pubkey, &carol_pubkey);
         bank_client
@@ -647,7 +647,7 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let contract_keypair = Keypair::new();
         let contract_pubkey = contract_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let start_date = Utc::now().date();
 
         let date_keypair = Keypair::new();
@@ -671,7 +671,7 @@ mod tests {
         assert_eq!(bank_client.get_balance(&contract_pubkey).unwrap(), 1);
 
         // Now, renege on a token. carol gets it.
-        let carol_pubkey = Pubkey::new_rand();
+        let carol_pubkey = solana_sdk::pubkey::new_rand();
         let instruction =
             vest_instruction::renege(&contract_pubkey, &alice_pubkey, &carol_pubkey, 1);
         bank_client

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -278,7 +278,7 @@ impl VoteState {
         vote_state.epoch_credits = vec![(0, 0, 0); MAX_EPOCH_CREDITS_HISTORY];
         let mut authorized_voters = AuthorizedVoters::default();
         for i in 0..=MAX_LEADER_SCHEDULE_EPOCH_OFFSET {
-            authorized_voters.insert(i, Pubkey::new_rand());
+            authorized_voters.insert(i, solana_sdk::pubkey::new_rand());
         }
         vote_state.authorized_voters = authorized_voters;
         vote_state
@@ -771,7 +771,7 @@ mod tests {
         pub fn new_for_test(auth_pubkey: &Pubkey) -> Self {
             Self::new(
                 &VoteInit {
-                    node_pubkey: Pubkey::new_rand(),
+                    node_pubkey: solana_sdk::pubkey::new_rand(),
                     authorized_voter: *auth_pubkey,
                     authorized_withdrawer: *auth_pubkey,
                     commission: 0,
@@ -783,11 +783,11 @@ mod tests {
 
     #[test]
     fn test_initialize_vote_account() {
-        let vote_account_pubkey = Pubkey::new_rand();
+        let vote_account_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account = Account::new_ref(100, VoteState::size_of(), &id());
         let vote_account = KeyedAccount::new(&vote_account_pubkey, false, &vote_account);
 
-        let node_pubkey = Pubkey::new_rand();
+        let node_pubkey = solana_sdk::pubkey::new_rand();
         let node_account = RefCell::new(Account::default());
         let keyed_accounts = &[];
         let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
@@ -839,12 +839,12 @@ mod tests {
     }
 
     fn create_test_account() -> (Pubkey, RefCell<Account>) {
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         (
             vote_pubkey,
             RefCell::new(vote_state::create_account(
                 &vote_pubkey,
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 0,
                 100,
             )),
@@ -852,16 +852,16 @@ mod tests {
     }
 
     fn create_test_account_with_authorized() -> (Pubkey, Pubkey, Pubkey, RefCell<Account>) {
-        let vote_pubkey = Pubkey::new_rand();
-        let authorized_voter = Pubkey::new_rand();
-        let authorized_withdrawer = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
+        let authorized_voter = solana_sdk::pubkey::new_rand();
+        let authorized_withdrawer = solana_sdk::pubkey::new_rand();
 
         (
             vote_pubkey,
             authorized_voter,
             authorized_withdrawer,
             RefCell::new(vote_state::create_account_with_authorized(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 &authorized_voter,
                 &authorized_withdrawer,
                 0,
@@ -990,7 +990,7 @@ mod tests {
         let (vote_pubkey, _authorized_voter, authorized_withdrawer, vote_account) =
             create_test_account_with_authorized();
 
-        let node_pubkey = Pubkey::new_rand();
+        let node_pubkey = solana_sdk::pubkey::new_rand();
         let node_account = RefCell::new(Account::default());
         let authorized_withdrawer_account = RefCell::new(Account::default());
 
@@ -1118,7 +1118,7 @@ mod tests {
         // another voter, unsigned
         let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, false, &vote_account)];
         let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
-        let authorized_voter_pubkey = Pubkey::new_rand();
+        let authorized_voter_pubkey = solana_sdk::pubkey::new_rand();
         let res = authorize(
             &keyed_accounts[0],
             &authorized_voter_pubkey,
@@ -1188,7 +1188,7 @@ mod tests {
         // another voter
         let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account)];
         let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
-        let authorized_withdrawer_pubkey = Pubkey::new_rand();
+        let authorized_withdrawer_pubkey = solana_sdk::pubkey::new_rand();
         let res = authorize(
             &keyed_accounts[0],
             &authorized_withdrawer_pubkey,
@@ -1263,7 +1263,7 @@ mod tests {
 
     #[test]
     fn test_vote_without_initialization() {
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account = RefCell::new(Account::new(100, VoteState::size_of(), &id()));
 
         let res = simulate_process_vote_unchecked(
@@ -1308,7 +1308,7 @@ mod tests {
 
     #[test]
     fn test_vote_double_lockout_after_expiration() {
-        let voter_pubkey = Pubkey::new_rand();
+        let voter_pubkey = solana_sdk::pubkey::new_rand();
         let mut vote_state = VoteState::new_for_test(&voter_pubkey);
 
         for i in 0..3 {
@@ -1336,7 +1336,7 @@ mod tests {
 
     #[test]
     fn test_expire_multiple_votes() {
-        let voter_pubkey = Pubkey::new_rand();
+        let voter_pubkey = solana_sdk::pubkey::new_rand();
         let mut vote_state = VoteState::new_for_test(&voter_pubkey);
 
         for i in 0..3 {
@@ -1367,7 +1367,7 @@ mod tests {
 
     #[test]
     fn test_vote_credits() {
-        let voter_pubkey = Pubkey::new_rand();
+        let voter_pubkey = solana_sdk::pubkey::new_rand();
         let mut vote_state = VoteState::new_for_test(&voter_pubkey);
 
         for i in 0..MAX_LOCKOUT_HISTORY {
@@ -1386,7 +1386,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_vote() {
-        let voter_pubkey = Pubkey::new_rand();
+        let voter_pubkey = solana_sdk::pubkey::new_rand();
         let mut vote_state = VoteState::new_for_test(&voter_pubkey);
         vote_state.process_slot_vote_unchecked(0);
         vote_state.process_slot_vote_unchecked(1);
@@ -1398,7 +1398,7 @@ mod tests {
 
     #[test]
     fn test_nth_recent_vote() {
-        let voter_pubkey = Pubkey::new_rand();
+        let voter_pubkey = solana_sdk::pubkey::new_rand();
         let mut vote_state = VoteState::new_for_test(&voter_pubkey);
         for i in 0..MAX_LOCKOUT_HISTORY {
             vote_state.process_slot_vote_unchecked(i as u64);
@@ -1429,9 +1429,9 @@ mod tests {
     /// check that two accounts with different data can be brought to the same state with one vote submission
     #[test]
     fn test_process_missed_votes() {
-        let account_a = Pubkey::new_rand();
+        let account_a = solana_sdk::pubkey::new_rand();
         let mut vote_state_a = VoteState::new_for_test(&account_a);
-        let account_b = Pubkey::new_rand();
+        let account_b = solana_sdk::pubkey::new_rand();
         let mut vote_state_b = VoteState::new_for_test(&account_b);
 
         // process some votes on account a
@@ -1598,7 +1598,7 @@ mod tests {
             &keyed_accounts[0],
             0,
             &KeyedAccount::new(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 false,
                 &RefCell::new(Account::default()),
             ),
@@ -1613,7 +1613,7 @@ mod tests {
             &keyed_accounts[0],
             101,
             &KeyedAccount::new(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 false,
                 &RefCell::new(Account::default()),
             ),
@@ -1629,7 +1629,7 @@ mod tests {
         let res = withdraw(
             &keyed_accounts[0],
             lamports,
-            &KeyedAccount::new(&Pubkey::new_rand(), false, &to_account),
+            &KeyedAccount::new(&solana_sdk::pubkey::new_rand(), false, &to_account),
             &signers,
         );
         assert_eq!(res, Ok(()));
@@ -1640,7 +1640,7 @@ mod tests {
         vote_account.borrow_mut().lamports = lamports;
 
         // authorize authorized_withdrawer
-        let authorized_withdrawer_pubkey = Pubkey::new_rand();
+        let authorized_withdrawer_pubkey = solana_sdk::pubkey::new_rand();
         let keyed_accounts = &[KeyedAccount::new(&vote_pubkey, true, &vote_account)];
         let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
         let res = authorize(
@@ -1777,7 +1777,7 @@ mod tests {
 
     #[test]
     fn test_get_and_update_authorized_voter() {
-        let original_voter = Pubkey::new_rand();
+        let original_voter = solana_sdk::pubkey::new_rand();
         let mut vote_state = VoteState::new(
             &VoteInit {
                 node_pubkey: original_voter,
@@ -1813,7 +1813,7 @@ mod tests {
         }
 
         // Set an authorized voter change at slot 7
-        let new_authorized_voter = Pubkey::new_rand();
+        let new_authorized_voter = solana_sdk::pubkey::new_rand();
         vote_state
             .set_new_authorized_voter(&new_authorized_voter, 5, 7, |_| Ok(()))
             .unwrap();
@@ -1837,7 +1837,7 @@ mod tests {
 
     #[test]
     fn test_set_new_authorized_voter() {
-        let original_voter = Pubkey::new_rand();
+        let original_voter = solana_sdk::pubkey::new_rand();
         let epoch_offset = 15;
         let mut vote_state = VoteState::new(
             &VoteInit {
@@ -1851,7 +1851,7 @@ mod tests {
 
         assert!(vote_state.prior_voters.last().is_none());
 
-        let new_voter = Pubkey::new_rand();
+        let new_voter = solana_sdk::pubkey::new_rand();
         // Set a new authorized voter
         vote_state
             .set_new_authorized_voter(&new_voter, 0, epoch_offset, |_| Ok(()))
@@ -1875,7 +1875,7 @@ mod tests {
             .unwrap();
 
         // Set a third and fourth authorized voter
-        let new_voter2 = Pubkey::new_rand();
+        let new_voter2 = solana_sdk::pubkey::new_rand();
         vote_state
             .set_new_authorized_voter(&new_voter2, 3, 3 + epoch_offset, |_| Ok(()))
             .unwrap();
@@ -1885,7 +1885,7 @@ mod tests {
             Some(&(new_voter, epoch_offset, 3 + epoch_offset))
         );
 
-        let new_voter3 = Pubkey::new_rand();
+        let new_voter3 = solana_sdk::pubkey::new_rand();
         vote_state
             .set_new_authorized_voter(&new_voter3, 6, 6 + epoch_offset, |_| Ok(()))
             .unwrap();
@@ -1936,7 +1936,7 @@ mod tests {
 
     #[test]
     fn test_authorized_voter_is_locked_within_epoch() {
-        let original_voter = Pubkey::new_rand();
+        let original_voter = solana_sdk::pubkey::new_rand();
         let mut vote_state = VoteState::new(
             &VoteInit {
                 node_pubkey: original_voter,
@@ -1950,7 +1950,7 @@ mod tests {
         // Test that it's not possible to set a new authorized
         // voter within the same epoch, even if none has been
         // explicitly set before
-        let new_voter = Pubkey::new_rand();
+        let new_voter = solana_sdk::pubkey::new_rand();
         assert_eq!(
             vote_state.set_new_authorized_voter(&new_voter, 1, 1, |_| Ok(())),
             Err(VoteError::TooSoonToReauthorize.into())
@@ -1987,7 +1987,7 @@ mod tests {
         for i in start_current_epoch..start_current_epoch + 2 * MAX_LEADER_SCHEDULE_EPOCH_OFFSET {
             vote_state.as_mut().map(|vote_state| {
                 vote_state.set_new_authorized_voter(
-                    &Pubkey::new_rand(),
+                    &solana_sdk::pubkey::new_rand(),
                     i,
                     i + MAX_LEADER_SCHEDULE_EPOCH_OFFSET,
                     |_| Ok(()),

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_parse_path() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1/2", pubkey)).unwrap();
         assert!(wallet_info.matches(&RemoteWalletInfo {
@@ -588,7 +588,7 @@ mod tests {
 
     #[test]
     fn test_remote_wallet_info_matches() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let info = RemoteWalletInfo {
             manufacturer: "Ledger".to_string(),
             model: "Nano S".to_string(),
@@ -608,7 +608,7 @@ mod tests {
         assert!(info.matches(&test_info));
         test_info.host_device_path = "/host/device/path".to_string();
         assert!(info.matches(&test_info));
-        let another_pubkey = Pubkey::new_rand();
+        let another_pubkey = solana_sdk::pubkey::new_rand();
         test_info.pubkey = another_pubkey;
         assert!(!info.matches(&test_info));
         test_info.pubkey = pubkey;
@@ -617,7 +617,7 @@ mod tests {
 
     #[test]
     fn test_get_pretty_path() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let pubkey_str = pubkey.to_string();
         let remote_wallet_info = RemoteWalletInfo {
             model: "nano-s".to_string(),

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -23,7 +23,7 @@ use test::Bencher;
 
 fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) {
     for t in 0..num {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
         pubkeys.push(pubkey);
         assert!(bank.get_account(&pubkey).is_none());
@@ -137,7 +137,7 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
     let mut old_pubkey = Pubkey::default();
     let zero_account = Account::new(0, 0, &Account::default().owner);
     for i in 0..1000 {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new((i + 1) as u64, 0, &Account::default().owner);
         accounts.store_slow(i, &pubkey, &account);
         accounts.store_slow(i, &old_pubkey, &zero_account);
@@ -170,7 +170,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
     let pubkeys: Arc<Vec<_>> = Arc::new(
         (0..num_keys)
             .map(|_| {
-                let pubkey = Pubkey::new_rand();
+                let pubkey = solana_sdk::pubkey::new_rand();
                 let account = Account::new(1, 0, &Account::default().owner);
                 accounts.store_slow(slot, &pubkey, &account);
                 pubkey
@@ -198,7 +198,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
             // Write to a different slot than the one being read from. Because
             // there's a new account pubkey being written to every time, will
             // compete for the accounts index lock on every store
-            accounts.store_slow(slot + 1, &Pubkey::new_rand(), &account);
+            accounts.store_slow(slot + 1, &solana_sdk::pubkey::new_rand(), &account);
         }
     })
 }

--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -4,13 +4,13 @@ extern crate test;
 
 use rand::{thread_rng, Rng};
 use solana_runtime::{accounts_db::AccountInfo, accounts_index::AccountsIndex};
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::pubkey;
 use test::Bencher;
 
 #[bench]
 fn bench_accounts_index(bencher: &mut Bencher) {
     const NUM_PUBKEYS: usize = 10_000;
-    let pubkeys: Vec<_> = (0..NUM_PUBKEYS).map(|_| solana_sdk::pubkey::new_rand()).collect();
+    let pubkeys: Vec<_> = (0..NUM_PUBKEYS).map(|_| pubkey::new_rand()).collect();
 
     const NUM_FORKS: u64 = 16;
 

--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -10,7 +10,7 @@ use test::Bencher;
 #[bench]
 fn bench_accounts_index(bencher: &mut Bencher) {
     const NUM_PUBKEYS: usize = 10_000;
-    let pubkeys: Vec<_> = (0..NUM_PUBKEYS).map(|_| Pubkey::new_rand()).collect();
+    let pubkeys: Vec<_> = (0..NUM_PUBKEYS).map(|_| solana_sdk::pubkey::new_rand()).collect();
 
     const NUM_FORKS: u64 = 16;
 

--- a/runtime/benches/bloom.rs
+++ b/runtime/benches/bloom.rs
@@ -102,7 +102,7 @@ fn bench_sigs_hashmap(bencher: &mut Bencher) {
 #[bench]
 fn bench_add_hash(bencher: &mut Bencher) {
     let mut rng = rand::thread_rng();
-    let hash_values: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+    let hash_values: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
         .take(1200)
         .collect();
     let mut fail = 0;
@@ -122,7 +122,7 @@ fn bench_add_hash(bencher: &mut Bencher) {
 #[bench]
 fn bench_add_hash_atomic(bencher: &mut Bencher) {
     let mut rng = rand::thread_rng();
-    let hash_values: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+    let hash_values: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
         .take(1200)
         .collect();
     let mut fail = 0;

--- a/runtime/benches/message_processor.rs
+++ b/runtime/benches/message_processor.rs
@@ -4,17 +4,17 @@ extern crate test;
 
 use log::*;
 use solana_runtime::message_processor::PreAccount;
-use solana_sdk::{account::Account, pubkey::Pubkey, rent::Rent};
+use solana_sdk::{account::Account, pubkey, rent::Rent};
 use test::Bencher;
 
 #[bench]
 fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     solana_logger::setup();
 
-    let owner = solana_sdk::pubkey::new_rand();
-    let non_owner = solana_sdk::pubkey::new_rand();
+    let owner = pubkey::new_rand();
+    let non_owner = pubkey::new_rand();
     let pre = PreAccount::new(
-        &solana_sdk::pubkey::new_rand(),
+        &pubkey::new_rand(),
         &Account::new(0, BUFSIZE, &owner),
         true,
         false,
@@ -36,7 +36,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     info!("data compare {} ns/iter", summary.median);
 
     let pre = PreAccount::new(
-        &solana_sdk::pubkey::new_rand(),
+        &pubkey::new_rand(),
         &Account::new(0, BUFSIZE, &owner),
         true,
         false,

--- a/runtime/benches/message_processor.rs
+++ b/runtime/benches/message_processor.rs
@@ -11,10 +11,10 @@ use test::Bencher;
 fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     solana_logger::setup();
 
-    let owner = Pubkey::new_rand();
-    let non_owner = Pubkey::new_rand();
+    let owner = solana_sdk::pubkey::new_rand();
+    let non_owner = solana_sdk::pubkey::new_rand();
     let pre = PreAccount::new(
-        &Pubkey::new_rand(),
+        &solana_sdk::pubkey::new_rand(),
         &Account::new(0, BUFSIZE, &owner),
         true,
         false,
@@ -36,7 +36,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     info!("data compare {} ns/iter", summary.median);
 
     let pre = PreAccount::new(
-        &Pubkey::new_rand(),
+        &solana_sdk::pubkey::new_rand(),
         &Account::new(0, BUFSIZE, &owner),
         true,
         false,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -876,7 +876,7 @@ pub fn create_test_accounts(
     slot: Slot,
 ) {
     for t in 0..num {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
         accounts.store_slow(slot, &pubkey, &account);
         pubkeys.push(pubkey);
@@ -1099,7 +1099,7 @@ mod tests {
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
 
-        let account = Account::new(1, 1, &Pubkey::new_rand()); // <-- owner is not the system program
+        let account = Account::new(1, 1, &solana_sdk::pubkey::new_rand()); // <-- owner is not the system program
         accounts.push((key0, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -1493,13 +1493,13 @@ mod tests {
         let accounts = Accounts::new(Vec::new(), &ClusterType::Development);
 
         // Load accounts owned by various programs into AccountsDB
-        let pubkey0 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
         let account0 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts.store_slow(0, &pubkey0, &account0);
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let account1 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts.store_slow(0, &pubkey1, &account1);
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         let account2 = Account::new(1, 0, &Pubkey::new(&[3; 32]));
         accounts.store_slow(0, &pubkey2, &account2);
 
@@ -1522,7 +1522,7 @@ mod tests {
                 &accounts.accounts_db.storage,
                 &ancestors,
                 &accounts.accounts_db.accounts_index,
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 &mut error_counters
             ),
             Err(TransactionError::ProgramAccountNotFound)
@@ -1729,7 +1729,7 @@ mod tests {
     fn test_collect_accounts_to_store() {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let rent_collector = RentCollector::default();
 
@@ -1848,7 +1848,7 @@ mod tests {
         let zero_account = Account::new(0, 0, &Account::default().owner);
         info!("storing..");
         for i in 0..2_000 {
-            let pubkey = Pubkey::new_rand();
+            let pubkey = solana_sdk::pubkey::new_rand();
             let account = Account::new((i + 1) as u64, 0, &Account::default().owner);
             accounts.store_slow(i, &pubkey, &account);
             accounts.store_slow(i, &old_pubkey, &zero_account);
@@ -1895,7 +1895,7 @@ mod tests {
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0, 1])];
         let tx = Transaction::new_with_compiled_instructions(
             &[&keypair],
-            &[Pubkey::new_rand(), instructions_key],
+            &[solana_sdk::pubkey::new_rand(), instructions_key],
             Hash::default(),
             vec![native_loader::id()],
             instructions,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4830,7 +4830,9 @@ pub mod tests {
         let accounts = AccountsDB::new_single();
 
         let pubkey_count = 100;
-        let pubkeys: Vec<_> = (0..pubkey_count).map(|_| solana_sdk::pubkey::new_rand()).collect();
+        let pubkeys: Vec<_> = (0..pubkey_count)
+            .map(|_| solana_sdk::pubkey::new_rand())
+            .collect();
 
         let some_lamport = 223;
         let no_data = 0;
@@ -4894,7 +4896,9 @@ pub mod tests {
         let accounts = AccountsDB::new_single();
 
         let pubkey_count = 100;
-        let pubkeys: Vec<_> = (0..pubkey_count).map(|_| solana_sdk::pubkey::new_rand()).collect();
+        let pubkeys: Vec<_> = (0..pubkey_count)
+            .map(|_| solana_sdk::pubkey::new_rand())
+            .collect();
 
         let some_lamport = 223;
         let no_data = 0;
@@ -5076,7 +5080,11 @@ pub mod tests {
         );
         // any random program data accounts
         assert_eq!(
-            AccountsDB::account_balance_for_capitalization(10, &solana_sdk::pubkey::new_rand(), false),
+            AccountsDB::account_balance_for_capitalization(
+                10,
+                &solana_sdk::pubkey::new_rand(),
+                false
+            ),
             10
         );
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2789,7 +2789,7 @@ pub mod tests {
         create_account(&db, &mut pubkeys, 0, 2, DEFAULT_FILE_SIZE as usize / 3, 0);
         assert!(check_storage(&db, 0, 2));
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new(1, DEFAULT_FILE_SIZE as usize / 3, &pubkey);
         db.store(1, &[(&pubkey, &account)]);
         db.store(1, &[(&pubkeys[0], &account)]);
@@ -2903,7 +2903,7 @@ pub mod tests {
     fn test_remove_unrooted_slot_snapshot() {
         let unrooted_slot = 9;
         let db = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let key = Pubkey::new_rand();
+        let key = solana_sdk::pubkey::new_rand();
         let account0 = Account::new(1, 0, &key);
         db.store(unrooted_slot, &[(&key, &account0)]);
 
@@ -2911,7 +2911,7 @@ pub mod tests {
         db.remove_unrooted_slot(unrooted_slot);
 
         // Add a new root
-        let key2 = Pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
         let new_root = unrooted_slot + 1;
         db.store(new_root, &[(&key2, &account0)]);
         db.add_root(new_root);
@@ -2937,14 +2937,14 @@ pub mod tests {
     ) {
         let ancestors = vec![(slot, 0)].into_iter().collect();
         for t in 0..num {
-            let pubkey = Pubkey::new_rand();
+            let pubkey = solana_sdk::pubkey::new_rand();
             let account = Account::new((t + 1) as u64, space, &Account::default().owner);
             pubkeys.push(pubkey);
             assert!(accounts.load_slow(&ancestors, &pubkey).is_none());
             accounts.store(slot, &[(&pubkey, &account)]);
         }
         for t in 0..num_vote {
-            let pubkey = Pubkey::new_rand();
+            let pubkey = solana_sdk::pubkey::new_rand();
             let account = Account::new((num + t + 1) as u64, space, &solana_vote_program::id());
             pubkeys.push(pubkey);
             let ancestors = vec![(slot, 0)].into_iter().collect();
@@ -3076,7 +3076,7 @@ pub mod tests {
         let accounts = AccountsDB::new_sized(paths, size);
         let mut keys = vec![];
         for i in 0..9 {
-            let key = Pubkey::new_rand();
+            let key = solana_sdk::pubkey::new_rand();
             let account = Account::new(i + 1, size as usize / 4, &key);
             accounts.store(0, &[(&key, &account)]);
             keys.push(key);
@@ -3108,7 +3108,7 @@ pub mod tests {
 
         let count = [0, 1];
         let status = [AccountStorageStatus::Available, AccountStorageStatus::Full];
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let account1 = Account::new(1, DEFAULT_FILE_SIZE as usize / 2, &pubkey1);
         accounts.store(0, &[(&pubkey1, &account1)]);
         {
@@ -3119,7 +3119,7 @@ pub mod tests {
             assert_eq!(r_stores[&0].status(), AccountStorageStatus::Available);
         }
 
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         let account2 = Account::new(1, DEFAULT_FILE_SIZE as usize / 2, &pubkey2);
         accounts.store(0, &[(&pubkey2, &account2)]);
         {
@@ -3199,7 +3199,7 @@ pub mod tests {
         //A slot is purged when a non root bank is cleaned up.  If a slot is behind root but it is
         //not root, it means we are retaining dead banks.
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new(1, 0, &Account::default().owner);
         //store an account
         accounts.store(0, &[(&pubkey, &account)]);
@@ -3280,8 +3280,8 @@ pub mod tests {
         solana_logger::setup();
 
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         let account = Account::new(1, 1, &Account::default().owner);
         let zero_lamport_account = Account::new(0, 0, &Account::default().owner);
 
@@ -3336,7 +3336,7 @@ pub mod tests {
         solana_logger::setup();
 
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new(1, 0, &Account::default().owner);
         let zero_lamport_account = Account::new(0, 0, &Account::default().owner);
 
@@ -3375,7 +3375,7 @@ pub mod tests {
         solana_logger::setup();
 
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new(1, 0, &Account::default().owner);
         //store an account
         accounts.store(0, &[(&pubkey, &account)]);
@@ -3401,8 +3401,8 @@ pub mod tests {
         solana_logger::setup();
 
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         let normal_account = Account::new(1, 0, &Account::default().owner);
         let zero_account = Account::new(0, 0, &Account::default().owner);
         //store an account
@@ -3431,8 +3431,8 @@ pub mod tests {
         solana_logger::setup();
 
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         let normal_account = Account::new(1, 0, &Account::default().owner);
         let zero_account = Account::new(0, 0, &Account::default().owner);
 
@@ -3473,7 +3473,7 @@ pub mod tests {
         solana_logger::setup();
 
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new(1, 0, &Account::default().owner);
         let zero_account = Account::new(0, 0, &Account::default().owner);
 
@@ -3510,7 +3510,7 @@ pub mod tests {
         solana_logger::setup();
 
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new(1, 0, &Account::default().owner);
         //store an account
         accounts.store(0, &[(&pubkey, &account)]);
@@ -3685,10 +3685,10 @@ pub mod tests {
         let owner = Account::default().owner;
 
         let account = Account::new(some_lamport, no_data, &owner);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let account2 = Account::new(some_lamport, no_data, &owner);
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
 
         let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
 
@@ -3764,7 +3764,7 @@ pub mod tests {
         let owner = Account::default().owner;
 
         let account = Account::new(some_lamport, no_data, &owner);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
 
@@ -3824,14 +3824,14 @@ pub mod tests {
         let owner = Account::default().owner;
 
         let account = Account::new(some_lamport, no_data, &owner);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
 
         let account2 = Account::new(some_lamport + 1, no_data, &owner);
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
 
         let filler_account = Account::new(some_lamport, no_data, &owner);
-        let filler_account_pubkey = Pubkey::new_rand();
+        let filler_account_pubkey = solana_sdk::pubkey::new_rand();
 
         let accounts = AccountsDB::new_single();
 
@@ -3886,9 +3886,9 @@ pub mod tests {
         let account3 = Account::new(some_lamport + 100_002, no_data, &owner);
         let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
 
-        let pubkey = Pubkey::new_rand();
-        let purged_pubkey1 = Pubkey::new_rand();
-        let purged_pubkey2 = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let purged_pubkey1 = solana_sdk::pubkey::new_rand();
+        let purged_pubkey2 = solana_sdk::pubkey::new_rand();
 
         let dummy_account = Account::new(dummy_lamport, no_data, &owner);
         let dummy_pubkey = Pubkey::default();
@@ -3968,7 +3968,7 @@ pub mod tests {
                 std::thread::Builder::new()
                     .name("account-writers".to_string())
                     .spawn(move || {
-                        let pubkey = Pubkey::new_rand();
+                        let pubkey = solana_sdk::pubkey::new_rand();
                         let mut account = Account::new(1, 0, &pubkey);
                         let mut i = 0;
                         loop {
@@ -3999,12 +3999,12 @@ pub mod tests {
         solana_logger::setup();
         let db = AccountsDB::new(Vec::new(), &ClusterType::Development);
         let key = Pubkey::default();
-        let key0 = Pubkey::new_rand();
+        let key0 = solana_sdk::pubkey::new_rand();
         let account0 = Account::new(1, 0, &key);
 
         db.store(0, &[(&key0, &account0)]);
 
-        let key1 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
         let account1 = Account::new(2, 0, &key);
         db.store(1, &[(&key1, &account1)]);
 
@@ -4033,12 +4033,12 @@ pub mod tests {
         let db = AccountsDB::new_single();
 
         let key = Pubkey::default();
-        let key0 = Pubkey::new_rand();
+        let key0 = solana_sdk::pubkey::new_rand();
         let account0 = Account::new(1, 0, &key);
 
         db.store(0, &[(&key0, &account0)]);
 
-        let key1 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
         let account1 = Account::new(2, 0, &key);
         db.store(1, &[(&key1, &account1)]);
 
@@ -4316,7 +4316,7 @@ pub mod tests {
         solana_logger::setup();
         let db = AccountsDB::new(Vec::new(), &ClusterType::Development);
 
-        let key = Pubkey::new_rand();
+        let key = solana_sdk::pubkey::new_rand();
         let some_data_len = 0;
         let some_slot: Slot = 0;
         let account = Account::new(1, some_data_len, &key);
@@ -4358,7 +4358,7 @@ pub mod tests {
         solana_logger::setup();
         let db = AccountsDB::new(Vec::new(), &ClusterType::Development);
 
-        let key = Pubkey::new_rand();
+        let key = solana_sdk::pubkey::new_rand();
         let some_data_len = 0;
         let some_slot: Slot = 0;
         let account = Account::new(1, some_data_len, &key);
@@ -4372,7 +4372,7 @@ pub mod tests {
             Ok(_)
         );
 
-        let native_account_pubkey = Pubkey::new_rand();
+        let native_account_pubkey = solana_sdk::pubkey::new_rand();
         db.store(
             some_slot,
             &[(
@@ -4563,7 +4563,7 @@ pub mod tests {
     #[should_panic(expected = "double remove of account in slot: 0/store: 0!!")]
     fn test_storage_remove_account_double_remove() {
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new(1, 0, &Account::default().owner);
         accounts.store(0, &[(&pubkey, &account)]);
         let storage_entry = accounts
@@ -4594,10 +4594,10 @@ pub mod tests {
         let dummy_account = Account::new(99_999_999, no_data, &owner);
         let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
 
-        let pubkey = Pubkey::new_rand();
-        let dummy_pubkey = Pubkey::new_rand();
-        let purged_pubkey1 = Pubkey::new_rand();
-        let purged_pubkey2 = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let dummy_pubkey = solana_sdk::pubkey::new_rand();
+        let purged_pubkey1 = solana_sdk::pubkey::new_rand();
+        let purged_pubkey2 = solana_sdk::pubkey::new_rand();
 
         let mut current_slot = 0;
         let accounts = AccountsDB::new_single();
@@ -4656,9 +4656,9 @@ pub mod tests {
         let dummy_account = Account::new(dummy_lamport, no_data, &owner);
         let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
 
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
-        let dummy_pubkey = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let dummy_pubkey = solana_sdk::pubkey::new_rand();
 
         let mut current_slot = 0;
         let accounts = AccountsDB::new_single();
@@ -4830,7 +4830,7 @@ pub mod tests {
         let accounts = AccountsDB::new_single();
 
         let pubkey_count = 100;
-        let pubkeys: Vec<_> = (0..pubkey_count).map(|_| Pubkey::new_rand()).collect();
+        let pubkeys: Vec<_> = (0..pubkey_count).map(|_| solana_sdk::pubkey::new_rand()).collect();
 
         let some_lamport = 223;
         let no_data = 0;
@@ -4894,7 +4894,7 @@ pub mod tests {
         let accounts = AccountsDB::new_single();
 
         let pubkey_count = 100;
-        let pubkeys: Vec<_> = (0..pubkey_count).map(|_| Pubkey::new_rand()).collect();
+        let pubkeys: Vec<_> = (0..pubkey_count).map(|_| solana_sdk::pubkey::new_rand()).collect();
 
         let some_lamport = 223;
         let no_data = 0;
@@ -5041,7 +5041,7 @@ pub mod tests {
             for current_slot in 0..1000 {
                 while alive_accounts.len() <= 10 {
                     alive_accounts.push((
-                        Pubkey::new_rand(),
+                        solana_sdk::pubkey::new_rand(),
                         Account::new(thread_rng().gen_range(0, 50), 0, &owner),
                     ));
                 }
@@ -5076,7 +5076,7 @@ pub mod tests {
         );
         // any random program data accounts
         assert_eq!(
-            AccountsDB::account_balance_for_capitalization(10, &Pubkey::new_rand(), false),
+            AccountsDB::account_balance_for_capitalization(10, &solana_sdk::pubkey::new_rand(), false),
             10
         );
     }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -610,7 +610,7 @@ mod tests {
         let root_slot = 0;
 
         let mut pubkeys: Vec<Pubkey> = std::iter::repeat_with(|| {
-            let new_pubkey = Pubkey::new_rand();
+            let new_pubkey = solana_sdk::pubkey::new_rand();
             index.upsert(root_slot, &new_pubkey, true, &mut vec![]);
             new_pubkey
         })
@@ -742,7 +742,7 @@ mod tests {
         let mut iter = index.iter(None::<Range<Pubkey>>);
         assert!(iter.next().is_none());
         let mut gc = vec![];
-        index.upsert(0, &Pubkey::new_rand(), true, &mut gc);
+        index.upsert(0, &solana_sdk::pubkey::new_rand(), true, &mut gc);
         assert!(iter.next().is_none());
     }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -674,7 +674,7 @@ pub mod tests {
         let path = &file.path;
         let mut av = AppendVec::new(&path, true, 1024 * 1024);
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let owner = Pubkey::default();
         let data_len = 3 as u64;
         let mut account = Account::new(0, data_len as usize, &owner);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4165,7 +4165,7 @@ mod tests {
     #[test]
     #[allow(clippy::float_cmp)]
     fn test_bank_new() {
-        let dummy_leader_pubkey = Pubkey::new_rand();
+        let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
         let dummy_leader_lamports = BOOTSTRAP_VALIDATOR_LAMPORTS;
         let mint_lamports = 10_000;
         let GenesisConfigInfo {
@@ -4275,7 +4275,7 @@ mod tests {
     fn test_bank_capitalization() {
         let bank = Arc::new(Bank::new(&GenesisConfig {
             accounts: (0..42)
-                .map(|_| (Pubkey::new_rand(), Account::new(42, 0, &Pubkey::default())))
+                .map(|_| (solana_sdk::pubkey::new_rand(), Account::new(42, 0, &Pubkey::default())))
                 .collect(),
             cluster_type: ClusterType::MainnetBeta,
             ..GenesisConfig::default()
@@ -4559,7 +4559,7 @@ mod tests {
     fn test_rent_distribution() {
         solana_logger::setup();
 
-        let bootstrap_validator_pubkey = Pubkey::new_rand();
+        let bootstrap_validator_pubkey = solana_sdk::pubkey::new_rand();
         let bootstrap_validator_stake_lamports = 30;
         let mut genesis_config = create_genesis_config_with_leader(
             10,
@@ -4582,7 +4582,7 @@ mod tests {
 
         let rent = Rent::free();
 
-        let validator_1_pubkey = Pubkey::new_rand();
+        let validator_1_pubkey = solana_sdk::pubkey::new_rand();
         let validator_1_stake_lamports = 20;
         let validator_1_staking_keypair = Keypair::new();
         let validator_1_voting_keypair = Keypair::new();
@@ -4615,7 +4615,7 @@ mod tests {
             validator_1_vote_account,
         );
 
-        let validator_2_pubkey = Pubkey::new_rand();
+        let validator_2_pubkey = solana_sdk::pubkey::new_rand();
         let validator_2_stake_lamports = 20;
         let validator_2_staking_keypair = Keypair::new();
         let validator_2_voting_keypair = Keypair::new();
@@ -4648,7 +4648,7 @@ mod tests {
             validator_2_vote_account,
         );
 
-        let validator_3_pubkey = Pubkey::new_rand();
+        let validator_3_pubkey = solana_sdk::pubkey::new_rand();
         let validator_3_stake_lamports = 30;
         let validator_3_staking_keypair = Keypair::new();
         let validator_3_voting_keypair = Keypair::new();
@@ -4806,7 +4806,7 @@ mod tests {
         const RENT_TO_BE_DISTRIBUTED: u64 = 120_525;
         const VALIDATOR_STAKE: u64 = 374_999_998_287_840;
 
-        let validator_pubkey = Pubkey::new_rand();
+        let validator_pubkey = solana_sdk::pubkey::new_rand();
         let mut genesis_config =
             create_genesis_config_with_leader(10, &validator_pubkey, VALIDATOR_STAKE)
                 .genesis_config;
@@ -4852,11 +4852,11 @@ mod tests {
         };
 
         let root_bank = Arc::new(Bank::new(&genesis_config));
-        let bank = create_child_bank_for_rent_test(&root_bank, &genesis_config, Pubkey::new_rand());
+        let bank = create_child_bank_for_rent_test(&root_bank, &genesis_config, solana_sdk::pubkey::new_rand());
 
-        let account_pubkey = Pubkey::new_rand();
+        let account_pubkey = solana_sdk::pubkey::new_rand();
         let account_balance = 1;
-        let mut account = Account::new(account_balance, 0, &Pubkey::new_rand());
+        let mut account = Account::new(account_balance, 0, &solana_sdk::pubkey::new_rand());
         account.executable = true;
         bank.store_account(&account_pubkey, &account);
 
@@ -5117,7 +5117,7 @@ mod tests {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_rent_eager_across_epoch_without_gap_under_multi_epoch_cycle() {
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let leader_lamports = 3;
         let mut genesis_config =
             create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -5187,7 +5187,7 @@ mod tests {
 
     #[test]
     fn test_rent_eager_across_epoch_with_gap_under_multi_epoch_cycle() {
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let leader_lamports = 3;
         let mut genesis_config =
             create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -5245,7 +5245,7 @@ mod tests {
 
     #[test]
     fn test_rent_eager_with_warmup_epochs_under_multi_epoch_cycle() {
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let leader_lamports = 3;
         let mut genesis_config =
             create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -5302,7 +5302,7 @@ mod tests {
     #[test]
     fn test_rent_eager_under_fixed_cycle_for_developemnt() {
         solana_logger::setup();
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let leader_lamports = 3;
         let mut genesis_config =
             create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -5439,7 +5439,7 @@ mod tests {
     fn map_to_test_bad_range() -> AccountMap<Pubkey, i8> {
         let mut map: AccountMap<Pubkey, i8> = AccountMap::new();
         // when empty, AccountMap (= std::collections::BTreeMap) doesn't sanitize given range...
-        map.insert(Pubkey::new_rand(), 1);
+        map.insert(solana_sdk::pubkey::new_rand(), 1);
         map
     }
 
@@ -5651,9 +5651,9 @@ mod tests {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(1);
         activate_all_features(&mut genesis_config);
 
-        let zero_lamport_pubkey = Pubkey::new_rand();
-        let rent_due_pubkey = Pubkey::new_rand();
-        let rent_exempt_pubkey = Pubkey::new_rand();
+        let zero_lamport_pubkey = solana_sdk::pubkey::new_rand();
+        let rent_due_pubkey = solana_sdk::pubkey::new_rand();
+        let rent_exempt_pubkey = solana_sdk::pubkey::new_rand();
 
         let mut bank = Arc::new(Bank::new(&genesis_config));
         let zero_lamports = 0;
@@ -5733,7 +5733,7 @@ mod tests {
 
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
 
-        let zero_lamport_pubkey = Pubkey::new_rand();
+        let zero_lamport_pubkey = solana_sdk::pubkey::new_rand();
 
         let genesis_bank1 = Arc::new(Bank::new(&genesis_config));
         let genesis_bank2 = Arc::new(Bank::new(&genesis_config));
@@ -5795,7 +5795,7 @@ mod tests {
             accounts: (0..42)
                 .map(|_| {
                     (
-                        Pubkey::new_rand(),
+                        solana_sdk::pubkey::new_rand(),
                         Account::new(1_000_000_000, 0, &Pubkey::default()),
                     )
                 })
@@ -5913,7 +5913,7 @@ mod tests {
             accounts: (0..42)
                 .map(|_| {
                     (
-                        Pubkey::new_rand(),
+                        solana_sdk::pubkey::new_rand(),
                         Account::new(1_000_000_000, 0, &Pubkey::default()),
                     )
                 })
@@ -5940,8 +5940,8 @@ mod tests {
         assert_eq!(bank.capitalization(), 42 * 1_000_000_000);
         assert!(bank.rewards.read().unwrap().is_empty());
 
-        let vote_id = Pubkey::new_rand();
-        let mut vote_account = vote_state::create_account(&vote_id, &Pubkey::new_rand(), 50, 100);
+        let vote_id = solana_sdk::pubkey::new_rand();
+        let mut vote_account = vote_state::create_account(&vote_id, &solana_sdk::pubkey::new_rand(), 50, 100);
         let (stake_id1, stake_account1) = crate::stakes::tests::create_stake_account(123, &vote_id);
         let (stake_id2, stake_account2) = crate::stakes::tests::create_stake_account(456, &vote_id);
 
@@ -6016,7 +6016,7 @@ mod tests {
         let mut bank = parent;
         for _ in 0..10 {
             let blockhash = bank.last_blockhash();
-            let pubkey = Pubkey::new_rand();
+            let pubkey = solana_sdk::pubkey::new_rand();
             let tx = system_transaction::transfer(&mint_keypair, &pubkey, 0, blockhash);
             bank.process_transaction(&tx).unwrap();
             bank.squash();
@@ -6034,7 +6034,7 @@ mod tests {
         bank0.process_transaction(&tx).unwrap();
 
         let bank1 = Arc::new(new_from_parent(&bank0));
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let blockhash = bank.last_blockhash();
         let tx = system_transaction::transfer(&keypair, &pubkey, 10, blockhash);
         bank1.process_transaction(&tx).unwrap();
@@ -6077,7 +6077,7 @@ mod tests {
     #[test]
     fn test_two_payments_to_one_party() {
         let (genesis_config, mint_keypair) = create_genesis_config(10_000);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let bank = Bank::new(&genesis_config);
         assert_eq!(bank.last_blockhash(), genesis_config.hash());
 
@@ -6092,8 +6092,8 @@ mod tests {
     #[test]
     fn test_one_source_two_tx_one_batch() {
         let (genesis_config, mint_keypair) = create_genesis_config(1);
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
         let bank = Bank::new(&genesis_config);
         assert_eq!(bank.last_blockhash(), genesis_config.hash());
 
@@ -6116,8 +6116,8 @@ mod tests {
     #[test]
     fn test_one_tx_two_out_atomic_fail() {
         let (genesis_config, mint_keypair) = create_genesis_config(1);
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
         let bank = Bank::new(&genesis_config);
         let instructions =
             system_instruction::transfer_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
@@ -6135,8 +6135,8 @@ mod tests {
     #[test]
     fn test_one_tx_two_out_atomic_pass() {
         let (genesis_config, mint_keypair) = create_genesis_config(2);
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
         let bank = Bank::new(&genesis_config);
         let instructions =
             system_instruction::transfer_many(&mint_keypair.pubkey(), &[(key1, 1), (key2, 1)]);
@@ -6195,7 +6195,7 @@ mod tests {
     fn test_insufficient_funds() {
         let (genesis_config, mint_keypair) = create_genesis_config(11_000);
         let bank = Bank::new(&genesis_config);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.transaction_count(), 1);
         assert_eq!(bank.get_balance(&pubkey), 1_000);
@@ -6218,7 +6218,7 @@ mod tests {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(10_000);
         let bank = Bank::new(&genesis_config);
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         bank.transfer(500, &mint_keypair, &pubkey).unwrap();
         assert_eq!(bank.get_balance(&pubkey), 500);
     }
@@ -6229,7 +6229,7 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(10_000);
         let bank = Arc::new(Bank::new(&genesis_config));
 
-        let normal_pubkey = Pubkey::new_rand();
+        let normal_pubkey = solana_sdk::pubkey::new_rand();
         let sysvar_pubkey = sysvar::clock::id();
         assert_eq!(bank.get_balance(&normal_pubkey), 0);
         assert_eq!(bank.get_balance(&sysvar_pubkey), 1);
@@ -6328,7 +6328,7 @@ mod tests {
     fn test_bank_tx_fee() {
         let arbitrary_transfer_amount = 42;
         let mint = arbitrary_transfer_amount * 100;
-        let leader = Pubkey::new_rand();
+        let leader = solana_sdk::pubkey::new_rand();
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,
@@ -6426,7 +6426,7 @@ mod tests {
     fn test_bank_blockhash_fee_schedule() {
         //solana_logger::setup();
 
-        let leader = Pubkey::new_rand();
+        let leader = solana_sdk::pubkey::new_rand();
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,
@@ -6478,7 +6478,7 @@ mod tests {
 
     #[test]
     fn test_filter_program_errors_and_collect_fee() {
-        let leader = Pubkey::new_rand();
+        let leader = solana_sdk::pubkey::new_rand();
         let GenesisConfigInfo {
             mut genesis_config,
             mint_keypair,
@@ -6550,12 +6550,12 @@ mod tests {
             genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config_with_leader(500, &Pubkey::new_rand(), 0);
+        } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
         let bank = Bank::new(&genesis_config);
 
-        let vote_pubkey0 = Pubkey::new_rand();
-        let vote_pubkey1 = Pubkey::new_rand();
-        let vote_pubkey2 = Pubkey::new_rand();
+        let vote_pubkey0 = solana_sdk::pubkey::new_rand();
+        let vote_pubkey1 = solana_sdk::pubkey::new_rand();
+        let vote_pubkey2 = solana_sdk::pubkey::new_rand();
         let authorized_voter = Keypair::new();
         let payer0 = Keypair::new();
         let payer1 = Keypair::new();
@@ -6609,7 +6609,7 @@ mod tests {
         );
         let tx1 = system_transaction::transfer(
             &authorized_voter,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             1,
             bank.last_blockhash(),
         );
@@ -6668,7 +6668,7 @@ mod tests {
         let key0 = Keypair::new();
         let key1 = Keypair::new();
         let key2 = Keypair::new();
-        let key3 = Pubkey::new_rand();
+        let key3 = solana_sdk::pubkey::new_rand();
 
         let message = Message {
             header: MessageHeader {
@@ -6823,7 +6823,7 @@ mod tests {
         let initial_state = bank0.hash_internal_state();
         assert_eq!(bank1.hash_internal_state(), initial_state);
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         bank0.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_ne!(bank0.hash_internal_state(), initial_state);
         bank1.transfer(1_000, &mint_keypair, &pubkey).unwrap();
@@ -6833,7 +6833,7 @@ mod tests {
         let bank2 = new_from_parent(&Arc::new(bank1));
         assert_ne!(bank0.hash_internal_state(), bank2.hash_internal_state());
 
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         info!("transfer 2 {}", pubkey2);
         bank2.transfer(10, &mint_keypair, &pubkey2).unwrap();
         bank2.update_accounts_hash();
@@ -6846,14 +6846,14 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(2_000);
         let bank0 = Bank::new(&genesis_config);
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         info!("transfer 0 {} mint: {}", pubkey, mint_keypair.pubkey());
         bank0.transfer(1_000, &mint_keypair, &pubkey).unwrap();
 
         let bank0_state = bank0.hash_internal_state();
         let bank0 = Arc::new(bank0);
         // Checkpointing should result in a new state while freezing the parent
-        let bank2 = Bank::new_from_parent(&bank0, &Pubkey::new_rand(), 1);
+        let bank2 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 1);
         assert_ne!(bank0_state, bank2.hash_internal_state());
         // Checkpointing should modify the checkpoint's state when freezed
         assert_ne!(bank0_state, bank0.hash_internal_state());
@@ -6862,13 +6862,13 @@ mod tests {
         let bank0_state = bank0.hash_internal_state();
         bank2.update_accounts_hash();
         assert!(bank2.verify_bank_hash());
-        let bank3 = Bank::new_from_parent(&bank0, &Pubkey::new_rand(), 2);
+        let bank3 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
         assert_eq!(bank0_state, bank0.hash_internal_state());
         assert!(bank2.verify_bank_hash());
         bank3.update_accounts_hash();
         assert!(bank3.verify_bank_hash());
 
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         info!("transfer 2 {}", pubkey2);
         bank2.transfer(10, &mint_keypair, &pubkey2).unwrap();
         bank2.update_accounts_hash();
@@ -6886,7 +6886,7 @@ mod tests {
 
     #[test]
     fn test_verify_snapshot_bank() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let (genesis_config, mint_keypair) = create_genesis_config(2_000);
         let bank = Bank::new(&genesis_config);
         bank.transfer(1_000, &mint_keypair, &pubkey).unwrap();
@@ -6910,7 +6910,7 @@ mod tests {
         assert_ne!(bank1.hash_internal_state(), initial_state);
 
         info!("transfer bank1");
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         bank1.transfer(1_000, &mint_keypair, &pubkey).unwrap();
         assert_ne!(bank1.hash_internal_state(), initial_state);
 
@@ -6937,8 +6937,8 @@ mod tests {
         let bank0 = Bank::new(&genesis_config);
         let bank1 = Bank::new(&genesis_config);
         assert_eq!(bank0.hash_internal_state(), bank1.hash_internal_state());
-        let key0 = Pubkey::new_rand();
-        let key1 = Pubkey::new_rand();
+        let key0 = solana_sdk::pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
         bank0.transfer(10, &mint_keypair, &key0).unwrap();
         bank0.transfer(20, &mint_keypair, &key1).unwrap();
 
@@ -6953,7 +6953,7 @@ mod tests {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(100);
         let bank = Bank::new(&genesis_config);
-        let key0 = Pubkey::new_rand();
+        let key0 = solana_sdk::pubkey::new_rand();
         bank.transfer(10, &mint_keypair, &key0).unwrap();
         let orig = bank.hash_internal_state();
 
@@ -7110,7 +7110,7 @@ mod tests {
 
     #[test]
     fn test_bank_get_account_modified_since_parent() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let bank1 = Arc::new(Bank::new(&genesis_config));
@@ -7145,7 +7145,7 @@ mod tests {
     fn test_bank_update_sysvar_account() {
         use sysvar::clock::Clock;
 
-        let dummy_clock_id = Pubkey::new_rand();
+        let dummy_clock_id = solana_sdk::pubkey::new_rand();
         let (genesis_config, _mint_keypair) = create_genesis_config(500);
 
         let expected_previous_slot = 3;
@@ -7210,7 +7210,7 @@ mod tests {
 
     #[test]
     fn test_bank_epoch_vote_accounts() {
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let leader_lamports = 3;
         let mut genesis_config =
             create_genesis_config_with_leader(5, &leader_pubkey, leader_lamports).genesis_config;
@@ -7391,9 +7391,9 @@ mod tests {
         let bank0 = Arc::new(Bank::new(&genesis_config));
 
         // Bank 1
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::new_rand(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 1));
         // Bank 2
-        let bank2 = Bank::new_from_parent(&bank0, &Pubkey::new_rand(), 2);
+        let bank2 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
 
         // transfer a token
         assert_eq!(
@@ -7416,7 +7416,7 @@ mod tests {
         assert_eq!(bank2.transaction_count(), 0);
         assert_eq!(bank1.transaction_count(), 1);
 
-        let bank6 = Bank::new_from_parent(&bank1, &Pubkey::new_rand(), 3);
+        let bank6 = Bank::new_from_parent(&bank1, &solana_sdk::pubkey::new_rand(), 3);
         assert_eq!(bank1.transaction_count(), 1);
         assert_eq!(bank6.transaction_count(), 1);
 
@@ -7448,7 +7448,7 @@ mod tests {
             genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config_with_leader(500, &Pubkey::new_rand(), 1);
+        } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 1);
         let bank = Arc::new(Bank::new(&genesis_config));
 
         let vote_accounts = bank.vote_accounts();
@@ -7496,7 +7496,7 @@ mod tests {
             genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config_with_leader(500, &Pubkey::new_rand(), 1);
+        } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 1);
         let bank = Arc::new(Bank::new(&genesis_config));
 
         let stake_delegations = bank.stake_delegations();
@@ -7580,7 +7580,7 @@ mod tests {
         // Should fail with InstructionError, but InstructionErrors are committable,
         // so is_delta should be true
         assert_eq!(
-            bank.transfer(10_001, &mint_keypair, &Pubkey::new_rand()),
+            bank.transfer(10_001, &mint_keypair, &solana_sdk::pubkey::new_rand()),
             Err(TransactionError::InstructionError(
                 0,
                 SystemError::ResultWithNegativeLamports.into(),
@@ -7611,7 +7611,7 @@ mod tests {
         );
 
         let bank0 = Arc::new(new_from_parent(&parent));
-        let pubkey0 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
         let program_id = Pubkey::new(&[2; 32]);
         let account0 = Account::new(1, 0, &program_id);
         bank0.store_account(&pubkey0, &account0);
@@ -7637,11 +7637,11 @@ mod tests {
         );
 
         let bank2 = Arc::new(new_from_parent(&bank1));
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let account1 = Account::new(3, 0, &program_id);
         bank2.store_account(&pubkey1, &account1);
         // Accounts with 0 lamports should be filtered out by Accounts::load_by_program()
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         let account2 = Account::new(0, 0, &program_id);
         bank2.store_account(&pubkey2, &account2);
 
@@ -7731,7 +7731,7 @@ mod tests {
             genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config_with_leader(500, &Pubkey::new_rand(), 0);
+        } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
         let mut bank = Bank::new(&genesis_config);
 
         fn mock_vote_processor(
@@ -7901,7 +7901,7 @@ mod tests {
             const LOTSA: usize = 4_096;
 
             (0..LOTSA).for_each(|_| {
-                let pubkey = Pubkey::new_rand();
+                let pubkey = solana_sdk::pubkey::new_rand();
                 genesis_config.add_account(
                     pubkey,
                     solana_stake_program::stake_state::create_lockup_stake_account(
@@ -8306,7 +8306,7 @@ mod tests {
         let nonce_tx = Transaction::new_signed_with_payer(
             &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
-                system_instruction::transfer(&custodian_pubkey, &Pubkey::new_rand(), 100_000),
+                system_instruction::transfer(&custodian_pubkey, &solana_sdk::pubkey::new_rand(), 100_000),
             ],
             Some(&custodian_pubkey),
             &[&custodian_keypair, &nonce_keypair],
@@ -8340,8 +8340,8 @@ mod tests {
         let bank0 = Arc::new(new_from_parent(&parent));
 
         let keypair = Keypair::new();
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
         let program_id = Pubkey::new(&[2; 32]);
         let keypair_account = Account::new(8, 0, &program_id);
         let account0 = Account::new(11, 0, &program_id);
@@ -8392,9 +8392,9 @@ mod tests {
 
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         let keypair0_account = Account::new(8, 0, &Pubkey::default());
         let keypair1_account = Account::new(9, 0, &Pubkey::default());
         let account0 = Account::new(11, 0, &&Pubkey::default());
@@ -8467,8 +8467,8 @@ mod tests {
         let mock_program_id = Pubkey::new(&[2u8; 32]);
         bank.add_builtin_program("mock_program", mock_program_id, mock_process_instruction);
 
-        let from_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
         let dup_pubkey = from_pubkey;
         let from_account = Account::new(100, 1, &mock_program_id);
         let to_account = Account::new(0, 1, &mock_program_id);
@@ -8510,8 +8510,8 @@ mod tests {
         let mock_program_id = Pubkey::new(&[2u8; 32]);
         bank.add_builtin_program("mock_program", mock_program_id, mock_process_instruction);
 
-        let from_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
         let dup_pubkey = from_pubkey;
         let from_account = Account::new(100, 1, &mock_program_id);
         let to_account = Account::new(0, 1, &mock_program_id);
@@ -8542,8 +8542,8 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let mut bank = Bank::new(&genesis_config);
 
-        let from_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
 
         let account_metas = vec![
             AccountMeta::new(from_pubkey, false),
@@ -8558,7 +8558,7 @@ mod tests {
             bank.last_blockhash(),
         );
 
-        tx.message.account_keys.push(Pubkey::new_rand());
+        tx.message.account_keys.push(solana_sdk::pubkey::new_rand());
 
         bank.add_builtin_program(
             "mock_vote",
@@ -8606,8 +8606,8 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let mut bank = Bank::new(&genesis_config);
 
-        let from_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
 
         let account_metas = vec![
             AccountMeta::new(from_pubkey, false),
@@ -8639,8 +8639,8 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let mut bank = Bank::new(&genesis_config);
 
-        let from_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
 
         let account_metas = vec![
             AccountMeta::new(from_pubkey, false),
@@ -8694,8 +8694,8 @@ mod tests {
         let (genesis_config, mint_keypair) = create_genesis_config(500);
         let mut bank = Bank::new(&genesis_config);
 
-        let from_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
 
         let account_metas = vec![
             AccountMeta::new(from_pubkey, false),
@@ -8716,7 +8716,7 @@ mod tests {
             bank.last_blockhash(),
         );
 
-        tx.message.account_keys.push(Pubkey::new_rand());
+        tx.message.account_keys.push(solana_sdk::pubkey::new_rand());
         assert_eq!(tx.message.account_keys.len(), 5);
         tx.message.instructions[0].accounts.remove(0);
         tx.message.instructions[0].accounts.push(4);
@@ -8736,7 +8736,7 @@ mod tests {
         let program_keys: Vec<_> = (0..max_programs)
             .enumerate()
             .map(|i| {
-                let key = Pubkey::new_rand();
+                let key = solana_sdk::pubkey::new_rand();
                 let name = format!("program{:?}", i);
                 bank.add_builtin_program(&name, key, mock_ok_vote_processor);
                 (key, name.as_bytes().to_vec())
@@ -8746,7 +8746,7 @@ mod tests {
         let keys: Vec<_> = (0..max_keys)
             .enumerate()
             .map(|_| {
-                let key = Pubkey::new_rand();
+                let key = solana_sdk::pubkey::new_rand();
                 let balance = if thread_rng().gen_ratio(9, 10) {
                     let lamports = if thread_rng().gen_ratio(1, 5) {
                         thread_rng().gen_range(0, 10)
@@ -8945,11 +8945,11 @@ mod tests {
         let mut bank = Bank::new(&genesis_config);
 
         // Add a new program
-        let program1_pubkey = Pubkey::new_rand();
+        let program1_pubkey = solana_sdk::pubkey::new_rand();
         bank.add_builtin_program("program", program1_pubkey, nested_processor);
 
         // Add a new program owned by the first
-        let program2_pubkey = Pubkey::new_rand();
+        let program2_pubkey = solana_sdk::pubkey::new_rand();
         let mut program2_account = Account::new(42, 1, &program1_pubkey);
         program2_account.executable = true;
         bank.store_account(&program2_pubkey, &program2_account);
@@ -8971,8 +8971,8 @@ mod tests {
         solana_logger::setup();
 
         let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000_000);
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
 
         let mut bank = Arc::new(Bank::new(&genesis_config));
         bank.lazy_rent_collection.store(true, Relaxed);
@@ -9021,7 +9021,7 @@ mod tests {
             mut genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config_with_leader(500, &Pubkey::new_rand(), 0);
+        } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
         genesis_config.fee_rate_governor = FeeRateGovernor::new(1, 0);
         let bank = Arc::new(Bank::new(&genesis_config));
 
@@ -9043,7 +9043,7 @@ mod tests {
         );
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), 500); // no transaction fee charged
 
-        let vote_pubkey = Pubkey::new_rand();
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_voter = Keypair::new();
 
         // VoteInstruction::Vote is allowed.  The transaction fails with a vote program instruction
@@ -9120,7 +9120,7 @@ mod tests {
         }
 
         let slot = 123;
-        let program_id = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
 
         let mut bank = Arc::new(Bank::new_from_parent(
             &Arc::new(Bank::new(&genesis_config)),
@@ -9159,7 +9159,7 @@ mod tests {
         }
 
         let slot = 123;
-        let loader_id = Pubkey::new_rand();
+        let loader_id = solana_sdk::pubkey::new_rand();
 
         let mut bank = Arc::new(Bank::new_from_parent(
             &Arc::new(Bank::new(&genesis_config)),
@@ -9189,7 +9189,7 @@ mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
 
         let slot = 123;
-        let program_id = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
 
         let mut bank = Arc::new(Bank::new_from_parent(
             &Arc::new(Bank::new(&genesis_config)),
@@ -9240,7 +9240,7 @@ mod tests {
         solana_logger::setup();
 
         let mut genesis_config =
-            create_genesis_config_with_leader(5, &Pubkey::new_rand(), 0).genesis_config;
+            create_genesis_config_with_leader(5, &solana_sdk::pubkey::new_rand(), 0).genesis_config;
 
         // ClusterType::Development - Native mint exists immediately
         assert_eq!(genesis_config.cluster_type, ClusterType::Development);
@@ -9306,16 +9306,16 @@ mod tests {
         solana_logger::setup();
 
         let mut genesis_config =
-            create_genesis_config_with_leader(5, &Pubkey::new_rand(), 0).genesis_config;
+            create_genesis_config_with_leader(5, &solana_sdk::pubkey::new_rand(), 0).genesis_config;
 
         // Testnet - Storage rewards pool is purged at epoch 93
         // Also this is with bad capitalization
         genesis_config.cluster_type = ClusterType::Testnet;
         genesis_config.inflation = Inflation::default();
-        let reward_pubkey = Pubkey::new_rand();
+        let reward_pubkey = solana_sdk::pubkey::new_rand();
         genesis_config.rewards_pools.insert(
             reward_pubkey,
-            Account::new(u64::MAX, 0, &Pubkey::new_rand()),
+            Account::new(u64::MAX, 0, &solana_sdk::pubkey::new_rand()),
         );
         let bank0 = Bank::new(&genesis_config);
         // because capitalization has been reset with bogus capitalization calculation allowing overflows,
@@ -9367,10 +9367,10 @@ mod tests {
 
     #[test]
     fn test_cached_executors() {
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
-        let key3 = Pubkey::new_rand();
-        let key4 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
+        let key3 = solana_sdk::pubkey::new_rand();
+        let key4 = solana_sdk::pubkey::new_rand();
         let executor: Arc<dyn Executor> = Arc::new(TestExecutor {});
         let mut cache = CachedExecutors::new(3);
 
@@ -9407,10 +9407,10 @@ mod tests {
         let (genesis_config, _) = create_genesis_config(1);
         let bank = Bank::new(&genesis_config);
 
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
-        let key3 = Pubkey::new_rand();
-        let key4 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
+        let key3 = solana_sdk::pubkey::new_rand();
+        let key4 = solana_sdk::pubkey::new_rand();
         let executor: Arc<dyn Executor> = Arc::new(TestExecutor {});
 
         let message = Message {
@@ -9457,7 +9457,7 @@ mod tests {
         assert!(executors.borrow().executors.contains_key(&key4));
 
         // Check inheritance
-        let bank = Bank::new_from_parent(&Arc::new(bank), &Pubkey::new_rand(), 1);
+        let bank = Bank::new_from_parent(&Arc::new(bank), &solana_sdk::pubkey::new_rand(), 1);
         let executors = bank.get_executors(&message, loaders);
         assert_eq!(executors.borrow().executors.len(), 4);
         assert!(executors.borrow().executors.contains_key(&key1));
@@ -9484,8 +9484,8 @@ mod tests {
         let (genesis_config, _) = create_genesis_config(1);
         let root = Arc::new(Bank::new(&genesis_config));
 
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
         let executor: Arc<dyn Executor> = Arc::new(TestExecutor {});
 
         let loaders = &[vec![(key1, Account::default()), (key2, Account::default())]];
@@ -9668,7 +9668,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_correction_feature() {
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let GenesisConfigInfo {
             mut genesis_config,
             voting_keypair,
@@ -9721,7 +9721,7 @@ mod tests {
 
     #[test]
     fn test_update_clock_timestamp() {
-        let leader_pubkey = Pubkey::new_rand();
+        let leader_pubkey = solana_sdk::pubkey::new_rand();
         let GenesisConfigInfo {
             genesis_config,
             voting_keypair,
@@ -9793,7 +9793,7 @@ mod tests {
             1,
         ));
 
-        let zero_lamport_pubkey = Pubkey::new_rand();
+        let zero_lamport_pubkey = solana_sdk::pubkey::new_rand();
 
         bank1.add_account_and_update_capitalization(
             &zero_lamport_pubkey,
@@ -9803,7 +9803,7 @@ mod tests {
         // (guaranteed because of large file size). We need this to ensure slot is
         // not cleaned up after clean is called, so that the bank hash still exists
         // when we call rehash() later in this test.
-        let large_account_pubkey = Pubkey::new_rand();
+        let large_account_pubkey = solana_sdk::pubkey::new_rand();
         bank1.add_account_and_update_capitalization(
             &large_account_pubkey,
             &Account::new(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4275,7 +4275,12 @@ mod tests {
     fn test_bank_capitalization() {
         let bank = Arc::new(Bank::new(&GenesisConfig {
             accounts: (0..42)
-                .map(|_| (solana_sdk::pubkey::new_rand(), Account::new(42, 0, &Pubkey::default())))
+                .map(|_| {
+                    (
+                        solana_sdk::pubkey::new_rand(),
+                        Account::new(42, 0, &Pubkey::default()),
+                    )
+                })
                 .collect(),
             cluster_type: ClusterType::MainnetBeta,
             ..GenesisConfig::default()
@@ -4852,7 +4857,11 @@ mod tests {
         };
 
         let root_bank = Arc::new(Bank::new(&genesis_config));
-        let bank = create_child_bank_for_rent_test(&root_bank, &genesis_config, solana_sdk::pubkey::new_rand());
+        let bank = create_child_bank_for_rent_test(
+            &root_bank,
+            &genesis_config,
+            solana_sdk::pubkey::new_rand(),
+        );
 
         let account_pubkey = solana_sdk::pubkey::new_rand();
         let account_balance = 1;
@@ -5941,7 +5950,8 @@ mod tests {
         assert!(bank.rewards.read().unwrap().is_empty());
 
         let vote_id = solana_sdk::pubkey::new_rand();
-        let mut vote_account = vote_state::create_account(&vote_id, &solana_sdk::pubkey::new_rand(), 50, 100);
+        let mut vote_account =
+            vote_state::create_account(&vote_id, &solana_sdk::pubkey::new_rand(), 50, 100);
         let (stake_id1, stake_account1) = crate::stakes::tests::create_stake_account(123, &vote_id);
         let (stake_id2, stake_account2) = crate::stakes::tests::create_stake_account(456, &vote_id);
 
@@ -7391,7 +7401,11 @@ mod tests {
         let bank0 = Arc::new(Bank::new(&genesis_config));
 
         // Bank 1
-        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 1));
+        let bank1 = Arc::new(Bank::new_from_parent(
+            &bank0,
+            &solana_sdk::pubkey::new_rand(),
+            1,
+        ));
         // Bank 2
         let bank2 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
 
@@ -8306,7 +8320,11 @@ mod tests {
         let nonce_tx = Transaction::new_signed_with_payer(
             &[
                 system_instruction::advance_nonce_account(&nonce_pubkey, &nonce_pubkey),
-                system_instruction::transfer(&custodian_pubkey, &solana_sdk::pubkey::new_rand(), 100_000),
+                system_instruction::transfer(
+                    &custodian_pubkey,
+                    &solana_sdk::pubkey::new_rand(),
+                    100_000,
+                ),
             ],
             Some(&custodian_pubkey),
             &[&custodian_keypair, &nonce_keypair],

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -313,7 +313,7 @@ mod tests {
         let bank_client = BankClient::new(bank);
 
         // Create 2-2 Multisig Transfer instruction.
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let mut transfer_instruction = system_instruction::transfer(&john_pubkey, &bob_pubkey, 42);
         transfer_instruction
             .accounts

--- a/runtime/src/bloom.rs
+++ b/runtime/src/bloom.rs
@@ -318,9 +318,10 @@ mod test {
             assert!(bloom.contains(hash_value));
         }
         // Round trip, inserting new hash values.
-        let more_hash_values: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
-            .take(1000)
-            .collect();
+        let more_hash_values: Vec<_> =
+            std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
+                .take(1000)
+                .collect();
         let bloom: AtomicBloom<_> = bloom.into();
         assert_eq!(bloom.num_bits, 9731);
         assert_eq!(bloom.bits.len(), (9731 + 63) / 64);

--- a/runtime/src/bloom.rs
+++ b/runtime/src/bloom.rs
@@ -264,7 +264,7 @@ mod test {
     #[test]
     fn test_atomic_bloom() {
         let mut rng = rand::thread_rng();
-        let hash_values: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        let hash_values: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
             .take(1200)
             .collect();
         let bloom: AtomicBloom<_> = Bloom::<Hash>::random(1287, 0.1, 7424).into();
@@ -279,7 +279,7 @@ mod test {
         for hash_value in hash_values {
             assert!(bloom.contains(&hash_value));
         }
-        let false_positive = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        let false_positive = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
             .take(10_000)
             .filter(|hash_value| bloom.contains(hash_value))
             .count();
@@ -291,7 +291,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let keys: Vec<_> = std::iter::repeat_with(|| rng.gen()).take(5).collect();
         let mut bloom = Bloom::<Hash>::new(9731, keys.clone());
-        let hash_values: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        let hash_values: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
             .take(1000)
             .collect();
         for hash_value in &hash_values {
@@ -318,7 +318,7 @@ mod test {
             assert!(bloom.contains(hash_value));
         }
         // Round trip, inserting new hash values.
-        let more_hash_values: Vec<_> = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        let more_hash_values: Vec<_> = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
             .take(1000)
             .collect();
         let bloom: AtomicBloom<_> = bloom.into();
@@ -339,7 +339,7 @@ mod test {
         for hash_value in &more_hash_values {
             assert!(bloom.contains(hash_value));
         }
-        let false_positive = std::iter::repeat_with(|| Hash::new_rand(&mut rng))
+        let false_positive = std::iter::repeat_with(|| solana_sdk::hash::new_rand(&mut rng))
             .take(10_000)
             .filter(|hash_value| bloom.contains(hash_value))
             .count();

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -129,13 +129,13 @@ pub(crate) mod tests {
         // Create some vote accounts for each pubkey
         let vote_accounts_map: HashMap<Pubkey, Vec<VoteAccountInfo>> = (0..10)
             .map(|_| {
-                let node_id = Pubkey::new_rand();
+                let node_id = solana_sdk::pubkey::new_rand();
                 (
                     node_id,
                     iter::repeat_with(|| {
-                        let authorized_voter = Pubkey::new_rand();
+                        let authorized_voter = solana_sdk::pubkey::new_rand();
                         VoteAccountInfo {
-                            vote_account: Pubkey::new_rand(),
+                            vote_account: solana_sdk::pubkey::new_rand(),
                             account: create_account_with_authorized(
                                 &node_id,
                                 &authorized_voter,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -46,7 +46,7 @@ pub struct GenesisConfigInfo {
 }
 
 pub fn create_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {
-    create_genesis_config_with_leader(mint_lamports, &Pubkey::new_rand(), 0)
+    create_genesis_config_with_leader(mint_lamports, &solana_sdk::pubkey::new_rand(), 0)
 }
 
 pub fn create_genesis_config_with_vote_accounts(
@@ -117,7 +117,7 @@ pub fn create_genesis_config_with_leader(
         mint_lamports,
         bootstrap_validator_pubkey,
         &Keypair::new(),
-        &Pubkey::new_rand(),
+        &solana_sdk::pubkey::new_rand(),
         bootstrap_validator_stake_lamports,
         BOOTSTRAP_VALIDATOR_LAMPORTS,
         ClusterType::Development,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -762,8 +762,8 @@ mod tests {
         let mut pre_accounts = vec![];
         let mut accounts = vec![];
         for i in 0..MAX_DEPTH {
-            program_ids.push(Pubkey::new_rand());
-            keys.push(Pubkey::new_rand());
+            program_ids.push(solana_sdk::pubkey::new_rand());
+            keys.push(solana_sdk::pubkey::new_rand());
             accounts.push(Rc::new(RefCell::new(Account::new(
                 i as u64,
                 1,
@@ -867,7 +867,7 @@ mod tests {
 
     #[test]
     fn test_verify_account_references() {
-        let accounts = vec![(Pubkey::new_rand(), RefCell::new(Account::default()))];
+        let accounts = vec![(solana_sdk::pubkey::new_rand(), RefCell::new(Account::default()))];
 
         assert!(MessageProcessor::verify_account_references(&accounts).is_ok());
 
@@ -890,7 +890,7 @@ mod tests {
                 program_id: *program_id,
                 rent: Rent::default(),
                 pre: PreAccount::new(
-                    &Pubkey::new_rand(),
+                    &solana_sdk::pubkey::new_rand(),
                     &Account {
                         owner: *owner,
                         lamports: std::u64::MAX,
@@ -943,8 +943,8 @@ mod tests {
     #[test]
     fn test_verify_account_changes_owner() {
         let system_program_id = system_program::id();
-        let alice_program_id = Pubkey::new_rand();
-        let mallory_program_id = Pubkey::new_rand();
+        let alice_program_id = solana_sdk::pubkey::new_rand();
+        let mallory_program_id = solana_sdk::pubkey::new_rand();
 
         assert_eq!(
             Change::new(&system_program_id, &system_program_id)
@@ -995,8 +995,8 @@ mod tests {
 
     #[test]
     fn test_verify_account_changes_executable() {
-        let owner = Pubkey::new_rand();
-        let mallory_program_id = Pubkey::new_rand();
+        let owner = solana_sdk::pubkey::new_rand();
+        let mallory_program_id = solana_sdk::pubkey::new_rand();
         let system_program_id = system_program::id();
 
         assert_eq!(
@@ -1102,7 +1102,7 @@ mod tests {
 
     #[test]
     fn test_verify_account_changes_data_len() {
-        let alice_program_id = Pubkey::new_rand();
+        let alice_program_id = solana_sdk::pubkey::new_rand();
 
         assert_eq!(
             Change::new(&system_program::id(), &system_program::id())
@@ -1122,8 +1122,8 @@ mod tests {
 
     #[test]
     fn test_verify_account_changes_data() {
-        let alice_program_id = Pubkey::new_rand();
-        let mallory_program_id = Pubkey::new_rand();
+        let alice_program_id = solana_sdk::pubkey::new_rand();
+        let mallory_program_id = solana_sdk::pubkey::new_rand();
 
         assert_eq!(
             Change::new(&alice_program_id, &alice_program_id)
@@ -1151,7 +1151,7 @@ mod tests {
 
     #[test]
     fn test_verify_account_changes_rent_epoch() {
-        let alice_program_id = Pubkey::new_rand();
+        let alice_program_id = solana_sdk::pubkey::new_rand();
 
         assert_eq!(
             Change::new(&alice_program_id, &system_program::id()).verify(),
@@ -1169,8 +1169,8 @@ mod tests {
 
     #[test]
     fn test_verify_account_changes_deduct_lamports_and_reassign_account() {
-        let alice_program_id = Pubkey::new_rand();
-        let bob_program_id = Pubkey::new_rand();
+        let alice_program_id = solana_sdk::pubkey::new_rand();
+        let bob_program_id = solana_sdk::pubkey::new_rand();
 
         // positive test of this capability
         assert_eq!(
@@ -1186,7 +1186,7 @@ mod tests {
 
     #[test]
     fn test_verify_account_changes_lamports() {
-        let alice_program_id = Pubkey::new_rand();
+        let alice_program_id = solana_sdk::pubkey::new_rand();
 
         assert_eq!(
             Change::new(&alice_program_id, &system_program::id())
@@ -1224,7 +1224,7 @@ mod tests {
 
     #[test]
     fn test_verify_account_changes_data_size_changed() {
-        let alice_program_id = Pubkey::new_rand();
+        let alice_program_id = solana_sdk::pubkey::new_rand();
 
         assert_eq!(
             Change::new(&alice_program_id, &system_program::id())
@@ -1299,8 +1299,8 @@ mod tests {
 
         let executors = Rc::new(RefCell::new(Executors::default()));
 
-        let from_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
         let account_metas = vec![
             AccountMeta::new(from_pubkey, true),
             AccountMeta::new_readonly(to_pubkey, false),
@@ -1456,8 +1456,8 @@ mod tests {
 
         let executors = Rc::new(RefCell::new(Executors::default()));
 
-        let from_pubkey = Pubkey::new_rand();
-        let to_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let to_pubkey = solana_sdk::pubkey::new_rand();
         let dup_pubkey = from_pubkey;
         let account_metas = vec![
             AccountMeta::new(from_pubkey, true),
@@ -1579,8 +1579,8 @@ mod tests {
             Ok(())
         }
 
-        let caller_program_id = Pubkey::new_rand();
-        let callee_program_id = Pubkey::new_rand();
+        let caller_program_id = solana_sdk::pubkey::new_rand();
+        let callee_program_id = solana_sdk::pubkey::new_rand();
         let mut message_processor = MessageProcessor::default();
         message_processor.add_program(callee_program_id, mock_process_instruction);
 
@@ -1588,12 +1588,12 @@ mod tests {
         program_account.executable = true;
         let executable_accounts = vec![(callee_program_id, RefCell::new(program_account))];
 
-        let owned_key = Pubkey::new_rand();
+        let owned_key = solana_sdk::pubkey::new_rand();
         let owned_account = Account::new(42, 1, &callee_program_id);
         let owned_preaccount = PreAccount::new(&owned_key, &owned_account, false, true);
 
-        let not_owned_key = Pubkey::new_rand();
-        let not_owned_account = Account::new(84, 1, &Pubkey::new_rand());
+        let not_owned_key = solana_sdk::pubkey::new_rand();
+        let not_owned_account = Account::new(84, 1, &solana_sdk::pubkey::new_rand());
         let not_owned_preaccount = PreAccount::new(&not_owned_key, &not_owned_account, false, true);
 
         #[allow(unused_mut)]
@@ -1682,7 +1682,7 @@ mod tests {
         ) -> Result<(), InstructionError> {
             Ok(())
         }
-        let program_id = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
         message_processor.add_program(program_id, mock_process_instruction);
         message_processor.add_loader(program_id, mock_ix_processor);
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -867,7 +867,10 @@ mod tests {
 
     #[test]
     fn test_verify_account_references() {
-        let accounts = vec![(solana_sdk::pubkey::new_rand(), RefCell::new(Account::default()))];
+        let accounts = vec![(
+            solana_sdk::pubkey::new_rand(),
+            RefCell::new(Account::default()),
+        )];
 
         assert!(MessageProcessor::verify_account_references(&accounts).is_ok());
 

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -148,7 +148,7 @@ mod tests {
 
         // collect rent on a already-existing account
         let collected = rent_collector.collect_from_existing_account(
-            &solana_sdk::pubkey::new_rand()
+            &solana_sdk::pubkey::new_rand(),
             &mut existing_account,
             true,
         );

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -138,7 +138,7 @@ mod tests {
 
         // collect rent on a newly-created account
         let collected = rent_collector.collect_from_created_account(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             &mut created_account,
             true,
         );
@@ -148,7 +148,7 @@ mod tests {
 
         // collect rent on a already-existing account
         let collected = rent_collector.collect_from_existing_account(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand()
             &mut existing_account,
             true,
         );
@@ -168,7 +168,7 @@ mod tests {
         let huge_lamports = 123_456_789_012;
         let tiny_lamports = 789_012;
         let mut collected;
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
 
         account.lamports = huge_lamports;
         assert_eq!(account.rent_epoch, 0);

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -191,7 +191,8 @@ pub mod tests {
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
     pub fn create_staked_node_accounts(stake: u64) -> ((Pubkey, Account), (Pubkey, Account)) {
         let vote_pubkey = solana_sdk::pubkey::new_rand();
-        let vote_account = vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
+        let vote_account =
+            vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
         (
             (vote_pubkey, vote_account),
             create_stake_account(stake, &vote_pubkey),
@@ -218,7 +219,8 @@ pub mod tests {
         epoch: Epoch,
     ) -> ((Pubkey, Account), (Pubkey, Account)) {
         let vote_pubkey = solana_sdk::pubkey::new_rand();
-        let vote_account = vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
+        let vote_account =
+            vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
         (
             (vote_pubkey, vote_account),
             create_warming_stake_account(stake, epoch, &vote_pubkey),

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -190,8 +190,8 @@ pub mod tests {
 
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
     pub fn create_staked_node_accounts(stake: u64) -> ((Pubkey, Account), (Pubkey, Account)) {
-        let vote_pubkey = Pubkey::new_rand();
-        let vote_account = vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 1);
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
+        let vote_account = vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
         (
             (vote_pubkey, vote_account),
             create_stake_account(stake, &vote_pubkey),
@@ -200,13 +200,13 @@ pub mod tests {
 
     //   add stake to a vote_pubkey                               (   stake    )
     pub fn create_stake_account(stake: u64, vote_pubkey: &Pubkey) -> (Pubkey, Account) {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         (
             stake_pubkey,
             stake_state::create_account(
                 &stake_pubkey,
                 &vote_pubkey,
-                &vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 1),
+                &vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1),
                 &Rent::free(),
                 stake,
             ),
@@ -217,8 +217,8 @@ pub mod tests {
         stake: u64,
         epoch: Epoch,
     ) -> ((Pubkey, Account), (Pubkey, Account)) {
-        let vote_pubkey = Pubkey::new_rand();
-        let vote_account = vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 1);
+        let vote_pubkey = solana_sdk::pubkey::new_rand();
+        let vote_account = vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
         (
             (vote_pubkey, vote_account),
             create_warming_stake_account(stake, epoch, &vote_pubkey),
@@ -231,13 +231,13 @@ pub mod tests {
         epoch: Epoch,
         vote_pubkey: &Pubkey,
     ) -> (Pubkey, Account) {
-        let stake_pubkey = Pubkey::new_rand();
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
         (
             stake_pubkey,
             stake_state::create_account_with_activation_epoch(
                 &stake_pubkey,
                 &vote_pubkey,
-                &vote_state::create_account(&vote_pubkey, &Pubkey::new_rand(), 0, 1),
+                &vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1),
                 &Rent::free(),
                 stake,
                 epoch,

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -399,8 +399,8 @@ mod tests {
     #[test]
     fn test_create_account() {
         let new_owner = Pubkey::new(&[9; 32]);
-        let from = Pubkey::new_rand();
-        let to = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref(100, 0, &system_program::id());
         let to_account = Account::new_ref(0, 0, &Pubkey::default());
 
@@ -429,7 +429,7 @@ mod tests {
     #[test]
     fn test_create_account_with_seed() {
         let new_owner = Pubkey::new(&[9; 32]);
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let seed = "shiny pepper";
         let to = Pubkey::create_with_seed(&from, seed, &new_owner).unwrap();
 
@@ -462,10 +462,10 @@ mod tests {
 
     #[test]
     fn test_address_create_with_seed_mismatch() {
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let seed = "dull boy";
-        let to = Pubkey::new_rand();
-        let owner = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
+        let owner = solana_sdk::pubkey::new_rand();
 
         assert_eq!(
             Address::create(&to, Some((&from, seed, &owner))),
@@ -476,7 +476,7 @@ mod tests {
     #[test]
     fn test_create_account_with_seed_missing_sig() {
         let new_owner = Pubkey::new(&[9; 32]);
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let seed = "dull boy";
         let to = Pubkey::create_with_seed(&from, seed, &new_owner).unwrap();
 
@@ -504,10 +504,10 @@ mod tests {
     fn test_create_with_zero_lamports() {
         // create account with zero lamports tranferred
         let new_owner = Pubkey::new(&[9; 32]);
-        let from = Pubkey::new_rand();
-        let from_account = Account::new_ref(100, 1, &Pubkey::new_rand()); // not from system account
+        let from = solana_sdk::pubkey::new_rand();
+        let from_account = Account::new_ref(100, 1, &solana_sdk::pubkey::new_rand()); // not from system account
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(0, 0, &Pubkey::default());
 
         assert_eq!(
@@ -537,10 +537,10 @@ mod tests {
     fn test_create_negative_lamports() {
         // Attempt to create account with more lamports than remaining in from_account
         let new_owner = Pubkey::new(&[9; 32]);
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref(100, 0, &system_program::id());
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(0, 0, &Pubkey::default());
 
         let result = create_account(
@@ -558,9 +558,9 @@ mod tests {
     #[test]
     fn test_request_more_than_allowed_data_length() {
         let from_account = Account::new_ref(100, 0, &system_program::id());
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(0, 0, &system_program::id());
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
 
         let signers = &[from, to].iter().cloned().collect::<HashSet<_>>();
         let address = &to.into();
@@ -603,11 +603,11 @@ mod tests {
     fn test_create_already_in_use() {
         // Attempt to create system account in account already owned by another program
         let new_owner = Pubkey::new(&[9; 32]);
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref(100, 0, &system_program::id());
 
         let original_program_owner = Pubkey::new(&[5; 32]);
-        let owned_key = Pubkey::new_rand();
+        let owned_key = solana_sdk::pubkey::new_rand();
         let owned_account = Account::new_ref(0, 0, &original_program_owner);
         let unchanged_account = owned_account.clone();
 
@@ -667,10 +667,10 @@ mod tests {
     fn test_create_unsigned() {
         // Attempt to create an account without signing the transfer
         let new_owner = Pubkey::new(&[9; 32]);
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref(100, 0, &system_program::id());
 
-        let owned_key = Pubkey::new_rand();
+        let owned_key = solana_sdk::pubkey::new_rand();
         let owned_account = Account::new_ref(0, 0, &Pubkey::default());
 
         let owned_address = owned_key.into();
@@ -717,10 +717,10 @@ mod tests {
     #[test]
     fn test_create_sysvar_invalid_id() {
         // Attempt to create system account in account already owned by another program
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref(100, 0, &system_program::id());
 
-        let to = Pubkey::new_rand();
+        let to = solana_sdk::pubkey::new_rand();
         let to_account = Account::new_ref(0, 0, &system_program::id());
 
         let signers = [from, to].iter().cloned().collect::<HashSet<_>>();
@@ -744,10 +744,10 @@ mod tests {
     fn test_create_data_populated() {
         // Attempt to create system account in account with populated data
         let new_owner = Pubkey::new(&[9; 32]);
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref(100, 0, &system_program::id());
 
-        let populated_key = Pubkey::new_rand();
+        let populated_key = solana_sdk::pubkey::new_rand();
         let populated_account = Account {
             data: vec![0, 1, 2, 3],
             ..Account::default()
@@ -774,7 +774,7 @@ mod tests {
 
     #[test]
     fn test_create_from_account_is_nonce_fail() {
-        let nonce = Pubkey::new_rand();
+        let nonce = solana_sdk::pubkey::new_rand();
         let nonce_account = Account::new_ref_data(
             42,
             &nonce::state::Versions::new_current(nonce::State::Initialized(
@@ -784,7 +784,7 @@ mod tests {
         )
         .unwrap();
         let from = KeyedAccount::new(&nonce, true, &nonce_account);
-        let new = Pubkey::new_rand();
+        let new = solana_sdk::pubkey::new_rand();
 
         let new_account = Account::new_ref(0, 0, &system_program::id());
 
@@ -799,7 +799,7 @@ mod tests {
                 &new_address,
                 42,
                 0,
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 &signers
             ),
             Err(InstructionError::InvalidArgument),
@@ -810,7 +810,7 @@ mod tests {
     fn test_assign() {
         let new_owner = Pubkey::new(&[9; 32]);
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let mut account = Account::new(100, 0, &system_program::id());
 
         assert_eq!(
@@ -843,7 +843,7 @@ mod tests {
     fn test_assign_to_sysvar() {
         let new_owner = sysvar::id();
 
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let mut from_account = Account::new(100, 0, &system_program::id());
 
         assert_eq!(
@@ -861,13 +861,13 @@ mod tests {
     fn test_process_bogus_instruction() {
         // Attempt to assign with no accounts
         let instruction = SystemInstruction::Assign {
-            owner: Pubkey::new_rand(),
+            owner: solana_sdk::pubkey::new_rand(),
         };
         let data = serialize(&instruction).unwrap();
         let result = process_instruction(&system_program::id(), &[], &data);
         assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
 
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref(100, 0, &system_program::id());
         // Attempt to transfer with no destination
         let instruction = SystemInstruction::Transfer { lamports: 0 };
@@ -882,7 +882,7 @@ mod tests {
 
     #[test]
     fn test_transfer_lamports() {
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
         let to = Pubkey::new(&[3; 32]);
         let to_account = Account::new_ref(1, 0, &to); // account owner should not matter
@@ -910,7 +910,7 @@ mod tests {
 
     #[test]
     fn test_transfer_with_seed() {
-        let base = Pubkey::new_rand();
+        let base = solana_sdk::pubkey::new_rand();
         let base_account = Account::new_ref(100, 0, &Pubkey::new(&[2; 32])); // account owner should not matter
         let from_base_keyed_account = KeyedAccount::new(&base, true, &base_account);
         let from_seed = "42";
@@ -966,7 +966,7 @@ mod tests {
 
     #[test]
     fn test_transfer_lamports_from_nonce_account_fail() {
-        let from = Pubkey::new_rand();
+        let from = solana_sdk::pubkey::new_rand();
         let from_account = Account::new_ref_data(
             100,
             &nonce::state::Versions::new_current(nonce::State::Initialized(nonce::state::Data {
@@ -1002,7 +1002,7 @@ mod tests {
         let alice_keypair = Keypair::new();
         let alice_pubkey = alice_keypair.pubkey();
         let seed = "seed";
-        let owner = Pubkey::new_rand();
+        let owner = solana_sdk::pubkey::new_rand();
         let alice_with_seed = Pubkey::create_with_seed(&alice_pubkey, seed, &owner).unwrap();
 
         bank_client
@@ -1043,8 +1043,8 @@ mod tests {
         let alice_pubkey = alice_keypair.pubkey();
         let bob_pubkey = bob_keypair.pubkey();
 
-        let program = Pubkey::new_rand();
-        let collector = Pubkey::new_rand();
+        let program = solana_sdk::pubkey::new_rand();
+        let collector = solana_sdk::pubkey::new_rand();
 
         let mint_lamports = 10000;
         let len1 = 123;
@@ -1070,7 +1070,7 @@ mod tests {
         let bank = Arc::new(Bank::new_from_parent(&bank, &collector, bank.slot() + 1));
         let bank_client = BankClient::new_shared(&bank);
         bank_client
-            .transfer_and_confirm(50, &alice_keypair, &Pubkey::new_rand())
+            .transfer_and_confirm(50, &alice_keypair, &solana_sdk::pubkey::new_rand())
             .unwrap();
 
         // super fun time; callback chooses to .clean_accounts(None) or not
@@ -1112,7 +1112,7 @@ mod tests {
         let alice_keypair = Keypair::new();
         let alice_pubkey = alice_keypair.pubkey();
         let seed = "seed";
-        let owner = Pubkey::new_rand();
+        let owner = solana_sdk::pubkey::new_rand();
         let alice_with_seed = Pubkey::create_with_seed(&alice_pubkey, seed, &owner).unwrap();
 
         bank_client
@@ -1576,7 +1576,7 @@ mod tests {
             &nonce::state::Versions::new_current(nonce::State::Initialized(
                 nonce::state::Data::default(),
             )),
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
         )
         .unwrap();
         assert_eq!(get_system_account_kind(&nonce_account), None);

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -104,7 +104,7 @@ mod tests {
     }
 
     fn setup() -> (Bank, Vec<Transaction>) {
-        let dummy_leader_pubkey = Pubkey::new_rand();
+        let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -112,9 +112,9 @@ mod tests {
         } = create_genesis_config_with_leader(500, &dummy_leader_pubkey, 100);
         let bank = Bank::new(&genesis_config);
 
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let keypair2 = Keypair::new();
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
 
         let txs = vec![
             system_transaction::transfer(&mint_keypair, &pubkey, 1, genesis_config.hash()),

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -62,7 +62,7 @@ impl<'a, 'b> Drop for TransactionBatch<'a, 'b> {
 mod tests {
     use super::*;
     use crate::genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo};
-    use solana_sdk::{pubkey::Pubkey, signature::Keypair, system_transaction};
+    use solana_sdk::{signature::Keypair, system_transaction};
 
     #[test]
     fn test_transaction_batch() {

--- a/runtime/tests/bank.rs
+++ b/runtime/tests/bank.rs
@@ -1,5 +1,5 @@
 use solana_runtime::bank::Bank;
-use solana_sdk::{genesis_config::create_genesis_config, hash::hash, pubkey::Pubkey};
+use solana_sdk::{genesis_config::create_genesis_config, hash::hash};
 use std::{sync::Arc, thread::Builder};
 
 #[test]

--- a/runtime/tests/bank.rs
+++ b/runtime/tests/bank.rs
@@ -8,7 +8,7 @@ fn test_race_register_tick_freeze() {
 
     let (mut genesis_config, _) = create_genesis_config(50);
     genesis_config.ticks_per_slot = 1;
-    let p = Pubkey::new_rand();
+    let p = solana_sdk::pubkey::new_rand();
     let hash = hash(p.as_ref());
 
     for _ in 0..1000 {

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -10,7 +10,7 @@ fn test_program_native_noop() {
     solana_logger::setup();
 
     let (genesis_config, alice_keypair) = create_genesis_config(50);
-    let program_id = Pubkey::new_rand();
+    let program_id = solana_sdk::pubkey::new_rand();
     let bank = Bank::new(&genesis_config);
     bank.add_native_program("solana_noop_program", &program_id);
 

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -1,9 +1,7 @@
 use solana_runtime::{
     bank::Bank, bank_client::BankClient, loader_utils::create_invoke_instruction,
 };
-use solana_sdk::{
-    client::SyncClient, genesis_config::create_genesis_config, pubkey::Pubkey, signature::Signer,
-};
+use solana_sdk::{client::SyncClient, genesis_config::create_genesis_config, signature::Signer};
 
 #[test]
 fn test_program_native_noop() {

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -105,7 +105,7 @@ fn test_stake_create_and_split_single_signature() {
         genesis_config,
         mint_keypair: staker_keypair,
         ..
-    } = create_genesis_config_with_leader(100_000_000_000, &Pubkey::new_rand(), 1_000_000);
+    } = create_genesis_config_with_leader(100_000_000_000, &solana_sdk::pubkey::new_rand(), 1_000_000);
 
     let staker_pubkey = staker_keypair.pubkey();
 
@@ -172,7 +172,7 @@ fn test_stake_create_and_split_to_existing_system_account() {
         genesis_config,
         mint_keypair: staker_keypair,
         ..
-    } = create_genesis_config_with_leader(100_000_000_000, &Pubkey::new_rand(), 1_000_000);
+    } = create_genesis_config_with_leader(100_000_000_000, &solana_sdk::pubkey::new_rand(), 1_000_000);
 
     let staker_pubkey = staker_keypair.pubkey();
 
@@ -255,7 +255,7 @@ fn test_stake_account_lifetime() {
         genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(100_000_000_000, &Pubkey::new_rand(), 1_000_000);
+    } = create_genesis_config_with_leader(100_000_000_000, &solana_sdk::pubkey::new_rand(), 1_000_000);
     let bank = Bank::new(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let mut bank = Arc::new(bank);
@@ -311,7 +311,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &stake_pubkey,
             &stake_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             1,
             None,
         )],
@@ -406,7 +406,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             lamports / 2 - split_staked + 1,
             None,
         )],
@@ -428,7 +428,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             lamports / 2,
             None,
         )],
@@ -444,7 +444,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             lamports / 2 - split_staked,
             None,
         )],
@@ -469,7 +469,7 @@ fn test_stake_account_lifetime() {
         &[stake_instruction::withdraw(
             &split_stake_pubkey,
             &stake_pubkey,
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             split_staked,
             None,
         )],
@@ -495,7 +495,7 @@ fn test_create_stake_account_from_seed() {
         genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(100_000_000_000, &Pubkey::new_rand(), 1_000_000);
+    } = create_genesis_config_with_leader(100_000_000_000, &solana_sdk::pubkey::new_rand(), 1_000_000);
     let bank = Bank::new(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let bank = Arc::new(bank);

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -105,7 +105,11 @@ fn test_stake_create_and_split_single_signature() {
         genesis_config,
         mint_keypair: staker_keypair,
         ..
-    } = create_genesis_config_with_leader(100_000_000_000, &solana_sdk::pubkey::new_rand(), 1_000_000);
+    } = create_genesis_config_with_leader(
+        100_000_000_000,
+        &solana_sdk::pubkey::new_rand(),
+        1_000_000,
+    );
 
     let staker_pubkey = staker_keypair.pubkey();
 
@@ -172,7 +176,11 @@ fn test_stake_create_and_split_to_existing_system_account() {
         genesis_config,
         mint_keypair: staker_keypair,
         ..
-    } = create_genesis_config_with_leader(100_000_000_000, &solana_sdk::pubkey::new_rand(), 1_000_000);
+    } = create_genesis_config_with_leader(
+        100_000_000_000,
+        &solana_sdk::pubkey::new_rand(),
+        1_000_000,
+    );
 
     let staker_pubkey = staker_keypair.pubkey();
 
@@ -255,7 +263,11 @@ fn test_stake_account_lifetime() {
         genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(100_000_000_000, &solana_sdk::pubkey::new_rand(), 1_000_000);
+    } = create_genesis_config_with_leader(
+        100_000_000_000,
+        &solana_sdk::pubkey::new_rand(),
+        1_000_000,
+    );
     let bank = Bank::new(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let mut bank = Arc::new(bank);
@@ -495,7 +507,11 @@ fn test_create_stake_account_from_seed() {
         genesis_config,
         mint_keypair,
         ..
-    } = create_genesis_config_with_leader(100_000_000_000, &solana_sdk::pubkey::new_rand(), 1_000_000);
+    } = create_genesis_config_with_leader(
+        100_000_000_000,
+        &solana_sdk::pubkey::new_rand(),
+        1_000_000,
+    );
     let bank = Bank::new(&genesis_config);
     let mint_pubkey = mint_keypair.pubkey();
     let bank = Arc::new(bank);

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -9,8 +9,8 @@ use solana_sdk::sysvar::instructions;
 use test::Bencher;
 
 fn make_instructions() -> Vec<Instruction> {
-    let meta = AccountMeta::new(Pubkey::new_rand(), false);
-    let inst = Instruction::new(Pubkey::new_rand(), &[0; 10], vec![meta; 4]);
+    let meta = AccountMeta::new(solana_sdk::pubkey::new_rand(), false);
+    let inst = Instruction::new(solana_sdk::pubkey::new_rand(), &[0; 10], vec![meta; 4]);
     vec![inst; 4]
 }
 

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -4,13 +4,13 @@ extern crate test;
 use bincode::{deserialize, serialize};
 use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::pubkey;
 use solana_sdk::sysvar::instructions;
 use test::Bencher;
 
 fn make_instructions() -> Vec<Instruction> {
-    let meta = AccountMeta::new(solana_sdk::pubkey::new_rand(), false);
-    let inst = Instruction::new(solana_sdk::pubkey::new_rand(), &[0; 10], vec![meta; 4]);
+    let meta = AccountMeta::new(pubkey::new_rand(), false);
+    let inst = Instruction::new(pubkey::new_rand(), &[0; 10], vec![meta; 4]);
     vec![inst; 4]
 }
 

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -310,7 +310,10 @@ mod tests {
             faucet_keypair.pubkey(),
             Account::new(10_000, 0, &Pubkey::default()),
         );
-        config.add_account(solana_sdk::pubkey::new_rand(), Account::new(1, 0, &Pubkey::default()));
+        config.add_account(
+            solana_sdk::pubkey::new_rand(),
+            Account::new(1, 0, &Pubkey::default()),
+        );
         config.add_native_instruction_processor("hi".to_string(), solana_sdk::pubkey::new_rand());
 
         assert_eq!(config.accounts.len(), 2);

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -310,8 +310,8 @@ mod tests {
             faucet_keypair.pubkey(),
             Account::new(10_000, 0, &Pubkey::default()),
         );
-        config.add_account(Pubkey::new_rand(), Account::new(1, 0, &Pubkey::default()));
-        config.add_native_instruction_processor("hi".to_string(), Pubkey::new_rand());
+        config.add_account(solana_sdk::pubkey::new_rand(), Account::new(1, 0, &Pubkey::default()));
+        config.add_native_instruction_processor("hi".to_string(), solana_sdk::pubkey::new_rand());
 
         assert_eq!(config.accounts.len(), 2);
         assert!(config

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -76,6 +76,17 @@ impl FromStr for Hash {
     }
 }
 
+/// New random hash value for tests and benchmarks.
+#[cfg(feature = "everything")]
+pub fn new_rand<R: ?Sized>(rng: &mut R) -> Hash
+where
+    R: rand::Rng,
+{
+    let mut buf = [0u8; HASH_BYTES];
+    rng.fill(&mut buf);
+    Hash::new(&buf)
+}
+
 impl Hash {
     pub fn new(hash_slice: &[u8]) -> Self {
         Hash(<[u8; HASH_BYTES]>::try_from(hash_slice).unwrap())
@@ -90,14 +101,13 @@ impl Hash {
     }
 
     /// New random hash value for tests and benchmarks.
-    #[cfg(feature = "everything")]
+    #[cfg(all(feature = "everything", not(target_arch = "bpf")))]
+    #[deprecated(since = "1.3.9", note = "Please use 'hash::new_rand' instead")]
     pub fn new_rand<R: ?Sized>(rng: &mut R) -> Self
     where
         R: rand::Rng,
     {
-        let mut buf = [0u8; HASH_BYTES];
-        rng.fill(&mut buf);
-        Hash::new(&buf)
+        new_rand(rng)
     }
 }
 

--- a/sdk/src/message.rs
+++ b/sdk/src/message.rs
@@ -444,7 +444,7 @@ mod tests {
     #[test]
     fn test_message_unique_program_ids_not_adjacent() {
         let program_id0 = Pubkey::default();
-        let program_id1 = Pubkey::new_rand();
+        let program_id1 = solana_sdk::pubkey::new_rand();
         let program_ids = get_program_ids(&[
             Instruction::new(program_id0, &0, vec![]),
             Instruction::new(program_id1, &0, vec![]),
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn test_message_unique_program_ids_order_preserved() {
-        let program_id0 = Pubkey::new_rand();
+        let program_id0 = solana_sdk::pubkey::new_rand();
         let program_id1 = Pubkey::default(); // Key less than program_id0
         let program_ids = get_program_ids(&[
             Instruction::new(program_id0, &0, vec![]),
@@ -558,7 +558,7 @@ mod tests {
     #[test]
     fn test_message_unique_keys_order_preserved() {
         let program_id = Pubkey::default();
-        let id0 = Pubkey::new_rand();
+        let id0 = solana_sdk::pubkey::new_rand();
         let id1 = Pubkey::default(); // Key less than id0
         let keys = get_keys(
             &[
@@ -574,7 +574,7 @@ mod tests {
     fn test_message_unique_keys_not_adjacent() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let id1 = Pubkey::new_rand();
+        let id1 = solana_sdk::pubkey::new_rand();
         let keys = get_keys(
             &[
                 Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
@@ -590,7 +590,7 @@ mod tests {
     fn test_message_signed_keys_first() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let id1 = Pubkey::new_rand();
+        let id1 = solana_sdk::pubkey::new_rand();
         let keys = get_keys(
             &[
                 Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
@@ -619,9 +619,9 @@ mod tests {
     fn test_message_readonly_keys_last() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default(); // Identical key/program_id should be de-duped
-        let id1 = Pubkey::new_rand();
-        let id2 = Pubkey::new_rand();
-        let id3 = Pubkey::new_rand();
+        let id1 = solana_sdk::pubkey::new_rand();
+        let id2 = solana_sdk::pubkey::new_rand();
+        let id3 = solana_sdk::pubkey::new_rand();
         let keys = get_keys(
             &[
                 Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id0, false)]),
@@ -639,8 +639,8 @@ mod tests {
 
     #[test]
     fn test_message_kitchen_sink() {
-        let program_id0 = Pubkey::new_rand();
-        let program_id1 = Pubkey::new_rand();
+        let program_id0 = solana_sdk::pubkey::new_rand();
+        let program_id1 = solana_sdk::pubkey::new_rand();
         let id0 = Pubkey::default();
         let keypair1 = Keypair::new();
         let id1 = keypair1.pubkey();
@@ -669,7 +669,7 @@ mod tests {
     #[test]
     fn test_message_payer_first() {
         let program_id = Pubkey::default();
-        let payer = Pubkey::new_rand();
+        let payer = solana_sdk::pubkey::new_rand();
         let id0 = Pubkey::default();
 
         let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]);
@@ -692,8 +692,8 @@ mod tests {
     #[test]
     fn test_message_program_last() {
         let program_id = Pubkey::default();
-        let id0 = Pubkey::new_rand();
-        let id1 = Pubkey::new_rand();
+        let id0 = solana_sdk::pubkey::new_rand();
+        let id1 = solana_sdk::pubkey::new_rand();
         let keys = get_keys(
             &[
                 Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id0, false)]),
@@ -710,8 +710,8 @@ mod tests {
     #[test]
     fn test_program_position() {
         let program_id0 = Pubkey::default();
-        let program_id1 = Pubkey::new_rand();
-        let id = Pubkey::new_rand();
+        let program_id1 = solana_sdk::pubkey::new_rand();
+        let id = solana_sdk::pubkey::new_rand();
         let message = Message::new(
             &[
                 Instruction::new(program_id0, &0, vec![AccountMeta::new(id, false)]),
@@ -726,12 +726,12 @@ mod tests {
 
     #[test]
     fn test_is_writable() {
-        let key0 = Pubkey::new_rand();
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
-        let key3 = Pubkey::new_rand();
-        let key4 = Pubkey::new_rand();
-        let key5 = Pubkey::new_rand();
+        let key0 = solana_sdk::pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
+        let key3 = solana_sdk::pubkey::new_rand();
+        let key4 = solana_sdk::pubkey::new_rand();
+        let key5 = solana_sdk::pubkey::new_rand();
 
         let message = Message {
             header: MessageHeader {
@@ -754,10 +754,10 @@ mod tests {
     #[test]
     fn test_get_account_keys_by_lock_type() {
         let program_id = Pubkey::default();
-        let id0 = Pubkey::new_rand();
-        let id1 = Pubkey::new_rand();
-        let id2 = Pubkey::new_rand();
-        let id3 = Pubkey::new_rand();
+        let id0 = solana_sdk::pubkey::new_rand();
+        let id1 = solana_sdk::pubkey::new_rand();
+        let id2 = solana_sdk::pubkey::new_rand();
+        let id3 = solana_sdk::pubkey::new_rand();
         let message = Message::new(
             &[
                 Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
@@ -776,12 +776,12 @@ mod tests {
     #[test]
     fn test_decompile_instructions() {
         solana_logger::setup();
-        let program_id0 = Pubkey::new_rand();
-        let program_id1 = Pubkey::new_rand();
-        let id0 = Pubkey::new_rand();
-        let id1 = Pubkey::new_rand();
-        let id2 = Pubkey::new_rand();
-        let id3 = Pubkey::new_rand();
+        let program_id0 = solana_sdk::pubkey::new_rand();
+        let program_id1 = solana_sdk::pubkey::new_rand();
+        let id0 = solana_sdk::pubkey::new_rand();
+        let id1 = solana_sdk::pubkey::new_rand();
+        let id2 = solana_sdk::pubkey::new_rand();
+        let id3 = solana_sdk::pubkey::new_rand();
         let instructions = vec![
             Instruction::new(program_id0, &0, vec![AccountMeta::new(id0, false)]),
             Instruction::new(program_id0, &0, vec![AccountMeta::new(id1, true)]),

--- a/sdk/src/nonce/account.rs
+++ b/sdk/src/nonce/account.rs
@@ -175,7 +175,7 @@ pub fn with_test_keyed_account<F>(lamports: u64, signer: bool, f: F)
 where
     F: Fn(&KeyedAccount),
 {
-    let pubkey = Pubkey::new_rand();
+    let pubkey = solana_sdk::pubkey::new_rand();
     let account = create_account(lamports);
     let keyed_account = KeyedAccount::new(&pubkey, signer, &account);
     f(&keyed_account)

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -301,7 +301,12 @@ mod tests {
 
     #[test]
     fn test_create_with_seed() {
-        assert!(Pubkey::create_with_seed(&solana_sdk::pubkey::new_rand(), "☉", &solana_sdk::pubkey::new_rand()).is_ok());
+        assert!(Pubkey::create_with_seed(
+            &solana_sdk::pubkey::new_rand(),
+            "☉",
+            &solana_sdk::pubkey::new_rand()
+        )
+        .is_ok());
         assert_eq!(
             Pubkey::create_with_seed(
                 &solana_sdk::pubkey::new_rand(),
@@ -337,7 +342,12 @@ mod tests {
         )
         .is_ok());
 
-        assert!(Pubkey::create_with_seed(&solana_sdk::pubkey::new_rand(), "", &solana_sdk::pubkey::new_rand(),).is_ok());
+        assert!(Pubkey::create_with_seed(
+            &solana_sdk::pubkey::new_rand(),
+            "",
+            &solana_sdk::pubkey::new_rand(),
+        )
+        .is_ok());
 
         assert_eq!(
             Pubkey::create_with_seed(

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -67,6 +67,12 @@ impl FromStr for Pubkey {
     }
 }
 
+/// New random Pubkey for tests and benchmarks.
+#[cfg(feature = "everything")]
+pub fn new_rand() -> Pubkey {
+    Pubkey::new(&rand::random::<[u8; 32]>())
+}
+
 impl Pubkey {
     pub fn new(pubkey_vec: &[u8]) -> Self {
         Self(
@@ -188,9 +194,11 @@ impl Pubkey {
         panic!("Unable to find a viable program address bump seed");
     }
 
-    #[cfg(feature = "everything")]
+    #[cfg(all(feature = "everything", not(target_arch = "bpf")))]
+    #[deprecated(since = "1.3.9", note = "Please use 'pubkey::new_rand' instead")]
     pub fn new_rand() -> Self {
-        Self::new(&rand::random::<[u8; 32]>())
+        // Consider removing Pubkey::new_rand() entirely in the v1.5 or v1.6 timeframe
+        new_rand()
     }
 
     pub fn to_bytes(self) -> [u8; 32] {

--- a/sdk/src/pubkey.rs
+++ b/sdk/src/pubkey.rs
@@ -268,7 +268,7 @@ mod tests {
 
     #[test]
     fn pubkey_fromstr() {
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         let mut pubkey_base58_str = bs58::encode(pubkey.0).into_string();
 
         assert_eq!(pubkey_base58_str.parse::<Pubkey>(), Ok(pubkey));
@@ -301,43 +301,43 @@ mod tests {
 
     #[test]
     fn test_create_with_seed() {
-        assert!(Pubkey::create_with_seed(&Pubkey::new_rand(), "☉", &Pubkey::new_rand()).is_ok());
+        assert!(Pubkey::create_with_seed(&solana_sdk::pubkey::new_rand(), "☉", &solana_sdk::pubkey::new_rand()).is_ok());
         assert_eq!(
             Pubkey::create_with_seed(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 from_utf8(&[127; MAX_SEED_LEN + 1]).unwrap(),
-                &Pubkey::new_rand()
+                &solana_sdk::pubkey::new_rand()
             ),
             Err(PubkeyError::MaxSeedLengthExceeded)
         );
         assert!(Pubkey::create_with_seed(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             "\
              \u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\
              ",
-            &Pubkey::new_rand()
+            &solana_sdk::pubkey::new_rand()
         )
         .is_ok());
         // utf-8 abuse ;)
         assert_eq!(
             Pubkey::create_with_seed(
-                &Pubkey::new_rand(),
+                &solana_sdk::pubkey::new_rand(),
                 "\
                  x\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\
                  ",
-                &Pubkey::new_rand()
+                &solana_sdk::pubkey::new_rand()
             ),
             Err(PubkeyError::MaxSeedLengthExceeded)
         );
 
         assert!(Pubkey::create_with_seed(
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
             std::str::from_utf8(&[0; MAX_SEED_LEN]).unwrap(),
-            &Pubkey::new_rand(),
+            &solana_sdk::pubkey::new_rand(),
         )
         .is_ok());
 
-        assert!(Pubkey::create_with_seed(&Pubkey::new_rand(), "", &Pubkey::new_rand(),).is_ok());
+        assert!(Pubkey::create_with_seed(&solana_sdk::pubkey::new_rand(), "", &solana_sdk::pubkey::new_rand(),).is_ok());
 
         assert_eq!(
             Pubkey::create_with_seed(
@@ -403,7 +403,7 @@ mod tests {
         // addresses must land off the curve and be unique
         let mut addresses = vec![];
         for _ in 0..1_000 {
-            let program_id = Pubkey::new_rand();
+            let program_id = solana_sdk::pubkey::new_rand();
             let bytes1 = rand::random::<[u8; 10]>();
             let bytes2 = rand::random::<[u8; 32]>();
             if let Ok(program_address) =
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn test_find_program_address() {
         for _ in 0..1_000 {
-            let program_id = Pubkey::new_rand();
+            let program_id = solana_sdk::pubkey::new_rand();
             let (address, bump_seed) =
                 Pubkey::find_program_address(&[b"Lil'", b"Bits"], &program_id);
             assert_eq!(
@@ -438,7 +438,7 @@ mod tests {
     #[test]
     fn test_read_write_pubkey() -> Result<(), Box<dyn std::error::Error>> {
         let filename = "test_pubkey.json";
-        let pubkey = Pubkey::new_rand();
+        let pubkey = solana_sdk::pubkey::new_rand();
         write_pubkey_file(filename, pubkey)?;
         let read = read_pubkey_file(filename)?;
         assert_eq!(read, pubkey);

--- a/sdk/src/stake_weighted_timestamp.rs
+++ b/sdk/src/stake_weighted_timestamp.rs
@@ -47,10 +47,10 @@ pub mod tests {
         let slot = 5;
         let slot_duration = Duration::from_millis(400);
         let expected_offset = (slot * slot_duration).as_secs();
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
-        let pubkey3 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey3 = solana_sdk::pubkey::new_rand();
         let unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)> = [
             (pubkey0, (0, recent_timestamp)),
             (pubkey1, (0, recent_timestamp)),

--- a/sdk/src/system_instruction.rs
+++ b/sdk/src/system_instruction.rs
@@ -491,9 +491,9 @@ mod tests {
 
     #[test]
     fn test_move_many() {
-        let alice_pubkey = Pubkey::new_rand();
-        let bob_pubkey = Pubkey::new_rand();
-        let carol_pubkey = Pubkey::new_rand();
+        let alice_pubkey = solana_sdk::pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
+        let carol_pubkey = solana_sdk::pubkey::new_rand();
         let to_lamports = vec![(bob_pubkey, 1), (carol_pubkey, 2)];
 
         let instructions = transfer_many(&alice_pubkey, &to_lamports);
@@ -504,8 +504,8 @@ mod tests {
 
     #[test]
     fn test_create_nonce_account() {
-        let from_pubkey = Pubkey::new_rand();
-        let nonce_pubkey = Pubkey::new_rand();
+        let from_pubkey = solana_sdk::pubkey::new_rand();
+        let nonce_pubkey = solana_sdk::pubkey::new_rand();
         let authorized = nonce_pubkey;
         let ixs = create_nonce_account(&from_pubkey, &nonce_pubkey, &authorized, 42);
         assert_eq!(ixs.len(), 2);

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -444,10 +444,10 @@ mod tests {
     #[test]
     fn test_refs() {
         let key = Keypair::new();
-        let key1 = Pubkey::new_rand();
-        let key2 = Pubkey::new_rand();
-        let prog1 = Pubkey::new_rand();
-        let prog2 = Pubkey::new_rand();
+        let key1 = solana_sdk::pubkey::new_rand();
+        let key2 = solana_sdk::pubkey::new_rand();
+        let prog1 = solana_sdk::pubkey::new_rand();
+        let prog2 = solana_sdk::pubkey::new_rand();
         let instructions = vec![
             CompiledInstruction::new(3, &(), vec![0, 1]),
             CompiledInstruction::new(4, &(), vec![0, 2]),
@@ -514,7 +514,7 @@ mod tests {
     fn test_sanitize_txs() {
         let key = Keypair::new();
         let id0 = Pubkey::default();
-        let program_id = Pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
         let ix = Instruction::new(
             program_id,
             &0,
@@ -610,7 +610,7 @@ mod tests {
     fn test_transaction_minimum_serialized_size() {
         let alice_keypair = Keypair::new();
         let alice_pubkey = alice_keypair.pubkey();
-        let bob_pubkey = Pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let ix = system_instruction::transfer(&alice_pubkey, &bob_pubkey, 42);
 
         let expected_data_size = size_of::<u32>() + size_of::<u64>();
@@ -688,7 +688,7 @@ mod tests {
     #[should_panic]
     fn test_partial_sign_mismatched_key() {
         let keypair = Keypair::new();
-        let fee_payer = Pubkey::new_rand();
+        let fee_payer = solana_sdk::pubkey::new_rand();
         let ix = Instruction::new(
             Pubkey::default(),
             &0,
@@ -770,7 +770,7 @@ mod tests {
         let program_id = Pubkey::default();
         let keypair0 = Keypair::new();
         let id0 = keypair0.pubkey();
-        let id1 = Pubkey::new_rand();
+        let id1 = solana_sdk::pubkey::new_rand();
         let ix = Instruction::new(
             program_id,
             &0,
@@ -821,7 +821,7 @@ mod tests {
         assert_eq!(tx.signatures[1], presigner_sig);
 
         // Wrong key should error, not panic
-        let another_pubkey = Pubkey::new_rand();
+        let another_pubkey = solana_sdk::pubkey::new_rand();
         let ix = Instruction::new(
             program_id,
             &0,

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -347,8 +347,8 @@ mod tests {
         let base_keypair = Keypair::new();
         let base_pubkey = base_keypair.pubkey();
         let lamports = rent + 1;
-        let stake_authority_pubkey = Pubkey::new_rand();
-        let withdraw_authority_pubkey = Pubkey::new_rand();
+        let stake_authority_pubkey = solana_sdk::pubkey::new_rand();
+        let withdraw_authority_pubkey = solana_sdk::pubkey::new_rand();
 
         let message = new_stake_account(
             &fee_payer_pubkey,
@@ -406,8 +406,8 @@ mod tests {
             .send_and_confirm_message(&signers, message)
             .unwrap();
 
-        let new_stake_authority_pubkey = Pubkey::new_rand();
-        let new_withdraw_authority_pubkey = Pubkey::new_rand();
+        let new_stake_authority_pubkey = solana_sdk::pubkey::new_rand();
+        let new_withdraw_authority_pubkey = solana_sdk::pubkey::new_rand();
         let messages = authorize_stake_accounts(
             &fee_payer_pubkey,
             &base_pubkey,
@@ -620,8 +620,8 @@ mod tests {
 
         let new_base_keypair = Keypair::new();
         let new_base_pubkey = new_base_keypair.pubkey();
-        let new_stake_authority_pubkey = Pubkey::new_rand();
-        let new_withdraw_authority_pubkey = Pubkey::new_rand();
+        let new_stake_authority_pubkey = solana_sdk::pubkey::new_rand();
+        let new_withdraw_authority_pubkey = solana_sdk::pubkey::new_rand();
         let balances = get_balances(&bank_client, &base_pubkey, num_accounts);
         let messages = move_stake_accounts(
             &fee_payer_pubkey,

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -645,7 +645,7 @@ mod tests {
     #[test]
     fn test_deserialize_protobuf_or_bincode_cell_data() {
         let from = Keypair::new();
-        let recipient = Pubkey::new_rand();
+        let recipient = solana_sdk::pubkey::new_rand();
         let transaction = system_transaction::transfer(&from, &recipient, 42, Hash::default());
         let with_meta = TransactionWithStatusMeta {
             transaction,

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -635,7 +635,7 @@ mod tests {
     use super::*;
     use crate::StoredConfirmedBlock;
     use prost::Message;
-    use solana_sdk::{hash::Hash, pubkey::Pubkey, signature::Keypair, system_transaction};
+    use solana_sdk::{hash::Hash, signature::Keypair, system_transaction};
     use solana_storage_proto::convert::generated;
     use solana_transaction_status::{
         ConfirmedBlock, TransactionStatusMeta, TransactionWithStatusMeta,

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -630,7 +630,7 @@ pub async fn test_process_distribute_tokens_with_client(
         sol_to_lamports(1.0),
     );
 
-    let alice_pubkey = Pubkey::new_rand();
+    let alice_pubkey = solana_sdk::pubkey::new_rand();
     let allocation = Allocation {
         recipient: alice_pubkey.to_string(),
         amount: if let Some(amount) = transfer_amount {
@@ -751,7 +751,7 @@ pub async fn test_process_distribute_stake_with_client(
         .await
         .unwrap();
 
-    let alice_pubkey = Pubkey::new_rand();
+    let alice_pubkey = solana_sdk::pubkey::new_rand();
     let allocation = Allocation {
         recipient: alice_pubkey.to_string(),
         amount: 1000.0,
@@ -896,7 +896,7 @@ mod tests {
 
     #[test]
     fn test_read_allocations() {
-        let alice_pubkey = Pubkey::new_rand();
+        let alice_pubkey = solana_sdk::pubkey::new_rand();
         let allocation = Allocation {
             recipient: alice_pubkey.to_string(),
             amount: 42.0,
@@ -916,9 +916,9 @@ mod tests {
 
     #[test]
     fn test_read_allocations_transfer_amount() {
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
         let file = NamedTempFile::new().unwrap();
         let input_csv = file.path().to_str().unwrap().to_string();
         let mut wtr = csv::WriterBuilder::new().from_writer(file);
@@ -955,8 +955,8 @@ mod tests {
 
     #[test]
     fn test_apply_previous_transactions() {
-        let alice = Pubkey::new_rand();
-        let bob = Pubkey::new_rand();
+        let alice = solana_sdk::pubkey::new_rand();
+        let bob = solana_sdk::pubkey::new_rand();
         let mut allocations = vec![
             Allocation {
                 recipient: alice.to_string(),
@@ -984,8 +984,8 @@ mod tests {
 
     #[test]
     fn test_has_same_recipient() {
-        let alice_pubkey = Pubkey::new_rand();
-        let bob_pubkey = Pubkey::new_rand();
+        let alice_pubkey = solana_sdk::pubkey::new_rand();
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
         let lockup0 = "2021-01-07T00:00:00Z".to_string();
         let lockup1 = "9999-12-31T23:59:59Z".to_string();
         let alice_alloc = Allocation {
@@ -1041,8 +1041,8 @@ mod tests {
             amount: 1.0,
             lockup_date: lockup_date_str.to_string(),
         };
-        let stake_account_address = Pubkey::new_rand();
-        let new_stake_account_address = Pubkey::new_rand();
+        let stake_account_address = solana_sdk::pubkey::new_rand();
+        let new_stake_account_address = solana_sdk::pubkey::new_rand();
         let lockup_authority = Keypair::new();
         let stake_args = StakeArgs {
             stake_account_address,
@@ -1092,7 +1092,7 @@ mod tests {
         fee_payer: &str,
         stake_args: Option<StakeArgs>,
     ) -> (Vec<Allocation>, DistributeTokensArgs) {
-        let recipient = Pubkey::new_rand();
+        let recipient = solana_sdk::pubkey::new_rand();
         let allocations = vec![Allocation {
             recipient: recipient.to_string(),
             amount: allocation_amount,
@@ -1369,7 +1369,7 @@ mod tests {
             // Underfunded stake-account
             let expensive_allocation_amount = 5000.0;
             let expensive_allocations = vec![Allocation {
-                recipient: Pubkey::new_rand().to_string(),
+                recipient: solana_sdk::pubkey::new_rand().to_string(),
                 amount: expensive_allocation_amount,
                 lockup_date: "".to_string(),
             }];

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -225,7 +225,7 @@ mod tests {
         };
         let info2 = TransactionInfo::default();
         let info3 = TransactionInfo {
-            recipient: Pubkey::new_rand(),
+            recipient: solana_sdk::pubkey::new_rand(),
             ..TransactionInfo::default()
         };
 

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -23,7 +23,7 @@ pub fn parse_accounts(message: &Message) -> Vec<ParsedAccount> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use solana_sdk::{message::MessageHeader, pubkey::Pubkey};
+    use solana_sdk::message::MessageHeader;
 
     #[test]
     fn test_parse_accounts() {

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -27,10 +27,10 @@ mod test {
 
     #[test]
     fn test_parse_accounts() {
-        let pubkey0 = Pubkey::new_rand();
-        let pubkey1 = Pubkey::new_rand();
-        let pubkey2 = Pubkey::new_rand();
-        let pubkey3 = Pubkey::new_rand();
+        let pubkey0 = solana_sdk::pubkey::new_rand();
+        let pubkey1 = solana_sdk::pubkey::new_rand();
+        let pubkey2 = solana_sdk::pubkey::new_rand();
+        let pubkey3 = solana_sdk::pubkey::new_rand();
         let mut message = Message::default();
         message.header = MessageHeader {
             num_required_signatures: 2,

--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -41,11 +41,11 @@ mod test {
 
     #[test]
     fn test_parse_bpf_loader_instructions() {
-        let account_pubkey = Pubkey::new_rand();
-        let program_id = Pubkey::new_rand();
+        let account_pubkey = solana_sdk::pubkey::new_rand();
+        let program_id = solana_sdk::pubkey::new_rand();
         let offset = 4242;
         let bytes = vec![8; 99];
-        let fee_payer = Pubkey::new_rand();
+        let fee_payer = solana_sdk::pubkey::new_rand();
         let account_keys = vec![fee_payer, account_pubkey];
         let missing_account_keys = vec![account_pubkey];
 

--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -37,15 +37,15 @@ pub fn parse_bpf_loader(
 #[cfg(test)]
 mod test {
     use super::*;
-    use solana_sdk::{message::Message, pubkey::Pubkey};
+    use solana_sdk::{message::Message, pubkey};
 
     #[test]
     fn test_parse_bpf_loader_instructions() {
-        let account_pubkey = solana_sdk::pubkey::new_rand();
-        let program_id = solana_sdk::pubkey::new_rand();
+        let account_pubkey = pubkey::new_rand();
+        let program_id = pubkey::new_rand();
         let offset = 4242;
         let bytes = vec![8; 99];
-        let fee_payer = solana_sdk::pubkey::new_rand();
+        let fee_payer = pubkey::new_rand();
         let account_keys = vec![fee_payer, account_pubkey];
         let missing_account_keys = vec![account_pubkey];
 

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -184,17 +184,17 @@ mod test {
     fn test_parse_stake_instruction() {
         let mut keys: Vec<Pubkey> = vec![];
         for _ in 0..6 {
-            keys.push(Pubkey::new_rand());
+            keys.push(solana_sdk::pubkey::new_rand());
         }
 
         let authorized = Authorized {
-            staker: Pubkey::new_rand(),
-            withdrawer: Pubkey::new_rand(),
+            staker: solana_sdk::pubkey::new_rand(),
+            withdrawer: solana_sdk::pubkey::new_rand(),
         };
         let lockup = Lockup {
             unix_timestamp: 1_234_567_890,
             epoch: 11,
-            custodian: Pubkey::new_rand(),
+            custodian: solana_sdk::pubkey::new_rand(),
         };
         let lamports = 55;
 
@@ -375,11 +375,11 @@ mod test {
     fn test_parse_set_lockup() {
         let mut keys: Vec<Pubkey> = vec![];
         for _ in 0..2 {
-            keys.push(Pubkey::new_rand());
+            keys.push(solana_sdk::pubkey::new_rand());
         }
         let unix_timestamp = 1_234_567_890;
         let epoch = 11;
-        let custodian = Pubkey::new_rand();
+        let custodian = solana_sdk::pubkey::new_rand();
 
         let lockup = LockupArgs {
             unix_timestamp: Some(unix_timestamp),

--- a/transaction-status/src/parse_system.rs
+++ b/transaction-status/src/parse_system.rs
@@ -205,7 +205,7 @@ mod test {
     fn test_parse_system_instruction() {
         let mut keys: Vec<Pubkey> = vec![];
         for _ in 0..6 {
-            keys.push(Pubkey::new_rand());
+            keys.push(solana_sdk::pubkey::new_rand());
         }
 
         let lamports = 55;
@@ -359,7 +359,7 @@ mod test {
     fn test_parse_system_instruction_nonce() {
         let mut keys: Vec<Pubkey> = vec![];
         for _ in 0..5 {
-            keys.push(Pubkey::new_rand());
+            keys.push(solana_sdk::pubkey::new_rand());
         }
 
         let instruction = system_instruction::advance_nonce_account(&keys[1], &keys[0]);

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -442,7 +442,7 @@ mod test {
     fn test_parse_token() {
         let mut keys: Vec<Pubkey> = vec![];
         for _ in 0..10 {
-            keys.push(Pubkey::new_rand());
+            keys.push(solana_sdk::pubkey::new_rand());
         }
 
         // Test InitializeMint variations
@@ -1027,7 +1027,7 @@ mod test {
     fn test_token_ix_not_enough_keys() {
         let mut keys: Vec<Pubkey> = vec![];
         for _ in 0..10 {
-            keys.push(Pubkey::new_rand());
+            keys.push(solana_sdk::pubkey::new_rand());
         }
 
         // Test InitializeMint variations


### PR DESCRIPTION
`Pubkey::new_rand()` and `Hash::new_rand()` are problematic.  They are unavailable when compiling `solana-sdk` with the "program" feature, but will come back when the "everything" (https://github.com/solana-labs/solana/pull/12985) feature.   

Due to how Cargo feature addition works, a program developer could inadvertently add a dependency on `Pubkey::new_rand()` due to the "everything" feature getting activated in a `[dev-dependency]` when building native only to later have their build fail when targetting BPF.

When `Pubkey` and `Hash` move into a new `solana-program-sdk` create (that `solana-sdk` depends on),  `Pubkey::new_rand()` and `Hash::new_rand()` cannot come along.   This will make it impossible to support the `new_rand()` functions where they currently live.

The migration plan:
1. Land this PR in master, v1.4 and v1.3
2. In v1.4, as `Pubkey` and `Hash` move into a new `solana-program-sdk` supply a stub for `Pubkey::new_rand()` when !BPF for now. `Hash::new_rand()` is believed to only be in use internally so remove it entirely in v1.4
3. v1.5/v1.6 timeframe, remove `Pubkey::new_rand()`
