### PR TITLE
fix: update StakeProgram.space()

### DIFF
--- a/web3.js/src/stake-program.js
+++ b/web3.js/src/stake-program.js
@@ -482,9 +482,13 @@ export class StakeProgram {
 
   /**
    * Max space of a Stake account
+   *
+   * This is generated from the solana-stake-program StakeState struct as
+   * `std::mem::size_of::<StakeState>()`:
+   * https://docs.rs/solana-stake-program/1.4.4/solana_stake_program/stake_state/enum.StakeState.html
    */
   static get space(): number {
-    return 4008;
+    return 200;
   }
 
   /**


### PR DESCRIPTION
#### Problem
Clients using our web3.js sdk are creating Stake accounts that are bigger than they need to be.

#### Summary of Changes
Update StakeProgram.space() value.
This is just a quick fix. Ideally, this number would be generated based on the actual StakeState rust struct.
