### PR TITLE
Translate data length as mutable

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -862,7 +862,7 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
                         )?;
                         let translated = translate(
                             memory_mapping,
-                            AccessType::Load,
+                            AccessType::Store,
                             unsafe { (account_info.data.as_ptr() as *const u64).offset(1) as u64 },
                             8,
                         )? as *mut u64;


### PR DESCRIPTION
#### Problem

Account data length is translated as RO but written to later.  Result of a bad merge and only exists on master.

#### Summary of Changes

Translate as RW

Don't have a good test to verify this yet, stabs taken today failed, tracked here: https://github.com/solana-labs/solana/issues/13955.

Fixes #
