### PR TITLE
feat: disable loader rate limiter for non solana endpoints

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1446,6 +1446,7 @@ export type ConfirmedSignatureInfo = {
  * A connection to a fullnode JSON RPC endpoint
  */
 export class Connection {
+  _rpcEndpoint: string;
   _rpcRequest: RpcRequest;
   _rpcWebSocket: RpcWebSocketClient;
   _rpcWebSocketConnected: boolean = false;
@@ -1487,6 +1488,8 @@ export class Connection {
    * @param commitment optional default commitment level
    */
   constructor(endpoint: string, commitment: ?Commitment) {
+    this._rpcEndpoint = endpoint;
+
     let url = urlParse(endpoint);
     const useHttps = url.protocol === 'https:';
 

--- a/web3.js/src/loader.js
+++ b/web3.js/src/loader.js
@@ -67,7 +67,7 @@ export class Loader {
       // Fetch program account info to check if it has already been created
       const programInfo = await connection.getAccountInfo(
         program.publicKey,
-        'single',
+        'singleGossip',
       );
 
       let transaction: Transaction | null = null;
@@ -127,7 +127,7 @@ export class Loader {
           transaction,
           [payer, program],
           {
-            commitment: 'single',
+            commitment: 'singleGossip',
             skipPreflight: true,
           },
         );
@@ -169,22 +169,15 @@ export class Loader {
       });
       transactions.push(
         sendAndConfirmTransaction(connection, transaction, [payer, program], {
-          commitment: 'single',
+          commitment: 'singleGossip',
           skipPreflight: true,
         }),
       );
 
       // Delay between sends in an attempt to reduce rate limit errors
-      const REQUESTS_PER_SECOND = 4;
-      await sleep(1000 / REQUESTS_PER_SECOND);
-
-      // Run up to 8 Loads in parallel to prevent too many parallel transactions from
-      // getting retried due to AccountInUse errors.
-      //
-      // TODO: 8 was selected empirically and should probably be revisited
-      if (transactions.length === 8) {
-        await Promise.all(transactions);
-        transactions = [];
+      if (connection._rpcEndpoint.includes('solana.com')) {
+        const REQUESTS_PER_SECOND = 4;
+        await sleep(1000 / REQUESTS_PER_SECOND);
       }
 
       offset += chunkSize;
@@ -217,7 +210,7 @@ export class Loader {
         transaction,
         [payer, program],
         {
-          commitment: 'single',
+          commitment: 'singleGossip',
           skipPreflight: true,
         },
       );

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -27,7 +27,7 @@ test('load BPF C program', async () => {
 
   const data = await fs.readFile('test/fixtures/noop-c/noop.so');
 
-  const connection = new Connection(url, 'recent');
+  const connection = new Connection(url, 'singleGossip');
   const {feeCalculator} = await connection.getRecentBlockhash();
   const fees =
     feeCalculator.lamportsPerSignature *
@@ -53,7 +53,7 @@ test('load BPF C program', async () => {
     programId: program.publicKey,
   });
   await sendAndConfirmTransaction(connection, transaction, [from], {
-    commitment: 'single',
+    commitment: 'singleGossip',
     skipPreflight: true,
   });
 });
@@ -64,7 +64,7 @@ describe('load BPF Rust program', () => {
     return;
   }
 
-  const connection = new Connection(url, 'recent');
+  const connection = new Connection(url, 'singleGossip');
 
   let program: Account;
   let signature: string;

--- a/web3.js/test/new-account-with-lamports.js
+++ b/web3.js/test/new-account-with-lamports.js
@@ -30,7 +30,7 @@ export async function newAccountWithLamports(
     account.publicKey,
     lamports,
   );
-  await connection.confirmTransaction(signature, 'single');
+  await connection.confirmTransaction(signature, 'singleGossip');
 
   return account;
 }


### PR DESCRIPTION
#### Problem
The loader tries to avoid rate limiting by sleeping after each transaction send but rate limiting is only enabled on solana.com endpoints.

#### Summary of Changes
- Use `singleGossip` commitment instead of `single` for load instructions
- Disabled transaction batch awaits since we don't have to worry about `AccountInUse` errors anymore
- Added a simple check to disable rate limiting when the endpoint is not hosted on solana.com

The ideal change is to react to 429 with a connection scoped rate limiter, leaving that for the future.

Fixes #
