### PR TITLE
Fail stake Initialize if account data is the wrong size

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -805,6 +805,9 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
         lockup: &Lockup,
         rent: &Rent,
     ) -> Result<(), InstructionError> {
+        if self.data_len()? != std::mem::size_of::<StakeState>() {
+            return Err(InstructionError::InvalidAccountData);
+        }
         if let StakeState::Uninitialized = self.state()? {
             let rent_exempt_reserve = rent.minimum_balance(self.data_len()?);
 
@@ -2163,6 +2166,43 @@ mod tests {
                 &Authorized::default(),
                 &Lockup::default(),
                 &Rent::free()
+            ),
+            Err(InstructionError::InvalidAccountData)
+        );
+    }
+
+    #[test]
+    fn test_initialize_incorrect_account_sizes() {
+        let stake_pubkey = solana_sdk::pubkey::new_rand();
+        let stake_lamports = 42;
+        let stake_account =
+            Account::new_ref(stake_lamports, std::mem::size_of::<StakeState>() + 1, &id());
+        let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
+
+        assert_eq!(
+            stake_keyed_account.initialize(
+                &Authorized::default(),
+                &Lockup::default(),
+                &Rent {
+                    lamports_per_byte_year: 42,
+                    ..Rent::free()
+                },
+            ),
+            Err(InstructionError::InvalidAccountData)
+        );
+
+        let stake_account =
+            Account::new_ref(stake_lamports, std::mem::size_of::<StakeState>() - 1, &id());
+        let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
+
+        assert_eq!(
+            stake_keyed_account.initialize(
+                &Authorized::default(),
+                &Lockup::default(),
+                &Rent {
+                    lamports_per_byte_year: 42,
+                    ..Rent::free()
+                },
             ),
             Err(InstructionError::InvalidAccountData)
         );


### PR DESCRIPTION
#### Problem
The ability to create stake accounts that are larger than needed for StakeState is problematic due to the `rent_exempt_reserve`. For instance, if a user splits active stake into a much larger account, it presents the opportunity to magically deactivate stake up to the new rent_exempt_reserve without waiting the otherwise required cooldown period.

#### Summary of Changes
- Check account data on Initialize and fail the transaction if the size is incorrect. Technically, too-small accounts are already handled by the `StateMut::state()` method, but `!=` seemed more self-documenting than `>`
