### PR TITLE
Add Bank::set_bpf_compute_budget_override()

### DIFF
--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -15,7 +15,7 @@ use solana_runtime::{
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
     loader_utils::load_program,
     process_instruction::{
-        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
+        BpfComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
     },
 };
 use solana_sdk::{
@@ -247,7 +247,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
 pub struct MockInvokeContext {
     key: Pubkey,
     logger: MockLogger,
-    compute_budget: ComputeBudget,
+    compute_budget: BpfComputeBudget,
     compute_meter: Rc<RefCell<MockComputeMeter>>,
 }
 impl InvokeContext for MockInvokeContext {
@@ -272,7 +272,7 @@ impl InvokeContext for MockInvokeContext {
     fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
         Rc::new(RefCell::new(self.logger.clone()))
     }
-    fn get_compute_budget(&self) -> &ComputeBudget {
+    fn get_bpf_compute_budget(&self) -> &BpfComputeBudget {
         &self.compute_budget
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -14,7 +14,7 @@ use solana_runtime::{
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
     loader_utils::load_program,
     process_instruction::{
-        ComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
+        BpfComputeBudget, ComputeMeter, Executor, InvokeContext, Logger, ProcessInstruction,
     },
 };
 use solana_sdk::{
@@ -718,14 +718,14 @@ fn test_program_bpf_call_depth() {
 
     let instruction = Instruction::new(
         program_id,
-        &(ComputeBudget::default().max_call_depth - 1),
+        &(BpfComputeBudget::default().max_call_depth - 1),
         vec![],
     );
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert!(result.is_ok());
 
     let instruction =
-        Instruction::new(program_id, &ComputeBudget::default().max_call_depth, vec![]);
+        Instruction::new(program_id, &BpfComputeBudget::default().max_call_depth, vec![]);
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert!(result.is_err());
 }
@@ -782,7 +782,7 @@ fn assert_instruction_count() {
 struct MockInvokeContext {
     pub key: Pubkey,
     pub logger: MockLogger,
-    pub compute_budget: ComputeBudget,
+    pub compute_budget: BpfComputeBudget,
     pub compute_meter: MockComputeMeter,
 }
 impl InvokeContext for MockInvokeContext {
@@ -807,7 +807,7 @@ impl InvokeContext for MockInvokeContext {
     fn get_logger(&self) -> Rc<RefCell<dyn Logger>> {
         Rc::new(RefCell::new(self.logger.clone()))
     }
-    fn get_compute_budget(&self) -> &ComputeBudget {
+    fn get_bpf_compute_budget(&self) -> &BpfComputeBudget {
         &self.compute_budget
     }
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -98,7 +98,7 @@ pub fn register_syscalls<'a>(
     callers_keyed_accounts: &'a [KeyedAccount<'a>],
     invoke_context: &'a mut dyn InvokeContext,
 ) -> Result<MemoryRegion, EbpfError<BPFError>> {
-    let compute_budget = invoke_context.get_compute_budget();
+    let compute_budget = invoke_context.get_bpf_compute_budget();
 
     // Syscall functions common across languages
 
@@ -1147,7 +1147,7 @@ fn call<'a>(
     let mut invoke_context = syscall.get_context_mut()?;
     invoke_context
         .get_compute_meter()
-        .consume(invoke_context.get_compute_budget().invoke_units)?;
+        .consume(invoke_context.get_bpf_compute_budget().invoke_units)?;
 
     // Translate data passed from the VM
 

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -33,7 +33,7 @@ pub mod bpf_loader2_program {
     solana_sdk::declare_id!("DFBnrgThdzH4W6wZ12uGPoWcMnvfZj11EHnxHcVxLPhD");
 }
 
-pub mod compute_budget_balancing {
+pub mod bpf_compute_budget_balancing {
     solana_sdk::declare_id!("HxvjqDSiF5sYdSYuCXsUnS8UeAoWsMT9iGoFP8pgV1mB");
 }
 
@@ -83,7 +83,7 @@ lazy_static! {
         (inflation_kill_switch::id(), "inflation kill switch"),
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),
         (bpf_loader2_program::id(), "bpf_loader2 program"),
-        (compute_budget_balancing::id(), "compute budget balancing"),
+        (bpf_compute_budget_balancing::id(), "compute budget balancing"),
         (sha256_syscall_enabled::id(), "sha256 syscall"),
         (no_overflow_rent_distribution::id(), "no overflow rent distribution"),
         (ristretto_mul_syscall_enabled::id(), "ristretto multiply syscall"),

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -416,10 +416,6 @@ impl MessageProcessor {
         }
     }
 
-    fn get_compute_budget(feature_set: &FeatureSet) -> ComputeBudget {
-        ComputeBudget::new(feature_set)
-    }
-
     /// Create the KeyedAccounts that will be passed to the program
     fn create_keyed_accounts<'a>(
         message: &'a Message,
@@ -667,6 +663,7 @@ impl MessageProcessor {
         instruction_recorder: Option<InstructionRecorder>,
         instruction_index: usize,
         feature_set: Arc<FeatureSet>,
+        compute_budget: ComputeBudget,
     ) -> Result<(), InstructionError> {
         // Fixup the special instructions key if present
         // before the account pre-values are taken care of
@@ -690,7 +687,7 @@ impl MessageProcessor {
             pre_accounts,
             self.programs.clone(), // get rid of clone
             log_collector,
-            Self::get_compute_budget(&feature_set),
+            compute_budget,
             executors,
             instruction_recorder,
             feature_set,
@@ -723,6 +720,7 @@ impl MessageProcessor {
         executors: Rc<RefCell<Executors>>,
         instruction_recorders: Option<&[InstructionRecorder]>,
         feature_set: Arc<FeatureSet>,
+        compute_budget: ComputeBudget,
     ) -> Result<(), TransactionError> {
         for (instruction_index, instruction) in message.instructions.iter().enumerate() {
             let instruction_recorder = instruction_recorders
@@ -739,6 +737,7 @@ impl MessageProcessor {
                 instruction_recorder,
                 instruction_index,
                 feature_set.clone(),
+                compute_budget,
             )
             .map_err(|err| TransactionError::InstructionError(instruction_index as u8, err))?;
         }
@@ -1327,6 +1326,7 @@ mod tests {
             executors.clone(),
             None,
             Arc::new(FeatureSet::all_enabled()),
+            ComputeBudget::new(&FeatureSet::all_enabled()),
         );
         assert_eq!(result, Ok(()));
         assert_eq!(accounts[0].borrow().lamports, 100);
@@ -1350,6 +1350,7 @@ mod tests {
             executors.clone(),
             None,
             Arc::new(FeatureSet::all_enabled()),
+            ComputeBudget::new(&FeatureSet::all_enabled()),
         );
         assert_eq!(
             result,
@@ -1377,6 +1378,7 @@ mod tests {
             executors,
             None,
             Arc::new(FeatureSet::all_enabled()),
+            ComputeBudget::new(&FeatureSet::all_enabled()),
         );
         assert_eq!(
             result,
@@ -1487,6 +1489,7 @@ mod tests {
             executors.clone(),
             None,
             Arc::new(FeatureSet::all_enabled()),
+            ComputeBudget::new(&FeatureSet::all_enabled()),
         );
         assert_eq!(
             result,
@@ -1514,6 +1517,7 @@ mod tests {
             executors.clone(),
             None,
             Arc::new(FeatureSet::all_enabled()),
+            ComputeBudget::new(&FeatureSet::all_enabled()),
         );
         assert_eq!(result, Ok(()));
 
@@ -1538,6 +1542,7 @@ mod tests {
             executors,
             None,
             Arc::new(FeatureSet::all_enabled()),
+            ComputeBudget::new(&FeatureSet::all_enabled()),
         );
         assert_eq!(result, Ok(()));
         assert_eq!(accounts[0].borrow().lamports, 80);

--- a/runtime/src/process_instruction.rs
+++ b/runtime/src/process_instruction.rs
@@ -76,7 +76,7 @@ pub trait InvokeContext {
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, AbiExample)]
 pub struct ComputeBudget {
     /// Number of compute units that an instruction is allowed.  Compute units
     /// are consumed by program execution, resources they use, etc...


### PR DESCRIPTION
From a program unit test environment, I want to be able to ratchet down the compute budget to avoid future regressions to my optimized program code.