### PR TITLE
rpc_subscriptions: Clean up default commitment handling for subscriptions

### DIFF
--- a/client/src/pubsub_client.rs
+++ b/client/src/pubsub_client.rs
@@ -1,4 +1,7 @@
-use crate::rpc_response::{Response as RpcResponse, RpcSignatureResult, SlotInfo};
+use crate::{
+    rpc_config::RpcSignatureSubscribeConfig,
+    rpc_response::{Response as RpcResponse, RpcSignatureResult, SlotInfo},
+};
 use log::*;
 use serde::de::DeserializeOwned;
 use serde_json::{
@@ -205,6 +208,7 @@ impl PubsubClient {
     pub fn signature_subscribe(
         url: &str,
         signature: &Signature,
+        config: Option<RpcSignatureSubscribeConfig>,
     ) -> Result<
         (
             PubsubSignatureResponse,
@@ -226,7 +230,7 @@ impl PubsubClient {
             "method":format!("{}Subscribe", SIGNATURE_OPERATION),
             "params":[
                 signature.to_string(),
-                {"enableReceivedNotification": true }
+                config
             ]
         })
         .to_string();

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -442,7 +442,15 @@ mod tests {
 
         let session = create_session();
         let (subscriber, _id_receiver, receiver) = Subscriber::new_test("signatureNotification");
-        rpc.signature_subscribe(session, subscriber, tx.signatures[0].to_string(), None);
+        rpc.signature_subscribe(
+            session,
+            subscriber,
+            tx.signatures[0].to_string(),
+            Some(RpcSignatureSubscribeConfig {
+                commitment: Some(CommitmentConfig::single()),
+                ..RpcSignatureSubscribeConfig::default()
+            }),
+        );
 
         process_transaction_and_notify(&bank_forks, &tx, &rpc.subscriptions, 0).unwrap();
 
@@ -472,7 +480,7 @@ mod tests {
             subscriber,
             tx.signatures[0].to_string(),
             Some(RpcSignatureSubscribeConfig {
-                commitment: None,
+                commitment: Some(CommitmentConfig::single()),
                 enable_received_notification: Some(true),
             }),
         );

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -2843,7 +2843,7 @@ After connecting to the RPC PubSub websocket at `ws://<ADDRESS>/`:
 
 - Submit subscription requests to the websocket using the methods below
 - Multiple subscriptions may be active at once
-- Many subscriptions take the optional [`commitment` parameter](jsonrpc-api.md#configuring-state-commitment), defining how finalized a change should be to trigger a notification. For subscriptions, if commitment is unspecified, the default value is `"single"`.
+- Many subscriptions take the optional [`commitment` parameter](jsonrpc-api.md#configuring-state-commitment), defining how finalized a change should be to trigger a notification. For subscriptions, if commitment is unspecified, the default value is `"singleGossip"`.
 
 ### accountSubscribe
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -6,7 +6,7 @@ use serial_test_derive::serial;
 use solana_client::{
     pubsub_client::PubsubClient,
     rpc_client::RpcClient,
-    rpc_config::RpcProgramAccountsConfig,
+    rpc_config::{RpcProgramAccountsConfig, RpcSignatureSubscribeConfig},
     rpc_response::RpcSignatureResult,
     thin_client::{create_client, ThinClient},
 };
@@ -179,6 +179,10 @@ fn test_local_cluster_signature_subscribe() {
     let (mut sig_subscribe_client, receiver) = PubsubClient::signature_subscribe(
         &format!("ws://{}", &non_bootstrap_info.rpc_pubsub.to_string()),
         &transaction.signatures[0],
+        Some(RpcSignatureSubscribeConfig {
+            commitment: Some(CommitmentConfig::recent()),
+            enable_received_notification: Some(true),
+        }),
     )
     .unwrap();
 


### PR DESCRIPTION
Problems:
* default commitment handling spread out across multiple functions
* inconsistent default commitment handling.  "recent" used for some, "single" for others.  Documentation claims that "single" was the default for all
* "single" is deprecated.  "singleGossip" is basically equivalent to "single" but with better guarantees.  Change default to "singleGossip", which should not impact non-buggy clients in any negative way.