### PR TITLE
Fix Primordial stake check

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -1005,6 +1005,7 @@ if [[ -n "$maybeWaitForSupermajority" && -n "$maybeWarpSlot" ]]; then
   fi
 fi
 
+echo "net.sh: Primordial stakes: $extraPrimordialStakes"
 if [[ $extraPrimordialStakes -gt 0 ]]; then
   # Extra primoridial stakes require that all of the validators start at
   # the same time. Force async init and wait for supermajority here.

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -225,6 +225,7 @@ EOF
       if [[ -f net/keypairs/bootstrap-validator-identity.json ]]; then
         export BOOTSTRAP_VALIDATOR_IDENTITY_KEYPAIR=net/keypairs/bootstrap-validator-identity.json
       fi
+      echo "remote-node.sh: Primordial stakes: $extraPrimordialStakes"
       if [[ "$extraPrimordialStakes" -gt 0 ]]; then
         if [[ "$extraPrimordialStakes" -gt "$numNodes" ]]; then
           echo "warning: extraPrimordialStakes($extraPrimordialStakes) clamped to numNodes($numNodes)"
@@ -419,8 +420,11 @@ EOF
         args+=(--keypair config/validator-identity.json)
       fi
 
-      if [[ ${#extraPrimordialStakes} -eq 0 ]]; then
+      if [[ ${extraPrimordialStakes} -eq 0 ]]; then
+        echo "0 Primordial stakes, staking with $internalNodesStakeLamports"
         multinode-demo/delegate-stake.sh "${args[@]}" "$internalNodesStakeLamports"
+      else
+        echo "Skipping staking with extra stakes: ${extraPrimordialStakes}"
       fi
     fi
     ;;


### PR DESCRIPTION
#### Problem

`extraPrimordialStakes` is set as a scalar of number of extra staked nodes, but it checks for the array size of the variable to tell if the validators should not be staked `${#extraPrimordialStakes}`.

#### Summary of Changes

Change that to checking if the scalar equals 0.

Fixes #
