### PR TITLE
propagates errors out of Packet::from_data

### DIFF
--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -39,12 +39,10 @@ impl Packet {
         Self { data, meta }
     }
 
-    pub fn from_data<T: Serialize>(dest: &SocketAddr, data: T) -> Self {
-        let mut me = Packet::default();
-        if let Err(e) = Self::populate_packet(&mut me, Some(dest), &data) {
-            logger::error!("Couldn't write to packet {:?}. Data skipped.", e);
-        }
-        me
+    pub fn from_data<T: Serialize>(dest: &SocketAddr, data: T) -> Result<Self> {
+        let mut packet = Packet::default();
+        Self::populate_packet(&mut packet, Some(dest), &data)?;
+        Ok(packet)
     }
 
     pub fn populate_packet<T: Serialize>(


### PR DESCRIPTION
#### Problem
Packet::from_data is ignoring serialization errors:
https://github.com/solana-labs/solana/blob/d08c3232e/sdk/src/packet.rs#L42-L48
This is likely never useful as the packet will be sent over the wire
taking bandwidth but at the receiving end will either fail to
deserialize or it will be invalid.

#### Summary of Changes
This commit will propagate the errors out of the function to the
call-site, allowing the call-site to handle the error.