### PR TITLE
marks pull request creation time only once per peer

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1541,6 +1541,8 @@ impl ClusterInfo {
         self.stats
             .new_pull_requests_count
             .add_relaxed(pulls.len() as u64);
+        // There are at most 2 unique peers here: The randomly
+        // selected pull peer, and possibly also the entrypoint.
         let peers: Vec<Pubkey> = pulls.iter().map(|(peer, _, _, _)| *peer).dedup().collect();
         {
             let mut gossip =

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1541,11 +1541,17 @@ impl ClusterInfo {
         self.stats
             .new_pull_requests_count
             .add_relaxed(pulls.len() as u64);
+        let peers: Vec<Pubkey> = pulls.iter().map(|(peer, _, _, _)| *peer).dedup().collect();
+        {
+            let mut gossip =
+                self.time_gossip_write_lock("mark_pull", &self.stats.mark_pull_request);
+            for peer in peers {
+                gossip.mark_pull_request_creation_time(&peer, now);
+            }
+        }
         pulls
             .into_iter()
-            .map(|(peer, filter, gossip, self_info)| {
-                self.time_gossip_write_lock("mark_pull", &self.stats.mark_pull_request)
-                    .mark_pull_request_creation_time(&peer, now);
+            .map(|(_, filter, gossip, self_info)| {
                 (gossip, Protocol::PullRequest(filter, self_info))
             })
             .collect()


### PR DESCRIPTION
#### Problem
mark_pull_request_creation time requires an exclusive lock on gossip:
https://github.com/solana-labs/solana/blob/16944e218/core/src/cluster_info.rs#L1547-L1548
Current code is redundantly marking each peer once for each request.
There are at most only 2 unique peers, whereas there are hundreds of
requests per each. So the lock is acquired hundreds of time longer than
necessary.

#### Summary of Changes
The commit de-duplicates peers and acquires the lock on gossip only once. 