### PR TITLE
Cap seeds not signers

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -9,6 +9,7 @@ static const uint8_t TEST_PRIVILEGE_ESCALATION_SIGNER = 2;
 static const uint8_t TEST_PRIVILEGE_ESCALATION_WRITABLE = 3;
 static const uint8_t TEST_PPROGRAM_NOT_EXECUTABLE = 4;
 static const uint8_t TEST_EMPTY_ACCOUNTS_SLICE = 5;
+static const uint8_t TEST_CAP_SEEDS = 6;
 
 static const int MINT_INDEX = 0;
 static const int ARGUMENT_INDEX = 1;
@@ -281,6 +282,33 @@ extern uint64_t entrypoint(const uint8_t *input) {
                                         data, SOL_ARRAY_SIZE(data)};
 
     sol_assert(SUCCESS == sol_invoke(&instruction, 0, 0));
+  }
+  case TEST_CAP_SEEDS: {
+    sol_log("Test cap seeds");
+    {
+      SolAccountMeta arguments[] = {};
+      uint8_t data[] = {};
+      const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+                                          arguments, SOL_ARRAY_SIZE(arguments),
+                                          data, SOL_ARRAY_SIZE(data)};
+      uint8_t seed[] = {"seed"};
+      const SolSignerSeed seeds[] = {
+          {seed, SOL_ARRAY_SIZE(seed)}, {seed, SOL_ARRAY_SIZE(seed)},
+          {seed, SOL_ARRAY_SIZE(seed)}, {seed, SOL_ARRAY_SIZE(seed)},
+          {seed, SOL_ARRAY_SIZE(seed)}, {seed, SOL_ARRAY_SIZE(seed)},
+          {seed, SOL_ARRAY_SIZE(seed)}, {seed, SOL_ARRAY_SIZE(seed)},
+          {seed, SOL_ARRAY_SIZE(seed)}, {seed, SOL_ARRAY_SIZE(seed)},
+          {seed, SOL_ARRAY_SIZE(seed)}, {seed, SOL_ARRAY_SIZE(seed)},
+          {seed, SOL_ARRAY_SIZE(seed)}, {seed, SOL_ARRAY_SIZE(seed)},
+          {seed, SOL_ARRAY_SIZE(seed)}, {seed, SOL_ARRAY_SIZE(seed)},
+          {seed, SOL_ARRAY_SIZE(seed)},
+      };
+      const SolSignerSeeds signers_seeds[] = {{seeds, SOL_ARRAY_SIZE(seeds)}};
+      sol_assert(SUCCESS == sol_invoke_signed(&instruction, accounts,
+                                              SOL_ARRAY_SIZE(accounts),
+                                              signers_seeds,
+                                              SOL_ARRAY_SIZE(signers_seeds)));
+    }
   }
   default:
     sol_panic();

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -21,6 +21,7 @@ const TEST_PRIVILEGE_ESCALATION_SIGNER: u8 = 2;
 const TEST_PRIVILEGE_ESCALATION_WRITABLE: u8 = 3;
 const TEST_PPROGRAM_NOT_EXECUTABLE: u8 = 4;
 const TEST_EMPTY_ACCOUNTS_SLICE: u8 = 5;
+const TEST_CAP_SEEDS: u8 = 6;
 
 // const MINT_INDEX: usize = 0;
 const ARGUMENT_INDEX: usize = 1;
@@ -371,6 +372,18 @@ fn process_instruction(
             msg!("Empty accounts slice");
             let instruction = create_instruction(*accounts[INVOKED_PROGRAM_INDEX].key, &[], vec![]);
             invoke(&instruction, &[])?;
+        }
+        TEST_CAP_SEEDS => {
+            msg!("Test program max seeds");
+            let instruction = create_instruction(*accounts[INVOKED_PROGRAM_INDEX].key, &[], vec![]);
+            invoke_signed(
+                &instruction,
+                accounts,
+                &[&[
+                    b"1", b"2", b"3", b"4", b"5", b"6", b"7", b"8", b"9", b"0", b"1", b"2", b"3",
+                    b"4", b"5", b"6", b"7",
+                ]],
+            )?;
         }
         _ => panic!(),
     }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -923,9 +923,6 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
                 signers_seeds_len,
                 self.loader_id,
             )?;
-            if signers_seeds.len() > MAX_SEEDS {
-                return Err(SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded).into());
-            }
             for signer_seeds in signers_seeds.iter() {
                 let untranslated_seeds = translate_slice::<&[u8]>(
                     memory_mapping,
@@ -933,6 +930,12 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
                     signer_seeds.len() as u64,
                     self.loader_id,
                 )?;
+                if untranslated_seeds.len() > MAX_SEEDS {
+                    return Err(SyscallError::InstructionError(
+                        InstructionError::MaxSeedLengthExceeded,
+                    )
+                    .into());
+                }
                 let seeds = untranslated_seeds
                     .iter()
                     .map(|untranslated_seed| {
@@ -1175,9 +1178,6 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
                 signers_seeds_len,
                 self.loader_id,
             )?;
-            if signers_seeds.len() > MAX_SEEDS {
-                return Err(SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded).into());
-            }
             Ok(signers_seeds
                 .iter()
                 .map(|signer_seeds| {
@@ -1187,6 +1187,12 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
                         signer_seeds.len,
                         self.loader_id,
                     )?;
+                    if seeds.len() > MAX_SEEDS {
+                        return Err(SyscallError::InstructionError(
+                            InstructionError::MaxSeedLengthExceeded,
+                        )
+                        .into());
+                    }
                     let seeds_bytes = seeds
                         .iter()
                         .map(|seed| {


### PR DESCRIPTION
#### Problem

Signers were being capped not the number of seeds

#### Summary of Changes

Cap the number of seeds when calling `invoke_signed`

Fixes #
