### PR TITLE
Add `flatten` to logs_subscribe commitment

### DIFF
--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -82,6 +82,7 @@ pub enum RpcTransactionLogsFilter {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransactionLogsConfig {
+    #[serde(flatten)]
     pub commitment: Option<CommitmentConfig>,
 }
 


### PR DESCRIPTION
#### Problem

Currently, commitment for `logs_subscribe` must be specified using the
non-flattened form in JSON, ie `{"commitment":{"commitment":"max}}`.

#### Summary of Changes

Bring commitment in line with documentation by specifying `flatten`

Fixes #
