### PR TITLE
Cli: deploy programs via TPU

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1033,6 +1033,7 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
     let mut leader_schedule: Option<RpcLeaderSchedule> = None;
     let mut leader_schedule_epoch = 0;
     let send_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+    let cluster_nodes = rpc_client.get_cluster_nodes().ok();
 
     loop {
         let mut status_retries = 15;
@@ -1044,8 +1045,11 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
                 .get_leader_schedule_with_commitment(Some(epoch_info.absolute_slot), commitment)?;
             leader_schedule_epoch = epoch_info.epoch;
         }
-        let tpu_address =
-            get_leader_tpu(rpc_client, epoch_info.slot_index, leader_schedule.as_ref());
+        let tpu_address = get_leader_tpu(
+            epoch_info.slot_index,
+            leader_schedule.as_ref(),
+            cluster_nodes.as_ref(),
+        );
 
         // Send all transactions
         let mut pending_transactions = HashMap::new();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,7 +1,8 @@
 use crate::{
-    checks::*, cluster_query::*, feature::*, inflation::*, nonce::*, spend_utils::*, stake::*,
-    validator_info::*, vote::*,
+    checks::*, cluster_query::*, feature::*, inflation::*, nonce::*, send_tpu::*, spend_utils::*,
+    stake::*, validator_info::*, vote::*,
 };
+use bincode::serialize;
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use clap::{value_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand};
 use log::*;
@@ -32,7 +33,7 @@ use solana_client::{
     rpc_client::RpcClient,
     rpc_config::{RpcLargestAccountsFilter, RpcSendTransactionConfig},
     rpc_request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS,
-    rpc_response::RpcKeyedAccount,
+    rpc_response::{RpcKeyedAccount, RpcLeaderSchedule},
 };
 #[cfg(not(test))]
 use solana_faucet::faucet::request_airdrop_transaction;
@@ -42,7 +43,7 @@ use solana_rbpf::vm::EbpfVm;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     bpf_loader, bpf_loader_deprecated,
-    clock::{Epoch, Slot, DEFAULT_TICKS_PER_SECOND},
+    clock::{Epoch, Slot},
     commitment_config::CommitmentConfig,
     decode_error::DecodeError,
     hash::Hash,
@@ -68,7 +69,7 @@ use std::{
     fmt::Write as FmtWrite,
     fs::File,
     io::{Read, Write},
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, SocketAddr, UdpSocket},
     str::FromStr,
     sync::Arc,
     thread::sleep,
@@ -1029,33 +1030,46 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
 ) -> Result<(), Box<dyn error::Error>> {
     let progress_bar = new_spinner_progress_bar();
     let mut send_retries = 5;
+    let mut leader_schedule: Option<RpcLeaderSchedule> = None;
+    let mut leader_schedule_epoch = 0;
+    let send_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+
     loop {
         let mut status_retries = 15;
+
+        progress_bar.set_message("Finding leader node...");
+        let epoch_info = rpc_client.get_epoch_info_with_commitment(commitment)?;
+        if epoch_info.epoch > leader_schedule_epoch || leader_schedule.is_none() {
+            leader_schedule = rpc_client
+                .get_leader_schedule_with_commitment(Some(epoch_info.absolute_slot), commitment)?;
+            leader_schedule_epoch = epoch_info.epoch;
+        }
+        let tpu_address =
+            get_leader_tpu(rpc_client, epoch_info.slot_index, leader_schedule.as_ref());
 
         // Send all transactions
         let mut pending_transactions = HashMap::new();
         let num_transactions = transactions.len();
         for transaction in transactions {
-            if cfg!(not(test)) {
-                // Delay ~1 tick between write transactions in an attempt to reduce AccountInUse errors
-                // when all the write transactions modify the same program account (eg, deploying a
-                // new program)
-                sleep(Duration::from_millis(1000 / DEFAULT_TICKS_PER_SECOND));
+            if let Some(tpu_address) = tpu_address {
+                let wire_transaction =
+                    serialize(&transaction).expect("serialization should succeed");
+                send_transaction_tpu(&send_socket, &tpu_address, &wire_transaction);
+            } else {
+                let _result = rpc_client
+                    .send_transaction_with_config(
+                        &transaction,
+                        RpcSendTransactionConfig {
+                            preflight_commitment: Some(commitment.commitment),
+                            ..RpcSendTransactionConfig::default()
+                        },
+                    )
+                    .ok();
             }
-
-            let _result = rpc_client
-                .send_transaction_with_config(
-                    &transaction,
-                    RpcSendTransactionConfig {
-                        preflight_commitment: Some(commitment.commitment),
-                        ..RpcSendTransactionConfig::default()
-                    },
-                )
-                .ok();
             pending_transactions.insert(transaction.signatures[0], transaction);
 
             progress_bar.set_message(&format!(
-                "[{}/{}] Transactions sent",
+                "[{}/{}] Total Transactions sent",
                 pending_transactions.len(),
                 num_transactions
             ));

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -64,6 +64,7 @@ use solana_stake_program::{
 use solana_transaction_status::{EncodedTransaction, UiTransactionEncoding};
 use solana_vote_program::vote_state::VoteAuthorize;
 use std::{
+    cmp::min,
     collections::HashMap,
     error,
     fmt::Write as FmtWrite,
@@ -1046,7 +1047,7 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
             leader_schedule_epoch = epoch_info.epoch;
         }
         let tpu_address = get_leader_tpu(
-            epoch_info.slot_index,
+            min(epoch_info.slot_index + 1, epoch_info.slots_in_epoch),
             leader_schedule.as_ref(),
             cluster_nodes.as_ref(),
         );

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1105,6 +1105,11 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
                         let _ = pending_transactions.remove(&signature);
                     }
                 }
+                progress_bar.set_message(&format!(
+                    "[{}/{}] Transactions confirmed",
+                    num_transactions - pending_transactions.len(),
+                    num_transactions
+                ));
             }
 
             if pending_transactions.is_empty() {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -26,6 +26,7 @@ pub mod cluster_query;
 pub mod feature;
 pub mod inflation;
 pub mod nonce;
+pub mod send_tpu;
 pub mod spend_utils;
 pub mod stake;
 pub mod test_utils;

--- a/cli/src/send_tpu.rs
+++ b/cli/src/send_tpu.rs
@@ -1,0 +1,31 @@
+use log::*;
+use solana_client::{rpc_client::RpcClient, rpc_response::RpcLeaderSchedule};
+use std::net::{SocketAddr, UdpSocket};
+
+pub fn get_leader_tpu(
+    rpc_client: &RpcClient,
+    slot_index: u64,
+    leader_schedule: Option<&RpcLeaderSchedule>,
+) -> Option<SocketAddr> {
+    let leader_schedule = leader_schedule?;
+    leader_schedule
+        .iter()
+        .find(|(_pubkey, slots)| slots.iter().any(|slot| *slot as u64 == slot_index))
+        .and_then(|(pubkey, _)| {
+            let cluster_nodes = rpc_client.get_cluster_nodes().ok()?;
+            cluster_nodes
+                .iter()
+                .find(|contact_info| contact_info.pubkey == *pubkey)
+                .and_then(|contact_info| contact_info.tpu)
+        })
+}
+
+pub fn send_transaction_tpu(
+    send_socket: &UdpSocket,
+    tpu_address: &SocketAddr,
+    wire_transaction: &[u8],
+) {
+    if let Err(err) = send_socket.send_to(wire_transaction, tpu_address) {
+        warn!("Failed to send transaction to {}: {:?}", tpu_address, err);
+    }
+}

--- a/cli/src/send_tpu.rs
+++ b/cli/src/send_tpu.rs
@@ -1,19 +1,17 @@
 use log::*;
-use solana_client::{rpc_client::RpcClient, rpc_response::RpcLeaderSchedule};
+use solana_client::rpc_response::{RpcContactInfo, RpcLeaderSchedule};
 use std::net::{SocketAddr, UdpSocket};
 
 pub fn get_leader_tpu(
-    rpc_client: &RpcClient,
     slot_index: u64,
     leader_schedule: Option<&RpcLeaderSchedule>,
+    cluster_nodes: Option<&Vec<RpcContactInfo>>,
 ) -> Option<SocketAddr> {
-    let leader_schedule = leader_schedule?;
-    leader_schedule
+    leader_schedule?
         .iter()
         .find(|(_pubkey, slots)| slots.iter().any(|slot| *slot as u64 == slot_index))
         .and_then(|(pubkey, _)| {
-            let cluster_nodes = rpc_client.get_cluster_nodes().ok()?;
-            cluster_nodes
+            cluster_nodes?
                 .iter()
                 .find(|contact_info| contact_info.pubkey == *pubkey)
                 .and_then(|contact_info| contact_info.tpu)

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use serde_json::{json, Number, Value};
 use solana_sdk::{
+    epoch_info::EpochInfo,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
     instruction::InstructionError,
     signature::Signature,
@@ -57,6 +58,13 @@ impl RpcSender for MockSender {
                     Value::String(PUBKEY.to_string()),
                     serde_json::to_value(FeeCalculator::default()).unwrap(),
                 ),
+            })?,
+            RpcRequest::GetEpochInfo => serde_json::to_value(EpochInfo {
+                epoch: 1,
+                slot_index: 2,
+                slots_in_epoch: 32,
+                absolute_slot: 34,
+                block_height: 34,
             })?,
             RpcRequest::GetFeeCalculatorForBlockhash => {
                 let value = if self.url == "blockhash_expired" {


### PR DESCRIPTION
#### Problem
`solana deploy` takes a long time against our public api nodes. HTTP request rate limiting slows transaction sends such that the blockhash expires before they are all even sent.

#### Summary of Changes
- Attempt to get the current leader's TPU address; if available, send program write transactions via TPU. Fallback to rpc if the leader can't be found.

Devnet: rate limit to 10 RPC requests in 2 seconds per IP
```
// With PR

$ time solana deploy spl_token_024.so --url http://devnet.solana.com
{"programId":"68vX6g5xLsoGKySjRY7ZgUTou7Mg6ivcACPCG7tdbv2t"}

real	1m33.757s
user	0m57.342s
sys	0m9.733s

// Master

$ time solana deploy spl_token_024.so --url http://devnet.solana.com
{"programId":"B748YAyHuV8q3F74R1yFs3QgXtf5YzdBTqEEQB15JbF9"}

real	10m32.374s
user	0m12.001s
sys	0m1.351s
```

Testnet: rate limit to 300 RPC requests in 1 seconds per IP
```
// With PR

$ time solana deploy spl_token_024.so --url http://testnet.solana.com
{"programId":"DJVbdCLvtRryDrZ6Xm7jEzqVbGjSQ7NwBV65e3rNfvyq"}

real	1m20.150s
user	0m2.821s
sys	0m0.383s

// Master 

$ time solana deploy spl_token_024.so --url http://testnet.solana.com
{"programId":"5uYhY3o1Pm9a23VReztPqh4gRfswAifmSKDnLqedsGwh"}

real	3m23.030s
user	0m56.253s
sys	0m9.604s
```
