### PR TITLE
Fix test_optimistic_confirmation_violation_without_tower()

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1804,16 +1804,20 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
 
     // monitor for actual votes from validator A
     let mut bad_vote_detected = false;
+    let mut a_votes = vec![];
     for _ in 0..100 {
         sleep(Duration::from_millis(100));
 
         if let Some(last_vote) = last_vote_in_tower(&val_a_ledger_path, &validator_a_pubkey) {
+            a_votes.push(last_vote);
             if votes_on_c_fork.contains(&last_vote) {
                 bad_vote_detected = true;
                 break;
             }
         }
     }
+
+    info!("Observed A's votes on: {:?}", a_votes);
 
     // an elaborate way of assert!(with_tower && !bad_vote_detected || ...)
     let expects_optimistic_confirmation_violation = !with_tower;

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1821,12 +1821,10 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
                 None,
             )
             .unwrap();
-            let ancestors = AncestorIterator::new(last_vote, &blockstore);
-            for a in ancestors {
-                if votes_on_c_fork.contains(&a) {
-                    bad_vote_detected = true;
-                    break;
-                }
+            let mut ancestors = AncestorIterator::new(last_vote, &blockstore);
+            if ancestors.any(|a| votes_on_c_fork.contains(&a)) {
+                bad_vote_detected = true;
+                break;
             }
         }
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1680,9 +1680,9 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
     // Each pubkeys are prefixed with A, B, C and D.
     // D is needed to:
     // 1) Propagate A's votes for S2 to validator C after A shuts down so that
-    // C can avoid NoPropagatedConfirmation erorrs and continue to generate blocks
-    // 2) Provide gosisp discovery for `A` when it restarts because `A` will restart
-    // at a different gossip port than the entrypoint saved in C's gosisp table
+    // C can avoid NoPropagatedConfirmation errors and continue to generate blocks
+    // 2) Provide gossip discovery for `A` when it restarts because `A` will restart
+    // at a different gossip port than the entrypoint saved in C's gossip table
     let validator_keys = vec![
         "28bN3xyvrP4E8LwEgtLjhnkb7cY4amQb6DrYAbAYjgRV4GAGgkVM2K7wnxnAS7WDneuavza7x21MiafLu1HkwQt4",
         "2saHBBoTkLMmttmPQP8KfBkcCw45S5cwtV3wTdGCscRC8uxdgvHxpHiWXKx4LvJjNJtnNcbSv5NdheokFFqnNDt8",


### PR DESCRIPTION
#### Problem
`test_optimistic_confirmation_violation_without_tower` is flaky with failure message: `"Violation expected because of removed persisted tower!"`. Example of failure case:

```
[2020-10-20T22:12:25.389384948Z INFO  local_cluster] collected validator C's votes: {29, 30, 31, 32}
[2020-10-20T22:12:36.152101878Z INFO  local_cluster] Observed A's votes on: [
    26, 26, 26, 26, 26, 26, 26, 26, 26, 33, 33, 33, 33, 33, 33, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 35, 44, 44, 44, 44, 44, 45, 45, 45, 45, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 46, 52, 52, 52, 52, 53, 53, 53, 53, 53, 53, 53, 53, 53, 53]
```
A's vote on `33` is a descendant of `C`'s block 32, but the test doesn't recognize this.

#### Summary of Changes
Check blockstore for descendants check 
Fixes #
