### PR TITLE
Add back BPF error logging

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -295,6 +295,12 @@ impl Executor for BPFExecutor {
                     }
                 }
                 Err(error) => {
+                    log!(
+                        logger,
+                        "Program {} vm error: {}",
+                        program.unsigned_key(),
+                        error
+                    );
                     let error = match error {
                         EbpfError::UserError(BPFError::SyscallError(
                             SyscallError::InstructionError(error),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -297,7 +297,7 @@ impl Executor for BPFExecutor {
                 Err(error) => {
                     log!(
                         logger,
-                        "Program {} vm error: {}",
+                        "Program {} BPF VM error: {}",
                         program.unsigned_key(),
                         error
                     );


### PR DESCRIPTION
#### Problem

Logging of the actual BPF was lost when stable logging was introduced

#### Summary of Changes

Add back the BPF specific error that led to the more generic `InstructionError`

Fixes #
