### PR TITLE
fix: add feePayer type in TransactionCtorFields

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -660,6 +660,7 @@ declare module '@solana/web3.js' {
     recentBlockhash?: Blockhash;
     nonceInfo?: NonceInformation;
     signatures?: Array<SignaturePubkeyPair>;
+    feePayer?: PublicKey;
   };
 
   export type SerializeConfig = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -665,6 +665,7 @@ declare module '@solana/web3.js' {
     recentBlockhash?: Blockhash,
     nonceInfo?: NonceInformation,
     signatures?: Array<SignaturePubkeyPair>,
+    feePayer?: PublicKey,
   |};
 
   declare export type SerializeConfig = {


### PR DESCRIPTION
#### Problem
as per changes in https://github.com/solana-labs/solana-web3.js/commit/55076b08ff36df46f56bd2fc87be6166dd68b124#diff-8417055da6f3ed2bd7c66ebc456bae8294dd483ed33f7e7a4142bfa11fe9cffcR122
currently it is breaking typescript as feePayer is not existed in TransactionCtorFields
#### Summary of Changes
Add `feePayer` to `TransactionCtorFields`
Fixes #
Add `feePayer` to `TransactionCtorFields`
