### PR TITLE
v1.4: Fix Bank accounts hash mismatch related to Clock::unix_timestamp (#13477)

### DIFF
--- a/docs/src/implemented-proposals/bank-timestamp-correction.md
+++ b/docs/src/implemented-proposals/bank-timestamp-correction.md
@@ -36,10 +36,8 @@ correction.
 In order to calculate the estimated timestamp for a particular Bank, the runtime
 first needs to get the most recent vote timestamps from the active validator
 set. The `Bank::vote_accounts()` method provides the vote accounts state, and
-these can be filtered to all accounts whose most recent timestamp is for an
-ancestor slot back to the current root. This should guarantee 2/3+ of the
-current cluster stake is represented, since by definition, roots must be
-confirmed by 2/3+ stake.
+these can be filtered to all accounts whose most recent timestamp was provided
+within the last epoch.
 
 From each vote timestamp, an estimate for the current Bank is calculated using
 the epoch's target ns_per_slot for any delta between the Bank slot and the

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1548,7 +1548,8 @@ impl Bank {
                     if (self
                         .feature_set
                         .is_active(&feature_set::timestamp_bounding::id())
-                        && self.ancestors.contains_key(&timestamp_slot))
+                        && self.slot().checked_sub(timestamp_slot)?
+                            <= self.epoch_schedule().slots_per_epoch)
                         || self.slot().checked_sub(timestamp_slot)?
                             <= DEPRECATED_TIMESTAMP_SLOT_RANGE as u64
                     {
@@ -4259,7 +4260,7 @@ pub fn goto_end_of_slot(bank: &mut Bank) {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::{
         accounts_index::{AccountMap, Ancestors},
@@ -9845,7 +9846,11 @@ mod tests {
         assert_eq!(bank.capitalization(), original_capitalization - 100);
     }
 
-    fn update_vote_account_timestamp(timestamp: BlockTimestamp, bank: &Bank, vote_pubkey: &Pubkey) {
+    pub fn update_vote_account_timestamp(
+        timestamp: BlockTimestamp,
+        bank: &Bank,
+        vote_pubkey: &Pubkey,
+    ) {
         let mut vote_account = bank.get_account(vote_pubkey).unwrap_or_default();
         let mut vote_state = VoteState::from(&vote_account).unwrap_or_default();
         vote_state.last_timestamp = timestamp;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -79,7 +79,7 @@ pub mod pull_request_ping_pong_check {
 }
 
 pub mod timestamp_bounding {
-    solana_sdk::declare_id!("8FyEA6ABYiMxX7Az6AopQN3mavLD8Rz3N4bvKnbbBFFq");
+    solana_sdk::declare_id!("2cGj3HJYPhBrtQizd7YbBxEsifFs5qhzabyFjUAp6dBa");
 }
 
 pub mod stake_program_v2 {


### PR DESCRIPTION
* Test for different ancestors with mismatch bank hash

* Test cleanup

* Remove nondeterministic ancestor check

* Update timestamp bounding feature key

* Update design doc

* Filter recent_timestamps to nodes voting within the last epoch

Co-authored-by: Stephen Akridge <sakridge@gmail.com>

#### Problem
Automatic backport didn't begin
