### PR TITLE
Bump criterion to v2.3.3

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -105,7 +105,11 @@ if [[ ! -e xargo-$version.md ]] || [[ ! -x bin/xargo ]]; then
 fi
 
 # Install Criterion
-version=v2.3.2
+if [[ $machine == "linux" ]]; then
+  version=v2.3.3
+else
+  version=v2.3.2
+fi
 if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
   (
     set -e


### PR DESCRIPTION
#### Problem

Criterion v2.3.2 has a bug that could lead to fork bombing on Linux.  This issue has been observed in the Solana Program Library's CI.

#### Summary of Changes

Upgrade Linux machines to use v2.3.3.  Since there are no osx release artifacts for v2.3.3 continue to use v2.3.2 for osx.

Fixes #
