### PR TITLE
Remove program cap from CLI checks

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1227,7 +1227,7 @@ fn do_process_deploy(
         CliError::DynamicProgramError(format!("Unable to read program file: {}", err))
     })?;
 
-    Executable::<BPFError>::from_elf(&program_data, Some(|x| bpf_verifier::check(x, true)))
+    Executable::<BPFError>::from_elf(&program_data, Some(|x| bpf_verifier::check(x, false)))
         .map_err(|err| CliError::DynamicProgramError(format!("ELF error: {}", err)))?;
 
     let loader_id = if use_deprecated_loader {


### PR DESCRIPTION
#### Problem

The CLI checks that the program is valid by calling the BPF verifier but does so using an old restriction that is not supported on any cluster any longer.  The restriction limits the size of a program artificially in the ELF verification but the cluster will support programs as big as account data will allow.

#### Summary of Changes

Remove the program cap in the CLI verification

Fixes #
