### PR TITLE
solana-tokens: enable confirmation of many transactions

### DIFF
--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -186,5 +186,5 @@ mod tests {
     // async fn test_process_spl_token_transfer_amount_allocations()
     // async fn test_check_spl_token_balances()
     //
-    // TODO: link to v1.4 tests
+    // https://github.com/solana-labs/solana/blob/5511d52c6284013a24ced10966d11d8f4585799e/tokens/src/spl_token.rs#L490-L685
 }


### PR DESCRIPTION
#### Problem
`solana-tokens` attempts to confirm all distribution transactions in one call to `get_signature_statuses`. However, the JSON-RPC service returns an error if the request includes more signatures than it's cap of 256.

#### Summary of Changes
- Chunk calls to `RpcClient::get_signature_statuses` to fit in request limit
