### PR TITLE
samples repair peers using WeightedIndex

### DIFF
--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -26,7 +26,7 @@
 
 use crate::contact_info::ContactInfo;
 use crate::crds_shards::CrdsShards;
-use crate::crds_value::{CrdsData, CrdsValue, CrdsValueLabel};
+use crate::crds_value::{CrdsData, CrdsValue, CrdsValueLabel, LowestSlot};
 use bincode::serialize;
 use indexmap::map::{rayon::ParValues, Entry, IndexMap, Iter, Values};
 use indexmap::set::IndexSet;
@@ -182,9 +182,14 @@ impl Crds {
         self.table.get(label)
     }
 
-    pub fn get_contact_info(&self, pubkey: &Pubkey) -> Option<&ContactInfo> {
-        let label = CrdsValueLabel::ContactInfo(*pubkey);
+    pub fn get_contact_info(&self, pubkey: Pubkey) -> Option<&ContactInfo> {
+        let label = CrdsValueLabel::ContactInfo(pubkey);
         self.table.get(&label)?.value.contact_info()
+    }
+
+    pub fn get_lowest_slot(&self, pubkey: Pubkey) -> Option<&LowestSlot> {
+        let lable = CrdsValueLabel::LowestSlot(pubkey);
+        self.table.get(&lable)?.value.lowest_slot()
     }
 
     /// Returns all entries which are ContactInfo.

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -31,6 +31,7 @@ pub enum Error {
     BlockstoreError(blockstore::BlockstoreError),
     FsExtra(fs_extra::error::Error),
     SnapshotError(snapshot_utils::SnapshotError),
+    WeightedIndexError(rand::distributions::weighted::WeightedError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -141,6 +142,11 @@ impl std::convert::From<blockstore::BlockstoreError> for Error {
 impl std::convert::From<snapshot_utils::SnapshotError> for Error {
     fn from(e: snapshot_utils::SnapshotError) -> Error {
         Error::SnapshotError(e)
+    }
+}
+impl std::convert::From<rand::distributions::weighted::WeightedError> for Error {
+    fn from(e: rand::distributions::weighted::WeightedError) -> Error {
+        Error::WeightedIndexError(e)
     }
 }
 

--- a/core/src/weighted_shuffle.rs
+++ b/core/src/weighted_shuffle.rs
@@ -37,6 +37,7 @@ where
 
 /// Returns the highest index after computing a weighted shuffle.
 /// Saves doing any sorting for O(n) max calculation.
+// TODO: Remove in favor of rand::distributions::WeightedIndex.
 pub fn weighted_best(weights_and_indexes: &[(u64, usize)], seed: [u8; 32]) -> usize {
     if weights_and_indexes.is_empty() {
         return 0;


### PR DESCRIPTION
#### Problem
To output one random sample, weighted_best generates n random numbers:
https://github.com/solana-labs/solana/blob/f751a5d4e/core/src/weighted_shuffle.rs#L38-L63
WeightedIndex does so with only one random number:
https://github.com/rust-random/rand/blob/eb02f0e46/src/distributions/weighted_index.rs#L223-L240
Additionally, if the index is already constructed, it only does a total
of O(log(n)) amount of work; which can be achieved if RepairCache,
caches the weighted index:
https://github.com/solana-labs/solana/blob/f751a5d4e/core/src/serve_repair.rs#L83

Also, the repair-peers code can be reorganized to have fewer redundant
unlock-then-lock code.

#### Summary of Changes
* Replaced `weighted_best` with `WeightedIndex`.
* Reorganized some of the locking code when selecting repair peer.
* Tests show ~20% improvement in timings and less variations.