### PR TITLE
more informative feature error message

### DIFF
--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -242,7 +242,22 @@ fn feature_activation_allowed(rpc_client: &RpcClient, quiet: bool) -> Result<boo
         .unwrap_or(false);
 
     if !feature_activation_allowed && !quiet {
-        println!("{}", style("Stake By Feature Set:").bold());
+        if active_stake_by_feature_set.get(&my_feature_set).is_none() {
+            println!(
+                "{}",
+                style("To activate features the tool and cluster feature sets must match, select a tool version that matches the cluster")
+                    .bold());
+        } else {
+            println!(
+                "{}",
+                style("To activate features the stake must be >= 95%").bold()
+            );
+        }
+        println!(
+            "{}",
+            style(format!("Tool Feture Set: {}", my_feature_set)).bold()
+        );
+        println!("{}", style("Cluster Feature Sets and Stakes:").bold());
         for (feature_set, percentage) in active_stake_by_feature_set.iter() {
             if *feature_set == 0 {
                 println!("unknown - {}%", percentage);


### PR DESCRIPTION
#### Problem

`solana feature` reports that "Activation is not allowed at this time" but doesn't tell the caller why 

#### Summary of Changes

Tell them why:

```
To activate features the tool and cluster feature sets must match, select a tool version that matches the cluster
Tool Feture Set: 3120449086
Cluster Feature Sets and Stakes:
2674527397 - 99% 

Feature                                      Description                              Status
MoqiU1vryuCGQSxFKA1SZ316JdLEFFhoAu6cKUNk7dN  pubkey log syscall                       active since slot 13824000
SECCKV5UVUsr8sTVSVAzULjdm87r7mLPaqH2FGZjevR  inflation kill switch                    active since slot 13392000
YCKSgA6XmjtkQrHBQjpyNrX6EMhJPcYcLWMVgWn36iv  max program call depth 64                active since slot 9072000
3h1BQWPDS5veRsq6mDBWruEpgPxRJkfwGexg5iiQ9mYg consistent recentblockhashes sysvar      active since slot 5414912
3zydSLUwuqqsV3wL5wBsaVgyvMox3XTHx7zLEuQf1U2Z correct bank timestamps                  inactive
4kpdyrcj5jS47CZb2oJGfVxjYbsMm2Kx97gFyZrxxwXz no overflow rent distribution            inactive
5RzEHTnf6D7JPZCvwEzjM19kzBsyjSU3HoMfXaQmVgnZ ping-pong packet check #12794            inactive
8FyEA6ABYiMxX7Az6AopQN3mavLD8Rz3N4bvKnbbBFFq add timestamp-correction bounding #13120 inactive
BHuZqHAj7JdZc68wVgZZcy51jZykvgrx4zptR44RyChe sol_log_compute_units syscall (#13243)   inactive
D7KfP7bZxpkYtD4Pc38t9htgs1k5k47Yhxe4rp6WDVi8 sha256 syscall                           inactive
DFBnrgThdzH4W6wZ12uGPoWcMnvfZj11EHnxHcVxLPhD bpf_loader2 program                      active since slot 5414912
E3PHP7w8kB7np3CTQ1qQ2tW3KCtjRSXBQgW9vM2mWv2Y secp256k1 program                        active since slot 5414912
E5JiFDQCwyC6QfT9REFyMpfK2mHcmv1GUDySU1Ue7TYv spl-token multisig fix                   active since slot 5414912
EdM9xggY5y7AhNMskRG8NgGMnaP4JFNsWi8ZZtyT1af5 max invoke call depth 4                  active since slot 9072000
EnvhHCLvg55P7PDtbvR1NwuTuAeodqpusV3MR5QEK8gs instructions sysvar                      active since slot 5414912
FtjnuAtJTWwX3Kx9m24LduNEhzaGuuPfDW6e14SX2Fy5 rent fixes (#10206, #10468, #11342)      active since slot 10800000
GaBtBJvmS4Arjj5W1NmFcyvPjsHN38UGYDq2MDwbs9Qu pico-inflation                           active since slot 5414912
HRe7A6aoxgjKzdjbBv6HTy7tJ4YWqE6tVmYCGho6S9Aq ristretto multiply syscall               inactive
HxvjqDSiF5sYdSYuCXsUnS8UeAoWsMT9iGoFP8pgV1mB compute budget balancing                 active since slot 9072000

Feature activation is not allowed at this time
```

Fixes #
