### PR TITLE
Explorer: fix slot links and block details page on devnet

### DIFF
--- a/explorer/src/components/common/Slot.tsx
+++ b/explorer/src/components/common/Slot.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
+import { clusterPath } from "utils/url";
 
 type CopyState = "copy" | "copied";
 type Props = {
@@ -30,7 +31,7 @@ export function Slot({ slot, link }: Props) {
   return link ? (
     <span className="text-monospace">
       {copyButton}
-      <Link className="" to={`/block/${slot}`}>
+      <Link to={clusterPath(`/block/${slot}`)}>
         {slot.toLocaleString("en-US")}
       </Link>
     </span>


### PR DESCRIPTION
#### Problem
- Slot links always default to mainnet explorer
- Block details page always loads from mainnet cluster first

#### Summary of Changes
- Fix bugs
- Don't report error when block is not found

Fixes #
