### PR TITLE
Add deploy err if program-account balance is too high

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1242,7 +1242,10 @@ fn do_process_deploy(
                 balance,
             ));
             balance_needed = balance;
-        } else if account.lamports > minimum_balance && !force_use_program_address {
+        } else if account.lamports > minimum_balance
+            && system_program::check_id(&account.owner)
+            && !force_use_program_address
+        {
             return Err(CliError::DynamicProgramError(format!(
                 "Program account has a balance: {:?}; it may already be in use",
                 Sol(account.lamports)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -49,6 +49,7 @@ use solana_sdk::{
     instruction::{Instruction, InstructionError},
     loader_instruction,
     message::Message,
+    native_token::Sol,
     pubkey::{Pubkey, MAX_SEED_LEN},
     signature::{keypair_from_seed, Keypair, Signature, Signer, SignerError},
     signers::Signers,
@@ -178,6 +179,7 @@ pub enum CliCommand {
         program_location: String,
         address: Option<SignerIndex>,
         use_deprecated_loader: bool,
+        force_use_system_account: bool,
     },
     // Stake Commands
     CreateStakeAccount {
@@ -609,13 +611,13 @@ pub fn parse_command(
                 signers.push(signer);
                 1
             });
-            let use_deprecated_loader = matches.is_present("use_deprecated_loader");
 
             Ok(CliCommandInfo {
                 command: CliCommand::Deploy {
                     program_location: matches.value_of("program_location").unwrap().to_string(),
                     address,
-                    use_deprecated_loader,
+                    use_deprecated_loader: matches.is_present("use_deprecated_loader"),
+                    force_use_system_account: matches.is_present("force_use_system_account"),
                 },
                 signers,
             })
@@ -1132,6 +1134,7 @@ fn process_deploy(
     program_location: &str,
     address: Option<SignerIndex>,
     use_deprecated_loader: bool,
+    force_use_system_account: bool,
 ) -> ProcessResult {
     const WORDS: usize = 12;
     // Create ephemeral keypair to use for program address, if not provided
@@ -1145,6 +1148,7 @@ fn process_deploy(
         program_location,
         address,
         use_deprecated_loader,
+        force_use_system_account,
         new_keypair,
     );
 
@@ -1173,6 +1177,7 @@ fn do_process_deploy(
     program_location: &str,
     address: Option<SignerIndex>,
     use_deprecated_loader: bool,
+    force_use_system_account: bool,
     new_keypair: Keypair,
 ) -> ProcessResult {
     let program_id = if let Some(i) = address {
@@ -1237,6 +1242,12 @@ fn do_process_deploy(
                 balance,
             ));
             balance_needed = balance;
+        } else if account.lamports > minimum_balance && !force_use_system_account {
+            return Err(CliError::DynamicProgramError(format!(
+                "Program account has a balance: {:?}; it may already be in use",
+                Sol(account.lamports)
+            ))
+            .into());
         }
         (instructions, balance_needed)
     } else {
@@ -1619,12 +1630,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             program_location,
             address,
             use_deprecated_loader,
+            force_use_system_account,
         } => process_deploy(
             &rpc_client,
             config,
             program_location,
             *address,
             *use_deprecated_loader,
+            *force_use_system_account,
         ),
 
         // Stake Commands
@@ -2241,7 +2254,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .arg(
                     Arg::with_name("address_signer")
                         .index(2)
-                        .value_name("ADDRESS_SIGNER")
+                        .value_name("PROGRAM_ADDRESS_SIGNER")
                         .takes_value(true)
                         .validator(is_valid_signer)
                         .help("The signer for the desired address of the program [default: new random address]")
@@ -2252,6 +2265,13 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(false)
                         .hidden(true) // Don't document this argument to discourage its use
                         .help("Use the deprecated BPF loader")
+                )
+                .arg(
+                    Arg::with_name("force_use_system_account")
+                        .long("force-use-system-account")
+                        .takes_value(false)
+                        .hidden(true) // Don't document this argument to discourage its use
+                        .help("Use the designated program id, even if it already holds a balance of SOL")
                 )
                 .arg(commitment_arg_with_default("max")),
         )
@@ -2621,6 +2641,7 @@ mod tests {
                     program_location: "/Users/test/program.o".to_string(),
                     address: None,
                     use_deprecated_loader: false,
+                    force_use_system_account: false,
                 },
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
             }
@@ -2642,6 +2663,7 @@ mod tests {
                     program_location: "/Users/test/program.o".to_string(),
                     address: Some(1),
                     use_deprecated_loader: false,
+                    force_use_system_account: false,
                 },
                 signers: vec![
                     read_keypair_file(&keypair_file).unwrap().into(),
@@ -2955,6 +2977,7 @@ mod tests {
             program_location: pathbuf.to_str().unwrap().to_string(),
             address: None,
             use_deprecated_loader: false,
+            force_use_system_account: false,
         };
         let result = process_command(&config);
         let json: Value = serde_json::from_str(&result.unwrap()).unwrap();
@@ -2973,6 +2996,7 @@ mod tests {
             program_location: "bad/file/location.so".to_string(),
             address: None,
             use_deprecated_loader: false,
+            force_use_system_account: false,
         };
         assert!(process_command(&config).is_err());
     }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -179,7 +179,7 @@ pub enum CliCommand {
         program_location: String,
         address: Option<SignerIndex>,
         use_deprecated_loader: bool,
-        force_use_system_account: bool,
+        force_use_program_address: bool,
     },
     // Stake Commands
     CreateStakeAccount {
@@ -617,7 +617,7 @@ pub fn parse_command(
                     program_location: matches.value_of("program_location").unwrap().to_string(),
                     address,
                     use_deprecated_loader: matches.is_present("use_deprecated_loader"),
-                    force_use_system_account: matches.is_present("force_use_system_account"),
+                    force_use_program_address: matches.is_present("force_use_program_address"),
                 },
                 signers,
             })
@@ -1134,7 +1134,7 @@ fn process_deploy(
     program_location: &str,
     address: Option<SignerIndex>,
     use_deprecated_loader: bool,
-    force_use_system_account: bool,
+    force_use_program_address: bool,
 ) -> ProcessResult {
     const WORDS: usize = 12;
     // Create ephemeral keypair to use for program address, if not provided
@@ -1148,7 +1148,7 @@ fn process_deploy(
         program_location,
         address,
         use_deprecated_loader,
-        force_use_system_account,
+        force_use_program_address,
         new_keypair,
     );
 
@@ -1164,7 +1164,7 @@ fn process_deploy(
             WORDS
         );
         eprintln!(
-            "then pass it as the [ADDRESS_SIGNER] argument to `solana deploy ...`\n{}\n{}\n{}",
+            "then pass it as the [PROGRAM_ADDRESS_SIGNER] argument to `solana deploy ...`\n{}\n{}\n{}",
             divider, phrase, divider
         );
     }
@@ -1177,7 +1177,7 @@ fn do_process_deploy(
     program_location: &str,
     address: Option<SignerIndex>,
     use_deprecated_loader: bool,
-    force_use_system_account: bool,
+    force_use_program_address: bool,
     new_keypair: Keypair,
 ) -> ProcessResult {
     let program_id = if let Some(i) = address {
@@ -1242,7 +1242,7 @@ fn do_process_deploy(
                 balance,
             ));
             balance_needed = balance;
-        } else if account.lamports > minimum_balance && !force_use_system_account {
+        } else if account.lamports > minimum_balance && !force_use_program_address {
             return Err(CliError::DynamicProgramError(format!(
                 "Program account has a balance: {:?}; it may already be in use",
                 Sol(account.lamports)
@@ -1630,14 +1630,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             program_location,
             address,
             use_deprecated_loader,
-            force_use_system_account,
+            force_use_program_address,
         } => process_deploy(
             &rpc_client,
             config,
             program_location,
             *address,
             *use_deprecated_loader,
-            *force_use_system_account,
+            *force_use_program_address,
         ),
 
         // Stake Commands
@@ -2267,8 +2267,8 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .help("Use the deprecated BPF loader")
                 )
                 .arg(
-                    Arg::with_name("force_use_system_account")
-                        .long("force-use-system-account")
+                    Arg::with_name("force_use_program_address")
+                        .long("force-use-program-address")
                         .takes_value(false)
                         .hidden(true) // Don't document this argument to discourage its use
                         .help("Use the designated program id, even if it already holds a balance of SOL")
@@ -2641,7 +2641,7 @@ mod tests {
                     program_location: "/Users/test/program.o".to_string(),
                     address: None,
                     use_deprecated_loader: false,
-                    force_use_system_account: false,
+                    force_use_program_address: false,
                 },
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
             }
@@ -2663,7 +2663,7 @@ mod tests {
                     program_location: "/Users/test/program.o".to_string(),
                     address: Some(1),
                     use_deprecated_loader: false,
-                    force_use_system_account: false,
+                    force_use_program_address: false,
                 },
                 signers: vec![
                     read_keypair_file(&keypair_file).unwrap().into(),
@@ -2977,7 +2977,7 @@ mod tests {
             program_location: pathbuf.to_str().unwrap().to_string(),
             address: None,
             use_deprecated_loader: false,
-            force_use_system_account: false,
+            force_use_program_address: false,
         };
         let result = process_command(&config);
         let json: Value = serde_json::from_str(&result.unwrap()).unwrap();
@@ -2996,7 +2996,7 @@ mod tests {
             program_location: "bad/file/location.so".to_string(),
             address: None,
             use_deprecated_loader: false,
-            force_use_system_account: false,
+            force_use_program_address: false,
         };
         assert!(process_command(&config).is_err());
     }

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -64,7 +64,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: None,
         use_deprecated_loader: false,
-        force_use_program_address: false,
+        allow_excessive_balance: false,
     };
 
     let response = process_command(&config);
@@ -99,7 +99,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
-        force_use_program_address: false,
+        allow_excessive_balance: false,
     };
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -131,7 +131,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
-        force_use_program_address: false,
+        allow_excessive_balance: false,
     };
     process_command(&config).unwrap_err();
 
@@ -140,7 +140,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
-        force_use_program_address: true,
+        allow_excessive_balance: true,
     };
     process_command(&config).unwrap();
     let account2 = rpc_client

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -55,7 +55,7 @@ fn test_cli_deploy_program() {
         faucet_host: None,
         faucet_port: faucet_addr.port(),
         pubkey: None,
-        lamports: 3 * minimum_balance_for_rent_exemption, // min balance for rent exemption for two programs + leftover for tx processing
+        lamports: 4 * minimum_balance_for_rent_exemption, // min balance for rent exemption for three programs + leftover for tx processing
     };
     config.signers = vec![&keypair];
     process_command(&config).unwrap();
@@ -64,6 +64,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: None,
         use_deprecated_loader: false,
+        force_use_system_account: false,
     };
 
     let response = process_command(&config);
@@ -98,6 +99,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
+        force_use_system_account: false,
     };
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -112,6 +114,44 @@ fn test_cli_deploy_program() {
 
     // Attempt to redeploy to the same address
     process_command(&config).unwrap_err();
+
+    // Attempt to deploy to account with excess balance
+    let custom_address_keypair = Keypair::new();
+    config.command = CliCommand::Airdrop {
+        faucet_host: None,
+        faucet_port: faucet_addr.port(),
+        pubkey: None,
+        lamports: 2 * minimum_balance_for_rent_exemption, // Anything over minimum_balance_for_rent_exemption should trigger err
+    };
+    config.signers = vec![&custom_address_keypair];
+    process_command(&config).unwrap();
+
+    config.signers = vec![&keypair, &custom_address_keypair];
+    config.command = CliCommand::Deploy {
+        program_location: pathbuf.to_str().unwrap().to_string(),
+        address: Some(1),
+        use_deprecated_loader: false,
+        force_use_system_account: false,
+    };
+    process_command(&config).unwrap_err();
+
+    // Use forcing parameter to deploy to account with excess balance
+    config.command = CliCommand::Deploy {
+        program_location: pathbuf.to_str().unwrap().to_string(),
+        address: Some(1),
+        use_deprecated_loader: false,
+        force_use_system_account: true,
+    };
+    process_command(&config).unwrap();
+    let account2 = rpc_client
+        .get_account_with_commitment(&custom_address_keypair.pubkey(), CommitmentConfig::recent())
+        .unwrap()
+        .value
+        .unwrap();
+    assert_eq!(account2.lamports, 2 * minimum_balance_for_rent_exemption);
+    assert_eq!(account2.owner, bpf_loader::id());
+    assert_eq!(account2.executable, true);
+    assert_eq!(account0.data, account2.data);
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -64,7 +64,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: None,
         use_deprecated_loader: false,
-        force_use_system_account: false,
+        force_use_program_address: false,
     };
 
     let response = process_command(&config);
@@ -99,7 +99,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
-        force_use_system_account: false,
+        force_use_program_address: false,
     };
     process_command(&config).unwrap();
     let account1 = rpc_client
@@ -131,7 +131,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
-        force_use_system_account: false,
+        force_use_program_address: false,
     };
     process_command(&config).unwrap_err();
 
@@ -140,7 +140,7 @@ fn test_cli_deploy_program() {
         program_location: pathbuf.to_str().unwrap().to_string(),
         address: Some(1),
         use_deprecated_loader: false,
-        force_use_system_account: true,
+        force_use_program_address: true,
     };
     process_command(&config).unwrap();
     let account2 = rpc_client


### PR DESCRIPTION
#### Problem
The `solana deploy` subcommand is easy to misuse in a way that could result in loss of funds. If a dev is not careful about which keypair they specify for `[ADDRESS_KEYPAIR]`, they may assign a system account with a lot of funds to the BPF Loader program which doesn't allow withdraws.

#### Summary of Changes
- Adds a balance check for the program account and aborts if that address has more lamports than the minimum rent-exempt balance for the program
- Adds a forcing flag to deploy anyway

Fixes #12978 
