### PR TITLE
Don't abort for missing epoch rewards; intead display warn

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1714,11 +1714,12 @@ pub fn process_show_stake_account(
 
             if state.stake_type == CliStakeType::Stake {
                 if let Some(activation_epoch) = state.activation_epoch {
-                    state.epoch_rewards = Some(fetch_epoch_rewards(
-                        rpc_client,
-                        stake_account_address,
-                        activation_epoch,
-                    )?);
+                    let rewards =
+                        fetch_epoch_rewards(rpc_client, stake_account_address, activation_epoch);
+                    match rewards {
+                        Ok(rewards) => state.epoch_rewards = Some(rewards),
+                        Err(error) => eprintln!("Failed to fetch epoch rewards: {:?}", error),
+                    };
                 }
             }
             Ok(config.output_format.formatted_string(&state))

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -698,11 +698,14 @@ pub fn process_show_vote_account(
         }
     }
 
-    let epoch_rewards = Some(crate::stake::fetch_epoch_rewards(
-        rpc_client,
-        vote_account_address,
-        1,
-    )?);
+    let epoch_rewards = match crate::stake::fetch_epoch_rewards(rpc_client, vote_account_address, 1)
+    {
+        Ok(rewards) => Some(rewards),
+        Err(error) => {
+            eprintln!("Failed to fetch epoch rewards: {:?}", error);
+            None
+        }
+    };
 
     let vote_account_data = CliVoteAccount {
         account_balance: vote_account.lamports,


### PR DESCRIPTION
#### Problem

Recently, `solana vote-account` && `solana stake-account` started to print rewards.
But, when validator is purposefully stalled at the warped bank for debugging/investigation, the command fails when trying to print rewards due to some missing data:

```
$ ./target/release/solana --url http://localhost:8899 vote-account FE9WXaL9cvXPBYzwGv2bgthnsDH8GiaK7nHamiib4CXy
Error: RPC request error: Failed to deserialize RPC error response: {"code":-32004,"message":"Block not available for slot 46656000"} [missing field `data`]

$ ./target/release/solana --url http://localhost:8899 stake-account 3Av8ZuvPY7NSGf36BVYN2zY7bNLHcJ6pZ7dCHSgYV5Pj
Error: RPC request error: Failed to deserialize RPC error response: {"code":-32004,"message":"Block not available for slot 46656000"} [missing field `data`]

```

#### Summary of Changes

Continue to run while printing a warning; rewards aren't essential.

Anyway, this occurs only when developing. Usually, this doesn't occur so I'm not hiding this lenient behavior under like `--force`.

(Well, I really want to `solana account --pretty`. Too tired of changing between the two..)
