### PR TITLE
Add EpochVoteAccounts sysvar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-noop-program",
+ "solana-program",
  "solana-rayon-threadlimit",
  "solana-sdk 1.5.0",
  "solana-secp256k1-program",

--- a/docs/src/apps/sysvars.md
+++ b/docs/src/apps/sysvars.md
@@ -31,6 +31,14 @@ for a given slot, etc. (Note: the epoch schedule is distinct from the
 - Address: `SysvarEpochSchedu1e111111111111111111111111`
 - Layout: [EpochSchedule](https://docs.rs/solana-program/VERSION_FOR_DOCS_RS/solana_program/epoch_schedule/struct.EpochSchedule.html)
 
+## EpochVoteAccounts
+
+The EpochVoteAccounts sysvar contains the address and total stake for all vote
+accounts with active stake for the current epoch.
+
+- Address: `SysvarEpochVoteAccounts11111111111111111111`
+- Layout: [EpochVoteAccounts](https://docs.rs/solana-program/VERSION_FOR_DOCS_RS/solana_program/epoch_vote_accounts/struct.EpochVoteAccounts.html)
+
 ## Fees
 
 The Fees sysvar contains the fee calculator for the current slot. It is updated

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2183,6 +2183,7 @@ dependencies = [
  "solana-logger",
  "solana-measure",
  "solana-metrics",
+ "solana-program",
  "solana-rayon-threadlimit",
  "solana-sdk",
  "solana-secp256k1-program",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -41,6 +41,7 @@ solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "1.5.0" }
 solana-logger = { path = "../logger", version = "1.5.0" }
 solana-measure = { path = "../measure", version = "1.5.0" }
 solana-metrics = { path = "../metrics", version = "1.5.0" }
+solana-program = { path = "../sdk/program", version = "1.5.0" }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "1.5.0" }
 solana-sdk = { path = "../sdk", version = "1.5.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.5.0" }

--- a/sdk/program/src/epoch_vote_accounts.rs
+++ b/sdk/program/src/epoch_vote_accounts.rs
@@ -1,0 +1,69 @@
+use crate::pubkey::Pubkey;
+use std::{iter::FromIterator, ops::Deref};
+
+// Vote account address and its active stake for the current epoch
+pub type VoteAccountStake = (Pubkey, u64);
+
+#[repr(C)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Default)]
+pub struct EpochVoteAccounts(Vec<VoteAccountStake>);
+
+impl EpochVoteAccounts {
+    pub fn add(&mut self, vote_account_address: Pubkey, active_stake: u64) {
+        match self.binary_search_by(|(probe, _)| vote_account_address.cmp(&probe)) {
+            Ok(index) => (self.0)[index] = (vote_account_address, active_stake),
+            Err(index) => (self.0).insert(index, (vote_account_address, active_stake)),
+        }
+    }
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn get(&self, vote_account_address: &Pubkey) -> Option<&u64> {
+        self.binary_search_by(|(probe, _)| vote_account_address.cmp(&probe))
+            .ok()
+            .map(|index| &self[index].1)
+    }
+    pub fn new(mut vote_account_stakes: Vec<VoteAccountStake>) -> Self {
+        vote_account_stakes.sort_by(|a, b| a.0.cmp(&b.0));
+        Self(vote_account_stakes)
+    }
+}
+
+impl FromIterator<(Pubkey, u64)> for EpochVoteAccounts {
+    fn from_iter<I: IntoIterator<Item = (Pubkey, u64)>>(iter: I) -> Self {
+        let vote_account_stakes: Vec<_> = iter.into_iter().collect();
+        Self::new(vote_account_stakes)
+    }
+}
+
+impl Deref for EpochVoteAccounts {
+    type Target = Vec<VoteAccountStake>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let p1 = Pubkey::new_unique();
+        let p2 = Pubkey::new_unique();
+        let p3 = Pubkey::new_unique();
+        assert!(p1 < p2);
+        assert!(p2 < p3);
+        // add accounts in reverse order
+        let vote_account_with_stake = vec![(p3, 3), (p2, 2), (p1, 1)];
+
+        let golden_epoch_vote_accounts = EpochVoteAccounts(vec![(p1, 1), (p2, 2), (p3, 3)]);
+
+        let epoch_vote_accounts = EpochVoteAccounts::new(vote_account_with_stake.clone());
+        assert_eq!(epoch_vote_accounts, golden_epoch_vote_accounts,);
+        assert_eq!(
+            vote_account_with_stake
+                .into_iter()
+                .collect::<EpochVoteAccounts>(),
+            golden_epoch_vote_accounts,
+        );
+    }
+}

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -12,6 +12,7 @@ pub mod decode_error;
 pub mod entrypoint;
 pub mod entrypoint_deprecated;
 pub mod epoch_schedule;
+pub mod epoch_vote_accounts;
 pub mod fee_calculator;
 pub mod hash;
 pub mod incinerator;

--- a/sdk/program/src/sysvar/epoch_vote_accounts.rs
+++ b/sdk/program/src/sysvar/epoch_vote_accounts.rs
@@ -1,0 +1,13 @@
+//! this account contains the sorted list of vote accounts and their active stake, if non-zero, for
+//! the current epoch
+//!
+pub use crate::epoch_vote_accounts::EpochVoteAccounts;
+
+use crate::sysvar::Sysvar;
+
+crate::declare_sysvar_id!(
+    "SysvarEpochVoteAccounts11111111111111111111",
+    EpochVoteAccounts
+);
+
+impl Sysvar for EpochVoteAccounts {}

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -4,6 +4,7 @@ use crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubk
 
 pub mod clock;
 pub mod epoch_schedule;
+pub mod epoch_vote_accounts;
 pub mod fees;
 pub mod instructions;
 pub mod recent_blockhashes;
@@ -16,6 +17,7 @@ pub mod stake_history;
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
     clock::check_id(id)
         || epoch_schedule::check_id(id)
+        || epoch_vote_accounts::check_id(id)
         || fees::check_id(id)
         || recent_blockhashes::check_id(id)
         || rent::check_id(id)

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -78,6 +78,10 @@ pub mod pull_request_ping_pong_check {
     solana_sdk::declare_id!("5RzEHTnf6D7JPZCvwEzjM19kzBsyjSU3HoMfXaQmVgnZ");
 }
 
+pub mod epoch_vote_accounts_sysvar {
+    solana_sdk::declare_id!("ERUw246vN9sUuqR3gwsuXGG89hF8CBMktcNgUSKJDQ5x");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -99,6 +103,7 @@ lazy_static! {
         (sol_log_compute_units_syscall::id(), "sol_log_compute_units syscall (#13243)"),
         (pubkey_log_syscall_enabled::id(), "pubkey log syscall"),
         (pull_request_ping_pong_check::id(), "ping-pong packet check #12794"),
+        (epoch_vote_accounts_sysvar::id(), "epoch vote accounts sysvar (#13315)"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
The EpochVoteAccounts sysvar contains the address and total stake for all vote accounts with active stake in the current epoch.

TODO:
* [ ] Add a test with hundreds of vote accounts