### PR TITLE
Add ledger-tool dead-slots and improve purge a lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,6 +4117,7 @@ dependencies = [
  "futures 0.3.5",
  "futures-util",
  "histogram",
+ "itertools 0.9.0",
  "log 0.4.8",
  "regex",
  "serde_json",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -934,8 +934,8 @@ fn backup_and_clear_blockstore(ledger_path: &Path, start_slot: Slot, shred_versi
 
         let end_slot = last_slot.unwrap();
         info!("Purging slots {} to {}", start_slot, end_slot);
-        blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact);
         blockstore.purge_from_next_slots(start_slot, end_slot);
+        blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact);
         info!("Purging done, compacting db..");
         if let Err(e) = blockstore.compact_storage(start_slot, end_slot) {
             warn!(

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -15,6 +15,7 @@ clap = "2.33.1"
 futures = "0.3.5"
 futures-util = "0.3.5"
 histogram = "*"
+itertools = "0.9.0"
 log = { version = "0.4.8" }
 regex = "1"
 serde_json = "1.0.56"

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1214,7 +1214,7 @@ fn main() {
                     .long("batch-size")
                     .value_name("NUM")
                     .takes_value(true)
-                    .default_value("10_000")
+                    .default_value("1_000")
                     .help("Removes at most BATCH_SIZE slots while purging in loop"),
             )
             .arg(

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -59,7 +59,11 @@ impl Blockstore {
             meta.next_slots
                 .retain(|slot| *slot < from_slot || *slot > to_slot);
             if meta.next_slots.len() != original_len {
-                info!("purge_from_next_slots: adjusted meta for slot {}", slot);
+                info!(
+                    "purge_from_next_slots: meta for slot {} no longer refers to slots {:?}",
+                    slot,
+                    from_slot..=to_slot
+                );
                 self.put_meta_bytes(
                     slot,
                     &bincode::serialize(&meta).expect("couldn't update meta"),


### PR DESCRIPTION
#### Problem

We need to support an incident where a validator must recover from very old slot (which are marked as dead because of corruption for unknown reason).

#### Summary of Changes

- Add debugging subcommand called `ledger-tool dead-slots` which just prints the dead slots.
- Fix unbound memory grow of `ledger-tool purge` by batching. Previously, we tried to create infinitely-large (well, practically) rockdb's WriteBatch, resulting in `std::bad_alloc` from libstd++ in librocksdb.
- Improve performance of `ledger-tool purge` by really disabling auto and manual compaction (--no-compaction haven't working to begin with due to a bug....)...

Combined with the changes, it's still slow but tolerable and finally we can purge any number of slots.

Note: This pr should be quickly backported way down to v1.3, so I tried to keep minimize diff and risk (of bugs).

Fixes #12907 