### PR TITLE
Revert "hidapi 1.2.4 is broken, lock version to 1.2.3"

### DIFF
--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://solana.com/"
 base32 = "0.4.0"
 console = "0.11.3"
 dialoguer = "0.6.2"
-hidapi = { version = "=1.2.3", default-features = false }
+hidapi = { version = "1.2.3", default-features = false }
 log = "0.4.8"
 num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }


### PR DESCRIPTION
Reverts solana-labs/solana#13822

No longer needed as hidapi 1.2.4 was yanked from crates.io