### PR TITLE
Check for DO_NOT_PUBLISH_TAR before uploading to CI

### DIFF
--- a/ci/publish-bpf-sdk.sh
+++ b/ci/publish-bpf-sdk.sh
@@ -16,21 +16,12 @@ fi
   [[ -f bpf-sdk.tar.bz2 ]]
 )
 
+source ci/upload-ci-artifact.sh
 echo --- AWS S3 Store
 if [[ -z $CHANNEL_OR_TAG ]]; then
   echo Skipped
 else
-  (
-    set -x
-    docker run \
-      --rm \
-      --env AWS_ACCESS_KEY_ID \
-      --env AWS_SECRET_ACCESS_KEY \
-      --volume "$PWD:/solana" \
-      eremite/aws-cli:2018.12.18 \
-      /usr/bin/s3cmd --acl-public put /solana/bpf-sdk.tar.bz2 \
-      s3://solana-sdk/"$CHANNEL_OR_TAG"/bpf-sdk.tar.bz2
-  )
+  upload-s3-artifact "/solana/bpf-sdk.tar.bz2" "s3://solana-sdk/$CHANNEL_OR_TAG/bpf-sdk.tar.bz2"
 fi
 
 exit 0

--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -113,19 +113,10 @@ for file in "${TARBALL_BASENAME}"-$TARGET.tar.bz2 "${TARBALL_BASENAME}"-$TARGET.
 
   if [[ -n $BUILDKITE ]]; then
     echo --- AWS S3 Store: "$file"
-    (
-      set -x
-      $DRYRUN docker run \
-        --rm \
-        --env AWS_ACCESS_KEY_ID \
-        --env AWS_SECRET_ACCESS_KEY \
-        --volume "$PWD:/solana" \
-        eremite/aws-cli:2018.12.18 \
-        /usr/bin/s3cmd --acl-public put /solana/"$file" s3://release.solana.com/"$CHANNEL_OR_TAG"/"$file"
+    upload-s3-artifact "/solana/$file" s3://release.solana.com/"$CHANNEL_OR_TAG"/"$file"
 
-      echo Published to:
-      $DRYRUN ci/format-url.sh https://release.solana.com/"$CHANNEL_OR_TAG"/"$file"
-    )
+    echo Published to:
+    $DRYRUN ci/format-url.sh https://release.solana.com/"$CHANNEL_OR_TAG"/"$file"
 
     if [[ -n $TAG ]]; then
       ci/upload-github-release-asset.sh "$file"
@@ -149,7 +140,9 @@ done
 
 
 # Create install wrapper for release.solana.com
-if [[ -n $BUILDKITE ]]; then
+if [[ -n $DO_NOT_PUBLISH_TAR ]]; then
+  echo "Skipping publishing install wrapper"
+elif [[ -n $BUILDKITE ]]; then
   cat > release.solana.com-install <<EOF
 SOLANA_RELEASE=$CHANNEL_OR_TAG
 SOLANA_INSTALL_INIT_ARGS=$CHANNEL_OR_TAG
@@ -158,19 +151,9 @@ EOF
   cat install/solana-install-init.sh >> release.solana.com-install
 
   echo --- AWS S3 Store: "install"
-  (
-    set -x
-    $DRYRUN docker run \
-      --rm \
-      --env AWS_ACCESS_KEY_ID \
-      --env AWS_SECRET_ACCESS_KEY \
-      --volume "$PWD:/solana" \
-      eremite/aws-cli:2018.12.18 \
-      /usr/bin/s3cmd --acl-public put /solana/release.solana.com-install s3://release.solana.com/"$CHANNEL_OR_TAG"/install
-
-    echo Published to:
-    $DRYRUN ci/format-url.sh https://release.solana.com/"$CHANNEL_OR_TAG"/install
-  )
+  $DRYRUN upload-s3-artifact "/solana/release.solana.com-install" "s3://release.solana.com/$CHANNEL_OR_TAG/install"
+  echo Published to:
+  $DRYRUN ci/format-url.sh https://release.solana.com/"$CHANNEL_OR_TAG"/install
 fi
 
 echo --- ok

--- a/ci/upload-ci-artifact.sh
+++ b/ci/upload-ci-artifact.sh
@@ -16,3 +16,16 @@ upload-ci-artifact() {
   fi
 }
 
+upload-s3-artifact() {
+  echo "--- artifact: $1 to $2"
+  (
+    set -x
+    docker run \
+      --rm \
+      --env AWS_ACCESS_KEY_ID \
+      --env AWS_SECRET_ACCESS_KEY \
+      --volume "$PWD:/solana" \
+      eremite/aws-cli:2018.12.18 \
+      /usr/bin/s3cmd --acl-public put "$1" "$2"
+  )
+}


### PR DESCRIPTION
#### Problem

Build pipelines which are not creating releases don't set the AWS credentials and probably shouldn't upload to aws.

#### Summary of Changes

Skip if DO_NOT_PUBLISH_TAR is set.

Fixes #
