### PR TITLE
fix: Add explicit "with fee payer" variants for web3 tx signing methods

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -666,9 +666,18 @@ declare module '@solana/web3.js' {
     compileMessage(): Message;
     serializeMessage(): Buffer;
     sign(...signers: Array<Account>): void;
+    signWithFeePayer(feePayer: Account, ...signers: Array<Account>): void;
     partialSign(...partialSigners: Array<Account>): void;
+    partialSignWithFeePayer(
+      feePayer: Account,
+      ...partialSigners: Array<Account>
+    ): void;
     addSignature(pubkey: PublicKey, signature: Buffer): void;
     setSigners(...signer: Array<PublicKey>): void;
+    setSignersWithFeePayer(
+      feePayer: PublicKey,
+      ...signer: Array<PublicKey>
+    ): void;
     verifySignatures(): boolean;
     serialize(config?: SerializeConfig): Buffer;
   }

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -670,9 +670,18 @@ declare module '@solana/web3.js' {
     compileMessage(): Message;
     serializeMessage(): Buffer;
     sign(...signers: Array<Account>): void;
+    signWithFeePayer(feePayer: Account, ...signers: Array<Account>): void;
     partialSign(...partialSigners: Array<Account>): void;
+    partialSignWithFeePayer(
+      feePayer: Account,
+      ...partialSigners: Array<Account>
+    ): void;
     addSignature(pubkey: PublicKey, signature: Buffer): void;
     setSigners(...signers: Array<PublicKey>): void;
+    setSignersWithFeePayer(
+      feePayer: PublicKey,
+      ...signers: Array<PublicKey>
+    ): void;
     verifySignatures(): boolean;
     serialize(config?: SerializeConfig): Buffer;
   }

--- a/web3.js/src/transaction.js
+++ b/web3.js/src/transaction.js
@@ -368,6 +368,17 @@ export class Transaction {
   }
 
   /**
+   * Specify the public keys which will be used to sign the Transaction
+   * with an explicit signer
+   *
+   * Signatures can be added with either `partialSign` or `addSignature`
+   */
+  setSignersWithFeePayer(feePayer: PublicKey, ...signers: Array<PublicKey>) {
+    const allSigners = [feePayer, ...signers];
+    this.setSigners(...allSigners);
+  }
+
+  /**
    * Specify the public keys which will be used to sign the Transaction.
    * The first signer will be used as the transaction fee payer account.
    *
@@ -390,6 +401,23 @@ export class Transaction {
         }
       })
       .map(publicKey => ({signature: null, publicKey}));
+  }
+
+  /**
+   * Sign the Transaction with the specified accounts. Multiple signatures may
+   * be applied to a Transaction. The first signature is considered "primary"
+   * and is used when testing for Transaction confirmation. The transaction fee
+   * payer is explicitly specified.
+   *
+   * Transaction fields should not be modified after the first call to `sign`,
+   * as doing so may invalidate the signature and cause the Transaction to be
+   * rejected.
+   *
+   * The Transaction must be assigned a valid `recentBlockhash` before invoking this method
+   */
+  signWithFeePayer(feePayer: Account, ...signers: Array<Account>) {
+    const allSigners = [feePayer, ...signers];
+    this.sign(...allSigners);
   }
 
   /**
@@ -426,6 +454,17 @@ export class Transaction {
       }));
 
     this.partialSign(...signers);
+  }
+
+  /**
+   * Partially sign a transaction with the specified accounts. All accounts must
+   * correspond to a public key that was previously provided to `setSigners`.
+   *
+   * All the caveats from the `sign` method apply to `partialSign`
+   */
+  partialSignWithFeePayer(feePayer: Account, ...signers: Array<Account>) {
+    const allSigners = [feePayer, ...signers];
+    this.partialSign(...allSigners);
   }
 
   /**


### PR DESCRIPTION
#### Problem

web3.js `Transaction.compileMessage()` will throw an error if the fee payer hasn't been set, but the API provides no methods mentioning a fee payer.  This confuses developers who don't know that the first signer is implicitly the fee payer (or read the docs?)

#### Summary of Changes

Provided `*WithFeePayer()` variants for all methods on `Transaction` related to signing, which take an explicit `feePayer` arg