### PR TITLE
Cleanup bpf test's Cargo.toml files

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1924,7 +1924,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-bpf-rust-deprecated_loader"
+name = "solana-bpf-rust-deprecated-loader"
 version = "1.5.0"
 dependencies = [
  "solana-program",

--- a/programs/bpf/rust/128bit/Cargo.toml
+++ b/programs/bpf/rust/128bit/Cargo.toml
@@ -13,7 +13,6 @@ solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 solana-bpf-rust-128bit-dep = { path = "../128bit_dep", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_128bit"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/alloc/Cargo.toml
+++ b/programs/bpf/rust/alloc/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_alloc"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/call_depth/Cargo.toml
+++ b/programs/bpf/rust/call_depth/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_call_depth"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/custom_heap/Cargo.toml
+++ b/programs/bpf/rust/custom_heap/Cargo.toml
@@ -16,7 +16,6 @@ default = ["custom-heap"]
 custom-heap = []
 
 [lib]
-name = "solana_bpf_rust_custom_heap"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/dep_crate/Cargo.toml
+++ b/programs/bpf/rust/dep_crate/Cargo.toml
@@ -13,7 +13,6 @@ byteorder = { version = "1", default-features = false }
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_dep_crate"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/deprecated_loader/Cargo.toml
+++ b/programs/bpf/rust/deprecated_loader/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "solana-bpf-rust-deprecated_loader"
+name = "solana-bpf-rust-deprecated-loader"
 version = "1.5.0"
 description = "Solana BPF test program written in Rust"
 authors = ["Solana Maintainers <maintainers@solana.foundation>"]
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_deprecated_loader"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/dup_accounts/Cargo.toml
+++ b/programs/bpf/rust/dup_accounts/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_dup_accounts"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/error_handling/Cargo.toml
+++ b/programs/bpf/rust/error_handling/Cargo.toml
@@ -15,7 +15,6 @@ solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 thiserror = "1.0"
 
 [lib]
-name = "solana_bpf_rust_error_handling"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/external_spend/Cargo.toml
+++ b/programs/bpf/rust/external_spend/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_external_spend"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/instruction_introspection/Cargo.toml
+++ b/programs/bpf/rust/instruction_introspection/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_instruction_introspection"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/invoke/Cargo.toml
+++ b/programs/bpf/rust/invoke/Cargo.toml
@@ -13,7 +13,6 @@ solana-bpf-rust-invoked = { path = "../invoked", default-features = false }
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_invoke"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/invoked/Cargo.toml
+++ b/programs/bpf/rust/invoked/Cargo.toml
@@ -1,5 +1,3 @@
-
-
 [package]
 name = "solana-bpf-rust-invoked"
 version = "1.5.0"
@@ -18,7 +16,6 @@ default = ["program"]
 program = []
 
 [lib]
-name = "solana_bpf_rust_invoked"
 crate-type = ["lib", "cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/iter/Cargo.toml
+++ b/programs/bpf/rust/iter/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_iter"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/many_args/Cargo.toml
+++ b/programs/bpf/rust/many_args/Cargo.toml
@@ -13,7 +13,6 @@ solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 solana-bpf-rust-many-args-dep = { path = "../many_args_dep", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_many_args"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/mem/Cargo.toml
+++ b/programs/bpf/rust/mem/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_mem"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/noop/Cargo.toml
+++ b/programs/bpf/rust/noop/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_noop"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/panic/Cargo.toml
+++ b/programs/bpf/rust/panic/Cargo.toml
@@ -16,7 +16,6 @@ default = ["custom-panic"]
 custom-panic = []
 
 [lib]
-name = "solana_bpf_rust_panic"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/param_passing/Cargo.toml
+++ b/programs/bpf/rust/param_passing/Cargo.toml
@@ -13,7 +13,6 @@ solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 solana-bpf-rust-param-passing-dep = { path = "../param_passing_dep", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_param_passing"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/rand/Cargo.toml
+++ b/programs/bpf/rust/rand/Cargo.toml
@@ -14,7 +14,6 @@ rand = "0.7"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_rand"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/ristretto/Cargo.toml
+++ b/programs/bpf/rust/ristretto/Cargo.toml
@@ -14,7 +14,6 @@ getrandom = { version = "0.1.14", features = ["dummy"] }
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_ristretto"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/sanity/Cargo.toml
+++ b/programs/bpf/rust/sanity/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_sanity"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/sha256/Cargo.toml
+++ b/programs/bpf/rust/sha256/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_sha256"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]

--- a/programs/bpf/rust/sysval/Cargo.toml
+++ b/programs/bpf/rust/sysval/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
 
 [lib]
-name = "solana_bpf_rust_sysval"
 crate-type = ["cdylib"]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
#### Problem

lib names are not required but the bpf tests specify it, confusing folks who wonder why it's there.

#### Summary of Changes

Remove them

Fixes #
