### PR TITLE
CI: Check monorepo for consistent crate versions

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -10,6 +10,8 @@ source ci/rust-version.sh nightly
 eval "$(ci/channel-info.sh)"
 cargo="$(readlink -f "./cargo")"
 
+scripts/increment-cargo-version.sh check
+
 echo --- build environment
 (
   set -x

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -78,6 +78,19 @@ minor)
   ;;
 dropspecial)
   ;;
+check)
+  badTomls=()
+  for Cargo_toml in "${Cargo_tomls[@]}"; do
+    if ! grep "^version *= *\"$currentVersion\"$" "$Cargo_toml" &>/dev/null; then
+      badTomls+=("$Cargo_toml")
+    fi
+  done
+  if [[ ${#badTomls[@]} -ne 0 ]]; then
+    echo "Error: Incorrect crate version specified in: ${badTomls[*]}"
+    exit 1
+  fi
+  exit 0
+  ;;
 -*)
   if [[ $1 =~ ^-[A-Za-z0-9]*$ ]]; then
     SPECIAL="$1"


### PR DESCRIPTION
#### Problem

When mergify backports commits that add a new monorepo member-crate, the specified crate version is not updated, leading to crate publication errors in the next release

#### Summary of Changes

Check that crate versions are consistent across the monorepo in CI