### PR TITLE
Simple cap by including sysvars and native programs

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -98,7 +98,10 @@ fn main() {
         } else {
             let mut pubkeys: Vec<Pubkey> = vec![];
             let mut time = Measure::start("hash");
-            let hash = accounts.accounts_db.update_accounts_hash(0, &ancestors).0;
+            let hash = accounts
+                .accounts_db
+                .update_accounts_hash(0, &ancestors, true)
+                .0;
             time.stop();
             println!("hash: {} {}", hash, time);
             create_test_accounts(&accounts, &mut pubkeys, 1, 0);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1220,9 +1220,9 @@ fn main() {
             .arg(
                 Arg::with_name("enable_simple_capitalization")
                     .required(false)
-                    .long("enable-simpler-capitalization")
+                    .long("enable-simple-capitalization")
                     .takes_value(false)
-                    .help("Enable simpler capitalization to test hardcoded cap adjustments"),
+                    .help("Enable simple capitalization to test hardcoded cap adjustments"),
             )
             .arg(
                 Arg::with_name("recalculate_capitalization")
@@ -2152,7 +2152,7 @@ fn main() {
                                     let old_cap = base_bank.set_capitalization();
                                     let new_cap = base_bank.capitalization();
                                     warn!(
-                                        "Skewing capitalization a bit to enable simpler capitalization as \
+                                        "Skewing capitalization a bit to enable simple capitalization as \
                                         requested: increasing {} from {} to {}",
                                         feature_account_balance, old_cap, new_cap,
                                     );

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1218,7 +1218,7 @@ fn main() {
                            bugs are feature-gated behind this)"),
             )
             .arg(
-                Arg::with_name("enable_simpler_capitalization")
+                Arg::with_name("enable_simple_capitalization")
                     .required(false)
                     .long("enable-simpler-capitalization")
                     .takes_value(false)
@@ -2126,13 +2126,13 @@ fn main() {
                             genesis_config.rent.minimum_balance(Feature::size_of()),
                             1,
                         );
-                        if arg_matches.is_present("enable_simpler_capitalization") {
+                        if arg_matches.is_present("enable_simple_capitalization") {
                             if base_bank
-                                .get_account(&feature_set::simpler_capitalization::id())
+                                .get_account(&feature_set::simple_capitalization::id())
                                 .is_none()
                             {
                                 base_bank.store_account(
-                                    &feature_set::simpler_capitalization::id(),
+                                    &feature_set::simple_capitalization::id(),
                                     &feature::create_account(
                                         &Feature { activated_at: None },
                                         feature_account_balance,
@@ -2159,7 +2159,7 @@ fn main() {
                                     assert_eq!(old_cap + feature_account_balance, new_cap);
                                 }
                             } else {
-                                warn!("Already simpler_capitalization is activated (or scheduled)");
+                                warn!("Already simple_capitalization is activated (or scheduled)");
                             }
                         }
                         if arg_matches.is_present("enable_stake_program_v2") {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1218,6 +1218,13 @@ fn main() {
                            bugs are feature-gated behind this)"),
             )
             .arg(
+                Arg::with_name("enable_simpler_capitalization")
+                    .required(false)
+                    .long("enable-simpler-capitalization")
+                    .takes_value(false)
+                    .help("Enable simpler capitalization to test hardcoded cap adjustments"),
+            )
+            .arg(
                 Arg::with_name("recalculate_capitalization")
                     .required(false)
                     .long("recalculate-capitalization")
@@ -2115,11 +2122,47 @@ fn main() {
                             .lazy_rent_collection
                             .store(true, std::sync::atomic::Ordering::Relaxed);
 
+                        let feature_account_balance = std::cmp::max(
+                            genesis_config.rent.minimum_balance(Feature::size_of()),
+                            1,
+                        );
+                        if arg_matches.is_present("enable_simpler_capitalization") {
+                            if base_bank
+                                .get_account(&feature_set::simpler_capitalization::id())
+                                .is_none()
+                            {
+                                base_bank.store_account(
+                                    &feature_set::simpler_capitalization::id(),
+                                    &feature::create_account(
+                                        &Feature { activated_at: None },
+                                        feature_account_balance,
+                                    ),
+                                );
+                                if base_bank
+                                    .get_account(&feature_set::cumulative_rent_related_fixes::id())
+                                    .is_some()
+                                {
+                                    // steal some lamports from the pretty old feature not to affect
+                                    // capitalizaion, which doesn't affect inflation behavior!
+                                    base_bank.store_account(
+                                        &feature_set::cumulative_rent_related_fixes::id(),
+                                        &Account::default(),
+                                    );
+                                } else {
+                                    let old_cap = base_bank.set_capitalization();
+                                    let new_cap = base_bank.capitalization();
+                                    warn!(
+                                        "Skewing capitalization a bit to enable simpler capitalization as \
+                                        requested: increasing {} from {} to {}",
+                                        feature_account_balance, old_cap, new_cap,
+                                    );
+                                    assert_eq!(old_cap + feature_account_balance, new_cap);
+                                }
+                            } else {
+                                warn!("Already simpler_capitalization is activated (or scheduled)");
+                            }
+                        }
                         if arg_matches.is_present("enable_stake_program_v2") {
-                            let feature_account_balance = std::cmp::max(
-                                genesis_config.rent.minimum_balance(Feature::size_of()),
-                                1,
-                            );
                             let mut force_enabled_count = 0;
                             if base_bank
                                 .get_account(&feature_set::stake_program_v2::id())

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -94,8 +94,12 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let slot = 0;
     create_test_accounts(&accounts, &mut pubkeys, num_accounts, slot);
     let ancestors = vec![(0, 0)].into_iter().collect();
-    let (_, total_lamports) = accounts.accounts_db.update_accounts_hash(0, &ancestors);
-    bencher.iter(|| assert!(accounts.verify_bank_hash_and_lamports(0, &ancestors, total_lamports)));
+    let (_, total_lamports) = accounts
+        .accounts_db
+        .update_accounts_hash(0, &ancestors, true);
+    bencher.iter(|| {
+        assert!(accounts.verify_bank_hash_and_lamports(0, &ancestors, total_lamports, true))
+    });
 }
 
 #[bench]
@@ -109,7 +113,9 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
     let ancestors = vec![(0, 0)].into_iter().collect();
     bencher.iter(|| {
-        accounts.accounts_db.update_accounts_hash(0, &ancestors);
+        accounts
+            .accounts_db
+            .update_accounts_hash(0, &ancestors, true);
     });
 }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -460,7 +460,11 @@ impl Accounts {
         accounts_balances
     }
 
-    pub fn calculate_capitalization(&self, ancestors: &Ancestors) -> u64 {
+    pub fn calculate_capitalization(
+        &self,
+        ancestors: &Ancestors,
+        simpler_capitalization_enabled: bool,
+    ) -> u64 {
         let balances =
             self.load_all_unchecked(ancestors)
                 .into_iter()
@@ -469,6 +473,7 @@ impl Accounts {
                         account.lamports,
                         &account.owner,
                         account.executable,
+                        simpler_capitalization_enabled,
                     )
                 });
 
@@ -481,11 +486,14 @@ impl Accounts {
         slot: Slot,
         ancestors: &Ancestors,
         total_lamports: u64,
+        simpler_capitalization_enabled: bool,
     ) -> bool {
-        if let Err(err) =
-            self.accounts_db
-                .verify_bank_hash_and_lamports(slot, ancestors, total_lamports)
-        {
+        if let Err(err) = self.accounts_db.verify_bank_hash_and_lamports(
+            slot,
+            ancestors,
+            total_lamports,
+            simpler_capitalization_enabled,
+        ) {
             warn!("verify_bank_hash failed: {:?}", err);
             false
         } else {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -463,7 +463,7 @@ impl Accounts {
     pub fn calculate_capitalization(
         &self,
         ancestors: &Ancestors,
-        simpler_capitalization_enabled: bool,
+        simple_capitalization_enabled: bool,
     ) -> u64 {
         let balances =
             self.load_all_unchecked(ancestors)
@@ -473,7 +473,7 @@ impl Accounts {
                         account.lamports,
                         &account.owner,
                         account.executable,
-                        simpler_capitalization_enabled,
+                        simple_capitalization_enabled,
                     )
                 });
 
@@ -486,13 +486,13 @@ impl Accounts {
         slot: Slot,
         ancestors: &Ancestors,
         total_lamports: u64,
-        simpler_capitalization_enabled: bool,
+        simple_capitalization_enabled: bool,
     ) -> bool {
         if let Err(err) = self.accounts_db.verify_bank_hash_and_lamports(
             slot,
             ancestors,
             total_lamports,
-            simpler_capitalization_enabled,
+            simple_capitalization_enabled,
         ) {
             warn!("verify_bank_hash failed: {:?}", err);
             false

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2231,9 +2231,9 @@ impl AccountsDB {
         lamports: u64,
         owner: &Pubkey,
         executable: bool,
-        simpler_capitalization_enabled: bool,
+        simple_capitalization_enabled: bool,
     ) -> u64 {
-        if simpler_capitalization_enabled {
+        if simple_capitalization_enabled {
             return lamports;
         }
 
@@ -2255,7 +2255,7 @@ impl AccountsDB {
         slot: Slot,
         ancestors: &Ancestors,
         check_hash: bool,
-        simpler_capitalization_enabled: bool,
+        simple_capitalization_enabled: bool,
     ) -> Result<(Hash, u64), BankHashVerificationError> {
         use BankHashVerificationError::*;
         let mut scan = Measure::start("scan");
@@ -2286,7 +2286,7 @@ impl AccountsDB {
                                             account_info.lamports,
                                             &account.account_meta.owner,
                                             account.account_meta.executable,
-                                            simpler_capitalization_enabled,
+                                            simple_capitalization_enabled,
                                         );
 
                                         if check_hash {
@@ -2349,10 +2349,10 @@ impl AccountsDB {
         &self,
         slot: Slot,
         ancestors: &Ancestors,
-        simpler_capitalization_enabled: bool,
+        simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
         let (hash, total_lamports) = self
-            .calculate_accounts_hash(slot, ancestors, false, simpler_capitalization_enabled)
+            .calculate_accounts_hash(slot, ancestors, false, simple_capitalization_enabled)
             .unwrap();
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
@@ -2365,12 +2365,12 @@ impl AccountsDB {
         slot: Slot,
         ancestors: &Ancestors,
         total_lamports: u64,
-        simpler_capitalization_enabled: bool,
+        simple_capitalization_enabled: bool,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
         let (calculated_hash, calculated_lamports) =
-            self.calculate_accounts_hash(slot, ancestors, true, simpler_capitalization_enabled)?;
+            self.calculate_accounts_hash(slot, ancestors, true, simple_capitalization_enabled)?;
 
         if calculated_lamports != total_lamports {
             warn!(

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2231,7 +2231,12 @@ impl AccountsDB {
         lamports: u64,
         owner: &Pubkey,
         executable: bool,
+        simpler_capitalization_enabled: bool,
     ) -> u64 {
+        if simpler_capitalization_enabled {
+            return lamports;
+        }
+
         let is_specially_retained = (solana_sdk::native_loader::check_id(owner) && executable)
             || solana_sdk::sysvar::check_id(owner);
 
@@ -2250,6 +2255,7 @@ impl AccountsDB {
         slot: Slot,
         ancestors: &Ancestors,
         check_hash: bool,
+        simpler_capitalization_enabled: bool,
     ) -> Result<(Hash, u64), BankHashVerificationError> {
         use BankHashVerificationError::*;
         let mut scan = Measure::start("scan");
@@ -2280,6 +2286,7 @@ impl AccountsDB {
                                             account_info.lamports,
                                             &account.account_meta.owner,
                                             account.account_meta.executable,
+                                            simpler_capitalization_enabled,
                                         );
 
                                         if check_hash {
@@ -2338,9 +2345,14 @@ impl AccountsDB {
         bank_hash_info.snapshot_hash
     }
 
-    pub fn update_accounts_hash(&self, slot: Slot, ancestors: &Ancestors) -> (Hash, u64) {
+    pub fn update_accounts_hash(
+        &self,
+        slot: Slot,
+        ancestors: &Ancestors,
+        simpler_capitalization_enabled: bool,
+    ) -> (Hash, u64) {
         let (hash, total_lamports) = self
-            .calculate_accounts_hash(slot, ancestors, false)
+            .calculate_accounts_hash(slot, ancestors, false, simpler_capitalization_enabled)
             .unwrap();
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
@@ -2353,11 +2365,12 @@ impl AccountsDB {
         slot: Slot,
         ancestors: &Ancestors,
         total_lamports: u64,
+        simpler_capitalization_enabled: bool,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
         let (calculated_hash, calculated_lamports) =
-            self.calculate_accounts_hash(slot, ancestors, true)?;
+            self.calculate_accounts_hash(slot, ancestors, true, simpler_capitalization_enabled)?;
 
         if calculated_lamports != total_lamports {
             warn!(
@@ -4000,8 +4013,8 @@ pub mod tests {
 
         let ancestors = linear_ancestors(latest_slot);
         assert_eq!(
-            daccounts.update_accounts_hash(latest_slot, &ancestors),
-            accounts.update_accounts_hash(latest_slot, &ancestors)
+            daccounts.update_accounts_hash(latest_slot, &ancestors, true),
+            accounts.update_accounts_hash(latest_slot, &ancestors, true)
         );
     }
 
@@ -4154,12 +4167,12 @@ pub mod tests {
 
         let ancestors = linear_ancestors(current_slot);
         info!("ancestors: {:?}", ancestors);
-        let hash = accounts.update_accounts_hash(current_slot, &ancestors);
+        let hash = accounts.update_accounts_hash(current_slot, &ancestors, true);
 
         accounts.clean_accounts(None);
 
         assert_eq!(
-            accounts.update_accounts_hash(current_slot, &ancestors),
+            accounts.update_accounts_hash(current_slot, &ancestors, true),
             hash
         );
 
@@ -4276,7 +4289,7 @@ pub mod tests {
         accounts.add_root(current_slot);
 
         accounts.print_accounts_stats("pre_f");
-        accounts.update_accounts_hash(4, &HashMap::default());
+        accounts.update_accounts_hash(4, &HashMap::default(), true);
 
         let accounts = f(accounts, current_slot);
 
@@ -4288,7 +4301,7 @@ pub mod tests {
         assert_load_account(&accounts, current_slot, dummy_pubkey, dummy_lamport);
 
         accounts
-            .verify_bank_hash_and_lamports(4, &HashMap::default(), 1222)
+            .verify_bank_hash_and_lamports(4, &HashMap::default(), 1222, true)
             .unwrap();
     }
 
@@ -4685,15 +4698,15 @@ pub mod tests {
 
         db.store(some_slot, &[(&key, &account)]);
         db.add_root(some_slot);
-        db.update_accounts_hash(some_slot, &ancestors);
+        db.update_accounts_hash(some_slot, &ancestors, true);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
             Ok(_)
         );
 
         db.bank_hashes.write().unwrap().remove(&some_slot).unwrap();
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
             Err(MissingBankHash)
         );
 
@@ -4708,7 +4721,7 @@ pub mod tests {
             .unwrap()
             .insert(some_slot, bank_hash_info);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
             Err(MismatchedBankHash)
         );
     }
@@ -4727,9 +4740,9 @@ pub mod tests {
 
         db.store(some_slot, &[(&key, &account)]);
         db.add_root(some_slot);
-        db.update_accounts_hash(some_slot, &ancestors);
+        db.update_accounts_hash(some_slot, &ancestors, true);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
             Ok(_)
         );
 
@@ -4741,15 +4754,19 @@ pub mod tests {
                 &solana_sdk::native_loader::create_loadable_account("foo", 1),
             )],
         );
-        db.update_accounts_hash(some_slot, &ancestors);
+        db.update_accounts_hash(some_slot, &ancestors, true);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, false),
+            Ok(_)
+        );
+        assert_matches!(
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 2, true),
             Ok(_)
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10),
-            Err(MismatchedTotalLamports(expected, actual)) if expected == 1 && actual == 10
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true),
+            Err(MismatchedTotalLamports(expected, actual)) if expected == 2 && actual == 10
         );
     }
 
@@ -4766,9 +4783,9 @@ pub mod tests {
             .unwrap()
             .insert(some_slot, BankHashInfo::default());
         db.add_root(some_slot);
-        db.update_accounts_hash(some_slot, &ancestors);
+        db.update_accounts_hash(some_slot, &ancestors, true);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 0),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 0, true),
             Ok(_)
         );
     }
@@ -4793,7 +4810,7 @@ pub mod tests {
         db.store_accounts_default(some_slot, accounts, &[some_hash]);
         db.add_root(some_slot);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
             Err(MismatchedAccountHash)
         );
     }
@@ -5269,14 +5286,14 @@ pub mod tests {
         );
 
         let no_ancestors = HashMap::default();
-        accounts.update_accounts_hash(current_slot, &no_ancestors);
+        accounts.update_accounts_hash(current_slot, &no_ancestors, true);
         accounts
-            .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300)
+            .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300, true)
             .unwrap();
 
         let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
         accounts
-            .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300)
+            .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300, true)
             .unwrap();
 
         // repeating should be no-op
@@ -5473,7 +5490,7 @@ pub mod tests {
     fn test_account_balance_for_capitalization_normal() {
         // system accounts
         assert_eq!(
-            AccountsDB::account_balance_for_capitalization(10, &Pubkey::default(), false),
+            AccountsDB::account_balance_for_capitalization(10, &Pubkey::default(), false, true),
             10
         );
         // any random program data accounts
@@ -5481,7 +5498,17 @@ pub mod tests {
             AccountsDB::account_balance_for_capitalization(
                 10,
                 &solana_sdk::pubkey::new_rand(),
-                false
+                false,
+                true,
+            ),
+            10
+        );
+        assert_eq!(
+            AccountsDB::account_balance_for_capitalization(
+                10,
+                &solana_sdk::pubkey::new_rand(),
+                false,
+                false,
             ),
             10
         );
@@ -5497,15 +5524,39 @@ pub mod tests {
             AccountsDB::account_balance_for_capitalization(
                 normal_sysvar.lamports,
                 &normal_sysvar.owner,
-                normal_sysvar.executable
+                normal_sysvar.executable,
+                false,
             ),
             0
+        );
+        assert_eq!(
+            AccountsDB::account_balance_for_capitalization(
+                normal_sysvar.lamports,
+                &normal_sysvar.owner,
+                normal_sysvar.executable,
+                true,
+            ),
+            1
         );
 
         // currently transactions can send any lamports to sysvars although this is not sensible.
         assert_eq!(
-            AccountsDB::account_balance_for_capitalization(10, &solana_sdk::sysvar::id(), false),
+            AccountsDB::account_balance_for_capitalization(
+                10,
+                &solana_sdk::sysvar::id(),
+                false,
+                false
+            ),
             9
+        );
+        assert_eq!(
+            AccountsDB::account_balance_for_capitalization(
+                10,
+                &solana_sdk::sysvar::id(),
+                false,
+                true
+            ),
+            10
         );
     }
 
@@ -5516,9 +5567,19 @@ pub mod tests {
             AccountsDB::account_balance_for_capitalization(
                 normal_native_program.lamports,
                 &normal_native_program.owner,
-                normal_native_program.executable
+                normal_native_program.executable,
+                false,
             ),
             0
+        );
+        assert_eq!(
+            AccountsDB::account_balance_for_capitalization(
+                normal_native_program.lamports,
+                &normal_native_program.owner,
+                normal_native_program.executable,
+                true,
+            ),
+            1
         );
 
         // test maliciously assigned bogus native loader account
@@ -5526,10 +5587,20 @@ pub mod tests {
             AccountsDB::account_balance_for_capitalization(
                 1,
                 &solana_sdk::native_loader::id(),
-                false
+                false,
+                false,
             ),
             1
-        )
+        );
+        assert_eq!(
+            AccountsDB::account_balance_for_capitalization(
+                1,
+                &solana_sdk::native_loader::id(),
+                false,
+                true,
+            ),
+            1
+        );
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2109,7 +2109,7 @@ impl Bank {
                     return;
                 }
             }
-        };
+        }
 
         assert!(
             !self.is_frozen(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10861,7 +10861,7 @@ pub(crate) mod tests {
             &feature::create_account(&Feature { activated_at: None }, feature_balance),
         );
 
-        // 16 is minimum adjusted cap increase in adjust_capitalization_for_existing_specially_retained_accounts
+        // 12 is minimum adjusted cap increase in adjust_capitalization_for_existing_specially_retained_accounts
         assert_capitalization_diff_with_new_bank(
             &bank1,
             || Bank::new_from_parent(&bank1, &Pubkey::default(), bank1.first_slot_in_next_epoch()),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10912,8 +10912,18 @@ pub(crate) mod tests {
             feature_builtins: (vec![]),
         };
 
-        let bank0 = Bank::new_with_paths(&genesis_config, Vec::new(), &[], None, Some(&builtins));
-        let bank1 = Arc::new(new_from_parent(&Arc::new(bank0)));
+        let bank0 = Arc::new(Bank::new_with_paths(
+            &genesis_config,
+            Vec::new(),
+            &[],
+            None,
+            Some(&builtins),
+        ));
+        let bank1 = Arc::new(Bank::new_from_parent(
+            &bank0,
+            &Pubkey::default(),
+            bank0.first_slot_in_next_epoch(),
+        ));
 
         // schedule activation of simpler capitalization
         bank1.store_account_and_update_capitalization(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10855,7 +10855,7 @@ pub(crate) mod tests {
         let bank0 = Bank::new(&genesis_config);
         let bank1 = Arc::new(new_from_parent(&Arc::new(bank0)));
 
-        // schedule activation of simpler capitalization
+        // schedule activation of simple capitalization
         bank1.store_account_and_update_capitalization(
             &feature_set::simple_capitalization::id(),
             &feature::create_account(&Feature { activated_at: None }, feature_balance),
@@ -10877,7 +10877,7 @@ pub(crate) mod tests {
         let feature_balance =
             std::cmp::max(genesis_config.rent.minimum_balance(Feature::size_of()), 1);
 
-        // activate all features but simpler capitalization
+        // activate all features but simple capitalization
         activate_all_features(&mut genesis_config);
         genesis_config
             .accounts
@@ -10919,13 +10919,14 @@ pub(crate) mod tests {
             None,
             Some(&builtins),
         ));
+        // move to next epoch to create now deprecated rewards sysvar intentionally
         let bank1 = Arc::new(Bank::new_from_parent(
             &bank0,
             &Pubkey::default(),
             bank0.first_slot_in_next_epoch(),
         ));
 
-        // schedule activation of simpler capitalization
+        // schedule activation of simple capitalization
         bank1.store_account_and_update_capitalization(
             &feature_set::simple_capitalization::id(),
             &feature::create_account(&Feature { activated_at: None }, feature_balance),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2002,6 +2002,8 @@ impl Bank {
             self.store_account(pubkey, account);
             self.capitalization.fetch_add(account.lamports, Relaxed);
         }
+        // updating sysvar (the fees sysvar in this case) now depends on feature activations in
+        // genesis_config.accounts above
         self.update_fees();
 
         for (pubkey, account) in genesis_config.rewards_pools.iter() {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1994,7 +1994,6 @@ impl Bank {
         // Bootstrap validator collects fees until `new_from_parent` is called.
         self.fee_rate_governor = genesis_config.fee_rate_governor.clone();
         self.fee_calculator = self.fee_rate_governor.create_fee_calculator();
-        self.update_fees();
 
         for (pubkey, account) in genesis_config.accounts.iter() {
             if self.get_account(&pubkey).is_some() {
@@ -2003,6 +2002,7 @@ impl Bank {
             self.store_account(pubkey, account);
             self.capitalization.fetch_add(account.lamports, Relaxed);
         }
+        self.update_fees();
 
         for (pubkey, account) in genesis_config.rewards_pools.iter() {
             if self.get_account(&pubkey).is_some() {
@@ -4432,7 +4432,7 @@ impl Bank {
                 .is_active(&feature_set::simpler_capitalization::id())
     }
 
-    pub fn simpler_capitalization_enabled_at_genesis(&self) -> bool {
+    fn simpler_capitalization_enabled_at_genesis(&self) -> bool {
         // genesis builtin initialization codepath is called even before the initial
         // feature activation, so we need to peek this flag at very early bank
         // initialization phase

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -98,7 +98,7 @@ pub mod filter_stake_delegation_accounts {
     solana_sdk::declare_id!("GE7fRxmW46K6EmCD9AMZSbnaJ2e3LfqCZzdHi9hmYAgi");
 }
 
-pub mod simpler_capitalization {
+pub mod simple_capitalization {
     solana_sdk::declare_id!("9r69RnnxABmpcPFfj1yhg4n9YFR2MNaLdKJCC6v3Speb");
 }
 
@@ -128,7 +128,7 @@ lazy_static! {
         (stake_program_v2::id(), "solana_stake_program v2"),
         (rewrite_stake::id(), "rewrite stake"),
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
-        (simpler_capitalization::id(), "simpler capitalization"),
+        (simple_capitalization::id(), "simpler capitalization"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -128,7 +128,7 @@ lazy_static! {
         (stake_program_v2::id(), "solana_stake_program v2"),
         (rewrite_stake::id(), "rewrite stake"),
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
-        (simple_capitalization::id(), "simpler capitalization"),
+        (simple_capitalization::id(), "simple capitalization"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -98,6 +98,10 @@ pub mod filter_stake_delegation_accounts {
     solana_sdk::declare_id!("GE7fRxmW46K6EmCD9AMZSbnaJ2e3LfqCZzdHi9hmYAgi");
 }
 
+pub mod simpler_capitalization {
+    solana_sdk::declare_id!("9r69RnnxABmpcPFfj1yhg4n9YFR2MNaLdKJCC6v3Speb");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -124,6 +128,7 @@ lazy_static! {
         (stake_program_v2::id(), "solana_stake_program v2"),
         (rewrite_stake::id(), "rewrite stake"),
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
+        (simpler_capitalization::id(), "simpler capitalization"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -149,6 +149,11 @@ impl GenesisConfig {
         hash(&serialized)
     }
 
+    pub fn disable_cap_altering_features_for_preciseness(&mut self) {
+        self.accounts
+            .remove(&crate::feature_set::simpler_capitalization::id());
+    }
+
     fn genesis_filename(ledger_path: &Path) -> PathBuf {
         Path::new(ledger_path).join("genesis.bin")
     }

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -151,7 +151,7 @@ impl GenesisConfig {
 
     pub fn disable_cap_altering_features_for_preciseness(&mut self) {
         self.accounts
-            .remove(&crate::feature_set::simpler_capitalization::id());
+            .remove(&crate::feature_set::simple_capitalization::id());
     }
 
     fn genesis_filename(ledger_path: &Path) -> PathBuf {


### PR DESCRIPTION
#### Problem

Simplify capitalization calculation by removing special casing.

#### Summary of Changes

Adjust cap while adding/updating sysvar and native program accounts correctly to simplify cap calculation.

~Also, this fixes a regression bug and a new bug introduced at #13403. In this sense, this pr is a follow up to #13403, #11750.~ (EDIT: this was done by separate pr)