### PR TITLE
adds the missing slash in cargo path

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -3,7 +3,7 @@
 # |cargo install| of the top-level crate will not install binaries for
 # other workspace crates or native program crates.
 here="$(dirname "$0")"
-cargo="$(readlink -f "${here}../cargo")"
+cargo="$(readlink -f "${here}/../cargo")"
 
 set -e
 


### PR DESCRIPTION
#### Problem
The lack of '/' is causing `./net.sh start ...` to fail.

#### Summary of Changes
Added a '/' to the path.