### PR TITLE
Explorer: speed up cluster stat loading

### DIFF
--- a/explorer/src/providers/stats/solanaDashboardInfo.tsx
+++ b/explorer/src/providers/stats/solanaDashboardInfo.tsx
@@ -45,13 +45,8 @@ export function dashboardInfoReducer(
   state: DashboardInfo,
   action: DashboardInfoAction
 ) {
-  const status =
-    state.avgSlotTime_1h !== 0 && state.epochInfo.absoluteSlot !== 0
-      ? ClusterStatsStatus.Ready
-      : ClusterStatsStatus.Loading;
-
   switch (action.type) {
-    case DashboardInfoActionType.SetPerfSamples:
+    case DashboardInfoActionType.SetPerfSamples: {
       if (action.data.length < 1) {
         return state;
       }
@@ -68,27 +63,43 @@ export function dashboardInfoReducer(
           return sum + cur;
         }, 0) / samplesInHour;
 
+      const status =
+        state.epochInfo.absoluteSlot !== 0
+          ? ClusterStatsStatus.Ready
+          : ClusterStatsStatus.Loading;
+
       return {
         ...state,
         avgSlotTime_1h,
         avgSlotTime_1min: samples[0],
         status,
       };
-    case DashboardInfoActionType.SetEpochInfo:
+    }
+
+    case DashboardInfoActionType.SetEpochInfo: {
+      const status =
+        state.avgSlotTime_1h !== 0
+          ? ClusterStatsStatus.Ready
+          : ClusterStatsStatus.Loading;
+
       return {
         ...state,
         epochInfo: action.data,
         status,
       };
+    }
+
     case DashboardInfoActionType.SetError:
       return {
         ...state,
         status: ClusterStatsStatus.Error,
       };
+
     case DashboardInfoActionType.Reset:
       return {
         ...action.data,
       };
+
     default:
       return state;
   }

--- a/explorer/src/providers/stats/solanaPerformanceInfo.tsx
+++ b/explorer/src/providers/stats/solanaPerformanceInfo.tsx
@@ -50,13 +50,8 @@ export function performanceInfoReducer(
   state: PerformanceInfo,
   action: PerformanceInfoAction
 ) {
-  const status =
-    state.avgTps !== 0 && state.transactionCount !== 0
-      ? ClusterStatsStatus.Ready
-      : ClusterStatsStatus.Loading;
-
   switch (action.type) {
-    case PerformanceInfoActionType.SetPerfSamples:
+    case PerformanceInfoActionType.SetPerfSamples: {
       if (action.data.length < 1) {
         return state;
       }
@@ -81,6 +76,11 @@ export function performanceInfoReducer(
         Math.max(...perfHistory.long)
       );
 
+      const status =
+        state.transactionCount !== 0
+          ? ClusterStatsStatus.Ready
+          : ClusterStatsStatus.Loading;
+
       return {
         ...state,
         historyMaxTps,
@@ -88,21 +88,32 @@ export function performanceInfoReducer(
         perfHistory,
         status,
       };
-    case PerformanceInfoActionType.SetTransactionCount:
+    }
+
+    case PerformanceInfoActionType.SetTransactionCount: {
+      const status =
+        state.avgTps !== 0
+          ? ClusterStatsStatus.Ready
+          : ClusterStatsStatus.Loading;
+
       return {
         ...state,
         transactionCount: action.data,
         status,
       };
+    }
+
     case PerformanceInfoActionType.SetError:
       return {
         ...state,
         status: ClusterStatsStatus.Error,
       };
+
     case PerformanceInfoActionType.Reset:
       return {
         ...action.data,
       };
+
     default:
       return state;
   }


### PR DESCRIPTION
#### Problem
Cluster stats are not shown until data has been fetched twice

#### Summary of Changes
Adjust reducer status calculation so that data is shown right away

Fixes #
