### PR TITLE
fix: change parsed type to any in ParsedInstruction

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -197,7 +197,7 @@ declare module '@solana/web3.js' {
   export type ParsedInstruction = {
     programId: PublicKey;
     program: string;
-    parsed: string;
+    parsed: any;
   };
 
   export type PartiallyDecodedInstruction = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -224,7 +224,7 @@ declare module '@solana/web3.js' {
   declare export type ParsedInstruction = {|
     programId: PublicKey,
     program: string,
-    parsed: string,
+    parsed: any,
   |};
 
   declare export type PartiallyDecodedInstruction = {|


### PR DESCRIPTION
#### Problem

The current type of `parsed` in `ParsedInstruction` is string, but according to the official doc it should be any.
https://github.com/solana-labs/solana/blob/master/web3.js/module.d.ts#L200

And actually, it is used to store a any type javascript object.
https://solana-labs.github.io/solana-web3.js/typedef/index.html#static-typedef-ParsedInstruction

#### Summary of Changes

Fixes #
Change `parsed` type to `any` from `string` in `ParsedInstruction`.
