### PR TITLE
Add logging in check_blockstore_max_root

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -610,10 +610,15 @@ impl JsonRpcRequestProcessor {
         T: std::fmt::Debug,
     {
         if result.is_err() {
-            if let BlockstoreError::SlotNotRooted = result.as_ref().unwrap_err() {
-                if slot > self.blockstore.max_root() {
-                    return Err(RpcCustomError::BlockNotAvailable { slot }.into());
-                }
+            let err = result.as_ref().unwrap_err();
+            debug!(
+                "check_blockstore_max_root, slot: {:?}, max root: {:?}, err: {:?}",
+                slot,
+                self.blockstore.max_root(),
+                err
+            );
+            if slot >= self.blockstore.max_root() {
+                return Err(RpcCustomError::BlockNotAvailable { slot }.into());
             }
         }
         Ok(())


### PR DESCRIPTION
#### Problem
Rpc module `ok()`s away BlockstoreErrors in `get_confirmed_block`.

#### Summary of Changes
- Log all BlockstoreErrors in `check_blockstore_max_root`
- Also, return BlockNotAvailable for slot = Blockstore::max_root() to allow for potential CacheBlockTimeService delay
