### PR TITLE
v1.3: rpc getConfirmedBlock backports

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -607,7 +607,7 @@ impl JsonRpcRequestProcessor {
         }
     }
 
-    fn check_slot_cleaned_up<T>(
+    fn check_slot_blockstore_status<T>(
         &self,
         result: &std::result::Result<T, BlockstoreError>,
         slot: Slot,
@@ -625,6 +625,9 @@ impl JsonRpcRequestProcessor {
                         .unwrap_or_default(),
                 }
                 .into());
+            }
+            if let BlockstoreError::SlotNotRooted = result.as_ref().unwrap_err() {
+                return Err(RpcCustomError::BlockNotAvailable { slot }.into());
             }
         }
         Ok(())
@@ -654,7 +657,7 @@ impl JsonRpcRequestProcessor {
                         .map(|confirmed_block| confirmed_block.encode(encoding)));
                 }
             }
-            self.check_slot_cleaned_up(&result, slot)?;
+            self.check_slot_blockstore_status(&result, slot)?;
             Ok(result
                 .ok()
                 .map(|confirmed_block| confirmed_block.encode(encoding)))
@@ -759,7 +762,7 @@ impl JsonRpcRequestProcessor {
                         .and_then(|confirmed_block| confirmed_block.block_time));
                 }
             }
-            self.check_slot_cleaned_up(&result, slot)?;
+            self.check_slot_blockstore_status(&result, slot)?;
             Ok(result.ok().unwrap_or(None))
         } else {
             Err(RpcCustomError::BlockNotAvailable { slot }.into())

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -616,10 +616,15 @@ impl JsonRpcRequestProcessor {
         T: std::fmt::Debug,
     {
         if result.is_err() {
-            if let BlockstoreError::SlotNotRooted = result.as_ref().unwrap_err() {
-                if slot > self.blockstore.max_root() {
-                    return Err(RpcCustomError::BlockNotAvailable { slot }.into());
-                }
+            let err = result.as_ref().unwrap_err();
+            debug!(
+                "check_blockstore_max_root, slot: {:?}, max root: {:?}, err: {:?}",
+                slot,
+                self.blockstore.max_root(),
+                err
+            );
+            if slot >= self.blockstore.max_root() {
+                return Err(RpcCustomError::BlockNotAvailable { slot }.into());
             }
         }
         Ok(())


### PR DESCRIPTION
Change to make handling of not-rooted vs empty blocks more consistent, and include logging to track any uncaught errors that cause a `null` response.
