### PR TITLE
Tune program logging

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -3788,7 +3788,10 @@ pub mod tests {
             "jsonrpc": "2.0",
             "result": {
                 "context":{"slot":0},
-                "value":{"err":null, "logs":[]}
+                "value":{"err":null, "logs":[
+                    "Program 11111111111111111111111111111111 invoke [1]",
+                    "Program 11111111111111111111111111111111 success"
+                ]}
             },
             "id": 1,
         });
@@ -3829,7 +3832,10 @@ pub mod tests {
             "jsonrpc": "2.0",
             "result": {
                 "context":{"slot":0},
-                "value":{"err":null, "logs":[]}
+                "value":{"err":null, "logs":[
+                    "Program 11111111111111111111111111111111 invoke [1]",
+                    "Program 11111111111111111111111111111111 success"
+                ]}
             },
             "id": 1,
         });
@@ -3849,7 +3855,10 @@ pub mod tests {
             "jsonrpc": "2.0",
             "result": {
                 "context":{"slot":0},
-                "value":{"err":null, "logs":[]}
+                "value":{"err":null, "logs":[
+                    "Program 11111111111111111111111111111111 invoke [1]",
+                    "Program 11111111111111111111111111111111 success"
+                ]}
             },
             "id": 1,
         });

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -381,7 +381,7 @@ impl Default for ProgramTest {
         solana_logger::setup_with_default(
             "solana_bpf_loader=debug,\
              solana_rbpf::vm=debug,\
-             solana_runtime::message_processor=info,\
+             solana_runtime::message_processor=debug,\
              solana_runtime::system_instruction_processor=trace,\
              solana_program_test=info",
         );

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -24,7 +24,7 @@ use solana_sdk::{
     instruction::InstructionError,
     keyed_account::{is_executable, next_keyed_account, KeyedAccount},
     loader_instruction::LoaderInstruction,
-    process_instruction::{ComputeMeter, Executor, InvokeContext},
+    process_instruction::{stable_log, ComputeMeter, Executor, InvokeContext},
     program_utils::limited_deserialize,
     pubkey::Pubkey,
 };
@@ -62,7 +62,7 @@ pub enum BPFError {
 impl UserDefinedError for BPFError {}
 
 /// Point all log messages to the log collector
-macro_rules! log{
+macro_rules! log {
     ($logger:ident, $message:expr) => {
         if let Ok(logger) = $logger.try_borrow_mut() {
             if logger.log_enabled() {
@@ -229,6 +229,7 @@ impl Executor for BPFExecutor {
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
         let logger = invoke_context.get_logger();
+        let invoke_depth = invoke_context.invoke_depth();
 
         let mut keyed_accounts_iter = keyed_accounts.iter();
         let program = next_keyed_account(&mut keyed_accounts_iter)?;
@@ -255,7 +256,7 @@ impl Executor for BPFExecutor {
                 }
             };
 
-            log!(logger, "Call BPF program {}", program.unsigned_key());
+            stable_log::program_invoke(&logger, program.unsigned_key(), invoke_depth);
             let instruction_meter = ThisInstructionMeter::new(compute_meter.clone());
             let before = compute_meter.borrow().get_remaining();
             let result = vm.execute_program_metered(
@@ -267,7 +268,8 @@ impl Executor for BPFExecutor {
             let after = compute_meter.borrow().get_remaining();
             log!(
                 logger,
-                "BPF program consumed {} of {} units",
+                "Program {} consumed {} of {} compute units",
+                program.unsigned_key(),
                 before - after,
                 before
             );
@@ -275,33 +277,25 @@ impl Executor for BPFExecutor {
                 Ok(status) => {
                     if status != SUCCESS {
                         let error: InstructionError = status.into();
-                        log!(
-                            logger,
-                            "BPF program {} failed: {}",
-                            program.unsigned_key(),
-                            error
-                        );
+                        stable_log::program_failure(&logger, program.unsigned_key(), &error);
                         return Err(error);
                     }
                 }
                 Err(error) => {
-                    log!(
-                        logger,
-                        "BPF program {} failed: {}",
-                        program.unsigned_key(),
-                        error
-                    );
-                    return match error {
+                    let error = match error {
                         EbpfError::UserError(BPFError::SyscallError(
                             SyscallError::InstructionError(error),
-                        )) => Err(error),
-                        _ => Err(BPFLoaderError::VirtualMachineFailedToRunProgram.into()),
+                        )) => error,
+                        _ => BPFLoaderError::VirtualMachineFailedToRunProgram.into(),
                     };
+
+                    stable_log::program_failure(&logger, program.unsigned_key(), &error);
+                    return Err(error);
                 }
             }
         }
         deserialize_parameters(program_id, parameter_accounts, &parameter_bytes)?;
-        log!(logger, "BPF program {} success", program.unsigned_key());
+        stable_log::program_success(&logger, program.unsigned_key());
         Ok(())
     }
 }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -21,7 +21,7 @@ use solana_sdk::{
     instruction::{AccountMeta, Instruction, InstructionError},
     keyed_account::KeyedAccount,
     message::Message,
-    process_instruction::{ComputeMeter, InvokeContext, Logger},
+    process_instruction::{stable_log, ComputeMeter, InvokeContext, Logger},
     program_error::ProgramError,
     pubkey::{Pubkey, PubkeyError},
 };
@@ -371,22 +371,16 @@ impl<'a> SyscallObject<BPFError> for SyscallLog<'a> {
         _rw_regions: &[MemoryRegion],
     ) -> Result<u64, EbpfError<BPFError>> {
         self.compute_meter.consume(self.cost)?;
-        let logger = self
-            .logger
-            .try_borrow_mut()
-            .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;
-        if logger.log_enabled() {
-            translate_string_and_do(
-                addr,
-                len,
-                ro_regions,
-                &self.loader_id,
-                &mut |string: &str| {
-                    logger.log(&format!("Program log: {}", string));
-                    Ok(0)
-                },
-            )?;
-        }
+        translate_string_and_do(
+            addr,
+            len,
+            ro_regions,
+            &self.loader_id,
+            &mut |string: &str| {
+                stable_log::program_log(&self.logger, string);
+                Ok(0)
+            },
+        )?;
         Ok(0)
     }
 }
@@ -409,16 +403,13 @@ impl SyscallObject<BPFError> for SyscallLogU64 {
         _rw_regions: &[MemoryRegion],
     ) -> Result<u64, EbpfError<BPFError>> {
         self.compute_meter.consume(self.cost)?;
-        let logger = self
-            .logger
-            .try_borrow_mut()
-            .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;
-        if logger.log_enabled() {
-            logger.log(&format!(
-                "Program log: {:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
+        stable_log::program_log(
+            &self.logger,
+            &format!(
+                "{:#x}, {:#x}, {:#x}, {:#x}, {:#x}",
                 arg1, arg2, arg3, arg4, arg5
-            ));
-        }
+            ),
+        );
         Ok(0)
     }
 }
@@ -474,14 +465,8 @@ impl<'a> SyscallObject<BPFError> for SyscallLogPubkey<'a> {
         _rw_regions: &[MemoryRegion],
     ) -> Result<u64, EbpfError<BPFError>> {
         self.compute_meter.consume(self.cost)?;
-        let logger = self
-            .logger
-            .try_borrow_mut()
-            .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;
-        if logger.log_enabled() {
-            let pubkey = translate_type!(Pubkey, pubkey_addr, ro_regions, self.loader_id)?;
-            logger.log(&format!("Program log: {}", pubkey));
-        }
+        let pubkey = translate_type!(Pubkey, pubkey_addr, ro_regions, self.loader_id)?;
+        stable_log::program_log(&self.logger, &pubkey.to_string());
         Ok(0)
     }
 }

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ $ok || {
   exit 1
 }
 
-export RUST_LOG=${RUST_LOG:-solana=info} # if RUST_LOG is unset, default to info
+export RUST_LOG=${RUST_LOG:-solana=info,solana_runtime::message_processor=debug} # if RUST_LOG is unset, default to info
 export RUST_BACKTRACE=1
 dataDir=$PWD/config/"$(basename "$0" .sh)"
 ledgerDir=$PWD/config/ledger

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -2,7 +2,50 @@ use crate::{
     bank::{Builtin, Builtins},
     system_instruction_processor,
 };
-use solana_sdk::{feature_set, pubkey::Pubkey, system_program};
+use solana_sdk::{
+    feature_set,
+    instruction::InstructionError,
+    keyed_account::KeyedAccount,
+    process_instruction::{stable_log, InvokeContext, ProcessInstructionWithContext},
+    pubkey::Pubkey,
+    system_program,
+};
+
+fn process_instruction_with_program_logging(
+    process_instruction: ProcessInstructionWithContext,
+    program_id: &Pubkey,
+    keyed_accounts: &[KeyedAccount],
+    instruction_data: &[u8],
+    invoke_context: &mut dyn InvokeContext,
+) -> Result<(), InstructionError> {
+    let logger = invoke_context.get_logger();
+    stable_log::program_invoke(&logger, program_id, invoke_context.invoke_depth());
+
+    let result = process_instruction(program_id, keyed_accounts, instruction_data, invoke_context);
+
+    match &result {
+        Ok(()) => stable_log::program_success(&logger, program_id),
+        Err(err) => stable_log::program_failure(&logger, program_id, err),
+    }
+    result
+}
+
+macro_rules! with_program_logging {
+    ($process_instruction:expr) => {
+        |program_id: &Pubkey,
+         keyed_accounts: &[KeyedAccount],
+         instruction_data: &[u8],
+         invoke_context: &mut dyn InvokeContext| {
+            process_instruction_with_program_logging(
+                $process_instruction,
+                program_id,
+                keyed_accounts,
+                instruction_data,
+                invoke_context,
+            )
+        }
+    };
+}
 
 /// Builtin programs that are always available
 fn genesis_builtins() -> Vec<Builtin> {
@@ -10,24 +53,26 @@ fn genesis_builtins() -> Vec<Builtin> {
         Builtin::new(
             "system_program",
             system_program::id(),
-            system_instruction_processor::process_instruction,
+            with_program_logging!(system_instruction_processor::process_instruction),
         ),
         Builtin::new(
             "vote_program",
             solana_vote_program::id(),
-            solana_vote_program::vote_instruction::process_instruction,
+            with_program_logging!(solana_vote_program::vote_instruction::process_instruction),
         ),
         // Remove legacy_stake_processor and move stake_instruction::process_instruction back to
         // genesis_builtins around the v1.6 timeframe
         Builtin::new(
             "stake_program",
             solana_stake_program::id(),
-            solana_stake_program::legacy_stake_processor::process_instruction,
+            with_program_logging!(
+                solana_stake_program::legacy_stake_processor::process_instruction
+            ),
         ),
         Builtin::new(
             "config_program",
             solana_config_program::id(),
-            solana_config_program::config_processor::process_instruction,
+            with_program_logging!(solana_config_program::config_processor::process_instruction),
         ),
     ]
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -256,6 +256,9 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
     fn pop(&mut self) {
         self.program_ids.pop();
     }
+    fn invoke_depth(&self) -> usize {
+        self.program_ids.len()
+    }
     fn verify_and_update(
         &mut self,
         message: &Message,
@@ -314,7 +317,7 @@ impl Logger for ThisLogger {
         log_enabled!(log::Level::Info) || self.log_collector.is_some()
     }
     fn log(&self, message: &str) {
-        info!("{}", message);
+        debug!("{}", message);
         if let Some(log_collector) = &self.log_collector {
             log_collector.log(message);
         }

--- a/web3.js/bin/localnet.sh
+++ b/web3.js/bin/localnet.sh
@@ -79,7 +79,7 @@ up)
 
   (
     set -x
-    RUST_LOG=${RUST_LOG:-solana=info}
+    RUST_LOG=${RUST_LOG:-solana=info,solana_runtime::message_processor=debug}
     ARGS=(
       --detach
       --name solana-localnet


### PR DESCRIPTION
This PR proposes some slight changes to the program logging format, which we can then commit to as being stable and document it as such.

### General Form
Program start is denoted by:
```
Program <address> invoke [<depth>]
```

Any program-generated output is guaranteed to be prefixed by "Program log:"
```
Program log: <program-generated output>
```

Successful program completion is denoted by:
```
Program <address> success
```

Program execution failure is denoted by:
```
Program <address> failed: <program error details>
```

Any other log messages are considered to be unstable and  may change in the future.   Currently only the BPF Loader supports this program logging scheme. Support for other program loaders, such as the native loader, may be added in the future

### Examples
Success:
```
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]
Program log: Instruction: Transfer
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4761 of 200000 units
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
```

Failure:
```
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]
Program log: Instruction: Transfer
Program log: Error: insufficient funds
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3122 of 200000 units
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA failed: custom program error: 0x1
```

Success with multiple CPIs:
```
Program badkenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8kn invoke [1]
Program log: FeatureProposalInstruction::Propose
Program log: Creating feature proposal account
Program log: Creating mint
Program log: Initializing mint
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
Program log: Instruction: InitializeMint
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 2989 of 158336 units
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
Program log: Creating delivery token account
Program log: Initializing delivery token account
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
Program log: Instruction: InitializeAccount
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4409 of 145387 units
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
Program log: Creating acceptance token account
Program log: Initializing acceptance token account
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
Program log: Instruction: InitializeAccount
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4409 of 130950 units
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
Program log: Minting 42 tokens
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
Program log: Instruction: MintTo
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4272 of 122476 units
Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
Program log: Funding feature id account
Program log: Allocating feature id account
Program badkenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8kn consumed 88615 of 200000 units
Program badkenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8kn success
```

Note that the **`Program <address> consumed <x> of <y> units`** log message is deliberately not documented in the General Form section right now.  This is intended to highlight that additional log message patterns may be present in the stream that the user is responsible for ignoring when parsing the stream