### PR TITLE
Remove associated functions on AccountsDb, replace with methods

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1386,14 +1386,9 @@ impl AccountsDB {
         bank_hashes.insert(slot, new_hash_info);
     }
 
-    pub fn load(
-        storage: &AccountStorage,
-        ancestors: &Ancestors,
-        accounts_index: &AccountsIndex<AccountInfo>,
-        pubkey: &Pubkey,
-    ) -> Option<(Account, Slot)> {
+    pub fn load(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
         let (slot, store_id, offset) = {
-            let (lock, index) = accounts_index.get(pubkey, Some(ancestors), None)?;
+            let (lock, index) = self.accounts_index.get(pubkey, Some(ancestors), None)?;
             let slot_list = lock.slot_list();
             let (
                 slot,
@@ -1406,7 +1401,7 @@ impl AccountsDB {
         };
 
         //TODO: thread this as a ref
-        storage
+        self.storage
             .get_account_storage_entry(slot, store_id)
             .and_then(|store| {
                 store
@@ -1443,7 +1438,7 @@ impl AccountsDB {
     }
 
     pub fn load_slow(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
-        Self::load(&self.storage, ancestors, &self.accounts_index, pubkey)
+        self.load(ancestors, pubkey)
     }
 
     fn get_account_from_storage(&self, slot: Slot, account_info: &AccountInfo) -> Option<Account> {


### PR DESCRIPTION
#### Problem
Associated functions in AccountsDb make function calls verbose.

#### Summary of Changes
Replace with methods

Fixes #
