### PR TITLE
Refactors common BPF test code into a shared module

### DIFF
--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -6,24 +6,22 @@ extern crate test;
 extern crate solana_bpf_loader_program;
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
-use solana_bpf_loader_program::syscalls::SyscallError;
 use solana_measure::measure::Measure;
 use solana_rbpf::vm::{EbpfVm, InstructionMeter};
 use solana_runtime::{
     bank::Bank,
     bank_client::BankClient,
+    bpf_test_utils::MockInvokeContext,
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
     loader_utils::load_program,
-    process_instruction::{
-        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
-    },
+    process_instruction::{ComputeMeter, InvokeContext},
 };
 use solana_sdk::{
     account::Account,
     bpf_loader,
     client::SyncClient,
     entrypoint::SUCCESS,
-    instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
+    instruction::{AccountMeta, Instruction},
     message::Message,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
@@ -193,7 +191,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     const BUDGET: u64 = 200_000;
     let loader_id = bpf_loader::id();
     let mut invoke_context = MockInvokeContext::default();
-    invoke_context.compute_meter.borrow_mut().remaining = BUDGET;
+    invoke_context.compute_meter.remaining = BUDGET;
     let compute_meter = invoke_context.get_compute_meter();
 
     let elf = load_elf("tuner").unwrap();
@@ -211,7 +209,11 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
 
     let mut measure = Measure::start("tune");
 
-    let accounts = [RefCell::new(Account::new(1, 10000001, &solana_sdk::pubkey::new_rand()))];
+    let accounts = [RefCell::new(Account::new(
+        1,
+        10000001,
+        &solana_sdk::pubkey::new_rand(),
+    ))];
     let keys = [solana_sdk::pubkey::new_rand()];
     let keyed_accounts: Vec<_> = keys
         .iter()
@@ -229,7 +231,8 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     )
     .unwrap();
 
-    let _ = vm.execute_program_metered(&mut serialized, &[], &[], instruction_meter.clone());    measure.stop();
+    let _ = vm.execute_program_metered(&mut serialized, &[], &[], instruction_meter.clone());
+    measure.stop();
     assert_eq!(
         0,
         instruction_meter.get_remaining(),
@@ -241,80 +244,6 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         measure.as_us(),
         vm.get_total_instruction_count(),
     );
-}
-
-#[derive(Debug, Default)]
-pub struct MockInvokeContext {
-    key: Pubkey,
-    logger: MockLogger,
-    compute_budget: ComputeBudget,
-    compute_meter: Rc<RefCell<MockComputeMeter>>,
-}
-impl InvokeContext for MockInvokeContext {
-    fn push(&mut self, _key: &Pubkey) -> Result<(), InstructionError> {
-        Ok(())
-    }
-    fn pop(&mut self) {}
-    fn verify_and_update(
-        &mut self,
-        _message: &Message,
-        _instruction: &CompiledInstruction,
-        _accounts: &[Rc<RefCell<Account>>],
-    ) -> Result<(), InstructionError> {
-        Ok(())
-    }
-    fn get_caller(&self) -> Result<&Pubkey, InstructionError> {
-        Ok(&self.key)
-    }
-    fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)] {
-        &[]
-    }
-    fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
-        Rc::new(RefCell::new(self.logger.clone()))
-    }
-    fn get_compute_budget(&self) -> &ComputeBudget {
-        &self.compute_budget
-    }
-    fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
-        self.compute_meter.clone()
-    }
-    fn add_executor(&mut self, _pubkey: &Pubkey, _executor: Arc<dyn Executor>) {}
-    fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
-        None
-    }
-    fn record_instruction(&self, _instruction: &Instruction) {}
-    fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
-        true
-    }
-}
-#[derive(Debug, Default, Clone)]
-pub struct MockLogger {
-    pub log: Rc<RefCell<Vec<String>>>,
-}
-impl Logger for MockLogger {
-    fn log_enabled(&self) -> bool {
-        true
-    }
-    fn log(&mut self, message: &str) {
-        self.log.borrow_mut().push(message.to_string());
-    }
-}
-#[derive(Debug, Default, Clone)]
-pub struct MockComputeMeter {
-    pub remaining: u64,
-}
-impl ComputeMeter for MockComputeMeter {
-    fn consume(&mut self, amount: u64) -> Result<(), InstructionError> {
-        let exceeded = self.remaining < amount;
-        self.remaining = self.remaining.saturating_sub(amount);
-        if exceeded {
-            return Err(InstructionError::ComputationalBudgetExceeded);
-        }
-        Ok(())
-    }
-    fn get_remaining(&self) -> u64 {
-        self.remaining
-    }
 }
 
 /// Passed to the VM to enforce the compute budget

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -7,15 +7,14 @@ use solana_bpf_loader_program::{
     create_vm,
     serialization::{deserialize_parameters, serialize_parameters},
 };
-use solana_rbpf::vm::{EbpfVm, InstructionMeter};
+use solana_rbpf::vm::EbpfVm;
 use solana_runtime::{
     bank::Bank,
     bank_client::BankClient,
+    bpf_test_utils::MockInvokeContext,
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
     loader_utils::load_program,
-    process_instruction::{
-        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
-    },
+    process_instruction::ComputeBudget,
 };
 use solana_sdk::{
     account::Account,
@@ -31,7 +30,7 @@ use solana_sdk::{
     sysvar::{clock, fees, rent, slot_hashes, stake_history},
     transaction::{Transaction, TransactionError},
 };
-use std::{cell::RefCell, env, fs::File, io::Read, path::PathBuf, rc::Rc, sync::Arc};
+use std::{cell::RefCell, env, fs::File, io::Read, path::PathBuf, sync::Arc};
 
 /// BPF program file extension
 const PLATFORM_FILE_EXTENSION_BPF: &str = "so";
@@ -773,82 +772,6 @@ fn assert_instruction_count() {
         let count = run_program(program.0, &program_id, &parameter_accounts[..], &[]).unwrap();
         println!("  {} : {:?} ({:?})", program.0, count, program.1,);
         assert!(count <= program.1);
-    }
-}
-
-// Mock InvokeContext
-
-#[derive(Debug, Default)]
-struct MockInvokeContext {
-    pub key: Pubkey,
-    pub logger: MockLogger,
-    pub compute_budget: ComputeBudget,
-    pub compute_meter: MockComputeMeter,
-}
-impl InvokeContext for MockInvokeContext {
-    fn push(&mut self, _key: &Pubkey) -> Result<(), InstructionError> {
-        Ok(())
-    }
-    fn pop(&mut self) {}
-    fn verify_and_update(
-        &mut self,
-        _message: &Message,
-        _instruction: &CompiledInstruction,
-        _accounts: &[Rc<RefCell<Account>>],
-    ) -> Result<(), InstructionError> {
-        Ok(())
-    }
-    fn get_caller(&self) -> Result<&Pubkey, InstructionError> {
-        Ok(&self.key)
-    }
-    fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)] {
-        &[]
-    }
-    fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
-        Rc::new(RefCell::new(self.logger.clone()))
-    }
-    fn get_compute_budget(&self) -> &ComputeBudget {
-        &self.compute_budget
-    }
-    fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
-        Rc::new(RefCell::new(self.compute_meter.clone()))
-    }
-    fn add_executor(&mut self, _pubkey: &Pubkey, _executor: Arc<dyn Executor>) {}
-    fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
-        None
-    }
-    fn record_instruction(&self, _instruction: &Instruction) {}
-    fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
-        true
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-struct MockComputeMeter {}
-impl ComputeMeter for MockComputeMeter {
-    fn consume(&mut self, _amount: u64) -> Result<(), InstructionError> {
-        Ok(())
-    }
-    fn get_remaining(&self) -> u64 {
-        u64::MAX
-    }
-}
-#[derive(Debug, Default, Clone)]
-struct MockLogger {}
-impl Logger for MockLogger {
-    fn log_enabled(&self) -> bool {
-        true
-    }
-    fn log(&mut self, _message: &str) {
-        // println!("{}", message);
-    }
-}
-
-struct TestInstructionMeter {}
-impl InstructionMeter for TestInstructionMeter {
-    fn consume(&mut self, _amount: u64) {}
-    fn get_remaining(&self) -> u64 {
-        u64::MAX
     }
 }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -313,101 +313,13 @@ mod tests {
     use super::*;
     use rand::Rng;
     use solana_runtime::{
+        bpf_test_utils::MockInvokeContext,
         feature_set::FeatureSet,
         message_processor::{Executors, ThisInvokeContext},
-        process_instruction::{ComputeBudget, Logger, ProcessInstruction},
+        process_instruction::ComputeBudget,
     };
-    use solana_sdk::{
-        account::Account, instruction::CompiledInstruction, instruction::Instruction,
-        message::Message, rent::Rent,
-    };
+    use solana_sdk::{account::Account, rent::Rent};
     use std::{cell::RefCell, fs::File, io::Read, ops::Range, rc::Rc};
-
-    #[derive(Debug, Default, Clone)]
-    pub struct MockComputeMeter {
-        pub remaining: u64,
-    }
-    impl ComputeMeter for MockComputeMeter {
-        fn consume(&mut self, amount: u64) -> Result<(), InstructionError> {
-            let exceeded = self.remaining < amount;
-            self.remaining = self.remaining.saturating_sub(amount);
-            if exceeded {
-                return Err(InstructionError::ComputationalBudgetExceeded);
-            }
-            Ok(())
-        }
-        fn get_remaining(&self) -> u64 {
-            self.remaining
-        }
-    }
-    #[derive(Debug, Default, Clone)]
-    pub struct MockLogger {
-        pub log: Rc<RefCell<Vec<String>>>,
-    }
-    impl Logger for MockLogger {
-        fn log_enabled(&self) -> bool {
-            true
-        }
-        fn log(&mut self, message: &str) {
-            self.log.borrow_mut().push(message.to_string());
-        }
-    }
-    #[derive(Debug)]
-    pub struct MockInvokeContext {
-        pub key: Pubkey,
-        pub logger: MockLogger,
-        pub compute_budget: ComputeBudget,
-        pub compute_meter: MockComputeMeter,
-    }
-    impl Default for MockInvokeContext {
-        fn default() -> Self {
-            MockInvokeContext {
-                key: Pubkey::default(),
-                logger: MockLogger::default(),
-                compute_budget: ComputeBudget::default(),
-                compute_meter: MockComputeMeter {
-                    remaining: std::u64::MAX,
-                },
-            }
-        }
-    }
-    impl InvokeContext for MockInvokeContext {
-        fn push(&mut self, _key: &Pubkey) -> Result<(), InstructionError> {
-            Ok(())
-        }
-        fn pop(&mut self) {}
-        fn verify_and_update(
-            &mut self,
-            _message: &Message,
-            _instruction: &CompiledInstruction,
-            _accounts: &[Rc<RefCell<Account>>],
-        ) -> Result<(), InstructionError> {
-            Ok(())
-        }
-        fn get_caller(&self) -> Result<&Pubkey, InstructionError> {
-            Ok(&self.key)
-        }
-        fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)] {
-            &[]
-        }
-        fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
-            Rc::new(RefCell::new(self.logger.clone()))
-        }
-        fn get_compute_budget(&self) -> &ComputeBudget {
-            &self.compute_budget
-        }
-        fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
-            Rc::new(RefCell::new(self.compute_meter.clone()))
-        }
-        fn add_executor(&mut self, _pubkey: &Pubkey, _executor: Arc<dyn Executor>) {}
-        fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
-            None
-        }
-        fn record_instruction(&self, _instruction: &Instruction) {}
-        fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
-            true
-        }
-    }
 
     struct TestInstructionMeter {
         remaining: u64,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1237,7 +1237,7 @@ fn call<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{MockComputeMeter, MockLogger};
+    use solana_runtime::bpf_test_utils::{MockComputeMeter, MockLogger};
     use solana_sdk::hash::hashv;
     use std::str::FromStr;
 

--- a/runtime/src/bpf_test_utils.rs
+++ b/runtime/src/bpf_test_utils.rs
@@ -1,0 +1,96 @@
+use crate::process_instruction::{
+    ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
+};
+use solana_sdk::{
+    account::Account, instruction::CompiledInstruction, instruction::Instruction,
+    instruction::InstructionError, message::Message, pubkey::Pubkey,
+};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
+
+#[derive(Debug, Default, Clone)]
+pub struct MockComputeMeter {
+    pub remaining: u64,
+}
+impl ComputeMeter for MockComputeMeter {
+    fn consume(&mut self, amount: u64) -> Result<(), InstructionError> {
+        let exceeded = self.remaining < amount;
+        self.remaining = self.remaining.saturating_sub(amount);
+        if exceeded {
+            return Err(InstructionError::ComputationalBudgetExceeded);
+        }
+        Ok(())
+    }
+    fn get_remaining(&self) -> u64 {
+        self.remaining
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MockLogger {
+    pub log: Rc<RefCell<Vec<String>>>,
+}
+impl Logger for MockLogger {
+    fn log_enabled(&self) -> bool {
+        true
+    }
+    fn log(&mut self, message: &str) {
+        self.log.borrow_mut().push(message.to_string());
+    }
+}
+
+#[derive(Debug)]
+pub struct MockInvokeContext {
+    pub key: Pubkey,
+    pub logger: MockLogger,
+    pub compute_budget: ComputeBudget,
+    pub compute_meter: MockComputeMeter,
+}
+impl Default for MockInvokeContext {
+    fn default() -> Self {
+        MockInvokeContext {
+            key: Pubkey::default(),
+            logger: MockLogger::default(),
+            compute_budget: ComputeBudget::default(),
+            compute_meter: MockComputeMeter {
+                remaining: std::i64::MAX as u64,
+            },
+        }
+    }
+}
+impl InvokeContext for MockInvokeContext {
+    fn push(&mut self, _key: &Pubkey) -> Result<(), InstructionError> {
+        Ok(())
+    }
+    fn pop(&mut self) {}
+    fn verify_and_update(
+        &mut self,
+        _message: &Message,
+        _instruction: &CompiledInstruction,
+        _accounts: &[Rc<RefCell<Account>>],
+    ) -> Result<(), InstructionError> {
+        Ok(())
+    }
+    fn get_caller(&self) -> Result<&Pubkey, InstructionError> {
+        Ok(&self.key)
+    }
+    fn get_programs(&self) -> &[(Pubkey, ProcessInstruction)] {
+        &[]
+    }
+    fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
+        Rc::new(RefCell::new(self.logger.clone()))
+    }
+    fn get_compute_budget(&self) -> &ComputeBudget {
+        &self.compute_budget
+    }
+    fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
+        Rc::new(RefCell::new(self.compute_meter.clone()))
+    }
+    fn add_executor(&mut self, _pubkey: &Pubkey, _executor: Arc<dyn Executor>) {}
+    fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
+        None
+    }
+    fn record_instruction(&self, _instruction: &Instruction) {}
+    fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
+        true
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -10,6 +10,7 @@ pub mod bank_forks;
 pub mod bank_utils;
 mod blockhash_queue;
 pub mod bloom;
+pub mod bpf_test_utils;
 pub mod builtins;
 pub mod commitment;
 pub mod epoch_stakes;


### PR DESCRIPTION
As requested in the review of https://github.com/solana-labs/solana/pull/12951.

#### Problem

There is some redundant testing code which could be shared for BPF test and bench.

#### Summary of Changes

The code was moved into `solana_runtime::bpf_test_utils`

Fixes #
