### PR TITLE
Explorer: add Raw instruction data to parsed instructions

### DIFF
--- a/explorer/src/components/instruction/RawParsedDetails.tsx
+++ b/explorer/src/components/instruction/RawParsedDetails.tsx
@@ -1,8 +1,21 @@
 import React from "react";
-import { ParsedInstruction } from "@solana/web3.js";
+import { ParsedInstruction, TransactionInstruction } from "@solana/web3.js";
 import { Address } from "components/common/Address";
+import { wrap } from "utils";
 
-export function RawParsedDetails({ ix }: { ix: ParsedInstruction }) {
+type RawParsedDetailsProps = {
+  ix: ParsedInstruction;
+  raw?: TransactionInstruction;
+};
+
+export function RawParsedDetails({ ix, raw }: RawParsedDetailsProps) {
+  let hex = null;
+  let b64 = null;
+  if (raw) {
+    hex = wrap(raw.data.toString("hex"), 50);
+    b64 = wrap(raw.data.toString("base64"), 50);
+  }
+
   return (
     <>
       <tr>
@@ -11,6 +24,24 @@ export function RawParsedDetails({ ix }: { ix: ParsedInstruction }) {
           <Address pubkey={ix.programId} alignRight link />
         </td>
       </tr>
+
+      {hex ? (
+        <tr>
+          <td>Instruction Data (Hex)</td>
+          <td className="text-lg-right">
+            <pre className="d-inline-block text-left mb-0">{hex}</pre>
+          </td>
+        </tr>
+      ) : null}
+
+      {b64 ? (
+        <tr>
+          <td>Instruction Data (Base64)</td>
+          <td className="text-lg-right">
+            <pre className="d-inline-block text-left mb-0">{b64}</pre>
+          </td>
+        </tr>
+      ) : null}
 
       <tr>
         <td>Instruction Data (JSON)</td>

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -41,6 +41,8 @@ type SignatureProps = {
   signature: TransactionSignature;
 };
 
+export const SignatureContext = React.createContext("");
+
 enum AutoRefresh {
   Active,
   Inactive,
@@ -107,7 +109,9 @@ export function TransactionDetailsPage({ signature: raw }: SignatureProps) {
         <>
           <StatusCard signature={signature} autoRefresh={autoRefresh} />
           <AccountsCard signature={signature} autoRefresh={autoRefresh} />
-          <InstructionsSection signature={signature} />
+          <SignatureContext.Provider value={signature}>
+            <InstructionsSection signature={signature} />
+          </SignatureContext.Provider>
           <ProgramLogSection signature={signature} />
         </>
       )}
@@ -400,6 +404,8 @@ function InstructionsSection({ signature }: SignatureProps) {
 
   if (!status?.data?.info || !details?.data?.transaction) return null;
 
+  const raw = details.data.raw?.transaction;
+
   const { transaction } = details.data.transaction;
   if (transaction.message.instructions.length === 0) {
     return <ErrorCard retry={refreshDetails} text="No instructions found" />;
@@ -460,7 +466,12 @@ function InstructionsSection({ signature }: SignatureProps) {
               />
             );
           default:
-            const props = { ix: next, result, index };
+            const props = {
+              ix: next,
+              result,
+              index,
+              raw: raw?.instructions[index],
+            };
             return <UnknownDetailsCard key={index} {...props} />;
         }
       }


### PR DESCRIPTION
#### Problem
The transaction Instruction UI  does not contain the raw instruction data. Users have requested access to the raw instruction data for debugging purposes. The current payload delivered to the UI only has a JSON representation of the instruction.

This issue was much deeper than expected. The transaction detail page is populated with a RPC call to `getParsedConfirmedTransaction` this RPC method is not documented on the [JSON RPC API](https://docs.solana.com/developing/clients/jsonrpc-api#json-rpc-api-reference) `getParsedConfirmedTransaction` only has a "parsed" JSON representation of the raw transaction instruction. I assume this was developed as an optimization for network bandwidth or something. 

The alternative RPC method `getConfirmedTransaction` includes the raw source data. There are[ some strange code paths around this feature](https://github.com/solana-labs/solana/blob/master/explorer/src/components/instruction/InstructionCard.tsx#L54-L62) There appears to be branching logic and display components for `RawParsedDetails` and `RawDetails`.  It's not clear to me when or if ever `RawDetails` gets rendered.  `RawParsedDetails` does not really render 'raw' details because the 'parsed' RPC payload never includes them. 


#### Summary of Changes
When the user clicks the "raw" button a request is made for the raw transaction details. This unfortunately fetches the entire raw transaction payload with all instructions. Luckily It is cached and all instructions now have their raw data sets.  Ideally I think a specific RPC method to fetch the raw TransactionInstruction records would be an optimization here. 


Adds a fetch action to the click event of the "raw" button on the
instruction UI. adds a `fetchRawTransaction` hook that is passed down to the
instruction UI components. Adds new `rawFetchTrigger` and `raw`
props passed to the instruction card components.

Fixes #12758

![solana-raw](https://user-images.githubusercontent.com/126209/100566478-05868400-327b-11eb-85b2-6f00b063e2ca.gif)



