### PR TITLE
duplicate (slot, index) retransmit Shred filter

### DIFF
--- a/core/src/shred_fetch_stage.rs
+++ b/core/src/shred_fetch_stage.rs
@@ -28,7 +28,7 @@ const DEFAULT_LRU_SIZE: usize = 10_000;
 pub type ShredsReceived = LruCache<u64, ()>;
 
 #[derive(Default)]
-struct ShredFetchStats {
+pub struct ShredFetchStats {
     index_overrun: usize,
     shred_count: usize,
     index_bad_deserialize: usize,
@@ -43,7 +43,7 @@ pub struct ShredFetchStage {
 }
 
 impl ShredFetchStage {
-    fn get_slot_index(p: &Packet, stats: &mut ShredFetchStats) -> Option<(u64, u32)> {
+    pub fn get_slot_index(p: &Packet, stats: &mut ShredFetchStats) -> Option<(u64, u32)> {
         let index_start = OFFSET_OF_SHRED_INDEX;
         let index_end = index_start + SIZE_OF_SHRED_INDEX;
         let slot_start = OFFSET_OF_SHRED_SLOT;


### PR DESCRIPTION
#### Problem

Duplicate shred slot/index combination could produce a lot of retransmit traffic.

#### Summary of Changes

Limit to retransmitting 2 shreds.

Fixes #
