### PR TITLE
Add store-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4768,6 +4768,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-store-tool"
+version = "1.5.0"
+dependencies = [
+ "clap",
+ "log 0.4.8",
+ "solana-logger 1.5.0",
+ "solana-measure",
+ "solana-runtime",
+ "solana-sdk 1.5.0",
+ "solana-version",
+]
+
+[[package]]
 name = "solana-streamer"
 version = "1.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "remote-wallet",
     "ramp-tps",
     "runtime",
+    "runtime/store-tool",
     "sdk",
     "sdk/cargo-build-bpf",
     "scripts",

--- a/runtime/store-tool/Cargo.toml
+++ b/runtime/store-tool/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+edition = "2018"
+name = "solana-store-tool"
+description = "Tool to inspect append vecs"
+version = "1.5.0"
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+publish = false
+
+[dependencies]
+log = { version = "0.4.8" }
+solana-logger = { path = "../../logger", version = "1.5.0" }
+solana-version = { path = "../../version", version = "1.5.0" }
+solana-measure = { path = "../../measure", version = "1.5.0" }
+solana-runtime = { path = "..", version = "1.5.0" }
+solana-sdk = { path = "../../sdk", version = "1.5.0" }
+clap = "2.33.1"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/store-tool/src/main.rs
+++ b/runtime/store-tool/src/main.rs
@@ -1,0 +1,47 @@
+use clap::{crate_description, crate_name, value_t_or_exit, App, Arg};
+use log::*;
+use solana_runtime::append_vec::AppendVec;
+
+fn main() {
+    solana_logger::setup_with_default("solana=info");
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(solana_version::version!())
+        .arg(
+            Arg::with_name("file")
+                .long("file")
+                .takes_value(true)
+                .value_name("<PATH>")
+                .help("store to open"),
+        )
+        .arg(
+            Arg::with_name("len")
+                .long("len")
+                .takes_value(true)
+                .value_name("LEN")
+                .help("len of store to open"),
+        )
+        .get_matches();
+
+    let file = value_t_or_exit!(matches, "file", String);
+    let len = value_t_or_exit!(matches, "len", usize);
+    let mut store = AppendVec::new_empty_map(len);
+    store.set_no_remove_on_drop();
+    store.set_file(file).expect("set_file failed");
+    let accounts = store.accounts(0);
+    info!(
+        "store: len: {} capacity: {} accounts: {}",
+        store.len(),
+        store.capacity(),
+        accounts.len()
+    );
+    for account in store.accounts(0) {
+        info!(
+            "  account: {:?} version: {} data: {} hash: {:?}",
+            account.meta.pubkey, account.meta.write_version, account.meta.data_len, account.hash
+        );
+    }
+}
+
+#[cfg(test)]
+pub mod test {}


### PR DESCRIPTION
#### Problem

No standalone way to inspect account stores offline.

#### Summary of Changes

Add a tool to open account stores and print their contents.

Fixes #
