### PR TITLE
explorer: prevent raw details from showing on inner instructions

### DIFF
--- a/explorer/src/components/instruction/InstructionCard.tsx
+++ b/explorer/src/components/instruction/InstructionCard.tsx
@@ -39,7 +39,7 @@ export function InstructionCard({
   const signature = useContext(SignatureContext);
   const details = useTransactionDetails(signature);
   let raw: TransactionInstruction | undefined = undefined;
-  if (details) {
+  if (details && childIndex === undefined) {
     raw = details?.data?.raw?.transaction.instructions[index];
   }
   const fetchRaw = useFetchRawTransaction();


### PR DESCRIPTION
#### Problem
Recent changes to transaction details page allow for raw instructions to be displayed on parsed instruction cards. This feature is currently unavailable for inner instructions. 

#### Summary of Changes
Disable raw details on CPI cards.
