### PR TITLE
Don't reset credits_observed due to stale voters

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -3454,6 +3454,33 @@ mod tests {
                 true,
             )
         );
+
+        // credis_observed isn't reset for stale vote accounts while no rewards
+        // given if the inflation is disabled
+        stake.credits_observed = 4;
+        assert_eq!(
+            Some((0, 0, 4)),
+            stake.calculate_rewards(
+                &PointValue {
+                    rewards: 0,
+                    points: 4
+                },
+                &vote_state,
+                None,
+                &mut null_tracer(),
+                true,
+            )
+        );
+
+        // assert the previous behavior is preserved where fix_stake_deactivate=false
+        assert_eq!(
+            (0, 0),
+            stake.calculate_points_and_credits(&vote_state, None, &mut null_tracer(), false)
+        );
+        assert_eq!(
+            (0, 4),
+            stake.calculate_points_and_credits(&vote_state, None, &mut null_tracer(), true)
+        );
     }
 
     #[test]

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -553,7 +553,7 @@ impl Stake {
     /// for a given stake and vote_state, calculate how many
     ///   points were earned (credits * stake) and new value
     ///   for credits_observed were the points paid
-    pub fn calculate_points_and_credits(
+    fn calculate_points_and_credits(
         &self,
         new_vote_state: &VoteState,
         stake_history: Option<&StakeHistory>,
@@ -562,7 +562,11 @@ impl Stake {
     ) -> (u128, u64) {
         // if there is no newer credits since observed, return no point
         if new_vote_state.credits() <= self.credits_observed {
-            return (0, 0);
+            if fix_stake_deactivate {
+                return (0, self.credits_observed);
+            } else {
+                return (0, 0);
+            }
         }
 
         let mut points = 0;

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -3439,7 +3439,7 @@ mod tests {
         );
 
         // now one with inflation disabled. no one gets paid, but we still need
-        // to advance the stake state's observed_credits field to prevent back-
+        // to advance the stake state's credits_observed field to prevent back-
         // paying rewards when inflation is turned on.
         assert_eq!(
             Some((0, 0, 4)),
@@ -3455,8 +3455,8 @@ mod tests {
             )
         );
 
-        // credis_observed isn't reset for stale vote accounts while no rewards
-        // given if the inflation is disabled
+        // credits_observed remains at previous level when vote_state credits are
+        // not advancing and inflation is disabled
         stake.credits_observed = 4;
         assert_eq!(
             Some((0, 0, 4)),


### PR DESCRIPTION
#### Problem

#13680 resets stake account's `credits_observed` to `0` (returned from `calculate_points_and_credits()`) for stale vote accounts. That makes the stake account is incorrectly eligible for inflation rewords:

https://github.com/solana-labs/solana/blob/0b00a1b4deef73add245d5a62b007c64bd7cd571/programs/stake/src/stake_state.rs#L625-L635

For fun fact, at the next epoch, `credits_observed` will reset back to vote's `credits`. Then, yet another next epoch, it'll be again be `0`. and so on.

So, when the inflation is activated at the odd-number after the `stake_program_v2` activation, our inflation would be skewed. On the other hand, it won't be skewed at the even-number after the activation.

#### Summary of Changes

- return current `credits_observed` value from `calculate_points_and_credits()`

todo
- [x] write a test
- [x] think about gating?

Fixes #
