### PR TITLE
Explorer: remove cluster stats error

### DIFF
--- a/explorer/src/providers/stats/solanaClusterStats.tsx
+++ b/explorer/src/providers/stats/solanaClusterStats.tsx
@@ -212,11 +212,9 @@ export function SolanaClusterStatsProvider({ children }: Props) {
       type: PerformanceInfoActionType.SetError,
       data: "Cluster stats timed out",
     });
-    if (cluster !== Cluster.Custom) {
-      reportError(new Error("Cluster stats timed out"), { url });
-    }
+    console.error("Cluster stats timed out");
     setActive(false);
-  }, [cluster, url]);
+  }, []);
 
   const retry = React.useCallback(() => {
     resetData();


### PR DESCRIPTION
#### Problem
In order to eliminate extra chatter in pager-duty, we will remove the error sent when the cluster stats page times out.

#### Summary of Changes
Remove Sentry call, and replace with console.error
