### PR TITLE
Reduce `ledger/snapshot/`  disk usage 

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -311,7 +311,7 @@ mod tests {
         let saved_slot = 4;
         let mut saved_archive_path = None;
 
-        for forks in 0..MAX_CACHE_ENTRIES + 2 {
+        for forks in 0..snapshot_utils::MAX_SNAPSHOTS + 2 {
             let bank = Bank::new_from_parent(
                 &bank_forks[forks as u64],
                 &Pubkey::default(),
@@ -381,7 +381,7 @@ mod tests {
         assert!(snapshot_utils::get_snapshot_paths(&snapshots_dir)
             .into_iter()
             .map(|path| path.slot)
-            .eq(3..=MAX_CACHE_ENTRIES as u64 + 2));
+            .eq(3..=snapshot_utils::MAX_SNAPSHOTS as u64 + 2));
 
         // Create a SnapshotPackagerService to create tarballs from all the pending
         // SnapshotPackage's on the channel. By the time this service starts, we have already

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -6,7 +6,6 @@ use crate::{
         bank_from_stream, bank_to_stream, SerdeStyle, SnapshotStorage, SnapshotStorages,
     },
     snapshot_package::{AccountsPackage, AccountsPackageSendError, AccountsPackageSender},
-    status_cache::MAX_CACHE_ENTRIES,
 };
 use bincode::{config::Options, serialize_into};
 use bzip2::bufread::BzDecoder;
@@ -41,6 +40,7 @@ pub const TAR_SNAPSHOTS_DIR: &str = "snapshots";
 pub const TAR_ACCOUNTS_DIR: &str = "accounts";
 pub const TAR_VERSION_FILE: &str = "version";
 
+pub const MAX_SNAPSHOTS: usize = 8; // Save some snapshots but not too many
 const MAX_SNAPSHOT_DATA_FILE_SIZE: u64 = 32 * 1024 * 1024 * 1024; // 32 GiB
 const VERSION_STRING_V1_2_0: &str = "1.2.0";
 const DEFAULT_SNAPSHOT_VERSION: SnapshotVersion = SnapshotVersion::V1_2_0;
@@ -882,7 +882,7 @@ pub fn verify_snapshot_archive<P, Q, R>(
 pub fn purge_old_snapshots(snapshot_path: &Path) {
     // Remove outdated snapshots
     let slot_snapshot_paths = get_snapshot_paths(snapshot_path);
-    let num_to_remove = slot_snapshot_paths.len().saturating_sub(MAX_CACHE_ENTRIES);
+    let num_to_remove = slot_snapshot_paths.len().saturating_sub(MAX_SNAPSHOTS);
     for slot_files in &slot_snapshot_paths[..num_to_remove] {
         let r = remove_snapshot(slot_files.slot, snapshot_path);
         if r.is_err() {


### PR DESCRIPTION
The `ledger/snapshot/` directory of mainnet-beta validators currently holds ~5.4GB of useless data.   Reduce the number of retained snapshots to lower disk usage