### PR TITLE
Report highest_confirmed_root and _slot in commitment metric

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -113,7 +113,17 @@ impl AggregateCommitmentService {
                     "aggregate-commitment-ms",
                     aggregate_commitment_time.as_ms() as i64,
                     i64
-                )
+                ),
+                (
+                    "highest-confirmed-root",
+                    update_commitment_slots.highest_confirmed_root as i64,
+                    i64
+                ),
+                (
+                    "highest-confirmed-slot",
+                    update_commitment_slots.highest_confirmed_slot as i64,
+                    i64
+                ),
             );
 
             // Triggers rpc_subscription notifications as soon as new commitment data is available,


### PR DESCRIPTION
#### Problem
In a cluster restart scenario, we may need to know the highest root confirmed by the cluster. This is currently hard to identify.

#### Summary of Changes
- Add a datapoint to report highest_confirmed_root on each calculation; include highest_confirmed_slot for good measure.

cc @mvines 
