### PR TITLE
processes pull-request callers only once per unique caller

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2023,8 +2023,9 @@ impl ClusterInfo {
         feature_set: Option<&FeatureSet>,
     ) -> Packets {
         let mut time = Measure::start("handle_pull_requests");
+        let callers = crds_value::filter_current(requests.iter().map(|r| &r.caller));
         self.time_gossip_write_lock("process_pull_reqs", &self.stats.process_pull_requests)
-            .process_pull_requests(requests.iter().map(|r| r.caller.clone()), timestamp());
+            .process_pull_requests(callers.cloned(), timestamp());
         self.update_data_budget(stakes.len());
         let mut packets = Packets::new_with_recycler(recycler.clone(), 64, "handle_pull_requests");
         let (caller_and_filters, addrs): (Vec<_>, Vec<_>) = {

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -240,8 +240,8 @@ impl Crds {
 
     /// Update the timestamp's of all the labels that are associated with Pubkey
     pub fn update_record_timestamp(&mut self, pubkey: &Pubkey, now: u64) {
-        for label in &CrdsValue::record_labels(pubkey) {
-            self.update_label_timestamp(label, now);
+        for label in CrdsValue::record_labels(*pubkey) {
+            self.update_label_timestamp(&label, now);
         }
     }
 


### PR DESCRIPTION
#### Problem
process_pull_requests acquires a write lock on crds table to update
records timestamp for each pull-request caller:
https://github.com/solana-labs/solana/blob/3087c9049/core/src/crds_gossip_pull.rs#L287-L300
However, pull-requests overlap a lot in callers and this function ends
up doing a lot of redundant duplicate work.

#### Summary of Changes
This commit obtains unique callers before acquiring an exclusive lock on
crds table.
