### PR TITLE
Add specific page for rpc endpoints

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -143,6 +143,7 @@ module.exports = {
     ],
     "Clusters": [
       "clusters",
+      "cluster/rpc-endpoints",
       "cluster/bench-tps",
       "cluster/performance-metrics"
     ],

--- a/docs/src/cluster/rpc-endpoints.md
+++ b/docs/src/cluster/rpc-endpoints.md
@@ -1,0 +1,20 @@
+---
+title: Solana Cluster RPC Endpoints
+---
+
+Solana maintains dedicated api nodes to fulfill [JSON-RPC](developing/clients/jsonrpc-api.md)
+requests for each public cluster, and third parties may as well. Here are the
+public RPC endpoints currently available and recommended for each public cluster:
+
+## Devnet
+
+- `https://devnet.solana.com` - single Solana-hosted api node; rate-limited
+
+## Testnet
+
+- `https://testnet.solana.com` - single Solana-hosted api node; rate-limited
+
+## Mainnet Beta
+
+- `https://api.mainnet-beta.solana.com` - Solana-hosted api node cluster, backed by a load balancer; rate-limited
+- `https://solana-api.projectserum.com` - Project Serum-hosted api node


### PR DESCRIPTION
#### Problem
We currently only recommend http://api.mainnet-beta.solana.com for mainnet beta. There are other RPC endpoints that are also available for use, such as https://solana-api.projectserum.com, but nowhere to share/recommend them.

#### Summary of Changes
- Add docs location to share recommended RPC endpoints

Fixes #13895 
