### PR TITLE
ci: Add downstream project build testing

### DIFF
--- a/cargo-build-bpf
+++ b/cargo-build-bpf
@@ -2,4 +2,4 @@
 
 here=$(dirname "$0")
 set -x
-exec cargo run --manifest-path $here/sdk/cargo-build-bpf/Cargo.toml -- --bpf-sdk $here/sdk/bpf "$@"
+exec $here/cargo run --manifest-path $here/sdk/cargo-build-bpf/Cargo.toml -- --bpf-sdk $here/sdk/bpf "$@"

--- a/ci/buildkite-pipeline.sh
+++ b/ci/buildkite-pipeline.sh
@@ -175,6 +175,30 @@ EOF
       "Stable-perf skipped as no relevant files were modified"
   fi
 
+  # Downstream backwards compatibility
+  if affects \
+             .rs$ \
+             Cargo.lock$ \
+             Cargo.toml$ \
+             ^ci/rust-version.sh \
+             ^ci/test-stable-perf.sh \
+             ^ci/test-stable.sh \
+             ^ci/test-local-cluster.sh \
+             ^core/build.rs \
+             ^fetch-perf-libs.sh \
+             ^programs/ \
+             ^sdk/ \
+             ^scripts/build-downstream-projects.sh \
+      ; then
+    cat >> "$output_file" <<"EOF"
+  - command: "scripts/build-downstream-projects.sh"
+    name: "downstream-projects"
+    timeout_in_minutes: 30
+EOF
+  else
+    annotate --style info \
+      "downstream-projects skipped as no relevant files were modified"
+  fi
   # Benches...
   if affects \
              .rs$ \

--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Builds known downstream projects against local solana source
+#
+
+set -e
+cd "$(dirname "$0")"/..
+source ci/_
+source scripts/read-cargo-variable.sh
+
+solana_ver=$(readCargoVariable version sdk/Cargo.toml)
+solana_dir=$PWD
+
+mkdir -p target/downstream-projects
+cd target/downstream-projects
+
+update_solana_dependencies() {
+  declare tomls=()
+  while IFS='' read -r line; do tomls+=("$line"); done < <(find "$1" -name Cargo.toml)
+
+  sed -i -e "s#\(solana-sdk = \"\).*\(\"\)#\1$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-sdk = { version = \"\).*\(\"\)#\1$solana_ver\2#g" "${tomls[@]}" || return $?
+  sed -i -e "s#\(solana-client = \"\).*\(\"\)#\1$solana_ver\2#g" "${tomls[@]}" || return $?
+}
+
+update_spl_token_dependencies() {
+  declare tomls=()
+  while IFS='' read -r line; do tomls+=("$line"); done < <(find "$1" -name Cargo.toml)
+
+  declare spl_token_ver="$2"
+  sed -i -e "s#\(spl-token = { version = \"\).*\(\"\)#\1$spl_token_ver\2#g" "${tomls[@]}" || return $?
+}
+
+patch_crates_io() {
+  cat >> "$1" <<EOF
+[patch.crates-io]
+solana-client = { path = "$solana_dir/client"}
+solana-sdk = { path = "$solana_dir/sdk" }
+EOF
+}
+
+example_helloworld() {
+  (
+    set -x
+    rm -rf example-helloworld
+    git clone https://github.com/solana-labs/example-helloworld.git
+    cd example-helloworld
+
+    update_solana_dependencies src/program-rust
+    patch_crates_io src/program-rust/Cargo.toml
+    echo "[workspace]" >> src/program-rust/Cargo.toml
+
+    "$solana_dir"/cargo-build-bpf \
+      --manifest-path src/program-rust/Cargo.toml \
+      --no-default-features --features program
+
+    # TODO: Build src/program-c/...
+  )
+}
+
+spl() {
+  (
+    set -x
+    rm -rf spl
+    git clone https://github.com/solana-labs/solana-program-library.git spl
+    cd spl
+
+    update_solana_dependencies .
+    patch_crates_io Cargo.toml
+
+    "$solana_dir"/cargo-build-bpf \
+      --manifest-path memo/program/Cargo.toml \
+      --no-default-features --features program
+
+    "$solana_dir"/cargo-build-bpf \
+      --manifest-path token/program/Cargo.toml \
+      --no-default-features --features program
+  )
+}
+
+serum_dex() {
+  (
+    set -x
+    rm -rf serum-dex
+    git clone https://github.com/project-serum/serum-dex.git  # TODO: Consider using a tag
+    cd serum-dex
+
+    update_solana_dependencies .
+    update_spl_token_dependencies . 2.0.8
+    patch_crates_io Cargo.toml
+    patch_crates_io dex/Cargo.toml
+    echo "[workspace]" >> dex/Cargo.toml
+
+    "$solana_dir"/cargo stable build
+
+    "$solana_dir"/cargo-build-bpf \
+      --manifest-path dex/Cargo.toml --no-default-features --features program
+  )
+}
+
+
+_ example_helloworld
+_ spl
+_ serum_dex

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -16,19 +16,7 @@ EOF
 here="$(dirname "$0")"
 cd "$here"/..
 source ci/semver_bash/semver.sh
-
-readCargoVariable() {
-  declare variable="$1"
-  declare Cargo_toml="$2"
-
-  while read -r name equals value _; do
-    if [[ $name = "$variable" && $equals = = ]]; then
-      echo "${value//\"/}"
-      return
-    fi
-  done < <(cat "$Cargo_toml")
-  echo "Unable to locate $variable in $Cargo_toml" 1>&2
-}
+source scripts/read-cargo-variable.sh
 
 ignores=(
   .cache

--- a/scripts/read-cargo-variable.sh
+++ b/scripts/read-cargo-variable.sh
@@ -1,0 +1,14 @@
+# source this file
+
+readCargoVariable() {
+  declare variable="$1"
+  declare Cargo_toml="$2"
+
+  while read -r name equals value _; do
+    if [[ $name = "$variable" && $equals = = ]]; then
+      echo "${value//\"/}"
+      return
+    fi
+  done < <(cat "$Cargo_toml")
+  echo "Unable to locate $variable in $Cargo_toml" 1>&2
+}


### PR DESCRIPTION
It's not nice to break downstream projects.  Add a new job in the CI build pipeline that fetches and builds example-helloworld, spl-token, and serum-dex against the PR.