### PR TITLE
TestValidator public interface cleanup

### DIFF
--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -33,7 +33,7 @@ fn test_cli_deploy_program() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
 
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -30,7 +30,7 @@ fn test_nonce() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
 
     full_battery_tests(leader_data, alice, None, false);
 
@@ -46,7 +46,7 @@ fn test_nonce_with_seed() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
 
     full_battery_tests(leader_data, alice, Some(String::from("seed")), false);
 
@@ -62,7 +62,7 @@ fn test_nonce_with_authority() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
 
     full_battery_tests(leader_data, alice, None, true);
 
@@ -238,7 +238,7 @@ fn test_create_account_with_seed() {
         alice: mint_keypair,
         ledger_path,
         ..
-    } = TestValidator::run_with_fees(1);
+    } = TestValidator::with_custom_fee(1);
 
     let (sender, receiver) = channel();
     run_local_faucet(mint_keypair, sender, None);

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -13,7 +13,7 @@ fn test_cli_request_airdrop() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -32,7 +32,7 @@ fn test_stake_delegation_force() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -129,7 +129,7 @@ fn test_seed_stake_delegation_and_deactivation() {
         ledger_path,
         vote_pubkey,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -218,7 +218,7 @@ fn test_stake_delegation_and_deactivation() {
         ledger_path,
         vote_pubkey,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -303,7 +303,7 @@ fn test_offline_stake_delegation_and_deactivation() {
         ledger_path,
         vote_pubkey,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -446,7 +446,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
         ledger_path,
         vote_pubkey,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -568,7 +568,7 @@ fn test_stake_authorize() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -848,7 +848,7 @@ fn test_stake_authorize_with_fee_payer() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run_with_fees(SIG_FEE);
+    } = TestValidator::with_custom_fee(SIG_FEE);
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -981,7 +981,7 @@ fn test_stake_split() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run_with_fees(1);
+    } = TestValidator::with_custom_fee(1);
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -1132,7 +1132,7 @@ fn test_stake_set_lockup() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run_with_fees(1);
+    } = TestValidator::with_custom_fee(1);
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();
@@ -1401,7 +1401,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -28,7 +28,7 @@ fn test_transfer() {
         alice: mint_keypair,
         ledger_path,
         ..
-    } = TestValidator::run_with_fees(1);
+    } = TestValidator::with_custom_fee(1);
 
     let (sender, receiver) = channel();
     run_local_faucet(mint_keypair, sender, None);
@@ -256,7 +256,7 @@ fn test_transfer_multisession_signing() {
         alice: mint_keypair,
         ledger_path,
         ..
-    } = TestValidator::run_with_fees(1);
+    } = TestValidator::with_custom_fee(1);
 
     let (sender, receiver) = channel();
     run_local_faucet(mint_keypair, sender, None);
@@ -383,7 +383,7 @@ fn test_transfer_all() {
         alice: mint_keypair,
         ledger_path,
         ..
-    } = TestValidator::run_with_fees(1);
+    } = TestValidator::with_custom_fee(1);
 
     let (sender, receiver) = channel();
     run_local_faucet(mint_keypair, sender, None);

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -25,7 +25,7 @@ fn test_vote_authorize_and_withdraw() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let (sender, receiver) = channel();
     run_local_faucet(alice, sender, None);
     let faucet_addr = receiver.recv().unwrap();

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -1,21 +1,20 @@
-use crate::{
-    cluster_info::Node,
-    contact_info::ContactInfo,
-    gossip_service::discover_cluster,
-    validator::{Validator, ValidatorConfig},
+use {
+    crate::{
+        cluster_info::Node,
+        contact_info::ContactInfo,
+        gossip_service::discover_cluster,
+        validator::{Validator, ValidatorConfig},
+    },
+    solana_ledger::create_new_tmp_ledger,
+    solana_sdk::{
+        fee_calculator::FeeRateGovernor,
+        hash::Hash,
+        native_token::sol_to_lamports,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+    },
+    std::{path::PathBuf, sync::Arc},
 };
-use solana_ledger::create_new_tmp_ledger;
-use solana_runtime::genesis_utils::{
-    bootstrap_validator_stake_lamports, BOOTSTRAP_VALIDATOR_LAMPORTS,
-};
-use solana_sdk::{
-    clock::DEFAULT_DEV_SLOTS_PER_EPOCH,
-    hash::Hash,
-    native_token::sol_to_lamports,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-};
-use std::{path::PathBuf, sync::Arc};
 
 pub struct TestValidator {
     pub server: Validator,
@@ -26,66 +25,53 @@ pub struct TestValidator {
     pub vote_pubkey: Pubkey,
 }
 
-pub struct TestValidatorOptions {
-    pub fees: u64,
-    pub bootstrap_validator_lamports: u64,
-    pub mint_lamports: u64,
+struct TestValidatorConfig {
+    fee_rate_governor: FeeRateGovernor,
+    validator_identity_lamports: u64,
+    validator_stake_lamports: u64,
+    mint_lamports: u64,
 }
 
-impl Default for TestValidatorOptions {
+impl Default for TestValidatorConfig {
     fn default() -> Self {
-        TestValidatorOptions {
-            fees: 0,
-            bootstrap_validator_lamports: BOOTSTRAP_VALIDATOR_LAMPORTS,
-            mint_lamports: sol_to_lamports(1_000_000.0),
+        TestValidatorConfig {
+            fee_rate_governor: FeeRateGovernor::new(0, 0),
+            validator_identity_lamports: sol_to_lamports(500.),
+            validator_stake_lamports: sol_to_lamports(1.),
+            mint_lamports: sol_to_lamports(500_000_000.),
         }
     }
 }
 
 impl TestValidator {
-    pub fn run() -> Self {
-        Self::run_with_options(TestValidatorOptions::default())
-    }
-
-    /// Instantiates a TestValidator with custom fees. The bootstrap_validator_lamports will
-    /// default to enough to cover 1 epoch of votes. This is an abitrary value based on current and
-    /// foreseen uses of TestValidator. May need to be bumped if uses change in the future.
-    pub fn run_with_fees(fees: u64) -> Self {
-        let bootstrap_validator_lamports = fees * DEFAULT_DEV_SLOTS_PER_EPOCH * 5;
-        Self::run_with_options(TestValidatorOptions {
-            fees,
-            bootstrap_validator_lamports,
-            ..TestValidatorOptions::default()
+    pub fn with_no_fee() -> Self {
+        Self::new(TestValidatorConfig {
+            fee_rate_governor: FeeRateGovernor::new(0, 0),
+            ..TestValidatorConfig::default()
         })
     }
 
-    /// Instantiates a TestValidator with completely customized options.
-    ///
-    /// Note: if `fees` are non-zero, be sure to set a value for `bootstrap_validator_lamports`
-    /// that can cover enough vote transaction fees for the test. TestValidatorOptions::default()
-    /// may not be sufficient.
-    pub fn run_with_options(options: TestValidatorOptions) -> Self {
+    pub fn with_custom_fee(target_lamports_per_signature: u64) -> Self {
+        Self::new(TestValidatorConfig {
+            fee_rate_governor: FeeRateGovernor::new(target_lamports_per_signature, 0),
+            ..TestValidatorConfig::default()
+        })
+    }
+
+    fn new(config: TestValidatorConfig) -> Self {
         use solana_ledger::genesis_utils::{
             create_genesis_config_with_leader_ex, GenesisConfigInfo,
         };
-        use solana_sdk::fee_calculator::FeeRateGovernor;
 
-        let TestValidatorOptions {
-            fees,
-            bootstrap_validator_lamports,
+        let TestValidatorConfig {
+            fee_rate_governor,
+            validator_identity_lamports,
+            validator_stake_lamports,
             mint_lamports,
-        } = options;
+        } = config;
         let node_keypair = Arc::new(Keypair::new());
         let node = Node::new_localhost_with_pubkey(&node_keypair.pubkey());
         let contact_info = node.info.clone();
-
-        if fees > 0 && bootstrap_validator_lamports < fees * DEFAULT_DEV_SLOTS_PER_EPOCH {
-            warn!(
-                "TestValidator::bootstrap_validator_lamports less than one epoch. \
-                Only enough to cover {:?} slots",
-                bootstrap_validator_lamports / fees
-            );
-        }
 
         let GenesisConfigInfo {
             mut genesis_config,
@@ -96,13 +82,13 @@ impl TestValidator {
             &contact_info.id,
             &Keypair::new(),
             &solana_sdk::pubkey::new_rand(),
-            bootstrap_validator_stake_lamports(),
-            bootstrap_validator_lamports,
+            validator_stake_lamports,
+            validator_identity_lamports,
             solana_sdk::genesis_config::ClusterType::Development,
         );
         genesis_config.rent.lamports_per_byte_year = 1;
         genesis_config.rent.exemption_threshold = 1.0;
-        genesis_config.fee_rate_governor = FeeRateGovernor::new(fees, 0);
+        genesis_config.fee_rate_governor = fee_rate_governor;
 
         let (ledger_path, blockhash) = create_new_tmp_ledger!(&genesis_config);
 

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -37,7 +37,7 @@ fn test_rpc_client() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let bob_pubkey = solana_sdk::pubkey::new_rand();
 
     let client = RpcClient::new_socket(leader_data.rpc);
@@ -51,10 +51,7 @@ fn test_rpc_client() {
 
     assert_eq!(client.get_balance(&bob_pubkey).unwrap(), 0);
 
-    assert_eq!(
-        client.get_balance(&alice.pubkey()).unwrap(),
-        sol_to_lamports(1_000_000.0)
-    );
+    let original_alice_balance = client.get_balance(&alice.pubkey()).unwrap();
 
     let (blockhash, _fee_calculator) = client.get_recent_blockhash().unwrap();
 
@@ -85,7 +82,7 @@ fn test_rpc_client() {
     );
     assert_eq!(
         client.get_balance(&alice.pubkey()).unwrap(),
-        sol_to_lamports(999_980.0)
+        original_alice_balance - sol_to_lamports(20.0)
     );
 
     server.close().unwrap();

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -62,7 +62,7 @@ fn test_rpc_send_tx() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let bob_pubkey = solana_sdk::pubkey::new_rand();
 
     let req = json_req!("getRecentBlockhash", json!([]));
@@ -127,7 +127,7 @@ fn test_rpc_invalid_requests() {
         leader_data,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
     let bob_pubkey = solana_sdk::pubkey::new_rand();
 
     // test invalid get_balance request
@@ -166,7 +166,7 @@ fn test_rpc_subscriptions() {
         ledger_path,
         genesis_hash,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
 
     let transactions_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     transactions_socket.connect(leader_data.tpu).unwrap();

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -267,7 +267,6 @@ mod tests {
         staking_utils::tests::setup_vote_and_stake_accounts,
     };
     use solana_runtime::bank::Bank;
-    use solana_runtime::genesis_utils::BOOTSTRAP_VALIDATOR_LAMPORTS;
     use solana_sdk::clock::NUM_CONSECUTIVE_LEADER_SLOTS;
     use solana_sdk::epoch_schedule::{
         EpochSchedule, DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET, DEFAULT_SLOTS_PER_EPOCH,
@@ -380,12 +379,9 @@ mod tests {
     #[test]
     fn test_next_leader_slot() {
         let pubkey = solana_sdk::pubkey::new_rand();
-        let mut genesis_config = create_genesis_config_with_leader(
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
-            &pubkey,
-            bootstrap_validator_stake_lamports(),
-        )
-        .genesis_config;
+        let mut genesis_config =
+            create_genesis_config_with_leader(42, &pubkey, bootstrap_validator_stake_lamports())
+                .genesis_config;
         genesis_config.epoch_schedule = EpochSchedule::custom(
             DEFAULT_SLOTS_PER_EPOCH,
             DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET,
@@ -433,12 +429,9 @@ mod tests {
     #[test]
     fn test_next_leader_slot_blockstore() {
         let pubkey = solana_sdk::pubkey::new_rand();
-        let mut genesis_config = create_genesis_config_with_leader(
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
-            &pubkey,
-            bootstrap_validator_stake_lamports(),
-        )
-        .genesis_config;
+        let mut genesis_config =
+            create_genesis_config_with_leader(42, &pubkey, bootstrap_validator_stake_lamports())
+                .genesis_config;
         genesis_config.epoch_schedule.warmup = false;
 
         let bank = Bank::new(&genesis_config);

--- a/ledger/src/leader_schedule_utils.rs
+++ b/ledger/src/leader_schedule_utils.rs
@@ -56,7 +56,6 @@ mod tests {
     use super::*;
     use solana_runtime::genesis_utils::{
         bootstrap_validator_stake_lamports, create_genesis_config_with_leader,
-        BOOTSTRAP_VALIDATOR_LAMPORTS,
     };
 
     #[test]
@@ -84,12 +83,9 @@ mod tests {
     #[test]
     fn test_leader_scheduler1_basic() {
         let pubkey = solana_sdk::pubkey::new_rand();
-        let genesis_config = create_genesis_config_with_leader(
-            BOOTSTRAP_VALIDATOR_LAMPORTS,
-            &pubkey,
-            bootstrap_validator_stake_lamports(),
-        )
-        .genesis_config;
+        let genesis_config =
+            create_genesis_config_with_leader(42, &pubkey, bootstrap_validator_stake_lamports())
+                .genesis_config;
         let bank = Bank::new(&genesis_config);
         assert_eq!(slot_leader_at(bank.slot(), &bank).unwrap(), pubkey);
     }

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -14,8 +14,8 @@ use solana_stake_program::stake_state::StakeState;
 use solana_vote_program::vote_state;
 use std::borrow::Borrow;
 
-// The default stake placed with the bootstrap validator
-pub const BOOTSTRAP_VALIDATOR_LAMPORTS: u64 = 42;
+// Default amount received by the bootstrap validator
+const BOOTSTRAP_VALIDATOR_LAMPORTS: u64 = 42;
 
 // fun fact: rustc is very close to make this const fn.
 pub fn bootstrap_validator_stake_lamports() -> u64 {

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -927,7 +927,7 @@ mod tests {
             alice,
             ledger_path,
             ..
-        } = TestValidator::run();
+        } = TestValidator::with_no_fee();
         let url = get_rpc_request_str(leader_data.rpc, false);
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
         test_process_distribute_tokens_with_client(&client, alice, None);
@@ -945,7 +945,7 @@ mod tests {
             alice,
             ledger_path,
             ..
-        } = TestValidator::run();
+        } = TestValidator::with_no_fee();
         let url = get_rpc_request_str(leader_data.rpc, false);
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
         test_process_distribute_tokens_with_client(&client, alice, Some(1.5));
@@ -963,7 +963,7 @@ mod tests {
             alice,
             ledger_path,
             ..
-        } = TestValidator::run();
+        } = TestValidator::with_no_fee();
         let url = get_rpc_request_str(leader_data.rpc, false);
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
         test_process_distribute_stake_with_client(&client, alice);
@@ -1270,7 +1270,7 @@ mod tests {
             alice,
             ledger_path,
             ..
-        } = TestValidator::run_with_fees(fees);
+        } = TestValidator::with_custom_fee(fees);
         let url = get_rpc_request_str(leader_data.rpc, false);
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
@@ -1372,7 +1372,7 @@ mod tests {
             alice,
             ledger_path,
             ..
-        } = TestValidator::run_with_fees(fees);
+        } = TestValidator::with_custom_fee(fees);
         let url = get_rpc_request_str(leader_data.rpc, false);
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
 
@@ -1501,7 +1501,7 @@ mod tests {
             alice,
             ledger_path,
             ..
-        } = TestValidator::run_with_fees(fees);
+        } = TestValidator::with_custom_fee(fees);
         let url = get_rpc_request_str(leader_data.rpc, false);
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
 
@@ -1622,7 +1622,7 @@ mod tests {
             alice,
             ledger_path,
             ..
-        } = TestValidator::run_with_fees(fees);
+        } = TestValidator::with_custom_fee(fees);
         let url = get_rpc_request_str(leader_data.rpc, false);
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
 

--- a/tokens/tests/commands.rs
+++ b/tokens/tests/commands.rs
@@ -12,7 +12,7 @@ fn test_process_distribute_with_rpc_client() {
         alice,
         ledger_path,
         ..
-    } = TestValidator::run();
+    } = TestValidator::with_no_fee();
 
     let client = RpcClient::new_socket(leader_data.rpc);
     test_process_distribute_tokens_with_client(&client, alice, None);


### PR DESCRIPTION
Start of some TestValidator cleanup in prep for potentially making it more client-facing and/or wrapping a `solana-test-validator` cli around it.  