### PR TITLE
Explorer: show inner instructions on token history

### DIFF
--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -3,7 +3,6 @@ import {
   PublicKey,
   ConfirmedSignatureInfo,
   ParsedInstruction,
-  ParsedInnerInstruction,
   PartiallyDecodedInstruction,
 } from "@solana/web3.js";
 import { CacheEntry, FetchStatus } from "providers/cache";
@@ -408,7 +407,7 @@ const TokenTransactionRow = React.memo(
               </td>
 
               <td>
-                <InstructionType instructionType={instructionType} tx={tx} />
+                <InstructionDetails instructionType={instructionType} tx={tx} />
               </td>
 
               <td className="forced-truncate">
@@ -422,7 +421,7 @@ const TokenTransactionRow = React.memo(
   }
 );
 
-function InstructionType({
+function InstructionDetails({
   instructionType,
   tx,
 }: {
@@ -436,6 +435,7 @@ function InstructionType({
       if ("parsed" in ix && ix.program === "spl-token") {
         return instructionTypeName(ix, tx);
       }
+      return undefined;
     })
     .filter((type) => type !== undefined);
 
@@ -443,19 +443,16 @@ function InstructionType({
     <>
       <p className="tree">
         {instructionTypes.length > 0 && (
-          <a
-            href="#"
+          <span
+
             onClick={(e) => {
               e.preventDefault();
               setExpanded(!expanded);
             }}
-          >
-            <span
-              className={`fe mr-2 ${
-                expanded ? "fe-minus-square" : "fe-plus-square"
-              }`}
-            ></span>
-          </a>
+            className={`c-pointer fe mr-2 ${
+              expanded ? "fe-minus-square" : "fe-plus-square"
+            }`}
+          ></span>
         )}
         {instructionType.name}
       </p>

--- a/explorer/src/components/common/Address.tsx
+++ b/explorer/src/components/common/Address.tsx
@@ -12,9 +12,17 @@ type Props = {
   link?: boolean;
   raw?: boolean;
   truncate?: boolean;
+  truncateUnknown?: boolean;
 };
 
-export function Address({ pubkey, alignRight, link, raw, truncate }: Props) {
+export function Address({
+  pubkey,
+  alignRight,
+  link,
+  raw,
+  truncate,
+  truncateUnknown,
+}: Props) {
   const [state, setState] = useState<CopyState>("copy");
   const address = pubkey.toBase58();
   const { cluster } = useCluster();
@@ -32,6 +40,10 @@ export function Address({ pubkey, alignRight, link, raw, truncate }: Props) {
     ) : (
       <span className="fe fe-check-circle"></span>
     );
+
+  if (truncateUnknown && address === displayAddress(address, cluster)) {
+    truncate = true;
+  }
 
   const content = (
     <>

--- a/explorer/src/components/common/Signature.tsx
+++ b/explorer/src/components/common/Signature.tsx
@@ -8,9 +8,10 @@ type Props = {
   signature: TransactionSignature;
   alignRight?: boolean;
   link?: boolean;
+  truncate?: boolean;
 };
 
-export function Signature({ signature, alignRight, link }: Props) {
+export function Signature({ signature, alignRight, link, truncate }: Props) {
   const [state, setState] = useState<CopyState>("copy");
 
   const copyToClipboard = () => navigator.clipboard.writeText(signature);
@@ -40,7 +41,10 @@ export function Signature({ signature, alignRight, link }: Props) {
       {copyButton}
       <span className="text-monospace">
         {link ? (
-          <Link className="" to={clusterPath(`/tx/${signature}`)}>
+          <Link
+            className={truncate ? "text-truncate address-truncate" : ""}
+            to={clusterPath(`/tx/${signature}`)}
+          >
             {signature}
           </Link>
         ) : (

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -193,6 +193,18 @@ h4.slot-pill {
   height: 24px;
 }
 
+.forced-truncate {
+  .address-truncate {
+    max-width: 180px;
+    display: inline-block;
+    vertical-align: bottom;
+
+    @include media-breakpoint-down(sm) {
+      max-width: 120px;
+    }
+  }
+}
+
 .address-truncate {
   @include media-breakpoint-down(md) {
     max-width: 180px;
@@ -203,6 +215,41 @@ h4.slot-pill {
   @include media-breakpoint-down(sm) {
     max-width: 120px;
   }
+}
+
+p.tree,
+ul.tree,
+ul.tree ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+ul.tree ul {
+  margin-left: 1.0em;
+}
+
+ul.tree li {
+  margin-left: 0.35em;
+  border-left: thin solid #808080;
+}
+
+ul.tree li:last-child {
+  border-left: none;
+}
+
+ul.tree li:before {
+  width: 1.4em;
+  height: 0.6em;
+  margin-right: 0.1em;
+  vertical-align: top;
+  border-bottom: thin solid #808080;
+  content: "";
+  display: inline-block;
+}
+
+ul.tree li:last-child:before {
+  border-left: thin solid #808080;
 }
 
 // work around for https://github.com/JedWatson/react-select/issues/3857

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -225,6 +225,10 @@ ul.tree ul {
   padding: 0;
 }
 
+p.tree span.c-pointer {
+  color: $primary-dark;
+}
+
 ul.tree ul {
   margin-left: 1.0em;
 }


### PR DESCRIPTION
#### Problem
The token history table doesn't show inner token instructions.

#### Proposed Solution
- Render inner token instructions and allow user to toggle if they're show or not.

Fixes https://github.com/solana-labs/solana/issues/11935