### PR TITLE
cargo-build-bpf: Add --bpf-out-dir argument to control where the final build products land

### DIFF
--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -57,13 +57,6 @@ fn main() {
         let install_dir =
             "target/".to_string() + &env::var("PROFILE").unwrap() + &"/bpf".to_string();
 
-        assert!(Command::new("mkdir")
-            .arg("-p")
-            .arg(&install_dir)
-            .status()
-            .expect("Unable to create BPF install directory")
-            .success());
-
         let rust_programs = [
             "128bit",
             "alloc",
@@ -93,21 +86,15 @@ fn main() {
                 "cargo:warning=(not a warning) Building Rust-based BPF programs: solana_bpf_rust_{}",
                 program
             );
-            assert!(Command::new("bash")
-                .current_dir(format!("rust/{}", program))
-                .args(&["../../../../cargo-build-bpf"])
+            assert!(Command::new("../../cargo-build-bpf")
+                .args(&[
+                    "--manifest-path",
+                    &format!("rust/{}/Cargo.toml", program),
+                    "--bpf-out-dir",
+                    &install_dir
+                ])
                 .status()
                 .expect("Error calling cargo-build-bpf from build.rs")
-                .success());
-            let src = format!(
-                "rust/{0}/solana_bpf_rust_{0}.so",
-                program,
-            );
-            assert!(Command::new("mv")
-                .arg(&src)
-                .arg(&install_dir)
-                .status()
-                .unwrap_or_else(|_| panic!("Failed to cp {} to {}", src, install_dir))
                 .success());
         }
 

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -54,7 +54,9 @@ fn load_bpf_program(
     name: &str,
 ) -> Pubkey {
     let path = create_bpf_path(name);
-    let mut file = File::open(path).unwrap();
+    let mut file = File::open(&path).unwrap_or_else(|err| {
+        panic!("Failed to open {}: {}", path.display(), err);
+    });
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     load_program(bank_client, payer_keypair, loader_id, elf)

--- a/sdk/bpf/scripts/dump.sh
+++ b/sdk/bpf/scripts/dump.sh
@@ -29,6 +29,11 @@ if ! command -v readelf > /dev/null; then
   exit 1
 fi
 
+set -e
+out_dir=$(dirname "$dump")
+if [[ ! -d $out_dir ]]; then
+  mkdir -p "$out_dir"
+fi
 dump_mangled=$dump.mangled
 
 (

--- a/sdk/bpf/scripts/strip.sh
+++ b/sdk/bpf/scripts/strip.sh
@@ -14,4 +14,10 @@ fi
 bpf_sdk=$(cd "$(dirname "$0")/.." && pwd)
 # shellcheck source=sdk/bpf/env.sh
 source "$bpf_sdk"/env.sh
+
+set -e
+out_dir=$(dirname "$so_stripped")
+if [[ ! -d $out_dir ]]; then
+  mkdir -p "$out_dir"
+fi
 "$bpf_sdk"/dependencies/llvm-native/bin/llvm-objcopy --strip-all "$so" "$so_stripped"


### PR DESCRIPTION
$PWD as the default output is great for a single program experience, but no good for `program/bpf/rust/...`