### PR TITLE
Add new inflation feature-ids

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4142,10 +4142,13 @@ impl Bank {
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 
-        if new_feature_activations.contains(&feature_set::inflation_kill_switch::id()) {
-            *self.inflation.write().unwrap() = Inflation::new_disabled();
-            self.fee_rate_governor.burn_percent = 100; // 100% fee burn
-            self.rent_collector.rent.burn_percent = 100; // 100% rent burn
+        if new_feature_activations.contains(&feature_set::full_inflation::id()) {
+            let mut full_inflation = Inflation::default();
+            full_inflation.foundation = 0.0;
+            full_inflation.foundation_term = 0.0;
+            *self.inflation.write().unwrap() = full_inflation;
+            self.fee_rate_governor.burn_percent = 50; // 50% fee burn
+            self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 
         if new_feature_activations.contains(&feature_set::spl_token_v2_multisig_fix::id()) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4159,10 +4159,7 @@ impl Bank {
         }
 
         if new_feature_activations.contains(&feature_set::full_inflation::id()) {
-            let mut full_inflation = Inflation::default();
-            full_inflation.foundation = 0.0;
-            full_inflation.foundation_term = 0.0;
-            *self.inflation.write().unwrap() = full_inflation;
+            *self.inflation.write().unwrap() = Inflation::full();
             self.fee_rate_governor.burn_percent = 50; // 50% fee burn
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -19,11 +19,11 @@ pub mod consistent_recent_blockhashes_sysvar {
 }
 
 pub mod pico_inflation {
-    solana_sdk::declare_id!("GaBtBJvmS4Arjj5W1NmFcyvPjsHN38UGYDq2MDwbs9Qu");
+    solana_sdk::declare_id!("4RWNif6C2WCNiKVW7otP4G7dkmkHGyKQWRpuZ1pxKU5m");
 }
 
-pub mod inflation_kill_switch {
-    solana_sdk::declare_id!("SECCKV5UVUsr8sTVSVAzULjdm87r7mLPaqH2FGZjevR");
+pub mod full_inflation {
+    solana_sdk::declare_id!("DT4n6ABDqs6w4bnfwrXT9rsprcPf6cdDga1egctaPkLC");
 }
 
 pub mod spl_token_v2_multisig_fix {
@@ -97,7 +97,7 @@ lazy_static! {
         (secp256k1_program_enabled::id(), "secp256k1 program"),
         (consistent_recent_blockhashes_sysvar::id(), "consistent recentblockhashes sysvar"),
         (pico_inflation::id(), "pico-inflation"),
-        (inflation_kill_switch::id(), "inflation kill switch"),
+        (full_inflation::id(), "full-inflation"),
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),
         (bpf_loader2_program::id(), "bpf_loader2 program"),
         (bpf_compute_budget_balancing::id(), "compute budget balancing"),

--- a/sdk/src/inflation.rs
+++ b/sdk/src/inflation.rs
@@ -69,6 +69,17 @@ impl Inflation {
         Self::new_fixed(0.0001) // 0.01% inflation
     }
 
+    pub fn full() -> Self {
+        Self {
+            initial: DEFAULT_INITIAL,
+            terminal: DEFAULT_TERMINAL,
+            taper: DEFAULT_TAPER,
+            foundation: 0.0,
+            foundation_term: 0.0,
+            __unused: 0.0,
+        }
+    }
+
     /// inflation rate at year
     pub fn total(&self, year: f64) -> f64 {
         assert!(year >= 0.0);


### PR DESCRIPTION
#### Problem
We need plumbing for pico- and full-inflation features in order to enable on testnet and mainnet-beta

#### Summary of Changes
- Add new pico_inflation feature-id (generated by [feature-proposal cli](https://github.com/solana-labs/solana-program-library/tree/master/feature-proposal/cli))
- Add full_inflation feature-id (generated by feature-proposal cli)
- Remove inflation_kill_switch feature
- Add inflation-start calculation so that Inflation values are correct on activation
- Add full_inflation values

cc @mvines 