### PR TITLE
Fix potential undefined behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776469997c56d7130b691a5edea1cbe63d7fef495f98b1b0ced0f3a5571c37aa"
+checksum = "cc04551635026d3ac7bc646698ea1836a85ed2a26b7094fe1d15d8b14854c4a2"
 dependencies = [
  "ouroboros_macro",
  "stable_deref_trait",
@@ -2420,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85165ba45bb44e86ddb86e33ad92640522d572229c5c326eb7eb81ef31b06ce7"
+checksum = "cec33dfceabec83cd0e95a5ce9d20e76ab3a5cbfef59659b8c927f69b93ed8ae"
 dependencies = [
  "Inflector",
  "proc-macro2 1.0.24",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1259,9 +1259,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ouroboros"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776469997c56d7130b691a5edea1cbe63d7fef495f98b1b0ced0f3a5571c37aa"
+checksum = "cc04551635026d3ac7bc646698ea1836a85ed2a26b7094fe1d15d8b14854c4a2"
 dependencies = [
  "ouroboros_macro",
  "stable_deref_trait",
@@ -1269,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85165ba45bb44e86ddb86e33ad92640522d572229c5c326eb7eb81ef31b06ce7"
+checksum = "cec33dfceabec83cd0e95a5ce9d20e76ab3a5cbfef59659b8c927f69b93ed8ae"
 dependencies = [
  "Inflector",
  "proc-macro2 1.0.24",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -29,7 +29,7 @@ memmap = "0.7.0"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
 num_cpus = "1.13.0"
-ouroboros = "0.4.0"
+ouroboros = "0.5.1"
 rand = "0.7.0"
 rayon = "1.4.1"
 regex = "1.3.9"


### PR DESCRIPTION
#### Problem
I'm the creator of the ouroboros crate. As Solana is the first big project to use it, I was curious to see where it was being used. Upon looking at the code I realized it was using the crate in a way I hadn't anticipated which could lead to undefined behavior. I've made an updated version of the crate (`0.5.1`) which solves these problems. This PR changes the code to use this version of the crate. I am planning to yank the older versions once this PR is accepted. To summarize the problem, my crate was not supposed to allow code to directly access fields inside a self-referencing struct, they are only supposed to be accessible through automatically generated helper functions to ensure safety. In writing the macro I had failed to account for fields explicitly marked as `pub`, which allowed code to access them in potentially unsafe ways.

#### Summary of Changes
- The version of `ouroboros` was bumped to `0.5.1`, an update which correctly prevents direct access of fields.
- The code was edited to access the fields of self-referencing structs only through the helper methods.
- The fields were made private again as there was no longer any need to make them public.
- I have checked to make sure `solana-runtime` compiles successfuly in a clean build on my machine.
