### PR TITLE
fix bpf lddw check

### DIFF
--- a/programs/bpf_loader/src/bpf_verifier.rs
+++ b/programs/bpf_loader/src/bpf_verifier.rs
@@ -83,7 +83,7 @@ fn check_imm_endian(insn: &ebpf::Insn, insn_ptr: usize) -> Result<(), BPFError> 
 }
 
 fn check_load_dw(prog: &[u8], insn_ptr: usize) -> Result<(), BPFError> {
-    if insn_ptr >= (prog.len() / ebpf::INSN_SIZE) {
+    if insn_ptr + 1 >= (prog.len() / ebpf::INSN_SIZE) {
         // Last instruction cannot be LD_DW because there would be no 2nd DW
         return Err(VerifierError::LDDWCannotBeLast.into());
     }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -371,6 +371,15 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "VerifierError(LDDWCannotBeLast)")]
+    fn test_bpf_loader_check_load_dw() {
+        let prog = &[
+            0x18, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66, 0x55, // first half of lddw
+        ];
+        bpf_verifier::check(prog, true).unwrap();
+    }
+
+    #[test]
     fn test_bpf_loader_write() {
         let program_id = solana_sdk::pubkey::new_rand();
         let program_key = solana_sdk::pubkey::new_rand();


### PR DESCRIPTION
#### Problem

BPF verifier does not correctly verify that lddw as last instruction in program is fully formed.

#### Summary of Changes

Check and add test

Fixes #
