### PR TITLE
caches vote-state de-serialized from vote accounts

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -5,9 +5,11 @@ use crate::{
 use chrono::prelude::*;
 use solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore, blockstore_db};
 use solana_measure::measure::Measure;
-use solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE};
+use solana_runtime::{
+    bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE,
+    vote_account::ArcVoteAccount,
+};
 use solana_sdk::{
-    account::Account,
     clock::{Slot, UnixTimestamp},
     hash::Hash,
     instruction::Instruction,
@@ -214,7 +216,7 @@ impl Tower {
         all_pubkeys: &mut PubkeyReferences,
     ) -> ComputedBankState
     where
-        F: Iterator<Item = (Pubkey, (u64, Account))>,
+        F: IntoIterator<Item = (Pubkey, (u64, ArcVoteAccount))>,
     {
         let mut voted_stakes = HashMap::new();
         let mut total_stake = 0;
@@ -228,20 +230,20 @@ impl Tower {
                 continue;
             }
             trace!("{} {} with stake {}", node_pubkey, key, voted_stake);
-            let vote_state = VoteState::from(&account);
-            if vote_state.is_none() {
-                datapoint_warn!(
-                    "tower_warn",
-                    (
-                        "warn",
-                        format!("Unable to get vote_state from account {}", key),
-                        String
-                    ),
-                );
-                continue;
-            }
-            let mut vote_state = vote_state.unwrap();
-
+            let mut vote_state = match account.vote_state().as_ref() {
+                Err(_) => {
+                    datapoint_warn!(
+                        "tower_warn",
+                        (
+                            "warn",
+                            format!("Unable to get vote_state from account {}", key),
+                            String
+                        ),
+                    );
+                    continue;
+                }
+                Ok(vote_state) => vote_state.clone(),
+            };
             for vote in &vote_state.votes {
                 let key = all_pubkeys.get_or_insert(&key);
                 lockout_intervals
@@ -376,9 +378,9 @@ impl Tower {
     }
 
     fn last_voted_slot_in_bank(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {
-        let vote_account = bank.vote_accounts().get(vote_account_pubkey)?.1.clone();
-        let bank_vote_state = VoteState::deserialize(&vote_account.data).ok()?;
-        bank_vote_state.last_voted_slot()
+        let (_stake, vote_account) = bank.get_vote_account(vote_account_pubkey)?;
+        let slot = vote_account.vote_state().as_ref().ok()?.last_voted_slot();
+        slot
     }
 
     pub fn new_vote_from_bank(&self, bank: &Bank, vote_account_pubkey: &Pubkey) -> (Vote, usize) {
@@ -509,7 +511,7 @@ impl Tower {
         descendants: &HashMap<Slot, HashSet<u64>>,
         progress: &ProgressMap,
         total_stake: u64,
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, Account)>,
+        epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
     ) -> SwitchForkDecision {
         self.last_voted_slot()
             .map(|last_voted_slot| {
@@ -703,7 +705,7 @@ impl Tower {
         descendants: &HashMap<Slot, HashSet<u64>>,
         progress: &ProgressMap,
         total_stake: u64,
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, Account)>,
+        epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
     ) -> SwitchForkDecision {
         let decision = self.make_check_switch_threshold_decision(
             switch_slot,
@@ -1058,10 +1060,12 @@ impl Tower {
         root: Slot,
         bank: &Bank,
     ) {
-        if let Some((_stake, vote_account)) = bank.vote_accounts().get(vote_account_pubkey) {
-            let vote_state = VoteState::deserialize(&vote_account.data)
-                .expect("vote_account isn't a VoteState?");
-            self.lockouts = vote_state;
+        if let Some((_stake, vote_account)) = bank.get_vote_account(vote_account_pubkey) {
+            self.lockouts = vote_account
+                .vote_state()
+                .as_ref()
+                .expect("vote_account isn't a VoteState?")
+                .clone();
             self.initialize_root(root);
             self.initialize_lockouts(|v| v.slot > root);
             trace!(
@@ -1286,7 +1290,8 @@ pub mod test {
         },
     };
     use solana_sdk::{
-        clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signer, slot_history::SlotHistory,
+        account::Account, clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signer,
+        slot_history::SlotHistory,
     };
     use solana_vote_program::{
         vote_state::{Vote, VoteStateVersions, MAX_LOCKOUT_HISTORY},
@@ -1604,7 +1609,7 @@ pub mod test {
         (bank_forks, progress, heaviest_subtree_fork_choice)
     }
 
-    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, (u64, Account))> {
+    fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, (u64, ArcVoteAccount))> {
         let mut stakes = vec![];
         for (lamports, votes) in stake_votes {
             let mut account = Account::default();
@@ -1619,7 +1624,10 @@ pub mod test {
                 &mut account.data,
             )
             .expect("serialize state");
-            stakes.push((solana_sdk::pubkey::new_rand(), (*lamports, account)));
+            stakes.push((
+                solana_sdk::pubkey::new_rand(),
+                (*lamports, ArcVoteAccount::from(account)),
+            ));
         }
         stakes
     }
@@ -1973,16 +1981,16 @@ pub mod test {
         }
 
         info!("local tower: {:#?}", tower.lockouts.votes);
-        let vote_accounts = vote_simulator
+        let observed = vote_simulator
             .bank_forks
             .read()
             .unwrap()
             .get(next_unlocked_slot)
             .unwrap()
-            .vote_accounts();
-        let observed = vote_accounts.get(&vote_pubkey).unwrap();
-        let state = VoteState::from(&observed.1).unwrap();
-        info!("observed tower: {:#?}", state.votes);
+            .get_vote_account(&vote_pubkey)
+            .unwrap();
+        let state = observed.1.vote_state();
+        info!("observed tower: {:#?}", state.as_ref().unwrap().votes);
 
         let num_slots_to_try = 200;
         cluster_votes

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -6,8 +6,8 @@ use crate::{
     {consensus::Stake, consensus::VotedStakes},
 };
 use solana_ledger::blockstore_processor::{ConfirmationProgress, ConfirmationTiming};
-use solana_runtime::{bank::Bank, bank_forks::BankForks};
-use solana_sdk::{account::Account, clock::Slot, hash::Hash, pubkey::Pubkey};
+use solana_runtime::{bank::Bank, bank_forks::BankForks, vote_account::ArcVoteAccount};
+use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     rc::Rc,
@@ -262,7 +262,7 @@ impl PropagatedStats {
         node_pubkey: &Pubkey,
         all_pubkeys: &mut PubkeyReferences,
         vote_account_pubkeys: &[Pubkey],
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, Account)>,
+        epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
     ) {
         let cached_pubkey = all_pubkeys.get_or_insert(node_pubkey);
         self.propagated_node_ids.insert(cached_pubkey);
@@ -440,7 +440,7 @@ mod test {
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys
             .iter()
             .skip(num_vote_accounts - staked_vote_accounts)
-            .map(|pubkey| (*pubkey, (1, Account::default())))
+            .map(|pubkey| (*pubkey, (1, ArcVoteAccount::default())))
             .collect();
 
         let mut stats = PropagatedStats::default();
@@ -507,7 +507,7 @@ mod test {
         let epoch_vote_accounts: HashMap<_, _> = vote_account_pubkeys
             .iter()
             .skip(num_vote_accounts - staked_vote_accounts)
-            .map(|pubkey| (*pubkey, (1, Account::default())))
+            .map(|pubkey| (*pubkey, (1, ArcVoteAccount::default())))
             .collect();
         stats.add_node_pubkey_internal(
             &node_pubkey,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -537,13 +537,15 @@ impl JsonRpcRequestProcessor {
         let epoch_vote_accounts = bank
             .epoch_vote_accounts(bank.get_epoch_and_slot_index(bank.slot()).0)
             .ok_or_else(Error::invalid_request)?;
+        let default_vote_state = VoteState::default();
         let (current_vote_accounts, delinquent_vote_accounts): (
             Vec<RpcVoteAccountInfo>,
             Vec<RpcVoteAccountInfo>,
         ) = vote_accounts
             .iter()
             .map(|(pubkey, (activated_stake, account))| {
-                let vote_state = VoteState::from(&account).unwrap_or_default();
+                let vote_state = account.vote_state();
+                let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
                 let last_vote = if let Some(vote) = vote_state.votes.iter().last() {
                     vote.slot
                 } else {

--- a/frozen-abi/src/abi_example.rs
+++ b/frozen-abi/src/abi_example.rs
@@ -188,6 +188,7 @@ example_impls! { f32, 0.0f32 }
 example_impls! { f64, 0.0f64 }
 example_impls! { String, String::new() }
 example_impls! { std::time::Duration, std::time::Duration::from_secs(0) }
+example_impls! { std::sync::Once, std::sync::Once::new() }
 
 use std::sync::atomic::*;
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -24,9 +24,11 @@ use rocksdb::DBRawIterator;
 use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, datapoint_error};
 use solana_rayon_threadlimit::get_thread_count;
-use solana_runtime::hardened_unpack::{unpack_genesis_archive, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE};
+use solana_runtime::{
+    hardened_unpack::{unpack_genesis_archive, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
+    vote_account::ArcVoteAccount,
+};
 use solana_sdk::{
-    account::Account,
     clock::{Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND, MS_PER_TICK},
     genesis_config::GenesisConfig,
     hash::Hash,
@@ -1623,7 +1625,7 @@ impl Blockstore {
         &self,
         slot: Slot,
         slot_duration: Duration,
-        stakes: &HashMap<Pubkey, (u64, Account)>,
+        stakes: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
     ) -> Result<()> {
         if !self.is_root(slot) {
             return Err(BlockstoreError::SlotNotRooted);
@@ -5817,7 +5819,7 @@ pub mod tests {
 
         // Build epoch vote_accounts HashMap to test stake-weighted block time
         for (i, keypair) in vote_keypairs.iter().enumerate() {
-            stakes.insert(keypair.pubkey(), (1 + i as u64, Account::default()));
+            stakes.insert(keypair.pubkey(), (1 + i as u64, ArcVoteAccount::default()));
         }
         for slot in &[1, 2, 3, 8] {
             blockstore
@@ -5876,7 +5878,7 @@ pub mod tests {
         // Build epoch vote_accounts HashMap to test stake-weighted block time
         let mut stakes = HashMap::new();
         for (i, keypair) in vote_keypairs.iter().enumerate() {
-            stakes.insert(keypair.pubkey(), (1 + i as u64, Account::default()));
+            stakes.insert(keypair.pubkey(), (1 + i as u64, ArcVoteAccount::default()));
         }
         let slot_duration = Duration::from_millis(400);
         for slot in &[1, 2, 3, 8] {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -24,10 +24,10 @@ use solana_runtime::{
     commitment::VOTE_THRESHOLD_SIZE,
     transaction_batch::TransactionBatch,
     transaction_utils::OrderedIterator,
+    vote_account::ArcVoteAccount,
     vote_sender_types::ReplayVoteSender,
 };
 use solana_sdk::{
-    account::Account,
     clock::{Slot, MAX_PROCESSING_AGE},
     genesis_config::GenesisConfig,
     hash::Hash,
@@ -36,7 +36,6 @@ use solana_sdk::{
     timing::duration_as_ms,
     transaction::{Result, Transaction, TransactionError},
 };
-use solana_vote_program::vote_state::VoteState;
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
@@ -868,8 +867,11 @@ fn load_frozen_forks(
         // for newer cluster confirmed roots
         let new_root_bank = {
             if *root == max_root {
-                supermajority_root_from_vote_accounts(bank.slot(), bank.total_epoch_stake(), bank.vote_accounts()
-                .into_iter()).and_then(|supermajority_root| {
+                supermajority_root_from_vote_accounts(
+                    bank.slot(),
+                    bank.total_epoch_stake(),
+                    bank.vote_accounts(),
+                ).and_then(|supermajority_root| {
                     if supermajority_root > *root {
                         // If there's a cluster confirmed root greater than our last
                         // replayed root, then beccause the cluster confirmed root should
@@ -960,30 +962,28 @@ fn supermajority_root(roots: &[(Slot, u64)], total_epoch_stake: u64) -> Option<S
 fn supermajority_root_from_vote_accounts<I>(
     bank_slot: Slot,
     total_epoch_stake: u64,
-    vote_accounts_iter: I,
+    vote_accounts: I,
 ) -> Option<Slot>
 where
-    I: Iterator<Item = (Pubkey, (u64, Account))>,
+    I: IntoIterator<Item = (Pubkey, (u64, ArcVoteAccount))>,
 {
-    let mut roots_stakes: Vec<(Slot, u64)> = vote_accounts_iter
+    let mut roots_stakes: Vec<(Slot, u64)> = vote_accounts
+        .into_iter()
         .filter_map(|(key, (stake, account))| {
             if stake == 0 {
                 return None;
             }
 
-            let vote_state = VoteState::from(&account);
-            if vote_state.is_none() {
-                warn!(
-                    "Unable to get vote_state from account {} in bank: {}",
-                    key, bank_slot
-                );
-                return None;
+            match account.vote_state().as_ref() {
+                Err(_) => {
+                    warn!(
+                        "Unable to get vote_state from account {} in bank: {}",
+                        key, bank_slot
+                    );
+                    None
+                }
+                Ok(vote_state) => vote_state.root_slot.map(|root_slot| (root_slot, stake)),
             }
-
-            vote_state
-                .unwrap()
-                .root_slot
-                .map(|root_slot| (root_slot, stake))
         })
         .collect();
 
@@ -1112,6 +1112,7 @@ pub mod tests {
         self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
     };
     use solana_sdk::{
+        account::Account,
         epoch_schedule::EpochSchedule,
         hash::Hash,
         pubkey::Pubkey,
@@ -1122,7 +1123,7 @@ pub mod tests {
     };
     use solana_vote_program::{
         self,
-        vote_state::{VoteStateVersions, MAX_LOCKOUT_HISTORY},
+        vote_state::{VoteState, VoteStateVersions, MAX_LOCKOUT_HISTORY},
         vote_transaction,
     };
     use std::{collections::BTreeSet, sync::RwLock};
@@ -3146,7 +3147,7 @@ pub mod tests {
     #[test]
     fn test_supermajority_root_from_vote_accounts() {
         let convert_to_vote_accounts =
-            |roots_stakes: Vec<(Slot, u64)>| -> Vec<(Pubkey, (u64, Account))> {
+            |roots_stakes: Vec<(Slot, u64)>| -> Vec<(Pubkey, (u64, ArcVoteAccount))> {
                 roots_stakes
                     .into_iter()
                     .map(|(root, stake)| {
@@ -3156,7 +3157,10 @@ pub mod tests {
                             Account::new(1, VoteState::size_of(), &solana_vote_program::id());
                         let versioned = VoteStateVersions::Current(Box::new(vote_state));
                         VoteState::serialize(&versioned, &mut vote_account.data).unwrap();
-                        (solana_sdk::pubkey::new_rand(), (stake, vote_account))
+                        (
+                            solana_sdk::pubkey::new_rand(),
+                            (stake, ArcVoteAccount::from(vote_account)),
+                        )
                     })
                     .collect_vec()
             };

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -3,7 +3,6 @@ use solana_sdk::{
     clock::{Epoch, Slot},
     pubkey::Pubkey,
 };
-use solana_vote_program::vote_state::VoteState;
 use std::{borrow::Borrow, collections::HashMap};
 
 /// Looks through vote accounts, and finds the latest slot that has achieved
@@ -27,54 +26,42 @@ pub fn vote_account_stakes(bank: &Bank) -> HashMap<Pubkey, u64> {
 
 /// Collect the staked nodes, as named by staked vote accounts from the given bank
 pub fn staked_nodes(bank: &Bank) -> HashMap<Pubkey, u64> {
-    to_staked_nodes(to_vote_states(bank.vote_accounts().into_iter()))
+    to_staked_nodes(bank.vote_accounts())
 }
 
 /// At the specified epoch, collect the delegate account balance and vote states for delegates
 /// that have non-zero balance in any of their managed staking accounts
 pub fn staked_nodes_at_epoch(bank: &Bank, epoch: Epoch) -> Option<HashMap<Pubkey, u64>> {
-    bank.epoch_vote_accounts(epoch)
-        .map(|vote_accounts| to_staked_nodes(to_vote_states(vote_accounts.iter())))
+    bank.epoch_vote_accounts(epoch).map(to_staked_nodes)
 }
 
-// input (vote_pubkey, (stake, vote_account)) => (stake, vote_state)
-fn to_vote_states<I, K, V>(
-    node_staked_accounts: I,
-) -> impl Iterator<Item = (u64 /*stake*/, VoteState)>
+fn to_staked_nodes<I, K, V>(
+    vote_accounts: I,
+) -> HashMap<Pubkey /*VoteState.node_pubkey*/, u64 /*stake*/>
 where
-    I: IntoIterator<Item = (K /*vote_pubkey*/, V)>,
+    I: IntoIterator<Item = (K /*vote pubkey*/, V)>,
     V: Borrow<(u64 /*stake*/, ArcVoteAccount)>,
 {
-    node_staked_accounts
-        .into_iter()
-        .filter_map(|(_, stake_vote_account)| {
-            let (stake, vote_account) = stake_vote_account.borrow();
-            let vote_state = vote_account.vote_state().as_ref().ok()?.clone();
-            Some((*stake, vote_state))
-        })
-}
-
-// (stake, vote_state) => (node, stake)
-fn to_staked_nodes(
-    node_staked_accounts: impl Iterator<Item = (u64, VoteState)>,
-) -> HashMap<Pubkey, u64> {
-    let mut map: HashMap<Pubkey, u64> = HashMap::new();
-    node_staked_accounts.for_each(|(stake, state)| {
-        map.entry(state.node_pubkey)
-            .and_modify(|s| *s += stake)
-            .or_insert(stake);
-    });
-    map
+    let mut out: HashMap<Pubkey, u64> = HashMap::new();
+    for (_ /*vote pubkey*/, stake_vote_account) in vote_accounts {
+        let (stake, vote_account) = stake_vote_account.borrow();
+        if let Ok(vote_state) = vote_account.vote_state().as_ref() {
+            out.entry(vote_state.node_pubkey)
+                .and_modify(|s| *s += *stake)
+                .or_insert(*stake);
+        }
+    }
+    out
 }
 
 fn epoch_stakes_and_lockouts(bank: &Bank, epoch: Epoch) -> Vec<(u64, Option<u64>)> {
-    let node_staked_accounts = bank
-        .epoch_vote_accounts(epoch)
+    bank.epoch_vote_accounts(epoch)
         .expect("Bank state for epoch is missing")
-        .iter();
-
-    to_vote_states(node_staked_accounts)
-        .map(|(stake, states)| (stake, states.root_slot))
+        .iter()
+        .filter_map(|(_ /*vote pubkey*/, (stake, vote_account))| {
+            let root_slot = vote_account.vote_state().as_ref().ok()?.root_slot;
+            Some((*stake, root_slot))
+        })
         .collect()
 }
 
@@ -108,8 +95,9 @@ pub(crate) mod tests {
     use crate::genesis_utils::{
         bootstrap_validator_stake_lamports, create_genesis_config, GenesisConfigInfo,
     };
+    use rand::Rng;
     use solana_sdk::{
-        account::from_account,
+        account::{from_account, Account},
         clock::Clock,
         instruction::Instruction,
         pubkey::Pubkey,
@@ -122,7 +110,10 @@ pub(crate) mod tests {
         stake_instruction,
         stake_state::{Authorized, Delegation, Lockup, Stake},
     };
-    use solana_vote_program::{vote_instruction, vote_state::VoteInit};
+    use solana_vote_program::{
+        vote_instruction,
+        vote_state::{VoteInit, VoteState, VoteStateVersions},
+    };
     use std::sync::Arc;
 
     fn new_from_parent(parent: &Arc<Bank>, slot: Slot) -> Bank {
@@ -345,8 +336,18 @@ pub(crate) mod tests {
                 &Clock::default(),
             ),
         ));
-
-        let result = to_staked_nodes(stakes.into_iter());
+        let mut rng = rand::thread_rng();
+        let vote_accounts = stakes.into_iter().map(|(stake, vote_state)| {
+            let account = Account::new_data(
+                rng.gen(), // lamports
+                &VoteStateVersions::Current(Box::new(vote_state)),
+                &Pubkey::new_unique(), // owner
+            )
+            .unwrap();
+            let vote_pubkey = Pubkey::new_unique();
+            (vote_pubkey, (stake, ArcVoteAccount::from(account)))
+        });
+        let result = to_staked_nodes(vote_accounts);
         assert_eq!(result.len(), 2);
         assert_eq!(result[&node1], 3);
         assert_eq!(result[&node2], 5);

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,7 +1,6 @@
-use crate::stakes::Stakes;
+use crate::{stakes::Stakes, vote_account::ArcVoteAccount};
 use serde::{Deserialize, Serialize};
-use solana_sdk::{account::Account, clock::Epoch, pubkey::Pubkey};
-use solana_vote_program::vote_state::VoteState;
+use solana_sdk::{clock::Epoch, pubkey::Pubkey};
 use std::{collections::HashMap, sync::Arc};
 
 pub type NodeIdToVoteAccounts = HashMap<Pubkey, NodeVoteAccounts>;
@@ -58,7 +57,7 @@ impl EpochStakes {
     }
 
     fn parse_epoch_vote_accounts(
-        epoch_vote_accounts: &HashMap<Pubkey, (u64, Account)>,
+        epoch_vote_accounts: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
         leader_schedule_epoch: Epoch,
     ) -> (u64, NodeIdToVoteAccounts, EpochAuthorizedVoters) {
         let mut node_id_to_vote_accounts: NodeIdToVoteAccounts = HashMap::new();
@@ -69,19 +68,21 @@ impl EpochStakes {
         let epoch_authorized_voters = epoch_vote_accounts
             .iter()
             .filter_map(|(key, (stake, account))| {
-                let vote_state = VoteState::from(&account);
-                if vote_state.is_none() {
-                    datapoint_warn!(
-                        "parse_epoch_vote_accounts",
-                        (
-                            "warn",
-                            format!("Unable to get vote_state from account {}", key),
-                            String
-                        ),
-                    );
-                    return None;
-                }
-                let vote_state = vote_state.unwrap();
+                let vote_state = account.vote_state();
+                let vote_state = match vote_state.as_ref() {
+                    Err(_) => {
+                        datapoint_warn!(
+                            "parse_epoch_vote_accounts",
+                            (
+                                "warn",
+                                format!("Unable to get vote_state from account {}", key),
+                                String
+                            ),
+                        );
+                        return None;
+                    }
+                    Ok(vote_state) => vote_state,
+                };
                 if *stake > 0 {
                     // Read out the authorized voters
                     let authorized_voter = vote_state
@@ -113,6 +114,7 @@ impl EpochStakes {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use solana_sdk::account::Account;
     use solana_vote_program::vote_state::create_account_with_authorized;
     use std::iter;
 
@@ -181,9 +183,12 @@ pub(crate) mod tests {
         let epoch_vote_accounts: HashMap<_, _> = vote_accounts_map
             .iter()
             .flat_map(|(_, vote_accounts)| {
-                vote_accounts
-                    .iter()
-                    .map(|v| (v.vote_account, (stake_per_account, v.account.clone())))
+                vote_accounts.iter().map(|v| {
+                    (
+                        v.vote_account,
+                        (stake_per_account, ArcVoteAccount::from(v.account.clone())),
+                    )
+                })
             })
             .collect();
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -29,6 +29,7 @@ pub mod status_cache;
 mod system_instruction_processor;
 pub mod transaction_batch;
 pub mod transaction_utils;
+pub mod vote_account;
 pub mod vote_sender_types;
 
 extern crate solana_config_program;

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -261,7 +261,7 @@ mod test_bank_serialize {
 
     // These some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "Giao4XJq9QgW78sqmT3nRMvENt4BgHXdzphCDGFPbXqW")]
+    #[frozen_abi(digest = "8bNY87hccyDYCRar1gM3NSvpvtiUM3W3rGeJLJayz42e")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperFuture {
         #[serde(serialize_with = "wrapper_future")]

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -1,0 +1,181 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+use solana_sdk::{account::Account, instruction::InstructionError};
+use solana_vote_program::vote_state::VoteState;
+use std::ops::Deref;
+use std::sync::{Arc, Once, RwLock, RwLockReadGuard};
+
+// The value here does not matter. It will be overwritten
+// at the first call to VoteAccount::vote_state().
+const INVALID_VOTE_STATE: Result<VoteState, InstructionError> =
+    Err(InstructionError::InvalidAccountData);
+
+#[derive(Clone, Debug, Default, PartialEq, AbiExample)]
+pub struct ArcVoteAccount(Arc<VoteAccount>);
+
+#[derive(Debug, AbiExample)]
+pub struct VoteAccount {
+    account: Account,
+    vote_state: RwLock<Result<VoteState, InstructionError>>,
+    vote_state_once: Once,
+}
+
+impl VoteAccount {
+    pub fn lamports(&self) -> u64 {
+        self.account.lamports
+    }
+
+    pub fn vote_state(&self) -> RwLockReadGuard<Result<VoteState, InstructionError>> {
+        self.vote_state_once.call_once(|| {
+            *self.vote_state.write().unwrap() = VoteState::deserialize(&self.account.data);
+        });
+        self.vote_state.read().unwrap()
+    }
+}
+
+impl Deref for ArcVoteAccount {
+    type Target = VoteAccount;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl Serialize for ArcVoteAccount {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.account.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ArcVoteAccount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let account = Account::deserialize(deserializer)?;
+        Ok(Self::from(account))
+    }
+}
+
+impl From<Account> for ArcVoteAccount {
+    fn from(account: Account) -> Self {
+        Self(Arc::new(VoteAccount::from(account)))
+    }
+}
+
+impl From<Account> for VoteAccount {
+    fn from(account: Account) -> Self {
+        Self {
+            account,
+            vote_state: RwLock::new(INVALID_VOTE_STATE),
+            vote_state_once: Once::new(),
+        }
+    }
+}
+
+impl Default for VoteAccount {
+    fn default() -> Self {
+        Self {
+            account: Account::default(),
+            vote_state: RwLock::new(INVALID_VOTE_STATE),
+            vote_state_once: Once::new(),
+        }
+    }
+}
+
+impl PartialEq<VoteAccount> for VoteAccount {
+    fn eq(&self, other: &Self) -> bool {
+        self.account == other.account
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::Rng;
+    use solana_sdk::{pubkey::Pubkey, sysvar::clock::Clock};
+    use solana_vote_program::vote_state::{VoteInit, VoteStateVersions};
+
+    fn new_rand_vote_account<R: Rng>(rng: &mut R) -> (Account, VoteState) {
+        let vote_init = VoteInit {
+            node_pubkey: Pubkey::new_unique(),
+            authorized_voter: Pubkey::new_unique(),
+            authorized_withdrawer: Pubkey::new_unique(),
+            commission: rng.gen(),
+        };
+        let clock = Clock {
+            slot: rng.gen(),
+            epoch_start_timestamp: rng.gen(),
+            epoch: rng.gen(),
+            leader_schedule_epoch: rng.gen(),
+            unix_timestamp: rng.gen(),
+        };
+        let vote_state = VoteState::new(&vote_init, &clock);
+        let account = Account::new_data(
+            rng.gen(), // lamports
+            &VoteStateVersions::Current(Box::new(vote_state.clone())),
+            &Pubkey::new_unique(), // owner
+        )
+        .unwrap();
+        (account, vote_state)
+    }
+
+    #[test]
+    fn test_vote_account() {
+        let mut rng = rand::thread_rng();
+        let (account, vote_state) = new_rand_vote_account(&mut rng);
+        let lamports = account.lamports;
+        let vote_account = ArcVoteAccount::from(account);
+        assert_eq!(lamports, vote_account.lamports());
+        assert_eq!(vote_state, *vote_account.vote_state().as_ref().unwrap());
+        // 2nd call to .vote_state() should return the cached value.
+        assert_eq!(vote_state, *vote_account.vote_state().as_ref().unwrap());
+    }
+
+    #[test]
+    fn test_vote_account_serialize() {
+        let mut rng = rand::thread_rng();
+        let (account, vote_state) = new_rand_vote_account(&mut rng);
+        let vote_account = ArcVoteAccount::from(account.clone());
+        assert_eq!(vote_state, *vote_account.vote_state().as_ref().unwrap());
+        // Assert than ArcVoteAccount has the same wire format as Account.
+        assert_eq!(
+            bincode::serialize(&account).unwrap(),
+            bincode::serialize(&vote_account).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_vote_account_deserialize() {
+        let mut rng = rand::thread_rng();
+        let (account, vote_state) = new_rand_vote_account(&mut rng);
+        let data = bincode::serialize(&account).unwrap();
+        let vote_account = ArcVoteAccount::from(account);
+        assert_eq!(vote_state, *vote_account.vote_state().as_ref().unwrap());
+        let other_vote_account: ArcVoteAccount = bincode::deserialize(&data).unwrap();
+        assert_eq!(vote_account, other_vote_account);
+        assert_eq!(
+            vote_state,
+            *other_vote_account.vote_state().as_ref().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_vote_account_round_trip() {
+        let mut rng = rand::thread_rng();
+        let (account, vote_state) = new_rand_vote_account(&mut rng);
+        let vote_account = ArcVoteAccount::from(account);
+        assert_eq!(vote_state, *vote_account.vote_state().as_ref().unwrap());
+        let data = bincode::serialize(&vote_account).unwrap();
+        let other_vote_account: ArcVoteAccount = bincode::deserialize(&data).unwrap();
+        // Assert that serialize->deserialized returns the same ArcVoteAccount.
+        assert_eq!(vote_account, other_vote_account);
+        assert_eq!(
+            vote_state,
+            *other_vote_account.vote_state().as_ref().unwrap()
+        );
+    }
+}

--- a/sdk/src/stake_weighted_timestamp.rs
+++ b/sdk/src/stake_weighted_timestamp.rs
@@ -1,7 +1,6 @@
 /// A helper for calculating a stake-weighted timestamp estimate from a set of timestamps and epoch
 /// stake.
 use solana_sdk::{
-    account::Account,
     clock::{Slot, UnixTimestamp},
     pubkey::Pubkey,
 };
@@ -19,9 +18,9 @@ pub enum EstimateType {
     Unbounded, // Deprecated.  Remove in the Solana v1.6.0 timeframe
 }
 
-pub fn calculate_stake_weighted_timestamp(
+pub fn calculate_stake_weighted_timestamp<T>(
     unique_timestamps: &HashMap<Pubkey, (Slot, UnixTimestamp)>,
-    stakes: &HashMap<Pubkey, (u64, Account)>,
+    stakes: &HashMap<Pubkey, (u64, T /*Account|ArcVoteAccount*/)>,
     slot: Slot,
     slot_duration: Duration,
     estimate_type: EstimateType,
@@ -44,9 +43,9 @@ pub fn calculate_stake_weighted_timestamp(
     }
 }
 
-fn calculate_unbounded_stake_weighted_timestamp(
+fn calculate_unbounded_stake_weighted_timestamp<T>(
     unique_timestamps: &HashMap<Pubkey, (Slot, UnixTimestamp)>,
-    stakes: &HashMap<Pubkey, (u64, Account)>,
+    stakes: &HashMap<Pubkey, (u64, T /*Account|ArcVoteAccount*/)>,
     slot: Slot,
     slot_duration: Duration,
 ) -> Option<UnixTimestamp> {
@@ -71,9 +70,9 @@ fn calculate_unbounded_stake_weighted_timestamp(
     }
 }
 
-fn calculate_bounded_stake_weighted_timestamp(
+fn calculate_bounded_stake_weighted_timestamp<T>(
     unique_timestamps: &HashMap<Pubkey, (Slot, UnixTimestamp)>,
-    stakes: &HashMap<Pubkey, (u64, Account)>,
+    stakes: &HashMap<Pubkey, (u64, T /*Account|ArcVoteAccount*/)>,
     slot: Slot,
     slot_duration: Duration,
     epoch_start_timestamp: Option<(Slot, UnixTimestamp)>,
@@ -135,7 +134,7 @@ fn calculate_bounded_stake_weighted_timestamp(
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use solana_sdk::native_token::sol_to_lamports;
+    use solana_sdk::{account::Account, native_token::sol_to_lamports};
 
     #[test]
     fn test_calculate_stake_weighted_timestamp() {


### PR DESCRIPTION
#### Problem
Gossip and other places repeatedly de-serialize vote-state stored in
vote accounts. Ideally the first de-serialization should cache the
result.

#### Summary of Changes
This commit adds new VoteAccount type which lazily de-serializes
VoteState from Account data and caches the result internally.

Serialize and Deserialize traits are manually implemented to match
existing code. So, despite changes to frozen_abi, this commit should be
backward compatible.