### PR TITLE
Add sol_log_bpf_compute_units syscall

### DIFF
--- a/programs/bpf/c/src/sanity/sanity.c
+++ b/programs/bpf/c/src/sanity/sanity.c
@@ -18,5 +18,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
   // program, no account keys or input data are expected but real
   // programs will have specific requirements so they can do their work.
   sol_log_params(&params);
+
+  sol_log_bpf_compute_units();
   return SUCCESS;
 }

--- a/programs/bpf/rust/sanity/src/lib.rs
+++ b/programs/bpf/rust/sanity/src/lib.rs
@@ -61,6 +61,7 @@ fn process_instruction(
         panic!();
     }
 
+    sol_log_bpf_compute_units();
     Ok(())
 }
 

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -10,6 +10,7 @@ use solana_rbpf::{
 use solana_runtime::{
     feature_set::{
         pubkey_log_syscall_enabled, ristretto_mul_syscall_enabled, sha256_syscall_enabled,
+        sol_log_bpf_compute_units_syscall,
     },
     message_processor::MessageProcessor,
     process_instruction::{ComputeMeter, InvokeContext, Logger},
@@ -122,6 +123,16 @@ pub fn register_syscalls<'a>(
         }),
     )?;
 
+    if invoke_context.is_feature_active(&sol_log_bpf_compute_units_syscall::id()) {
+        vm.register_syscall_with_context_ex(
+            "sol_log_bpf_compute_units_",
+            Box::new(SyscallLogBpfComputeUnits {
+                cost: 0,
+                compute_meter: invoke_context.get_compute_meter(),
+                logger: invoke_context.get_logger(),
+            }),
+        )?;
+    }
     if invoke_context.is_feature_active(&pubkey_log_syscall_enabled::id()) {
         vm.register_syscall_with_context_ex(
             "sol_log_pubkey",
@@ -408,6 +419,38 @@ impl SyscallObject<BPFError> for SyscallLogU64 {
             logger.log(&format!(
                 "Program log: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
                 arg1, arg2, arg3, arg4, arg5
+            ));
+        }
+        Ok(0)
+    }
+}
+
+/// Log current compute consumption
+pub struct SyscallLogBpfComputeUnits {
+    cost: u64,
+    compute_meter: Rc<RefCell<dyn ComputeMeter>>,
+    logger: Rc<RefCell<dyn Logger>>,
+}
+impl SyscallObject<BPFError> for SyscallLogBpfComputeUnits {
+    fn call(
+        &mut self,
+        _arg1: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        _ro_regions: &[MemoryRegion],
+        _rw_regions: &[MemoryRegion],
+    ) -> Result<u64, EbpfError<BPFError>> {
+        self.compute_meter.consume(self.cost)?;
+        let mut logger = self
+            .logger
+            .try_borrow_mut()
+            .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;
+        if logger.log_enabled() {
+            logger.log(&format!(
+                "Program consumption: {} units remaining",
+                self.compute_meter.borrow().get_remaining()
             ));
         }
         Ok(0)

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -65,6 +65,10 @@ pub mod cumulative_rent_related_fixes {
     solana_sdk::declare_id!("FtjnuAtJTWwX3Kx9m24LduNEhzaGuuPfDW6e14SX2Fy5");
 }
 
+pub mod sol_log_bpf_compute_units_syscall {
+    solana_sdk::declare_id!("BHuZqHAj7JdZc68wVgZZcy51jZykvgrx4zptR44RyChe");
+}
+
 pub mod pubkey_log_syscall_enabled {
     solana_sdk::declare_id!("MoqiU1vryuCGQSxFKA1SZ316JdLEFFhoAu6cKUNk7dN");
 }
@@ -91,6 +95,7 @@ lazy_static! {
         (max_program_call_depth_64::id(), "max program call depth 64"),
         (timestamp_correction::id(), "correct bank timestamps"),
         (cumulative_rent_related_fixes::id(), "rent fixes (#10206, #10468, #11342)"),
+        (sol_log_bpf_compute_units_syscall::id(), "sol_log_bpf_compute_units syscall (#13243)"),
         (pubkey_log_syscall_enabled::id(), "pubkey log syscall"),
         (pull_request_ping_pong_check::id(), "ping-pong packet check #12794"),
         /*************** ADD NEW FEATURES HERE ***************/

--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -134,6 +134,12 @@ void sol_log_64_(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 #define sol_log_64 sol_log_64_
 
 /**
+ * Prints the current BPF compute unit consumption to stdout
+ */
+void sol_log_bpf_compute_units_();
+#define sol_log_bpf_compute_units() sol_log_bpf_compute_units_()
+
+/**
  * Size of Public key in bytes
  */
 #define SIZE_PUBKEY 32

--- a/sdk/program/src/log.rs
+++ b/sdk/program/src/log.rs
@@ -96,3 +96,17 @@ pub fn sol_log_params(accounts: &[AccountInfo], data: &[u8]) {
     info!("Instruction data");
     sol_log_slice(data);
 }
+
+/// Logs the current BPF compute unit consumption
+#[inline]
+pub fn sol_log_bpf_compute_units() {
+    #[cfg(target_arch = "bpf")]
+    unsafe {
+        sol_log_bpf_compute_units_();
+    }
+}
+
+#[cfg(target_arch = "bpf")]
+extern "C" {
+    fn sol_log_bpf_compute_units_();
+}


### PR DESCRIPTION
The runtime outputs a nice log message at the end of executing my program stating the amount of compute units consumed.   But now I want to reduce the usage and have no idea where to look.   My only option is to start carving out parts of my program and seeing what that does to the final compute units consumed.   This is painful.

But now I can pepper my program with `sol_log_consumption()`s tracing and easily see the compute units get consumed.