### PR TITLE
solana-tokens: optimize PickleDb dumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4985,6 +4985,7 @@ dependencies = [
  "clap",
  "console",
  "csv",
+ "ctrlc",
  "dirs-next",
  "indexmap",
  "indicatif",

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33.0"
 console = "0.11.3"
 csv = "1.1.3"
+ctrlc = { version = "3.1.5", features = ["termination"] }
 dirs-next = "2.0.0"
 indexmap = "1.5.1"
 indicatif = "0.15.0"

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -12,9 +12,7 @@ use solana_clap_utils::{
 use solana_cli_config::CONFIG_FILE;
 use solana_remote_wallet::remote_wallet::maybe_wallet_manager;
 use solana_sdk::native_token::sol_to_lamports;
-use std::error::Error;
-use std::ffi::OsString;
-use std::process::exit;
+use std::{error::Error, ffi::OsString, process::exit};
 
 fn get_matches<'a, I, T>(args: I) -> ArgMatches<'a>
 where

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -2076,6 +2076,8 @@ mod tests {
         let read_db = db::open_db(&db_file, true).unwrap();
         let transaction_info = db::read_transaction_infos(&read_db);
         assert_eq!(transaction_info.len(), 1);
+
+        test_validator.close();
     }
 
     #[test]

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -360,6 +360,7 @@ fn distribute_allocations(
             }
         };
     }
+    db.dump()?;
     Ok(())
 }
 
@@ -600,6 +601,7 @@ fn update_finalized_transactions(
             }
         }
     }
+    db.dump()?;
     Ok(confirmations)
 }
 

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -35,9 +35,11 @@ use solana_stake_program::{
 };
 use spl_associated_token_account_v1_0::get_associated_token_address;
 use spl_token_v2_0::solana_program::program_error::ProgramError;
+#[cfg(not(test))]
+use std::process;
 use std::{
     cmp::{self},
-    io, process,
+    io,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -257,6 +259,7 @@ fn distribute_allocations(
     for allocation in allocations.iter() {
         if exit.load(Ordering::SeqCst) {
             db.dump()?;
+            #[cfg(not(test))]
             process::exit(0);
         }
         let new_stake_account_keypair = Keypair::new();
@@ -321,6 +324,7 @@ fn distribute_allocations(
     {
         if exit.load(Ordering::SeqCst) {
             db.dump()?;
+            #[cfg(not(test))]
             process::exit(0);
         }
         let new_stake_account_address = new_stake_account_keypair.pubkey();
@@ -618,6 +622,7 @@ fn update_finalized_transactions(
         }
         if exit.load(Ordering::SeqCst) {
             db.dump()?;
+            #[cfg(not(test))]
             process::exit(0);
         }
     }

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -48,7 +48,7 @@ pub fn open_db(path: &str, dry_run: bool) -> Result<PickleDb, Error> {
     let policy = if dry_run {
         PickleDbDumpPolicy::NeverDump
     } else {
-        PickleDbDumpPolicy::AutoDump
+        PickleDbDumpPolicy::DumpUponRequest
     };
     let path = Path::new(path);
     let db = if path.exists() {

--- a/tokens/src/main.rs
+++ b/tokens/src/main.rs
@@ -1,7 +1,16 @@
 use solana_cli_config::{Config, CONFIG_FILE};
 use solana_client::rpc_client::RpcClient;
 use solana_tokens::{arg_parser::parse_args, args::Command, commands, spl_token};
-use std::{env, error::Error, path::Path, process};
+use std::{
+    env,
+    error::Error,
+    path::Path,
+    process,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let command_args = parse_args(env::args_os())?;
@@ -18,10 +27,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     let json_rpc_url = command_args.url.unwrap_or(config.json_rpc_url);
     let client = RpcClient::new(json_rpc_url);
 
+    let exit = Arc::new(AtomicBool::default());
+    let _exit = exit.clone();
+    // Initialize CTRL-C handler to ensure db changes are written before exit.
+    ctrlc::set_handler(move || {
+        _exit.store(true, Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl-C handler");
+
     match command_args.command {
         Command::DistributeTokens(mut args) => {
             spl_token::update_token_args(&client, &mut args.spl_token_args)?;
-            commands::process_allocations(&client, &args)?;
+            commands::process_allocations(&client, &args, exit)?;
         }
         Command::Balances(mut args) => {
             spl_token::update_decimals(&client, &mut args.spl_token_args)?;


### PR DESCRIPTION
#### Problem
Currently, `solana-tokens` dumps PickleDb database information on every change, including after every distribution send. This can take a long time when there are a lot of transactions, which can disrupt transaction confirmation: eg. for a distribution set of ~500 transactions, the db dumps take long enough that the earliest transaction signatures are no longer in the node's status cache.

#### Summary of Changes
- Change PickleDb configuration to DumpUponRequest. Dump changes once after send loop and again after transaction confirmation loop. In the case of a mid-loop error, all intermediate changes should be written automatically, since PickleDb's drop implementation ensures dumping on destruction of the object.
- Add Ctrl-C handler to ensure all db changes are written on SIGINT and SIGTERM, even if mid-loop
