### PR TITLE
Remove stake split overflow opportunities

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -910,7 +910,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                     // verify full withdrawal can cover rent in new split account
                         || (lamports < split_rent_exempt_reserve && lamports == self.lamports()?)
                     // verify enough lamports left in previous stake and not full withdrawal
-                            || (lamports > self.lamports()? - meta.rent_exempt_reserve
+                            || (lamports + meta.rent_exempt_reserve > self.lamports()?
                             && lamports != self.lamports()?)
                     {
                         return Err(InstructionError::InsufficientFunds);
@@ -929,7 +929,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
                         // account, this prevents any magic activation of stake by prefunding the
                         // split account.
                         (
-                            lamports - meta.rent_exempt_reserve,
+                            lamports.saturating_sub(meta.rent_exempt_reserve),
                             lamports - split_rent_exempt_reserve,
                         )
                     } else {


### PR DESCRIPTION
#### Problem
If we upgrade to stake-program-v2 before performing the accounts rewrite (https://github.com/solana-labs/solana/pull/13461), there are a couple opportunities for overflow on split operations against accounts where `rent_exempt_reserve > self.lamports()`.

#### Summary of Changes
Fix them
