### PR TITLE
align cluster and sim logging as hex

### DIFF
--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -41,7 +41,10 @@ pub(crate) fn sol_log(message: &str) {
 }
 
 pub(crate) fn sol_log_64(arg1: u64, arg2: u64, arg3: u64, arg4: u64, arg5: u64) {
-    sol_log(&format!("{} {} {} {} {}", arg1, arg2, arg3, arg4, arg5));
+    sol_log(&format!(
+        "{:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
+        arg1, arg2, arg3, arg4, arg5
+    ));
 }
 
 pub(crate) fn sol_log_compute_units() {


### PR DESCRIPTION
#### Problem

Simulation and cluster logging don't format messages the same when printing values from a program

#### Summary of Changes

Align them to hexadecimal format

Fixes #
