### PR TITLE
Make readme testnet section less ambiguous

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ $ cargo test
 ### Starting a local testnet
 Start your own testnet locally, instructions are in the [online docs](https://docs.solana.com/cluster/bench-tps).
 
-### Accessing the remote testnet
-* `testnet` - public stable testnet accessible via devnet.solana.com. Runs 24/7
+### Accessing the remote development cluster
+* `devnet` - stable public cluster for development accessible via
+devnet.solana.com. Runs 24/7. Learn more about the [public clusters](https://docs.solana.com/clusters)
 
 # Benchmarking
 


### PR DESCRIPTION
#### Problem
Our readme refers to a `testnet`, but then directs users to `devnet.solana.com`. This is confusing to people who know about `testnet.solana.com`

#### Summary of Changes
Make this section consistent wrt `devnet` language
