### PR TITLE
Improve TestValidator instantiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4964,6 +4964,7 @@ dependencies = [
  "solana-cli-config",
  "solana-client",
  "solana-core",
+ "solana-logger 1.5.0",
  "solana-remote-wallet",
  "solana-runtime",
  "solana-sdk",

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -10,7 +10,7 @@ use solana_client::{
     rpc_client::RpcClient,
 };
 use solana_core::contact_info::ContactInfo;
-use solana_core::test_validator::{TestValidator, TestValidatorOptions};
+use solana_core::test_validator::TestValidator;
 use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
     commitment_config::CommitmentConfig,
@@ -231,17 +231,14 @@ fn full_battery_tests(
 
 #[test]
 fn test_create_account_with_seed() {
+    solana_logger::setup();
     let TestValidator {
         server,
         leader_data,
         alice: mint_keypair,
         ledger_path,
         ..
-    } = TestValidator::run_with_options(TestValidatorOptions {
-        fees: 1,
-        bootstrap_validator_lamports: 42_000,
-        ..TestValidatorOptions::default()
-    });
+    } = TestValidator::run_with_fees(1);
 
     let (sender, receiver) = channel();
     run_local_faucet(mint_keypair, sender, None);

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -9,7 +9,7 @@ use solana_client::{
     nonce_utils,
     rpc_client::RpcClient,
 };
-use solana_core::test_validator::{TestValidator, TestValidatorOptions};
+use solana_core::test_validator::TestValidator;
 use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
     account_utils::StateMut,
@@ -848,11 +848,7 @@ fn test_stake_authorize_with_fee_payer() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run_with_options(TestValidatorOptions {
-        fees: SIG_FEE,
-        bootstrap_validator_lamports: 42_000,
-        ..TestValidatorOptions::default()
-    });
+    } = TestValidator::run_with_fees(SIG_FEE);
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -985,11 +981,7 @@ fn test_stake_split() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run_with_options(TestValidatorOptions {
-        fees: 1,
-        bootstrap_validator_lamports: 42_000,
-        ..TestValidatorOptions::default()
-    });
+    } = TestValidator::run_with_fees(1);
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -1140,11 +1132,7 @@ fn test_stake_set_lockup() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run_with_options(TestValidatorOptions {
-        fees: 1,
-        bootstrap_validator_lamports: 42_000,
-        ..TestValidatorOptions::default()
-    });
+    } = TestValidator::run_with_fees(1);
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -9,7 +9,7 @@ use solana_client::{
     nonce_utils,
     rpc_client::RpcClient,
 };
-use solana_core::test_validator::{TestValidator, TestValidatorOptions};
+use solana_core::test_validator::TestValidator;
 use solana_faucet::faucet::run_local_faucet;
 use solana_sdk::{
     commitment_config::CommitmentConfig,
@@ -21,17 +21,14 @@ use std::{fs::remove_dir_all, sync::mpsc::channel};
 
 #[test]
 fn test_transfer() {
+    solana_logger::setup();
     let TestValidator {
         server,
         leader_data,
         alice: mint_keypair,
         ledger_path,
         ..
-    } = TestValidator::run_with_options(TestValidatorOptions {
-        fees: 1,
-        bootstrap_validator_lamports: 42_000,
-        ..TestValidatorOptions::default()
-    });
+    } = TestValidator::run_with_fees(1);
 
     let (sender, receiver) = channel();
     run_local_faucet(mint_keypair, sender, None);
@@ -252,17 +249,14 @@ fn test_transfer() {
 
 #[test]
 fn test_transfer_multisession_signing() {
+    solana_logger::setup();
     let TestValidator {
         server,
         leader_data,
         alice: mint_keypair,
         ledger_path,
         ..
-    } = TestValidator::run_with_options(TestValidatorOptions {
-        fees: 1,
-        bootstrap_validator_lamports: 42_000,
-        ..TestValidatorOptions::default()
-    });
+    } = TestValidator::run_with_fees(1);
 
     let (sender, receiver) = channel();
     run_local_faucet(mint_keypair, sender, None);
@@ -382,17 +376,14 @@ fn test_transfer_multisession_signing() {
 
 #[test]
 fn test_transfer_all() {
+    solana_logger::setup();
     let TestValidator {
         server,
         leader_data,
         alice: mint_keypair,
         ledger_path,
         ..
-    } = TestValidator::run_with_options(TestValidatorOptions {
-        fees: 1,
-        bootstrap_validator_lamports: 42_000,
-        ..TestValidatorOptions::default()
-    });
+    } = TestValidator::run_with_fees(1);
 
     let (sender, receiver) = channel();
     run_local_faucet(mint_keypair, sender, None);

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -8,6 +8,7 @@ use solana_ledger::create_new_tmp_ledger;
 use solana_sdk::{
     clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
     hash::Hash,
+    native_token::sol_to_lamports,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
 };
@@ -34,7 +35,7 @@ impl Default for TestValidatorOptions {
         TestValidatorOptions {
             fees: 0,
             bootstrap_validator_lamports: BOOTSTRAP_VALIDATOR_LAMPORTS,
-            mint_lamports: 1_000_000,
+            mint_lamports: sol_to_lamports(1_000_000.0),
         }
     }
 }

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use solana_ledger::create_new_tmp_ledger;
 use solana_sdk::{
+    clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
     hash::Hash,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
@@ -43,6 +44,23 @@ impl TestValidator {
         Self::run_with_options(TestValidatorOptions::default())
     }
 
+    /// Instantiates a TestValidator with custom fees. The bootstrap_validator_lamports will
+    /// default to enough to cover 1 epoch of votes. This is an abitrary value based on current and
+    /// foreseen uses of TestValidator. May need to be bumped if uses change in the future.
+    pub fn run_with_fees(fees: u64) -> Self {
+        let bootstrap_validator_lamports = fees * DEFAULT_DEV_SLOTS_PER_EPOCH * 5;
+        Self::run_with_options(TestValidatorOptions {
+            fees,
+            bootstrap_validator_lamports,
+            ..TestValidatorOptions::default()
+        })
+    }
+
+    /// Instantiates a TestValidator with completely customized options.
+    ///
+    /// Note: if `fees` are non-zero, be sure to set a value for `bootstrap_validator_lamports`
+    /// that can cover enough vote transaction fees for the test. TestValidatorOptions::default()
+    /// may not be sufficient.
     pub fn run_with_options(options: TestValidatorOptions) -> Self {
         use solana_ledger::genesis_utils::{
             create_genesis_config_with_leader_ex, GenesisConfigInfo,
@@ -57,6 +75,14 @@ impl TestValidator {
         let node_keypair = Arc::new(Keypair::new());
         let node = Node::new_localhost_with_pubkey(&node_keypair.pubkey());
         let contact_info = node.info.clone();
+
+        if fees > 0 && bootstrap_validator_lamports < fees * DEFAULT_DEV_SLOTS_PER_EPOCH {
+            warn!(
+                "TestValidator::bootstrap_validator_lamports less than one epoch. \
+                Only enough to cover {:?} slots",
+                bootstrap_validator_lamports / fees
+            );
+        }
 
         let GenesisConfigInfo {
             mut genesis_config,

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -12,7 +12,8 @@ use solana_runtime::{
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
 };
 use solana_sdk::{
-    commitment_config::CommitmentConfig, rpc_port, signature::Signer, system_transaction,
+    commitment_config::CommitmentConfig, native_token::sol_to_lamports, rpc_port,
+    signature::Signer, system_transaction,
 };
 use std::{
     fs::remove_dir_all,
@@ -50,11 +51,14 @@ fn test_rpc_client() {
 
     assert_eq!(client.get_balance(&bob_pubkey).unwrap(), 0);
 
-    assert_eq!(client.get_balance(&alice.pubkey()).unwrap(), 1_000_000);
+    assert_eq!(
+        client.get_balance(&alice.pubkey()).unwrap(),
+        sol_to_lamports(1_000_000.0)
+    );
 
     let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
 
-    let tx = system_transaction::transfer(&alice, &bob_pubkey, 20, blockhash);
+    let tx = system_transaction::transfer(&alice, &bob_pubkey, sol_to_lamports(20.0), blockhash);
     let signature = client.send_transaction(&tx).unwrap();
 
     let mut confirmed_tx = false;
@@ -75,8 +79,14 @@ fn test_rpc_client() {
 
     assert!(confirmed_tx);
 
-    assert_eq!(client.get_balance(&bob_pubkey).unwrap(), 20);
-    assert_eq!(client.get_balance(&alice.pubkey()).unwrap(), 999_980);
+    assert_eq!(
+        client.get_balance(&bob_pubkey).unwrap(),
+        sol_to_lamports(20.0)
+    );
+    assert_eq!(
+        client.get_balance(&alice.pubkey()).unwrap(),
+        sol_to_lamports(999_980.0)
+    );
 
     server.close().unwrap();
     remove_dir_all(ledger_path).unwrap();

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -35,4 +35,5 @@ url = "2.1"
 bincode = "1.3.1"
 solana-banks-server = { path = "../banks-server", version = "1.5.0" }
 solana-core = { path = "../core", version = "1.5.0" }
+solana-logger = { path = "../logger", version = "1.5.0" }
 solana-runtime = { path = "../runtime", version = "1.5.0" }

--- a/tokens/tests/commands.rs
+++ b/tokens/tests/commands.rs
@@ -1,6 +1,5 @@
 use solana_banks_client::start_tcp_client;
-use solana_core::test_validator::{TestValidator, TestValidatorOptions};
-use solana_sdk::native_token::sol_to_lamports;
+use solana_core::test_validator::TestValidator;
 use solana_tokens::commands::test_process_distribute_tokens_with_client;
 use std::fs::remove_dir_all;
 use tokio::runtime::Runtime;
@@ -14,10 +13,7 @@ fn test_process_distribute_with_rpc_client() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run_with_options(TestValidatorOptions {
-        mint_lamports: sol_to_lamports(9_000_000.0),
-        ..TestValidatorOptions::default()
-    });
+    } = TestValidator::run();
 
     Runtime::new().unwrap().block_on(async {
         let mut banks_client = start_tcp_client(leader_data.rpc_banks).await.unwrap();

--- a/tokens/tests/commands.rs
+++ b/tokens/tests/commands.rs
@@ -7,6 +7,7 @@ use tokio::runtime::Runtime;
 
 #[test]
 fn test_process_distribute_with_rpc_client() {
+    solana_logger::setup();
     let TestValidator {
         server,
         leader_data,


### PR DESCRIPTION
#### Problem
It is a common pattern to use `TestValidator::new_with_options()` to specify one or two options and use `TestValidatorOptions::default()` for the rest. This can be problematic if `fees` are set to non-zero, but `bootstrap_validator_lamports` are left as default -- the default value is 42 lamports, which may not be enough to cover many or any votes! This results in a TestValidator that doesn't make confirmations or roots.

#### Summary of Changes
- Add `TestValidator::run_with_fees()` that simplifies starting a TestValidator with non-zero fees and ensures a sane value for `bootstrap_validator_lamports`
- Add warning for a custom TestValidator when the bootstrap-validator cannot cover 1 epoch of vote fees
- Add logging to solana-tokens integration test to help catch low bootstrap_validator_lamports in the future
- And for good measure... bump up the completely unrealistic default mint lamports, which might eliminate the need for `TestValidator::new_with_options()` in many cases

cc @garious 
