### PR TITLE
fix: fallback to connection commitment when confirming transactions

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -2178,7 +2178,7 @@ export class Connection {
     assert(decodedSignature.length === 64, 'signature has invalid length');
 
     const start = Date.now();
-    const subscriptionCommitment: Commitment = commitment || this.commitment;
+    const subscriptionCommitment = commitment || this.commitment;
 
     let subscriptionId;
     let response: RpcResponseAndContext<SignatureResult> | null = null;

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -2163,8 +2163,6 @@ export class Connection {
 
   /**
    * Confirm the transaction identified by the specified signature.
-   *
-   * If `commitment` is not specified, default to 'max'.
    */
   async confirmTransaction(
     signature: TransactionSignature,
@@ -2180,7 +2178,7 @@ export class Connection {
     assert(decodedSignature.length === 64, 'signature has invalid length');
 
     const start = Date.now();
-    const subscriptionCommitment: Commitment = commitment || 'max';
+    const subscriptionCommitment: Commitment = commitment || this.commitment;
 
     let subscriptionId;
     let response: RpcResponseAndContext<SignatureResult> | null = null;

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -129,6 +129,7 @@ describe('load BPF Rust program', () => {
       transaction,
       [payerAccount],
       {
+        commitment: 'max',
         skipPreflight: true,
       },
     );

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1351,7 +1351,7 @@ describe('token methods', () => {
     return;
   }
 
-  const connection = new Connection(url);
+  const connection = new Connection(url, 'recent');
   const newAccount = new Account().publicKey;
 
   let testToken: Token;
@@ -1364,7 +1364,6 @@ describe('token methods', () => {
     const payerAccount = new Account();
     await connection.confirmTransaction(
       await connection.requestAirdrop(payerAccount.publicKey, 100000000000),
-      'single',
     );
 
     const mintOwner = new Account();
@@ -1402,7 +1401,7 @@ describe('token methods', () => {
       new u64(1),
     );
 
-    await connection.confirmTransaction(testSignature);
+    await connection.confirmTransaction(testSignature, 'max');
 
     testOwner = accountOwner;
     testToken = token;


### PR DESCRIPTION
#### Problem
When confirming transactions without an explicit commitment level, the web3 sdk falls back to `max` commitment. This behavior is not consistent to how any of the other `Connection` methods work. When an app chooses a particular commitment level for their `Connection`, the expectation should be that the commitment is applied unless explicitly overridden.

#### Summary of Changes
- Fallback to `Connection.commitment` rather than `max`

Fixes #
