### PR TITLE
Revert "Release: Omit spl-token CLI binary"

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -116,6 +116,8 @@ mkdir -p "$installDir/bin"
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
   "$cargo" $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
+  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
+  "$cargo" $maybeRustVersion install spl-token-cli --root "$installDir"
 )
 
 for bin in "${BINS[@]}"; do


### PR DESCRIPTION
#### Problem

#13588 

#### Summary of Changes

Put `spl-token` CLI binary back in for v1.4.9 release