### PR TITLE
Use zstd for create-snapshot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1860,7 +1860,7 @@ fn main() {
                                 bank.src.slot_deltas(&bank.src.roots()),
                                 output_directory,
                                 storages,
-                                CompressionType::Bzip2,
+                                CompressionType::Zstd,
                                 snapshot_version,
                             )
                         })


### PR DESCRIPTION
#### Problem

The snapshot archive format is inconsistent between `solana-validator` and `solana-ledger-tool create-snapshot`.

#### Summary of Changes

Fix it.
