### PR TITLE
Disable snapshot compression for run.sh to reduce system load

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -103,6 +103,7 @@ args=(
   --enable-rpc-exit
   --enable-rpc-transaction-history
   --init-complete-file "$dataDir"/init-completed
+  --snapshot-compression none
   --require-tower
 )
 solana-validator "${args[@]}" &


### PR DESCRIPTION
.tar snapshots are larger but less expensive to generate.  For `run.sh`, I think this is a better trade off to reduce the overall system load on a dev machine