### PR TITLE
Fix Bank accounts hash mismatch related to Clock::unix_timestamp

### DIFF
--- a/docs/src/implemented-proposals/bank-timestamp-correction.md
+++ b/docs/src/implemented-proposals/bank-timestamp-correction.md
@@ -35,7 +35,9 @@ correction.
 
 In order to calculate the estimated timestamp for a particular Bank, the runtime
 first needs to get the most recent vote timestamps from the active validator
-set. The `Bank::vote_accounts()` method provides the vote accounts state.
+set. The `Bank::vote_accounts()` method provides the vote accounts state, and
+these can be filtered to all accounts whose most recent timestamp was provided
+within the last epoch.
 
 From each vote timestamp, an estimate for the current Bank is calculated using
 the epoch's target ns_per_slot for any delta between the Bank slot and the

--- a/docs/src/implemented-proposals/bank-timestamp-correction.md
+++ b/docs/src/implemented-proposals/bank-timestamp-correction.md
@@ -35,11 +35,7 @@ correction.
 
 In order to calculate the estimated timestamp for a particular Bank, the runtime
 first needs to get the most recent vote timestamps from the active validator
-set. The `Bank::vote_accounts()` method provides the vote accounts state, and
-these can be filtered to all accounts whose most recent timestamp is for an
-ancestor slot back to the current root. This should guarantee 2/3+ of the
-current cluster stake is represented, since by definition, roots must be
-confirmed by 2/3+ stake.
+set. The `Bank::vote_accounts()` method provides the vote accounts state.
 
 From each vote timestamp, an estimate for the current Bank is calculated using
 the epoch's target ns_per_slot for any delta between the Bank slot and the

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1545,10 +1545,9 @@ impl Bank {
             .filter_map(|(pubkey, (_, account))| {
                 VoteState::from(&account).and_then(|state| {
                     let timestamp_slot = state.last_timestamp.slot;
-                    if (self
+                    if self
                         .feature_set
                         .is_active(&feature_set::timestamp_bounding::id())
-                        && self.ancestors.contains_key(&timestamp_slot))
                         || self.slot().checked_sub(timestamp_slot)?
                             <= DEPRECATED_TIMESTAMP_SLOT_RANGE as u64
                     {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1545,9 +1545,11 @@ impl Bank {
             .filter_map(|(pubkey, (_, account))| {
                 VoteState::from(&account).and_then(|state| {
                     let timestamp_slot = state.last_timestamp.slot;
-                    if self
+                    if (self
                         .feature_set
                         .is_active(&feature_set::timestamp_bounding::id())
+                        && self.slot().checked_sub(timestamp_slot)?
+                            <= self.epoch_schedule().slots_per_epoch)
                         || self.slot().checked_sub(timestamp_slot)?
                             <= DEPRECATED_TIMESTAMP_SLOT_RANGE as u64
                     {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4258,19 +4258,8 @@ pub fn goto_end_of_slot(bank: &mut Bank) {
     }
 }
 
-use solana_vote_program::vote_state::BlockTimestamp;
-use solana_vote_program::vote_state::VoteStateVersions;
-pub fn update_vote_account_timestamp(timestamp: BlockTimestamp, bank: &Bank, vote_pubkey: &Pubkey) {
-    let mut vote_account = bank.get_account(vote_pubkey).unwrap_or_default();
-    let mut vote_state = VoteState::from(&vote_account).unwrap_or_default();
-    vote_state.last_timestamp = timestamp;
-    let versioned = VoteStateVersions::Current(Box::new(vote_state));
-    VoteState::to(&versioned, &mut vote_account).unwrap();
-    bank.store_account(vote_pubkey, &vote_account);
-}
-
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::{
         accounts_index::{AccountMap, Ancestors},
@@ -9856,6 +9845,19 @@ mod tests {
         // Account is now empty, and the account lamports were burnt
         assert_eq!(bank.get_balance(&inline_spl_token_v2_0::id()), 0);
         assert_eq!(bank.capitalization(), original_capitalization - 100);
+    }
+
+    pub fn update_vote_account_timestamp(
+        timestamp: BlockTimestamp,
+        bank: &Bank,
+        vote_pubkey: &Pubkey,
+    ) {
+        let mut vote_account = bank.get_account(vote_pubkey).unwrap_or_default();
+        let mut vote_state = VoteState::from(&vote_account).unwrap_or_default();
+        vote_state.last_timestamp = timestamp;
+        let versioned = VoteStateVersions::Current(Box::new(vote_state));
+        VoteState::to(&versioned, &mut vote_account).unwrap();
+        bank.store_account(vote_pubkey, &vote_account);
     }
 
     #[test]

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -292,9 +292,21 @@ impl BankForks {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::genesis_utils::{create_genesis_config, GenesisConfigInfo};
+    use crate::{
+        bank::update_vote_account_timestamp,
+        genesis_utils::{
+            create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
+        },
+    };
     use solana_sdk::hash::Hash;
-    use solana_sdk::pubkey::Pubkey;
+    use solana_sdk::{
+        clock::UnixTimestamp,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        stake_weighted_timestamp::DEPRECATED_TIMESTAMP_SLOT_RANGE,
+        sysvar::epoch_schedule::EpochSchedule,
+    };
+    use solana_vote_program::vote_state::BlockTimestamp;
 
     #[test]
     fn test_bank_forks_new() {
@@ -377,5 +389,75 @@ mod tests {
         let child_bank = Bank::new_from_parent(&bank_forks[0u64], &Pubkey::default(), 1);
         bank_forks.insert(child_bank);
         assert_eq!(bank_forks.active_banks(), vec![1]);
+    }
+
+    #[test]
+    fn test_bank_forks_different_set_root() {
+        solana_logger::setup();
+        let leader_keypair = Keypair::new();
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair: _,
+            voting_keypair,
+        } = create_genesis_config_with_leader(10_000, &leader_keypair.pubkey(), 1_000);
+        let slots_in_epoch = 32;
+        genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
+
+        let bank0 = Bank::new(&genesis_config);
+        let mut bank_forks0 = BankForks::new(bank0);
+
+        let bank1 = Bank::new(&genesis_config);
+        let mut bank_forks1 = BankForks::new(bank1);
+        bank_forks0.set_root(0, &None, None);
+
+        let additional_timestamp_secs = 2;
+
+        let num_slots = slots_in_epoch + DEPRECATED_TIMESTAMP_SLOT_RANGE as u64 + 1;
+        for slot in 1..num_slots {
+            // Just after the epoch boundary, timestamp a vote that will shift
+            // Clock::unix_timestamp from Bank::unix_timestamp_from_genesis()
+            let update_timestamp_case = slot == slots_in_epoch;
+
+            let child1 = Bank::new_from_parent(&bank_forks0[slot - 1], &Pubkey::default(), slot);
+            if update_timestamp_case {
+                let recent_timestamp: UnixTimestamp = child1.unix_timestamp_from_genesis();
+                update_vote_account_timestamp(
+                    BlockTimestamp {
+                        slot: child1.slot(),
+                        timestamp: recent_timestamp + additional_timestamp_secs,
+                    },
+                    &child1,
+                    &voting_keypair.pubkey(),
+                );
+            }
+            bank_forks0.insert(child1);
+            bank_forks0.set_root(slot, &None, None);
+
+            let child2 = Bank::new_from_parent(&bank_forks1[slot - 1], &Pubkey::default(), slot);
+            if update_timestamp_case {
+                let recent_timestamp: UnixTimestamp = child2.unix_timestamp_from_genesis();
+                update_vote_account_timestamp(
+                    BlockTimestamp {
+                        slot: child2.slot(),
+                        timestamp: recent_timestamp + additional_timestamp_secs,
+                    },
+                    &child2,
+                    &voting_keypair.pubkey(),
+                );
+            }
+            bank_forks1.insert(child2);
+        }
+        let child1 =
+            Bank::new_from_parent(&bank_forks0[num_slots - 1], &Pubkey::default(), num_slots);
+        let child2 =
+            Bank::new_from_parent(&bank_forks1[num_slots - 1], &Pubkey::default(), num_slots);
+        bank_forks1.set_root(num_slots - 1, &None, None);
+
+        child1.freeze();
+        child2.freeze();
+
+        info!("child0.ancestors: {:?}", child1.ancestors);
+        info!("child1.ancestors: {:?}", child2.ancestors);
+        assert_eq!(child1.hash(), child2.hash());
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -79,7 +79,7 @@ pub mod pull_request_ping_pong_check {
 }
 
 pub mod timestamp_bounding {
-    solana_sdk::declare_id!("8FyEA6ABYiMxX7Az6AopQN3mavLD8Rz3N4bvKnbbBFFq");
+    solana_sdk::declare_id!("2cGj3HJYPhBrtQizd7YbBxEsifFs5qhzabyFjUAp6dBa");
 }
 
 pub mod stake_program_v2 {


### PR DESCRIPTION
#### Problem
The `timestamp_bounding` feature broke testnet, as `Bank::ancestors` is not deterministic across nodes.
This filtering was intended to minimize the effect of delinquent vote accounts; however, since delinquent accounts shouldn't reflect much stake, and since timestamps are being bounded by PoH, this no longer seems necessary.

#### Summary of Changes
- Remove non-deterministic filtering
- Update docs
- Update feature key to re-enable once testnet is back up
