### PR TITLE
Ignore more paths in increment-cargo-version.sh

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -30,8 +30,20 @@ readCargoVariable() {
   echo "Unable to locate $variable in $Cargo_toml" 1>&2
 }
 
-# shellcheck disable=2207
-Cargo_tomls=($(find . -mindepth 2 -name Cargo.toml -not -path './web3.js/examples/*'))
+ignores=(
+  .cache
+  .cargo
+  target
+  web3.js/examples
+)
+
+not_paths=()
+for ignore in "${ignores[@]}"; do
+  not_paths+=(-not -path "*/$ignore/*")
+done
+
+# shellcheck disable=2207,SC2068 # Don't want a positional arg if `not-paths` is empty
+Cargo_tomls=($(find . -mindepth 2 -name Cargo.toml ${not_paths[@]}))
 # shellcheck disable=2207
 markdownFiles=($(find . -name "*.md"))
 


### PR DESCRIPTION
#### Problem

Some of our CI scripts instantiate tree-local .cargo and .cache dirs.  These send `increment-cargo-version.sh` down a time consuming rabbit hole of useless work.

#### Summary of Changes

Ignore tree-local .cache and .cargo dirs in `increment-cargo-version.sh`

cc/ @CriesofCarrots 