### PR TITLE
feat: allow setting explicit fee payer for transaction

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -653,7 +653,7 @@ declare module '@solana/web3.js' {
     instructions: Array<TransactionInstruction>;
     recentBlockhash?: Blockhash;
     nonceInfo?: NonceInformation;
-    feePayer: PublicKey | null;
+    feePayer?: PublicKey;
 
     constructor(opts?: TransactionCtorFields);
     static from(buffer: Buffer | Uint8Array | Array<number>): Transaction;

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -657,7 +657,7 @@ declare module '@solana/web3.js' {
     instructions: Array<TransactionInstruction>;
     recentBlockhash: ?Blockhash;
     nonceInfo: ?NonceInformation;
-    feePayer: PublicKey | null;
+    feePayer: ?PublicKey;
 
     constructor(opts?: TransactionCtorFields): Transaction;
     static from(buffer: Buffer | Uint8Array | Array<number>): Transaction;

--- a/web3.js/src/message.js
+++ b/web3.js/src/message.js
@@ -83,16 +83,6 @@ export class Message {
     );
   }
 
-  findSignerIndex(signer: PublicKey): number {
-    const index = this.accountKeys.findIndex(accountKey => {
-      return accountKey.equals(signer);
-    });
-    if (index < 0) {
-      throw new Error(`unknown signer: ${signer.toString()}`);
-    }
-    return index;
-  }
-
   serialize(): Buffer {
     const numKeys = this.accountKeys.length;
 

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -176,7 +176,7 @@ describe('load BPF Rust program', () => {
     );
   });
 
-  test('simulate transaction without signature verification', async () => {
+  test('deprecated - simulate transaction without signature verification', async () => {
     const simulatedTransaction = new Transaction().add({
       keys: [
         {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
@@ -185,6 +185,33 @@ describe('load BPF Rust program', () => {
     });
 
     simulatedTransaction.setSigners(payerAccount.publicKey);
+    const {err, logs} = (
+      await connection.simulateTransaction(simulatedTransaction)
+    ).value;
+    expect(err).toBeNull();
+
+    if (logs === null) {
+      expect(logs).not.toBeNull();
+      return;
+    }
+
+    expect(logs.length).toBeGreaterThanOrEqual(2);
+    expect(logs[0]).toEqual(`Call BPF program ${program.publicKey.toBase58()}`);
+    expect(logs[logs.length - 1]).toEqual(
+      `BPF program ${program.publicKey.toBase58()} success`,
+    );
+  });
+
+  test('simulate transaction without signature verification', async () => {
+    const simulatedTransaction = new Transaction({
+      feePayer: payerAccount.publicKey,
+    }).add({
+      keys: [
+        {pubkey: payerAccount.publicKey, isSigner: true, isWritable: true},
+      ],
+      programId: program.publicKey,
+    });
+
     const {err, logs} = (
       await connection.simulateTransaction(simulatedTransaction)
     ).value;

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -198,8 +198,8 @@ test('get program accounts', async () => {
     },
   ]);
 
-  if (transaction.recentBlockhash === null) {
-    expect(transaction.recentBlockhash).not.toBeNull();
+  if (!transaction.recentBlockhash) {
+    expect(transaction.recentBlockhash).toBeTruthy();
     return;
   }
 


### PR DESCRIPTION
#### Problem
When transactions are serialized and a fee payer cannot be determined, an error is thrown that says: `"Transaction feePayer required"`. The transaction API only has a getter for `feePayer` and so it's unclear to devs on how to specify one.

#### Summary of Changes
- Allow setting `transaction.feePayer`
- Deprecate `setSigners`
- Deprecate and add warning for when devs sign a transaction with an account that isn't required to sign
- Fix some type definitions

Fixes #
