### PR TITLE
fix: fix TypeError when confirmed block is not found

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -2535,10 +2535,11 @@ export class Connection {
    */
   async getConfirmedBlock(slot: number): Promise<ConfirmedBlock> {
     const unsafeRes = await this._rpcRequest('getConfirmedBlock', [slot]);
-    const {result, error} = GetConfirmedBlockRpcResult(unsafeRes);
-    if (error) {
-      throw new Error('failed to get confirmed block: ' + result.error.message);
+    const res = GetConfirmedBlockRpcResult(unsafeRes);
+    if (res.error) {
+      throw new Error('failed to get confirmed block: ' + res.error.message);
     }
+    const result = res.result;
     assert(typeof result !== 'undefined');
     if (!result) {
       throw new Error('Confirmed block ' + slot + ' not found');

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1120,13 +1120,15 @@ test('get confirmed block', async () => {
       params: [Number.MAX_SAFE_INTEGER],
     },
     {
-      error: null,
+      error: {
+        message: `Block not available for slot ${Number.MAX_SAFE_INTEGER}`,
+      },
       result: null,
     },
   ]);
   await expect(
     connection.getConfirmedBlock(Number.MAX_SAFE_INTEGER),
-  ).rejects.toThrow();
+  ).rejects.toThrow(`Block not available for slot ${Number.MAX_SAFE_INTEGER}`);
 });
 
 test('get recent blockhash', async () => {


### PR DESCRIPTION
#### Problem
When a confirmed block is not found, the web3 sdk throws a TypeError error is not defined due to referencing the wrong "result"

#### Summary of Changes
- Fix bug

Fixes #
