### PR TITLE
explorer: add serum new order v2 instruction mapping

### DIFF
--- a/explorer/src/components/instruction/serum/types.ts
+++ b/explorer/src/components/instruction/serum/types.ts
@@ -23,6 +23,7 @@ const SERUM_CODE_LOOKUP: { [key: number]: string } = {
   6: "Cancel Order By Client Id",
   7: "Disable Market",
   8: "Sweep Fees",
+  9: "New Order",
 };
 
 export function parseSerumInstructionTitle(


### PR DESCRIPTION
#### Problem
There was a Serum instruction not mapped in Explorer that was determined to be New Order (v2).

#### Summary of Changes
Add mapping.