### PR TITLE
Cli: output stake account credits-observed for verbose/json

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -541,7 +541,15 @@ impl CliStakeVec {
 }
 
 impl QuietDisplay for CliStakeVec {}
-impl VerboseDisplay for CliStakeVec {}
+impl VerboseDisplay for CliStakeVec {
+    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        for state in &self.0 {
+            writeln!(w)?;
+            VerboseDisplay::write_str(state, w)?;
+        }
+        Ok(())
+    }
+}
 
 impl fmt::Display for CliStakeVec {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -562,7 +570,12 @@ pub struct CliKeyedStakeState {
 }
 
 impl QuietDisplay for CliKeyedStakeState {}
-impl VerboseDisplay for CliKeyedStakeState {}
+impl VerboseDisplay for CliKeyedStakeState {
+    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        writeln!(w, "Stake Pubkey: {}", self.stake_pubkey)?;
+        VerboseDisplay::write_str(&self.stake_state, w)
+    }
+}
 
 impl fmt::Display for CliKeyedStakeState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -658,6 +671,8 @@ pub struct CliStakeState {
     pub stake_type: CliStakeType,
     pub account_balance: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub credits_observed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delegated_stake: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delegated_vote_account_address: Option<String>,
@@ -686,7 +701,15 @@ pub struct CliStakeState {
 }
 
 impl QuietDisplay for CliStakeState {}
-impl VerboseDisplay for CliStakeState {}
+impl VerboseDisplay for CliStakeState {
+    fn write_str(&self, w: &mut dyn std::fmt::Write) -> std::fmt::Result {
+        write!(w, "{}", self)?;
+        if let Some(credits) = self.credits_observed {
+            writeln!(w, "Credits Observed: {}", credits)?;
+        }
+        Ok(())
+    }
+}
 
 impl fmt::Display for CliStakeState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -168,17 +168,19 @@ pub fn parse_args<'a>(
     let CliCommandInfo { command, signers } =
         parse_command(&matches, &default_signer, &mut wallet_manager)?;
 
-    let mut output_format = matches
+    let verbose = matches.is_present("verbose");
+    let output_format = matches
         .value_of("output_format")
         .map(|value| match value {
             "json" => OutputFormat::Json,
             "json-compact" => OutputFormat::JsonCompact,
             _ => unreachable!(),
         })
-        .unwrap_or(OutputFormat::Display);
-    if output_format == OutputFormat::Display && matches.is_present("verbose") {
-        output_format = OutputFormat::DisplayVerbose;
-    }
+        .unwrap_or(if verbose {
+            OutputFormat::DisplayVerbose
+        } else {
+            OutputFormat::Display
+        });
 
     let commitment = matches
         .subcommand_name()
@@ -201,7 +203,7 @@ pub fn parse_args<'a>(
             keypair_path: default_signer_path,
             rpc_client: None,
             rpc_timeout,
-            verbose: matches.is_present("verbose"),
+            verbose,
             output_format,
             commitment,
             send_transaction_config: RpcSendTransactionConfig::default(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -168,7 +168,7 @@ pub fn parse_args<'a>(
     let CliCommandInfo { command, signers } =
         parse_command(&matches, &default_signer, &mut wallet_manager)?;
 
-    let output_format = matches
+    let mut output_format = matches
         .value_of("output_format")
         .map(|value| match value {
             "json" => OutputFormat::Json,
@@ -176,6 +176,9 @@ pub fn parse_args<'a>(
             _ => unreachable!(),
         })
         .unwrap_or(OutputFormat::Display);
+    if output_format == OutputFormat::Display && matches.is_present("verbose") {
+        output_format = OutputFormat::DisplayVerbose;
+    }
 
     let commitment = matches
         .subcommand_name()

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1528,6 +1528,7 @@ pub fn build_stake_state(
             CliStakeState {
                 stake_type: CliStakeType::Stake,
                 account_balance,
+                credits_observed: Some(stake.credits_observed),
                 delegated_stake: Some(stake.delegation.stake),
                 delegated_vote_account_address: if stake.delegation.voter_pubkey
                     != Pubkey::default()

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1580,6 +1580,7 @@ pub fn build_stake_state(
             CliStakeState {
                 stake_type: CliStakeType::Initialized,
                 account_balance,
+                credits_observed: Some(0),
                 authorized: Some(authorized.into()),
                 lockup,
                 use_lamports_unit,


### PR DESCRIPTION
#### Problem
We removed credits-observed data from the cli display because it is not super accessible to users. It is still available via JSON-RPC, however it would be useful for inflation analysis to be able to get this information quickly via cli.

#### Summary of Changes
- Add credits_observed to verbose and json CliStakeStake prints

cc @ryoqun 
