### PR TITLE
feat: increase timeout in `confirmTransaction`

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -2206,7 +2206,7 @@ export class Connection {
       case 'recent':
       case 'single':
       case 'singleGossip': {
-        timeoutMs = 10 * 1000;
+        timeoutMs = 30 * 1000;
         break;
       }
       // exhaust enums to ensure full coverage
@@ -2225,7 +2225,9 @@ export class Connection {
     if (response === null) {
       const duration = (Date.now() - start) / 1000;
       throw new Error(
-        `Transaction was not confirmed in ${duration.toFixed(2)} seconds`,
+        `Transaction was not confirmed in ${duration.toFixed(
+          2,
+        )} seconds. It is unknown if it succeeded or failed. Check signature ${signature} using the Solana Explorer or CLI tools.`,
       );
     }
 


### PR DESCRIPTION
#### Problem

Developers have reported needing to change the timeout to suit their
use cases, or not completely understanding what the timeout meant for
their transaction, since it could timeout and still get processed.

#### Summary of Changes

Add a `timeoutMs` parameter to `confirmTransaction` and more
information to the error message.

Fixes https://github.com/solana-labs/solana-web3.js/issues/998

Question: do you think `timeoutMs` should be added to `ConfirmOptions` in `connection.js`?  The timeout isn't explicitly related to confirmations as far as the validators are concerned, but it could make things easier for people trying to customize the timeout.