### PR TITLE
ci: Include sdk/bpf in the main release tarball

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -85,6 +85,9 @@ echo --- Creating release tarball
   source ci/rust-version.sh stable
   scripts/cargo-install-all.sh +"$rust_stable" "${RELEASE_BASENAME}"
 
+  mkdir -p "${RELEASE_BASENAME}"/bin/sdk/bpf
+  cp -a sdk/bpf/* "${RELEASE_BASENAME}"/bin/sdk/bpf
+
   tar cvf "${TARBALL_BASENAME}"-$TARGET.tar "${RELEASE_BASENAME}"
   bzip2 "${TARBALL_BASENAME}"-$TARGET.tar
   cp "${RELEASE_BASENAME}"/bin/solana-install-init solana-install-init-$TARGET


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana-program-library/blob/master/bpf-sdk-install.sh

#### Summary of Changes
`bpf-sdk.tar.bz2` is small enough to embedded directly into what `solana-install init` installs.   Then with the help of 
https://github.com/solana-labs/solana/pull/13025, you can easily build a program with your current solana install:
```bash
$ $(eval solana-install info --eval)
$ ${SOLANA_INSTALL_ACTIVE_RELEASE}/bin/bpf-sdk/rust/build.sh .
```
(at least for now, until we make this even easier)