### PR TITLE
web3.js: update expected program log messages

### DIFF
--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -171,9 +171,11 @@ describe('load BPF Rust program', () => {
     }
 
     expect(logs.length).toBeGreaterThanOrEqual(2);
-    expect(logs[0]).toEqual(`Call BPF program ${program.publicKey.toBase58()}`);
+    expect(logs[0]).toEqual(
+      `Program ${program.publicKey.toBase58()} invoke [1]`,
+    );
     expect(logs[logs.length - 1]).toEqual(
-      `BPF program ${program.publicKey.toBase58()} success`,
+      `Program ${program.publicKey.toBase58()} success`,
     );
   });
 
@@ -197,9 +199,11 @@ describe('load BPF Rust program', () => {
     }
 
     expect(logs.length).toBeGreaterThanOrEqual(2);
-    expect(logs[0]).toEqual(`Call BPF program ${program.publicKey.toBase58()}`);
+    expect(logs[0]).toEqual(
+      `Program ${program.publicKey.toBase58()} invoke [1]`,
+    );
     expect(logs[logs.length - 1]).toEqual(
-      `BPF program ${program.publicKey.toBase58()} success`,
+      `Program ${program.publicKey.toBase58()} success`,
     );
   });
 
@@ -224,9 +228,11 @@ describe('load BPF Rust program', () => {
     }
 
     expect(logs.length).toBeGreaterThanOrEqual(2);
-    expect(logs[0]).toEqual(`Call BPF program ${program.publicKey.toBase58()}`);
+    expect(logs[0]).toEqual(
+      `Program ${program.publicKey.toBase58()} invoke [1]`,
+    );
     expect(logs[logs.length - 1]).toEqual(
-      `BPF program ${program.publicKey.toBase58()} success`,
+      `Program ${program.publicKey.toBase58()} success`,
     );
   });
 


### PR DESCRIPTION
The program logging is changing and becoming stable via https://github.com/solana-labs/solana/pull/13556.   Update web3.js tests to use the new format

CI blocked until #13556 lands on master