### PR TITLE
Add ability to setup additional accounts in local cluster

### DIFF
--- a/bench-exchange/tests/bench_exchange.rs
+++ b/bench-exchange/tests/bench_exchange.rs
@@ -39,7 +39,7 @@ fn test_exchange_local_cluster() {
     } = config;
     let accounts_in_groups = batch_size * account_groups;
 
-    let cluster = LocalCluster::new(&ClusterConfig {
+    let cluster = LocalCluster::new(&mut ClusterConfig {
         node_stakes: vec![100_000; NUM_NODES],
         cluster_lamports: 100_000_000_000_000,
         validator_configs: vec![ValidatorConfig::default(); NUM_NODES],

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -15,7 +15,7 @@ fn test_bench_tps_local_cluster(config: Config) {
 
     solana_logger::setup();
     const NUM_NODES: usize = 1;
-    let cluster = LocalCluster::new(&ClusterConfig {
+    let cluster = LocalCluster::new(&mut ClusterConfig {
         node_stakes: vec![999_990; NUM_NODES],
         cluster_lamports: 200_000_000,
         validator_configs: vec![ValidatorConfig::default(); NUM_NODES],

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -379,7 +379,7 @@ mod test {
         let mut accounts_info = AccountsInfo::default();
 
         let one_sol = sol_to_lamports(1.0);
-        let cluster = LocalCluster::new(&ClusterConfig {
+        let cluster = LocalCluster::new(&mut ClusterConfig {
             cluster_type: ClusterType::MainnetBeta,
             node_stakes: vec![10; 1],
             cluster_lamports: sol_to_lamports(1_000_000_000.0),


### PR DESCRIPTION
#### Problem
Tests may need to set up additional accounts outside of validator accounts for testing

#### Summary of Changes
Add those accounts at startup in genesis

Fixes #
