### PR TITLE
Allow GNUSparse for genesis.bin

### DIFF
--- a/runtime/src/hardened_unpack.rs
+++ b/runtime/src/hardened_unpack.rs
@@ -227,6 +227,7 @@ fn unpack_genesis<A: Read, P: AsRef<Path>>(
 fn is_valid_genesis_archive_entry(parts: &[&str], kind: tar::EntryType) -> bool {
     trace!("validating: {:?} {:?}", parts, kind);
     match (parts, kind) {
+        (["genesis.bin"], GNUSparse) => true,
         (["genesis.bin"], Regular) => true,
         (["rocksdb"], Directory) => true,
         (["rocksdb", ..], GNUSparse) => true,


### PR DESCRIPTION
#### Problem

it seems that some system creates a sparse file for `genesis.bin`....

#### Summary of Changes

Allow it.

Fixes #
