### PR TITLE
fix: coerce partially decoded instructions on parsed confirmed transactions

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -2602,6 +2602,18 @@ export class Connection {
     assert(typeof result !== 'undefined');
     if (result === null) return result;
 
+    if (result.meta.innerInstructions) {
+      result.meta.innerInstructions.forEach(inner => {
+        inner.instructions.forEach(ix => {
+          ix.programId = new PublicKey(ix.programId);
+
+          if (ix.accounts) {
+            ix.accounts = ix.accounts.map(account => new PublicKey(account));
+          }
+        });
+      });
+    }
+
     const {
       accountKeys,
       instructions,

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -368,11 +368,6 @@ const SimulatedTransactionResponseValidator = jsonRpcResultAndContext(
   }),
 );
 
-type PartiallyDecodedInnerInstruction = {
-  index: number,
-  instructions: PartiallyDecodedInstruction[],
-};
-
 type ParsedInnerInstruction = {
   index: number,
   instructions: (ParsedInstruction | PartiallyDecodedInstruction)[],

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -375,7 +375,7 @@ type PartiallyDecodedInnerInstruction = {
 
 type ParsedInnerInstruction = {
   index: number,
-  instructions: (ParsedInstruction | PartiallyDecodedInnerInstruction)[],
+  instructions: (ParsedInstruction | PartiallyDecodedInstruction)[],
 };
 
 /**

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -999,6 +999,99 @@ test('get confirmed transaction', async () => {
   expect(nullResponse).toBeNull();
 });
 
+test('get parsed confirmed transaction coerces public keys of inner instructions', async () => {
+  if (!mockRpcEnabled) {
+    return;
+  }
+
+  const connection = new Connection(url);
+
+  const confirmedTransaction =
+    '4ADvAUQYxkh4qWKYE9QLW8gCLomGG94QchDLG4quvpBz1WqARYvzWQDDitKduAKspuy1DjcbnaDAnCAfnKpJYs48';
+
+  mockRpc.push([
+    url,
+    {
+      method: 'getConfirmedTransaction',
+      params: [confirmedTransaction, 'jsonParsed'],
+    },
+    {
+      error: null,
+      result: {
+        slot: 353050305,
+        transaction: {
+          message: {
+            accountKeys: [
+              {
+                pubkey: 'va12u4o9DipLEB2z4fuoHszroq1U9NcAB9aooFDPJSf',
+                signer: true,
+                writable: true,
+              },
+            ],
+            instructions: [
+              {
+                accounts: ['va12u4o9DipLEB2z4fuoHszroq1U9NcAB9aooFDPJSf'],
+                data:
+                  '37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7',
+                programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+              },
+            ],
+            recentBlockhash: 'GeyAFFRY3WGpmam2hbgrKw4rbU2RKzfVLm5QLSeZwTZE',
+          },
+          signatures: [
+            'w2Zeq8YkpyB463DttvfzARD7k9ZxGEwbsEw4boEK7jDp3pfoxZbTdLFSsEPhzXhpCcjGi2kHtHFobgX49MMhbWt',
+            '4oCEqwGrMdBeMxpzuWiukCYqSfV4DsSKXSiVVCh1iJ6pS772X7y219JZP3mgqBz5PhsvprpKyhzChjYc3VSBQXzG',
+          ],
+        },
+        meta: {
+          fee: 10000,
+          postBalances: [499260347380, 15298080, 1, 1, 1],
+          preBalances: [499260357380, 15298080, 1, 1, 1],
+          innerInstructions: [
+            {
+              index: 0,
+              instructions: [
+                {
+                  parsed: {},
+                  program: 'spl-token',
+                  programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                },
+                {
+                  accounts: [
+                    'EeJqWk5pczNjsqqY3jia9xfFNG1dD68te4s8gsdCuEk7',
+                    '6tVrjJhFm5SAvvdh6tysjotQurCSELpxuW3JaAAYeC1m',
+                  ],
+                  data: 'ai3535',
+                  programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                },
+              ],
+            },
+          ],
+          status: {Ok: null},
+          err: null,
+        },
+      },
+    },
+  ]);
+
+  const result = await connection.getParsedConfirmedTransaction(
+    confirmedTransaction,
+  );
+
+  expect(
+    result.meta.innerInstructions[0].instructions[0].programId,
+  ).toBeInstanceOf(PublicKey);
+  expect(
+    result.meta.innerInstructions[0].instructions[1].programId,
+  ).toBeInstanceOf(PublicKey);
+  expect(
+    result.meta.innerInstructions[0].instructions[1].accounts[0],
+  ).toBeInstanceOf(PublicKey);
+  expect(
+    result.meta.innerInstructions[0].instructions[1].accounts[1],
+  ).toBeInstanceOf(PublicKey);
+});
+
 test('get confirmed block', async () => {
   const connection = new Connection(url);
 


### PR DESCRIPTION
#### Problem
PartiallyDecodedInnerInstructions contain a programId and accounts, which are all supposed to be PublicKey or PublicKey[] types. These are being provided as strings.

#### Summary of Changes
Coerce public keys on parsed confirmed transactions. 

Fixes https://github.com/solana-labs/solana/issues/13965
