### PR TITLE
ip-echo-server: Don't use framed decoder, it can't be read-limited

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,7 +4444,6 @@ dependencies = [
  "solana-logger 1.5.0",
  "solana-version",
  "tokio 0.1.22",
- "tokio-codec",
  "url 2.1.1",
 ]
 

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -22,7 +22,6 @@ solana-clap-utils = { path = "../clap-utils", version = "1.5.0" }
 solana-logger = { path = "../logger", version = "1.5.0" }
 solana-version = { path = "../version", version = "1.5.0" }
 tokio = "0.1"
-tokio-codec = "0.1"
 url = "2.1.1"
 
 [lib]


### PR DESCRIPTION
#### Problem

Similarly to #13543, the server side of ip-echo-server will consume far more data than it needs

#### Summary of Changes

Limit reads to the size of the expected single request