### PR TITLE
de-mut some InvokeContext methods

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -64,14 +64,14 @@ impl UserDefinedError for BPFError {}
 /// Point all log messages to the log collector
 macro_rules! log{
     ($logger:ident, $message:expr) => {
-        if let Ok(mut logger) = $logger.try_borrow_mut() {
+        if let Ok(logger) = $logger.try_borrow_mut() {
             if logger.log_enabled() {
                 logger.log($message);
             }
         }
     };
     ($logger:ident, $fmt:expr, $($arg:tt)*) => {
-        if let Ok(mut logger) = $logger.try_borrow_mut() {
+        if let Ok(logger) = $logger.try_borrow_mut() {
             if logger.log_enabled() {
                 logger.log(&format!($fmt, $($arg)*));
             }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -371,7 +371,7 @@ impl<'a> SyscallObject<BPFError> for SyscallLog<'a> {
         _rw_regions: &[MemoryRegion],
     ) -> Result<u64, EbpfError<BPFError>> {
         self.compute_meter.consume(self.cost)?;
-        let mut logger = self
+        let logger = self
             .logger
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;
@@ -409,7 +409,7 @@ impl SyscallObject<BPFError> for SyscallLogU64 {
         _rw_regions: &[MemoryRegion],
     ) -> Result<u64, EbpfError<BPFError>> {
         self.compute_meter.consume(self.cost)?;
-        let mut logger = self
+        let logger = self
             .logger
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;
@@ -441,7 +441,7 @@ impl SyscallObject<BPFError> for SyscallLogBpfComputeUnits {
         _rw_regions: &[MemoryRegion],
     ) -> Result<u64, EbpfError<BPFError>> {
         self.compute_meter.consume(self.cost)?;
-        let mut logger = self
+        let logger = self
             .logger
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;
@@ -474,7 +474,7 @@ impl<'a> SyscallObject<BPFError> for SyscallLogPubkey<'a> {
         _rw_regions: &[MemoryRegion],
     ) -> Result<u64, EbpfError<BPFError>> {
         self.compute_meter.consume(self.cost)?;
-        let mut logger = self
+        let logger = self
             .logger
             .try_borrow_mut()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1222,13 +1222,9 @@ fn call<'a>(
         return Err(SyscallError::InstructionError(InstructionError::AccountNotExecutable).into());
     }
     let executable_accounts = vec![(callee_program_id, program_account)];
-    let mut message_processor = MessageProcessor::default();
-    for (program_id, process_instruction) in invoke_context.get_programs().iter() {
-        message_processor.add_program(*program_id, *process_instruction);
-    }
 
     #[allow(clippy::deref_addrof)]
-    match message_processor.process_cross_program_instruction(
+    match MessageProcessor::process_cross_program_instruction(
         &message,
         &executable_accounts,
         &accounts,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -293,10 +293,10 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         self.compute_meter.clone()
     }
-    fn add_executor(&mut self, pubkey: &Pubkey, executor: Arc<dyn Executor>) {
+    fn add_executor(&self, pubkey: &Pubkey, executor: Arc<dyn Executor>) {
         self.executors.borrow_mut().insert(*pubkey, executor);
     }
-    fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
+    fn get_executor(&self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         self.executors.borrow().get(&pubkey)
     }
     fn record_instruction(&self, instruction: &Instruction) {
@@ -315,7 +315,7 @@ impl Logger for ThisLogger {
     fn log_enabled(&self) -> bool {
         log_enabled!(log::Level::Info) || self.log_collector.is_some()
     }
-    fn log(&mut self, message: &str) {
+    fn log(&self, message: &str) {
         info!("{}", message);
         if let Some(log_collector) = &self.log_collector {
             log_collector.log(message);

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -52,9 +52,9 @@ pub trait InvokeContext {
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>>;
     /// Loaders may need to do work in order to execute a program.  Cache
     /// the work that can be re-used across executions
-    fn add_executor(&mut self, pubkey: &Pubkey, executor: Arc<dyn Executor>);
+    fn add_executor(&self, pubkey: &Pubkey, executor: Arc<dyn Executor>);
     /// Get the completed loader work that can be re-used across executions
-    fn get_executor(&mut self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>>;
+    fn get_executor(&self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>>;
     /// Record invoked instruction
     fn record_instruction(&self, instruction: &Instruction);
     /// Get the bank's active feature set
@@ -156,7 +156,7 @@ pub trait ComputeMeter {
 pub trait Logger {
     fn log_enabled(&self) -> bool;
     /// Log a message
-    fn log(&mut self, message: &str);
+    fn log(&self, message: &str);
 }
 
 /// Program executor
@@ -197,7 +197,7 @@ impl Logger for MockLogger {
     fn log_enabled(&self) -> bool {
         true
     }
-    fn log(&mut self, message: &str) {
+    fn log(&self, message: &str) {
         self.log.borrow_mut().push(message.to_string());
     }
 }
@@ -249,8 +249,8 @@ impl InvokeContext for MockInvokeContext {
     fn get_compute_meter(&self) -> Rc<RefCell<dyn ComputeMeter>> {
         Rc::new(RefCell::new(self.compute_meter.clone()))
     }
-    fn add_executor(&mut self, _pubkey: &Pubkey, _executor: Arc<dyn Executor>) {}
-    fn get_executor(&mut self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
+    fn add_executor(&self, _pubkey: &Pubkey, _executor: Arc<dyn Executor>) {}
+    fn get_executor(&self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         None
     }
     fn record_instruction(&self, _instruction: &Instruction) {}


### PR DESCRIPTION
Some InvokeContext methods are `mut` when they don't need to be.

Also simplify the CPI interface into MessageProcessor