### PR TITLE
Fix escaping in wait-for-stake

### DIFF
--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -70,7 +70,8 @@ function wait_for_bootstrap_validator_stake_drop {
   loadConfigFile
 
   # shellcheck disable=SC2154
-  ssh "${sshOptions[@]}" "${validatorIpList[0]}" '$HOME/.cargo/bin/solana wait-for-max-stake $max_stake --url http://127.0.0.1:8899'
+  # shellcheck disable=SC2029
+  ssh "${sshOptions[@]}" "${validatorIpList[0]}" "\$HOME/.cargo/bin/solana wait-for-max-stake $max_stake --url http://127.0.0.1:8899"
 }
 
 function get_slot {


### PR DESCRIPTION
#### Problem

$max_stake in wait-for-stake doesn't get expanded in single quotes.

#### Summary of Changes

build up statement with single quotes where required.

Fixes #
