### PR TITLE
Add --eval flag to `solana-install info`

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -568,8 +568,20 @@ fn release_channel_version_url(release_channel: &str) -> String {
     )
 }
 
-pub fn info(config_file: &str, local_info_only: bool) -> Result<Option<UpdateManifest>, String> {
+pub fn info(
+    config_file: &str,
+    local_info_only: bool,
+    eval: bool,
+) -> Result<Option<UpdateManifest>, String> {
     let config = Config::load(config_file)?;
+
+    if eval {
+        println!(
+            "SOLANA_INSTALL_ACTIVE_RELEASE={}",
+            &config.active_release_dir().to_str().unwrap_or("")
+        );
+        return Ok(None);
+    }
 
     println_name_value("Configuration:", &config_file);
     println_name_value(
@@ -753,7 +765,7 @@ fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> std::io::Resul
 
 pub fn update(config_file: &str) -> Result<bool, String> {
     let mut config = Config::load(config_file)?;
-    let update_manifest = info(config_file, false)?;
+    let update_manifest = info(config_file, false, false)?;
 
     let release_dir = if let Some(explicit_release) = &config.explicit_release {
         let (download_url, release_dir) = match explicit_release {

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -160,6 +160,11 @@ pub fn main() -> Result<(), String> {
                         .help(
                         "only display local information, don't check the cluster for new updates",
                     ),
+                )
+                .arg(
+                    Arg::with_name("eval")
+                        .long("eval")
+                        .help("display information in a format that can be used with `eval`"),
                 ),
         )
         .subcommand(
@@ -234,7 +239,8 @@ pub fn main() -> Result<(), String> {
         ("init", Some(matches)) => handle_init(&matches, &config_file),
         ("info", Some(matches)) => {
             let local_info_only = matches.is_present("local_info_only");
-            command::info(config_file, local_info_only).map(|_| ())
+            let eval = matches.is_present("eval");
+            command::info(config_file, local_info_only, eval).map(|_| ())
         }
         ("deploy", Some(matches)) => {
             let from_keypair_file = matches.value_of("from_keypair_file").unwrap();


### PR DESCRIPTION
```
$ solana-install info --eval
SOLANA_INSTALL_ACTIVE_RELEASE=/Users/mvines/.local/share/solana/install/active_release
```

I'm keeping the output slim for now, just a single `SOLANA_INSTALL_ACTIVE_RELEASE` env var.  More can be added later if needed