### PR TITLE
Truncate logs immediately upon collection.  Also reduce limit from 100k to 10k

### DIFF
--- a/runtime/src/log_collector.rs
+++ b/runtime/src/log_collector.rs
@@ -1,18 +1,58 @@
 use std::cell::RefCell;
 
+const LOG_MESSAGES_BYTES_LIMIT: usize = 10 * 1000;
+
+#[derive(Default)]
+struct LogCollectorInner {
+    messages: Vec<String>,
+    bytes_written: usize,
+    limit_warning: bool,
+}
+
 #[derive(Default)]
 pub struct LogCollector {
-    messages: RefCell<Vec<String>>,
+    inner: RefCell<LogCollectorInner>,
 }
 
 impl LogCollector {
     pub fn log(&self, message: &str) {
-        self.messages.borrow_mut().push(message.to_string())
+        let mut inner = self.inner.borrow_mut();
+
+        if inner.bytes_written + message.len() >= LOG_MESSAGES_BYTES_LIMIT {
+            if !inner.limit_warning {
+                inner.limit_warning = true;
+                inner.messages.push(String::from("Log truncated"));
+            }
+        } else {
+            inner.bytes_written += message.len();
+            inner.messages.push(message.to_string());
+        }
     }
 }
 
 impl Into<Vec<String>> for LogCollector {
     fn into(self) -> Vec<String> {
-        self.messages.into_inner()
+        self.inner.into_inner().messages
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_messages_bytes_limit() {
+        let lc = LogCollector::default();
+
+        for _i in 0..LOG_MESSAGES_BYTES_LIMIT * 2 {
+            lc.log("x");
+        }
+
+        let logs: Vec<_> = lc.into();
+        assert_eq!(logs.len(), LOG_MESSAGES_BYTES_LIMIT);
+        for log in logs.iter().take(LOG_MESSAGES_BYTES_LIMIT - 1) {
+            assert_eq!(*log, "x".to_string());
+        }
+        assert_eq!(logs.last(), Some(&"Log truncated".to_string()));
     }
 }


### PR DESCRIPTION
Log truncation was happening after transaction execution, meaning that a program could generate megabytes of logging before it was later truncated.  Better to not let the program generate that amount of logging to begin with.

Also reduced the log limit from 100k per transaction to 10k per instruction to discourage programs from being spammy