### PR TITLE
Explorer: correct system instruction names

### DIFF
--- a/explorer/src/components/instruction/system/NonceAdvanceDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/NonceAdvanceDetailsCard.tsx
@@ -6,13 +6,13 @@ import {
 } from "@solana/web3.js";
 import { InstructionCard } from "../InstructionCard";
 import { Address } from "components/common/Address";
-import { AdvanceNonceAccountInfo } from "./types";
+import { AdvanceNonceInfo } from "./types";
 
 export function NonceAdvanceDetailsCard(props: {
   ix: ParsedInstruction;
   index: number;
   result: SignatureResult;
-  info: AdvanceNonceAccountInfo;
+  info: AdvanceNonceInfo;
 }) {
   const { ix, index, result, info } = props;
 

--- a/explorer/src/components/instruction/system/NonceAuthorizeDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/NonceAuthorizeDetailsCard.tsx
@@ -6,13 +6,13 @@ import {
 } from "@solana/web3.js";
 import { InstructionCard } from "../InstructionCard";
 import { Address } from "components/common/Address";
-import { AuthorizeNonceAccountInfo } from "./types";
+import { AuthorizeNonceInfo } from "./types";
 
 export function NonceAuthorizeDetailsCard(props: {
   ix: ParsedInstruction;
   index: number;
   result: SignatureResult;
-  info: AuthorizeNonceAccountInfo;
+  info: AuthorizeNonceInfo;
 }) {
   const { ix, index, result, info } = props;
 

--- a/explorer/src/components/instruction/system/NonceInitializeDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/NonceInitializeDetailsCard.tsx
@@ -6,13 +6,13 @@ import {
 } from "@solana/web3.js";
 import { InstructionCard } from "../InstructionCard";
 import { Address } from "components/common/Address";
-import { InitializeNonceAccountInfo } from "./types";
+import { InitializeNonceInfo } from "./types";
 
 export function NonceInitializeDetailsCard(props: {
   ix: ParsedInstruction;
   index: number;
   result: SignatureResult;
-  info: InitializeNonceAccountInfo;
+  info: InitializeNonceInfo;
 }) {
   const { ix, index, result, info } = props;
 

--- a/explorer/src/components/instruction/system/NonceWithdrawDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/NonceWithdrawDetailsCard.tsx
@@ -7,13 +7,13 @@ import {
 import { lamportsToSolString } from "utils";
 import { InstructionCard } from "../InstructionCard";
 import { Address } from "components/common/Address";
-import { WithdrawNonceAccountInfo } from "./types";
+import { WithdrawNonceInfo } from "./types";
 
 export function NonceWithdrawDetailsCard(props: {
   ix: ParsedInstruction;
   index: number;
   result: SignatureResult;
-  info: WithdrawNonceAccountInfo;
+  info: WithdrawNonceInfo;
 }) {
   const { ix, index, result, info } = props;
 

--- a/explorer/src/components/instruction/system/SystemDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/SystemDetailsCard.tsx
@@ -28,10 +28,10 @@ import {
   AssignInfo,
   AssignWithSeedInfo,
   TransferInfo,
-  AdvanceNonceAccountInfo,
-  AuthorizeNonceAccountInfo,
-  InitializeNonceAccountInfo,
-  WithdrawNonceAccountInfo,
+  AdvanceNonceInfo,
+  AuthorizeNonceInfo,
+  InitializeNonceInfo,
+  WithdrawNonceInfo,
 } from "./types";
 
 type DetailsProps = {
@@ -73,20 +73,20 @@ export function SystemDetailsCard(props: DetailsProps) {
         const info = coerce(parsed.info, TransferInfo);
         return <TransferDetailsCard info={info} {...props} />;
       }
-      case "advanceNonceAccount": {
-        const info = coerce(parsed.info, AdvanceNonceAccountInfo);
+      case "advanceNonce": {
+        const info = coerce(parsed.info, AdvanceNonceInfo);
         return <NonceAdvanceDetailsCard info={info} {...props} />;
       }
-      case "withdrawNonceAccount": {
-        const info = coerce(parsed.info, WithdrawNonceAccountInfo);
+      case "withdrawNonce": {
+        const info = coerce(parsed.info, WithdrawNonceInfo);
         return <NonceWithdrawDetailsCard info={info} {...props} />;
       }
-      case "authorizeNonceAccount": {
-        const info = coerce(parsed.info, AuthorizeNonceAccountInfo);
+      case "authorizeNonce": {
+        const info = coerce(parsed.info, AuthorizeNonceInfo);
         return <NonceAuthorizeDetailsCard info={info} {...props} />;
       }
-      case "initializeNonceAccount": {
-        const info = coerce(parsed.info, InitializeNonceAccountInfo);
+      case "initializeNonce": {
+        const info = coerce(parsed.info, InitializeNonceInfo);
         return <NonceInitializeDetailsCard info={info} {...props} />;
       }
       default:

--- a/explorer/src/components/instruction/system/types.ts
+++ b/explorer/src/components/instruction/system/types.ts
@@ -38,17 +38,13 @@ export const CreateAccountWithSeedInfo = pick({
   owner: Pubkey,
 });
 
-export type AdvanceNonceInfo = StructType<
-  typeof AdvanceNonceInfo
->;
+export type AdvanceNonceInfo = StructType<typeof AdvanceNonceInfo>;
 export const AdvanceNonceInfo = pick({
   nonceAccount: Pubkey,
   nonceAuthority: Pubkey,
 });
 
-export type WithdrawNonceInfo = StructType<
-  typeof WithdrawNonceInfo
->;
+export type WithdrawNonceInfo = StructType<typeof WithdrawNonceInfo>;
 export const WithdrawNonceInfo = pick({
   nonceAccount: Pubkey,
   destination: Pubkey,
@@ -56,17 +52,13 @@ export const WithdrawNonceInfo = pick({
   lamports: number(),
 });
 
-export type InitializeNonceInfo = StructType<
-  typeof InitializeNonceInfo
->;
+export type InitializeNonceInfo = StructType<typeof InitializeNonceInfo>;
 export const InitializeNonceInfo = pick({
   nonceAccount: Pubkey,
   nonceAuthority: Pubkey,
 });
 
-export type AuthorizeNonceInfo = StructType<
-  typeof AuthorizeNonceInfo
->;
+export type AuthorizeNonceInfo = StructType<typeof AuthorizeNonceInfo>;
 export const AuthorizeNonceInfo = pick({
   nonceAccount: Pubkey,
   nonceAuthority: Pubkey,

--- a/explorer/src/components/instruction/system/types.ts
+++ b/explorer/src/components/instruction/system/types.ts
@@ -38,36 +38,36 @@ export const CreateAccountWithSeedInfo = pick({
   owner: Pubkey,
 });
 
-export type AdvanceNonceAccountInfo = StructType<
-  typeof AdvanceNonceAccountInfo
+export type AdvanceNonceInfo = StructType<
+  typeof AdvanceNonceInfo
 >;
-export const AdvanceNonceAccountInfo = pick({
+export const AdvanceNonceInfo = pick({
   nonceAccount: Pubkey,
   nonceAuthority: Pubkey,
 });
 
-export type WithdrawNonceAccountInfo = StructType<
-  typeof WithdrawNonceAccountInfo
+export type WithdrawNonceInfo = StructType<
+  typeof WithdrawNonceInfo
 >;
-export const WithdrawNonceAccountInfo = pick({
+export const WithdrawNonceInfo = pick({
   nonceAccount: Pubkey,
   destination: Pubkey,
   nonceAuthority: Pubkey,
   lamports: number(),
 });
 
-export type InitializeNonceAccountInfo = StructType<
-  typeof InitializeNonceAccountInfo
+export type InitializeNonceInfo = StructType<
+  typeof InitializeNonceInfo
 >;
-export const InitializeNonceAccountInfo = pick({
+export const InitializeNonceInfo = pick({
   nonceAccount: Pubkey,
   nonceAuthority: Pubkey,
 });
 
-export type AuthorizeNonceAccountInfo = StructType<
-  typeof AuthorizeNonceAccountInfo
+export type AuthorizeNonceInfo = StructType<
+  typeof AuthorizeNonceInfo
 >;
-export const AuthorizeNonceAccountInfo = pick({
+export const AuthorizeNonceInfo = pick({
   nonceAccount: Pubkey,
   nonceAuthority: Pubkey,
   newAuthorized: Pubkey,
@@ -115,9 +115,9 @@ export const SystemInstructionType = enums([
   "assign",
   "assignWithSeed",
   "transfer",
-  "advanceNonceAccount",
-  "withdrawNonceAccount",
-  "authorizeNonceAccount",
-  "initializeNonceAccount",
+  "advanceNonce",
+  "withdrawNonce",
+  "authorizeNonce",
+  "initializeNonce",
   // "transferWithSeed", TODO: Add support for transfer with seed
 ]);


### PR DESCRIPTION
#### Problem
Some system instruction names were previously parsed with a different naming scheme. The server now parses the system instruction so it is important that the names on the frontend match.

#### Summary of Changes
Compare to backend names and update.
