### PR TITLE
ledger-tool cap: output credits_observed

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2120,6 +2120,7 @@ fn main() {
                             activation_epoch: Epoch,
                             deactivation_epoch: Option<Epoch>,
                             point_value: Option<PointValue>,
+                            credits_observed: Option<u64>,
                         }
                         use solana_stake_program::stake_state::InflationPointCalculationEvent;
                         let mut stake_calcuration_details: HashMap<Pubkey, CalculationDetail> =
@@ -2170,6 +2171,11 @@ fn main() {
                                     }
                                     InflationPointCalculationEvent::RentExemptReserve(reserve) => {
                                         detail.rent_exempt_reserve = *reserve;
+                                    }
+                                    InflationPointCalculationEvent::CreditsObserved(
+                                        credits_observed,
+                                    ) => {
+                                        detail.credits_observed = Some(*credits_observed);
                                     }
                                     InflationPointCalculationEvent::Delegation(
                                         delegation,
@@ -2311,6 +2317,7 @@ fn main() {
                                         deactivation_epoch: String,
                                         earned_epochs: String,
                                         earned_credits: String,
+                                        credits_observed: String,
                                         base_rewards: String,
                                         stake_rewards: String,
                                         vote_rewards: String,
@@ -2354,6 +2361,9 @@ fn main() {
                                         ),
                                         earned_epochs: format_or_na(detail.map(|d| d.epochs)),
                                         earned_credits: format_or_na(detail.map(|d| d.credits)),
+                                        credits_observed: format_or_na(
+                                            detail.and_then(|d| d.credits_observed),
+                                        ),
                                         base_rewards: format_or_na(detail.map(|d| d.base_rewards)),
                                         stake_rewards: format_or_na(
                                             detail.map(|d| d.stake_rewards),

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -38,6 +38,7 @@ pub enum InflationPointCalculationEvent {
     RentExemptReserve(u64),
     Delegation(Delegation, Pubkey),
     Commission(u8),
+    CreditsObserved(u64),
 }
 
 fn null_tracer() -> Option<impl FnMut(&InflationPointCalculationEvent)> {
@@ -519,6 +520,11 @@ impl Stake {
         )
         .map(|(stakers_reward, voters_reward, credits_observed)| {
             self.credits_observed = credits_observed;
+            if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer {
+                inflation_point_calc_tracer(&InflationPointCalculationEvent::CreditsObserved(
+                    credits_observed,
+                ));
+            }
             self.delegation.stake += stakers_reward;
             (stakers_reward, voters_reward)
         })


### PR DESCRIPTION
#### Problem

`ledger-tool capitalization` can't output stake's `credits_observed`

#### Summary of Changes

Make debugging easier by enabling to print it.

Fixes #
