### PR TITLE
drops older gossip packets when load shedding

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2462,7 +2462,7 @@ impl ClusterInfo {
         while let Ok(packet) = requests_receiver.try_recv() {
             let num_packets = packets.len() + packet.packets.len();
             if num_packets > MAX_GOSSIP_TRAFFIC {
-                let excess_count = usize::min(MAX_GOSSIP_TRAFFIC - num_packets, packets.len());
+                let excess_count = usize::min(num_packets - MAX_GOSSIP_TRAFFIC, packets.len());
                 self.stats
                     .gossip_packets_dropped_count
                     .add_relaxed(excess_count as u64);

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -89,6 +89,18 @@ impl<T: Clone + Default + Sized> Default for PinnedVec<T> {
     }
 }
 
+impl<T: Clone + Default + Sized> Into<Vec<T>> for PinnedVec<T> {
+    fn into(mut self) -> Vec<T> {
+        if self.pinned {
+            unpin(self.x.as_mut_ptr());
+            self.pinned = false;
+        }
+        self.pinnable = false;
+        self.recycler = None;
+        std::mem::take(&mut self.x)
+    }
+}
+
 pub struct PinnedIter<'a, T>(std::slice::Iter<'a, T>);
 
 pub struct PinnedIterMut<'a, T>(std::slice::IterMut<'a, T>);
@@ -106,6 +118,15 @@ impl<'a, T: Clone + Default + Sized> Iterator for PinnedIterMut<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+}
+
+impl<T: Clone + Default + Sized> IntoIterator for PinnedVec<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        <Self as Into<Vec<T>>>::into(self).into_iter()
     }
 }
 
@@ -169,14 +190,8 @@ impl<T: Clone + Default + Send + Sized> IntoParallelIterator for PinnedVec<T> {
     type Item = T;
     type Iter = rayon::vec::IntoIter<T>;
 
-    fn into_par_iter(mut self) -> Self::Iter {
-        if self.pinned {
-            unpin(self.x.as_mut_ptr());
-            self.pinned = false;
-        }
-        self.pinnable = false;
-        self.recycler = None;
-        std::mem::take(&mut self.x).into_par_iter()
+    fn into_par_iter(self) -> Self::Iter {
+        <Self as Into<Vec<T>>>::into(self).into_par_iter()
     }
 }
 


### PR DESCRIPTION
#### Problem
Gossip drops incoming packets when overloaded:
https://github.com/solana-labs/solana/blob/f6a73098a/core/src/cluster_info.rs#L2462-L2475
However newer packets are dropped in favor of the older ones.
This is probably not ideal as newer packets are more likely to contain
more recent data, so dropping them will keep the validator state
lagging.

#### Summary of Changes
The commit buffers the packet into a `VecDeque`.
When there are too many packets, it drops from the beginning of the `VecDeque`.