### PR TITLE
excludes origin from prune set

### DIFF
--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -35,7 +35,7 @@ pub const CRDS_GOSSIP_PUSH_FANOUT: usize = 6;
 pub const CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS: u64 = 30000;
 pub const CRDS_GOSSIP_PRUNE_MSG_TIMEOUT_MS: u64 = 500;
 pub const CRDS_GOSSIP_PRUNE_STAKE_THRESHOLD_PCT: f64 = 0.15;
-pub const CRDS_GOSSIP_PRUNE_MIN_INGRESS_NODES: usize = 2;
+pub const CRDS_GOSSIP_PRUNE_MIN_INGRESS_NODES: usize = 3;
 // Do not push to peers which have not been updated for this long.
 const PUSH_ACTIVE_TIMEOUT_MS: u64 = 60_000;
 
@@ -135,18 +135,19 @@ impl CrdsGossipPush {
         );
 
         let mut keep = HashSet::new();
-        let mut peer_stake_sum = *stakes.get(origin).unwrap_or(&0);
+        let mut peer_stake_sum = 0;
         keep.insert(*origin);
         for next in shuffle {
+            let (next_peer, next_stake) = staked_peers[next];
+            if next_peer == *origin {
+                continue;
+            }
+            keep.insert(next_peer);
+            peer_stake_sum += next_stake;
             if peer_stake_sum >= prune_stake_threshold
                 && keep.len() >= CRDS_GOSSIP_PRUNE_MIN_INGRESS_NODES
             {
                 break;
-            }
-            let (next_peer, next_stake) = staked_peers[next];
-            if next_peer != *origin {
-                keep.insert(next_peer);
-                peer_stake_sum += next_stake;
             }
         }
 

--- a/core/src/crds_gossip_push.rs
+++ b/core/src/crds_gossip_push.rs
@@ -135,15 +135,18 @@ impl CrdsGossipPush {
         );
 
         let mut keep = HashSet::new();
-        let mut peer_stake_sum = 0;
+        let mut peer_stake_sum = *stakes.get(origin).unwrap_or(&0);
+        keep.insert(*origin);
         for next in shuffle {
-            let (next_peer, next_stake) = staked_peers[next];
-            keep.insert(next_peer);
-            peer_stake_sum += next_stake;
             if peer_stake_sum >= prune_stake_threshold
                 && keep.len() >= CRDS_GOSSIP_PRUNE_MIN_INGRESS_NODES
             {
                 break;
+            }
+            let (next_peer, next_stake) = staked_peers[next];
+            if next_peer != *origin {
+                keep.insert(next_peer);
+                peer_stake_sum += next_stake;
             }
         }
 


### PR DESCRIPTION
#### Problem
On the receiving end, prune messages are ignored if the origin points to
the node itself:
https://github.com/solana-labs/solana/blob/631f029fe/core/src/crds_gossip_push.rs#L285-L295
So to avoid sending these over the wire, the requester can exclude
origin from the prune set.

#### Summary of Changes
The commit excludes origin from prune set. This reduces prune messages by ~25%.