### PR TITLE
feat: print program logs when transaction send fails

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -2857,6 +2857,14 @@ export class Connection {
     const unsafeRes = await this._rpcRequest('sendTransaction', args);
     const res = SendTransactionRpcResult(unsafeRes);
     if (res.error) {
+      if (res.error.data) {
+        const logs = res.error.data.logs;
+        if (logs && Array.isArray(logs)) {
+          const traceIndent = '\n    ';
+          const logTrace = traceIndent + logs.join(traceIndent);
+          console.error(res.error.message, logTrace);
+        }
+      }
       throw new Error('failed to send transaction: ' + res.error.message);
     }
     assert(typeof res.result !== 'undefined');


### PR DESCRIPTION
#### Problem
It's not clear when an instruction fails from an inner instruction because there is no log trace returned from `sendTransaction` in the `Connection` api

#### Summary of Changes
- Error log the program logs if the transaction fails and logs are present

```
Transaction simulation failed: Error processing Instruction 1: custom program error: 0x2 
    Call BPF program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
    Program log: Instruction: InitializeAccount
    Program log: Error: Invalid Mint
    BPF program consumed 3579 of 200000 units
    BPF program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: custom program error: 0x2
```

Fixes https://github.com/solana-labs/solana/issues/13212
