### PR TITLE
Use info for failed to match slot vote error

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -315,7 +315,7 @@ impl VoteState {
             return Err(VoteError::VoteTooOld);
         }
         if i != vote.slots.len() {
-            warn!(
+            info!(
                 "{} dropped vote {:?} failed to match slot:  {:?}",
                 self.node_pubkey, vote, slot_hashes,
             );


### PR DESCRIPTION
#### Problem

Fairly common but normal error of processing a vote which is a slot ahead of where the current validator is at is at `warn` level.

#### Summary of Changes

Lower level to `info`.

Fixes #
