### PR TITLE
Explorer: Display CPI details for transaction

### DIFF
--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -42,6 +42,7 @@ import {
   parseSerumInstructionTitle,
 } from "components/instruction/serum/types";
 import { INNER_INSTRUCTIONS_SLOT } from "pages/TransactionDetailsPage";
+import { useCluster, Cluster } from "providers/cluster";
 
 type InstructionType = {
   name: string;
@@ -270,6 +271,7 @@ const TokenTransactionRow = React.memo(
     details: CacheEntry<Details> | undefined;
   }) => {
     const fetchDetails = useFetchTransactionDetails();
+    const { cluster } = useCluster();
 
     // Fetch details on load
     React.useEffect(() => {
@@ -331,8 +333,9 @@ const TokenTransactionRow = React.memo(
           )[] = [];
 
           if (
-            transaction.slot >= INNER_INSTRUCTIONS_SLOT &&
-            transaction.meta?.innerInstructions
+            transaction.meta?.innerInstructions &&
+            (cluster !== Cluster.MainnetBeta ||
+              transaction.slot >= INNER_INSTRUCTIONS_SLOT)
           ) {
             transaction.meta.innerInstructions.forEach((ix) => {
               if (ix.index === index) {

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -338,7 +338,7 @@ const TokenTransactionRow = React.memo(
         if (details?.data?.transaction?.transaction) {
           transactionInstruction = intoTransactionInstruction(
             details.data.transaction.transaction,
-            index
+            ix
           );
         }
 
@@ -444,7 +444,6 @@ function InstructionDetails({
       <p className="tree">
         {instructionTypes.length > 0 && (
           <span
-
             onClick={(e) => {
               e.preventDefault();
               setExpanded(!expanded);

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -3,7 +3,6 @@ import {
   PublicKey,
   ConfirmedSignatureInfo,
   ParsedInstruction,
-  ParsedInnerInstruction,
   PartiallyDecodedInstruction,
 } from "@solana/web3.js";
 import { CacheEntry, FetchStatus } from "providers/cache";
@@ -408,7 +407,7 @@ const TokenTransactionRow = React.memo(
               </td>
 
               <td>
-                <InstructionType instructionType={instructionType} tx={tx} />
+                <InstructionDetails instructionType={instructionType} tx={tx} />
               </td>
 
               <td className="forced-truncate">
@@ -422,7 +421,7 @@ const TokenTransactionRow = React.memo(
   }
 );
 
-function InstructionType({
+function InstructionDetails({
   instructionType,
   tx,
 }: {
@@ -436,6 +435,7 @@ function InstructionType({
       if ("parsed" in ix && ix.program === "spl-token") {
         return instructionTypeName(ix, tx);
       }
+      return undefined;
     })
     .filter((type) => type !== undefined);
 
@@ -443,19 +443,16 @@ function InstructionType({
     <>
       <p className="tree">
         {instructionTypes.length > 0 && (
-          <a
-            href="#"
+          <span
+
             onClick={(e) => {
               e.preventDefault();
               setExpanded(!expanded);
             }}
-          >
-            <span
-              className={`fe mr-2 ${
-                expanded ? "fe-minus-square" : "fe-plus-square"
-              }`}
-            ></span>
-          </a>
+            className={`c-pointer fe mr-2 ${
+              expanded ? "fe-minus-square" : "fe-plus-square"
+            }`}
+          ></span>
         )}
         {instructionType.name}
       </p>

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   PublicKey,
   ConfirmedSignatureInfo,
@@ -41,7 +41,7 @@ import {
   isSerumInstruction,
   parseSerumInstructionTitle,
 } from "components/instruction/serum/types";
-import { INNER_INSTRUCTIONS_SLOT } from "pages/TransactionDetailsPage";
+import { INNER_INSTRUCTIONS_START_SLOT } from "pages/TransactionDetailsPage";
 import { useCluster, Cluster } from "providers/cluster";
 
 type InstructionType = {
@@ -327,7 +327,7 @@ const TokenTransactionRow = React.memo(
         .map((ix, index): InstructionType | undefined => {
           let name = "Unknown";
 
-          let innerInstructions: (
+          const innerInstructions: (
             | ParsedInstruction
             | PartiallyDecodedInstruction
           )[] = [];
@@ -335,7 +335,7 @@ const TokenTransactionRow = React.memo(
           if (
             transaction.meta?.innerInstructions &&
             (cluster !== Cluster.MainnetBeta ||
-              transaction.slot >= INNER_INSTRUCTIONS_SLOT)
+              transaction.slot >= INNER_INSTRUCTIONS_START_SLOT)
           ) {
             transaction.meta.innerInstructions.forEach((ix) => {
               if (ix.index === index) {
@@ -441,7 +441,7 @@ function InstructionDetails({
   instructionType: InstructionType;
   tx: ConfirmedSignatureInfo;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = React.useState(false);
 
   let instructionTypes = instructionType.innerInstructions
     .map((ix) => {

--- a/explorer/src/components/common/Address.tsx
+++ b/explorer/src/components/common/Address.tsx
@@ -12,9 +12,17 @@ type Props = {
   link?: boolean;
   raw?: boolean;
   truncate?: boolean;
+  truncateUnknown?: boolean;
 };
 
-export function Address({ pubkey, alignRight, link, raw, truncate }: Props) {
+export function Address({
+  pubkey,
+  alignRight,
+  link,
+  raw,
+  truncate,
+  truncateUnknown,
+}: Props) {
   const [state, setState] = useState<CopyState>("copy");
   const address = pubkey.toBase58();
   const { cluster } = useCluster();
@@ -32,6 +40,10 @@ export function Address({ pubkey, alignRight, link, raw, truncate }: Props) {
     ) : (
       <span className="fe fe-check-circle"></span>
     );
+
+  if (truncateUnknown && address === displayAddress(address, cluster)) {
+    truncate = true;
+  }
 
   const content = (
     <>

--- a/explorer/src/components/common/Signature.tsx
+++ b/explorer/src/components/common/Signature.tsx
@@ -8,9 +8,10 @@ type Props = {
   signature: TransactionSignature;
   alignRight?: boolean;
   link?: boolean;
+  truncate?: boolean;
 };
 
-export function Signature({ signature, alignRight, link }: Props) {
+export function Signature({ signature, alignRight, link, truncate }: Props) {
   const [state, setState] = useState<CopyState>("copy");
 
   const copyToClipboard = () => navigator.clipboard.writeText(signature);
@@ -40,7 +41,10 @@ export function Signature({ signature, alignRight, link }: Props) {
       {copyButton}
       <span className="text-monospace">
         {link ? (
-          <Link className="" to={clusterPath(`/tx/${signature}`)}>
+          <Link
+            className={truncate ? "text-truncate address-truncate" : ""}
+            to={clusterPath(`/tx/${signature}`)}
+          >
             {signature}
           </Link>
         ) : (

--- a/explorer/src/components/common/Signature.tsx
+++ b/explorer/src/components/common/Signature.tsx
@@ -42,7 +42,7 @@ export function Signature({ signature, alignRight, link, truncate }: Props) {
       <span className="text-monospace">
         {link ? (
           <Link
-            className={truncate ? "text-truncate address-truncate" : ""}
+            className={truncate ? "text-truncate signature-truncate" : ""}
             to={clusterPath(`/tx/${signature}`)}
           >
             {signature}

--- a/explorer/src/components/instruction/InstructionCard.tsx
+++ b/explorer/src/components/instruction/InstructionCard.tsx
@@ -20,6 +20,8 @@ type InstructionProps = {
   index: number;
   ix: TransactionInstruction | ParsedInstruction;
   defaultRaw?: boolean;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 };
 
 export function InstructionCard({
@@ -29,6 +31,8 @@ export function InstructionCard({
   index,
   ix,
   defaultRaw,
+  innerCards,
+  childIndex,
 }: InstructionProps) {
   const [resultClass] = ixResult(result, index);
   const [showRaw, setShowRaw] = React.useState(defaultRaw || false);
@@ -55,6 +59,7 @@ export function InstructionCard({
         <h3 className="card-header-title mb-0 d-flex align-items-center">
           <span className={`badge badge-soft-${resultClass} mr-2`}>
             #{index + 1}
+            {childIndex !== undefined ? `.${childIndex + 1}` : ""}
           </span>
           {title}
         </h3>
@@ -95,6 +100,9 @@ export function InstructionCard({
           </tbody>
         </table>
       </div>
+      {innerCards && innerCards.length > 0 && (
+        <div className="inner-cards">{innerCards}</div>
+      )}
     </div>
   );
 }

--- a/explorer/src/components/instruction/InstructionCard.tsx
+++ b/explorer/src/components/instruction/InstructionCard.tsx
@@ -97,12 +97,17 @@ export function InstructionCard({
             ) : (
               children
             )}
+            {innerCards && innerCards.length > 0 && (
+              <tr>
+                <td colSpan={2}>
+                  Inner Instructions
+                  <div className="inner-cards">{innerCards}</div>
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
-      {innerCards && innerCards.length > 0 && (
-        <div className="inner-cards">{innerCards}</div>
-      )}
     </div>
   );
 }

--- a/explorer/src/components/instruction/MemoDetailsCard.tsx
+++ b/explorer/src/components/instruction/MemoDetailsCard.tsx
@@ -7,14 +7,25 @@ export function MemoDetailsCard({
   ix,
   index,
   result,
+  innerCards,
+  childIndex,
 }: {
   ix: ParsedInstruction;
   index: number;
   result: SignatureResult;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
   const data = wrap(ix.parsed, 50);
   return (
-    <InstructionCard ix={ix} index={index} result={result} title="Memo">
+    <InstructionCard
+      ix={ix}
+      index={index}
+      result={result}
+      title="Memo"
+      innerCards={innerCards}
+      childIndex={childIndex}
+    >
       <tr>
         <td>Data (UTF-8)</td>
         <td className="text-lg-right">

--- a/explorer/src/components/instruction/SerumDetailsCard.tsx
+++ b/explorer/src/components/instruction/SerumDetailsCard.tsx
@@ -29,8 +29,10 @@ export function SerumDetailsCard(props: {
   index: number;
   result: SignatureResult;
   signature: string;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, signature } = props;
+  const { ix, index, result, signature, innerCards, childIndex } = props;
 
   const { url } = useCluster();
 
@@ -91,6 +93,8 @@ export function SerumDetailsCard(props: {
       index={index}
       result={result}
       title={`Serum: ${title || "Unknown"}`}
+      innerCards={innerCards}
+      childIndex={childIndex}
       defaultRaw
     />
   );

--- a/explorer/src/components/instruction/TokenSwapDetailsCard.tsx
+++ b/explorer/src/components/instruction/TokenSwapDetailsCard.tsx
@@ -10,11 +10,15 @@ export function TokenSwapDetailsCard({
   index,
   result,
   signature,
+  innerCards,
+  childIndex,
 }: {
   ix: TransactionInstruction;
   index: number;
   result: SignatureResult;
   signature: string;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
   const { url } = useCluster();
 
@@ -34,6 +38,8 @@ export function TokenSwapDetailsCard({
       index={index}
       result={result}
       title={`Token Swap: ${title || "Unknown"}`}
+      innerCards={innerCards}
+      childIndex={childIndex}
       defaultRaw
     />
   );

--- a/explorer/src/components/instruction/UnknownDetailsCard.tsx
+++ b/explorer/src/components/instruction/UnknownDetailsCard.tsx
@@ -10,10 +10,14 @@ export function UnknownDetailsCard({
   ix,
   index,
   result,
+  innerCards,
+  childIndex,
 }: {
   ix: TransactionInstruction | ParsedInstruction;
   index: number;
   result: SignatureResult;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
   return (
     <InstructionCard
@@ -21,6 +25,8 @@ export function UnknownDetailsCard({
       index={index}
       result={result}
       title="Unknown"
+      innerCards={innerCards}
+      childIndex={childIndex}
       defaultRaw
     />
   );

--- a/explorer/src/components/instruction/bpf-loader/BpfLoaderDetailsCard.tsx
+++ b/explorer/src/components/instruction/bpf-loader/BpfLoaderDetailsCard.tsx
@@ -19,6 +19,8 @@ type DetailsProps = {
   ix: ParsedInstruction;
   index: number;
   result: SignatureResult;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 };
 
 export function BpfLoaderDetailsCard(props: DetailsProps) {
@@ -50,10 +52,12 @@ type Props<T> = {
   index: number;
   result: SignatureResult;
   info: T;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 };
 
 export function BpfLoaderWriteDetailsCard(props: Props<WriteInfo>) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
   const bytes = wrap(info.bytes, 50);
   return (
     <InstructionCard
@@ -61,6 +65,8 @@ export function BpfLoaderWriteDetailsCard(props: Props<WriteInfo>) {
       index={index}
       result={result}
       title="BPF Loader 2: Write"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>
@@ -94,7 +100,7 @@ export function BpfLoaderWriteDetailsCard(props: Props<WriteInfo>) {
 }
 
 export function BpfLoaderFinalizeDetailsCard(props: Props<FinalizeInfo>) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -102,6 +108,8 @@ export function BpfLoaderFinalizeDetailsCard(props: Props<FinalizeInfo>) {
       index={index}
       result={result}
       title="BPF Loader 2: Finalize"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/serum/CancelOrderByClientIdDetails.tsx
+++ b/explorer/src/components/instruction/serum/CancelOrderByClientIdDetails.tsx
@@ -9,8 +9,10 @@ export function CancelOrderByClientIdDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: CancelOrderByClientId;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -18,6 +20,8 @@ export function CancelOrderByClientIdDetailsCard(props: {
       index={index}
       result={result}
       title="Serum: Cancel Order By Client Id"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Market</td>

--- a/explorer/src/components/instruction/serum/CancelOrderDetails.tsx
+++ b/explorer/src/components/instruction/serum/CancelOrderDetails.tsx
@@ -9,8 +9,10 @@ export function CancelOrderDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: CancelOrder;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -18,6 +20,8 @@ export function CancelOrderDetailsCard(props: {
       index={index}
       result={result}
       title="Serum: Cancel Order"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/serum/ConsumeEventsDetails.tsx
+++ b/explorer/src/components/instruction/serum/ConsumeEventsDetails.tsx
@@ -9,8 +9,10 @@ export function ConsumeEventsDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: ConsumeEvents;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -18,6 +20,8 @@ export function ConsumeEventsDetailsCard(props: {
       index={index}
       result={result}
       title="Serum: Consume Events"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/serum/InitializeMarketDetailsCard.tsx
+++ b/explorer/src/components/instruction/serum/InitializeMarketDetailsCard.tsx
@@ -9,8 +9,10 @@ export function InitializeMarketDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: InitializeMarket;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -18,6 +20,8 @@ export function InitializeMarketDetailsCard(props: {
       index={index}
       result={result}
       title="Serum: Initialize Market"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/serum/MatchOrdersDetailsCard.tsx
+++ b/explorer/src/components/instruction/serum/MatchOrdersDetailsCard.tsx
@@ -9,8 +9,10 @@ export function MatchOrdersDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: MatchOrders;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -18,6 +20,8 @@ export function MatchOrdersDetailsCard(props: {
       index={index}
       result={result}
       title="Serum: Match Orders"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/serum/NewOrderDetailsCard.tsx
+++ b/explorer/src/components/instruction/serum/NewOrderDetailsCard.tsx
@@ -9,8 +9,10 @@ export function NewOrderDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: NewOrder;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -18,6 +20,8 @@ export function NewOrderDetailsCard(props: {
       index={index}
       result={result}
       title="Serum: New Order"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/serum/SettleFundsDetailsCard.tsx
+++ b/explorer/src/components/instruction/serum/SettleFundsDetailsCard.tsx
@@ -9,8 +9,10 @@ export function SettleFundsDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: SettleFunds;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -18,6 +20,8 @@ export function SettleFundsDetailsCard(props: {
       index={index}
       result={result}
       title="Serum: Settle Funds"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/stake/AuthorizeDetailsCard.tsx
+++ b/explorer/src/components/instruction/stake/AuthorizeDetailsCard.tsx
@@ -13,8 +13,10 @@ export function AuthorizeDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: AuthorizeInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -22,6 +24,8 @@ export function AuthorizeDetailsCard(props: {
       index={index}
       result={result}
       title="Stake Authorize"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/stake/DeactivateDetailsCard.tsx
+++ b/explorer/src/components/instruction/stake/DeactivateDetailsCard.tsx
@@ -13,8 +13,10 @@ export function DeactivateDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: DeactivateInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -22,6 +24,8 @@ export function DeactivateDetailsCard(props: {
       index={index}
       result={result}
       title="Deactivate Stake"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/stake/DelegateDetailsCard.tsx
+++ b/explorer/src/components/instruction/stake/DelegateDetailsCard.tsx
@@ -13,8 +13,10 @@ export function DelegateDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: DelegateInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -22,6 +24,8 @@ export function DelegateDetailsCard(props: {
       index={index}
       result={result}
       title="Delegate Stake"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/stake/InitializeDetailsCard.tsx
+++ b/explorer/src/components/instruction/stake/InitializeDetailsCard.tsx
@@ -14,8 +14,10 @@ export function InitializeDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: InitializeInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -23,6 +25,8 @@ export function InitializeDetailsCard(props: {
       index={index}
       result={result}
       title="Stake Initialize"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/stake/SplitDetailsCard.tsx
+++ b/explorer/src/components/instruction/stake/SplitDetailsCard.tsx
@@ -14,11 +14,20 @@ export function SplitDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: SplitInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
-    <InstructionCard ix={ix} index={index} result={result} title="Split Stake">
+    <InstructionCard
+      ix={ix}
+      index={index}
+      result={result}
+      title="Split Stake"
+      innerCards={innerCards}
+      childIndex={childIndex}
+    >
       <tr>
         <td>Program</td>
         <td className="text-lg-right">

--- a/explorer/src/components/instruction/stake/StakeDetailsCard.tsx
+++ b/explorer/src/components/instruction/stake/StakeDetailsCard.tsx
@@ -29,6 +29,8 @@ type DetailsProps = {
   ix: ParsedInstruction;
   result: SignatureResult;
   index: number;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 };
 
 export function StakeDetailsCard(props: DetailsProps) {

--- a/explorer/src/components/instruction/stake/WithdrawDetailsCard.tsx
+++ b/explorer/src/components/instruction/stake/WithdrawDetailsCard.tsx
@@ -14,8 +14,10 @@ export function WithdrawDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: WithdrawInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -23,6 +25,8 @@ export function WithdrawDetailsCard(props: {
       index={index}
       result={result}
       title="Withdraw Stake"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/AllocateDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/AllocateDetailsCard.tsx
@@ -13,8 +13,10 @@ export function AllocateDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: AllocateInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -22,6 +24,8 @@ export function AllocateDetailsCard(props: {
       index={index}
       result={result}
       title="Allocate Account"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/AllocateWithSeedDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/AllocateWithSeedDetailsCard.tsx
@@ -14,8 +14,10 @@ export function AllocateWithSeedDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: AllocateWithSeedInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -23,6 +25,8 @@ export function AllocateWithSeedDetailsCard(props: {
       index={index}
       result={result}
       title="Allocate Account w/ Seed"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/AssignDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/AssignDetailsCard.tsx
@@ -13,8 +13,10 @@ export function AssignDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: AssignInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -22,6 +24,8 @@ export function AssignDetailsCard(props: {
       index={index}
       result={result}
       title="Assign Account"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/AssignWithSeedDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/AssignWithSeedDetailsCard.tsx
@@ -14,8 +14,10 @@ export function AssignWithSeedDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: AssignWithSeedInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -23,6 +25,8 @@ export function AssignWithSeedDetailsCard(props: {
       index={index}
       result={result}
       title="Assign Account w/ Seed"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/CreateDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/CreateDetailsCard.tsx
@@ -14,8 +14,10 @@ export function CreateDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: CreateAccountInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -23,6 +25,8 @@ export function CreateDetailsCard(props: {
       index={index}
       result={result}
       title="Create Account"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/CreateWithSeedDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/CreateWithSeedDetailsCard.tsx
@@ -15,8 +15,10 @@ export function CreateWithSeedDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: CreateAccountWithSeedInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -24,6 +26,8 @@ export function CreateWithSeedDetailsCard(props: {
       index={index}
       result={result}
       title="Create Account w/ Seed"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/NonceAdvanceDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/NonceAdvanceDetailsCard.tsx
@@ -13,8 +13,10 @@ export function NonceAdvanceDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: AdvanceNonceInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -22,6 +24,8 @@ export function NonceAdvanceDetailsCard(props: {
       index={index}
       result={result}
       title="Advance Nonce"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/NonceAuthorizeDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/NonceAuthorizeDetailsCard.tsx
@@ -13,8 +13,10 @@ export function NonceAuthorizeDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: AuthorizeNonceInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -22,6 +24,8 @@ export function NonceAuthorizeDetailsCard(props: {
       index={index}
       result={result}
       title="Authorize Nonce"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/NonceInitializeDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/NonceInitializeDetailsCard.tsx
@@ -13,8 +13,10 @@ export function NonceInitializeDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: InitializeNonceInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -22,6 +24,8 @@ export function NonceInitializeDetailsCard(props: {
       index={index}
       result={result}
       title="Initialize Nonce"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/NonceWithdrawDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/NonceWithdrawDetailsCard.tsx
@@ -14,8 +14,10 @@ export function NonceWithdrawDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: WithdrawNonceInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
     <InstructionCard
@@ -23,6 +25,8 @@ export function NonceWithdrawDetailsCard(props: {
       index={index}
       result={result}
       title="Withdraw Nonce"
+      innerCards={innerCards}
+      childIndex={childIndex}
     >
       <tr>
         <td>Program</td>

--- a/explorer/src/components/instruction/system/SystemDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/SystemDetailsCard.tsx
@@ -39,6 +39,8 @@ type DetailsProps = {
   ix: ParsedInstruction;
   result: SignatureResult;
   index: number;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 };
 
 export function SystemDetailsCard(props: DetailsProps) {

--- a/explorer/src/components/instruction/system/TransferDetailsCard.tsx
+++ b/explorer/src/components/instruction/system/TransferDetailsCard.tsx
@@ -14,11 +14,20 @@ export function TransferDetailsCard(props: {
   index: number;
   result: SignatureResult;
   info: TransferInfo;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 }) {
-  const { ix, index, result, info } = props;
+  const { ix, index, result, info, innerCards, childIndex } = props;
 
   return (
-    <InstructionCard ix={ix} index={index} result={result} title="Transfer">
+    <InstructionCard
+      ix={ix}
+      index={index}
+      result={result}
+      title="Transfer"
+      innerCards={innerCards}
+      childIndex={childIndex}
+    >
       <tr>
         <td>Program</td>
         <td className="text-lg-right">

--- a/explorer/src/components/instruction/token-swap/types.ts
+++ b/explorer/src/components/instruction/token-swap/types.ts
@@ -14,7 +14,7 @@ export const PROGRAM_IDS: string[] = [
 
 const INSTRUCTION_LOOKUP: { [key: number]: string } = {
   0: "Initialize Swap",
-  1: "Swap",
+  1: "Exchange",
   2: "Deposit",
   3: "Withdraw",
 };

--- a/explorer/src/components/instruction/token/TokenDetailsCard.tsx
+++ b/explorer/src/components/instruction/token/TokenDetailsCard.tsx
@@ -32,6 +32,8 @@ type DetailsProps = {
   ix: ParsedInstruction;
   result: SignatureResult;
   index: number;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 };
 
 export function TokenDetailsCard(props: DetailsProps) {
@@ -56,6 +58,8 @@ type InfoProps = {
   result: SignatureResult;
   index: number;
   title: string;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
 };
 
 function TokenInstruction(props: InfoProps) {
@@ -195,6 +199,8 @@ function TokenInstruction(props: InfoProps) {
       index={props.index}
       result={props.result}
       title={props.title}
+      innerCards={props.innerCards}
+      childIndex={props.childIndex}
     >
       {attributes}
     </InstructionCard>

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -6,7 +6,7 @@ import {
   useTransactionDetails,
 } from "providers/transactions";
 import { useFetchTransactionDetails } from "providers/transactions/details";
-import { useCluster, ClusterStatus } from "providers/cluster";
+import { useCluster, ClusterStatus, Cluster } from "providers/cluster";
 import {
   TransactionSignature,
   SystemProgram,
@@ -409,6 +409,7 @@ function AccountsCard({
 function InstructionsSection({ signature }: SignatureProps) {
   const status = useTransactionStatus(signature);
   const details = useTransactionDetails(signature);
+  const { cluster } = useCluster();
   const fetchDetails = useFetchTransactionDetails();
   const refreshDetails = () => fetchDetails(signature);
 
@@ -428,8 +429,9 @@ function InstructionsSection({ signature }: SignatureProps) {
   } = {};
 
   if (
-    details.data.transaction.slot >= INNER_INSTRUCTIONS_SLOT &&
-    meta?.innerInstructions
+    meta?.innerInstructions &&
+    (cluster !== Cluster.MainnetBeta ||
+      details.data.transaction.slot >= INNER_INSTRUCTIONS_SLOT)
   ) {
     meta.innerInstructions.forEach((parsed: ParsedInnerInstruction) => {
       if (!innerInstructions[parsed.index]) {

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -16,6 +16,7 @@ import {
   SignatureResult,
   ParsedTransaction,
   ParsedInnerInstruction,
+  Transaction,
 } from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
 import { lamportsToSolString } from "utils";
@@ -462,6 +463,7 @@ function InstructionsSection({ signature }: SignatureProps) {
             signature,
             tx: transaction,
             childIndex,
+            raw,
           });
 
           innerCards.push(res);
@@ -475,6 +477,7 @@ function InstructionsSection({ signature }: SignatureProps) {
         signature,
         tx: transaction,
         innerCards,
+        raw,
       });
     }
   );
@@ -529,6 +532,7 @@ function renderInstructionCard({
   signature,
   innerCards,
   childIndex,
+  raw,
 }: {
   ix: ParsedInstruction | PartiallyDecodedInstruction;
   tx: ParsedTransaction;
@@ -537,6 +541,7 @@ function renderInstructionCard({
   signature: TransactionSignature;
   innerCards?: JSX.Element[];
   childIndex?: number;
+  raw?: Transaction;
 }) {
   const key = `${index}-${childIndex}`;
 

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -42,7 +42,7 @@ import { MemoDetailsCard } from "components/instruction/MemoDetailsCard";
 
 const AUTO_REFRESH_INTERVAL = 2000;
 const ZERO_CONFIRMATION_BAILOUT = 5;
-export const INNER_INSTRUCTIONS_SLOT = 46915769;
+export const INNER_INSTRUCTIONS_START_SLOT = 46915769;
 
 type SignatureProps = {
   signature: TransactionSignature;
@@ -424,14 +424,14 @@ function InstructionsSection({ signature }: SignatureProps) {
     return <ErrorCard retry={refreshDetails} text="No instructions found" />;
   }
 
-  let innerInstructions: {
+  const innerInstructions: {
     [index: number]: (ParsedInstruction | PartiallyDecodedInstruction)[];
   } = {};
 
   if (
     meta?.innerInstructions &&
     (cluster !== Cluster.MainnetBeta ||
-      details.data.transaction.slot >= INNER_INSTRUCTIONS_SLOT)
+      details.data.transaction.slot >= INNER_INSTRUCTIONS_START_SLOT)
   ) {
     meta.innerInstructions.forEach((parsed: ParsedInnerInstruction) => {
       if (!innerInstructions[parsed.index]) {

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -455,7 +455,7 @@ function InstructionsSection({ signature }: SignatureProps) {
             ix.programId = new PublicKey(ix.programId);
           }
 
-          let res = RenderInstruction({
+          let res = renderInstructionCard({
             index,
             ix,
             result,
@@ -468,7 +468,7 @@ function InstructionsSection({ signature }: SignatureProps) {
         });
       }
 
-      return RenderInstruction({
+      return renderInstructionCard({
         index,
         ix: instruction,
         result,
@@ -521,7 +521,7 @@ function ProgramLogSection({ signature }: SignatureProps) {
   );
 }
 
-function RenderInstruction({
+function renderInstructionCard({
   ix,
   tx,
   result,

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -42,6 +42,7 @@ import { MemoDetailsCard } from "components/instruction/MemoDetailsCard";
 
 const AUTO_REFRESH_INTERVAL = 2000;
 const ZERO_CONFIRMATION_BAILOUT = 5;
+const INNER_INSTRUCTIONS_SLOT = 46915769;
 
 type SignatureProps = {
   signature: TransactionSignature;
@@ -426,7 +427,10 @@ function InstructionsSection({ signature }: SignatureProps) {
     [index: number]: (ParsedInstruction | PartiallyDecodedInstruction)[];
   } = {};
 
-  if (meta?.innerInstructions) {
+  if (
+    details.data.transaction.slot >= INNER_INSTRUCTIONS_SLOT &&
+    meta?.innerInstructions
+  ) {
     meta.innerInstructions.forEach((parsed: ParsedInnerInstruction) => {
       if (!innerInstructions[parsed.index]) {
         innerInstructions[parsed.index] = [];

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -42,7 +42,7 @@ import { MemoDetailsCard } from "components/instruction/MemoDetailsCard";
 
 const AUTO_REFRESH_INTERVAL = 2000;
 const ZERO_CONFIRMATION_BAILOUT = 5;
-const INNER_INSTRUCTIONS_SLOT = 46915769;
+export const INNER_INSTRUCTIONS_SLOT = 46915769;
 
 type SignatureProps = {
   signature: TransactionSignature;

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -258,6 +258,14 @@ ul.tree li:last-child:before {
 
 div.inner-cards {
   margin: 1.5rem;
+
+  .card {
+    background-color: $gray-700-dark;
+  }
+
+  .table td {
+    border-top: 1px solid $gray-800-dark;
+  }
 }
 
 // work around for https://github.com/JedWatson/react-select/issues/3857

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -256,6 +256,10 @@ ul.tree li:last-child:before {
   border-left: thin solid #808080;
 }
 
+div.inner-cards {
+  margin: 1.5rem;
+}
+
 // work around for https://github.com/JedWatson/react-select/issues/3857
 .search-bar__input {
   width: 100% !important;

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -193,6 +193,18 @@ h4.slot-pill {
   height: 24px;
 }
 
+.forced-truncate {
+  .address-truncate {
+    max-width: 180px;
+    display: inline-block;
+    vertical-align: bottom;
+
+    @include media-breakpoint-down(sm) {
+      max-width: 120px;
+    }
+  }
+}
+
 .address-truncate {
   @include media-breakpoint-down(md) {
     max-width: 180px;
@@ -203,6 +215,41 @@ h4.slot-pill {
   @include media-breakpoint-down(sm) {
     max-width: 120px;
   }
+}
+
+p.tree,
+ul.tree,
+ul.tree ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+ul.tree ul {
+  margin-left: 1.0em;
+}
+
+ul.tree li {
+  margin-left: 0.35em;
+  border-left: thin solid #808080;
+}
+
+ul.tree li:last-child {
+  border-left: none;
+}
+
+ul.tree li:before {
+  width: 1.4em;
+  height: 0.6em;
+  margin-right: 0.1em;
+  vertical-align: top;
+  border-bottom: thin solid #808080;
+  content: "";
+  display: inline-block;
+}
+
+ul.tree li:last-child:before {
+  border-left: thin solid #808080;
 }
 
 // work around for https://github.com/JedWatson/react-select/issues/3857

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -225,6 +225,10 @@ ul.tree ul {
   padding: 0;
 }
 
+p.tree span.c-pointer {
+  color: $primary-dark;
+}
+
 ul.tree ul {
   margin-left: 1.0em;
 }

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -205,7 +205,7 @@ h4.slot-pill {
   }
 }
 
-.address-truncate {
+.address-truncate, .signature-truncate {
   @include media-breakpoint-down(md) {
     max-width: 180px;
     display: inline-block;

--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -12,6 +12,8 @@ import {
   ParsedTransaction,
   TransactionInstruction,
   Transaction,
+  PartiallyDecodedInstruction,
+  ParsedInstruction,
 } from "@solana/web3.js";
 import { TokenRegistry } from "tokenRegistry";
 import { Cluster } from "providers/cluster";
@@ -79,10 +81,9 @@ export function displayAddress(address: string, cluster: Cluster): string {
 
 export function intoTransactionInstruction(
   tx: ParsedTransaction,
-  index: number
+  instruction: ParsedInstruction | PartiallyDecodedInstruction
 ): TransactionInstruction | undefined {
   const message = tx.message;
-  const instruction = message.instructions[index];
   if ("parsed" in instruction) return;
 
   const keys = [];


### PR DESCRIPTION
#### Problem
Beyond displaying the instructions in the transaction message, we should also display which CPI's were called by each transaction instruction.

#### Summary of Changes
- Displays inner instructions within outer card.
- Render inner token instructions on token history page and allow user to toggle if they're shown or not.

Fixes https://github.com/solana-labs/solana/issues/11754, https://github.com/solana-labs/solana/issues/11935