### PR TITLE
Bound ip-echo-server reply read

### DIFF
--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -1,4 +1,4 @@
-use crate::HEADER_LENGTH;
+use crate::{ip_echo_server_reply_length, HEADER_LENGTH};
 use bytes::Bytes;
 use log::*;
 use serde_derive::{Deserialize, Serialize};
@@ -177,11 +177,7 @@ pub fn ip_echo_server(tcp: std::net::TcpListener) -> IpEchoServer {
                     } else {
                         // "\0\0\0\0" header is added to ensure a valid response will never
                         // conflict with the first four bytes of a valid HTTP response.
-                        let mut bytes = vec![
-                            0;
-                            HEADER_LENGTH + bincode::serialized_size(&peer_addr.ip()).unwrap()
-                                as usize
-                        ];
+                        let mut bytes = vec![0u8; ip_echo_server_reply_length()];
                         bincode::serialize_into(&mut bytes[HEADER_LENGTH..], &peer_addr.ip())
                             .unwrap();
                         Ok(Bytes::from(bytes))

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -32,7 +32,7 @@ fn ip_echo_server_request(
     ip_echo_server_addr: &SocketAddr,
     msg: IpEchoServerMessage,
 ) -> Result<IpAddr, String> {
-    let mut data = Vec::new();
+    let mut data = vec![0u8; ip_echo_server_reply_length()];
 
     let timeout = Duration::new(5, 0);
     TcpStream::connect_timeout(ip_echo_server_addr, timeout)
@@ -49,7 +49,7 @@ fn ip_echo_server_request(
             stream.set_read_timeout(Some(Duration::new(10, 0)))?;
             stream.write_all(&bytes)?;
             stream.shutdown(std::net::Shutdown::Write)?;
-            stream.read_to_end(&mut data)
+            stream.read(data.as_mut_slice())
         })
         .and_then(|_| {
             // It's common for users to accidentally confuse the validator's gossip port and JSON

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -23,6 +23,10 @@ pub struct UdpSocketPair {
 pub type PortRange = (u16, u16);
 
 pub(crate) const HEADER_LENGTH: usize = 4;
+pub(crate) fn ip_echo_server_reply_length() -> usize {
+    let largest_ip_addr = IpAddr::from([0u16; 8]); // IPv6 variant
+    HEADER_LENGTH + bincode::serialized_size(&largest_ip_addr).unwrap() as usize
+}
 
 fn ip_echo_server_request(
     ip_echo_server_addr: &SocketAddr,


### PR DESCRIPTION
#### Problem

ip-echo-server will happily read arbitrarily long replies

#### Summary of Changes

- A little cleanup
- Bound the reply read to the expected reply length