### PR TITLE
Disable the PubSub vote subscription by default

### DIFF
--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -1002,11 +1002,12 @@ mod tests {
         // Setup Subscriptions
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
-        let subscriptions = RpcSubscriptions::new(
+        let subscriptions = RpcSubscriptions::new_with_vote_subscription(
             &exit,
             bank_forks,
             block_commitment_cache,
             optimistically_confirmed_bank,
+            true,
         );
         rpc.subscriptions = Arc::new(subscriptions);
         rpc.vote_subscribe(session, subscriber);

--- a/core/src/rpc_pubsub_service.rs
+++ b/core/src/rpc_pubsub_service.rs
@@ -18,6 +18,8 @@ use std::{
 
 #[derive(Debug, Clone)]
 pub struct PubSubConfig {
+    pub enable_vote_subscription: bool,
+
     // See the corresponding fields in
     // https://github.com/paritytech/ws-rs/blob/be4d47575bae55c60d9f51b47480d355492a94fc/src/lib.rs#L131
     // for a complete description of each field in this struct
@@ -30,8 +32,9 @@ pub struct PubSubConfig {
 impl Default for PubSubConfig {
     fn default() -> Self {
         Self {
-            max_connections: 1000,             // Arbitrary, default of 100 is too low
-            max_fragment_size: 50 * 1024,      // 50KB
+            enable_vote_subscription: false,
+            max_connections: 1000, // Arbitrary, default of 100 is too low
+            max_fragment_size: 50 * 1024, // 50KB
             max_in_buffer_capacity: 50 * 1024, // 50KB
             max_out_buffer_capacity: 15 * 1024 * 1024, // max account size (10MB), then 5MB extra for base64 encoding overhead/etc
         }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -344,11 +344,12 @@ impl Validator {
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
 
-        let subscriptions = Arc::new(RpcSubscriptions::new(
+        let subscriptions = Arc::new(RpcSubscriptions::new_with_vote_subscription(
             &exit,
             bank_forks.clone(),
             block_commitment_cache.clone(),
             optimistically_confirmed_bank.clone(),
+            config.pubsub_config.enable_vote_subscription,
         ));
 
         let (completed_data_sets_sender, completed_data_sets_receiver) =

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2834,7 +2834,7 @@ Result:
 {"jsonrpc":"2.0","result":true,"id":1}
 ```
 
-### Subscription Websocket
+## Subscription Websocket
 
 After connecting to the RPC PubSub websocket at `ws://<ADDRESS>/`:
 
@@ -3355,7 +3355,11 @@ Result:
 {"jsonrpc": "2.0","result": true,"id": 1}
 ```
 
-### voteSubscribe
+### voteSubscribe - Unstable, disabled by default
+
+**This subscription is unstable and only available if the validator was started
+with the `--rpc-pubsub-enable-vote-subscription` flag.  The format of this
+subscription may change in the future**
 
 Subscribe to receive notification anytime a new vote is observed in gossip.
 These votes are pre-consensus therefore there is no guarantee these votes will

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1265,6 +1265,12 @@ pub fn main() {
                 .help("IP address to bind the RPC port [default: use --bind-address]"),
         )
         .arg(
+            Arg::with_name("rpc_pubsub_enable_vote_subscription")
+                .long("rpc-pubsub-enable-vote-subscription")
+                .takes_value(false)
+                .help("Enable the unstable RPC PubSub `voteSubscribe` subscription"),
+        )
+        .arg(
             Arg::with_name("rpc_pubsub_max_connections")
                 .long("rpc-pubsub-max-connections")
                 .value_name("NUMBER")
@@ -1469,6 +1475,7 @@ pub fn main() {
             )
         }),
         pubsub_config: PubSubConfig {
+            enable_vote_subscription: matches.is_present("rpc_pubsub_enable_vote_subscription"),
             max_connections: value_t_or_exit!(matches, "rpc_pubsub_max_connections", usize),
             max_fragment_size: value_t_or_exit!(matches, "rpc_pubsub_max_fragment_size", usize),
             max_in_buffer_capacity: value_t_or_exit!(


### PR DESCRIPTION
The --rpc-pubsub-enable-vote-subscription flag may be used to enable it. The current vote subscription is problematic because it emits a notification for *every* vote, so hundreds a second in a real cluster. Critically it's also missing information about *who* is voting, rendering all those notifications practically useless.

Until these two issues can be resolved, the vote subscription is not much more than a potential DoS vector.
