### PR TITLE
explorer: hotfix: customUrl effect is preventing redirects, add check

### DIFF
--- a/explorer/src/providers/cluster.tsx
+++ b/explorer/src/providers/cluster.tsx
@@ -143,7 +143,7 @@ export function ClusterProvider({ children }: ClusterProviderProps) {
 
   // Remove customUrl param if dev setting is disabled
   React.useEffect(() => {
-    if (!enableCustomUrl) {
+    if (!enableCustomUrl && query.has("customUrl")) {
       query.delete("customUrl");
       history.push({ ...location, search: query.toString() });
     }


### PR DESCRIPTION
#### Problem
Developer customUrl flag is preventing redirects in certain situations.

#### Summary of Changes
Check if customUrl field is set before pushing to the history stack (preventing redirect). This *should* resolve situations where incoming links use deprecated URL patterns (e.g. /accounts/:address) 
