### PR TITLE
Use bank timestamp to populate Blockstore::blocktime_cf when correction active

### DIFF
--- a/core/src/cache_block_time_service.rs
+++ b/core/src/cache_block_time_service.rs
@@ -1,7 +1,7 @@
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use solana_ledger::blockstore::Blockstore;
 use solana_measure::measure::Measure;
-use solana_runtime::bank::Bank;
+use solana_runtime::{bank::Bank, feature_set};
 use solana_sdk::timing::slot_duration_from_slots_per_year;
 use std::{
     collections::HashMap,
@@ -60,13 +60,24 @@ impl CacheBlockTimeService {
     }
 
     fn cache_block_time(bank: Arc<Bank>, blockstore: &Arc<Blockstore>) {
-        let slot_duration = slot_duration_from_slots_per_year(bank.slots_per_year());
-        let epoch = bank.epoch_schedule().get_epoch(bank.slot());
-        let stakes = HashMap::new();
-        let stakes = bank.epoch_vote_accounts(epoch).unwrap_or(&stakes);
+        if bank
+            .feature_set
+            .is_active(&feature_set::timestamp_correction::id())
+        {
+            if let Err(e) = blockstore.cache_block_time(bank.slot(), bank.clock().unix_timestamp) {
+                error!("cache_block_time failed: slot {:?} {:?}", bank.slot(), e);
+            }
+        } else {
+            let slot_duration = slot_duration_from_slots_per_year(bank.slots_per_year());
+            let epoch = bank.epoch_schedule().get_epoch(bank.slot());
+            let stakes = HashMap::new();
+            let stakes = bank.epoch_vote_accounts(epoch).unwrap_or(&stakes);
 
-        if let Err(e) = blockstore.cache_block_time(bank.slot(), slot_duration, stakes) {
-            error!("cache_block_time failed: slot {:?} {:?}", bank.slot(), e);
+            if let Err(e) =
+                blockstore.cache_block_time_from_slot_entries(bank.slot(), slot_duration, stakes)
+            {
+                error!("cache_block_time failed: slot {:?} {:?}", bank.slot(), e);
+            }
         }
     }
 


### PR DESCRIPTION
#### Problem
As of `feature_set::timestamp_correction`, block times are being calculated twice: once to correct the Bank timestamp when the Bank is created, and again to store in Blockstore once a bank is rooted.

The duplication is unnecessary, and also makes it more difficult than it needs to be to iterate on the timestamp correction (as in #13120 ) and keep Bank and Blockstore in sync

#### Summary of Changes
- Read the corrected timestamp from the `Bank::clock()` and just store that in `Blockstore::blocktime_cf`
