### PR TITLE
Force unset CARGO to use correct version of cargo

### DIFF
--- a/sdk/bpf/rust/build.sh
+++ b/sdk/bpf/rust/build.sh
@@ -34,6 +34,10 @@ export RUSTFLAGS="
     -C link-arg=-no-threads \
     -C linker=$bpf_sdk/dependencies/llvm-native/bin/ld.lld"
 
+# CARGO may be set if build.sh is run from within cargo, causing
+# incompatibilities between cargo and xargo versions
+unset CARGO
+
 # Setup xargo
 export XARGO_HOME="$bpf_sdk/dependencies/xargo"
 export XARGO_RUST_SRC="$bpf_sdk/dependencies/rust-bpf-sysroot/src"


### PR DESCRIPTION
#### Problem

If `build.sh` is run from within `cargo` on Linux environments, it can fail because CARGO is set to the wrong executable.

#### Summary of Changes

Force CARGO to be unset

Fixes https://github.com/solana-labs/solana-program-library/issues/646
