### PR TITLE
Enable log to see stake progress

### DIFF
--- a/system-test/automation_utils.sh
+++ b/system-test/automation_utils.sh
@@ -71,7 +71,7 @@ function wait_for_bootstrap_validator_stake_drop {
 
   # shellcheck disable=SC2154
   # shellcheck disable=SC2029
-  ssh "${sshOptions[@]}" "${validatorIpList[0]}" "\$HOME/.cargo/bin/solana wait-for-max-stake $max_stake --url http://127.0.0.1:8899"
+  ssh "${sshOptions[@]}" "${validatorIpList[0]}" "RUST_LOG=info \$HOME/.cargo/bin/solana wait-for-max-stake $max_stake --url http://127.0.0.1:8899"
 }
 
 function get_slot {


### PR DESCRIPTION
#### Problem

No log about progress with staking with wait-for-stake.

#### Summary of Changes

Enable `info` logs for staking progress.

Fixes #
