### PR TITLE
Update FeatureSet::active to include slot-activated

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3950,7 +3950,7 @@ impl Bank {
         let slot = self.slot();
 
         for feature_id in &self.feature_set.inactive {
-            let mut activated = false;
+            let mut activated = None;
             if let Some(mut account) = self.get_account(feature_id) {
                 if let Some(mut feature) = Feature::from_account(&account) {
                     match feature.activated_at {
@@ -3962,21 +3962,21 @@ impl Bank {
                                     self.store_account(feature_id, &account);
                                 }
                                 newly_activated.insert(*feature_id);
-                                activated = true;
+                                activated = Some(slot);
                                 info!("Feature {} activated at slot {}", feature_id, slot);
                             }
                         }
                         Some(activation_slot) => {
                             if slot >= activation_slot {
                                 // Feature is already active
-                                activated = true;
+                                activated = Some(activation_slot);
                             }
                         }
                     }
                 }
             }
-            if activated {
-                active.insert(*feature_id);
+            if let Some(slot) = activated {
+                active.insert(*feature_id, slot);
             } else {
                 inactive.insert(*feature_id);
             }

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -133,7 +133,7 @@ impl FeatureSet {
     }
 
     pub fn activated_slot(&self, feature_id: &Pubkey) -> Option<Slot> {
-        self.active.get(feature_id).map(|slot| *slot)
+        self.active.get(feature_id).copied()
     }
 
     pub fn cumulative_rent_related_fixes_enabled(&self) -> bool {

--- a/runtime/src/feature_set.rs
+++ b/runtime/src/feature_set.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use solana_sdk::{
+    clock::Slot,
     hash::{Hash, Hasher},
     pubkey::Pubkey,
 };
@@ -114,21 +115,25 @@ lazy_static! {
 /// `FeatureSet` holds the set of currently active/inactive runtime features
 #[derive(AbiExample, Debug, Clone)]
 pub struct FeatureSet {
-    pub active: HashSet<Pubkey>,
+    pub active: HashMap<Pubkey, Slot>,
     pub inactive: HashSet<Pubkey>,
 }
 impl Default for FeatureSet {
     fn default() -> Self {
         // All features disabled
         Self {
-            active: HashSet::new(),
+            active: HashMap::new(),
             inactive: FEATURE_NAMES.keys().cloned().collect(),
         }
     }
 }
 impl FeatureSet {
     pub fn is_active(&self, feature_id: &Pubkey) -> bool {
-        self.active.contains(feature_id)
+        self.active.contains_key(feature_id)
+    }
+
+    pub fn activated_slot(&self, feature_id: &Pubkey) -> Option<Slot> {
+        self.active.get(feature_id).map(|slot| *slot)
     }
 
     pub fn cumulative_rent_related_fixes_enabled(&self) -> bool {
@@ -138,7 +143,7 @@ impl FeatureSet {
     /// All features enabled, useful for testing
     pub fn all_enabled() -> Self {
         Self {
-            active: FEATURE_NAMES.keys().cloned().collect(),
+            active: FEATURE_NAMES.keys().cloned().map(|key| (key, 0)).collect(),
             inactive: HashSet::new(),
         }
     }


### PR DESCRIPTION
#### Problem
In some cases (at least [this one case](https://github.com/solana-labs/solana/pull/13120)), a Bank method needs to know the slot a feature activation occurred. Currently, this involves deserializing the Feature account, which is expensive if it needs to be done every slot.

#### Summary of Changes
Extend FeatureSet::active to include the slot an active feature was activated

I do not think this needs to be gated, as it doesn't change the behavior of current code. But would appreciate the sanity-check.
