### PR TITLE
Add non-progress bar download status

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1042,6 +1042,7 @@ fn test_snapshot_download() {
         &cluster.entry_point_info.rpc,
         &validator_archive_path,
         archive_snapshot_hash,
+        false,
     )
     .unwrap();
 


### PR DESCRIPTION
#### Problem

Progress bar is not visible when the IO is redirected to a file so user has no information about what the node is doing or how long the snapshot download might take.

#### Summary of Changes

Add an alternate display mode which is triggered when the output is redirected to a file.

Fixes #
