### PR TITLE
Expand CPI returning error test

### DIFF
--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -133,15 +133,25 @@ fn process_instruction(
 
             info!("Test return error");
             {
+                assert_eq!(
+                    10,
+                    **accounts[INVOKED_ARGUMENT_INDEX].try_borrow_lamports()?
+                );
+                assert_eq!(0, accounts[INVOKED_ARGUMENT_INDEX].try_borrow_data()?[0]);
                 let instruction = create_instruction(
                     *accounts[INVOKED_PROGRAM_INDEX].key,
-                    &[(accounts[ARGUMENT_INDEX].key, true, true)],
+                    &[(accounts[INVOKED_ARGUMENT_INDEX].key, false, true)],
                     vec![TEST_RETURN_ERROR],
                 );
                 assert_eq!(
                     invoke(&instruction, accounts),
                     Err(ProgramError::Custom(42))
                 );
+                assert_eq!(
+                    10,
+                    **accounts[INVOKED_ARGUMENT_INDEX].try_borrow_lamports()?
+                );
+                assert_eq!(0, accounts[INVOKED_ARGUMENT_INDEX].try_borrow_data()?[0]);
             }
 
             info!("Test refcell usage");

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -107,6 +107,14 @@ fn process_instruction(
         }
         TEST_RETURN_ERROR => {
             info!("return error");
+            const ARGUMENT_INDEX: usize = 0;
+
+            // modify lamports that should be dropped
+            assert_eq!(10, **accounts[ARGUMENT_INDEX].try_borrow_lamports()?);
+            **accounts[ARGUMENT_INDEX].try_borrow_mut_lamports()? += 1;
+            // modify data that should be dropped
+            assert_eq!(0, accounts[ARGUMENT_INDEX].try_borrow_mut_data()?[0]);
+            accounts[ARGUMENT_INDEX].try_borrow_mut_data()?[0] = 1;
             return Err(ProgramError::Custom(42));
         }
         TEST_DERIVED_SIGNERS => {


### PR DESCRIPTION
#### Problem

State of account not enforced by test when a CPI returns an error

#### Summary of Changes

Expand the test coverage to enforce that all modifications to the account are dropped if the CPI returns an error

Fixes #
