### PR TITLE
Add back shredding broadcast stats

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -6,7 +6,7 @@ use rand::seq::SliceRandom;
 use raptorq::{Decoder, Encoder};
 use solana_ledger::entry::{create_ticks, Entry};
 use solana_ledger::shred::{
-    max_entries_per_n_shred, max_ticks_per_n_shreds, Shred, Shredder,
+    max_entries_per_n_shred, max_ticks_per_n_shreds, ProcessShredsStats, Shred, Shredder,
     MAX_DATA_SHREDS_PER_FEC_BLOCK, RECOMMENDED_FEC_RATE, SHRED_PAYLOAD_SIZE,
     SIZE_OF_DATA_SHRED_IGNORED_TAIL, SIZE_OF_DATA_SHRED_PAYLOAD,
 };
@@ -40,7 +40,9 @@ fn make_shreds(num_shreds: usize) -> Vec<Shred> {
     let entries = make_large_unchained_entries(txs_per_entry, num_entries);
     let shredder =
         Shredder::new(1, 0, RECOMMENDED_FEC_RATE, Arc::new(Keypair::new()), 0, 0).unwrap();
-    let data_shreds = shredder.entries_to_data_shreds(&entries, true, 0).0;
+    let data_shreds = shredder
+        .entries_to_data_shreds(&entries, true, 0, &mut ProcessShredsStats::default())
+        .0;
     assert!(data_shreds.len() >= num_shreds);
     data_shreds
 }

--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -445,7 +445,7 @@ pub mod test {
         entry::create_ticks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         get_tmp_ledger_path,
-        shred::{max_ticks_per_n_shreds, Shredder, RECOMMENDED_FEC_RATE},
+        shred::{max_ticks_per_n_shreds, ProcessShredsStats, Shredder, RECOMMENDED_FEC_RATE},
     };
     use solana_runtime::bank::Bank;
     use solana_sdk::{
@@ -474,7 +474,8 @@ pub mod test {
         let shredder = Shredder::new(slot, 0, RECOMMENDED_FEC_RATE, keypair, 0, 0)
             .expect("Expected to create a new shredder");
 
-        let coding_shreds = shredder.data_shreds_to_coding_shreds(&data_shreds[0..]);
+        let coding_shreds = shredder
+            .data_shreds_to_coding_shreds(&data_shreds[0..], &mut ProcessShredsStats::default());
         (
             data_shreds.clone(),
             coding_shreds.clone(),

--- a/core/src/broadcast_stage/broadcast_metrics.rs
+++ b/core/src/broadcast_stage/broadcast_metrics.rs
@@ -13,22 +13,6 @@ pub(crate) struct BroadcastShredBatchInfo {
 }
 
 #[derive(Default, Clone)]
-pub(crate) struct ProcessShredsStats {
-    // Per-slot elapsed time
-    pub(crate) shredding_elapsed: u64,
-    pub(crate) receive_elapsed: u64,
-}
-impl ProcessShredsStats {
-    pub(crate) fn update(&mut self, new_stats: &ProcessShredsStats) {
-        self.shredding_elapsed += new_stats.shredding_elapsed;
-        self.receive_elapsed += new_stats.receive_elapsed;
-    }
-    pub(crate) fn reset(&mut self) {
-        *self = Self::default();
-    }
-}
-
-#[derive(Default, Clone)]
 pub struct TransmitShredsStats {
     pub transmit_elapsed: u64,
     pub send_mmsg_elapsed: u64,


### PR DESCRIPTION
#### Problem

Lots of shredding time a bit of a mystery since stats are not implemented in a scalable way and thus disabled.

#### Summary of Changes

Accumulate serialize/gen-data/gen-coding stats for the slot and report them with the other broadcast stats.

Fixes #
