### PR TITLE
Use pico inflation for ledger-tool capitalization --enable-inflation

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2002,7 +2002,7 @@ fn main() {
                         }
 
                         if arg_matches.is_present("enable_inflation") {
-                            let inflation = Inflation::default();
+                            let inflation = Inflation::pico();
                             println!(
                                 "Forcing to: {:?} (was: {:?})",
                                 inflation,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3919,7 +3919,7 @@ impl Bank {
         let new_feature_activations = self.compute_active_feature_set(!init_finish_or_warp);
 
         if new_feature_activations.contains(&feature_set::pico_inflation::id()) {
-            *self.inflation.write().unwrap() = Inflation::new_fixed(0.0001); // 0.01% inflation
+            *self.inflation.write().unwrap() = Inflation::pico();
             self.fee_rate_governor.burn_percent = 50; // 50% fee burn
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }

--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -66,7 +66,7 @@ impl Inflation {
     }
 
     pub fn pico() -> Self {
-       Self::new_fixed(0.0001) // 0.01% inflation
+        Self::new_fixed(0.0001) // 0.01% inflation
     }
 
     /// inflation rate at year

--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -65,6 +65,10 @@ impl Inflation {
         }
     }
 
+    pub fn pico() -> Self {
+       Self::new_fixed(0.0001) // 0.01% inflation
+    }
+
     /// inflation rate at year
     pub fn total(&self, year: f64) -> f64 {
         assert!(year >= 0.0);


### PR DESCRIPTION
#### Problem

`ledger-tool` isn't using pico inflation.

#### Summary of Changes

Use it.

This is incompatible change but I think it's ok to break compat for `ledger-tool`, right?