### PR TITLE
Ignore errors from subshell correctly

### DIFF
--- a/system-test/testnet-automation.sh
+++ b/system-test/testnet-automation.sh
@@ -23,21 +23,18 @@ $(eval echo "$@")"
   fi
 
   (
-    set +e
     execution_step "Collecting Logfiles from Nodes"
     collect_logs
-  )
+  ) || echo "Error from collecting logs"
 
   (
-    set +e
     execution_step "Stop Network Software"
     "${REPO_ROOT}"/net/net.sh stop
-  )
+  ) || echo "Error from stopping nodes"
 
   (
-    set +e
     analyze_packet_loss
-  )
+  ) || echo "Error from packet loss analysis"
 
   execution_step "Deleting Testnet"
   "${REPO_ROOT}"/net/"${CLOUD_PROVIDER}".sh delete -p "${TESTNET_TAG}"


### PR DESCRIPTION
#### Problem

`set +e` will ignore errors in the subshell, but the error will be still propagated out of the subshell and since `set -e` is present above, then on an error in the subshell, the error will cause an abort in the main script which is not desirable since the machines will not be shut down correctly.

#### Summary of Changes

Ignore subshell errors with `||` instead.

Fixes #
