### PR TITLE
provide full Rust panic messages in BPF and add memory optimizations

### DIFF
--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2018"
 [dependencies]
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
+[features]
+default = ["custom-panic"]
+custom-panic = []
+
 [lib]
 name = "solana_bpf_rust_panic"
 crate-type = ["cdylib"]

--- a/programs/bpf/rust/panic/src/lib.rs
+++ b/programs/bpf/rust/panic/src/lib.rs
@@ -1,8 +1,24 @@
 //! @brief Example Rust-based BPF program that panics
 
-extern crate solana_program;
-
+#[cfg(all(feature = "custom-panic", target_arch = "bpf"))]
 #[no_mangle]
-pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
-    panic!();
+fn custom_panic(info: &core::panic::PanicInfo<'_>) {
+    // Note: Full panic reporting is included here for testing purposes
+    solana_program::info!("program custom panic enabled");
+    solana_program::info!(&format!("{}", info));
+}
+
+extern crate solana_program;
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    assert_eq!(1, 2);
+    Ok(())
 }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -759,8 +759,8 @@ fn assert_instruction_count() {
             ("multiple_static", 8),
             ("noop", 57),
             ("relative_call", 10),
-            ("sanity", 1140),
-            ("sanity++", 1140),
+            ("sanity", 176),
+            ("sanity++", 176),
             ("struct_pass", 8),
             ("struct_ret", 22),
         ]);
@@ -768,16 +768,16 @@ fn assert_instruction_count() {
     #[cfg(feature = "bpf_rust")]
     {
         programs.extend_from_slice(&[
-            ("solana_bpf_rust_128bit", 543),
-            ("solana_bpf_rust_alloc", 19082),
+            ("solana_bpf_rust_128bit", 572),
+            ("solana_bpf_rust_alloc", 12777),
             ("solana_bpf_rust_dep_crate", 2),
             ("solana_bpf_rust_external_spend", 538),
-            ("solana_bpf_rust_iter", 723),
-            ("solana_bpf_rust_many_args", 231),
+            ("solana_bpf_rust_iter", 724),
+            ("solana_bpf_rust_many_args", 237),
             ("solana_bpf_rust_noop", 488),
-            ("solana_bpf_rust_param_passing", 46),
+            ("solana_bpf_rust_param_passing", 48),
             ("solana_bpf_rust_ristretto", 19399),
-            ("solana_bpf_rust_sanity", 1965),
+            ("solana_bpf_rust_sanity", 894),
         ]);
     }
 

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -533,11 +533,7 @@ fn test_program_bpf_invoke() {
             &[TEST_SUCCESS, bump_seed1, bump_seed2, bump_seed3],
             account_metas.clone(),
         );
-        let noop_instruction = Instruction::new(
-            noop_program_id,
-            &(),
-            vec![]
-        );
+        let noop_instruction = Instruction::new(noop_program_id, &(), vec![]);
         let message = Message::new(&[instruction, noop_instruction], Some(&mint_pubkey));
         let tx = Transaction::new(
             &[

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -41,7 +41,7 @@ use thiserror::Error as ThisError;
 pub enum SyscallError {
     #[error("{0}: {1:?}")]
     InvalidString(Utf8Error, Vec<u8>),
-    #[error("BPF program called abort()!")]
+    #[error("BPF program panicked")]
     Abort,
     #[error("BPF program Panicked in {0} at {1}:{2}")]
     Panic(String, u64, u64),

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -174,7 +174,7 @@ if [[ ! -e rust-bpf-$machine-$version.md || ! -e rust-bpf-$machine ]]; then
 fi
 
 # Install Rust-BPF Sysroot sources
-version=v0.12
+version=v0.13
 if [[ ! -e rust-bpf-sysroot-$version.md || ! -e rust-bpf-sysroot ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

BPF programs only print line/col when they panic, this can provide some info but a lot of useful information is withheld from developers.

#### Summary of Changes

- Add full fledged panic messages:
```
[2020-11-06T23:17:12.406449000Z INFO  solana_runtime::message_processor] Finalized account CGLhHSuWsp1gT4B7MY2KACqp9RUwQRhcUFfVSuxpSajZ
[2020-11-06T23:17:12.410952000Z INFO  solana_runtime::message_processor] Call BPF program CGLhHSuWsp1gT4B7MY2KACqp9RUwQRhcUFfVSuxpSajZ
[2020-11-06T23:17:12.412418000Z INFO  solana_runtime::message_processor] Program log: Panicked at: 'assertion failed: `(left == right)`
      left: `1`,
     right: `2`', rust/panic/src/lib.rs:22:5
[2020-11-06T23:17:12.412454000Z INFO  solana_runtime::message_processor] BPF program consumed 5453 of 200000 units
[2020-11-06T23:17:12.412500000Z INFO  solana_runtime::message_processor] BPF program CGLhHSuWsp1gT4B7MY2KACqp9RUwQRhcUFfVSuxpSajZ failed: BPF program panicked
```
- Add the ability for developers to override the default panic handler to do what they want.  One thing they might want to do is to disable it completely which can reduce the shared object size by not pulling in the `fmt`, etc... stuff from `libstd`.  Typical programs that already use a lot of `libstd` will only incur a small difference (8k increase in shared object size for SPL Token).
- Added docs to explain how to provide custom panic handlers
- The custom panic handler also requires an update of the BPF sysroot to v0.13 which also pulls in optimizations to the standard memory functions (memcpy, memset, etc...)
  - Continuing the compiler optimizations to allow for unaligned read/writes, the functions now copy data in blocks of 8 where possible rather than byte-by-byte. 
    - Reduces a 2048 byte memset followed by memcpy from 24k to 3k BPF instructions
    - SPL Token program which does only small memory operations still sees a reduction in instruction count by 10-20% depending on the instruction.

Fixes #
