### PR TITLE
explorer: wrap bytes field on bpf-loader-2 write instruction

### DIFF
--- a/explorer/src/components/instruction/RawDetails.tsx
+++ b/explorer/src/components/instruction/RawDetails.tsx
@@ -1,15 +1,7 @@
 import React from "react";
 import { TransactionInstruction } from "@solana/web3.js";
 import { Address } from "components/common/Address";
-
-function wrap(input: string, length: number): string {
-  var result = [];
-  while (input.length) {
-    result.push(input.substr(0, length));
-    input = input.substr(length);
-  }
-  return result.join("\n");
-}
+import { wrap } from "utils";
 
 export function RawDetails({ ix }: { ix: TransactionInstruction }) {
   const data = wrap(ix.data.toString("hex"), 50);

--- a/explorer/src/components/instruction/bpf-loader/BpfLoaderDetailsCard.tsx
+++ b/explorer/src/components/instruction/bpf-loader/BpfLoaderDetailsCard.tsx
@@ -12,6 +12,7 @@ import { IX_STRUCTS } from "./types";
 import { reportError } from "utils/sentry";
 import { UnknownDetailsCard } from "../UnknownDetailsCard";
 import { Address } from "components/common/Address";
+import { wrap } from "utils";
 
 type DetailsProps = {
   tx: ParsedTransaction;
@@ -50,7 +51,7 @@ type Props = {
 
 export function BpfLoaderWriteDetailsCard(props: Props) {
   const { ix, index, result, info } = props;
-
+  const bytes = wrap(info.bytes, 50);
   return (
     <InstructionCard
       ix={ix}
@@ -77,7 +78,7 @@ export function BpfLoaderWriteDetailsCard(props: Props) {
           Bytes <span className="text-muted">(base 64)</span>
         </td>
         <td className="text-lg-right">
-          <code className="d-inline-block">{info.bytes}</code>
+          <pre className="d-inline-block text-left mb-0">{bytes}</pre>
         </td>
       </tr>
 

--- a/explorer/src/components/instruction/stake/types.ts
+++ b/explorer/src/components/instruction/stake/types.ts
@@ -10,8 +10,8 @@ const Initialize = pick({
     withdrawer: Pubkey,
   }),
   lockup: pick({
-    epoch: number(),
     unixTimestamp: number(),
+    epoch: number(),
     custodian: Pubkey,
   }),
 });

--- a/explorer/src/utils/index.tsx
+++ b/explorer/src/utils/index.tsx
@@ -90,3 +90,12 @@ export function slotsToHumanString(
 ): string {
   return HUMANIZER.humanize(slots * slotTime);
 }
+
+export function wrap(input: string, length: number): string {
+  var result = [];
+  while (input.length) {
+    result.push(input.substr(0, length));
+    input = input.substr(length);
+  }
+  return result.join("\n");
+}


### PR DESCRIPTION
#### Problem
The bytes row of the BPF Loader 2 write instruction does not wrap the base 64 output.

#### Summary of Changes
- Move wrap function to util
- Apply wrap function to bytes row

