### PR TITLE
CLI: Print address ephemeral keypair seed phrase to stderr on deploy failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,6 +3630,7 @@ dependencies = [
  "solana_rbpf",
  "tempfile",
  "thiserror",
+ "tiny-bip39",
  "url 2.1.1",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,6 +47,7 @@ solana-version = { path = "../version", version = "1.5.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.5.0" }
 solana-vote-signer = { path = "../vote-signer", version = "1.5.0" }
 thiserror = "1.0.21"
+tiny-bip39 = "0.7.0"
 url = "2.1.1"
 
 [dev-dependencies]


### PR DESCRIPTION
#### Problem

`solana deploy` falls back to an ephemeral address keypair if the user doesn't supply one. Since the user doesn't have the keypair, failed deploys can't be retried, leading to bricked accounts

#### Summary of Changes

Generate the ephemeral keypair via BIP39 seed phrase and print it to `stderr` on error


```
$ solana deploy yep.so
==============================================================================
To reuse this address, recover the ephemeral keypair file with
`solana-keygen recover` and the following 12-word seed phrase,
then pass it as the [ADDRESS_SIGNER] argument to `solana deploy ...`
==============================================================================
tuna arrive fantasy favorite decide acoustic winner toss art measure this wild
==============================================================================
Error: oh no!
```