### PR TITLE
Move slot cleanup to AccountsBackgroundService

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -17,7 +17,9 @@ use solana_ledger::{
 };
 use solana_measure::measure::Measure;
 use solana_perf::packet::to_packets_chunked;
-use solana_runtime::{bank::Bank, bank_forks::BankForks};
+use solana_runtime::{
+    accounts_background_service::ABSRequestSender, bank::Bank, bank_forks::BankForks,
+};
 use solana_sdk::{
     hash::Hash,
     signature::Keypair,
@@ -323,7 +325,7 @@ fn main() {
                 poh_recorder.lock().unwrap().set_bank(&bank);
                 assert!(poh_recorder.lock().unwrap().bank().is_some());
                 if bank.slot() > 32 {
-                    bank_forks.set_root(root, &None, None);
+                    bank_forks.set_root(root, &ABSRequestSender::default(), None);
                     root += 1;
                 }
                 debug!(

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -249,6 +249,7 @@ mod tests {
     use super::*;
     use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
     use solana_runtime::{
+        accounts_background_service::ABSRequestSender,
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs},
     };
@@ -539,7 +540,7 @@ mod tests {
             &working_bank,
         );
         for x in 0..root {
-            bank_forks.set_root(x, &None, None);
+            bank_forks.set_root(x, &ABSRequestSender::default(), None);
         }
 
         // Add an additional bank/vote that will root slot 2
@@ -576,7 +577,11 @@ mod tests {
             .read()
             .unwrap()
             .highest_confirmed_root();
-        bank_forks.set_root(root, &None, Some(highest_confirmed_root));
+        bank_forks.set_root(
+            root,
+            &ABSRequestSender::default(),
+            Some(highest_confirmed_root),
+        );
         let highest_confirmed_root_bank = bank_forks.get(highest_confirmed_root);
         assert!(highest_confirmed_root_bank.is_some());
 
@@ -641,7 +646,11 @@ mod tests {
             .read()
             .unwrap()
             .highest_confirmed_root();
-        bank_forks.set_root(root, &None, Some(highest_confirmed_root));
+        bank_forks.set_root(
+            root,
+            &ABSRequestSender::default(),
+            Some(highest_confirmed_root),
+        );
         let highest_confirmed_root_bank = bank_forks.get(highest_confirmed_root);
         assert!(highest_confirmed_root_bank.is_some());
     }

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1245,6 +1245,7 @@ pub mod test {
     };
     use solana_ledger::{blockstore::make_slot_entries, get_tmp_ledger_path};
     use solana_runtime::{
+        accounts_background_service::ABSRequestSender,
         bank::Bank,
         bank_forks::BankForks,
         genesis_utils::{
@@ -1417,7 +1418,7 @@ pub mod test {
                 new_root,
                 &self.bank_forks,
                 &mut self.progress,
-                &None,
+                &ABSRequestSender::default(),
                 &mut PubkeyReferences::default(),
                 None,
                 &mut self.heaviest_subtree_fork_choice,

--- a/core/src/optimistically_confirmed_bank_tracker.rs
+++ b/core/src/optimistically_confirmed_bank_tracker.rs
@@ -167,7 +167,9 @@ impl OptimisticallyConfirmedBankTracker {
 mod tests {
     use super::*;
     use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
-    use solana_runtime::commitment::BlockCommitmentCache;
+    use solana_runtime::{
+        accounts_background_service::ABSRequestSender, commitment::BlockCommitmentCache,
+    };
     use solana_sdk::pubkey::Pubkey;
 
     #[test]
@@ -279,7 +281,10 @@ mod tests {
         let bank5 = bank_forks.read().unwrap().get(5).unwrap().clone();
         let bank7 = Bank::new_from_parent(&bank5, &Pubkey::default(), 7);
         bank_forks.write().unwrap().insert(bank7);
-        bank_forks.write().unwrap().set_root(7, &None, None);
+        bank_forks
+            .write()
+            .unwrap()
+            .set_root(7, &ABSRequestSender::default(), None);
         OptimisticallyConfirmedBankTracker::process_notification(
             BankNotification::OptimisticallyConfirmed(6),
             &bank_forks,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2732,7 +2732,9 @@ pub mod tests {
         blockstore_processor::fill_blockstore_slot_with_ticks,
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
     };
-    use solana_runtime::commitment::BlockCommitment;
+    use solana_runtime::{
+        accounts_background_service::ABSRequestSender, commitment::BlockCommitment,
+    };
     use solana_sdk::{
         clock::MAX_RECENT_BLOCKHASHES,
         fee_calculator::DEFAULT_BURN_PERCENT,
@@ -2833,7 +2835,10 @@ pub mod tests {
             bank_forks.write().unwrap().insert(new_bank);
 
             for root in roots.iter() {
-                bank_forks.write().unwrap().set_root(*root, &None, Some(0));
+                bank_forks
+                    .write()
+                    .unwrap()
+                    .set_root(*root, &ABSRequestSender::default(), Some(0));
                 let mut stakes = HashMap::new();
                 stakes.insert(leader_vote_keypair.pubkey(), (1, Account::default()));
                 let block_time = bank_forks

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -187,7 +187,7 @@ mod tests {
 
         let (s, snapshot_request_receiver) = unbounded();
         let (accounts_package_sender, _r) = channel();
-        let request_sender = ABSRequestSender::new(Some(s), None);
+        let request_sender = ABSRequestSender::new(Some(s));
         let snapshot_request_handler = SnapshotRequestHandler {
             snapshot_config: snapshot_test_config.snapshot_config.clone(),
             snapshot_request_receiver,
@@ -444,7 +444,7 @@ mod tests {
                 (*add_root_interval * num_set_roots * 2) as u64,
             );
             let mut current_bank = snapshot_test_config.bank_forks[0].clone();
-            let request_sender = ABSRequestSender::new(Some(snapshot_sender), None);
+            let request_sender = ABSRequestSender::new(Some(snapshot_sender));
             for _ in 0..num_set_roots {
                 for _ in 0..*add_root_interval {
                     let new_slot = current_bank.slot() + 1;

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -43,7 +43,7 @@ mod tests {
         snapshot_packager_service::SnapshotPackagerService,
     };
     use solana_runtime::{
-        accounts_background_service::SnapshotRequestHandler,
+        accounts_background_service::{ABSRequestSender, SnapshotRequestHandler},
         bank::{Bank, BankSlotDelta},
         bank_forks::{BankForks, CompressionType, SnapshotConfig},
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -187,7 +187,7 @@ mod tests {
 
         let (s, snapshot_request_receiver) = unbounded();
         let (accounts_package_sender, _r) = channel();
-        let snapshot_request_sender = Some(s);
+        let request_sender = ABSRequestSender::new(Some(s), None);
         let snapshot_request_handler = SnapshotRequestHandler {
             snapshot_config: snapshot_test_config.snapshot_config.clone(),
             snapshot_request_receiver,
@@ -202,7 +202,7 @@ mod tests {
             // kick in
             if slot % set_root_interval == 0 || slot == last_slot - 1 {
                 // set_root should send a snapshot request
-                bank_forks.set_root(bank.slot(), &snapshot_request_sender, None);
+                bank_forks.set_root(bank.slot(), &request_sender, None);
                 snapshot_request_handler.handle_snapshot_requests();
             }
         }
@@ -444,7 +444,7 @@ mod tests {
                 (*add_root_interval * num_set_roots * 2) as u64,
             );
             let mut current_bank = snapshot_test_config.bank_forks[0].clone();
-            let snapshot_sender = Some(snapshot_sender);
+            let request_sender = ABSRequestSender::new(Some(snapshot_sender), None);
             for _ in 0..num_set_roots {
                 for _ in 0..*add_root_interval {
                     let new_slot = current_bank.slot() + 1;
@@ -455,7 +455,7 @@ mod tests {
                 }
                 snapshot_test_config.bank_forks.set_root(
                     current_bank.slot(),
-                    &snapshot_sender,
+                    &request_sender,
                     None,
                 );
             }

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -8,16 +8,18 @@ use crate::{
     snapshot_package::AccountsPackageSender,
     snapshot_utils,
 };
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::{Receiver, SendError, Sender};
 use log::*;
 use rand::{thread_rng, Rng};
 use solana_measure::measure::Measure;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, RwLock,
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+    thread::{self, sleep, Builder, JoinHandle},
+    time::Duration,
 };
-use std::thread::{self, sleep, Builder, JoinHandle};
-use std::time::Duration;
 
 const INTERVAL_MS: u64 = 100;
 const SHRUNKEN_ACCOUNT_PER_SEC: usize = 250;
@@ -27,6 +29,8 @@ const CLEAN_INTERVAL_BLOCKS: u64 = 100;
 
 pub type SnapshotRequestSender = Sender<SnapshotRequest>;
 pub type SnapshotRequestReceiver = Receiver<SnapshotRequest>;
+pub type PrunedBanksSender = Sender<Vec<Arc<Bank>>>;
+pub type PrunedBanksReceiver = Receiver<Vec<Arc<Bank>>>;
 
 pub struct SnapshotRequest {
     pub snapshot_root_bank: Arc<Bank>,
@@ -109,6 +113,72 @@ impl SnapshotRequestHandler {
     }
 }
 
+#[derive(Default)]
+pub struct ABSRequestSender {
+    snapshot_request_sender: Option<SnapshotRequestSender>,
+    pruned_banks_sender: Option<PrunedBanksSender>,
+}
+
+impl ABSRequestSender {
+    pub fn new(
+        snapshot_request_sender: Option<SnapshotRequestSender>,
+        pruned_banks_sender: Option<PrunedBanksSender>,
+    ) -> Self {
+        ABSRequestSender {
+            snapshot_request_sender,
+            pruned_banks_sender,
+        }
+    }
+
+    pub fn is_snapshot_creation_enabled(&self) -> bool {
+        self.snapshot_request_sender.is_some()
+    }
+
+    pub fn send_snapshot_request(
+        &self,
+        snapshot_request: SnapshotRequest,
+    ) -> Result<(), SendError<SnapshotRequest>> {
+        if let Some(ref snapshot_request_sender) = self.snapshot_request_sender {
+            snapshot_request_sender.send(snapshot_request)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn send_pruned_banks(
+        &self,
+        pruned_banks: Vec<Arc<Bank>>,
+    ) -> Result<(), SendError<Vec<Arc<Bank>>>> {
+        if let Some(ref pruned_banks_sender) = self.pruned_banks_sender {
+            pruned_banks_sender.send(pruned_banks)
+        } else {
+            // If there is no sender, the banks are dropped immediately, which
+            // is not recommended for anything other than tests.
+            Ok(())
+        }
+    }
+}
+
+pub struct ABSRequestHandler {
+    pub snapshot_request_handler: Option<SnapshotRequestHandler>,
+    pub pruned_banks_receiver: PrunedBanksReceiver,
+}
+
+impl ABSRequestHandler {
+    // Returns the latest requested snapshot block height, if one exists
+    pub fn handle_snapshot_requests(&self) -> Option<u64> {
+        self.snapshot_request_handler
+            .as_ref()
+            .and_then(|snapshot_request_handler| {
+                snapshot_request_handler.handle_snapshot_requests()
+            })
+    }
+
+    pub fn handle_pruned_banks<'a>(&'a self) -> impl Iterator<Item = Arc<Bank>> + 'a {
+        self.pruned_banks_receiver.try_iter().flatten()
+    }
+}
+
 pub struct AccountsBackgroundService {
     t_background: JoinHandle<()>,
 }
@@ -117,12 +187,16 @@ impl AccountsBackgroundService {
     pub fn new(
         bank_forks: Arc<RwLock<BankForks>>,
         exit: &Arc<AtomicBool>,
-        snapshot_request_handler: Option<SnapshotRequestHandler>,
+        request_handler: ABSRequestHandler,
     ) -> Self {
         info!("AccountsBackgroundService active");
         let exit = exit.clone();
         let mut consumed_budget = 0;
         let mut last_cleaned_block_height = 0;
+        let mut pending_drop_banks = vec![];
+        let mut dropped_count = 0;
+        let mut total_scan_pending_total_drop_banks_time = 0;
+        let mut total_drop_banks_time = 0;
         let t_background = Builder::new()
             .name("solana-accounts-background".to_string())
             .spawn(move || loop {
@@ -148,14 +222,9 @@ impl AccountsBackgroundService {
                 //
                 // However, this is impossible because BankForks.set_root() will always flush the snapshot
                 // request for `N` to the snapshot request channel before setting a root `R > N`, and
-                // snapshot_request_handler.handle_snapshot_requests() will always look for the latest
+                // snapshot_request_handler.handle_requests() will always look for the latest
                 // available snapshot in the channel.
-                let snapshot_block_height =
-                    snapshot_request_handler
-                        .as_ref()
-                        .and_then(|snapshot_request_handler| {
-                            snapshot_request_handler.handle_snapshot_requests()
-                        });
+                let snapshot_block_height = request_handler.handle_snapshot_requests();
 
                 if let Some(snapshot_block_height) = snapshot_block_height {
                     // Safe, see proof above
@@ -175,13 +244,97 @@ impl AccountsBackgroundService {
                     }
                 }
 
+                pending_drop_banks.extend(request_handler.handle_pruned_banks());
+                pending_drop_banks = Self::scan_for_drops(
+                    pending_drop_banks,
+                    &mut dropped_count,
+                    &mut total_scan_pending_total_drop_banks_time,
+                    &mut total_drop_banks_time,
+                );
                 sleep(Duration::from_millis(INTERVAL_MS));
             })
             .unwrap();
         Self { t_background }
     }
 
+    fn scan_for_drops(
+        pending_drop_banks: Vec<Arc<Bank>>,
+        dropped_count: &mut usize,
+        total_scan_pending_total_drop_banks_time: &mut u64,
+        total_drop_banks_time: &mut u64,
+    ) -> Vec<Arc<Bank>> {
+        let mut scan_time = Measure::start("total_scan_pending_total_drop_banks_time");
+
+        // Should use `drain_filter()`, but not available in stable Rust yet.
+        let (to_drop, to_keep): (Vec<Arc<Bank>>, Vec<Arc<Bank>>) = pending_drop_banks
+            .into_iter()
+            .partition(|bank| Arc::strong_count(bank) == 1);
+        scan_time.stop();
+        *total_scan_pending_total_drop_banks_time += scan_time.as_us();
+
+        *dropped_count += to_drop.len();
+
+        // Drop the banks that are dead
+        let mut drop_time = Measure::start("total_drop_banks_time");
+        drop(to_drop);
+        drop_time.stop();
+        *total_drop_banks_time += drop_time.as_us();
+
+        if *dropped_count >= 100 {
+            datapoint_info!(
+                "drop-banks-timing",
+                (
+                    "total_scan_pending_total_drop_banks_time",
+                    *total_scan_pending_total_drop_banks_time,
+                    i64
+                ),
+                ("total_drop_banks_time", *total_drop_banks_time, i64),
+                ("dropped_count", *dropped_count, i64),
+            );
+            *total_scan_pending_total_drop_banks_time = 0;
+            *total_drop_banks_time = 0;
+            *dropped_count = 0;
+        }
+
+        to_keep
+    }
+
     pub fn join(self) -> thread::Result<()> {
         self.t_background.join()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::genesis_utils::create_genesis_config;
+    use solana_sdk::pubkey::Pubkey;
+
+    #[test]
+    fn test_scan_for_drops() {
+        let genesis = create_genesis_config(10);
+        let bank = Arc::new(Bank::new(&genesis.genesis_config));
+
+        // Handle empty case
+        assert!(AccountsBackgroundService::scan_for_drops(vec![], &mut 0, &mut 0, &mut 0).is_empty());
+
+        // All banks should be dropped because there's only one reference to the bank
+        assert!(
+            AccountsBackgroundService::scan_for_drops(vec![bank], &mut 0, &mut 0, &mut 0).is_empty()
+        );
+
+        let bank0 = Arc::new(Bank::new(&genesis.genesis_config));
+        let bank0_ref = bank0.clone();
+        let bank1 = Arc::new(Bank::new_from_parent(&bank0, &Pubkey::default(), 1));
+
+        // With an additional reference, only the single referenced bank should be dropped
+        let result =
+            AccountsBackgroundService::scan_for_drops(vec![bank0, bank1], &mut 0, &mut 0, &mut 0);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].slot(), 0);
+
+        // Drop the reference, everything should be dropped
+        drop(bank0_ref);
+        assert!(AccountsBackgroundService::scan_for_drops(result, &mut 0, &mut 0, &mut 0).is_empty());
     }
 }


### PR DESCRIPTION
#### Problem
Working towards: https://github.com/solana-labs/solana/pull/13140

Bank drop()->purge_slot() can race with AccountsBackgroundService flushing the cache.

#### Summary of Changes
Send slots to be dropped to AccountsBackgroundService on Bank::drop()

Fixes #
