### PR TITLE
Cap number of program address seeds

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -534,9 +534,9 @@ impl<'a> SyscallObject<BPFError> for SyscallCreateProgramAddress<'a> {
         // TODO need ref?
         let untranslated_seeds =
             translate_slice!(&[&u8], seeds_addr, seeds_len, ro_regions, self.loader_id)?;
-            if untranslated_seeds.len() > MAX_SEEDS {
-                return Ok(1);
-            }
+        if untranslated_seeds.len() > MAX_SEEDS {
+            return Ok(1);
+        }
         let seeds = untranslated_seeds
             .iter()
             .map(|untranslated_seed| {


### PR DESCRIPTION
#### Problem

`create_program_address` has no cap on the number of seeds that can be passed which can lead to a large hash compute load

#### Summary of Changes

Cap the maximum number of seeds to a reasonable amount

Fixes #