### PR TITLE
Fix stake split rent-exempt adjustment

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -771,11 +771,12 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                     );
 
                     // verify enough lamports for rent in new split account
-                    if split.lamports()? + lamports < split_rent_exempt_reserve
+                    if lamports < split_rent_exempt_reserve.saturating_sub(split.lamports()?)
                     // verify full withdrawal can cover rent in new split account
                         || (lamports < split_rent_exempt_reserve && lamports == self.lamports()?)
                     // verify enough lamports left in previous stake and not full withdrawal
-                        || (lamports + meta.rent_exempt_reserve > self.lamports()? && lamports != self.lamports()?)
+                            || (lamports > self.lamports()? - meta.rent_exempt_reserve
+                            && lamports != self.lamports()?)
                     {
                         return Err(InstructionError::InsufficientFunds);
                     }
@@ -822,7 +823,8 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                     // enough lamports for rent in new stake
                     if lamports < split_rent_exempt_reserve
                     // verify enough lamports left in previous stake
-                        || (lamports + meta.rent_exempt_reserve > self.lamports()? && lamports != self.lamports()?)
+                        || (lamports + meta.rent_exempt_reserve > self.lamports()?
+                            && lamports != self.lamports()?)
                     {
                         return Err(InstructionError::InsufficientFunds);
                     }

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -46,6 +46,10 @@ impl Rent {
         (burned_portion, rent_collected - burned_portion)
     }
     /// minimum balance due for a given size Account::data.len()
+    ///
+    /// Note: a stripped-down version of this calculation is used in
+    /// calculate_split_rent_exempt_reserve in the stake program. When this function is updated, --
+    /// eg. when making rent variable -- the stake program will need to be refactored
     pub fn minimum_balance(&self, data_len: usize) -> u64 {
         let bytes = data_len as u64;
         (((ACCOUNT_STORAGE_OVERHEAD + bytes) * self.lamports_per_byte_year) as f64


### PR DESCRIPTION
#### Problem
Stake split doesn't properly handle the stake deduction from a Delegated original account when the new account has a balance less than the rent-exempt reserve. The original stake needs to be reduced by the entire balance transferred, except in the case of splitting the entire source stake, when it should simply be zeroed.

Stake split also errors on an attempt to split all of a source account to a new account that holds a balance. This is inconsistent with the behavior for a partial split, where an existing balance is acceptable and used to cover the rent-exempt reserve (see`test_split_with_rent()`).

#### Summary of Changes
- Fix math

Before/after examples added in comments.

This is WIP as I need to coordinate gating with @t-nelson 
cc: @ryoqun @mvines 
