### PR TITLE
CI: Gate user config dir removal hammer

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -19,9 +19,6 @@ export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings"
 source scripts/ulimit-n.sh
 
-# Clear cached json keypair files
-rm -rf "$HOME/.config/solana"
-
 # Clear the C dependency files, if dependency moves these files are not regenerated
 test -d target/debug/bpf && find target/debug/bpf -name '*.d' -delete
 test -d target/release/bpf && find target/release/bpf -name '*.d' -delete


### PR DESCRIPTION
#### Problem

Running CI scripts locally deletes the user's config dir.  Which isn't nice 'cause there might be a keypair in there.

#### Summary of Changes

Remove it

It might be safe to just remove this altogether. I haven't found a reference to `solana-keygen new` where we don't explicitly `-o output.json`.  Originally added in https://github.com/solana-labs/solana/commit/b670b9bcdef84b26785b6f8f92247cf6924961c2 cc/ @garious 