### PR TITLE
feat: support pre and post token balances

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -142,12 +142,20 @@ declare module '@solana/web3.js' {
     instructions: CompiledInstruction[];
   };
 
+  export type TokenBalance = {
+    accountIndex: number;
+    mint: string;
+    uiTokenAmount: TokenAmount;
+  };
+
   export type ConfirmedTransactionMeta = {
     fee: number;
     innerInstructions?: CompiledInnerInstruction[];
     preBalances: Array<number>;
     postBalances: Array<number>;
     logMessages?: Array<string>;
+    preTokenBalances?: Array<TokenBalance>;
+    postTokenBalances?: Array<TokenBalance>;
     err: TransactionError | null;
   };
 
@@ -162,6 +170,8 @@ declare module '@solana/web3.js' {
     preBalances: Array<number>;
     postBalances: Array<number>;
     logMessages?: Array<string>;
+    preTokenBalances?: Array<TokenBalance>;
+    postTokenBalances?: Array<TokenBalance>;
     err: TransactionError | null;
   };
 

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -157,12 +157,20 @@ declare module '@solana/web3.js' {
     instructions: CompiledInstruction[],
   };
 
+  declare export type TokenBalance = {
+    accountIndex: number,
+    mint: string,
+    uiTokenAmount: TokenAmount,
+  };
+
   declare export type ConfirmedTransactionMeta = {
     fee: number,
     innerInstructions?: CompiledInnerInstruction[],
     preBalances: Array<number>,
     postBalances: Array<number>,
     logMessages?: Array<string>,
+    preTokenBalances?: Array<TokenBalance>,
+    postTokenBalances?: Array<TokenBalance>,
     err: TransactionError | null,
   };
 
@@ -177,6 +185,8 @@ declare module '@solana/web3.js' {
     preBalances: Array<number>,
     postBalances: Array<number>,
     logMessages?: Array<string>,
+    preTokenBalances?: Array<TokenBalance>,
+    postTokenBalances?: Array<TokenBalance>,
     err: TransactionError | null,
   };
 

--- a/web3.js/package-lock.json
+++ b/web3.js/package-lock.json
@@ -7781,7 +7781,7 @@
         },
         "is-obj": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
           "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
           "dev": true
         }

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -373,6 +373,12 @@ type ParsedInnerInstruction = {
   instructions: (ParsedInstruction | PartiallyDecodedInstruction)[],
 };
 
+type TokenBalance = {
+  accountIndex: number,
+  mint: string,
+  uiTokenAmount: TokenAmount,
+};
+
 /**
  * Metadata for a parsed confirmed transaction on the ledger
  *

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1189,28 +1189,32 @@ const ConfirmedTransactionMetaResult = struct.union([
     postBalances: struct.array(['number']),
     logMessages: struct.union([struct.array(['string']), 'null', 'undefined']),
     preTokenBalances: struct.union([
-      struct.pick({
-        arrayIndex: 'number',
-        mint: 'string',
-        uiTokenAmount: struct.pick({
-          amount: 'string',
-          decimals: 'number',
-          uiAmount: 'number',
+      struct.array([
+        struct.pick({
+          accountIndex: 'number',
+          mint: 'string',
+          uiTokenAmount: struct.pick({
+            amount: 'string',
+            decimals: 'number',
+            uiAmount: 'number',
+          }),
         }),
-      }),
+      ]),
       'null',
       'undefined',
     ]),
     postTokenBalances: struct.union([
-      struct.pick({
-        arrayIndex: 'number',
-        mint: 'string',
-        uiTokenAmount: struct.pick({
-          amount: 'string',
-          decimals: 'number',
-          uiAmount: 'number',
+      struct.array([
+        struct.pick({
+          accountIndex: 'number',
+          mint: 'string',
+          uiTokenAmount: struct.pick({
+            amount: 'string',
+            decimals: 'number',
+            uiAmount: 'number',
+          }),
         }),
-      }),
+      ]),
       'null',
       'undefined',
     ]),
@@ -1251,28 +1255,32 @@ const ParsedConfirmedTransactionMetaResult = struct.union([
     postBalances: struct.array(['number']),
     logMessages: struct.union([struct.array(['string']), 'null', 'undefined']),
     preTokenBalances: struct.union([
-      struct.pick({
-        arrayIndex: 'number',
-        mint: 'string',
-        uiTokenAmount: struct.pick({
-          amount: 'string',
-          decimals: 'number',
-          uiAmount: 'number',
+      struct.array([
+        struct.pick({
+          accountIndex: 'number',
+          mint: 'string',
+          uiTokenAmount: struct.pick({
+            amount: 'string',
+            decimals: 'number',
+            uiAmount: 'number',
+          }),
         }),
-      }),
+      ]),
       'null',
       'undefined',
     ]),
     postTokenBalances: struct.union([
-      struct.pick({
-        arrayIndex: 'number',
-        mint: 'string',
-        uiTokenAmount: struct.pick({
-          amount: 'string',
-          decimals: 'number',
-          uiAmount: 'number',
+      struct.array([
+        struct.pick({
+          accountIndex: 'number',
+          mint: 'string',
+          uiTokenAmount: struct.pick({
+            amount: 'string',
+            decimals: 'number',
+            uiAmount: 'number',
+          }),
         }),
-      }),
+      ]),
       'null',
       'undefined',
     ]),

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -382,6 +382,8 @@ type ParsedInnerInstruction = {
  * @property {Array<number>} preBalances The balances of the transaction accounts before processing
  * @property {Array<number>} postBalances The balances of the transaction accounts after processing
  * @property {Array<string>} logMessages An array of program log messages emitted during a transaction
+ * @property {Array<TokenBalance>} preTokenBalances The token balances of the transaction accounts before processing
+ * @property {Array<TokenBalance>} postTokenBalances The token balances of the transaction accounts after processing
  * @property {object|null} err The error result of transaction processing
  */
 type ParsedConfirmedTransactionMeta = {
@@ -390,6 +392,8 @@ type ParsedConfirmedTransactionMeta = {
   preBalances: Array<number>,
   postBalances: Array<number>,
   logMessages?: Array<string>,
+  preTokenBalances?: Array<TokenBalance>,
+  postTokenBalances?: Array<TokenBalance>,
   err: TransactionError | null,
 };
 
@@ -1178,6 +1182,32 @@ const ConfirmedTransactionMetaResult = struct.union([
     preBalances: struct.array(['number']),
     postBalances: struct.array(['number']),
     logMessages: struct.union([struct.array(['string']), 'null', 'undefined']),
+    preTokenBalances: struct.union([
+      struct.pick({
+        arrayIndex: 'number',
+        mint: 'string',
+        uiTokenAmount: struct.pick({
+          amount: 'string',
+          decimals: 'number',
+          uiAmount: 'number',
+        }),
+      }),
+      'null',
+      'undefined',
+    ]),
+    postTokenBalances: struct.union([
+      struct.pick({
+        arrayIndex: 'number',
+        mint: 'string',
+        uiTokenAmount: struct.pick({
+          amount: 'string',
+          decimals: 'number',
+          uiAmount: 'number',
+        }),
+      }),
+      'null',
+      'undefined',
+    ]),
   }),
 ]);
 /**
@@ -1214,6 +1244,32 @@ const ParsedConfirmedTransactionMetaResult = struct.union([
     preBalances: struct.array(['number']),
     postBalances: struct.array(['number']),
     logMessages: struct.union([struct.array(['string']), 'null', 'undefined']),
+    preTokenBalances: struct.union([
+      struct.pick({
+        arrayIndex: 'number',
+        mint: 'string',
+        uiTokenAmount: struct.pick({
+          amount: 'string',
+          decimals: 'number',
+          uiAmount: 'number',
+        }),
+      }),
+      'null',
+      'undefined',
+    ]),
+    postTokenBalances: struct.union([
+      struct.pick({
+        arrayIndex: 'number',
+        mint: 'string',
+        uiTokenAmount: struct.pick({
+          amount: 'string',
+          decimals: 'number',
+          uiAmount: 'number',
+        }),
+      }),
+      'null',
+      'undefined',
+    ]),
   }),
 ]);
 


### PR DESCRIPTION
#### Problem
Web3 should support the pre and post token balances (for deltas) on a confirmed block.

#### Summary of Changes
Add type support for pre and post token balances on confirmed block metadata.

