### PR TITLE
Fix signature index check in secp256k1 verify

### DIFF
--- a/sdk/src/secp256k1.rs
+++ b/sdk/src/secp256k1.rs
@@ -72,7 +72,7 @@ pub fn verify_eth_addresses(
 
         // Parse out signature
         let signature_index = offsets.signature_instruction_index as usize;
-        if signature_index > instruction_datas.len() {
+        if signature_index >= instruction_datas.len() {
             return Err(Secp256k1Error::InvalidInstructionDataSize);
         }
         let signature_instruction = instruction_datas[signature_index];


### PR DESCRIPTION
#### Problem
Index check doesn't prevent invalid indices properly. If `signature_index` is 1 and there is only one instruction data, the check doesn't fail.

#### Summary of Changes
- Fix off-by-one

Fixes #
