### PR TITLE
Don't hold dashmap write lock in store create

### DIFF
--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -3,6 +3,7 @@
 extern crate test;
 
 use dashmap::DashMap;
+use rand::Rng;
 use solana_runtime::{
     accounts::{create_test_accounts, Accounts},
     bank::*,
@@ -146,6 +147,60 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
     bencher.iter(|| {
         accounts.accounts_db.clean_accounts(None);
     });
+}
+
+#[bench]
+#[ignore]
+fn bench_concurrent_read_write(bencher: &mut Bencher) {
+    let num_readers = 5;
+    let accounts = Arc::new(Accounts::new(
+        vec![
+            PathBuf::from(std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string()))
+                .join("concurrent_read_write"),
+        ],
+        &ClusterType::Development,
+    ));
+    let num_keys = 1000;
+    let slot = 0;
+    accounts.add_root(slot);
+    let pubkeys: Arc<Vec<_>> = Arc::new(
+        (0..num_keys)
+            .map(|_| {
+                let pubkey = Pubkey::new_rand();
+                let account = Account::new(1, 0, &Account::default().owner);
+                accounts.store_slow(slot, &pubkey, &account);
+                pubkey
+            })
+            .collect(),
+    );
+
+    for _ in 0..num_readers {
+        let accounts = accounts.clone();
+        let pubkeys = pubkeys.clone();
+        Builder::new()
+            .name("readers".to_string())
+            .spawn(move || {
+                let mut rng = rand::thread_rng();
+                loop {
+                    let i = rng.gen_range(0, num_keys);
+                    test::black_box(accounts.load_slow(&HashMap::new(), &pubkeys[i]).unwrap());
+                }
+            })
+            .unwrap();
+    }
+
+    let num_new_keys = 1000;
+    let new_accounts: Vec<_> = (0..num_new_keys)
+        .map(|_| Account::new(1, 0, &Account::default().owner))
+        .collect();
+    bencher.iter(|| {
+        for account in &new_accounts {
+            // Write to a different slot than the one being read from. Because
+            // there's a new account pubkey being written to every time, will
+            // compete for the accounts index lock on every store
+            accounts.store_slow(slot + 1, &Pubkey::new_rand(), &account);
+        }
+    })
 }
 
 #[bench]

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -12,8 +12,12 @@ use solana_sdk::{
     genesis_config::{create_genesis_config, ClusterType},
     pubkey::Pubkey,
 };
-use std::sync::RwLock;
-use std::{collections::HashMap, path::PathBuf, sync::Arc, thread::Builder};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+    thread::Builder,
+};
 use test::Bencher;
 
 fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -447,7 +447,6 @@ struct AccountsStats {
     delta_hash_num: AtomicU64,
 
     last_store_report: AtomicU64,
-    get_slot_stores: AtomicU64,
     store_hash_accounts: AtomicU64,
     store_accounts: AtomicU64,
     store_update_index: AtomicU64,
@@ -1364,12 +1363,7 @@ impl AccountsDB {
 
     fn find_storage_candidate(&self, slot: Slot) -> Arc<AccountStorageEntry> {
         let mut create_extra = false;
-        let mut get_slot_stores = Measure::start("get_slot_stores");
         let slot_stores_lock = self.storage.get_slot_stores(slot);
-        get_slot_stores.stop();
-        self.stats
-            .get_slot_stores
-            .fetch_add(get_slot_stores.as_us(), Ordering::Relaxed);
         if let Some(slot_stores_lock) = slot_stores_lock {
             let slot_stores = slot_stores_lock.read().unwrap();
             if !slot_stores.is_empty() {
@@ -1862,14 +1856,6 @@ impl AccountsDB {
                 self.stats
                     .delta_hash_accumulate_time_total_us
                     .swap(0, Ordering::Relaxed),
-                i64
-            ),
-        );
-        datapoint_info!(
-            "accounts_db_store_timings2",
-            (
-                "get_slot_stores",
-                self.stats.get_slot_stores.swap(0, Ordering::Relaxed),
                 i64
             ),
         );

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1410,20 +1410,16 @@ impl AccountsDB {
             Arc::new(self.new_storage_entry(slot, &Path::new(&self.paths[path_index]), size));
         let store_for_index = store.clone();
 
-        let slot_storages: SlotStores = self
-            .storage
-            .get_slot_stores(slot)
-            .or_else(||
+        let slot_storages: SlotStores = self.storage.get_slot_stores(slot).unwrap_or_else(||
             // DashMap entry.or_insert() returns a RefMut, essentially a write lock,
             // which is dropped after this block ends, minimizing time held by the lock.
             // However, we still want to persist the reference to the `SlotStores` behind
             // the lock, hence we clone it out, (`SlotStores` is an Arc so is cheap to clone).
-            Some(self.storage
+            self.storage
                 .0
                 .entry(slot)
                 .or_insert(Arc::new(RwLock::new(HashMap::new())))
-                .clone()))
-            .unwrap();
+                .clone());
 
         slot_storages
             .write()


### PR DESCRIPTION
#### Problem
@sakridge  noticed that `get_slot_storages()` in AccountsDb was occasionally very slow: 
<img width="1696" alt="Screen Shot 2020-10-19 at 11 22 09 PM" src="https://user-images.githubusercontent.com/3374799/96548018-fa930980-1261-11eb-94a7-eb6bd3366883.png">

#### Summary of Changes
At first I thought it might be some bug in `DashMap`, but I ran

1) The benchmarks as included in this PR here
2) Variations of this benchmark with multiple readers/no writers
3) Varying numbers of keys in the maps
4) Reading randomly chosen keys in the map instead of the same key 

And throughout DashMap seemed to outperform/perform as well as the `Arc<RwLock>`

Turns out the issue is holding the write lock on the dashmap while waiting on a separate write lock here: https://github.com/solana-labs/solana/blob/942e4273ba52cade3d0a3e93dd7661230c98466f/runtime/src/accounts_db.rs#L1418-L1421, where the second write lock is taking a while (probably contention with reads?). This makes me think it might be worthwhile to turn the inner SlotStore into a `DashMap` as well 😄 

The simplest fix is just add a clone here: https://github.com/solana-labs/solana/blob/942e4273ba52cade3d0a3e93dd7661230c98466f/runtime/src/accounts_db.rs#L1413-L1417 (tested and the results look good), but I think you can also avoid taking the write lock every time as this PR implements.

After results:
<img width="1591" alt="Screen Shot 2020-10-19 at 11 34 44 PM" src="https://user-images.githubusercontent.com/3374799/96549000-b6a10400-1263-11eb-988f-0a398260ded4.png">

Fixes #
