### PR TITLE
Fix slow/stuck unstaking due to toggling in epoch

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1,6 +1,7 @@
 use crate::{
     cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
     spend_utils::{resolve_spend_tx_and_check_account_balance, SpendAmount},
+    stake::is_stake_program_v2_enabled,
 };
 use chrono::{Local, TimeZone};
 use clap::{value_t, value_t_or_exit, App, AppSettings, Arg, ArgMatches, SubCommand};
@@ -1349,6 +1350,8 @@ pub fn process_show_stakes(
     let stake_history = from_account(&stake_history_account).ok_or_else(|| {
         CliError::RpcRequestError("Failed to deserialize stake history".to_string())
     })?;
+    // At v1.6, this check can be removed and simply passed as `true`
+    let stake_program_v2_enabled = is_stake_program_v2_enabled(rpc_client);
 
     let mut stake_accounts: Vec<CliKeyedStakeState> = vec![];
     for (stake_pubkey, stake_account) in all_stake_accounts {
@@ -1364,6 +1367,7 @@ pub fn process_show_stakes(
                                 use_lamports_unit,
                                 &stake_history,
                                 &clock,
+                                stake_program_v2_enabled,
                             ),
                         });
                     }
@@ -1382,6 +1386,7 @@ pub fn process_show_stakes(
                                 use_lamports_unit,
                                 &stake_history,
                                 &clock,
+                                stake_program_v2_enabled,
                             ),
                         });
                     }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -35,6 +35,7 @@ use solana_sdk::{
     account::from_account,
     account_utils::StateMut,
     clock::{Clock, Epoch, Slot, UnixTimestamp, SECONDS_PER_DAY},
+    feature, feature_set,
     message::Message,
     pubkey::Pubkey,
     system_instruction::SystemError,
@@ -1501,6 +1502,7 @@ pub fn build_stake_state(
     use_lamports_unit: bool,
     stake_history: &StakeHistory,
     clock: &Clock,
+    stake_program_v2_enabled: bool,
 ) -> CliStakeState {
     match stake_state {
         StakeState::Stake(
@@ -1512,9 +1514,12 @@ pub fn build_stake_state(
             stake,
         ) => {
             let current_epoch = clock.epoch;
-            let (active_stake, activating_stake, deactivating_stake) = stake
-                .delegation
-                .stake_activating_and_deactivating(current_epoch, Some(stake_history), true);
+            let (active_stake, activating_stake, deactivating_stake) =
+                stake.delegation.stake_activating_and_deactivating(
+                    current_epoch,
+                    Some(stake_history),
+                    stake_program_v2_enabled,
+                );
             let lockup = if lockup.is_in_force(clock, None) {
                 Some(lockup.into())
             } else {
@@ -1710,6 +1715,7 @@ pub fn process_show_stake_account(
                 use_lamports_unit,
                 &stake_history,
                 &clock,
+                is_stake_program_v2_enabled(rpc_client), // At v1.6, this check can be removed and simply passed as `true`
             );
 
             if state.stake_type == CliStakeType::Stake {
@@ -1879,6 +1885,15 @@ pub fn process_delegate_stake(
         );
         log_instruction_custom_error::<StakeError>(result, &config)
     }
+}
+
+pub fn is_stake_program_v2_enabled(rpc_client: &RpcClient) -> bool {
+    rpc_client
+        .get_account(&feature_set::stake_program_v2::id())
+        .ok()
+        .and_then(|account| feature::from_account(&account))
+        .and_then(|feature| feature.activated_at)
+        .is_some()
 }
 
 #[cfg(test)]

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1514,7 +1514,7 @@ pub fn build_stake_state(
             let current_epoch = clock.epoch;
             let (active_stake, activating_stake, deactivating_stake) = stake
                 .delegation
-                .stake_activating_and_deactivating(current_epoch, Some(stake_history));
+                .stake_activating_and_deactivating(current_epoch, Some(stake_history), true);
             let lockup = if lockup.is_in_force(clock, None) {
                 Some(lockup.into())
             } else {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1039,8 +1039,11 @@ impl JsonRpcRequestProcessor {
             solana_sdk::account::from_account::<StakeHistory>(&stake_history_account)
                 .ok_or_else(Error::internal_error)?;
 
-        let (active, activating, deactivating) =
-            delegation.stake_activating_and_deactivating(epoch, Some(&stake_history));
+        let (active, activating, deactivating) = delegation.stake_activating_and_deactivating(
+            epoch,
+            Some(&stake_history),
+            bank.stake_program_v2_enabled(),
+        );
         let stake_activation_state = if deactivating > 0 {
             StakeActivationState::Deactivating
         } else if activating > 0 {

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -234,7 +234,10 @@ pub(crate) mod tests {
         let result: Vec<_> = epoch_stakes_and_lockouts(&bank, first_leader_schedule_epoch);
         assert_eq!(
             result,
-            vec![(leader_stake.stake(first_leader_schedule_epoch, None), None)]
+            vec![(
+                leader_stake.stake(first_leader_schedule_epoch, None, true),
+                None
+            )]
         );
 
         // epoch stakes and lockouts are saved off for the future epoch, should
@@ -244,8 +247,14 @@ pub(crate) mod tests {
         let stake_history =
             from_account::<StakeHistory>(&bank.get_account(&stake_history::id()).unwrap()).unwrap();
         let mut expected = vec![
-            (leader_stake.stake(bank.epoch(), Some(&stake_history)), None),
-            (other_stake.stake(bank.epoch(), Some(&stake_history)), None),
+            (
+                leader_stake.stake(bank.epoch(), Some(&stake_history), true),
+                None,
+            ),
+            (
+                other_stake.stake(bank.epoch(), Some(&stake_history), true),
+                None,
+            ),
         ];
 
         expected.sort();

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -213,8 +213,14 @@ impl Delegation {
         self.activation_epoch == std::u64::MAX
     }
 
-    pub fn stake(&self, epoch: Epoch, history: Option<&StakeHistory>) -> u64 {
-        self.stake_activating_and_deactivating(epoch, history).0
+    pub fn stake(
+        &self,
+        epoch: Epoch,
+        history: Option<&StakeHistory>,
+        fix_stake_deactivate: bool,
+    ) -> u64 {
+        self.stake_activating_and_deactivating(epoch, history, fix_stake_deactivate)
+            .0
     }
 
     #[allow(clippy::comparison_chain)]
@@ -222,11 +228,13 @@ impl Delegation {
         &self,
         target_epoch: Epoch,
         history: Option<&StakeHistory>,
+        fix_stake_deactivate: bool,
     ) -> (u64, u64, u64) {
         let delegated_stake = self.stake;
 
         // first, calculate an effective and activating stake
-        let (effective_stake, activating_stake) = self.stake_and_activating(target_epoch, history);
+        let (effective_stake, activating_stake) =
+            self.stake_and_activating(target_epoch, history, fix_stake_deactivate);
 
         // then de-activate some portion if necessary
         if target_epoch < self.deactivation_epoch {
@@ -302,12 +310,16 @@ impl Delegation {
         &self,
         target_epoch: Epoch,
         history: Option<&StakeHistory>,
+        fix_stake_deactivate: bool,
     ) -> (u64, u64) {
         let delegated_stake = self.stake;
 
         if self.is_bootstrap() {
             // fully effective immediately
             (delegated_stake, 0)
+        } else if fix_stake_deactivate && self.activation_epoch == self.deactivation_epoch {
+            // order important; and this correctly consider boostrap stakes first
+            (0, 0)
         } else if target_epoch == self.activation_epoch {
             // all is activating
             (0, delegated_stake)
@@ -441,8 +453,13 @@ pub struct PointValue {
 }
 
 impl Stake {
-    pub fn stake(&self, epoch: Epoch, history: Option<&StakeHistory>) -> u64 {
-        self.delegation.stake(epoch, history)
+    pub fn stake(
+        &self,
+        epoch: Epoch,
+        history: Option<&StakeHistory>,
+        fix_stake_deactivate: bool,
+    ) -> u64 {
+        self.delegation.stake(epoch, history, fix_stake_deactivate)
     }
 
     pub fn redeem_rewards(
@@ -451,12 +468,14 @@ impl Stake {
         vote_state: &VoteState,
         stake_history: Option<&StakeHistory>,
         inflation_point_calc_tracer: &mut Option<impl FnMut(&InflationPointCalculationEvent)>,
+        fix_stake_deactivate: bool,
     ) -> Option<(u64, u64)> {
         self.calculate_rewards(
             point_value,
             vote_state,
             stake_history,
             inflation_point_calc_tracer,
+            fix_stake_deactivate,
         )
         .map(|(stakers_reward, voters_reward, credits_observed)| {
             self.credits_observed = credits_observed;
@@ -470,9 +489,15 @@ impl Stake {
         vote_state: &VoteState,
         stake_history: Option<&StakeHistory>,
         inflation_point_calc_tracer: &mut Option<impl FnMut(&InflationPointCalculationEvent)>,
+        fix_stake_deactivate: bool,
     ) -> u128 {
-        self.calculate_points_and_credits(vote_state, stake_history, inflation_point_calc_tracer)
-            .0
+        self.calculate_points_and_credits(
+            vote_state,
+            stake_history,
+            inflation_point_calc_tracer,
+            fix_stake_deactivate,
+        )
+        .0
     }
 
     /// for a given stake and vote_state, calculate how many
@@ -483,6 +508,7 @@ impl Stake {
         new_vote_state: &VoteState,
         stake_history: Option<&StakeHistory>,
         inflation_point_calc_tracer: &mut Option<impl FnMut(&InflationPointCalculationEvent)>,
+        fix_stake_deactivate: bool,
     ) -> (u128, u64) {
         // if there is no newer credits since observed, return no point
         if new_vote_state.credits() <= self.credits_observed {
@@ -495,7 +521,11 @@ impl Stake {
         for (epoch, final_epoch_credits, initial_epoch_credits) in
             new_vote_state.epoch_credits().iter().copied()
         {
-            let stake = u128::from(self.delegation.stake(epoch, stake_history));
+            let stake = u128::from(self.delegation.stake(
+                epoch,
+                stake_history,
+                fix_stake_deactivate,
+            ));
 
             // figure out how much this stake has seen that
             //   for which the vote account has a record
@@ -542,11 +572,13 @@ impl Stake {
         vote_state: &VoteState,
         stake_history: Option<&StakeHistory>,
         inflation_point_calc_tracer: &mut Option<impl FnMut(&InflationPointCalculationEvent)>,
+        fix_stake_deactivate: bool,
     ) -> Option<(u64, u64, u64)> {
         let (points, credits_observed) = self.calculate_points_and_credits(
             vote_state,
             stake_history,
             inflation_point_calc_tracer,
+            fix_stake_deactivate,
         );
 
         if points == 0 || point_value.points == 0 {
@@ -597,7 +629,7 @@ impl Stake {
         // can't redelegate if stake is active.  either the stake
         //  is freshly activated or has fully de-activated.  redelegation
         //  implies re-activation
-        if self.stake(clock.epoch, Some(stake_history)) != 0 {
+        if self.stake(clock.epoch, Some(stake_history), true) != 0 {
             return Err(StakeError::TooSoonToRedelegate);
         }
         self.delegation.stake = stake_lamports;
@@ -951,7 +983,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         let meta = match self.state()? {
             StakeState::Stake(meta, stake) => {
                 // stake must be fully de-activated
-                if stake.stake(clock.epoch, Some(stake_history)) != 0 {
+                if stake.stake(clock.epoch, Some(stake_history), true) != 0 {
                     return Err(StakeError::MergeActivatedStake.into());
                 }
                 meta
@@ -965,7 +997,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         let source_meta = match source_stake.state()? {
             StakeState::Stake(meta, stake) => {
                 // stake must be fully de-activated
-                if stake.stake(clock.epoch, Some(stake_history)) != 0 {
+                if stake.stake(clock.epoch, Some(stake_history), true) != 0 {
                     return Err(StakeError::MergeActivatedStake.into());
                 }
                 meta
@@ -1007,7 +1039,9 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                     .check(&signers, StakeAuthorize::Withdrawer)?;
                 // if we have a deactivation epoch and we're in cooldown
                 let staked = if clock.epoch >= stake.delegation.deactivation_epoch {
-                    stake.delegation.stake(clock.epoch, Some(stake_history))
+                    stake
+                        .delegation
+                        .stake(clock.epoch, Some(stake_history), true)
                 } else {
                     // Assume full stake if the stake account hasn't been
                     //  de-activated, because in the future the exposed stake
@@ -1067,6 +1101,7 @@ pub fn redeem_rewards(
     point_value: &PointValue,
     stake_history: Option<&StakeHistory>,
     inflation_point_calc_tracer: &mut Option<impl FnMut(&InflationPointCalculationEvent)>,
+    fix_stake_deactivate: bool,
 ) -> Result<(u64, u64), InstructionError> {
     if let StakeState::Stake(meta, mut stake) = stake_account.state()? {
         let vote_state: VoteState =
@@ -1085,6 +1120,7 @@ pub fn redeem_rewards(
             &vote_state,
             stake_history,
             inflation_point_calc_tracer,
+            fix_stake_deactivate,
         ) {
             stake_account.lamports += stakers_reward;
             vote_account.lamports += voters_reward;
@@ -1105,12 +1141,18 @@ pub fn calculate_points(
     stake_account: &Account,
     vote_account: &Account,
     stake_history: Option<&StakeHistory>,
+    fix_stake_deactivate: bool,
 ) -> Result<u128, InstructionError> {
     if let StakeState::Stake(_meta, stake) = stake_account.state()? {
         let vote_state: VoteState =
             StateMut::<VoteStateVersions>::state(vote_account)?.convert_to_current();
 
-        Ok(stake.calculate_points(&vote_state, stake_history, &mut null_tracer()))
+        Ok(stake.calculate_points(
+            &vote_state,
+            stake_history,
+            &mut null_tracer(),
+            fix_stake_deactivate,
+        ))
     } else {
         Err(InstructionError::InvalidAccountData)
     }
@@ -1134,6 +1176,7 @@ pub fn new_stake_history_entry<'a, I>(
     epoch: Epoch,
     stakes: I,
     history: Option<&StakeHistory>,
+    fix_stake_deactivate: bool,
 ) -> StakeHistoryEntry
 where
     I: Iterator<Item = &'a Delegation>,
@@ -1144,7 +1187,10 @@ where
         (a.0 + b.0, a.1 + b.1, a.2 + b.2)
     }
     let (effective, activating, deactivating) = stakes.fold((0, 0, 0), |sum, stake| {
-        add(sum, stake.stake_activating_and_deactivating(epoch, history))
+        add(
+            sum,
+            stake.stake_activating_and_deactivating(epoch, history, fix_stake_deactivate),
+        )
     });
 
     StakeHistoryEntry {
@@ -1486,6 +1532,7 @@ mod tests {
                 epoch,
                 delegations.iter().chain(bootstrap_delegation.iter()),
                 Some(&stake_history),
+                true,
             );
             stake_history.add(epoch, entry);
         }
@@ -1508,25 +1555,34 @@ mod tests {
         let mut stake_history = StakeHistory::default();
         // assert that this stake follows step function if there's no history
         assert_eq!(
-            stake.stake_activating_and_deactivating(stake.activation_epoch, Some(&stake_history)),
+            stake.stake_activating_and_deactivating(
+                stake.activation_epoch,
+                Some(&stake_history),
+                true
+            ),
             (0, stake.stake, 0)
         );
         for epoch in stake.activation_epoch + 1..stake.deactivation_epoch {
             assert_eq!(
-                stake.stake_activating_and_deactivating(epoch, Some(&stake_history)),
+                stake.stake_activating_and_deactivating(epoch, Some(&stake_history), true),
                 (stake.stake, 0, 0)
             );
         }
         // assert that this stake is full deactivating
         assert_eq!(
-            stake.stake_activating_and_deactivating(stake.deactivation_epoch, Some(&stake_history)),
+            stake.stake_activating_and_deactivating(
+                stake.deactivation_epoch,
+                Some(&stake_history),
+                true
+            ),
             (stake.stake, 0, stake.stake)
         );
         // assert that this stake is fully deactivated if there's no history
         assert_eq!(
             stake.stake_activating_and_deactivating(
                 stake.deactivation_epoch + 1,
-                Some(&stake_history)
+                Some(&stake_history),
+                true,
             ),
             (0, 0, 0)
         );
@@ -1541,7 +1597,7 @@ mod tests {
         );
         // assert that this stake is broken, because above setup is broken
         assert_eq!(
-            stake.stake_activating_and_deactivating(1, Some(&stake_history)),
+            stake.stake_activating_and_deactivating(1, Some(&stake_history), true),
             (0, stake.stake, 0)
         );
 
@@ -1556,7 +1612,7 @@ mod tests {
         );
         // assert that this stake is broken, because above setup is broken
         assert_eq!(
-            stake.stake_activating_and_deactivating(2, Some(&stake_history)),
+            stake.stake_activating_and_deactivating(2, Some(&stake_history), true),
             (increment, stake.stake - increment, 0)
         );
 
@@ -1575,7 +1631,8 @@ mod tests {
         assert_eq!(
             stake.stake_activating_and_deactivating(
                 stake.deactivation_epoch + 1,
-                Some(&stake_history)
+                Some(&stake_history),
+                true,
             ),
             (stake.stake, 0, stake.stake) // says "I'm still waiting for deactivation"
         );
@@ -1593,10 +1650,156 @@ mod tests {
         assert_eq!(
             stake.stake_activating_and_deactivating(
                 stake.deactivation_epoch + 2,
-                Some(&stake_history)
+                Some(&stake_history),
+                true,
             ),
             (stake.stake - increment, 0, stake.stake - increment) // hung, should be lower
         );
+    }
+
+    mod same_epoch_activation_then_deactivation {
+        use super::*;
+
+        enum OldDeactivationBehavior {
+            Stuck,
+            Slow,
+        }
+
+        fn do_test(
+            old_behavior: OldDeactivationBehavior,
+            fix_stake_deactivate: bool,
+            expected_stakes: &[(u64, u64, u64)],
+        ) {
+            let cluster_stake = 1_000;
+            let activating_stake = 10_000;
+            let some_stake = 700;
+            let some_epoch = 0;
+
+            let stake = Delegation {
+                stake: some_stake,
+                activation_epoch: some_epoch,
+                deactivation_epoch: some_epoch,
+                ..Delegation::default()
+            };
+
+            let mut stake_history = StakeHistory::default();
+            let cluster_deactivation_at_stake_modified_epoch = match old_behavior {
+                OldDeactivationBehavior::Stuck => 0,
+                OldDeactivationBehavior::Slow => 1000,
+            };
+
+            let stake_history_entries = vec![
+                (
+                    cluster_stake,
+                    activating_stake,
+                    cluster_deactivation_at_stake_modified_epoch,
+                ),
+                (cluster_stake, activating_stake, 1000),
+                (cluster_stake, activating_stake, 1000),
+                (cluster_stake, activating_stake, 100),
+                (cluster_stake, activating_stake, 100),
+                (cluster_stake, activating_stake, 100),
+                (cluster_stake, activating_stake, 100),
+            ];
+
+            for (epoch, (effective, activating, deactivating)) in
+                stake_history_entries.into_iter().enumerate()
+            {
+                stake_history.add(
+                    epoch as Epoch,
+                    StakeHistoryEntry {
+                        effective,
+                        activating,
+                        deactivating,
+                    },
+                );
+            }
+
+            assert_eq!(
+                expected_stakes,
+                (0..expected_stakes.len())
+                    .map(|epoch| stake.stake_activating_and_deactivating(
+                        epoch as u64,
+                        Some(&stake_history),
+                        fix_stake_deactivate
+                    ))
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        #[test]
+        fn test_old_behavior_slow() {
+            do_test(
+                OldDeactivationBehavior::Slow,
+                false,
+                &[
+                    (0, 0, 0),
+                    (13, 0, 13),
+                    (10, 0, 10),
+                    (8, 0, 8),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                ],
+            );
+        }
+
+        #[test]
+        fn test_old_behavior_stuck() {
+            do_test(
+                OldDeactivationBehavior::Stuck,
+                false,
+                &[
+                    (0, 0, 0),
+                    (17, 0, 17),
+                    (17, 0, 17),
+                    (17, 0, 17),
+                    (17, 0, 17),
+                    (17, 0, 17),
+                    (17, 0, 17),
+                ],
+            );
+        }
+
+        #[test]
+        fn test_new_behavior_previously_slow() {
+            // any stake accounts activated and deactivated at the same epoch
+            // shouldn't been activated (then deactivated) at all!
+
+            do_test(
+                OldDeactivationBehavior::Slow,
+                true,
+                &[
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                ],
+            );
+        }
+
+        #[test]
+        fn test_new_behavior_previously_stuck() {
+            // any stake accounts activated and deactivated at the same epoch
+            // shouldn't been activated (then deactivated) at all!
+
+            do_test(
+                OldDeactivationBehavior::Stuck,
+                true,
+                &[
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                    (0, 0, 0),
+                ],
+            );
+        }
     }
 
     #[test]
@@ -1658,7 +1861,7 @@ mod tests {
                 (0, history.deactivating)
             };
             assert_eq!(
-                stake.stake_activating_and_deactivating(epoch, Some(&stake_history)),
+                stake.stake_activating_and_deactivating(epoch, Some(&stake_history), true),
                 (expected_stake, expected_activating, expected_deactivating)
             );
         }
@@ -1685,7 +1888,7 @@ mod tests {
         for epoch in 0..epochs {
             let stake = delegations
                 .iter()
-                .map(|delegation| delegation.stake(epoch, Some(&stake_history)))
+                .map(|delegation| delegation.stake(epoch, Some(&stake_history), true))
                 .sum::<u64>();
             max_stake = max_stake.max(stake);
             min_stake = min_stake.min(stake);
@@ -1744,7 +1947,7 @@ mod tests {
 
         let mut prev_total_effective_stake = delegations
             .iter()
-            .map(|delegation| delegation.stake(0, Some(&stake_history)))
+            .map(|delegation| delegation.stake(0, Some(&stake_history), true))
             .sum::<u64>();
 
         // uncomment and add ! for fun with graphing
@@ -1752,7 +1955,7 @@ mod tests {
         for epoch in 1..epochs {
             let total_effective_stake = delegations
                 .iter()
-                .map(|delegation| delegation.stake(epoch, Some(&stake_history)))
+                .map(|delegation| delegation.stake(epoch, Some(&stake_history), true))
                 .sum::<u64>();
 
             let delta = if total_effective_stake > prev_total_effective_stake {
@@ -2548,6 +2751,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2566,6 +2770,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2601,6 +2806,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2614,7 +2820,7 @@ mod tests {
         // no overflow on points
         assert_eq!(
             u128::from(stake.delegation.stake) * epoch_slots,
-            stake.calculate_points(&vote_state, None, &mut null_tracer())
+            stake.calculate_points(&vote_state, None, &mut null_tracer(), true)
         );
     }
 
@@ -2642,6 +2848,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2660,6 +2867,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2675,6 +2883,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2693,6 +2902,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2709,6 +2919,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2731,6 +2942,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
 
@@ -2747,6 +2959,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
         vote_state.commission = 99;
@@ -2760,6 +2973,7 @@ mod tests {
                 &vote_state,
                 None,
                 &mut null_tracer(),
+                true,
             )
         );
     }

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -318,7 +318,8 @@ impl Delegation {
             // fully effective immediately
             (delegated_stake, 0)
         } else if fix_stake_deactivate && self.activation_epoch == self.deactivation_epoch {
-            // order important; and this correctly consider boostrap stakes first
+            // activated but instantly deactivated; no stake at all regardless of target_epoch
+            // this must be after the bootstrap check and // before all-is-activating check
             (0, 0)
         } else if target_epoch == self.activation_epoch {
             // all is activating

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -319,7 +319,7 @@ impl Delegation {
             (delegated_stake, 0)
         } else if fix_stake_deactivate && self.activation_epoch == self.deactivation_epoch {
             // activated but instantly deactivated; no stake at all regardless of target_epoch
-            // this must be after the bootstrap check and // before all-is-activating check
+            // this must be after the bootstrap check and before all-is-activating check
             (0, 0)
         } else if target_epoch == self.activation_epoch {
             // all is activating

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4071,7 +4071,8 @@ impl Bank {
     }
 
     pub fn stake_program_v2_enabled(&self) -> bool {
-        self.feature_set.stake_program_v2_enabled()
+        self.feature_set
+            .is_active(&feature_set::stake_program_v2::id())
     }
 
     // This is called from snapshot restore AND for each epoch boundary

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -828,7 +828,7 @@ impl Bank {
             capitalization: AtomicU64::new(parent.capitalization()),
             inflation: parent.inflation.clone(),
             transaction_count: AtomicU64::new(parent.transaction_count()),
-            stakes: RwLock::new(parent.stakes.read().unwrap().clone_with_epoch(epoch)),
+            stakes: RwLock::new(parent.stakes.read().unwrap().clone()),
             epoch_stakes: parent.epoch_stakes.clone(),
             parent_hash: parent.hash(),
             parent_slot: parent.slot(),
@@ -860,8 +860,6 @@ impl Bank {
             ("block_height", new.block_height, i64)
         );
 
-        let leader_schedule_epoch = epoch_schedule.get_leader_schedule_epoch(slot);
-        new.update_epoch_stakes(leader_schedule_epoch);
         new.ancestors.insert(new.slot(), 0);
         new.parents().iter().enumerate().for_each(|(i, p)| {
             new.ancestors.insert(p.slot(), i + 1);
@@ -871,7 +869,15 @@ impl Bank {
         if parent.epoch() < new.epoch() {
             new.apply_feature_activations(false);
         }
+        let cloned = new
+            .stakes
+            .read()
+            .unwrap()
+            .clone_with_epoch(epoch, new.stake_program_v2_enabled());
+        *new.stakes.write().unwrap() = cloned;
 
+        let leader_schedule_epoch = epoch_schedule.get_leader_schedule_epoch(slot);
+        new.update_epoch_stakes(leader_schedule_epoch);
         new.update_slot_hashes();
         new.update_rewards(parent.epoch(), reward_calc_tracer);
         new.update_stake_history(Some(parent.epoch()));
@@ -1315,8 +1321,11 @@ impl Bank {
 
         let old_vote_balance_and_staked = self.stakes.read().unwrap().vote_balance_and_staked();
 
-        let validator_point_value =
-            self.pay_validator_rewards(validator_rewards, reward_calc_tracer);
+        let validator_point_value = self.pay_validator_rewards(
+            validator_rewards,
+            reward_calc_tracer,
+            self.stake_program_v2_enabled(),
+        );
 
         if !self
             .feature_set
@@ -1429,6 +1438,7 @@ impl Bank {
         &mut self,
         rewards: u64,
         reward_calc_tracer: &mut Option<impl FnMut(&RewardCalculationEvent)>,
+        fix_stake_deactivate: bool,
     ) -> f64 {
         let stake_history = self.stakes.read().unwrap().history().clone();
 
@@ -1442,8 +1452,13 @@ impl Bank {
                     .map(move |(_stake_pubkey, stake_account)| (stake_account, vote_account))
             })
             .map(|(stake_account, vote_account)| {
-                stake_state::calculate_points(&stake_account, &vote_account, Some(&stake_history))
-                    .unwrap_or(0)
+                stake_state::calculate_points(
+                    &stake_account,
+                    &vote_account,
+                    Some(&stake_history),
+                    fix_stake_deactivate,
+                )
+                .unwrap_or(0)
             })
             .sum();
 
@@ -1474,6 +1489,7 @@ impl Bank {
                     &point_value,
                     Some(&stake_history),
                     &mut reward_calc_tracer.as_mut(),
+                    fix_stake_deactivate,
                 );
                 if let Ok((stakers_reward, _voters_reward)) = redeemed {
                     self.store_account(&stake_pubkey, &stake_account);
@@ -3413,7 +3429,10 @@ impl Bank {
         self.rc.accounts.store_slow(self.slot(), pubkey, account);
 
         if Stakes::is_stake(account) {
-            self.stakes.write().unwrap().store(pubkey, account);
+            self.stakes
+                .write()
+                .unwrap()
+                .store(pubkey, account, self.stake_program_v2_enabled());
         }
     }
 
@@ -3860,9 +3879,11 @@ impl Bank {
                 .filter(|(_key, account)| (Stakes::is_stake(account)))
             {
                 if Stakes::is_stake(account) {
-                    if let Some(old_vote_account) =
-                        self.stakes.write().unwrap().store(pubkey, account)
-                    {
+                    if let Some(old_vote_account) = self.stakes.write().unwrap().store(
+                        pubkey,
+                        account,
+                        self.stake_program_v2_enabled(),
+                    ) {
                         overwritten_vote_accounts.push(OverwrittenVoteAccount {
                             account: old_vote_account,
                             transaction_index,
@@ -4047,6 +4068,10 @@ impl Bank {
 
     pub fn cumulative_rent_related_fixes_enabled(&self) -> bool {
         self.feature_set.cumulative_rent_related_fixes_enabled()
+    }
+
+    pub fn stake_program_v2_enabled(&self) -> bool {
+        self.feature_set.stake_program_v2_enabled()
     }
 
     // This is called from snapshot restore AND for each epoch boundary
@@ -6033,7 +6058,8 @@ pub(crate) mod tests {
                     .map(move |(_stake_pubkey, stake_account)| (stake_account, vote_account))
             })
             .map(|(stake_account, vote_account)| {
-                stake_state::calculate_points(&stake_account, &vote_account, None).unwrap_or(0)
+                stake_state::calculate_points(&stake_account, &vote_account, None, true)
+                    .unwrap_or(0)
             })
             .sum();
 
@@ -7453,7 +7479,7 @@ pub(crate) mod tests {
             // epoch_stakes are a snapshot at the leader_schedule_slot_offset boundary
             //   in the prior epoch (0 in this case)
             assert_eq!(
-                leader_stake.stake(0, None),
+                leader_stake.stake(0, None, true),
                 vote_accounts.unwrap().get(&leader_vote_account).unwrap().0
             );
 
@@ -7469,7 +7495,7 @@ pub(crate) mod tests {
 
         assert!(child.epoch_vote_accounts(epoch).is_some());
         assert_eq!(
-            leader_stake.stake(child.epoch(), None),
+            leader_stake.stake(child.epoch(), None, true),
             child
                 .epoch_vote_accounts(epoch)
                 .unwrap()
@@ -7487,7 +7513,7 @@ pub(crate) mod tests {
         );
         assert!(child.epoch_vote_accounts(epoch).is_some());
         assert_eq!(
-            leader_stake.stake(child.epoch(), None),
+            leader_stake.stake(child.epoch(), None, true),
             child
                 .epoch_vote_accounts(epoch)
                 .unwrap()

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -81,6 +81,7 @@ fn warmed_up(bank: &Bank, stake_pubkey: &Pubkey) -> bool {
                 )
                 .unwrap(),
             ),
+            true,
         )
 }
 
@@ -95,6 +96,7 @@ fn get_staked(bank: &Bank, stake_pubkey: &Pubkey) -> u64 {
                 )
                 .unwrap(),
             ),
+            true,
         )
 }
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -155,6 +155,10 @@ impl FeatureSet {
         self.is_active(&cumulative_rent_related_fixes::id())
     }
 
+    pub fn stake_program_v2_enabled(&self) -> bool {
+        self.is_active(&stake_program_v2::id())
+    }
+
     /// All features enabled, useful for testing
     pub fn all_enabled() -> Self {
         Self {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -155,10 +155,6 @@ impl FeatureSet {
         self.is_active(&cumulative_rent_related_fixes::id())
     }
 
-    pub fn stake_program_v2_enabled(&self) -> bool {
-        self.is_active(&stake_program_v2::id())
-    }
-
     /// All features enabled, useful for testing
     pub fn all_enabled() -> Self {
         Self {


### PR DESCRIPTION
#### Problem

if activation_epoch == deactivation_epoch, there should be no need for cooldown. But we incorrectly require it not at the epoch, but at the following epochs. And if stake history says no other deactivating stakes, the cooldown could be stuck. Otherwise (most of time), we incorrectly cool-downs the quickly-deactivated stake account very slowly.

For details, please see the attached test.

#### Summary of Changes

We need to ensure to return `(0, 0)` (= no effective stake, no activating stake) for stake account activated-then-deactivated in a single epoch.

Special gating required because of duality of codepath when calculating stakes: instruction processor and normal runtime:
- old instruction processor (legacy_stake_program): call `stake_and_activating(..., false);`
- new instruction processor (stake_program): call `stake_and_activating(..., true);`
- runtime/bank: call `stake_and_activating(..., flag)` where `flag` is conditioned by runtime feature.

Fixes #10982

Context: #13460 #13471.
