### PR TITLE
ledger-tool cap: no eager rent collection for less noise

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2014,6 +2014,9 @@ fn main() {
                         let next_epoch = base_bank
                             .epoch_schedule()
                             .get_first_slot_in_epoch(warp_epoch);
+                        base_bank
+                            .lazy_rent_collection
+                            .store(true, std::sync::atomic::Ordering::Relaxed);
                         let warped_bank =
                             Bank::new_from_parent(&base_bank, base_bank.collector_id(), next_epoch);
                         warped_bank.freeze();


### PR DESCRIPTION
#### Problem

`ledger-tool cap --warp-epoch {--enable-inflation}` can create a lot of unwanted noise because of rent collection.

#### Summary of Changes

Disable it for inflation only.

Fixes #
