### PR TITLE
uses thread-pool when handling push messages

### DIFF
--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -24,6 +24,7 @@
 //! A value is updated to a new version if the labels match, and the value
 //! wallclock is later, or the value hash is greater.
 
+use crate::contact_info::ContactInfo;
 use crate::crds_shards::CrdsShards;
 use crate::crds_value::{CrdsValue, CrdsValueLabel};
 use bincode::serialize;
@@ -158,6 +159,11 @@ impl Crds {
 
     pub fn lookup_versioned(&self, label: &CrdsValueLabel) -> Option<&VersionedCrdsValue> {
         self.table.get(label)
+    }
+
+    pub fn get_contact_info(&self, pubkey: &Pubkey) -> Option<&ContactInfo> {
+        let label = CrdsValueLabel::ContactInfo(*pubkey);
+        self.table.get(&label)?.value.contact_info()
     }
 
     fn update_label_timestamp(&mut self, id: &CrdsValueLabel, now: u64) {


### PR DESCRIPTION
#### Problem
From runtime profiles, the majority time of solana-listen thread:
https://github.com/solana-labs/solana/blob/55b0428ff/core/src/cluster_info.rs#L2720
is spent handling push messages. The code here:
https://github.com/solana-labs/solana/blob/55b0428ff/core/src/cluster_info.rs#L2272-L2364
may utilize the idle gossip thread-pool.

#### Summary of Changes
Updated the code to use rayon parallel iterators.