### PR TITLE
Fix pr crossing for sysvar keyed-accounts

### DIFF
--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -94,7 +94,7 @@ mod tests {
 
     #[repr(C)]
     #[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
-    pub struct TestSysvar {
+    struct TestSysvar {
         something: Pubkey,
     }
     crate::declare_id!("TestSysvar111111111111111111111111111111111");
@@ -137,32 +137,5 @@ mod tests {
         let mut small_data = vec![];
         account_info.data = Rc::new(RefCell::new(&mut small_data));
         assert_eq!(test_sysvar.to_account_info(&mut account_info), None);
-    }
-
-    #[test]
-    fn test_sysvar_keyed_account_to_from() {
-        let test_sysvar = TestSysvar::default();
-        let key = crate::sysvar::tests::id();
-        let wrong_key = Pubkey::new_unique();
-
-        let account = test_sysvar.create_account(42);
-        let test_sysvar = TestSysvar::from_account(&account).unwrap();
-        assert_eq!(test_sysvar, TestSysvar::default());
-
-        let mut account = Account::new(42, TestSysvar::size_of(), &key);
-        test_sysvar.to_account(&mut account).unwrap();
-        let test_sysvar = TestSysvar::from_account(&account).unwrap();
-        assert_eq!(test_sysvar, TestSysvar::default());
-
-        let account = RefCell::new(account);
-        let keyed_account = KeyedAccount::new(&key, false, &account);
-        let new_test_sysvar = TestSysvar::from_keyed_account(&keyed_account).unwrap();
-        assert_eq!(test_sysvar, new_test_sysvar);
-
-        let keyed_account = KeyedAccount::new(&wrong_key, false, &account);
-        assert_eq!(
-            TestSysvar::from_keyed_account(&keyed_account),
-            Err(InstructionError::InvalidArgument)
-        );
     }
 }


### PR DESCRIPTION
#### Problem

PR crossed between sysvar tests and keyed_accounts move to solana-sdk

#### Summary of Changes

Fixes #
