### PR TITLE
Fix avx check with newest nightly compiler

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1047,18 +1047,22 @@ fn report_target_features() {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        // Validator binaries built on a machine with AVX support will generate invalid opcodes
-        // when run on machines without AVX causing a non-obvious process abort.  Instead detect
-        // the mismatch and error cleanly.
-        #[target_feature(enable = "avx")]
-        {
-            if is_x86_feature_detected!("avx") {
-                info!("AVX detected");
-            } else {
-                error!("Your machine does not have AVX support, please rebuild from source on your machine");
-                process::exit(1);
-            }
-        }
+        unsafe { check_avx() };
+    }
+}
+
+// Validator binaries built on a machine with AVX support will generate invalid opcodes
+// when run on machines without AVX causing a non-obvious process abort.  Instead detect
+// the mismatch and error cleanly.
+#[target_feature(enable = "avx")]
+unsafe fn check_avx() {
+    if is_x86_feature_detected!("avx") {
+        info!("AVX detected");
+    } else {
+        error!(
+            "Your machine does not have AVX support, please rebuild from source on your machine"
+        );
+        process::exit(1);
     }
 }
 


### PR DESCRIPTION
#### Problem

Compiler error with nightly about using target_feature on non-function.

#### Summary of Changes

Move target_feature code to a function.

Fixes #
