### PR TITLE
Explorer: don't throw error for unexpected token instructions

### DIFF
--- a/explorer/src/providers/accounts/index.tsx
+++ b/explorer/src/providers/accounts/index.tsx
@@ -243,7 +243,7 @@ export function useMintAccountInfo(
       const data = accountInfo?.data?.details?.data;
       if (!data) return;
       if (data.program !== "spl-token" || data.parsed.type !== "mint") {
-        throw new Error("Expected mint");
+        return;
       }
 
       return coerce(data.parsed.info, MintAccountInfo);
@@ -263,7 +263,7 @@ export function useTokenAccountInfo(
     const data = accountInfo?.data?.details?.data;
     if (!data) return;
     if (data.program !== "spl-token" || data.parsed.type !== "account") {
-      throw new Error("Expected token account");
+      return;
     }
 
     return coerce(data.parsed.info, TokenAccountInfo);


### PR DESCRIPTION
#### Problem
Token instructions might not reference valid tokens / mints and this causes the explorer to throw and report an error. The explorer should handle invalid token instructions and instructions where transfers are made between two non-token accounts.

#### Summary of Changes
- Don't throw error

Fixes #
