### PR TITLE
validator: --gossip-host may now be specified with --entrypoint

### DIFF
--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -94,7 +94,7 @@ fn parse_matches() -> ArgMatches<'static> {
                         .value_name("HOST")
                         .takes_value(true)
                         .validator(solana_net_utils::is_host)
-                        .help("Gossip DNS name or IP address for the node \
+                        .help("Gossip DNS name or IP address for the node to advertise in gossip \
                                [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not provided]"),
                 )
                 .arg(


### PR DESCRIPTION
It's currently an error to specify `--gossip-host` with `--entrypoint` to `solana-validator`, but:
1. `solana-gossip spy` allows it
2. There's no reason not to allow it and gives the validator flexibility over the IP address they advertise in gossip