### PR TITLE
Explorer: trim whitespace in search bar

### DIFF
--- a/explorer/src/components/SearchBar.tsx
+++ b/explorer/src/components/SearchBar.tsx
@@ -164,7 +164,8 @@ function buildTokenOptions(search: string, cluster: Cluster) {
   }
 }
 
-function buildOptions(search: string, cluster: Cluster) {
+function buildOptions(rawSearch: string, cluster: Cluster) {
+  const search = rawSearch.trim();
   if (search.length === 0) return [];
 
   const options = [];


### PR DESCRIPTION
#### Problem
White space in the search input box will cause a valid search to have no results.

#### Summary of Changes
The solution is to auto trim white space when the user submits a query.

Fixes https://github.com/solana-labs/explorer/issues/170
