### PR TITLE
Fix logsSubscribe

### DIFF
--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -87,7 +87,7 @@ pub trait RpcSolPubSub {
         meta: Self::Metadata,
         subscriber: Subscriber<RpcResponse<RpcLogsResponse>>,
         filter: RpcTransactionLogsFilter,
-        config: RpcTransactionLogsConfig,
+        config: Option<RpcTransactionLogsConfig>,
     );
 
     // Unsubscribe from logs notification subscription.
@@ -269,7 +269,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         _meta: Self::Metadata,
         subscriber: Subscriber<RpcResponse<RpcLogsResponse>>,
         filter: RpcTransactionLogsFilter,
-        config: RpcTransactionLogsConfig,
+        config: Option<RpcTransactionLogsConfig>,
     ) {
         info!("logs_subscribe");
 
@@ -306,7 +306,7 @@ impl RpcSolPubSub for RpcSolPubSubImpl {
         self.subscriptions.add_logs_subscription(
             address,
             include_votes,
-            config.commitment,
+            config.and_then(|config| config.commitment),
             sub_id,
             subscriber,
         )

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -3013,7 +3013,7 @@ Request:
   "params": [
     {
       "mentions": [ "11111111111111111111111111111111" ]
-    }
+    },
     {
       "commitment": "max"
     }


### PR DESCRIPTION
#### Problem
`logsSubscribe` docs say `commitment` is optional. It isn't. If you try the 2nd docs example, it fails expecting a tuple of length 2.
Also, docs example c+p returns a parse error due to missing comma.

#### Summary of Changes
Fix commitment handling to really be optional; add comma in docs
