### PR TITLE
macos portable rust-bpf

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -144,7 +144,7 @@ if [[ ! -e llvm-native-$version.md ]]; then
 fi
 
 # Install Rust-BPF
-version=v0.2.4
+version=v0.2.5
 if [[ ! -e rust-bpf-$version.md ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

BPF tools depend dynamically on local macos openssl libraries

#### Summary of Changes

Pull these in statically

These tools have been validated against a clean macos system

Fixes #
