### PR TITLE
Fix heaviest subtree log

### DIFF
--- a/core/src/heaviest_subtree_fork_choice.rs
+++ b/core/src/heaviest_subtree_fork_choice.rs
@@ -187,6 +187,7 @@ impl HeaviestSubtreeForkChoice {
             .expect("new root must exist in fork_infos map")
             .parent = None;
         self.root = new_root;
+        self.last_root_time = Instant::now();
     }
 
     pub fn add_root_parent(&mut self, root_parent: Slot) {


### PR DESCRIPTION
#### Problem
Spammy log because last print time isn't updated on root

#### Summary of Changes
Update last print on root

Fixes #
