### PR TITLE
Allow feature builtins to overwrite existing builtins

### DIFF
--- a/ledger/src/builtins.rs
+++ b/ledger/src/builtins.rs
@@ -1,4 +1,7 @@
-use solana_runtime::bank::{Builtin, Builtins};
+use solana_runtime::{
+    bank::{Builtin, Builtins},
+    builtins::ActivationType,
+};
 use solana_sdk::{feature_set, genesis_config::ClusterType, pubkey::Pubkey};
 
 /// Builtin programs that are always available
@@ -21,15 +24,16 @@ fn genesis_builtins(cluster_type: ClusterType) -> Vec<Builtin> {
 }
 
 /// Builtin programs activated dynamically by feature
-fn feature_builtins() -> Vec<(Builtin, Pubkey)> {
+fn feature_builtins() -> Vec<(Builtin, Pubkey, ActivationType)> {
     let builtins = vec![(
         solana_bpf_loader_program!(),
         feature_set::bpf_loader2_program::id(),
+        ActivationType::NewProgram,
     )];
 
     builtins
         .into_iter()
-        .map(|(b, p)| (Builtin::new(&b.0, b.1, b.2), p))
+        .map(|(b, p, t)| (Builtin::new(&b.0, b.1, b.2), p, t))
         .collect()
 }
 

--- a/programs/failure/tests/failure.rs
+++ b/programs/failure/tests/failure.rs
@@ -12,7 +12,7 @@ fn test_program_native_failure() {
     let (genesis_config, alice_keypair) = create_genesis_config(50);
     let program_id = solana_sdk::pubkey::new_rand();
     let bank = Bank::new(&genesis_config);
-    bank.add_native_program("solana_failure_program", &program_id);
+    bank.add_native_program("solana_failure_program", &program_id, false);
 
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -130,7 +130,7 @@ fn do_bench_transactions(
         Pubkey::new(&BUILTIN_PROGRAM_ID),
         process_instruction,
     );
-    bank.add_native_program("solana_noop_program", &Pubkey::new(&NOOP_PROGRAM_ID));
+    bank.add_native_program("solana_noop_program", &Pubkey::new(&NOOP_PROGRAM_ID), false);
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
     let transactions = create_transactions(&bank_client, &mint_keypair);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -9288,7 +9288,7 @@ mod tests {
         assert_eq!(bank.get_account_modified_slot(&program_id).unwrap().1, slot);
 
         Arc::get_mut(&mut bank).unwrap().replace_builtin(
-            "mock_program",
+            "mock_program v2",
             program_id,
             mock_ix_processor,
         );

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -30,8 +30,14 @@ fn genesis_builtins() -> Vec<Builtin> {
     ]
 }
 
+#[derive(AbiExample, Debug, Clone)]
+pub enum ActivationType {
+    NewProgram,
+    NewVersion,
+}
+
 /// Builtin programs activated dynamically by feature
-fn feature_builtins() -> Vec<(Builtin, Pubkey)> {
+fn feature_builtins() -> Vec<(Builtin, Pubkey, ActivationType)> {
     vec![(
         Builtin::new(
             "secp256k1_program",
@@ -39,6 +45,7 @@ fn feature_builtins() -> Vec<(Builtin, Pubkey)> {
             solana_secp256k1_program::process_instruction,
         ),
         feature_set::secp256k1_program_enabled::id(),
+        ActivationType::NewProgram,
     )]
 }
 

--- a/runtime/tests/noop.rs
+++ b/runtime/tests/noop.rs
@@ -10,7 +10,7 @@ fn test_program_native_noop() {
     let (genesis_config, alice_keypair) = create_genesis_config(50);
     let program_id = solana_sdk::pubkey::new_rand();
     let bank = Bank::new(&genesis_config);
-    bank.add_native_program("solana_noop_program", &program_id);
+    bank.add_native_program("solana_noop_program", &program_id, false);
 
     // Call user program
     let instruction = create_invoke_instruction(alice_keypair.pubkey(), program_id, &1u8);


### PR DESCRIPTION
#### Problem
Right now, there is no easy way to redeploy a native program (to fix issues, eg). One appealing approach would be to deploy the updated program using feature_builtins, but this requires a way to overwrite an active builtin.

#### Summary of Changes
- Add a method to enable overwriting existing builtins
- Use this method in `ensure_feature_builtins` to allow a feature_builtin to replace an existing builtin

Needed for #13394 
