### PR TITLE
Move instruction recording into MessageProcesor

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -211,7 +211,6 @@ impl program_stubs::SyscallStubs for SyscallStubs {
         INVOKE_CONTEXT.with(|invoke_context| {
             let invoke_context = invoke_context.borrow_mut();
             caller = *invoke_context.get_caller().expect("get_caller");
-            invoke_context.record_instruction(&instruction);
 
             mock_invoke_context.programs = invoke_context.get_programs().to_vec();
             // TODO: Populate MockInvokeContext more, or rework to avoid MockInvokeContext entirely.

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1367,7 +1367,6 @@ fn call<'a>(
         memory_mapping,
     )?;
     verify_instruction(syscall, &instruction, &signers)?;
-    invoke_context.record_instruction(&instruction);
     let message = Message::new(&[instruction], None);
     let callee_program_id_index = message.instructions[0].program_id_index as usize;
     let callee_program_id = message.account_keys[callee_program_id_index];

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2523,15 +2523,14 @@ impl Bank {
             });
     }
 
-    fn compile_recorded_instructions(
+    fn collect_recorded_instructions(
         inner_instructions: &mut Vec<Option<InnerInstructionsList>>,
         instruction_recorders: Option<Vec<InstructionRecorder>>,
-        message: &Message,
     ) {
         inner_instructions.push(instruction_recorders.map(|instruction_recorders| {
             instruction_recorders
                 .into_iter()
-                .map(|r| r.compile_instructions(message))
+                .map(|r| r.into_inner())
                 .collect()
         }));
     }
@@ -2696,10 +2695,9 @@ impl Bank {
                         transaction_log_messages.push(log_messages);
                     }
 
-                    Self::compile_recorded_instructions(
+                    Self::collect_recorded_instructions(
                         &mut inner_instructions,
                         instruction_recorders,
-                        &tx.message,
                     );
 
                     Self::refcells_to_accounts(

--- a/runtime/src/instruction_recorder.rs
+++ b/runtime/src/instruction_recorder.rs
@@ -1,26 +1,19 @@
 use std::{cell::RefCell, rc::Rc};
 
-use solana_sdk::{
-    instruction::{CompiledInstruction, Instruction},
-    message::Message,
-};
+use solana_sdk::instruction::CompiledInstruction;
 
 /// Records and compiles cross-program invoked instructions
 #[derive(Clone, Default)]
 pub struct InstructionRecorder {
-    inner: Rc<RefCell<Vec<Instruction>>>,
+    inner: Rc<RefCell<Vec<CompiledInstruction>>>,
 }
 
 impl InstructionRecorder {
-    pub fn compile_instructions(&self, message: &Message) -> Vec<CompiledInstruction> {
-        self.inner
-            .borrow()
-            .iter()
-            .map(|ix| message.compile_instruction(ix))
-            .collect()
+    pub(crate) fn into_inner(self) -> Vec<CompiledInstruction> {
+        std::mem::take(&mut self.inner.borrow_mut())
     }
 
-    pub fn record_instruction(&self, instruction: Instruction) {
+    pub fn record_instruction(&self, instruction: CompiledInstruction) {
         self.inner.borrow_mut().push(instruction);
     }
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -8,7 +8,7 @@ use solana_sdk::{
     account::Account,
     clock::Epoch,
     feature_set::{instructions_sysvar_enabled, FeatureSet},
-    instruction::{CompiledInstruction, Instruction, InstructionError},
+    instruction::{CompiledInstruction, InstructionError},
     keyed_account::{create_keyed_readonly_accounts, KeyedAccount},
     message::Message,
     native_loader,
@@ -300,7 +300,7 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
     fn get_executor(&self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         self.executors.borrow().get(&pubkey)
     }
-    fn record_instruction(&self, instruction: &Instruction) {
+    fn record_instruction(&self, instruction: &CompiledInstruction) {
         if let Some(recorder) = &self.instruction_recorder {
             recorder.record_instruction(instruction.clone());
         }
@@ -499,6 +499,8 @@ impl MessageProcessor {
         if let Some(instruction) = message.instructions.get(0) {
             // Verify the calling program hasn't misbehaved
             invoke_context.verify_and_update(message, instruction, accounts)?;
+
+            invoke_context.record_instruction(&instruction);
 
             // Construct keyed accounts
             let keyed_accounts =

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -4,7 +4,7 @@ use solana_sdk::{
         bpf_compute_budget_balancing, max_invoke_depth_4, max_program_call_depth_64,
         pubkey_log_syscall_enabled, FeatureSet,
     },
-    instruction::{CompiledInstruction, Instruction, InstructionError},
+    instruction::{CompiledInstruction, InstructionError},
     keyed_account::KeyedAccount,
     message::Message,
     pubkey::Pubkey,
@@ -58,7 +58,7 @@ pub trait InvokeContext {
     /// Get the completed loader work that can be re-used across executions
     fn get_executor(&self, pubkey: &Pubkey) -> Option<Arc<dyn Executor>>;
     /// Record invoked instruction
-    fn record_instruction(&self, instruction: &Instruction);
+    fn record_instruction(&self, instruction: &CompiledInstruction);
     /// Get the bank's active feature set
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
 }
@@ -335,7 +335,7 @@ impl InvokeContext for MockInvokeContext {
     fn get_executor(&self, _pubkey: &Pubkey) -> Option<Arc<dyn Executor>> {
         None
     }
-    fn record_instruction(&self, _instruction: &Instruction) {}
+    fn record_instruction(&self, _instruction: &CompiledInstruction) {}
     fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
         true
     }


### PR DESCRIPTION
Inner instruction recording was way out in `programs/bpf_loader/src/syscalls.rs` when it really belongs in `runtime/src/message_processor.rs`.  This removes duplication across syscall implementations, avoids the need to recompile inner instructions, and ensures the inner instructions are fully validated before recording them.