### PR TITLE
Restore bank feature used to deprecate Rewards sysvar

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1396,7 +1396,7 @@ impl Bank {
 
         if !self
             .feature_set
-            .is_active(&feature_set::pico_inflation::id())
+            .is_active(&feature_set::deprecate_rewards_sysvar::id())
         {
             // this sysvar can be retired once `pico_inflation` is enabled on all clusters
             self.update_sysvar_account(&sysvar::rewards::id(), |account| {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -18,6 +18,10 @@ pub mod consistent_recent_blockhashes_sysvar {
     solana_sdk::declare_id!("3h1BQWPDS5veRsq6mDBWruEpgPxRJkfwGexg5iiQ9mYg");
 }
 
+pub mod deprecate_rewards_sysvar {
+    solana_sdk::declare_id!("GaBtBJvmS4Arjj5W1NmFcyvPjsHN38UGYDq2MDwbs9Qu");
+}
+
 pub mod pico_inflation {
     solana_sdk::declare_id!("4RWNif6C2WCNiKVW7otP4G7dkmkHGyKQWRpuZ1pxKU5m");
 }
@@ -96,6 +100,7 @@ lazy_static! {
         (instructions_sysvar_enabled::id(), "instructions sysvar"),
         (secp256k1_program_enabled::id(), "secp256k1 program"),
         (consistent_recent_blockhashes_sysvar::id(), "consistent recentblockhashes sysvar"),
+        (deprecate_rewards_sysvar::id(), "deprecate unused rewards sysvar"),
         (pico_inflation::id(), "pico-inflation"),
         (full_inflation::id(), "full-inflation"),
         (spl_token_v2_multisig_fix::id(), "spl-token multisig fix"),


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/13671 repurposed the pico-inflation feature name. However, that feature id was also being used to sneakily deprecate the Rewards sysvar.
Since pico-inflation had once been activated on testnet, when a testnet node was updated to the new code, the Rewards-sysvar deprecation was rolled back, causing the node to fork off.

#### Summary of Changes
Restore the needed feature; describe what it actually does.
