### PR TITLE
watchtower: Fix all clear duration message

### DIFF
--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -457,6 +457,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         } else {
             if !last_notification_msg.is_empty() {
                 let alarm_duration = Instant::now().duration_since(last_success);
+                let alarm_duration = alarm_duration - config.interval; // Subtract the period before the first error
                 let alarm_duration = Duration::from_secs(alarm_duration.as_secs()); // Drop milliseconds in message
 
                 let all_clear_msg = format!(


### PR DESCRIPTION
#### Problem
The "all clear" alert includes the duration between the last success and the first error.

```
00:01 - Success
00:02 - Error
00:03 - Success (All clear after 2 minutes)
```

#### Summary of Changes
Remove the duration before the first error

```
00:01 - Success
00:02 - Error
00:03 - Success (All clear after 1 minute)
```

Fixes #
