### PR TITLE
Use msg! in program entrypoint

### DIFF
--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -67,7 +67,7 @@ macro_rules! entrypoint {
         #[no_mangle]
         fn custom_panic(info: &core::panic::PanicInfo<'_>) {
             // Full panic reporting
-            $crate::info!(&format!("{}", info));
+            $crate::msg!("{}", info);
         }
 
         /// # Safety


### PR DESCRIPTION
#### Problem

Program entrypoint uses deprecated `info!`

#### Summary of Changes

Use `msg!`

Fixes #
