### PR TITLE
Adapt to feature::create_account

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -9861,7 +9861,7 @@ mod tests {
         let feature = Feature { activated_at: None };
         bank.store_account(
             &feature_set::timestamp_bounding::id(),
-            &feature.create_account(42),
+            &feature::create_account(&feature, 42),
         );
         for _ in 0..30 {
             bank = new_from_parent(&Arc::new(bank));


### PR DESCRIPTION
Build broken when https://github.com/solana-labs/solana/pull/13120 landed since it went green on an earlier version of the code.  Adjust to work with HEAD.