### PR TITLE
Fix parsing CreateAccountWithSeed instructions

### DIFF
--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -92,7 +92,9 @@ pub enum SystemInstruction {
     /// # Account references
     ///   0. [WRITE, SIGNER] Funding account
     ///   1. [WRITE] Created account
-    ///   2. [SIGNER] Base account
+    ///   2. [SIGNER] (optional) Base account; the account matching the base Pubkey below must be
+    ///                          provided as a signer, but may be the same as the funding account
+    ///                          and provided as account 0
     CreateAccountWithSeed {
         /// Base public key
         base: Pubkey,


### PR DESCRIPTION
#### Problem
Based on the CreateAccountWithSeed documentation, the system instruction parser expected those instructions to always load 3 accounts. However, these instructions can succeed with only two, eg https://explorer.solana.com/tx/4aYb68NDK5bDwLufW9TUKawKS8Yfp59pzXRKVhXkq8F3LMXrMbG3wetR6a9k32oudE4U4KET6rMH5uykg9mv1Mbn

This is because the base pubkey is provided in the instruction data, and is only required to be a signer in the accounts list, not a particular indexed account in the list. In other words, the funding key may serve as the base key of the derived address without being passed in as a 3rd account index, since it is already a signer.

#### Summary of Changes
- Fix system instruction parser to properly handle 2- and 3-account cases
- Update CreateAccountWithSeed documentation to indicate that the 3rd account is optional if base account == funding account
- Add CreateAccountWithSeed test so that both 2- and 3-account cases are illustrated

Fixes #13354
