### PR TITLE
Custom heap is BPF only

### DIFF
--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -45,7 +45,10 @@ pub const HEAP_LENGTH: usize = 32 * 1024;
 #[macro_export]
 macro_rules! entrypoint {
     ($process_instruction:ident) => {
-        #[cfg(all(not(feature = "custom-heap"), not(test)))]
+        /// A program can provide their own custom heap implementation by adding
+        /// a `custom-heap` feature to `Cargo.toml` and implementing their own
+        /// `global_allocator`.
+        #[cfg(all(not(feature = "custom-heap"), target_arch = "bpf"))]
         #[global_allocator]
         static A: $crate::entrypoint::BumpAllocator = $crate::entrypoint::BumpAllocator {
             start: $crate::entrypoint::HEAP_START_ADDRESS,


### PR DESCRIPTION
#### Problem

Custom heaps only apply to BPF programs but its inclusion in `entrypoint!` means it also shows up when using `program-test` so programs must feature guard the use of `entrypoint!` from the outside

#### Summary of Changes

Add feature guard to the `entrypoint!` macro to avoid the conflict or doing this:
https://github.com/solana-labs/solana-program-library/blob/487ad2d2d7cb0b8a58f02a156a659e6c8a74f354/examples/rust/logging/src/entrypoint.rs#L3

Mentioned: https://github.com/solana-labs/solana-program-library/issues/829


Fixes #
