### PR TITLE
RPC: Don't send base64 TXs to old clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,6 +2444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pickledb"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,7 +3025,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -3139,7 +3148,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.1",
 ]
 
 [[package]]
@@ -3147,6 +3165,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -3681,6 +3708,7 @@ dependencies = [
  "log 0.4.8",
  "rayon",
  "reqwest",
+ "semver 0.11.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3690,6 +3718,7 @@ dependencies = [
  "solana-net-utils",
  "solana-sdk 1.5.0",
  "solana-transaction-status",
+ "solana-version",
  "solana-vote-program",
  "thiserror",
  "tungstenite",
@@ -3992,7 +4021,7 @@ dependencies = [
  "lazy_static",
  "nix",
  "reqwest",
- "semver",
+ "semver 0.9.0",
  "serde",
  "serde_derive",
  "serde_yaml",
@@ -4348,7 +4377,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "parking_lot 0.10.2",
- "semver",
+ "semver 0.9.0",
  "solana-sdk 1.5.0",
  "thiserror",
  "url 2.1.1",
@@ -5877,6 +5906,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,6 +18,7 @@ jsonrpc-core = "15.0.0"
 log = "0.4.8"
 rayon = "1.4.0"
 reqwest = { version = "0.10.8", default-features = false, features = ["blocking", "rustls-tls", "json"] }
+semver = "0.11.0"
 serde = "1.0.112"
 serde_derive = "1.0.103"
 serde_json = "1.0.56"
@@ -26,6 +27,7 @@ solana-clap-utils = { path = "../clap-utils", version = "1.5.0" }
 solana-net-utils = { path = "../net-utils", version = "1.5.0" }
 solana-sdk = { path = "../sdk", version = "1.5.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.5.0" }
+solana-version = { path = "../version", version = "1.5.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.5.0" }
 thiserror = "1.0"
 tungstenite = "0.10.1"

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -1,10 +1,10 @@
 use crate::{
     client_error::Result,
     rpc_request::RpcRequest,
-    rpc_response::{Response, RpcResponseContext},
+    rpc_response::{Response, RpcResponseContext, RpcVersionInfo},
     rpc_sender::RpcSender,
 };
-use serde_json::{Number, Value};
+use serde_json::{json, Number, Value};
 use solana_sdk::{
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     instruction::InstructionError,
@@ -12,6 +12,7 @@ use solana_sdk::{
     transaction::{self, Transaction, TransactionError},
 };
 use solana_transaction_status::TransactionStatus;
+use solana_version::Version;
 use std::{collections::HashMap, sync::RwLock};
 
 pub const PUBKEY: &str = "7RoSF9fUmdphVCpabEoefH81WwrW7orsWonXWqTXkKV8";
@@ -119,6 +120,13 @@ impl RpcSender for MockSender {
                 Value::String(signature)
             }
             RpcRequest::GetMinimumBalanceForRentExemption => Value::Number(Number::from(20)),
+            RpcRequest::GetVersion => {
+                let version = Version::default();
+                json!(RpcVersionInfo {
+                    solana_core: version.to_string(),
+                    feature_set: Some(version.feature_set),
+                })
+            }
             _ => Value::Null,
         };
         Ok(val)


### PR DESCRIPTION
#### Problem

There are still some pre-1.3.16 development clusters in the wild.  They don't like `base64` TXs from newer CLIs

#### Summary of Changes

Query the cluster version when sending a TX and encode `base58` if it's older than 1.3.16