### PR TITLE
explorer: hotfix - undefined nonce instruction check

### DIFF
--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -201,7 +201,10 @@ function StatusCard({
   const transaction = details?.data?.transaction?.transaction;
   const blockhash = transaction?.message.recentBlockhash;
   const isNonce = (() => {
-    if (!transaction) return false;
+    if (!transaction || transaction.message.instructions.length < 1) {
+      return false;
+    }
+
     const ix = intoTransactionInstruction(
       transaction,
       transaction.message.instructions[0]


### PR DESCRIPTION
#### Problem
There is a function called isNonce that is failing to check if the instruction is fully defined.

#### Summary of Changes
Return false if the instruction is not populated. 