### PR TITLE
Surface transaction logs in rpc client

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1618,9 +1618,9 @@ pub(crate) fn fetch_epoch_rewards(
                 kind:
                     ClientErrorKind::RpcError(rpc_request::RpcError::RpcResponseError {
                         code: rpc_custom_error::JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE,
-                        message: _,
+                        ..
                     }),
-                request: _,
+                ..
             }) => {
                 // RPC node doesn't have this block
                 break;

--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -1,6 +1,8 @@
 use crate::{
     client_error::Result,
-    rpc_request::{RpcError, RpcRequest},
+    rpc_custom_error,
+    rpc_request::{RpcError, RpcRequest, RpcResponseErrorData},
+    rpc_response::RpcSimulateTransactionResult,
     rpc_sender::RpcSender,
 };
 use log::*;
@@ -31,7 +33,7 @@ impl HttpSender {
 struct RpcErrorObject {
     code: i64,
     message: String,
-    /*data field omitted*/
+    data: serde_json::Value,
 }
 
 impl RpcSender for HttpSender {
@@ -72,11 +74,27 @@ impl RpcSender for HttpSender {
                     if json["error"].is_object() {
                         return match serde_json::from_value::<RpcErrorObject>(json["error"].clone())
                         {
-                            Ok(rpc_error_object) => Err(RpcError::RpcResponseError {
-                                code: rpc_error_object.code,
-                                message: rpc_error_object.message,
+                            Ok(rpc_error_object) => {
+                                let data = match rpc_error_object.code {
+                                    rpc_custom_error::JSON_RPC_SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE => {
+                                        match serde_json::from_value::<RpcSimulateTransactionResult>(json["error"]["data"].clone()) {
+                                            Ok(data) => RpcResponseErrorData::SendTransactionPreflightFailure(data),
+                                            Err(err) => {
+                                                debug!("Failed to deserialize RpcSimulateTransactionResult: {:?}", err);
+                                                RpcResponseErrorData::Empty
+                                            }
+                                        }
+                                    },
+                                    _ => RpcResponseErrorData::Empty
+                                };
+
+                                Err(RpcError::RpcResponseError {
+                                    code: rpc_error_object.code,
+                                    message: rpc_error_object.message,
+                                    data,
+                                }
+                                .into())
                             }
-                            .into()),
                             Err(err) => Err(RpcError::RpcRequestError(format!(
                                 "Failed to deserialize RPC error response: {} [{}]",
                                 serde_json::to_string(&json["error"]).unwrap(),


### PR DESCRIPTION
RpcClient eats transaction logs, which can be very useful when debugging why a transaction simulation failed.  In addition to deserialized and surfacing the logs:

1. Augment `Display` for `RpcError` to include the number of logs that are available:
    `RPC response error -32002: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2 [12 log messages]`. (note the "12 log messages" at the end)
2. Output the log messages themselves under `debug!()`:

```
$ RUST_LOG=solana=debug spl-token create-account FHJLyV1tWfX4Agfof4EZfgXz91Xxu8t1cuj5DoSb1rmK`
Creating associated account for vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg
⠁ 
[2020-11-03T22:40:56.665056000Z DEBUG solana_client::rpc_client] -32002 Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2
[2020-11-03T22:40:56.665122000Z DEBUG solana_client::rpc_client]   1: Call BPF program 5vXnHJkHwqo9UJ3L8WM6YnW4TmhujV4AKs1mS9DpsFAG
[2020-11-03T22:40:56.665143000Z DEBUG solana_client::rpc_client]   2: Program log: Transfer 2039280 lamports to the associated token account
[2020-11-03T22:40:56.665172000Z DEBUG solana_client::rpc_client]   3: Program log: Allocate space for the associated token account
[2020-11-03T22:40:56.665198000Z DEBUG solana_client::rpc_client]   4: Program log: Assign the associated token account to the SPL Token program
[2020-11-03T22:40:56.665226000Z DEBUG solana_client::rpc_client]   5: Program log: Initialize the associated token account
[2020-11-03T22:40:56.665253000Z DEBUG solana_client::rpc_client]   6: Call BPF program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
[2020-11-03T22:40:56.665278000Z DEBUG solana_client::rpc_client]   7: Program log: Instruction: InitializeAccount
[2020-11-03T22:40:56.665302000Z DEBUG solana_client::rpc_client]   8: Program log: Error: Invalid Mint
[2020-11-03T22:40:56.665327000Z DEBUG solana_client::rpc_client]   9: BPF program consumed 4559 of 179347 units
[2020-11-03T22:40:56.665351000Z DEBUG solana_client::rpc_client]  10: BPF program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: custom program error: 0x2
[2020-11-03T22:40:56.665378000Z DEBUG solana_client::rpc_client]  11: BPF program consumed 25911 of 200000 units
RPC response error -32002: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x2 [12 log messages]
```