### PR TITLE
Cannot change owner if account is executable

### DIFF
--- a/docs/src/developing/programming-model/runtime.md
+++ b/docs/src/developing/programming-model/runtime.md
@@ -30,6 +30,7 @@ adhere to the runtime policy.
 The policy is as follows:
 - Only the owner of the account may change owner.
   - And only if the account is writable.
+  - And only if the account is not executable
   - And only if the data is zero-initialized or empty.
 - An account not assigned to the program cannot have its balance decrease.
 - The balance of read-only and executable accounts may not change.


### PR DESCRIPTION
#### Problem

An executable account that is zero-initialized or empty can have its owner changed by its owner

#### Summary of Changes

Executable accounts cannot change ownership

Fixes #13906
