### PR TITLE
Default preflight_commitment to confirmation commitment

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1264,7 +1264,10 @@ impl RpcClient {
         self.send_and_confirm_transaction_with_spinner_and_config(
             transaction,
             commitment,
-            RpcSendTransactionConfig::default(),
+            RpcSendTransactionConfig {
+                preflight_commitment: Some(commitment.commitment),
+                ..RpcSendTransactionConfig::default()
+            },
         )
     }
 

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -2933,15 +2933,10 @@ export class Connection {
     const skipPreflight = options && options.skipPreflight;
     const preflightCommitment = options && options.preflightCommitment;
 
-    if (skipPreflight && preflightCommitment) {
-      throw new Error(
-        'cannot set preflightCommitment when skipPreflight is enabled',
-      );
-    }
-
     if (skipPreflight) {
       config.skipPreflight = skipPreflight;
-    } else if (preflightCommitment) {
+    }
+    if (preflightCommitment) {
       config.preflightCommitment = preflightCommitment;
     }
 

--- a/web3.js/src/util/send-and-confirm-raw-transaction.js
+++ b/web3.js/src/util/send-and-confirm-raw-transaction.js
@@ -19,9 +19,14 @@ export async function sendAndConfirmRawTransaction(
   rawTransaction: Buffer,
   options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
+  const sendOptions = options && {
+    skipPreflight: options.skipPreflight,
+    preflightCommitment: options.preflightCommitment || options.commitment,
+  };
+
   const signature = await connection.sendRawTransaction(
     rawTransaction,
-    options,
+    sendOptions,
   );
 
   const status = (

--- a/web3.js/src/util/send-and-confirm-transaction.js
+++ b/web3.js/src/util/send-and-confirm-transaction.js
@@ -23,10 +23,15 @@ export async function sendAndConfirmTransaction(
   signers: Array<Account>,
   options?: ConfirmOptions,
 ): Promise<TransactionSignature> {
+  const sendOptions = options && {
+    skipPreflight: options.skipPreflight,
+    preflightCommitment: options.preflightCommitment || options.commitment,
+  };
+
   const signature = await connection.sendTransaction(
     transaction,
     signers,
-    options,
+    sendOptions,
   );
 
   const status = (


### PR DESCRIPTION
`RpcClient::send_and_confirm_transaction_with_spinner_and_commitment()` - the user cannot specify a preflight commitment set it to the user-supplied commitment instead of max, which is more likely to be what the user really wants

`sendAndConfirmTransaction()`/`sendAndConfirmRawTransaction()` - same 