### PR TITLE
Blockstore exact purge cleanup

### DIFF
--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -273,21 +273,13 @@ impl Blockstore {
                 .cloned()
                 .flat_map(|entry| entry.transactions)
             {
-                batch.delete::<cf::TransactionStatus>((0, transaction.signatures[0], slot))?;
-                batch.delete::<cf::TransactionStatus>((1, transaction.signatures[0], slot))?;
-                for pubkey in transaction.message.account_keys {
-                    batch.delete::<cf::AddressSignatures>((
-                        0,
-                        pubkey,
-                        slot,
-                        transaction.signatures[0],
-                    ))?;
-                    batch.delete::<cf::AddressSignatures>((
-                        1,
-                        pubkey,
-                        slot,
-                        transaction.signatures[0],
-                    ))?;
+                if let Some(&signature) = transaction.signatures.get(0) {
+                    batch.delete::<cf::TransactionStatus>((0, signature, slot))?;
+                    batch.delete::<cf::TransactionStatus>((1, signature, slot))?;
+                    for pubkey in transaction.message.account_keys {
+                        batch.delete::<cf::AddressSignatures>((0, pubkey, slot, signature))?;
+                        batch.delete::<cf::AddressSignatures>((1, pubkey, slot, signature))?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Problem
Blockstore exact purge can't handle malformed transactions (no signatures)

#### Summary of Changes
- Properly check index and skip deletes, since transactions with no signatures cannot have related TransactionStatus or AddressSignature records
