### PR TITLE
Fix fragile tests in prep of stake rewrite pr

### DIFF
--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -31,10 +31,10 @@ pub struct TestValidatorOptions {
 
 impl Default for TestValidatorOptions {
     fn default() -> Self {
-        use solana_ledger::genesis_utils::bootstrap_validator_lamports;
+        use solana_runtime::genesis_utils::BOOTSTRAP_VALIDATOR_LAMPORTS;
         TestValidatorOptions {
             fees: 0,
-            bootstrap_validator_lamports: bootstrap_validator_lamports(),
+            bootstrap_validator_lamports: BOOTSTRAP_VALIDATOR_LAMPORTS,
             mint_lamports: sol_to_lamports(1_000_000.0),
         }
     }
@@ -94,7 +94,7 @@ impl TestValidator {
             &contact_info.id,
             &Keypair::new(),
             &solana_sdk::pubkey::new_rand(),
-            42 + bootstrap_validator_lamports,
+            solana_runtime::genesis_utils::bootstrap_validator_stake_lamports(),
             bootstrap_validator_lamports,
             solana_sdk::genesis_config::ClusterType::Development,
         );

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -4,6 +4,7 @@ use crate::{
     gossip_service::discover_cluster,
     validator::{Validator, ValidatorConfig},
 };
+use solana_runtime::genesis_utils::{BOOTSTRAP_VALIDATOR_LAMPORTS, bootstrap_validator_stake_lamports};
 use solana_ledger::create_new_tmp_ledger;
 use solana_sdk::{
     clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
@@ -31,7 +32,6 @@ pub struct TestValidatorOptions {
 
 impl Default for TestValidatorOptions {
     fn default() -> Self {
-        use solana_runtime::genesis_utils::BOOTSTRAP_VALIDATOR_LAMPORTS;
         TestValidatorOptions {
             fees: 0,
             bootstrap_validator_lamports: BOOTSTRAP_VALIDATOR_LAMPORTS,
@@ -94,7 +94,7 @@ impl TestValidator {
             &contact_info.id,
             &Keypair::new(),
             &solana_sdk::pubkey::new_rand(),
-            solana_runtime::genesis_utils::bootstrap_validator_stake_lamports(),
+            bootstrap_validator_stake_lamports(),
             bootstrap_validator_lamports,
             solana_sdk::genesis_config::ClusterType::Development,
         );

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -4,8 +4,10 @@ use crate::{
     gossip_service::discover_cluster,
     validator::{Validator, ValidatorConfig},
 };
-use solana_runtime::genesis_utils::{BOOTSTRAP_VALIDATOR_LAMPORTS, bootstrap_validator_stake_lamports};
 use solana_ledger::create_new_tmp_ledger;
+use solana_runtime::genesis_utils::{
+    bootstrap_validator_stake_lamports, BOOTSTRAP_VALIDATOR_LAMPORTS,
+};
 use solana_sdk::{
     clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
     hash::Hash,

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -31,10 +31,10 @@ pub struct TestValidatorOptions {
 
 impl Default for TestValidatorOptions {
     fn default() -> Self {
-        use solana_ledger::genesis_utils::BOOTSTRAP_VALIDATOR_LAMPORTS;
+        use solana_ledger::genesis_utils::bootstrap_validator_lamports;
         TestValidatorOptions {
             fees: 0,
-            bootstrap_validator_lamports: BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports: bootstrap_validator_lamports(),
             mint_lamports: sol_to_lamports(1_000_000.0),
         }
     }
@@ -94,7 +94,7 @@ impl TestValidator {
             &contact_info.id,
             &Keypair::new(),
             &solana_sdk::pubkey::new_rand(),
-            42,
+            42 + bootstrap_validator_lamports,
             bootstrap_validator_lamports,
             solana_sdk::genesis_config::ClusterType::Development,
         );

--- a/ledger/src/genesis_utils.rs
+++ b/ledger/src/genesis_utils.rs
@@ -1,5 +1,5 @@
 pub use solana_runtime::genesis_utils::{
-    bootstrap_validator_lamports, create_genesis_config_with_leader,
+    bootstrap_validator_stake_lamports, create_genesis_config_with_leader,
     create_genesis_config_with_leader_ex, GenesisConfigInfo,
 };
 
@@ -9,6 +9,6 @@ pub fn create_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {
     create_genesis_config_with_leader(
         mint_lamports,
         &solana_sdk::pubkey::new_rand(),
-        bootstrap_validator_lamports(),
+        bootstrap_validator_stake_lamports(),
     )
 }

--- a/ledger/src/genesis_utils.rs
+++ b/ledger/src/genesis_utils.rs
@@ -1,6 +1,6 @@
 pub use solana_runtime::genesis_utils::{
-    create_genesis_config_with_leader, create_genesis_config_with_leader_ex, GenesisConfigInfo,
-    BOOTSTRAP_VALIDATOR_LAMPORTS,
+    bootstrap_validator_lamports, create_genesis_config_with_leader,
+    create_genesis_config_with_leader_ex, GenesisConfigInfo,
 };
 
 // same as genesis_config::create_genesis_config, but with bootstrap_validator staking logic
@@ -9,6 +9,6 @@ pub fn create_genesis_config(mint_lamports: u64) -> GenesisConfigInfo {
     create_genesis_config_with_leader(
         mint_lamports,
         &solana_sdk::pubkey::new_rand(),
-        BOOTSTRAP_VALIDATOR_LAMPORTS,
+        bootstrap_validator_lamports(),
     )
 }

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -260,8 +260,8 @@ mod tests {
     use crate::{
         blockstore::make_slot_entries,
         genesis_utils::{
-            create_genesis_config, create_genesis_config_with_leader, GenesisConfigInfo,
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports, create_genesis_config, create_genesis_config_with_leader,
+            GenesisConfigInfo,
         },
         get_tmp_ledger_path,
         staking_utils::tests::setup_vote_and_stake_accounts,
@@ -380,9 +380,9 @@ mod tests {
     fn test_next_leader_slot() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let mut genesis_config = create_genesis_config_with_leader(
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports(),
             &pubkey,
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports(),
         )
         .genesis_config;
         genesis_config.epoch_schedule = EpochSchedule::custom(
@@ -433,9 +433,9 @@ mod tests {
     fn test_next_leader_slot_blockstore() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let mut genesis_config = create_genesis_config_with_leader(
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports(),
             &pubkey,
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports(),
         )
         .genesis_config;
         genesis_config.epoch_schedule.warmup = false;
@@ -519,7 +519,7 @@ mod tests {
             mut genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config(10_000);
+        } = create_genesis_config(10_000 * bootstrap_validator_lamports());
         genesis_config.epoch_schedule.warmup = false;
 
         let bank = Bank::new(&genesis_config);
@@ -533,7 +533,7 @@ mod tests {
             &mint_keypair,
             &vote_account,
             &validator_identity,
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports(),
         );
         let node_pubkey = validator_identity.pubkey();
 

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -260,13 +260,14 @@ mod tests {
     use crate::{
         blockstore::make_slot_entries,
         genesis_utils::{
-            bootstrap_validator_lamports, create_genesis_config, create_genesis_config_with_leader,
-            GenesisConfigInfo,
+            bootstrap_validator_stake_lamports, create_genesis_config,
+            create_genesis_config_with_leader, GenesisConfigInfo,
         },
         get_tmp_ledger_path,
         staking_utils::tests::setup_vote_and_stake_accounts,
     };
     use solana_runtime::bank::Bank;
+    use solana_runtime::genesis_utils::BOOTSTRAP_VALIDATOR_LAMPORTS;
     use solana_sdk::clock::NUM_CONSECUTIVE_LEADER_SLOTS;
     use solana_sdk::epoch_schedule::{
         EpochSchedule, DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET, DEFAULT_SLOTS_PER_EPOCH,
@@ -380,9 +381,9 @@ mod tests {
     fn test_next_leader_slot() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let mut genesis_config = create_genesis_config_with_leader(
-            bootstrap_validator_lamports(),
+            BOOTSTRAP_VALIDATOR_LAMPORTS,
             &pubkey,
-            bootstrap_validator_lamports(),
+            bootstrap_validator_stake_lamports(),
         )
         .genesis_config;
         genesis_config.epoch_schedule = EpochSchedule::custom(
@@ -433,9 +434,9 @@ mod tests {
     fn test_next_leader_slot_blockstore() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let mut genesis_config = create_genesis_config_with_leader(
-            bootstrap_validator_lamports(),
+            BOOTSTRAP_VALIDATOR_LAMPORTS,
             &pubkey,
-            bootstrap_validator_lamports(),
+            bootstrap_validator_stake_lamports(),
         )
         .genesis_config;
         genesis_config.epoch_schedule.warmup = false;
@@ -519,7 +520,7 @@ mod tests {
             mut genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config(10_000 * bootstrap_validator_lamports());
+        } = create_genesis_config(10_000 * bootstrap_validator_stake_lamports());
         genesis_config.epoch_schedule.warmup = false;
 
         let bank = Bank::new(&genesis_config);
@@ -533,7 +534,7 @@ mod tests {
             &mint_keypair,
             &vote_account,
             &validator_identity,
-            bootstrap_validator_lamports(),
+            bootstrap_validator_stake_lamports(),
         );
         let node_pubkey = validator_identity.pubkey();
 

--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -55,14 +55,14 @@ fn sort_stakes(stakes: &mut Vec<(Pubkey, u64)>) {
 mod tests {
     use super::*;
     use solana_runtime::genesis_utils::{
-        create_genesis_config_with_leader, BOOTSTRAP_VALIDATOR_LAMPORTS,
+        bootstrap_validator_lamports, create_genesis_config_with_leader,
     };
 
     #[test]
     fn test_leader_schedule_via_bank() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let genesis_config =
-            create_genesis_config_with_leader(0, &pubkey, BOOTSTRAP_VALIDATOR_LAMPORTS)
+            create_genesis_config_with_leader(0, &pubkey, bootstrap_validator_lamports())
                 .genesis_config;
         let bank = Bank::new(&genesis_config);
 
@@ -84,9 +84,9 @@ mod tests {
     fn test_leader_scheduler1_basic() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let genesis_config = create_genesis_config_with_leader(
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports(),
             &pubkey,
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
+            bootstrap_validator_lamports(),
         )
         .genesis_config;
         let bank = Bank::new(&genesis_config);

--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -55,14 +55,15 @@ fn sort_stakes(stakes: &mut Vec<(Pubkey, u64)>) {
 mod tests {
     use super::*;
     use solana_runtime::genesis_utils::{
-        bootstrap_validator_lamports, create_genesis_config_with_leader,
+        bootstrap_validator_stake_lamports, create_genesis_config_with_leader,
+        BOOTSTRAP_VALIDATOR_LAMPORTS,
     };
 
     #[test]
     fn test_leader_schedule_via_bank() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let genesis_config =
-            create_genesis_config_with_leader(0, &pubkey, bootstrap_validator_lamports())
+            create_genesis_config_with_leader(0, &pubkey, bootstrap_validator_stake_lamports())
                 .genesis_config;
         let bank = Bank::new(&genesis_config);
 
@@ -84,9 +85,9 @@ mod tests {
     fn test_leader_scheduler1_basic() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let genesis_config = create_genesis_config_with_leader(
-            bootstrap_validator_lamports(),
+            BOOTSTRAP_VALIDATOR_LAMPORTS + bootstrap_validator_stake_lamports(),
             &pubkey,
-            bootstrap_validator_lamports(),
+            bootstrap_validator_stake_lamports(),
         )
         .genesis_config;
         let bank = Bank::new(&genesis_config);

--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -85,7 +85,7 @@ mod tests {
     fn test_leader_scheduler1_basic() {
         let pubkey = solana_sdk::pubkey::new_rand();
         let genesis_config = create_genesis_config_with_leader(
-            BOOTSTRAP_VALIDATOR_LAMPORTS + bootstrap_validator_stake_lamports(),
+            BOOTSTRAP_VALIDATOR_LAMPORTS,
             &pubkey,
             bootstrap_validator_stake_lamports(),
         )

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -101,7 +101,7 @@ where
 pub(crate) mod tests {
     use super::*;
     use crate::genesis_utils::{
-        create_genesis_config, GenesisConfigInfo, BOOTSTRAP_VALIDATOR_LAMPORTS,
+        bootstrap_validator_lamports, create_genesis_config, GenesisConfigInfo,
     };
     use solana_sdk::{
         account::from_account,
@@ -178,10 +178,10 @@ pub(crate) mod tests {
     #[test]
     fn test_epoch_stakes_and_lockouts() {
         solana_logger::setup();
-        let stake = BOOTSTRAP_VALIDATOR_LAMPORTS * 100;
+        let stake = bootstrap_validator_lamports();
         let leader_stake = Stake {
             delegation: Delegation {
-                stake: BOOTSTRAP_VALIDATOR_LAMPORTS,
+                stake: bootstrap_validator_lamports(),
                 activation_epoch: std::u64::MAX, // mark as bootstrap
                 ..Delegation::default()
             },
@@ -194,7 +194,7 @@ pub(crate) mod tests {
             genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config(10_000);
+        } = create_genesis_config(10_000 * bootstrap_validator_lamports());
 
         let bank = Bank::new(&genesis_config);
         let vote_account = Keypair::new();

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -101,7 +101,7 @@ where
 pub(crate) mod tests {
     use super::*;
     use crate::genesis_utils::{
-        bootstrap_validator_lamports, create_genesis_config, GenesisConfigInfo,
+        bootstrap_validator_stake_lamports, create_genesis_config, GenesisConfigInfo,
     };
     use solana_sdk::{
         account::from_account,
@@ -178,10 +178,10 @@ pub(crate) mod tests {
     #[test]
     fn test_epoch_stakes_and_lockouts() {
         solana_logger::setup();
-        let stake = bootstrap_validator_lamports();
+        let stake = bootstrap_validator_stake_lamports();
         let leader_stake = Stake {
             delegation: Delegation {
-                stake: bootstrap_validator_lamports(),
+                stake: bootstrap_validator_stake_lamports(),
                 activation_epoch: std::u64::MAX, // mark as bootstrap
                 ..Delegation::default()
             },
@@ -194,7 +194,7 @@ pub(crate) mod tests {
             genesis_config,
             mint_keypair,
             ..
-        } = create_genesis_config(10_000 * bootstrap_validator_lamports());
+        } = create_genesis_config(10_000 * bootstrap_validator_stake_lamports());
 
         let bank = Bank::new(&genesis_config);
         let vote_account = Keypair::new();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4297,8 +4297,9 @@ pub(crate) mod tests {
     use crate::{
         accounts_index::{AccountMap, Ancestors, ITER_BATCH_SIZE},
         genesis_utils::{
-            activate_all_features, bootstrap_validator_lamports, create_genesis_config_with_leader,
-            create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
+            activate_all_features, bootstrap_validator_stake_lamports,
+            create_genesis_config_with_leader, create_genesis_config_with_vote_accounts,
+            GenesisConfigInfo, ValidatorVoteKeypairs,
         },
         native_loader::NativeLoaderError,
         status_cache::MAX_CACHE_ENTRIES,
@@ -4366,7 +4367,7 @@ pub(crate) mod tests {
     #[allow(clippy::float_cmp)]
     fn test_bank_new() {
         let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
-        let dummy_leader_lamports = bootstrap_validator_lamports();
+        let dummy_leader_stake_lamports = bootstrap_validator_stake_lamports();
         let mint_lamports = 10_000;
         let GenesisConfigInfo {
             mut genesis_config,
@@ -4376,7 +4377,7 @@ pub(crate) mod tests {
         } = create_genesis_config_with_leader(
             mint_lamports,
             &dummy_leader_pubkey,
-            dummy_leader_lamports,
+            dummy_leader_stake_lamports,
         );
 
         genesis_config.rent = Rent {
@@ -4389,7 +4390,7 @@ pub(crate) mod tests {
         assert_eq!(bank.get_balance(&mint_keypair.pubkey()), mint_lamports);
         assert_eq!(
             bank.get_balance(&voting_keypair.pubkey()),
-            dummy_leader_lamports /* 1 token goes to the vote account associated with dummy_leader_lamports */
+            dummy_leader_stake_lamports /* 1 token goes to the vote account associated with dummy_leader_lamports */
         );
 
         let rent_account = bank.get_account(&sysvar::rent::id()).unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4297,9 +4297,8 @@ pub(crate) mod tests {
     use crate::{
         accounts_index::{AccountMap, Ancestors, ITER_BATCH_SIZE},
         genesis_utils::{
-            activate_all_features, create_genesis_config_with_leader,
+            activate_all_features, bootstrap_validator_lamports, create_genesis_config_with_leader,
             create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
         },
         native_loader::NativeLoaderError,
         status_cache::MAX_CACHE_ENTRIES,
@@ -4367,7 +4366,7 @@ pub(crate) mod tests {
     #[allow(clippy::float_cmp)]
     fn test_bank_new() {
         let dummy_leader_pubkey = solana_sdk::pubkey::new_rand();
-        let dummy_leader_lamports = BOOTSTRAP_VALIDATOR_LAMPORTS;
+        let dummy_leader_lamports = bootstrap_validator_lamports();
         let mint_lamports = 10_000;
         let GenesisConfigInfo {
             mut genesis_config,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -121,13 +121,6 @@ pub fn create_genesis_config_with_leader(
     bootstrap_validator_pubkey: &Pubkey,
     bootstrap_validator_stake_lamports: u64,
 ) -> GenesisConfigInfo {
-    // boostrap_validator_stake_lamports is used both for stake and vote accounts
-    if mint_lamports < BOOTSTRAP_VALIDATOR_LAMPORTS + bootstrap_validator_stake_lamports * 2 {
-        warn!(
-            "mint {} is too small {}",
-            mint_lamports, bootstrap_validator_stake_lamports
-        );
-    }
     create_genesis_config_with_leader_ex(
         mint_lamports,
         bootstrap_validator_pubkey,

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -1,4 +1,3 @@
-use log::*;
 use solana_sdk::{
     account::Account,
     feature::{self, Feature},


### PR DESCRIPTION
#### Problem

Existing tests are creating bad stake accounts which are less than `rent_exempt_reserve`, notably only `42` lamports... #13461 will forbid such accounts. So, fix tests first.

#### Summary of Changes

Not ideal, but just hacky mindless replacement: `BOOTSTRAP_VALIDATOR_LAMPORTS` => `bootstrap_validator_lamports()`

Fixes #
