### PR TITLE
Don't use stale executor cache

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1985,6 +1985,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-invoke-and-error"
+version = "1.5.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
+name = "solana-bpf-rust-invoke-and-ok"
+version = "1.5.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "solana-bpf-rust-invoked"
 version = "1.5.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -47,6 +47,8 @@ members = [
     "rust/external_spend",
     "rust/instruction_introspection",
     "rust/invoke",
+    "rust/invoke_and_error",
+    "rust/invoke_and_ok",
     "rust/invoked",
     "rust/iter",
     "rust/many_args",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -37,17 +37,17 @@ fn rerun_if_changed(files: &[&str], directories: &[&str], excludes: &[&str]) {
 fn main() {
     let bpf_c = env::var("CARGO_FEATURE_BPF_C").is_ok();
     if bpf_c {
-        let install_dir =
-            "OUT_DIR=../target/".to_string() + &env::var("PROFILE").unwrap() + &"/bpf".to_string();
+         let install_dir =
+             "OUT_DIR=../target/".to_string() + &env::var("PROFILE").unwrap() + &"/bpf".to_string();
 
         println!("cargo:warning=(not a warning) Building C-based BPF programs");
-        assert!(Command::new("make")
-            .current_dir("c")
-            .arg("programs")
-            .arg(&install_dir)
-            .status()
-            .expect("Failed to build C-based BPF programs")
-            .success());
+         assert!(Command::new("make")
+             .current_dir("c")
+             .arg("programs")
+             .arg(&install_dir)
+             .status()
+             .expect("Failed to build C-based BPF programs")
+             .success());
 
         rerun_if_changed(&["c/makefile"], &["c/src", "../../sdk"], &["/target/"]);
     }
@@ -70,6 +70,8 @@ fn main() {
             "external_spend",
             "instruction_introspection",
             "invoke",
+            "invoke_and_error",
+            "invoke_and_ok",
             "invoked",
             "iter",
             "many_args",

--- a/programs/bpf/rust/invoke_and_error/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_error/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "solana-bpf-rust-invoke-and-error"
+version = "1.5.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/invoke_and_error/Xargo.toml
+++ b/programs/bpf/rust/invoke_and_error/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/bpf/rust/invoke_and_error/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_error/src/lib.rs
@@ -1,0 +1,32 @@
+//! @brief Invokes an instruction and returns an error, the instruction invoked
+//! uses the instruction data provided and all the accounts
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, instruction::AccountMeta,
+    instruction::Instruction, program::invoke, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let to_call = accounts[0].key;
+    let infos = accounts;
+    let instruction = Instruction {
+        accounts: accounts[1..]
+            .iter()
+            .map(|acc| AccountMeta {
+                pubkey: *acc.key,
+                is_signer: acc.is_signer,
+                is_writable: acc.is_writable,
+            })
+            .collect(),
+        data: instruction_data.to_owned(),
+        program_id: *to_call,
+    };
+    let _ = invoke(&instruction, &infos);
+
+    Err(42.into())
+}

--- a/programs/bpf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_ok/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "solana-bpf-rust-invoke-and-ok"
+version = "1.5.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "1.5.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/invoke_and_ok/Xargo.toml
+++ b/programs/bpf/rust/invoke_and_ok/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/bpf/rust/invoke_and_ok/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_ok/src/lib.rs
@@ -1,0 +1,32 @@
+//! @brief Invokes an instruction and returns an error, the instruction invoked
+//! uses the instruction data provided and all the accounts
+
+use solana_program::{
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, instruction::AccountMeta,
+    instruction::Instruction, program::invoke, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let to_call = accounts[0].key;
+    let infos = accounts;
+    let instruction = Instruction {
+        accounts: accounts[1..]
+            .iter()
+            .map(|acc| AccountMeta {
+                pubkey: *acc.key,
+                is_signer: acc.is_signer,
+                is_writable: acc.is_writable,
+            })
+            .collect(),
+        data: instruction_data.to_owned(),
+        program_id: *to_call,
+    };
+    let _ = invoke(&instruction, &infos);
+
+    Ok(())
+}

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -273,25 +273,23 @@ impl CachedExecutors {
         })
     }
     fn put(&mut self, pubkey: &Pubkey, executor: Arc<dyn Executor>) {
-        if !self.executors.contains_key(pubkey) {
-            if self.executors.len() >= self.max {
-                let mut least = u64::MAX;
-                let default_key = Pubkey::default();
-                let mut least_key = &default_key;
-                for (key, (count, _)) in self.executors.iter() {
-                    let count = count.load(Relaxed);
-                    if count < least {
-                        least = count;
-                        least_key = key;
-                    }
+        if !self.executors.contains_key(pubkey) && self.executors.len() >= self.max {
+            let mut least = u64::MAX;
+            let default_key = Pubkey::default();
+            let mut least_key = &default_key;
+            for (key, (count, _)) in self.executors.iter() {
+                let count = count.load(Relaxed);
+                if count < least {
+                    least = count;
+                    least_key = key;
                 }
-                let least_key = *least_key;
-                let _ = self.executors.remove(&least_key);
             }
-            let _ = self
-                .executors
-                .insert(*pubkey, (AtomicU64::new(0), executor));
+            let least_key = *least_key;
+            let _ = self.executors.remove(&least_key);
         }
+        let _ = self
+            .executors
+            .insert(*pubkey, (AtomicU64::new(0), executor));
     }
     fn remove(&mut self, pubkey: &Pubkey) {
         let _ = self.executors.remove(pubkey);
@@ -2786,7 +2784,9 @@ impl Bank {
                         loader_refcells,
                     );
 
-                    self.update_executors(executors);
+                    if process_result.is_ok() {
+                        self.update_executors(executors);
+                    }
 
                     let nonce_rollback =
                         if let Err(TransactionError::InstructionError(_, _)) = &process_result {


### PR DESCRIPTION
#### Problem

A stale cached executor could be run even if the account is not marked executable because the loader always adds the executor on successful finalize instruction even if the overall transaction fails.

#### Summary of Changes

Don't use it.  This solution is not optimized because it still populates the cache with an unused entry

Fixes #
