### PR TITLE
feat: add support for inner instructions metadata

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -151,14 +151,9 @@ declare module '@solana/web3.js' {
     err: TransactionError | null;
   };
 
-  export type PartiallyDecodedInnerInstruction = {
-    index: number;
-    instructions: PartiallyDecodedInstruction[];
-  };
-
   export type ParsedInnerInstruction = {
     index: number;
-    instructions: (ParsedInstruction | PartiallyDecodedInnerInstruction)[];
+    instructions: (ParsedInstruction | PartiallyDecodedInstruction)[];
   };
 
   export type ParsedConfirmedTransactionMeta = {

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -1,5 +1,4 @@
 declare module '@solana/web3.js' {
-  import {Buffer} from 'buffer';
   import * as BufferLayout from 'buffer-layout';
 
   // === src/publickey.js ===
@@ -138,8 +137,28 @@ declare module '@solana/web3.js' {
     logs: Array<string> | null;
   };
 
+  export type PartiallyDecodedInnerInstruction = {
+    index: number;
+    instructions: PartiallyDecodedInstruction[];
+  };
+
   export type ConfirmedTransactionMeta = {
     fee: number;
+    innerInstructions?: PartiallyDecodedInnerInstruction[];
+    preBalances: Array<number>;
+    postBalances: Array<number>;
+    logMessages?: Array<string>;
+    err: TransactionError | null;
+  };
+
+  export type ParsedInnerInstruction = {
+    index: number;
+    instructions: ParsedInstruction[];
+  };
+
+  export type ParsedConfirmedTransactionMeta = {
+    fee: number;
+    innerInstructions?: ParsedInnerInstruction[];
     preBalances: Array<number>;
     postBalances: Array<number>;
     logMessages?: Array<string>;
@@ -199,7 +218,7 @@ declare module '@solana/web3.js' {
   export type ParsedConfirmedTransaction = {
     slot: number;
     transaction: ParsedTransaction;
-    meta: ConfirmedTransactionMeta | null;
+    meta: ParsedConfirmedTransactionMeta | null;
   };
 
   export type ParsedAccountData = {

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -137,23 +137,28 @@ declare module '@solana/web3.js' {
     logs: Array<string> | null;
   };
 
-  export type PartiallyDecodedInnerInstruction = {
+  export type CompiledInnerInstruction = {
     index: number;
-    instructions: PartiallyDecodedInstruction[];
+    instructions: CompiledInstruction[];
   };
 
   export type ConfirmedTransactionMeta = {
     fee: number;
-    innerInstructions?: PartiallyDecodedInnerInstruction[];
+    innerInstructions?: CompiledInnerInstruction[];
     preBalances: Array<number>;
     postBalances: Array<number>;
     logMessages?: Array<string>;
     err: TransactionError | null;
   };
 
+  export type PartiallyDecodedInnerInstruction = {
+    index: number;
+    instructions: PartiallyDecodedInstruction[];
+  };
+
   export type ParsedInnerInstruction = {
     index: number;
-    instructions: ParsedInstruction[];
+    instructions: (ParsedInstruction | PartiallyDecodedInnerInstruction)[];
   };
 
   export type ParsedConfirmedTransactionMeta = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -152,8 +152,28 @@ declare module '@solana/web3.js' {
     logs: Array<string> | null,
   };
 
+  declare export type PartiallyDecodedInnerInstruction = {
+    index: number,
+    instructions: PartiallyDecodedInstruction[],
+  };
+
   declare export type ConfirmedTransactionMeta = {
     fee: number,
+    innerInstructions?: PartiallyDecodedInnerInstruction[],
+    preBalances: Array<number>,
+    postBalances: Array<number>,
+    logMessages?: Array<string>,
+    err: TransactionError | null,
+  };
+
+  declare export type ParsedInnerInstruction = {
+    index: number,
+    instructions: ParsedInstruction[],
+  };
+
+  declare export type ParsedConfirmedTransactionMeta = {
+    fee: number,
+    innerInstructions?: ParsedInnerInstruction[],
     preBalances: Array<number>,
     postBalances: Array<number>,
     logMessages?: Array<string>,
@@ -225,7 +245,7 @@ declare module '@solana/web3.js' {
   declare export type ParsedConfirmedTransaction = {
     slot: number,
     transaction: ParsedTransaction,
-    meta: ConfirmedTransactionMeta | null,
+    meta: ParsedConfirmedTransactionMeta | null,
   };
 
   declare export type KeyedAccountInfo = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -152,23 +152,28 @@ declare module '@solana/web3.js' {
     logs: Array<string> | null,
   };
 
-  declare export type PartiallyDecodedInnerInstruction = {
+  declare export type CompiledInnerInstruction = {
     index: number,
-    instructions: PartiallyDecodedInstruction[],
+    instructions: CompiledInstruction[],
   };
 
   declare export type ConfirmedTransactionMeta = {
     fee: number,
-    innerInstructions?: PartiallyDecodedInnerInstruction[],
+    innerInstructions?: CompiledInnerInstruction[],
     preBalances: Array<number>,
     postBalances: Array<number>,
     logMessages?: Array<string>,
     err: TransactionError | null,
   };
 
+  declare export type PartiallyDecodedInnerInstruction = {
+    index: number,
+    instructions: PartiallyDecodedInstruction[],
+  };
+
   declare export type ParsedInnerInstruction = {
     index: number,
-    instructions: ParsedInstruction[],
+    instructions: (ParsedInstruction | PartiallyDecodedInnerInstruction)[],
   };
 
   declare export type ParsedConfirmedTransactionMeta = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -166,14 +166,9 @@ declare module '@solana/web3.js' {
     err: TransactionError | null,
   };
 
-  declare export type PartiallyDecodedInnerInstruction = {
-    index: number,
-    instructions: PartiallyDecodedInstruction[],
-  };
-
   declare export type ParsedInnerInstruction = {
     index: number,
-    instructions: (ParsedInstruction | PartiallyDecodedInnerInstruction)[],
+    instructions: (ParsedInstruction | PartiallyDecodedInstruction)[],
   };
 
   declare export type ParsedConfirmedTransactionMeta = {

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -367,11 +367,42 @@ const SimulatedTransactionResponseValidator = jsonRpcResultAndContext(
   }),
 );
 
+type ParsedInnerInstruction = {
+  index: number,
+  instructions: ParsedInstruction[],
+};
+
+/**
+ * Metadata for a parsed confirmed transaction on the ledger
+ *
+ * @typedef {Object} ParsedConfirmedTransactionMeta
+ * @property {number} fee The fee charged for processing the transaction
+ * @property {Array<ParsedInnerInstruction>} innerInstructions An array of cross program invoked parsed instructions
+ * @property {Array<number>} preBalances The balances of the transaction accounts before processing
+ * @property {Array<number>} postBalances The balances of the transaction accounts after processing
+ * @property {Array<string>} logMessages An array of program log messages emitted during a transaction
+ * @property {object|null} err The error result of transaction processing
+ */
+type ParsedConfirmedTransactionMeta = {
+  fee: number,
+  innerInstructions?: ParsedInnerInstruction[],
+  preBalances: Array<number>,
+  postBalances: Array<number>,
+  logMessages?: Array<string>,
+  err: TransactionError | null,
+};
+
+type PartiallyDecodedInnerInstruction = {
+  index: number,
+  instructions: PartiallyDecodedInstruction[],
+};
+
 /**
  * Metadata for a confirmed transaction on the ledger
  *
  * @typedef {Object} ConfirmedTransactionMeta
  * @property {number} fee The fee charged for processing the transaction
+ * @property {Array<PartiallyDecodedInnerInstruction>} innerInstructions An array of cross program invoked instructions
  * @property {Array<number>} preBalances The balances of the transaction accounts before processing
  * @property {Array<number>} postBalances The balances of the transaction accounts after processing
  * @property {Array<string>} logMessages An array of program log messages emitted during a transaction
@@ -379,6 +410,7 @@ const SimulatedTransactionResponseValidator = jsonRpcResultAndContext(
  */
 type ConfirmedTransactionMeta = {
   fee: number,
+  innerInstructions?: PartiallyDecodedInnerInstruction[],
   preBalances: Array<number>,
   postBalances: Array<number>,
   logMessages?: Array<string>,
@@ -478,7 +510,7 @@ type ParsedTransaction = {
 type ParsedConfirmedTransaction = {
   slot: number,
   transaction: ParsedTransaction,
-  meta: ConfirmedTransactionMeta | null,
+  meta: ParsedConfirmedTransactionMeta | null,
 };
 
 /**
@@ -1126,6 +1158,60 @@ const ConfirmedTransactionMetaResult = struct.union([
   struct.pick({
     err: TransactionErrorResult,
     fee: 'number',
+    innerInstructions: struct.union(
+      struct.array([
+        struct({
+          index: 'number',
+          instructions: struct.array([
+            struct.union([
+              struct({
+                accounts: struct.array(['number']),
+                data: 'string',
+                programIdIndex: 'number',
+              }),
+            ]),
+          ]),
+        }),
+      ]),
+      'null',
+      'undefined',
+    ),
+    preBalances: struct.array(['number']),
+    postBalances: struct.array(['number']),
+    logMessages: struct.union([struct.array(['string']), 'null', 'undefined']),
+  }),
+]);
+/**
+ * @private
+ */
+const ParsedConfirmedTransactionMetaResult = struct.union([
+  'null',
+  struct.pick({
+    err: TransactionErrorResult,
+    fee: 'number',
+    innerInstructions: struct.union(
+      struct.array([
+        struct({
+          index: 'number',
+          instructions: struct.array([
+            struct.union([
+              struct({
+                accounts: struct.array(['string']),
+                data: 'string',
+                programId: 'string',
+              }),
+              struct({
+                parsed: 'any',
+                program: 'string',
+                programId: 'string',
+              }),
+            ]),
+          ]),
+        }),
+      ]),
+      'null',
+      'undefined',
+    ),
     preBalances: struct.array(['number']),
     postBalances: struct.array(['number']),
     logMessages: struct.union([struct.array(['string']), 'null', 'undefined']),
@@ -1186,7 +1272,7 @@ const GetParsedConfirmedTransactionRpcResult = jsonRpcResult(
     struct.pick({
       slot: 'number',
       transaction: ParsedConfirmedTransactionResult,
-      meta: ConfirmedTransactionMetaResult,
+      meta: ParsedConfirmedTransactionMetaResult,
     }),
   ]),
 );

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -367,9 +367,14 @@ const SimulatedTransactionResponseValidator = jsonRpcResultAndContext(
   }),
 );
 
+type PartiallyDecodedInnerInstruction = {
+  index: number,
+  instructions: PartiallyDecodedInstruction[],
+};
+
 type ParsedInnerInstruction = {
   index: number,
-  instructions: ParsedInstruction[],
+  instructions: (ParsedInstruction | PartiallyDecodedInnerInstruction)[],
 };
 
 /**
@@ -392,9 +397,9 @@ type ParsedConfirmedTransactionMeta = {
   err: TransactionError | null,
 };
 
-type PartiallyDecodedInnerInstruction = {
+type CompiledInnerInstruction = {
   index: number,
-  instructions: PartiallyDecodedInstruction[],
+  instructions: CompiledInstruction[],
 };
 
 /**
@@ -402,7 +407,7 @@ type PartiallyDecodedInnerInstruction = {
  *
  * @typedef {Object} ConfirmedTransactionMeta
  * @property {number} fee The fee charged for processing the transaction
- * @property {Array<PartiallyDecodedInnerInstruction>} innerInstructions An array of cross program invoked instructions
+ * @property {Array<CompiledInnerInstruction>} innerInstructions An array of cross program invoked instructions
  * @property {Array<number>} preBalances The balances of the transaction accounts before processing
  * @property {Array<number>} postBalances The balances of the transaction accounts after processing
  * @property {Array<string>} logMessages An array of program log messages emitted during a transaction
@@ -410,7 +415,7 @@ type PartiallyDecodedInnerInstruction = {
  */
 type ConfirmedTransactionMeta = {
   fee: number,
-  innerInstructions?: PartiallyDecodedInnerInstruction[],
+  innerInstructions?: CompiledInnerInstruction[],
   preBalances: Array<number>,
   postBalances: Array<number>,
   logMessages?: Array<string>,
@@ -1163,13 +1168,11 @@ const ConfirmedTransactionMetaResult = struct.union([
         struct({
           index: 'number',
           instructions: struct.array([
-            struct.union([
-              struct({
-                accounts: struct.array(['number']),
-                data: 'string',
-                programIdIndex: 'number',
-              }),
-            ]),
+            struct({
+              accounts: struct.array(['number']),
+              data: 'string',
+              programIdIndex: 'number',
+            }),
           ]),
         }),
       ]),


### PR DESCRIPTION
#### Problem
Web3 does not support inner transactions meta
https://docs.solana.com/apps/jsonrpc-api#getconfirmedtransaction

#### Summary of Changes
Add information about inner transactions in rpc responses 
