### PR TITLE
Groom solana-watchtower

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5148,9 +5148,7 @@ dependencies = [
  "solana-metrics",
  "solana-notifier",
  "solana-sdk",
- "solana-transaction-status",
  "solana-version",
- "solana-vote-program",
 ]
 
 [[package]]

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -20,13 +20,7 @@ solana-logger = { path = "../logger", version = "1.5.0" }
 solana-metrics = { path = "../metrics", version = "1.5.0" }
 solana-notifier = { path = "../notifier", version = "1.5.0" }
 solana-sdk = { path = "../sdk", version = "1.5.0" }
-solana-transaction-status = { path = "../transaction-status", version = "1.5.0" }
 solana-version = { path = "../version", version = "1.5.0" }
-solana-vote-program = { path = "../programs/vote", version = "1.5.0" }
-
-[[bin]]
-name = "solana-watchtower"
-path = "src/main.rs"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
* Remove --notify-on-transaction support. It's not longer useful due to the volume of transactions on mainnet-beta and there are now other means of monitoring transactions
* Remove support to monitor all validators in a cluster for delinquency. This feature is no longer useful with hundreds of validators.
* Perform all RPC activity in the same place, also clean up Sol display
* Add --unhealthy_threshold option, which configures now many consecutive failures must occur to trigger a notification (default: 1)
