### PR TITLE
Add cargo-test-bpf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,6 +3763,7 @@ dependencies = [
 name = "solana-cargo-test-bpf"
 version = "1.5.0"
 dependencies = [
+ "cargo_metadata",
  "clap",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,6 +3760,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-cargo-test-bpf"
+version = "1.5.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "solana-clap-utils"
 version = "1.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "runtime/store-tool",
     "sdk",
     "sdk/cargo-build-bpf",
+    "sdk/cargo-test-bpf",
     "scripts",
     "stake-accounts",
     "stake-monitor",

--- a/cargo-test-bpf
+++ b/cargo-test-bpf
@@ -9,5 +9,6 @@ for a in "$@"; do
   fi
 done
 
+export CARGO_BUILD_BPF="$here"/cargo-build-bpf
 set -x
-exec "$here"/cargo run --manifest-path "$here"/sdk/cargo-build-bpf/Cargo.toml -- $maybe_bpf_sdk "$@"
+exec "$here"/cargo run --manifest-path "$here"/sdk/cargo-test-bpf/Cargo.toml -- $maybe_bpf_sdk "$@"

--- a/programs/bpf/rust/.gitignore
+++ b/programs/bpf/rust/.gitignore
@@ -1,2 +1,0 @@
-*.so
-*-dump.txt

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -76,6 +76,7 @@ else
 
   BINS=(
     cargo-build-bpf
+    cargo-test-bpf
     solana
     solana-bench-exchange
     solana-bench-tps

--- a/sdk/cargo-test-bpf/Cargo.toml
+++ b/sdk/cargo-test-bpf/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "solana-cargo-test-bpf"
+version = "1.5.0"
+description = "Execute all unit and integration tests after building with the Solana BPF SDK"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+homepage = "https://solana.com/"
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+clap = "2.33.3"
+
+[[bin]]
+name = "cargo-test-bpf"
+path = "src/main.rs"

--- a/sdk/cargo-test-bpf/Cargo.toml
+++ b/sdk/cargo-test-bpf/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.3"
+cargo_metadata = "0.12.0"
 
 [[bin]]
 name = "cargo-test-bpf"

--- a/sdk/cargo-test-bpf/src/main.rs
+++ b/sdk/cargo-test-bpf/src/main.rs
@@ -1,0 +1,192 @@
+use clap::{
+    crate_description, crate_name, crate_version, value_t, values_t, App, AppSettings, Arg,
+};
+use std::{
+    env,
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::exit,
+    process::Command,
+};
+
+struct Config {
+    bpf_sdk: Option<String>,
+    bpf_out_dir: Option<String>,
+    cargo: PathBuf,
+    cargo_build_bpf: PathBuf,
+    extra_cargo_test_args: Vec<String>,
+    features: Vec<String>,
+    manifest_path: Option<String>,
+    no_default_features: bool,
+    verbose: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            bpf_sdk: None,
+            bpf_out_dir: None,
+            cargo: PathBuf::from("cargo"),
+            cargo_build_bpf: PathBuf::from("cargo-build-bpf"),
+            extra_cargo_test_args: vec![],
+            features: vec![],
+            manifest_path: None,
+            no_default_features: false,
+            verbose: false,
+        }
+    }
+}
+
+fn spawn<I, S>(program: &Path, args: I)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let args = args.into_iter().collect::<Vec<_>>();
+    print!("Running: {}", program.display());
+    for arg in args.iter() {
+        print!(" {}", arg.as_ref().to_str().unwrap_or("?"));
+    }
+    println!();
+
+    let mut child = Command::new(program)
+        .args(&args)
+        .spawn()
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to execute {}: {}", program.display(), err);
+            exit(1);
+        });
+
+    let exit_status = child.wait().expect("failed to wait on child");
+    if !exit_status.success() {
+        exit(1);
+    }
+}
+
+fn test_bpf(config: Config) {
+    let mut cargo_args = vec![];
+    if config.no_default_features {
+        cargo_args.push("--no-default-features");
+    }
+    for feature in &config.features {
+        cargo_args.push("--features");
+        cargo_args.push(feature);
+    }
+    if let Some(manifest_path) = config.manifest_path.as_ref() {
+        cargo_args.push("--manifest-path");
+        cargo_args.push(&manifest_path);
+    }
+    if config.verbose {
+        cargo_args.push("--verbose");
+    }
+
+    let mut build_bpf_args = cargo_args.clone();
+    if let Some(bpf_sdk) = config.bpf_sdk.as_ref() {
+        build_bpf_args.push("--bpf-sdk");
+        build_bpf_args.push(bpf_sdk);
+    }
+    if let Some(bpf_out_dir) = config.bpf_out_dir.as_ref() {
+        build_bpf_args.push("--bpf-out-dir");
+        build_bpf_args.push(bpf_out_dir);
+    }
+    spawn(&config.cargo_build_bpf, &build_bpf_args);
+
+    env::set_var("bpf", "1"); // Hint to solana-program-test that it should load BPF programs
+    cargo_args.insert(0, "test");
+    for extra_cargo_test_arg in &config.extra_cargo_test_args {
+        cargo_args.push(&extra_cargo_test_arg);
+    }
+    spawn(&config.cargo, &cargo_args);
+}
+
+fn main() {
+    let mut args = env::args().collect::<Vec<_>>();
+    // When run as a cargo subcommand, the first program argument is the subcommand name.
+    // Remove it
+    if let Some(arg1) = args.get(1) {
+        if arg1 == "test-bpf" {
+            args.remove(1);
+        }
+    }
+
+    let matches = App::new(crate_name!())
+        .about(crate_description!())
+        .version(crate_version!())
+        .setting(AppSettings::TrailingVarArg)
+        .arg(
+            Arg::with_name("bpf_sdk")
+                .long("bpf-sdk")
+                .value_name("PATH")
+                .takes_value(true)
+                .help("Path to the Solana BPF SDK"),
+        )
+        .arg(
+            Arg::with_name("features")
+                .long("features")
+                .value_name("FEATURES")
+                .takes_value(true)
+                .multiple(true)
+                .help("Space-separated list of features to activate"),
+        )
+        .arg(
+            Arg::with_name("no_default_features")
+                .long("no-default-features")
+                .takes_value(false)
+                .help("Do not activate the `default` feature"),
+        )
+        .arg(
+            Arg::with_name("manifest_path")
+                .long("manifest-path")
+                .value_name("PATH")
+                .takes_value(true)
+                .help("Path to Cargo.toml"),
+        )
+        .arg(
+            Arg::with_name("bpf_out_dir")
+                .long("bpf-out-dir")
+                .value_name("DIRECTORY")
+                .takes_value(true)
+                .help("Place final BPF build artifacts in this directory"),
+        )
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .long("verbose")
+                .takes_value(false)
+                .help("Use verbose output"),
+        )
+        .arg(
+            Arg::with_name("extra_cargo_test_args")
+                .value_name("extra args for cargo test")
+                .index(1)
+                .multiple(true)
+                .help("All extra arguments are passed through to cargo test"),
+        )
+        .get_matches_from(args);
+
+    let mut config = Config {
+        bpf_sdk: value_t!(matches, "bpf_sdk", String).ok(),
+        bpf_out_dir: value_t!(matches, "bpf_out_dir", String).ok(),
+        extra_cargo_test_args: values_t!(matches, "extra_cargo_test_args", String)
+            .ok()
+            .unwrap_or_else(Vec::new),
+        features: values_t!(matches, "features", String)
+            .ok()
+            .unwrap_or_else(Vec::new),
+        manifest_path: value_t!(matches, "manifest_path", String).ok(),
+        no_default_features: matches.is_present("no_default_features"),
+        verbose: matches.is_present("verbose"),
+        ..Config::default()
+    };
+
+    if let Ok(cargo_build_bpf) = env::var("CARGO_BUILD_BPF") {
+        config.cargo_build_bpf = PathBuf::from(cargo_build_bpf);
+    }
+    if let Ok(cargo_build_bpf) = env::var("CARGO") {
+        config.cargo = PathBuf::from(cargo_build_bpf);
+    }
+
+    test_bpf(config);
+
+    // TODO: args after -- go to ct
+}


### PR DESCRIPTION
When testing a program crate, you typically need to build the crate as BPF and then the tests for the host.  The workflow for this is usually:
```
$ cargo build-bpf
$ bpf=1 cargo test ...
```
where `bpf=1` is a signal to the `solana-program-test` crate to load your program as BPF instead of for the host.   

But for a normal crate the workflow is simply `cargo test ...`.   In some of the SPL program crates, we've attempted to simulate the normal `cargo test` workflow by adding `build.rs` files that automatically run `cargo build-bpf`.  This is not nice for various reasons, such as:
1. You end up building the crate twice, for BPF and host
2. The `build.rs` requires a number of exceptions to avoid clippy and xargo
3. docs.rs obviously doesn't have `cargo build-bpf` so documentation generation on crate publishing doesn't work
4. The env var approach, `bpf=1`, is clunky

Introducing `cargo test-bpf`, which attempts to wrap up this workflow into a single command that mirrors what `cargo test` does for normal crates.