### PR TITLE
Cache account stores, flush from AccountsBackgroundService

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -6,9 +6,7 @@ use solana_runtime::{
     accounts_index::Ancestors,
 };
 use solana_sdk::{genesis_config::ClusterType, pubkey::Pubkey};
-use std::env;
-use std::fs;
-use std::path::PathBuf;
+use std::{collections::HashSet, env, fs, path::PathBuf};
 
 fn main() {
     solana_logger::setup();
@@ -56,7 +54,8 @@ fn main() {
     if fs::remove_dir_all(path.clone()).is_err() {
         println!("Warning: Couldn't remove {:?}", path);
     }
-    let accounts = Accounts::new(vec![path], &ClusterType::Testnet);
+    let accounts =
+        Accounts::new_with_config(vec![path], &ClusterType::Testnet, HashSet::new(), false);
     println!("Creating {} accounts", num_accounts);
     let mut create_time = Measure::start("create accounts");
     let pubkeys: Vec<_> = (0..num_slots)

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -2,7 +2,7 @@ use clap::{crate_description, crate_name, value_t, App, Arg};
 use rayon::prelude::*;
 use solana_measure::measure::Measure;
 use solana_runtime::{
-    accounts::{create_test_accounts, update_accounts, Accounts},
+    accounts::{create_test_accounts, update_accounts_bench, Accounts},
     accounts_index::Ancestors,
 };
 use solana_sdk::{genesis_config::ClusterType, pubkey::Pubkey};
@@ -92,7 +92,7 @@ fn main() {
             time.stop();
             println!("{}", time);
             for slot in 0..num_slots {
-                update_accounts(&accounts, &pubkeys, ((x + 1) * num_slots + slot) as u64);
+                update_accounts_bench(&accounts, &pubkeys, ((x + 1) * num_slots + slot) as u64);
                 accounts.add_root((x * num_slots + slot) as u64);
             }
         } else {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -78,6 +78,7 @@ pub struct TvuConfig {
     pub trusted_validators: Option<HashSet<Pubkey>>,
     pub repair_validators: Option<HashSet<Pubkey>>,
     pub accounts_hash_fault_injection_slots: u64,
+    pub caching_enabled: bool,
 }
 
 impl Tvu {
@@ -272,7 +273,7 @@ impl Tvu {
             bank_forks.clone(),
             &exit,
             accounts_background_request_handler,
-            false,
+            tvu_config.caching_enabled,
         );
 
         Tvu {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -78,7 +78,7 @@ pub struct TvuConfig {
     pub trusted_validators: Option<HashSet<Pubkey>>,
     pub repair_validators: Option<HashSet<Pubkey>>,
     pub accounts_hash_fault_injection_slots: u64,
-    pub caching_enabled: bool,
+    pub accounts_db_caching_enabled: bool,
 }
 
 impl Tvu {
@@ -273,7 +273,7 @@ impl Tvu {
             bank_forks.clone(),
             &exit,
             accounts_background_request_handler,
-            tvu_config.caching_enabled,
+            tvu_config.accounts_db_caching_enabled,
         );
 
         Tvu {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -272,6 +272,7 @@ impl Tvu {
             bank_forks.clone(),
             &exit,
             accounts_background_request_handler,
+            false,
         );
 
         Tvu {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -119,6 +119,7 @@ pub struct ValidatorConfig {
     pub no_poh_speed_test: bool,
     pub poh_pinned_cpu_core: usize,
     pub account_indexes: HashSet<AccountIndex>,
+    pub caching_enabled: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -164,6 +165,7 @@ impl Default for ValidatorConfig {
             no_poh_speed_test: true,
             poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
             account_indexes: HashSet::new(),
+            caching_enabled: false,
         }
     }
 }
@@ -629,6 +631,7 @@ impl Validator {
                 trusted_validators: config.trusted_validators.clone(),
                 repair_validators: config.repair_validators.clone(),
                 accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
+                caching_enabled: config.caching_enabled,
             },
         );
 
@@ -960,6 +963,7 @@ fn new_banks_from_ledger(
         frozen_accounts: config.frozen_accounts.clone(),
         debug_keys: config.debug_keys.clone(),
         account_indexes: config.account_indexes.clone(),
+        caching_enabled: config.caching_enabled,
         ..blockstore_processor::ProcessOptions::default()
     };
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -119,7 +119,7 @@ pub struct ValidatorConfig {
     pub no_poh_speed_test: bool,
     pub poh_pinned_cpu_core: usize,
     pub account_indexes: HashSet<AccountIndex>,
-    pub caching_enabled: bool,
+    pub accounts_db_caching_enabled: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -165,7 +165,7 @@ impl Default for ValidatorConfig {
             no_poh_speed_test: true,
             poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
             account_indexes: HashSet::new(),
-            caching_enabled: false,
+            accounts_db_caching_enabled: false,
         }
     }
 }
@@ -631,7 +631,7 @@ impl Validator {
                 trusted_validators: config.trusted_validators.clone(),
                 repair_validators: config.repair_validators.clone(),
                 accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
-                caching_enabled: config.caching_enabled,
+                accounts_db_caching_enabled: config.accounts_db_caching_enabled,
             },
         );
 
@@ -963,7 +963,7 @@ fn new_banks_from_ledger(
         frozen_accounts: config.frozen_accounts.clone(),
         debug_keys: config.debug_keys.clone(),
         account_indexes: config.account_indexes.clone(),
-        caching_enabled: config.caching_enabled,
+        accounts_db_caching_enabled: config.accounts_db_caching_enabled,
         ..blockstore_processor::ProcessOptions::default()
     };
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -216,7 +216,7 @@ mod tests {
             if slot % set_root_interval == 0 || slot == last_slot - 1 {
                 // set_root should send a snapshot request
                 bank_forks.set_root(bank.slot(), &request_sender, None);
-                snapshot_request_handler.handle_snapshot_requests();
+                snapshot_request_handler.handle_snapshot_requests(false);
             }
         }
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -162,6 +162,7 @@ mod tests {
             None,
             None,
             HashSet::new(),
+            false,
         )
         .unwrap();
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -105,6 +105,7 @@ mod tests {
                 None,
                 None,
                 HashSet::new(),
+                false,
             );
             bank0.freeze();
             let mut bank_forks = BankForks::new(bank0);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1926,6 +1926,7 @@ fn main() {
                     );
                     assert!(bank.is_complete());
                     bank.squash();
+                    bank.force_flush_accounts_cache();
                     bank.clean_accounts(true);
                     bank.update_accounts_hash();
                     if rehash {

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -69,7 +69,7 @@ pub fn load(
                     process_options.debug_keys.clone(),
                     Some(&crate::builtins::get(process_options.bpf_jit)),
                     process_options.account_indexes.clone(),
-                    process_options.caching_enabled,
+                    process_options.accounts_db_caching_enabled,
                 )
                 .expect("Load from snapshot failed");
                 if let Some(shrink_paths) = shrink_paths {

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -69,6 +69,7 @@ pub fn load(
                     process_options.debug_keys.clone(),
                     Some(&crate::builtins::get(process_options.bpf_jit)),
                     process_options.account_indexes.clone(),
+                    process_options.caching_enabled,
                 )
                 .expect("Load from snapshot failed");
                 if let Some(shrink_paths) = shrink_paths {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -346,7 +346,7 @@ pub struct ProcessOptions {
     pub frozen_accounts: Vec<Pubkey>,
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
     pub account_indexes: HashSet<AccountIndex>,
-    pub caching_enabled: bool,
+    pub accounts_db_caching_enabled: bool,
 }
 
 pub fn process_blockstore(
@@ -372,7 +372,7 @@ pub fn process_blockstore(
         opts.debug_keys.clone(),
         Some(&crate::builtins::get(opts.bpf_jit)),
         opts.account_indexes.clone(),
-        opts.caching_enabled,
+        opts.accounts_db_caching_enabled,
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -371,6 +371,7 @@ pub fn process_blockstore(
         opts.debug_keys.clone(),
         Some(&crate::builtins::get(opts.bpf_jit)),
         opts.account_indexes.clone(),
+        false,
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");
@@ -2903,6 +2904,7 @@ pub mod tests {
             None,
             None,
             HashSet::new(),
+            false,
         );
         *bank.epoch_schedule()
     }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -928,10 +928,9 @@ fn load_frozen_forks(
                 leader_schedule_cache.set_root(&new_root_bank);
                 new_root_bank.squash();
 
-                // Flush all the rooted accounts. Must be called after `squash()`,
-                // so that AccountsDb knows what the roots are.
-                new_root_bank.force_flush_accounts_cache();
                 if last_free.elapsed() > Duration::from_secs(10) {
+                    // Must be called after `squash()`, so that AccountsDb knows what
+                    // the roots are for the cache flushing in exhaustively_free_unused_resource().
                     // This could take few secs; so update last_free later
                     new_root_bank.exhaustively_free_unused_resource();
                     last_free = Instant::now();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -346,6 +346,7 @@ pub struct ProcessOptions {
     pub frozen_accounts: Vec<Pubkey>,
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
     pub account_indexes: HashSet<AccountIndex>,
+    pub caching_enabled: bool,
 }
 
 pub fn process_blockstore(
@@ -371,7 +372,7 @@ pub fn process_blockstore(
         opts.debug_keys.clone(),
         Some(&crate::builtins::get(opts.bpf_jit)),
         opts.account_indexes.clone(),
-        false,
+        opts.caching_enabled,
     );
     let bank0 = Arc::new(bank0);
     info!("processing ledger for slot 0...");

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -928,6 +928,9 @@ fn load_frozen_forks(
                 leader_schedule_cache.set_root(&new_root_bank);
                 new_root_bank.squash();
 
+                // Flush all the rooted accounts. Must be called after `squash()`,
+                // so that AccountsDb knows what the roots are.
+                new_root_bank.force_flush_accounts_cache();
                 if last_free.elapsed() > Duration::from_secs(10) {
                     // This could take few secs; so update last_free later
                     new_root_bank.exhaustively_free_unused_resource();

--- a/run.sh
+++ b/run.sh
@@ -105,6 +105,7 @@ args=(
   --init-complete-file "$dataDir"/init-completed
   --snapshot-compression none
   --require-tower
+  --accounts-db-caching-enabled
 )
 # shellcheck disable=SC2086
 solana-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS &

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -61,7 +61,7 @@ fn test_accounts_create(bencher: &mut Bencher) {
 fn test_accounts_squash(bencher: &mut Bencher) {
     let (mut genesis_config, _) = create_genesis_config(100_000);
     genesis_config.rent.burn_percent = 100; // Avoid triggering an assert in Bank::distribute_rent_to_validators()
-    let bank1 = Arc::new(Bank::new_with_paths(
+    let mut prev_bank = Arc::new(Bank::new_with_paths(
         &genesis_config,
         vec![PathBuf::from("bench_a1")],
         &[],
@@ -70,18 +70,19 @@ fn test_accounts_squash(bencher: &mut Bencher) {
         HashSet::new(),
     ));
     let mut pubkeys: Vec<Pubkey> = vec![];
-    deposit_many(&bank1, &mut pubkeys, 250_000);
-    bank1.freeze();
+    deposit_many(&prev_bank, &mut pubkeys, 250_000);
+    prev_bank.freeze();
 
     // Measures the performance of the squash operation.
     // This mainly consists of the freeze operation which calculates the
     // merkle hash of the account state and distribution of fees and rent
     let mut slot = 1u64;
     bencher.iter(|| {
-        let bank2 = Arc::new(Bank::new_from_parent(&bank1, &Pubkey::default(), slot));
-        bank2.deposit(&pubkeys[0], 1);
-        bank2.squash();
+        let next_bank = Arc::new(Bank::new_from_parent(&prev_bank, &Pubkey::default(), slot));
+        next_bank.deposit(&pubkeys[0], 1);
+        next_bank.squash();
         slot += 1;
+        prev_bank = next_bank;
     });
 }
 

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -50,6 +50,7 @@ fn test_accounts_create(bencher: &mut Bencher) {
         None,
         None,
         HashSet::new(),
+        false,
     );
     bencher.iter(|| {
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -68,6 +69,7 @@ fn test_accounts_squash(bencher: &mut Bencher) {
         None,
         None,
         HashSet::new(),
+        false,
     ));
     let mut pubkeys: Vec<Pubkey> = vec![];
     deposit_many(&prev_bank, &mut pubkeys, 250_000);
@@ -88,9 +90,11 @@ fn test_accounts_squash(bencher: &mut Bencher) {
 
 #[bench]
 fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
-    let accounts = Accounts::new(
+    let accounts = Accounts::new_with_config(
         vec![PathBuf::from("bench_accounts_hash_internal")],
         &ClusterType::Development,
+        HashSet::new(),
+        false,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     let num_accounts = 60_000;
@@ -108,9 +112,11 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
 #[bench]
 fn test_update_accounts_hash(bencher: &mut Bencher) {
     solana_logger::setup();
-    let accounts = Accounts::new(
+    let accounts = Accounts::new_with_config(
         vec![PathBuf::from("update_accounts_hash")],
         &ClusterType::Development,
+        HashSet::new(),
+        false,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
@@ -125,9 +131,11 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
 #[bench]
 fn test_accounts_delta_hash(bencher: &mut Bencher) {
     solana_logger::setup();
-    let accounts = Accounts::new(
+    let accounts = Accounts::new_with_config(
         vec![PathBuf::from("accounts_delta_hash")],
         &ClusterType::Development,
+        HashSet::new(),
+        false,
     );
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100_000, 0);
@@ -139,9 +147,11 @@ fn test_accounts_delta_hash(bencher: &mut Bencher) {
 #[bench]
 fn bench_delete_dependencies(bencher: &mut Bencher) {
     solana_logger::setup();
-    let accounts = Accounts::new(
+    let accounts = Accounts::new_with_config(
         vec![PathBuf::from("accounts_delete_deps")],
         &ClusterType::Development,
+        HashSet::new(),
+        false,
     );
     let mut old_pubkey = Pubkey::default();
     let zero_account = Account::new(0, 0, &Account::default().owner);
@@ -166,12 +176,14 @@ fn store_accounts_with_possible_contention<F: 'static>(
     F: Fn(&Accounts, &[Pubkey]) + Send + Copy,
 {
     let num_readers = 5;
-    let accounts = Arc::new(Accounts::new(
+    let accounts = Arc::new(Accounts::new_with_config(
         vec![
             PathBuf::from(std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string()))
                 .join(bench_name),
         ],
         &ClusterType::Development,
+        HashSet::new(),
+        false,
     ));
     let num_keys = 1000;
     let slot = 0;

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -148,8 +148,8 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
     for i in 0..1000 {
         let pubkey = solana_sdk::pubkey::new_rand();
         let account = Account::new((i + 1) as u64, 0, &Account::default().owner);
-        accounts.store_slow(i, &pubkey, &account);
-        accounts.store_slow(i, &old_pubkey, &zero_account);
+        accounts.store_slow_uncached(i, &pubkey, &account);
+        accounts.store_slow_uncached(i, &old_pubkey, &zero_account);
         old_pubkey = pubkey;
         accounts.add_root(i);
     }
@@ -181,7 +181,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
             .map(|_| {
                 let pubkey = solana_sdk::pubkey::new_rand();
                 let account = Account::new(1, 0, &Account::default().owner);
-                accounts.store_slow(slot, &pubkey, &account);
+                accounts.store_slow_uncached(slot, &pubkey, &account);
                 pubkey
             })
             .collect(),
@@ -207,7 +207,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
             // Write to a different slot than the one being read from. Because
             // there's a new account pubkey being written to every time, will
             // compete for the accounts index lock on every store
-            accounts.store_slow(slot + 1, &solana_sdk::pubkey::new_rand(), &account);
+            accounts.store_slow_uncached(slot + 1, &solana_sdk::pubkey::new_rand(), &account);
         }
     })
 }

--- a/runtime/benches/accounts_index.rs
+++ b/runtime/benches/accounts_index.rs
@@ -47,7 +47,7 @@ fn bench_accounts_index(bencher: &mut Bencher) {
             );
             reclaims.clear();
         }
-        index.add_root(root);
+        index.add_root(root, false);
         root += 1;
         fork += 1;
     });

--- a/runtime/benches/append_vec.rs
+++ b/runtime/benches/append_vec.rs
@@ -46,9 +46,9 @@ fn append_vec_sequential_read(bencher: &mut Bencher) {
     let vec = AppendVec::new(&path.path, true, 64 * 1024);
     let size = 1_000;
     let mut indexes = add_test_accounts(&vec, size);
-    indexes.pop();
     bencher.iter(|| {
         let (sample, pos) = indexes.pop().unwrap();
+        println!("reading pos {} {}", sample, pos);
         let (account, _next) = vec.get_account(pos).unwrap();
         let (_meta, test) = create_test_account(sample);
         assert_eq!(account.data, test.data.as_slice());
@@ -60,8 +60,7 @@ fn append_vec_random_read(bencher: &mut Bencher) {
     let path = get_append_vec_path("random_read");
     let vec = AppendVec::new(&path.path, true, 64 * 1024);
     let size = 1_000;
-    let mut indexes = add_test_accounts(&vec, size);
-    indexes.pop();
+    let indexes = add_test_accounts(&vec, size);
     bencher.iter(|| {
         let random_index: usize = thread_rng().gen_range(0, indexes.len());
         let (sample, pos) = &indexes[random_index];

--- a/runtime/benches/append_vec.rs
+++ b/runtime/benches/append_vec.rs
@@ -46,6 +46,7 @@ fn append_vec_sequential_read(bencher: &mut Bencher) {
     let vec = AppendVec::new(&path.path, true, 64 * 1024);
     let size = 1_000;
     let mut indexes = add_test_accounts(&vec, size);
+    indexes.pop();
     bencher.iter(|| {
         let (sample, pos) = indexes.pop().unwrap();
         let (account, _next) = vec.get_account(pos).unwrap();
@@ -60,6 +61,7 @@ fn append_vec_random_read(bencher: &mut Bencher) {
     let vec = AppendVec::new(&path.path, true, 64 * 1024);
     let size = 1_000;
     let indexes = add_test_accounts(&vec, size);
+    indexes.pop();
     bencher.iter(|| {
         let random_index: usize = thread_rng().gen_range(0, indexes.len());
         let (sample, pos) = &indexes[random_index];

--- a/runtime/benches/append_vec.rs
+++ b/runtime/benches/append_vec.rs
@@ -60,7 +60,7 @@ fn append_vec_random_read(bencher: &mut Bencher) {
     let path = get_append_vec_path("random_read");
     let vec = AppendVec::new(&path.path, true, 64 * 1024);
     let size = 1_000;
-    let indexes = add_test_accounts(&vec, size);
+    let mut indexes = add_test_accounts(&vec, size);
     indexes.pop();
     bencher.iter(|| {
         let random_index: usize = thread_rng().gen_range(0, indexes.len());

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -450,7 +450,7 @@ impl Accounts {
     /// scans underlying accounts_db for this delta (slot) with a map function
     ///   from LoadedAccount to B
     /// returns only the latest/current version of B for this slot
-    fn scan_slot<F, B>(&self, slot: Slot, func: F) -> Vec<B>
+    pub fn scan_slot<F, B>(&self, slot: Slot, func: F) -> Vec<B>
     where
         F: Fn(LoadedAccount) -> Option<B> + Send + Sync,
         B: Send + Default,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -681,10 +681,6 @@ impl Accounts {
         self.accounts_db.store_cached(slot, &[(pubkey, account)]);
     }
 
-    pub fn flush_accounts_cache(&self) {
-        self.accounts_db.force_flush_accounts_cache();
-    }
-
     fn is_locked_readonly(&self, key: &Pubkey) -> bool {
         self.readonly_locks
             .read()

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -274,7 +274,9 @@ impl AccountsBackgroundService {
                 // available snapshot in the channel.
                 let snapshot_block_height =
                     request_handler.handle_snapshot_requests(caching_enabled);
-                bank.flush_accounts_cache_if_needed();
+                if caching_enabled {
+                    bank.flush_accounts_cache_if_needed();
+                }
 
                 if let Some(snapshot_block_height) = snapshot_block_height {
                     // Safe, see proof above
@@ -297,7 +299,9 @@ impl AccountsBackgroundService {
                     if bank.block_height() - last_cleaned_block_height
                         > (CLEAN_INTERVAL_BLOCKS + thread_rng().gen_range(0, 10))
                     {
-                        bank.force_flush_accounts_cache();
+                        if caching_enabled {
+                            bank.force_flush_accounts_cache();
+                        }
                         bank.clean_accounts(true);
                         last_cleaned_block_height = bank.block_height();
                     }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -286,7 +286,7 @@ impl AccountsBackgroundService {
                     if accounts_db_caching_enabled {
                         bank.shrink_candidate_slots();
                     } else {
-                        // under sustained writes, shrink can lag behind so cap to	                    bank.shrink_candidate_slots();
+                        // under sustained writes, shrink can lag behind so cap to
                         // SHRUNKEN_ACCOUNT_PER_INTERVAL (which is based on INTERVAL_MS,
                         // which in turn roughly asscociated block time)
                         consumed_budget = bank

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -25,9 +25,6 @@ use std::{
 };
 
 const INTERVAL_MS: u64 = 100;
-const SHRUNKEN_ACCOUNT_PER_SEC: usize = 250;
-const SHRUNKEN_ACCOUNT_PER_INTERVAL: usize =
-    SHRUNKEN_ACCOUNT_PER_SEC / (1000 / INTERVAL_MS as usize);
 const CLEAN_INTERVAL_BLOCKS: u64 = 100;
 
 pub type SnapshotRequestSender = Sender<SnapshotRequest>;
@@ -91,9 +88,11 @@ impl SnapshotRequestHandler {
                 snapshot_root_bank.update_accounts_hash();
                 hash_time.stop();
 
-                let mut shrink_time = Measure::start("shrink_time");
-                snapshot_root_bank.process_stale_slot_with_budget(0, SHRUNKEN_ACCOUNT_PER_INTERVAL);
-                shrink_time.stop();
+                let mut flush_accounts_cache_time = Measure::start("flush_accounts_cache_time");
+
+                // Force flush all the roots from the cache so that the snapshot can be taken.
+                snapshot_root_bank.force_flush_accounts_cache();
+                flush_accounts_cache_time.stop();
 
                 let mut clean_time = Measure::start("clean_time");
                 // Don't clean the slot we're snapshotting because it may have zero-lamport
@@ -102,6 +101,10 @@ impl SnapshotRequestHandler {
                 // the frozen hash.
                 snapshot_root_bank.clean_accounts(true);
                 clean_time.stop();
+
+                let mut shrink_time = Measure::start("shrink_time");
+                snapshot_root_bank.shrink_candidate_slots();
+                shrink_time.stop();
 
                 // Generate an accounts package
                 let mut snapshot_time = Measure::start("snapshot_time");
@@ -130,6 +133,12 @@ impl SnapshotRequestHandler {
 
                 datapoint_info!(
                     "handle_snapshot_requests-timing",
+                    ("hash_time", hash_time.as_us(), i64),
+                    (
+                        "flush_accounts_cache_time",
+                        flush_accounts_cache_time.as_us(),
+                        i64
+                    ),
                     ("shrink_time", shrink_time.as_us(), i64),
                     ("clean_time", clean_time.as_us(), i64),
                     ("snapshot_time", snapshot_time.as_us(), i64),
@@ -138,7 +147,6 @@ impl SnapshotRequestHandler {
                         purge_old_snapshots_time.as_us(),
                         i64
                     ),
-                    ("hash_time", hash_time.as_us(), i64),
                 );
                 snapshot_root_bank.block_height()
             })
@@ -211,7 +219,6 @@ impl AccountsBackgroundService {
     ) -> Self {
         info!("AccountsBackgroundService active");
         let exit = exit.clone();
-        let mut consumed_budget = 0;
         let mut last_cleaned_block_height = 0;
         let mut removed_slots_count = 0;
         let mut total_remove_slots_time = 0;
@@ -251,25 +258,19 @@ impl AccountsBackgroundService {
                 // snapshot_request_handler.handle_requests() will always look for the latest
                 // available snapshot in the channel.
                 let snapshot_block_height = request_handler.handle_snapshot_requests();
+                bank.flush_accounts_cache_if_needed();
 
                 if let Some(snapshot_block_height) = snapshot_block_height {
                     // Safe, see proof above
                     assert!(last_cleaned_block_height <= snapshot_block_height);
                     last_cleaned_block_height = snapshot_block_height;
                 } else {
-                    // under sustained writes, shrink can lag behind so cap to
-                    // SHRUNKEN_ACCOUNT_PER_INTERVAL (which is based on INTERVAL_MS,
-                    // which in turn roughly asscociated block time)
-                    consumed_budget = bank
-                        .process_stale_slot_with_budget(
-                            consumed_budget,
-                            SHRUNKEN_ACCOUNT_PER_INTERVAL,
-                        )
-                        .min(SHRUNKEN_ACCOUNT_PER_INTERVAL);
+                    bank.shrink_candidate_slots();
 
                     if bank.block_height() - last_cleaned_block_height
                         > (CLEAN_INTERVAL_BLOCKS + thread_rng().gen_range(0, 10))
                     {
+                        bank.force_flush_accounts_cache();
                         bank.clean_accounts(true);
                         last_cleaned_block_height = bank.block_height();
                     }

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -147,8 +147,8 @@ impl AccountsCache {
         std::mem::replace(&mut self.cached_roots.write().unwrap(), HashSet::new())
     }
 
-    // Removes slots less than or equal to `max_root`. Only safe to call with roots, otherwise
-    // the slot removed could still be undergoing replay!
+    // Removes slots less than or equal to `max_root`. Only safe to pass in a rooted slot,
+    // otherwise the slot removed could still be undergoing replay!
     pub fn remove_slots_le(&self, max_root: Slot) -> Vec<(Slot, SlotCache)> {
         let mut removed_slots = vec![];
         self.cache.retain(|slot, slot_cache| {

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -1,0 +1,236 @@
+use dashmap::DashMap;
+use solana_sdk::{account::Account, clock::Slot, hash::Hash, pubkey::Pubkey};
+use std::{
+    collections::HashSet,
+    ops::Deref,
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc, RwLock,
+    },
+};
+
+pub type SlotCache = Arc<SlotCacheInner>;
+
+#[derive(Default, Debug)]
+pub struct SlotCacheInner {
+    cache: DashMap<Pubkey, CachedAccount>,
+    same_account_writes: AtomicU64,
+    same_account_writes_size: AtomicU64,
+    unique_account_writes_size: AtomicU64,
+    is_frozen: AtomicBool,
+}
+
+impl SlotCacheInner {
+    pub fn report_slot_store_metrics(&self) {
+        datapoint_info!(
+            "slot_repeated_writes",
+            (
+                "same_account_writes",
+                self.same_account_writes.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "same_account_writes_size",
+                self.same_account_writes_size.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "unique_account_writes_size",
+                self.unique_account_writes_size.load(Ordering::Relaxed),
+                i64
+            )
+        );
+    }
+
+    pub fn insert(&self, pubkey: &Pubkey, account: Account, hash: Hash) {
+        if self.cache.contains_key(pubkey) {
+            self.same_account_writes.fetch_add(1, Ordering::Relaxed);
+            self.same_account_writes_size
+                .fetch_add(account.data.len() as u64, Ordering::Relaxed);
+        } else {
+            self.unique_account_writes_size
+                .fetch_add(account.data.len() as u64, Ordering::Relaxed);
+        }
+        self.cache.insert(*pubkey, CachedAccount { account, hash });
+    }
+
+    pub fn get_cloned(&self, pubkey: &Pubkey) -> Option<CachedAccount> {
+        self.cache
+            .get(pubkey)
+            // 1) Maybe can eventually use a Cow to avoid a clone on every read
+            // 2) Popping is only safe if its guaranteed only replay/banking threads
+            // are reading from the AccountsDb
+            .map(|account_ref| account_ref.value().clone())
+    }
+
+    pub fn mark_slot_frozen(&self) {
+        self.is_frozen.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_frozen(&self) -> bool {
+        self.is_frozen.load(Ordering::SeqCst)
+    }
+}
+
+impl Deref for SlotCacheInner {
+    type Target = DashMap<Pubkey, CachedAccount>;
+    fn deref(&self) -> &Self::Target {
+        &self.cache
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedAccount {
+    pub account: Account,
+    pub hash: Hash,
+}
+
+#[derive(Debug, Default)]
+pub struct AccountsCache {
+    cache: DashMap<Slot, SlotCache>,
+    cached_roots: RwLock<HashSet<Slot>>,
+}
+
+impl AccountsCache {
+    pub fn report_size(&self) {
+        let total_unique_writes_size: u64 = self
+            .cache
+            .iter()
+            .map(|item| {
+                let slot_cache = item.value();
+                slot_cache
+                    .unique_account_writes_size
+                    .load(Ordering::Relaxed)
+            })
+            .sum();
+        datapoint_info!(
+            "accounts_cache_size",
+            ("num_roots", self.cached_roots.read().unwrap().len(), i64),
+            ("num_slots", self.cache.len(), i64),
+            ("total_unique_writes_size", total_unique_writes_size, i64),
+        );
+    }
+
+    pub fn store(&self, slot: Slot, pubkey: &Pubkey, account: Account, hash: Hash) {
+        let slot_cache = self.slot_cache(slot).unwrap_or_else(||
+            // DashMap entry.or_insert() returns a RefMut, essentially a write lock,
+            // which is dropped after this block ends, minimizing time held by the lock.
+            // However, we still want to persist the reference to the `SlotStores` behind
+            // the lock, hence we clone it out, (`SlotStores` is an Arc so is cheap to clone).
+            self
+                .cache
+                .entry(slot)
+                .or_insert(Arc::new(SlotCacheInner::default()))
+                .clone());
+
+        slot_cache.insert(pubkey, account, hash);
+    }
+
+    pub fn load(&self, slot: Slot, pubkey: &Pubkey) -> Option<CachedAccount> {
+        self.slot_cache(slot)
+            .and_then(|slot_cache| slot_cache.get_cloned(pubkey))
+    }
+
+    pub fn remove_slot(&self, slot: Slot) -> Option<SlotCache> {
+        self.cache.remove(&slot).map(|(_, slot_cache)| slot_cache)
+    }
+
+    pub fn slot_cache(&self, slot: Slot) -> Option<SlotCache> {
+        self.cache.get(&slot).map(|result| result.value().clone())
+    }
+
+    pub fn add_root(&self, root: Slot) {
+        self.cached_roots.write().unwrap().insert(root);
+    }
+
+    pub fn clear_roots(&self) -> HashSet<Slot> {
+        std::mem::replace(&mut self.cached_roots.write().unwrap(), HashSet::new())
+    }
+
+    // Removes slots less than or equal to `max_root`. Only safe to call with roots, otherwise
+    // the slot removed could still be undergoing replay!
+    pub fn remove_slots_le(&self, max_root: Slot) -> Vec<(Slot, SlotCache)> {
+        let mut removed_slots = vec![];
+        self.cache.retain(|slot, slot_cache| {
+            let should_remove = *slot <= max_root;
+            if should_remove {
+                removed_slots.push((*slot, slot_cache.clone()))
+            }
+            !should_remove
+        });
+        removed_slots
+    }
+
+    pub fn find_older_frozen_slots(&self, num_to_retain: usize) -> Vec<Slot> {
+        if self.cache.len() > num_to_retain {
+            let mut slots: Vec<_> = self
+                .cache
+                .iter()
+                .filter_map(|item| {
+                    let (slot, slot_cache) = item.pair();
+                    if slot_cache.is_frozen() {
+                        Some(*slot)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            slots.sort_unstable();
+            slots.truncate(slots.len().saturating_sub(num_to_retain));
+            slots
+        } else {
+            vec![]
+        }
+    }
+
+    pub fn num_slots(&self) -> usize {
+        self.cache.len()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remove_slots_le() {
+        let cache = AccountsCache::default();
+        // Cache is empty, should return nothing
+        assert!(cache.remove_slots_le(1).is_empty());
+        let inserted_slot = 0;
+        cache.store(
+            inserted_slot,
+            &Pubkey::new_unique(),
+            Account::new(1, 0, &Pubkey::default()),
+            Hash::default(),
+        );
+        // If the cache is told the size limit is 0, it should return the one slot
+        let removed = cache.remove_slots_le(0);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].0, inserted_slot);
+    }
+
+    #[test]
+    fn test_find_older_frozen_slots() {
+        let cache = AccountsCache::default();
+        // Cache is empty, should return nothing
+        assert!(cache.find_older_frozen_slots(0).is_empty());
+        let inserted_slot = 0;
+        cache.store(
+            inserted_slot,
+            &Pubkey::new_unique(),
+            Account::new(1, 0, &Pubkey::default()),
+            Hash::default(),
+        );
+
+        // If the cache is told the size limit is 0, it should return nothing because there's only
+        // one cached slot
+        assert!(cache.find_older_frozen_slots(1).is_empty());
+        // If the cache is told the size limit is 0, it should return nothing, because there's no
+        // frozen slots
+        assert!(cache.find_older_frozen_slots(0).is_empty());
+        cache.slot_cache(inserted_slot).unwrap().mark_slot_frozen();
+        // If the cache is told the size limit is 0, it should return the one frozen slot
+        assert_eq!(cache.find_older_frozen_slots(0), vec![inserted_slot]);
+    }
+}

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -89,6 +89,7 @@ pub struct CachedAccount {
 pub struct AccountsCache {
     cache: DashMap<Slot, SlotCache>,
     cached_roots: RwLock<HashSet<Slot>>,
+    max_flushed_root: AtomicU64,
 }
 
 impl AccountsCache {
@@ -185,6 +186,14 @@ impl AccountsCache {
 
     pub fn num_slots(&self) -> usize {
         self.cache.len()
+    }
+
+    pub fn fetch_max_flush_root(&self) -> Slot {
+        self.max_flushed_root.load(Ordering::Relaxed)
+    }
+
+    pub fn set_max_flush_root(&self, root: Slot) {
+        self.max_flushed_root.fetch_max(root, Ordering::Relaxed);
     }
 }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1814,6 +1814,10 @@ impl AccountsDB {
             self.page_align(size),
         ));
 
+        if store.append_vec_id() == CACHE_VIRTUAL_STORAGE_ID {
+            panic!("We've run out of storage ids!");
+        }
+
         debug!(
             "creating store: {} slot: {} len: {} size: {} from: {} path: {:?}",
             store.append_vec_id(),
@@ -1862,10 +1866,11 @@ impl AccountsDB {
                 .or_insert(Arc::new(RwLock::new(HashMap::new())))
                 .clone());
 
-        slot_storages
+        assert!(slot_storages
             .write()
             .unwrap()
-            .insert(store.append_vec_id(), store);
+            .insert(store.append_vec_id(), store)
+            .is_none());
     }
 
     pub fn purge_slot(&self, slot: Slot) {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1758,16 +1758,12 @@ impl AccountsDB {
             HashMap::new(),
         );
         let num_candidates = shrink_slots.len();
-        self.thread_pool_clean.install(|| {
-            shrink_slots
-                .par_iter()
-                .for_each(|(slot, slot_shrink_candidates)| {
-                    let mut measure = Measure::start("shrink_candidate_slots-ms");
-                    self.do_shrink_slot_stores(*slot, slot_shrink_candidates.values());
-                    measure.stop();
-                    inc_new_counter_info!("shrink_candidate_slots-ms", measure.as_ms() as usize);
-                })
-        });
+        for (slot, slot_shrink_candidates) in shrink_slots {
+            let mut measure = Measure::start("shrink_candidate_slots-ms");
+            self.do_shrink_slot_stores(slot, slot_shrink_candidates.values());
+            measure.stop();
+            inc_new_counter_info!("shrink_candidate_slots-ms", measure.as_ms() as usize);
+        }
         num_candidates
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -20,7 +20,9 @@
 
 use crate::{
     accounts_cache::{AccountsCache, CachedAccount, SlotCache},
-    accounts_index::{AccountIndex, AccountsIndex, Ancestors, IndexKey, SlotList, SlotSlice},
+    accounts_index::{
+        AccountIndex, AccountsIndex, Ancestors, IndexKey, IsCached, SlotList, SlotSlice,
+    },
     append_vec::{AppendVec, StoredAccountMeta, StoredMeta},
 };
 use blake3::traits::digest::Digest;
@@ -124,6 +126,12 @@ pub struct AccountInfo {
     /// purposes to remove accounts with zero balance.
     lamports: u64,
 }
+impl IsCached for AccountInfo {
+    fn is_cached(&self) -> bool {
+        self.store_id == CACHE_VIRTUAL_STORAGE_ID
+    }
+}
+
 /// An offset into the AccountsDB::storage vector
 pub type AppendVecId = usize;
 pub type SnapshotStorage = Vec<Arc<AccountStorageEntry>>;
@@ -796,7 +804,6 @@ impl AccountsDB {
                             &mut reclaims,
                             max_clean_root,
                             &self.account_indexes,
-                            |account_info| account_info.store_id == CACHE_VIRTUAL_STORAGE_ID,
                         );
                     }
                     reclaims

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -865,7 +865,7 @@ impl<T: 'static + Clone> AccountsIndex<T> {
         let mut w_roots_tracker = self.roots_tracker.write().unwrap();
         w_roots_tracker.roots.insert(slot);
         w_roots_tracker.uncleaned_roots.insert(slot);
-        // AccountsCache `flush_accounts_cache()` relies on roots being added in order
+        // `AccountsDb::flush_accounts_cache()` relies on roots being added in order
         assert!(slot >= w_roots_tracker.max_root);
         w_roots_tracker.max_root = slot;
     }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1667,7 +1667,12 @@ pub mod tests {
             slots.len()
         );
 
-        index.purge_exact(&account_key, &slots.into_iter().collect(), &mut vec![], account_index);
+        index.purge_exact(
+            &account_key,
+            &slots.into_iter().collect(),
+            &mut vec![],
+            account_index,
+        );
 
         assert!(secondary_index.index.is_empty());
         assert!(secondary_index.reverse_index.is_empty());

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1731,7 +1731,7 @@ pub mod tests {
             &mut reclaims,
             None,
             &HashSet::new(),
-            |_| true,
+            |_| false,
         );
         assert!(reclaims.is_empty());
         assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
@@ -1748,7 +1748,7 @@ pub mod tests {
             &mut reclaims,
             None,
             &HashSet::new(),
-            |_| true,
+            |_| false,
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -1763,7 +1763,7 @@ pub mod tests {
             &mut reclaims,
             None,
             &HashSet::new(),
-            |_| true,
+            |_| false,
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -1778,7 +1778,7 @@ pub mod tests {
             &mut reclaims,
             Some(6),
             &HashSet::new(),
-            |_| true,
+            |_| false,
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -1792,7 +1792,7 @@ pub mod tests {
             &mut reclaims,
             Some(5),
             &HashSet::new(),
-            |_| true,
+            |_| false,
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -1807,7 +1807,7 @@ pub mod tests {
             &mut reclaims,
             Some(2),
             &HashSet::new(),
-            |_| true,
+            |_| false,
         );
         assert!(reclaims.is_empty());
         assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
@@ -1822,7 +1822,7 @@ pub mod tests {
             &mut reclaims,
             Some(1),
             &HashSet::new(),
-            |_| true,
+            |_| false,
         );
         assert!(reclaims.is_empty());
         assert_eq!(slot_list, vec![(1, true), (2, true), (5, true), (9, true)]);
@@ -1837,7 +1837,7 @@ pub mod tests {
             &mut reclaims,
             Some(7),
             &HashSet::new(),
-            |_| true,
+            |_| false,
         );
         assert_eq!(reclaims, vec![(1, true), (2, true)]);
         assert_eq!(slot_list, vec![(5, true), (9, true)]);
@@ -2006,7 +2006,7 @@ pub mod tests {
         assert!(secondary_index.get(&secondary_key1).is_empty());
         assert_eq!(secondary_index.get(&secondary_key2), vec![account_key]);
 
-        // If another fork reintroduces secondary_key1, then it should be readded to the
+        // If another fork reintroduces secondary_key1, then it should be re-added to the
         // index
         let fork = slot + 1;
         index.upsert(
@@ -2033,7 +2033,7 @@ pub mod tests {
                     &mut vec![],
                     None,
                     account_index,
-                    |_| true,
+                    |_| false,
                 )
             });
         assert!(secondary_index.get(&secondary_key2).is_empty());

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -926,6 +926,10 @@ impl<T: 'static + Clone> AccountsIndex<T> {
             .contains(&slot)
     }
 
+    pub fn num_roots(&self) -> usize {
+        self.roots_tracker.read().unwrap().roots.len()
+    }
+
     pub fn all_roots(&self) -> Vec<Slot> {
         self.roots_tracker
             .read()

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -54,10 +54,21 @@ pub struct AccountMeta {
     pub rent_epoch: Epoch,
 }
 
+impl<'a> From<&'a Account> for AccountMeta {
+    fn from(account: &'a Account) -> Self {
+        Self {
+            lamports: account.lamports,
+            owner: account.owner,
+            executable: account.executable,
+            rent_epoch: account.rent_epoch,
+        }
+    }
+}
+
 /// References to Memory Mapped memory
 /// The Account is stored separately from its data, so getting the actual account requires a clone
 #[derive(PartialEq, Debug)]
-pub struct StoredAccount<'a> {
+pub struct StoredAccountMeta<'a> {
     pub meta: &'a StoredMeta,
     /// account data
     pub account_meta: &'a AccountMeta,
@@ -66,7 +77,7 @@ pub struct StoredAccount<'a> {
     pub hash: &'a Hash,
 }
 
-impl<'a> StoredAccount<'a> {
+impl<'a> StoredAccountMeta<'a> {
     pub fn clone_account(&self) -> Account {
         Account {
             lamports: self.account_meta.lamports,
@@ -366,13 +377,13 @@ impl AppendVec {
         Some((unsafe { &*ptr }, next))
     }
 
-    pub fn get_account<'a>(&'a self, offset: usize) -> Option<(StoredAccount<'a>, usize)> {
+    pub fn get_account<'a>(&'a self, offset: usize) -> Option<(StoredAccountMeta<'a>, usize)> {
         let (meta, next): (&'a StoredMeta, _) = self.get_type(offset)?;
         let (account_meta, next): (&'a AccountMeta, _) = self.get_type(next)?;
         let (hash, next): (&'a Hash, _) = self.get_type(next)?;
         let (data, next) = self.get_slice(next, meta.data_len as usize)?;
         Some((
-            StoredAccount {
+            StoredAccountMeta {
                 meta,
                 account_meta,
                 data,
@@ -392,7 +403,7 @@ impl AppendVec {
         self.path.clone()
     }
 
-    pub fn accounts(&self, mut start: usize) -> Vec<StoredAccount> {
+    pub fn accounts(&self, mut start: usize) -> Vec<StoredAccountMeta> {
         let mut accounts = vec![];
         while let Some((account, next)) = self.get_account(start) {
             accounts.push(account);
@@ -411,12 +422,7 @@ impl AppendVec {
         let mut rv = Vec::with_capacity(accounts.len());
         for ((stored_meta, account), hash) in accounts.iter().zip(hashes) {
             let meta_ptr = stored_meta as *const StoredMeta;
-            let account_meta = AccountMeta {
-                lamports: account.lamports,
-                owner: account.owner,
-                executable: account.executable,
-                rent_epoch: account.rent_epoch,
-            };
+            let account_meta = AccountMeta::from(*account);
             let account_meta_ptr = &account_meta as *const AccountMeta;
             let data_len = stored_meta.data_len as usize;
             let data_ptr = account.data.as_ptr();
@@ -511,7 +517,7 @@ pub mod tests {
         }
     }
 
-    impl<'a> StoredAccount<'a> {
+    impl<'a> StoredAccountMeta<'a> {
         #[allow(clippy::cast_ref_to_mut)]
         fn set_data_len_unsafe(&self, new_data_len: u64) {
             // UNSAFE: cast away & (= const ref) to &mut to force to mutate append-only (=read-only) AppendVec

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -452,9 +452,12 @@ impl AppendVec {
         account: &Account,
         hash: Hash,
     ) -> Option<usize> {
-        self.append_accounts(&[(storage_meta, account)], &[hash])
-            .first()
-            .cloned()
+        let res = self.append_accounts(&[(storage_meta, account)], &[hash]);
+        if res.len() == 1 {
+            None
+        } else {
+            res.first().cloned()
+        }
     }
 }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -442,7 +442,11 @@ impl AppendVec {
                 break;
             }
         }
-        rv.push(*offset);
+
+        // The last entry in this offset needs to be the u64 aligned offset, because that's
+        // where the *next* entry will begin to be stored.
+        rv.push(u64_align!(*offset));
+
         rv
     }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -74,6 +74,7 @@ pub struct StoredAccountMeta<'a> {
     pub account_meta: &'a AccountMeta,
     pub data: &'a [u8],
     pub offset: usize,
+    pub stored_size: usize,
     pub hash: &'a Hash,
 }
 
@@ -382,12 +383,14 @@ impl AppendVec {
         let (account_meta, next): (&'a AccountMeta, _) = self.get_type(next)?;
         let (hash, next): (&'a Hash, _) = self.get_type(next)?;
         let (data, next) = self.get_slice(next, meta.data_len as usize)?;
+        let stored_size = next - offset;
         Some((
             StoredAccountMeta {
                 meta,
                 account_meta,
                 data,
                 offset,
+                stored_size,
                 hash,
             },
             next,
@@ -439,6 +442,7 @@ impl AppendVec {
                 break;
             }
         }
+        rv.push(*offset);
         rv
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6752,7 +6752,7 @@ pub(crate) mod tests {
             .accounts
             .accounts_db
             .accounts_index
-            .add_root(genesis_bank1.slot() + 1);
+            .add_root(genesis_bank1.slot() + 1, false);
         bank1_without_zero
             .rc
             .accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1998,8 +1998,8 @@ impl Bank {
             // freeze is a one-way trip, idempotent
             self.freeze_started.store(true, Relaxed);
             *hash = self.hash_internal_state();
+            self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());
         }
-        self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());
     }
 
     // Should not be called outside of startup, will race with

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -11672,7 +11672,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_store_scan_consistency_unrooted() {
-        for accounts_db_caching_enabled in &[true] {
+        for accounts_db_caching_enabled in &[false, true] {
             test_store_scan_consistency(
                 *accounts_db_caching_enabled,
                 |bank0, bank_to_scan_sender, pubkeys_to_modify, program_id, starting_lamports| {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -874,7 +874,7 @@ impl Bank {
     pub(crate) fn new_with_config(
         genesis_config: &GenesisConfig,
         account_indexes: HashSet<AccountIndex>,
-        caching_enabled: bool,
+        accounts_db_caching_enabled: bool,
     ) -> Self {
         Self::new_with_paths(
             &genesis_config,
@@ -883,7 +883,7 @@ impl Bank {
             None,
             None,
             account_indexes,
-            caching_enabled,
+            accounts_db_caching_enabled,
         )
     }
 
@@ -894,7 +894,7 @@ impl Bank {
         debug_keys: Option<Arc<HashSet<Pubkey>>>,
         additional_builtins: Option<&Builtins>,
         account_indexes: HashSet<AccountIndex>,
-        caching_enabled: bool,
+        accounts_db_caching_enabled: bool,
     ) -> Self {
         let mut bank = Self::default();
         bank.ancestors.insert(bank.slot(), 0);
@@ -905,7 +905,7 @@ impl Bank {
             paths,
             &genesis_config.cluster_type,
             account_indexes,
-            caching_enabled,
+            accounts_db_caching_enabled,
         ));
         bank.process_genesis_config(genesis_config);
         bank.finish_init(genesis_config, additional_builtins);

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -174,6 +174,12 @@ impl BankForks {
         highest_confirmed_root: Option<Slot>,
     ) {
         let old_epoch = self.root_bank().epoch();
+        // After setting the root here, we have to ensure that no other banks < root that
+        // are frozen are concurrently replayed. This is because the flush cache logic in
+        // Accounts assumes at this point every unrooted slot `S` < root at this point is
+        // purgeable. If any such slot `S` is still being written to, the `clean_accounts()`
+        // logic may fail an assertion because it does not expect to find any cleanable slots
+        // that still exist in the cache.
         self.root = root;
         let set_root_start = Instant::now();
         let root_bank = self

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -174,12 +174,6 @@ impl BankForks {
         highest_confirmed_root: Option<Slot>,
     ) {
         let old_epoch = self.root_bank().epoch();
-        // After setting the root here, we have to ensure that no other banks < root that
-        // are not frozen are concurrently replayed. This is because the flush cache logic in
-        // Accounts assumes at this point every unrooted slot `S` < root at this point is
-        // purgeable. If any such slot `S` is still being written to, the `clean_accounts()`
-        // logic may fail an assertion because it does not expect to find any cleanable slots
-        // that still exist in the cache.
         self.root = root;
         let set_root_start = Instant::now();
         let root_bank = self

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -175,7 +175,7 @@ impl BankForks {
     ) {
         let old_epoch = self.root_bank().epoch();
         // After setting the root here, we have to ensure that no other banks < root that
-        // are frozen are concurrently replayed. This is because the flush cache logic in
+        // are not frozen are concurrently replayed. This is because the flush cache logic in
         // Accounts assumes at this point every unrooted slot `S` < root at this point is
         // purgeable. If any such slot `S` is still being written to, the `clean_accounts()`
         // logic may fail an assertion because it does not expect to find any cleanable slots

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 pub mod accounts;
 pub mod accounts_background_service;
+pub mod accounts_cache;
 pub mod accounts_db;
 pub mod accounts_index;
 pub mod append_vec;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -271,7 +271,7 @@ where
     P: AsRef<Path>,
 {
     let mut accounts_db =
-        AccountsDB::new_with_indexes(account_paths.to_vec(), cluster_type, account_indexes);
+        AccountsDB::new_with_config(account_paths.to_vec(), cluster_type, account_indexes, false);
     let AccountsDbFields(storage, version, slot, bank_hash_info) = accounts_db_fields;
 
     // convert to two level map of slot -> id -> account storage entry

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -365,6 +365,10 @@ where
         );
     }
 
+    if max_id > AppendVecId::MAX / 2 {
+        panic!("Storage id {} larger than allowed max", max_id);
+    }
+
     accounts_db.next_id.store(max_id + 1, Ordering::Relaxed);
     accounts_db
         .write_version

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -117,6 +117,7 @@ where
         .deserialize_from::<R, T>(reader)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn bank_from_stream<R, P>(
     serde_style: SerdeStyle,
     stream: &mut BufReader<R>,
@@ -127,6 +128,7 @@ pub(crate) fn bank_from_stream<R, P>(
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
     account_indexes: HashSet<AccountIndex>,
+    caching_enabled: bool,
 ) -> std::result::Result<Bank, Error>
 where
     R: Read,
@@ -146,6 +148,7 @@ where
                 debug_keys,
                 additional_builtins,
                 account_indexes,
+                caching_enabled,
             )?;
             Ok(bank)
         }};
@@ -223,6 +226,7 @@ impl<'a, C: TypeContext<'a>> Serialize for SerializableAccountsDB<'a, C> {
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 impl<'a, C> IgnoreAsHelper for SerializableAccountsDB<'a, C> {}
 
+#[allow(clippy::too_many_arguments)]
 fn reconstruct_bank_from_fields<E, P>(
     bank_fields: BankFieldsToDeserialize,
     accounts_db_fields: AccountsDbFields<E>,
@@ -233,6 +237,7 @@ fn reconstruct_bank_from_fields<E, P>(
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
     account_indexes: HashSet<AccountIndex>,
+    caching_enabled: bool,
 ) -> Result<Bank, Error>
 where
     E: Into<AccountStorageEntry>,
@@ -244,6 +249,7 @@ where
         append_vecs_path,
         &genesis_config.cluster_type,
         account_indexes,
+        caching_enabled,
     )?;
     accounts_db.freeze_accounts(&bank_fields.ancestors, frozen_account_pubkeys);
 
@@ -265,13 +271,18 @@ fn reconstruct_accountsdb_from_fields<E, P>(
     stream_append_vecs_path: P,
     cluster_type: &ClusterType,
     account_indexes: HashSet<AccountIndex>,
+    caching_enabled: bool,
 ) -> Result<AccountsDB, Error>
 where
     E: Into<AccountStorageEntry>,
     P: AsRef<Path>,
 {
-    let mut accounts_db =
-        AccountsDB::new_with_config(account_paths.to_vec(), cluster_type, account_indexes, false);
+    let mut accounts_db = AccountsDB::new_with_config(
+        account_paths.to_vec(),
+        cluster_type,
+        account_indexes,
+        caching_enabled,
+    );
     let AccountsDbFields(storage, version, slot, bank_hash_info) = accounts_db_fields;
 
     // convert to two level map of slot -> id -> account storage entry

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -70,6 +70,7 @@ where
         stream_append_vecs_path,
         &ClusterType::Development,
         HashSet::new(),
+        false,
     )
 }
 
@@ -217,6 +218,7 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
         None,
         None,
         HashSet::new(),
+        false,
     )
     .unwrap();
     dbank.src = ref_sc;

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -121,7 +121,8 @@ where
 fn test_accounts_serialize_style(serde_style: SerdeStyle) {
     solana_logger::setup();
     let (_accounts_dir, paths) = get_temp_accounts_paths(4).unwrap();
-    let accounts = Accounts::new(paths, &ClusterType::Development);
+    let accounts =
+        Accounts::new_with_config(paths, &ClusterType::Development, HashSet::new(), false);
 
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100, 0);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -181,7 +181,9 @@ fn test_bank_serialize_style(serde_style: SerdeStyle) {
     let key3 = Keypair::new();
     bank2.deposit(&key3.pubkey(), 0);
 
+    bank2.freeze();
     bank2.squash();
+    bank2.force_flush_accounts_cache();
 
     let snapshot_storages = bank2.get_snapshot_storages();
     let mut buf = vec![];

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -573,6 +573,7 @@ pub fn remove_snapshot<P: AsRef<Path>>(slot: Slot, snapshot_path: P) -> Result<(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn bank_from_archive<P: AsRef<Path>>(
     account_paths: &[PathBuf],
     frozen_account_pubkeys: &[Pubkey],
@@ -583,6 +584,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
     account_indexes: HashSet<AccountIndex>,
+    caching_enabled: bool,
 ) -> Result<Bank> {
     // Untar the snapshot into a temporary directory
     let unpack_dir = tempfile::Builder::new()
@@ -608,6 +610,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
         debug_keys,
         additional_builtins,
         account_indexes,
+        caching_enabled,
     )?;
 
     if !bank.verify_snapshot_bank() {
@@ -744,6 +747,7 @@ pub fn untar_snapshot_in<P: AsRef<Path>, Q: AsRef<Path>>(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn rebuild_bank_from_snapshots<P>(
     snapshot_version: &str,
     account_paths: &[PathBuf],
@@ -754,6 +758,7 @@ fn rebuild_bank_from_snapshots<P>(
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
     account_indexes: HashSet<AccountIndex>,
+    caching_enabled: bool,
 ) -> Result<Bank>
 where
     P: AsRef<Path>,
@@ -791,6 +796,7 @@ where
                 debug_keys,
                 additional_builtins,
                 account_indexes,
+                caching_enabled,
             ),
         }?)
     })?;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -584,7 +584,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
     account_indexes: HashSet<AccountIndex>,
-    caching_enabled: bool,
+    accounts_db_caching_enabled: bool,
 ) -> Result<Bank> {
     // Untar the snapshot into a temporary directory
     let unpack_dir = tempfile::Builder::new()
@@ -610,7 +610,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
         debug_keys,
         additional_builtins,
         account_indexes,
-        caching_enabled,
+        accounts_db_caching_enabled,
     )?;
 
     if !bank.verify_snapshot_bank() {
@@ -758,7 +758,7 @@ fn rebuild_bank_from_snapshots<P>(
     debug_keys: Option<Arc<HashSet<Pubkey>>>,
     additional_builtins: Option<&Builtins>,
     account_indexes: HashSet<AccountIndex>,
-    caching_enabled: bool,
+    accounts_db_caching_enabled: bool,
 ) -> Result<Bank>
 where
     P: AsRef<Path>,
@@ -796,7 +796,7 @@ where
                 debug_keys,
                 additional_builtins,
                 account_indexes,
-                caching_enabled,
+                accounts_db_caching_enabled,
             ),
         }?)
     })?;

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1144,7 +1144,9 @@ mod tests {
     #[test]
     fn test_create_zero_lamport_with_clean() {
         with_create_zero_lamport(|bank| {
+            bank.freeze();
             bank.squash();
+            bank.force_flush_accounts_cache();
             // do clean and assert that it actually did its job
             assert_eq!(3, bank.get_snapshot_storages().len());
             bank.clean_accounts(false);

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -25,7 +25,7 @@ fn test_shrink_and_clean() {
             if exit_for_shrink.load(Ordering::Relaxed) {
                 break;
             }
-            accounts_for_shrink.process_stale_slot();
+            accounts_for_shrink.process_stale_slot_v1();
         });
 
         let mut alive_accounts = vec![];

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -45,7 +45,7 @@ fn test_shrink_and_clean() {
 
             for (pubkey, account) in alive_accounts.iter_mut() {
                 account.lamports -= 1;
-                accounts.store(current_slot, &[(&pubkey, &account)]);
+                accounts.store_uncached(current_slot, &[(&pubkey, &account)]);
             }
             accounts.add_root(current_slot);
         }
@@ -108,7 +108,7 @@ fn test_bad_bank_hash() {
             .iter()
             .map(|idx| (&accounts_keys[*idx].0, &accounts_keys[*idx].1))
             .collect();
-        db.store(some_slot, &account_refs);
+        db.store_uncached(some_slot, &account_refs);
 
         for (key, account) in &account_refs {
             assert_eq!(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1424,8 +1424,8 @@ pub fn main() {
                 .help("Enable an accounts index, indexed by the selected account field"),
         )
         .arg(
-            Arg::with_name("enable_cache")
-                .long("enable-cache")
+            Arg::with_name("accounts_db_caching_enabled")
+                .long("accounts-db-caching-enabled")
                 .help("Enable accounts caching"),
         )
         .get_matches();
@@ -1598,7 +1598,7 @@ pub fn main() {
         poh_pinned_cpu_core: value_of(&matches, "poh_pinned_cpu_core")
             .unwrap_or(poh_service::DEFAULT_PINNED_CPU_CORE),
         account_indexes,
-        caching_enabled: matches.is_present("enable_cache"),
+        accounts_db_caching_enabled: matches.is_present("accounts_db_caching_enabled"),
         ..ValidatorConfig::default()
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1423,6 +1423,11 @@ pub fn main() {
                 .value_name("INDEX")
                 .help("Enable an accounts index, indexed by the selected account field"),
         )
+        .arg(
+            Arg::with_name("enable_cache")
+                .long("enable-cache")
+                .help("Enable accounts caching"),
+        )
         .get_matches();
 
     let identity_keypair = Arc::new(keypair_of(&matches, "identity").unwrap_or_else(Keypair::new));
@@ -1593,6 +1598,7 @@ pub fn main() {
         poh_pinned_cpu_core: value_of(&matches, "poh_pinned_cpu_core")
             .unwrap_or(poh_service::DEFAULT_PINNED_CPU_CORE),
         account_indexes,
+        caching_enabled: matches.is_present("enable_cache"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
Storing same account multiple times in a slot, especially large accounts, is inefficient for storage

#### Summary of Changes
1) Introduce `AccountsCache` for accounts
2) Flush rooted slots from `AccountsBackgroundService` periodically
3) Flush slots on startup from `BlockstoreProcessor`

Based on initial validator test runs, so haven't seen much improvement in replay times and snapshot sizes, but may be a bigger issue if the same accounts are touched more often in the same slot.

Fixes #
