### PR TITLE
removes recursive read-locks on gossip

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1205,9 +1205,10 @@ impl ClusterInfo {
         // self.tvu_peers() already filters on:
         //   node.id != self.id() &&
         //     node.shred_verion == self.my_shred_version()
+        let nodes = self.tvu_peers();
         let nodes = {
             let gossip = self.gossip.read().unwrap();
-            self.tvu_peers()
+            nodes
                 .into_iter()
                 .filter(|node| {
                     ContactInfo::is_valid_address(&node.serve_repair)


### PR DESCRIPTION
#### Problem
ClusterInfo::tvu_peers acquires a read-lock on gossip:
https://github.com/solana-labs/solana/blob/f0e934145/core/src/cluster_info.rs#L1171-L1185
and so, ClusterInfo::repair_peers is recursively locking gossip for
read twice:
https://github.com/solana-labs/solana/blob/f0e934145/core/src/cluster_info.rs#L1202-L1223
But std::sync::RwLock is not re-entrant (recursive).

#### Summary of Changes
Removed recursive double locks.