### PR TITLE
explorer: Token history dropdown filter

### DIFF
--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -47,7 +47,7 @@ import { Link } from "react-router-dom";
 import { Location } from "history";
 import { useQuery } from "utils/url";
 
-const TRUNCATE_TOKEN_DISPLAY = 8;
+const TRUNCATE_TOKEN_DISPLAY = 10;
 
 type InstructionType = {
   name: string;
@@ -304,11 +304,11 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
     };
   };
 
-  const FILTER_OPTIONS: (TokenInfoWithPubkey | null)[] = [null];
+  const filterOptions: (TokenInfoWithPubkey | null)[] = [null];
   const nameLookup: { [mint: string]: string } = {};
 
   tokens.forEach((token) => {
-    FILTER_OPTIONS.push(token);
+    filterOptions.push(token);
     const pubkey = token.info.mint.toBase58();
     nameLookup[pubkey] = formatTokenDisplay(pubkey, cluster);
   });
@@ -328,7 +328,7 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
           show ? " show" : ""
         }`}
       >
-        {FILTER_OPTIONS.map((filterOption) => {
+        {filterOptions.map((filterOption) => {
           const key = filterOption?.info.mint.toBase58() || null;
           return (
             <Link
@@ -596,7 +596,7 @@ function formatTokenDisplay(pubkey: string, cluster: Cluster): string {
   let display = displayAddress(pubkey, cluster);
 
   if (display === pubkey) {
-    display = display.slice(0, TRUNCATE_TOKEN_DISPLAY) + "...";
+    display = display.slice(0, TRUNCATE_TOKEN_DISPLAY) + "\u2026";
   }
 
   return display;

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -172,12 +172,16 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
       return oldestSlot !== undefined && tx.slot >= oldestSlot;
     });
 
-  const filtered = mintAndTxs.filter(({ mint }) => {
-    if (filter === "") {
-      return true;
-    }
-    return mint.toBase58() === filter;
-  });
+  const filtered = React.useMemo(
+    () =>
+      mintAndTxs.filter(({ mint }) => {
+        if (filter === ALL_TOKENS) {
+          return true;
+        }
+        return mint.toBase58() === filter;
+      }),
+    [filter, mintAndTxs]
+  );
 
   React.useEffect(() => {
     if (!fetching && filtered.length < 1 && !allFoundOldest) {
@@ -332,12 +336,7 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
           return (
             <Link
               key={filterOption}
-              to={(location: Location) =>
-                buildLocation(
-                  location,
-                  filterOption
-                )
-              }
+              to={(location: Location) => buildLocation(location, filterOption)}
               className={`dropdown-item${
                 filterOption === filter ? " active" : ""
               }`}

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -95,12 +95,16 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
   const [showDropdown, setDropdown] = React.useState(false);
   const filter = useQueryFilter();
 
-  const filteredTokens = React.useMemo(() => tokens.filter((token) => {
-    if (filter === ALL_TOKENS) {
-      return true;
-    }
-    return token.info.mint.toBase58() === filter;
-  }), [tokens, filter]);
+  const filteredTokens = React.useMemo(
+    () =>
+      tokens.filter((token) => {
+        if (filter === ALL_TOKENS) {
+          return true;
+        }
+        return token.info.mint.toBase58() === filter;
+      }),
+    [tokens, filter]
+  );
 
   const fetchHistories = React.useCallback(
     (refresh?: boolean) => {

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -47,7 +47,7 @@ import { Link } from "react-router-dom";
 import { Location } from "history";
 import { useQuery } from "utils/url";
 
-const TRUNCATE_TOKEN_DISPLAY = 10;
+const TRUNCATE_TOKEN_LENGTH = 10;
 
 type InstructionType = {
   name: string;
@@ -175,7 +175,6 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
     if (filter === "") {
       return true;
     }
-
     return mint.toBase58() === filter;
   });
 
@@ -310,7 +309,7 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
   tokens.forEach((token) => {
     filterOptions.push(token);
     const pubkey = token.info.mint.toBase58();
-    nameLookup[pubkey] = formatTokenDisplay(pubkey, cluster);
+    nameLookup[pubkey] = formatTokenName(pubkey, cluster);
   });
 
   return (
@@ -346,10 +345,7 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
             >
               {filterOption === null
                 ? "All Tokens"
-                : formatTokenDisplay(
-                    filterOption.info.mint.toBase58(),
-                    cluster
-                  )}
+                : formatTokenName(filterOption.info.mint.toBase58(), cluster)}
             </Link>
           );
         })}
@@ -592,11 +588,11 @@ function InstructionDetails({
   );
 }
 
-function formatTokenDisplay(pubkey: string, cluster: Cluster): string {
+function formatTokenName(pubkey: string, cluster: Cluster): string {
   let display = displayAddress(pubkey, cluster);
 
   if (display === pubkey) {
-    display = display.slice(0, TRUNCATE_TOKEN_DISPLAY) + "\u2026";
+    display = display.slice(0, TRUNCATE_TOKEN_LENGTH) + "\u2026";
   }
 
   return display;

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -80,7 +80,7 @@ const useQueryFilter = (): string => {
   return filter || "";
 };
 
-type DropdownProps = {
+type FilterProps = {
   filter: string;
   toggle: () => void;
   show: boolean;
@@ -215,12 +215,12 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
     <div className="card">
       <div className="card-header align-items-center">
         <h3 className="card-header-title">Token History</h3>
-        <DisplayDropdown
+        <FilterDropdown
           filter={filter}
           toggle={() => setDropdown((show) => !show)}
           show={showDropdown}
           tokens={tokens}
-        ></DisplayDropdown>
+        ></FilterDropdown>
         <button
           className="btn btn-white btn-sm"
           disabled={fetching}
@@ -288,15 +288,15 @@ function TokenHistoryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
   );
 }
 
-const DisplayDropdown = ({ filter, toggle, show, tokens }: DropdownProps) => {
+const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
   const { cluster } = useCluster();
 
-  const buildLocation = (location: Location, display: string) => {
+  const buildLocation = (location: Location, filter: string) => {
     const params = new URLSearchParams(location.search);
-    if (display === "") {
+    if (filter === "") {
       params.delete("filter");
     } else {
-      params.set("filter", display);
+      params.set("filter", filter);
     }
     return {
       ...location,
@@ -304,11 +304,11 @@ const DisplayDropdown = ({ filter, toggle, show, tokens }: DropdownProps) => {
     };
   };
 
-  const DISPLAY_OPTIONS: (TokenInfoWithPubkey | null)[] = [null];
+  const FILTER_OPTIONS: (TokenInfoWithPubkey | null)[] = [null];
   const nameLookup: { [mint: string]: string } = {};
 
   tokens.forEach((token) => {
-    DISPLAY_OPTIONS.push(token);
+    FILTER_OPTIONS.push(token);
     const pubkey = token.info.mint.toBase58();
     nameLookup[pubkey] = formatTokenDisplay(pubkey, cluster);
   });
@@ -328,26 +328,26 @@ const DisplayDropdown = ({ filter, toggle, show, tokens }: DropdownProps) => {
           show ? " show" : ""
         }`}
       >
-        {DISPLAY_OPTIONS.map((displayOption) => {
-          const key = displayOption?.info.mint.toBase58() || null;
+        {FILTER_OPTIONS.map((filterOption) => {
+          const key = filterOption?.info.mint.toBase58() || null;
           return (
             <Link
               key={key}
               to={(location: Location) =>
                 buildLocation(
                   location,
-                  displayOption?.info.mint.toBase58() || ""
+                  filterOption?.info.mint.toBase58() || ""
                 )
               }
               className={`dropdown-item${
-                displayOption?.info.mint.toBase58() === filter ? " active" : ""
+                filterOption?.info.mint.toBase58() === filter ? " active" : ""
               }`}
               onClick={toggle}
             >
-              {displayOption === null
+              {filterOption === null
                 ? "All Tokens"
                 : formatTokenDisplay(
-                    displayOption.info.mint.toBase58(),
+                    filterOption.info.mint.toBase58(),
                     cluster
                   )}
             </Link>

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -48,6 +48,7 @@ import { Location } from "history";
 import { useQuery } from "utils/url";
 
 const TRUNCATE_TOKEN_LENGTH = 10;
+const ALL_TOKENS = "";
 
 type InstructionType = {
   name: string;
@@ -303,12 +304,12 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
     };
   };
 
-  const filterOptions: (TokenInfoWithPubkey | null)[] = [null];
+  const filterOptions: string[] = [ALL_TOKENS];
   const nameLookup: { [mint: string]: string } = {};
 
   tokens.forEach((token) => {
-    filterOptions.push(token);
     const pubkey = token.info.mint.toBase58();
+    filterOptions.push(pubkey);
     nameLookup[pubkey] = formatTokenName(pubkey, cluster);
   });
 
@@ -328,24 +329,23 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
         }`}
       >
         {filterOptions.map((filterOption) => {
-          const key = filterOption?.info.mint.toBase58() || null;
           return (
             <Link
-              key={key}
+              key={filterOption}
               to={(location: Location) =>
                 buildLocation(
                   location,
-                  filterOption?.info.mint.toBase58() || ""
+                  filterOption
                 )
               }
               className={`dropdown-item${
-                filterOption?.info.mint.toBase58() === filter ? " active" : ""
+                filterOption === filter ? " active" : ""
               }`}
               onClick={toggle}
             >
-              {filterOption === null
+              {filterOption === ALL_TOKENS
                 ? "All Tokens"
-                : formatTokenName(filterOption.info.mint.toBase58(), cluster)}
+                : formatTokenName(filterOption, cluster)}
             </Link>
           );
         })}

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -321,3 +321,8 @@ div.inner-cards {
     content:'';
   }
 }
+
+.dropdown-menu.token-filter {
+  max-height: 20rem;
+  overflow-y: auto;
+}


### PR DESCRIPTION
#### Problem
There previously was no way to filter by token on the token history card.

#### Summary of Changes
This adds a dropdown filter in the top right corner.

Fixes https://github.com/solana-labs/solana/issues/13323