### PR TITLE
Forcibly reduce credits_observed to the last epoch

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2030,7 +2030,7 @@ fn main() {
                             epochs: usize,
                             voter: Pubkey,
                             point: u128,
-                            stake: u128,
+                            stake: u64,
                             total_stake: u64,
                             rent_exempt_reserve: u64,
                             credits: u128,
@@ -2055,16 +2055,17 @@ fn main() {
                                 match event {
                                     InflationPointCalculationEvent::CalculatedPoints(
                                         point,
-                                        stake,
                                         credits,
                                     ) => {
                                         // Don't sum for epochs where no credits are earned
                                         if *credits > 0 {
                                             detail.epochs += 1;
                                             detail.point += *point;
-                                            detail.stake += *stake;
                                             detail.credits += *credits;
                                         }
+                                    }
+                                    InflationPointCalculationEvent::Stake(stake) => {
+                                        detail.stake = *stake;
                                     }
                                     InflationPointCalculationEvent::SplitRewards(
                                         all,

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -519,8 +519,8 @@ impl Stake {
         let mut points = 0;
         let mut new_credits_observed = self.credits_observed;
 
-        for (epoch, final_epoch_credits, initial_epoch_credits) in
-            new_vote_state.epoch_credits().iter().copied()
+        if let Some((epoch, final_epoch_credits, initial_epoch_credits)) =
+            new_vote_state.epoch_credits().last().copied()
         {
             let stake = u128::from(self.delegation.stake(
                 epoch,
@@ -535,7 +535,7 @@ impl Stake {
                 final_epoch_credits - initial_epoch_credits
             } else if self.credits_observed < final_epoch_credits {
                 // the staker registered sometime during the epoch, partial credit
-                final_epoch_credits - new_credits_observed
+                final_epoch_credits - self.credits_observed
             } else {
                 // the staker has already observed or been redeemed this epoch
                 //  or was activated after this epoch
@@ -543,8 +543,8 @@ impl Stake {
             };
             let earned_credits = u128::from(earned_credits);
 
-            // don't want to assume anything about order of the iterator...
-            new_credits_observed = new_credits_observed.max(final_epoch_credits);
+            // try to update credits_observed
+            new_credits_observed = final_epoch_credits;
 
             // finally calculate points for this epoch
             points += stake * earned_credits;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1324,6 +1324,7 @@ impl Bank {
         let old_vote_balance_and_staked = self.stakes.read().unwrap().vote_balance_and_staked();
 
         let validator_point_value = self.pay_validator_rewards(
+            prev_epoch,
             validator_rewards,
             reward_calc_tracer,
             self.stake_program_v2_enabled(),
@@ -1438,6 +1439,7 @@ impl Bank {
     ///   successfully load and parse, return the lamport value of one point
     fn pay_validator_rewards(
         &mut self,
+        target_epoch: Epoch,
         rewards: u64,
         reward_calc_tracer: &mut Option<impl FnMut(&RewardCalculationEvent)>,
         fix_stake_deactivate: bool,
@@ -1457,7 +1459,7 @@ impl Bank {
                 stake_state::calculate_points(
                     &stake_account,
                     &vote_account,
-                    Some(&stake_history),
+                    Some((target_epoch, &stake_history)),
                     fix_stake_deactivate,
                 )
                 .unwrap_or(0)
@@ -1489,7 +1491,7 @@ impl Bank {
                     stake_account,
                     vote_account,
                     &point_value,
-                    Some(&stake_history),
+                    Some((target_epoch, &stake_history)),
                     &mut reward_calc_tracer.as_mut(),
                     fix_stake_deactivate,
                 );


### PR DESCRIPTION
#### Problem

The initial inflation reward could be unexpected if inflation has not been enabled since genesis. (i.e. Virtually all of live clusters)
Subsequent inflation rewards are correct, though.

Conceptually, inflation rewards should be a _fair_ distribution of a stake-weighted contribution metrics (called points) across validators for some reasonable recent timespan.

The current implementation fulfils it for all inflation rewards but the first one.
The reason is that the initial inflation reward calculation is based on the full timespan since genesis.
Specifically, the initial inflation calculation uses all epochs since genesis as the timespan for points summation.

This is due to implantation remnant before periodic forced inflation rewards distribution (the `solana redeem` age) 
Technically, this is caused because stake account's `credits_observed` (key component of points calculation) aren't updated at all, until the very first inflation reward.
After that, as `credits_observed` is initialized, the inflation is calculated for each last epoch.

This creates the following counter intuitive inflation rewards.
As an extreme example, we reward _currently undelegated_ stake account. (But this happens only once at the first epoch after inflation is enabled)

Currently, `HDAhLXUZmFyvxT2gnGv36opsU6ZAXEEmcEzHMAghTBoT` is undelegated:

```
$ ./target/release/solana stake-account HDAhLXUZmFyvxT2gnGv36opsU6ZAXEEmcEzHMAghTBoT
Balance: 0.00228288 SOL
Rent Exempt Reserve: 0.00228288 SOL
Stake account is undelegated
Stake Authority: 9LQhe3fHy9i7RVWMiFiyon3GfC9rCzoXiwc9DjaAY3b7
Withdraw Authority: 9LQhe3fHy9i7RVWMiFiyon3GfC9rCzoXiwc9DjaAY3b7
```

But, if we would enable the inflation now, the stake account receives `+0.000016081` SOL. That's because initial inflation doesn't only look at the last epoch, but the entire blockchain history. So, this matches to the fact the stake account was actually delegating some SOLs (=~ ◎60) from epoch 58 to epoch 65:

```
        HDAhLXUZmFyvxT2gnGv36opsU6ZAXEEmcEzHMAghTBoT: Delegation {
            voter_pubkey: FKsC411dik9ktS6xPADxs4Fk2SCENvAiuccQHLAPndvk,
            stake: 59987617120,
            activation_epoch: 58,
            deactivation_epoch: 65,
            warmup_cooldown_rate: 0.25,
        },

```

```
HDAhLXUZmFyvxT2gnGv36opsU6ZAXEEmcEzHMAghTBoT(Stake11111111111111111111111111111111111111): ◎0.002282880 => ◎0.002298961 (+◎0.000016081 0.704417227%)
```

For comparison, similarly-sized stake account only receives `0.000000014` SOL.

```
H6rtteTo41ifz9XwMRx3yHXywssiGQizZYNCDQr4wZj1(Stake11111111111111111111111111111111111111): ◎0.010000000 => ◎0.010000014 (+◎0.000000014 0.000140000%)
```


In other words, staker will be rewarded proportional to the full delegated duration, not only the last epoch, with current implementation. So, this is a situation of act sooner and earn more.



#### Summary of Changes


Ideally, I think we should only consider the last epoch?
To realize that, this pr forcibly overwrites credits_observed before calculating inflation.

But this phenomenon is only one-time. and pico-inflation reward is very small. So, might not worth to fix this...

#### Context

Found via `ledger-tool capitalization` check.
