### PR TITLE
Fixes potential crash in slice translation of BPF syscalls.

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -313,7 +313,7 @@ fn translate_slice_mut<'a, T>(
             memory_mapping,
             access_type,
             vm_addr,
-            len * size_of::<T>() as u64,
+            len.saturating_mul(size_of::<T>() as u64),
             loader_id,
         ) {
             Ok(value) => Ok(unsafe { from_raw_parts_mut(value as *mut T, len as usize) }),


### PR DESCRIPTION
#### Problem
I accidentally reverted #13624 in #13732 while refactoring `translate_slice_mut`.

#### Summary of Changes
Replaces panicking multiplication by `saturating_mul`.

Fixes #
