### PR TITLE
add zsh trouble shooting note to ledger docs

### DIFF
--- a/docs/src/wallet-guide/hardware-wallets/ledger.md
+++ b/docs/src/wallet-guide/hardware-wallets/ledger.md
@@ -55,6 +55,9 @@ solana-keygen pubkey usb://ledger?key=1
 solana-keygen pubkey usb://ledger?key=2
 ```
 
+* NOTE: keypair url parameters are ignored in **zsh**
+&nbsp;[see troubleshooting for more info](#troubleshooting)
+
 You can use other values for the number after `key=` as well.
 Any of the addresses displayed by these commands are valid Solana wallet
 addresses. The private portion associated with each address is stored securely


### PR DESCRIPTION
#### Problem

First use of the Ledger wallet with the CLI running in **zsh** following the docs will error. There is great troubleshooting information but it may be missed on first glance if stepping through the documenation.
 
#### Summary of Changes

Added a foot note below the first code example to call attention to the troubleshooting documentation for **zsh** users.
