### PR TITLE
Plumb args for validator boot disk size and client machine type

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -134,7 +134,7 @@ Manage testnet instances
                     - Attempt to generate a TLS certificate using this
                       DNS name (useful only when the -a and -P options
                       are also provided)
-   --custom-machine-type
+   --custom-machine-type [type]
                     - Set a custom machine type without assuming whether or not
                       GPU is enabled.  Set this explicitly with --enable-gpu/-g to call out the presence of GPUs.
    --enable-gpu     - Use with --custom-machine-type to specify whether or not GPUs should be used/enabled
@@ -150,6 +150,10 @@ Manage testnet instances
    --self-destruct-hours [number]
                     - Specify lifetime of the allocated instances in hours. 0 to
                       disable. Only supported on GCE. (default: $selfDestructHours)
+   --validator-boot-disk-size-gb [number]
+                    - Specify validator boot disk size in gb.
+   --client-machine-type [type]
+                    - custom client machine type
 
  config-specific options:
    -P               - Use public network IP addresses (default: $publicNetwork)
@@ -202,6 +206,12 @@ while [[ -n $1 ]]; do
       shift
     elif [[ $1 = --custom-machine-type ]]; then
       customMachineType="$2"
+      shift 2
+    elif [[ $1 = --client-machine-type ]]; then
+      clientMachineType="$2"
+      shift 2
+    elif [[ $1 = --validator-boot-disk-size-gb ]]; then
+      validatorBootDiskSizeInGb="$2"
       shift 2
     elif [[ $1 == --self-destruct-hours ]]; then
       maybeTimeout=$2


### PR DESCRIPTION
#### Problem

Running a network with modified client machine or boot disk size is not possible.

#### Summary of Changes

Plumb through arguments for those.

Fixes #
