### PR TITLE
Add counter metrics to rpc-subscriptions

### DIFF
--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -772,6 +772,7 @@ impl RpcSubscriptions {
                         debug!("slot notify: {:?}", slot_info);
                         let subscriptions = subscriptions.slot_subscriptions.read().unwrap();
                         for (_, sink) in subscriptions.iter() {
+                            inc_new_counter_info!("rpc-subscription-notify-slot", 1);
                             notifier.notify(slot_info, sink);
                         }
                     }
@@ -782,6 +783,7 @@ impl RpcSubscriptions {
                         debug!("vote notify: {:?}", vote_info);
                         let subscriptions = subscriptions.vote_subscriptions.read().unwrap();
                         for (_, sink) in subscriptions.iter() {
+                            inc_new_counter_info!("rpc-subscription-notify-vote", 1);
                             notifier.notify(
                                 RpcVote {
                                     slots: vote_info.slots.clone(),
@@ -796,6 +798,7 @@ impl RpcSubscriptions {
                         debug!("root notify: {:?}", root);
                         let subscriptions = subscriptions.root_subscriptions.read().unwrap();
                         for (_, sink) in subscriptions.iter() {
+                            inc_new_counter_info!("rpc-subscription-notify-root", 1);
                             notifier.notify(root, sink);
                         }
                     }
@@ -936,6 +939,7 @@ impl RpcSubscriptions {
                 num_signatures_notified,
                 signatures_time,
             );
+            inc_new_counter_info!("rpc-subscription-notify-bank-or-gossip", total_notified);
             datapoint_info!(
                 "rpc_subscriptions",
                 ("source", source.to_string(), String),


### PR DESCRIPTION
#### Problem
Rpc-subscription metrics only include bank/gossip notifications, those that we expected to be the longest-running, but not necessarily the most frequent.

#### Summary of Changes
- Add counter metrics for all notifications
