### PR TITLE
Docs: Correct the system.conf NOFILE variable name

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -94,7 +94,11 @@ Add
 LimitNOFILE=500000
 ```
 to the `[Service]` section of your systemd service file, if you use one,
-otherwise add it to `/etc/systemd/system.conf`.
+otherwise add
+```
+DefaultLimitNOFILE=500000
+```
+to the `[Manager]` section of `/etc/systemd/system.conf`.
 ```bash
 sudo systemctl daemon-reload
 ```


### PR DESCRIPTION
#### Problem

Validator system tuning section suggests setting the wrong variable name for `/etc/systemd/system.conf`

#### Summary of Changes

Suggest setting the correct variable name