### PR TITLE
Show more detailed vote history in shorter format

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -582,6 +582,41 @@ pub struct CliEpochReward {
     pub apr: f64,
 }
 
+fn show_votes_and_credits(
+    f: &mut fmt::Formatter,
+    votes: &[CliLockout],
+    epoch_voting_history: &[CliEpochVotingHistory],
+) -> fmt::Result {
+    if votes.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(f, "Recent Votes:")?;
+    for vote in votes {
+        writeln!(f, "- slot: {}", vote.slot)?;
+        writeln!(f, "  confirmation count: {}", vote.confirmation_count)?;
+    }
+    writeln!(f, "Epoch Voting History (without skipped slots):")?;
+    for entry in epoch_voting_history {
+        writeln!(
+            f, // tame fmt so that this will be folded like following
+            "- epoch: {}",
+            entry.epoch
+        )?;
+        writeln!(
+            f,
+            "  credits range: [{}..{})",
+            entry.prev_credits, entry.credits
+        )?;
+        writeln!(
+            f,
+            "  credits/slots: {}/{}",
+            entry.credits_earned, entry.slots_in_epoch
+        )?;
+    }
+    Ok(())
+}
+
 fn show_epoch_rewards(
     f: &mut fmt::Formatter,
     epoch_rewards: &Option<Vec<CliEpochReward>>,
@@ -1009,24 +1044,7 @@ impl fmt::Display for CliVoteAccount {
             unix_timestamp_to_string(self.recent_timestamp.timestamp),
             self.recent_timestamp.slot
         )?;
-        if !self.votes.is_empty() {
-            writeln!(f, "Recent Votes:")?;
-            for vote in &self.votes {
-                writeln!(
-                    f,
-                    "- slot: {}\n  confirmation count: {}",
-                    vote.slot, vote.confirmation_count
-                )?;
-            }
-            writeln!(f, "Epoch Voting History:")?;
-            for epoch_info in &self.epoch_voting_history {
-                writeln!(
-                    f,
-                    "- epoch: {}\n  slots in epoch: {}\n  credits earned: {}",
-                    epoch_info.epoch, epoch_info.slots_in_epoch, epoch_info.credits_earned,
-                )?;
-            }
-        }
+        show_votes_and_credits(f, &self.votes, &self.epoch_voting_history)?;
         show_epoch_rewards(f, &self.epoch_rewards)?;
         Ok(())
     }
@@ -1065,6 +1083,8 @@ pub struct CliEpochVotingHistory {
     pub epoch: Epoch,
     pub slots_in_epoch: u64,
     pub credits_earned: u64,
+    pub credits: u64,
+    pub prev_credits: u64,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -597,7 +597,10 @@ fn show_votes_and_credits(
         writeln!(f, "  confirmation count: {}", vote.confirmation_count)?;
     }
     writeln!(f, "Epoch Voting History:")?;
-    writeln!(f, "* missed credits include slots unavailable to vote on due to delinquent leaders")?;
+    writeln!(
+        f,
+        "* missed credits include slots unavailable to vote on due to delinquent leaders",
+    )?;
     for entry in epoch_voting_history {
         writeln!(
             f, // tame fmt so that this will be folded like following

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -596,7 +596,8 @@ fn show_votes_and_credits(
         writeln!(f, "- slot: {}", vote.slot)?;
         writeln!(f, "  confirmation count: {}", vote.confirmation_count)?;
     }
-    writeln!(f, "Epoch Voting History (without skipped slots):")?;
+    writeln!(f, "Epoch Voting History:")?;
+    writeln!(f, "* missed credits include slots unavailable to vote on due to delinquent leaders")?;
     for entry in epoch_voting_history {
         writeln!(
             f, // tame fmt so that this will be folded like following

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -685,13 +685,15 @@ pub fn process_show_vote_account(
         for vote in &vote_state.votes {
             votes.push(vote.into());
         }
-        for (epoch, credits, prev_credits) in vote_state.epoch_credits() {
+        for (epoch, credits, prev_credits) in vote_state.epoch_credits().iter().copied() {
             let credits_earned = credits - prev_credits;
-            let slots_in_epoch = epoch_schedule.get_slots_in_epoch(*epoch);
+            let slots_in_epoch = epoch_schedule.get_slots_in_epoch(epoch);
             epoch_voting_history.push(CliEpochVotingHistory {
-                epoch: *epoch,
+                epoch,
                 slots_in_epoch,
                 credits_earned,
+                credits,
+                prev_credits,
             });
         }
     }


### PR DESCRIPTION
#### Problem

Sometimes we want to view human-friendly raw data of vote accounts. But, `solana vote-account` is too kind to show that level of detailed information. It only shows some computed information.

#### Summary of Changes

Show everything, also tidy up formatting a bit, inspired by `solana epoch-info`.

before

```
Epoch Voting History:
- epoch: 90
  slots in epoch: 432000
  credits earned: 376266
- epoch: 91
  slots in epoch: 432000
  credits earned: 431241
- epoch: 92
  slots in epoch: 432000
  credits earned: 387252

```

after

```
Epoch Voting History:
* missed credits include slots unavailable to vote on due to delinquent leaders
- epoch: 90
  credits range: [0..376266)
  credits/slots: 376266/432000
- epoch: 91
  credits range: [376266..807507)
  credits/slots: 431241/432000
- epoch: 92
  credits range: [807507..1194759)
  credits/slots: 387252/432000

```

Context #13233 