### PR TITLE
Rent account passed to loader can be read-only

### DIFF
--- a/sdk/program/src/loader_instruction.rs
+++ b/sdk/program/src/loader_instruction.rs
@@ -47,7 +47,7 @@ pub fn write(
 pub fn finalize(account_pubkey: &Pubkey, program_id: &Pubkey) -> Instruction {
     let account_metas = vec![
         AccountMeta::new(*account_pubkey, true),
-        AccountMeta::new(rent::id(), false),
+        AccountMeta::new_readonly(rent::id(), false),
     ];
     Instruction::new(*program_id, &LoaderInstruction::Finalize, account_metas)
 }


### PR DESCRIPTION
#### Problem

Loader finalize instruction helper specifies the rent sysvar as read-write when it doesn't need to be

#### Summary of Changes

Specify the rent sysvar as a read-only account

Fixes #
