### PR TITLE
Release: Omit spl-token CLI binary (v1.4)

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -116,8 +116,6 @@ mkdir -p "$installDir/bin"
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
   "$cargo" $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
-  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  "$cargo" $maybeRustVersion install spl-token-cli --root "$installDir"
 )
 
 for bin in "${BINS[@]}"; do


### PR DESCRIPTION
#### Problem

`ouroboros` yanked the crate version that v1.4 `solana-runtime` depends on.  `spl-token` CLI depends on v1.4 `solana-runtime`.  v1.4 ships the `spl-token` CLI binary with its releases... You see where this is going...

#### Summary of Changes

Break the cycle.  Remove `spl-token` CLI binary from the v1.4.8 release