### PR TITLE
Explorer: tweak cluster stats page

### DIFF
--- a/explorer/src/pages/ClusterStatsPage.tsx
+++ b/explorer/src/pages/ClusterStatsPage.tsx
@@ -54,7 +54,7 @@ function StatsCardBody() {
 
   const { avgSlotTime_1h, avgSlotTime_1min, epochInfo } = dashboardInfo;
   const hourlySlotTime = Math.round(1000 * avgSlotTime_1h);
-  const averageSlotTime = Math.round(1000 * avgSlotTime_1min) + "ms";
+  const averageSlotTime = Math.round(1000 * avgSlotTime_1min);
   const { slotIndex, slotsInEpoch } = epochInfo;
   const currentEpoch = epochInfo.epoch.toString();
   const epochProgress = ((100 * slotIndex) / slotsInEpoch).toFixed(1) + "%";
@@ -81,20 +81,24 @@ function StatsCardBody() {
         </tr>
       )}
       <tr>
-        <td className="w-100">Slot time</td>
-        <td className="text-lg-right text-monospace">{averageSlotTime}</td>
+        <td className="w-100">Slot time (1min average)</td>
+        <td className="text-lg-right text-monospace">{averageSlotTime}ms</td>
+      </tr>
+      <tr>
+        <td className="w-100">Slot time (1hr average)</td>
+        <td className="text-lg-right text-monospace">{hourlySlotTime}ms</td>
       </tr>
       <tr>
         <td className="w-100">Epoch</td>
-        <td className="text-lg-right text-monospace">{currentEpoch} </td>
+        <td className="text-lg-right text-monospace">{currentEpoch}</td>
       </tr>
       <tr>
         <td className="w-100">Epoch progress</td>
-        <td className="text-lg-right text-monospace">{epochProgress} </td>
+        <td className="text-lg-right text-monospace">{epochProgress}</td>
       </tr>
       <tr>
-        <td className="w-100">Epoch time remaining</td>
-        <td className="text-lg-right text-monospace">{epochTimeRemaining} </td>
+        <td className="w-100">Epoch time remaining (approx.)</td>
+        <td className="text-lg-right text-monospace">~{epochTimeRemaining}</td>
       </tr>
     </TableCardBody>
   );


### PR DESCRIPTION
#### Problem
- Can't view hourly slot time average
- Not clear that epoch time remaining is approximate

#### Summary of Changes
![Screen Shot 2020-10-29 at 11 25 16 AM](https://user-images.githubusercontent.com/1076145/97521969-a8788380-19d9-11eb-95c6-b40a2f03102d.png)


Fixes #
