### PR TITLE
Improved Transaction Forwarding

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -522,6 +522,7 @@ impl CliConfig<'_> {
             commitment: CommitmentConfig::recent(),
             send_transaction_config: RpcSendTransactionConfig {
                 skip_preflight: true,
+                preflight_commitment: Some(CommitmentConfig::recent().commitment),
                 ..RpcSendTransactionConfig::default()
             },
             ..Self::default()
@@ -1406,6 +1407,7 @@ fn send_deploy_messages(
             config.commitment,
             RpcSendTransactionConfig {
                 skip_preflight: true,
+                preflight_commitment: Some(config.commitment.commitment),
                 ..RpcSendTransactionConfig::default()
             },
         )
@@ -1815,6 +1817,7 @@ fn process_set_program_upgrade_authority(
             config.commitment,
             RpcSendTransactionConfig {
                 skip_preflight: true,
+                preflight_commitment: Some(config.commitment.commitment),
                 ..RpcSendTransactionConfig::default()
             },
         )

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -58,7 +58,7 @@ type PacketsAndOffsets = (Packets, Vec<usize>);
 pub type UnprocessedPackets = Vec<PacketsAndOffsets>;
 
 /// Transaction forwarding
-pub const FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET: u64 = 1;
+pub const FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET: u64 = 2;
 
 // Fixed thread size seems to be fastest on GCP setup
 pub const NUM_THREADS: u32 = 4;

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -237,7 +237,7 @@ impl JsonRpcRequestProcessor {
         let cluster_info = Arc::new(ClusterInfo::default());
         let tpu_address = cluster_info.my_contact_info().tpu;
         let (sender, receiver) = channel();
-        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
 
         Self {
             config: JsonRpcConfig::default(),
@@ -2906,7 +2906,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
 
         cluster_info.insert_info(ContactInfo::new_with_pubkey_socketaddr(
             &leader_pubkey,
@@ -4306,7 +4306,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
 
         let mut bad_transaction = system_transaction::transfer(
             &mint_keypair,
@@ -4502,7 +4502,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
         assert_eq!(request_processor.validator_exit(), false);
         assert_eq!(exit.load(Ordering::Relaxed), false);
     }
@@ -4534,7 +4534,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
         assert_eq!(request_processor.validator_exit(), true);
         assert_eq!(exit.load(Ordering::Relaxed), true);
     }
@@ -4625,7 +4625,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         );
-        SendTransactionService::new(tpu_address, &bank_forks, None, receiver);
+        SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
         assert_eq!(
             request_processor.get_block_commitment(0),
             RpcBlockCommitment {

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -251,6 +251,8 @@ impl JsonRpcService {
         trusted_validators: Option<HashSet<Pubkey>>,
         override_health_check: Arc<AtomicBool>,
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
+        send_transaction_retry_ms: u64,
+        send_transaction_leader_forward_count: u64,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -323,6 +325,8 @@ impl JsonRpcService {
             &bank_forks,
             leader_info,
             receiver,
+            send_transaction_retry_ms,
+            send_transaction_leader_forward_count,
         ));
 
         #[cfg(test)]
@@ -456,6 +460,8 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
             optimistically_confirmed_bank,
+            1000,
+            1,
         );
         let thread = rpc_service.thread_hdl.thread();
         assert_eq!(thread.name().unwrap(), "solana-jsonrpc");

--- a/core/src/send_transaction_service.rs
+++ b/core/src/send_transaction_service.rs
@@ -68,16 +68,21 @@ impl LeaderInfo {
             .collect();
     }
 
-    pub fn get_leader_tpus(&self, count: u64) -> Vec<&SocketAddr> {
+    pub fn get_leader_tpus(&self, max_count: u64) -> Vec<&SocketAddr> {
         let recorder = self.poh_recorder.lock().unwrap();
-        let leaders: Vec<_> = (0..count)
+        let leaders: Vec<_> = (0..max_count)
             .filter_map(|i| recorder.leader_after_n_slots(i * NUM_CONSECUTIVE_LEADER_SLOTS))
             .collect();
         drop(recorder);
-        leaders
-            .into_iter()
-            .filter_map(|leader| self.recent_peers.get(&leader))
-            .collect()
+        let mut unique_leaders = vec![];
+        for leader in leaders.iter() {
+            if let Some(addr) = self.recent_peers.get(leader) {
+                if !unique_leaders.contains(&addr) {
+                    unique_leaders.push(addr);
+                }
+            }
+        }
+        unique_leaders
     }
 }
 
@@ -272,9 +277,20 @@ impl SendTransactionService {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::contact_info::ContactInfo;
+    use solana_ledger::{
+        blockstore::Blockstore, get_tmp_ledger_path, leader_schedule_cache::LeaderScheduleCache,
+    };
+    use solana_runtime::genesis_utils::{
+        create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
+    };
     use solana_sdk::{
-        genesis_config::create_genesis_config, pubkey::Pubkey, signature::Signer,
+        genesis_config::create_genesis_config,
+        poh_config::PohConfig,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
         system_transaction,
+        timing::timestamp,
     };
     use std::sync::mpsc::channel;
 
@@ -438,5 +454,114 @@ mod test {
                 ..ProcessTransactionsResult::default()
             }
         );
+    }
+
+    #[test]
+    fn test_get_leader_tpus() {
+        let ledger_path = get_tmp_ledger_path!();
+        {
+            let blockstore = Blockstore::open(&ledger_path).unwrap();
+
+            let validator_vote_keypairs0 = ValidatorVoteKeypairs::new_rand();
+            let validator_vote_keypairs1 = ValidatorVoteKeypairs::new_rand();
+            let validator_vote_keypairs2 = ValidatorVoteKeypairs::new_rand();
+            let validator_keypairs = vec![
+                &validator_vote_keypairs0,
+                &validator_vote_keypairs1,
+                &validator_vote_keypairs2,
+            ];
+            let GenesisConfigInfo {
+                genesis_config,
+                mint_keypair: _,
+                voting_keypair: _,
+            } = create_genesis_config_with_vote_accounts(
+                1_000_000_000,
+                &validator_keypairs,
+                vec![10_000; 3],
+            );
+            let bank = Arc::new(Bank::new(&genesis_config));
+
+            let (poh_recorder, _entry_receiver) = PohRecorder::new(
+                0,
+                bank.last_blockhash(),
+                0,
+                Some((2, 2)),
+                bank.ticks_per_slot(),
+                &Pubkey::default(),
+                &Arc::new(blockstore),
+                &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
+                &Arc::new(PohConfig::default()),
+            );
+
+            let node_keypair = Arc::new(Keypair::new());
+            let cluster_info = Arc::new(ClusterInfo::new(
+                ContactInfo::new_localhost(&node_keypair.pubkey(), timestamp()),
+                node_keypair,
+            ));
+
+            let validator0_socket = SocketAddr::from(([127, 0, 0, 1], 1111));
+            let validator1_socket = SocketAddr::from(([127, 0, 0, 1], 2222));
+            let validator2_socket = SocketAddr::from(([127, 0, 0, 1], 3333));
+            let recent_peers: HashMap<_, _> = vec![
+                (
+                    validator_vote_keypairs0.node_keypair.pubkey(),
+                    validator0_socket,
+                ),
+                (
+                    validator_vote_keypairs1.node_keypair.pubkey(),
+                    validator1_socket,
+                ),
+                (
+                    validator_vote_keypairs2.node_keypair.pubkey(),
+                    validator2_socket,
+                ),
+            ]
+            .iter()
+            .cloned()
+            .collect();
+            let leader_info = LeaderInfo {
+                cluster_info,
+                poh_recorder: Arc::new(Mutex::new(poh_recorder)),
+                recent_peers: recent_peers.clone(),
+            };
+
+            let slot = bank.slot();
+            let first_leader =
+                solana_ledger::leader_schedule_utils::slot_leader_at(slot, &bank).unwrap();
+            assert_eq!(
+                leader_info.get_leader_tpus(1),
+                vec![recent_peers.get(&first_leader).unwrap()]
+            );
+
+            let second_leader = solana_ledger::leader_schedule_utils::slot_leader_at(
+                slot + NUM_CONSECUTIVE_LEADER_SLOTS,
+                &bank,
+            )
+            .unwrap();
+            let mut expected_leader_sockets = vec![
+                recent_peers.get(&first_leader).unwrap(),
+                recent_peers.get(&second_leader).unwrap(),
+            ];
+            expected_leader_sockets.dedup();
+            assert_eq!(leader_info.get_leader_tpus(2), expected_leader_sockets);
+
+            let third_leader = solana_ledger::leader_schedule_utils::slot_leader_at(
+                slot + (2 * NUM_CONSECUTIVE_LEADER_SLOTS),
+                &bank,
+            )
+            .unwrap();
+            let mut expected_leader_sockets = vec![
+                recent_peers.get(&first_leader).unwrap(),
+                recent_peers.get(&second_leader).unwrap(),
+                recent_peers.get(&third_leader).unwrap(),
+            ];
+            expected_leader_sockets.dedup();
+            assert_eq!(leader_info.get_leader_tpus(3), expected_leader_sockets);
+
+            for x in 4..8 {
+                assert!(leader_info.get_leader_tpus(x).len() <= recent_peers.len());
+            }
+        }
+        Blockstore::destroy(&ledger_path).unwrap();
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -106,6 +106,8 @@ pub struct ValidatorConfig {
     pub debug_keys: Option<Arc<HashSet<Pubkey>>>,
     pub contact_debug_interval: u64,
     pub bpf_jit: bool,
+    pub send_transaction_retry_ms: u64,
+    pub send_transaction_leader_forward_count: u64,
 }
 
 impl Default for ValidatorConfig {
@@ -144,6 +146,8 @@ impl Default for ValidatorConfig {
             debug_keys: None,
             contact_debug_interval: DEFAULT_CONTACT_DEBUG_INTERVAL,
             bpf_jit: false,
+            send_transaction_retry_ms: 2000,
+            send_transaction_leader_forward_count: 2,
         }
     }
 }
@@ -433,6 +437,8 @@ impl Validator {
                         config.trusted_validators.clone(),
                         rpc_override_health_check.clone(),
                         optimistically_confirmed_bank.clone(),
+                        config.send_transaction_retry_ms,
+                        config.send_transaction_leader_forward_count,
                     ),
                     pubsub_service: PubSubService::new(
                         config.pubsub_config.clone(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -798,6 +798,12 @@ pub fn main() {
         PubSubConfig::default().max_in_buffer_capacity.to_string();
     let default_rpc_pubsub_max_out_buffer_capacity =
         PubSubConfig::default().max_out_buffer_capacity.to_string();
+    let default_rpc_send_transaction_retry_ms = ValidatorConfig::default()
+        .send_transaction_retry_ms
+        .to_string();
+    let default_rpc_send_transaction_leader_forward_count = ValidatorConfig::default()
+        .send_transaction_leader_forward_count
+        .to_string();
 
     let matches = App::new(crate_name!()).about(crate_description!())
         .version(solana_version::version!())
@@ -1279,6 +1285,24 @@ pub fn main() {
                 .help("The maximum size in bytes to which the outgoing websocket buffer can grow."),
         )
         .arg(
+            Arg::with_name("rpc_send_transaction_retry_ms")
+                .long("rpc-send-retry-ms")
+                .value_name("MILLISECS")
+                .takes_value(true)
+                .validator(is_parsable::<u64>)
+                .default_value(&default_rpc_send_transaction_retry_ms)
+                .help("The rate at which transactions sent via rpc service are retried."),
+        )
+        .arg(
+            Arg::with_name("rpc_send_transaction_leader_forward_count")
+                .long("rpc-send-leader-count")
+                .value_name("NUMBER")
+                .takes_value(true)
+                .validator(is_parsable::<u64>)
+                .default_value(&default_rpc_send_transaction_leader_forward_count)
+                .help("The number of upcoming leaders to which to forward transactions sent via rpc service."),
+        )
+        .arg(
             Arg::with_name("halt_on_trusted_validators_accounts_hash_mismatch")
                 .long("halt-on-trusted-validators-accounts-hash-mismatch")
                 .requires("trusted_validators")
@@ -1483,6 +1507,12 @@ pub fn main() {
         debug_keys,
         contact_debug_interval,
         bpf_jit: matches.is_present("bpf_jit"),
+        send_transaction_retry_ms: value_t_or_exit!(matches, "rpc_send_transaction_retry_ms", u64),
+        send_transaction_leader_forward_count: value_t_or_exit!(
+            matches,
+            "rpc_send_transaction_leader_forward_count",
+            u64
+        ),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

Transaction forwarding is fragile, single node can be down/behind/etc and retry at 5 seconds is too conservative.

#### Summary of Changes

Forward to multiple leaders and make it configurable
TODO:
- [x] de-dupe leaders when multiple leaders are specified
- [x] testing
- [x] Hold more transactions than 1 slot away in banking stage, maybe the range of 2-3 leader slots.

Fixes #
