### PR TITLE
scans crds table in parallel for finding old labels

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -95,6 +95,9 @@ name = "banking_stage"
 name = "blockstore"
 
 [[bench]]
+name = "crds"
+
+[[bench]]
 name = "crds_gossip_pull"
 
 [[bench]]

--- a/core/benches/crds.rs
+++ b/core/benches/crds.rs
@@ -16,26 +16,16 @@ fn bench_find_old_labels(bencher: &mut Bencher) {
     let thread_pool = ThreadPoolBuilder::new().build().unwrap();
     let mut rng = thread_rng();
     let mut crds = Crds::default();
-    let mut num_inserts = 0;
     let now = CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS + CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS / 1000;
-    for _ in 0..50_000 {
-        if crds
-            .insert(CrdsValue::new_rand(&mut rng), rng.gen_range(0, now))
-            .is_ok()
-        {
-            num_inserts += 1;
-        }
-    }
-    assert_eq!(num_inserts, 50_000);
+    std::iter::repeat_with(|| (CrdsValue::new_rand(&mut rng), rng.gen_range(0, now)))
+        .take(50_000)
+        .for_each(|(v, ts)| assert!(crds.insert(v, ts).is_ok()));
     let mut timeouts = HashMap::new();
     timeouts.insert(Pubkey::default(), CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS);
-    let mut fail = 0;
     bencher.iter(|| {
-        let out = crds.find_old_labels(&thread_pool, now, &timeouts).len();
-        if out < 10 || out > 250 {
-            fail += 1;
-        }
+        let out = crds.find_old_labels(&thread_pool, now, &timeouts);
+        assert!(out.len() > 10);
+        assert!(out.len() < 250);
         out
     });
-    assert_eq!(fail, 0);
 }

--- a/core/benches/crds.rs
+++ b/core/benches/crds.rs
@@ -1,0 +1,41 @@
+#![feature(test)]
+
+extern crate test;
+
+use rand::{thread_rng, Rng};
+use rayon::ThreadPoolBuilder;
+use solana_core::crds::Crds;
+use solana_core::crds_gossip_pull::CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS;
+use solana_core::crds_value::CrdsValue;
+use solana_sdk::pubkey::Pubkey;
+use std::collections::HashMap;
+use test::Bencher;
+
+#[bench]
+fn bench_find_old_labels(bencher: &mut Bencher) {
+    let thread_pool = ThreadPoolBuilder::new().build().unwrap();
+    let mut rng = thread_rng();
+    let mut crds = Crds::default();
+    let mut num_inserts = 0;
+    let now = CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS + CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS / 1000;
+    for _ in 0..50_000 {
+        if crds
+            .insert(CrdsValue::new_rand(&mut rng), rng.gen_range(0, now))
+            .is_ok()
+        {
+            num_inserts += 1;
+        }
+    }
+    assert_eq!(num_inserts, 50_000);
+    let mut timeouts = HashMap::new();
+    timeouts.insert(Pubkey::default(), CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS);
+    let mut fail = 0;
+    bencher.iter(|| {
+        let out = crds.find_old_labels(&thread_pool, now, &timeouts).len();
+        if out < 10 || out > 250 {
+            fail += 1;
+        }
+        out
+    });
+    assert_eq!(fail, 0);
+}

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1665,6 +1665,7 @@ impl ClusterInfo {
 
     fn handle_purge(
         self: &Arc<Self>,
+        thread_pool: &ThreadPool,
         bank_forks: &Option<Arc<RwLock<BankForks>>>,
         stakes: &HashMap<Pubkey, u64>,
     ) {
@@ -1682,7 +1683,7 @@ impl ClusterInfo {
         let timeouts = self.gossip.read().unwrap().make_timeouts(stakes, timeout);
         let num_purged = self
             .time_gossip_write_lock("purge", &self.stats.purge)
-            .purge(timestamp(), &timeouts);
+            .purge(thread_pool, timestamp(), &timeouts);
         inc_new_counter_info!("cluster_info-purge-count", num_purged);
     }
 
@@ -1743,7 +1744,7 @@ impl ClusterInfo {
                         return;
                     }
 
-                    self.handle_purge(&bank_forks, &stakes);
+                    self.handle_purge(&thread_pool, &bank_forks, &stakes);
 
                     self.handle_adopt_shred_version(&mut adopt_shred_version);
 

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -232,7 +232,12 @@ impl CrdsGossip {
         self.pull.make_timeouts(&self.id, stakes, epoch_ms)
     }
 
-    pub fn purge(&mut self, now: u64, timeouts: &HashMap<Pubkey, u64>) -> usize {
+    pub fn purge(
+        &mut self,
+        thread_pool: &ThreadPool,
+        now: u64,
+        timeouts: &HashMap<Pubkey, u64>,
+    ) -> usize {
         let mut rv = 0;
         if now > self.push.msg_timeout {
             let min = now - self.push.msg_timeout;
@@ -247,7 +252,9 @@ impl CrdsGossip {
             let min = self.pull.crds_timeout;
             assert_eq!(timeouts[&self.id], std::u64::MAX);
             assert_eq!(timeouts[&Pubkey::default()], min);
-            rv = self.pull.purge_active(&mut self.crds, now, &timeouts);
+            rv = self
+                .pull
+                .purge_active(thread_pool, &mut self.crds, now, &timeouts);
         }
         if now > 5 * self.pull.crds_timeout {
             let min = now - 5 * self.pull.crds_timeout;

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -254,7 +254,7 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
             );
         });
         // push for a bit
-        let (queue_size, bytes_tx) = network_run_push(network, start, end);
+        let (queue_size, bytes_tx) = network_run_push(thread_pool, network, start, end);
         total_bytes += bytes_tx;
         trace!(
             "network_simulator_push_{}: queue_size: {} bytes: {}",
@@ -278,7 +278,12 @@ fn network_simulator(thread_pool: &ThreadPool, network: &mut Network, max_conver
     }
 }
 
-fn network_run_push(network: &mut Network, start: usize, end: usize) -> (usize, usize) {
+fn network_run_push(
+    thread_pool: &ThreadPool,
+    network: &mut Network,
+    start: usize,
+    end: usize,
+) -> (usize, usize) {
     let mut bytes: usize = 0;
     let mut num_msgs: usize = 0;
     let mut total: usize = 0;
@@ -295,7 +300,7 @@ fn network_run_push(network: &mut Network, start: usize, end: usize) -> (usize, 
             .map(|node| {
                 let mut node_lock = node.lock().unwrap();
                 let timeouts = node_lock.make_timeouts_test();
-                node_lock.purge(now, &timeouts);
+                node_lock.purge(thread_pool, now, &timeouts);
                 node_lock.new_push_messages(vec![], now)
             })
             .collect();


### PR DESCRIPTION
#### Problem
From runtime profiles, the majority time of ClusterInfo::handle_purge
https://github.com/solana-labs/solana/blob/0776fa05c/core/src/cluster_info.rs#L1605-L1626
is spent scanning crds table finding old labels:
https://github.com/solana-labs/solana/blob/0776fa05c/core/src/crds.rs#L175-L197

This can be done in parallel given that gossip thread-pool:
https://github.com/solana-labs/solana/blob/0776fa05c/core/src/cluster_info.rs#L1637-L1641
is idle when handle_purge is invoked:
https://github.com/solana-labs/solana/blob/0776fa05c/core/src/cluster_info.rs#L1681

#### Summary of Changes
Updated the code to use rayon parallel iterators.
For a crds table roughly the size of current mainnet, I see ~4x speed up on my machine with 4 cores.