### PR TITLE
explorer: Introduce details card for memo instruction

### DIFF
--- a/explorer/src/components/instruction/MemoDetailsCard.tsx
+++ b/explorer/src/components/instruction/MemoDetailsCard.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ParsedInstruction, SignatureResult } from "@solana/web3.js";
+import { InstructionCard } from "./InstructionCard";
+import { wrap } from "utils";
+
+export function MemoDetailsCard({
+  ix,
+  index,
+  result,
+}: {
+  ix: ParsedInstruction;
+  index: number;
+  result: SignatureResult;
+}) {
+  const data = wrap(ix.parsed, 50);
+  return (
+    <InstructionCard ix={ix} index={index} result={result} title="Memo">
+      <tr>
+        <td>Data (UTF-8)</td>
+        <td className="text-lg-right">
+          <pre className="d-inline-block text-left mb-0">{data}</pre>
+        </td>
+      </tr>
+    </InstructionCard>
+  );
+}

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -32,6 +32,7 @@ import { Slot } from "components/common/Slot";
 import { isTokenSwapInstruction } from "components/instruction/token-swap/types";
 import { TokenSwapDetailsCard } from "components/instruction/TokenSwapDetailsCard";
 import { isSerumInstruction } from "components/instruction/serum/types";
+import { MemoDetailsCard } from "components/instruction/MemoDetailsCard";
 
 const AUTO_REFRESH_INTERVAL = 2000;
 const ZERO_CONFIRMATION_BAILOUT = 5;
@@ -444,6 +445,15 @@ function InstructionsSection({ signature }: SignatureProps) {
               <StakeDetailsCard
                 key={index}
                 tx={transaction}
+                ix={next}
+                result={result}
+                index={index}
+              />
+            );
+          case "spl-memo":
+            return (
+              <MemoDetailsCard
+                key={index}
                 ix={next}
                 result={result}
                 index={index}


### PR DESCRIPTION
#### Problem
spl-memo instructions don't have a details card associated with them. 

#### Summary of Changes
Adds details card displaying UTF-8 data of memo. 
