### PR TITLE
Initial solana-test-validator command-line program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4014,6 +4014,7 @@ dependencies = [
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",
+ "solana-program-test",
  "solana-rayon-threadlimit",
  "solana-runtime",
  "solana-sdk",
@@ -5070,12 +5071,14 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "indicatif",
  "libc",
  "log 0.4.8",
  "rand 0.7.3",
  "serde_json",
  "signal-hook",
  "solana-clap-utils",
+ "solana-cli-config",
  "solana-client",
  "solana-core",
  "solana-download-utils",
@@ -5089,7 +5092,7 @@ dependencies = [
  "solana-sdk",
  "solana-version",
  "solana-vote-program",
- "solana-vote-signer",
+ "symlink",
 ]
 
 [[package]]

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -141,6 +141,4 @@ fn test_cli_deploy_program() {
     assert_eq!(account2.owner, bpf_loader::id());
     assert_eq!(account2.executable, true);
     assert_eq!(account0.data, account2.data);
-
-    test_validator.close();
 }

--- a/cli/tests/deploy.rs
+++ b/cli/tests/deploy.rs
@@ -21,10 +21,11 @@ fn test_cli_deploy_program() {
     pathbuf.push("noop");
     pathbuf.set_extension("so");
 
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
 
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -22,13 +22,21 @@ use std::sync::mpsc::channel;
 
 #[test]
 fn test_nonce() {
-    full_battery_tests(TestValidator::with_no_fees(), None, false);
+    let mint_keypair = Keypair::new();
+    full_battery_tests(
+        TestValidator::with_no_fees(mint_keypair.pubkey()),
+        mint_keypair,
+        None,
+        false,
+    );
 }
 
 #[test]
 fn test_nonce_with_seed() {
+    let mint_keypair = Keypair::new();
     full_battery_tests(
-        TestValidator::with_no_fees(),
+        TestValidator::with_no_fees(mint_keypair.pubkey()),
+        mint_keypair,
         Some(String::from("seed")),
         false,
     );
@@ -36,16 +44,23 @@ fn test_nonce_with_seed() {
 
 #[test]
 fn test_nonce_with_authority() {
-    full_battery_tests(TestValidator::with_no_fees(), None, true);
+    let mint_keypair = Keypair::new();
+    full_battery_tests(
+        TestValidator::with_no_fees(mint_keypair.pubkey()),
+        mint_keypair,
+        None,
+        true,
+    );
 }
 
 fn full_battery_tests(
     test_validator: TestValidator,
+    mint_keypair: Keypair,
     seed: Option<String>,
     use_nonce_authority: bool,
 ) {
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -202,10 +217,11 @@ fn full_battery_tests(
 #[test]
 fn test_create_account_with_seed() {
     solana_logger::setup();
-    let test_validator = TestValidator::with_custom_fees(1);
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_custom_fees(mint_keypair.pubkey(), 1);
 
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let offline_nonce_authority_signer = keypair_from_seed(&[1u8; 32]).unwrap();

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -210,8 +210,6 @@ fn full_battery_tests(
     check_recent_balance(1000, &rpc_client, &config_payer.signers[0].pubkey());
     check_recent_balance(800, &rpc_client, &nonce_account);
     check_recent_balance(200, &rpc_client, &payee_pubkey);
-
-    test_validator.close();
 }
 
 #[test]
@@ -333,6 +331,4 @@ fn test_create_account_with_seed() {
     check_recent_balance(31, &rpc_client, &offline_nonce_authority_signer.pubkey());
     check_recent_balance(4000, &rpc_client, &online_nonce_creator_signer.pubkey());
     check_recent_balance(10, &rpc_client, &to_address);
-
-    test_validator.close();
 }

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -2,15 +2,19 @@ use solana_cli::cli::{process_command, CliCommand, CliConfig};
 use solana_client::rpc_client::RpcClient;
 use solana_core::test_validator::TestValidator;
 use solana_faucet::faucet::run_local_faucet;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+use solana_sdk::{
+    commitment_config::CommitmentConfig,
+    signature::{Keypair, Signer},
+};
 use std::sync::mpsc::channel;
 
 #[test]
 fn test_cli_request_airdrop() {
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
 
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let mut bob_config = CliConfig::recent_for_tests();

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -38,6 +38,4 @@ fn test_cli_request_airdrop() {
         .unwrap()
         .value;
     assert_eq!(balance, 50);
-
-    test_validator.close();
 }

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -108,8 +108,6 @@ fn test_stake_delegation_force() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-
-    test_validator.close();
 }
 
 #[test]
@@ -189,8 +187,6 @@ fn test_seed_stake_delegation_and_deactivation() {
         fee_payer: 0,
     };
     process_command(&config_validator).unwrap();
-
-    test_validator.close();
 }
 
 #[test]
@@ -266,8 +262,6 @@ fn test_stake_delegation_and_deactivation() {
         fee_payer: 0,
     };
     process_command(&config_validator).unwrap();
-
-    test_validator.close();
 }
 
 #[test]
@@ -400,8 +394,6 @@ fn test_offline_stake_delegation_and_deactivation() {
         fee_payer: 0,
     };
     process_command(&config_payer).unwrap();
-
-    test_validator.close();
 }
 
 #[test]
@@ -516,8 +508,6 @@ fn test_nonced_stake_delegation_and_deactivation() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-
-    test_validator.close();
 }
 
 #[test]
@@ -789,8 +779,6 @@ fn test_stake_authorize() {
     .unwrap()
     .blockhash;
     assert_ne!(nonce_hash, new_nonce_hash);
-
-    test_validator.close();
 }
 
 #[test]
@@ -916,8 +904,6 @@ fn test_stake_authorize_with_fee_payer() {
     // `config_offline` however has paid 1 sig due to being both authority
     // and fee payer
     check_recent_balance(100_000 - SIG_FEE, &rpc_client, &offline_pubkey);
-
-    test_validator.close();
 }
 
 #[test]
@@ -1061,8 +1047,6 @@ fn test_stake_split() {
         &rpc_client,
         &split_account.pubkey(),
     );
-
-    test_validator.close();
 }
 
 #[test]
@@ -1324,8 +1308,6 @@ fn test_stake_set_lockup() {
     );
     assert_eq!(current_lockup.epoch, lockup.epoch.unwrap());
     assert_eq!(current_lockup.custodian, offline_pubkey);
-
-    test_validator.close();
 }
 
 #[test]
@@ -1538,6 +1520,4 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     let seed_address =
         Pubkey::create_with_seed(&stake_pubkey, seed, &solana_stake_program::id()).unwrap();
     check_recent_balance(50_000, &rpc_client, &seed_address);
-
-    test_validator.close();
 }

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -26,9 +26,10 @@ use std::sync::mpsc::channel;
 
 #[test]
 fn test_stake_delegation_force() {
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -115,9 +116,10 @@ fn test_stake_delegation_force() {
 fn test_seed_stake_delegation_and_deactivation() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -195,9 +197,10 @@ fn test_seed_stake_delegation_and_deactivation() {
 fn test_stake_delegation_and_deactivation() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -271,9 +274,10 @@ fn test_stake_delegation_and_deactivation() {
 fn test_offline_stake_delegation_and_deactivation() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -404,9 +408,10 @@ fn test_offline_stake_delegation_and_deactivation() {
 fn test_nonced_stake_delegation_and_deactivation() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -519,9 +524,10 @@ fn test_nonced_stake_delegation_and_deactivation() {
 fn test_stake_authorize() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -792,9 +798,10 @@ fn test_stake_authorize_with_fee_payer() {
     solana_logger::setup();
     const SIG_FEE: u64 = 42;
 
-    let test_validator = TestValidator::with_custom_fees(SIG_FEE);
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_custom_fees(mint_keypair.pubkey(), SIG_FEE);
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -917,9 +924,10 @@ fn test_stake_authorize_with_fee_payer() {
 fn test_stake_split() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_custom_fees(1);
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_custom_fees(mint_keypair.pubkey(), 1);
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -1061,9 +1069,10 @@ fn test_stake_split() {
 fn test_stake_set_lockup() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_custom_fees(1);
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_custom_fees(mint_keypair.pubkey(), 1);
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -1323,9 +1332,10 @@ fn test_stake_set_lockup() {
 fn test_offline_nonced_create_stake_account_and_withdraw() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -22,10 +22,11 @@ use std::sync::mpsc::channel;
 #[test]
 fn test_transfer() {
     solana_logger::setup();
-    let test_validator = TestValidator::with_custom_fees(1);
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_custom_fees(mint_keypair.pubkey(), 1);
 
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
@@ -243,10 +244,11 @@ fn test_transfer() {
 #[test]
 fn test_transfer_multisession_signing() {
     solana_logger::setup();
-    let test_validator = TestValidator::with_custom_fees(1);
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_custom_fees(mint_keypair.pubkey(), 1);
 
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let to_pubkey = Pubkey::new(&[1u8; 32]);
@@ -363,10 +365,11 @@ fn test_transfer_multisession_signing() {
 #[test]
 fn test_transfer_all() {
     solana_logger::setup();
-    let test_validator = TestValidator::with_custom_fees(1);
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_custom_fees(mint_keypair.pubkey(), 1);
 
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -237,8 +237,6 @@ fn test_transfer() {
     process_command(&config).unwrap();
     check_recent_balance(28, &rpc_client, &offline_pubkey);
     check_recent_balance(40, &rpc_client, &recipient_pubkey);
-
-    test_validator.close();
 }
 
 #[test]
@@ -358,8 +356,6 @@ fn test_transfer_multisession_signing() {
     check_recent_balance(1, &rpc_client, &offline_from_signer.pubkey());
     check_recent_balance(1, &rpc_client, &offline_fee_payer_signer.pubkey());
     check_recent_balance(42, &rpc_client, &to_pubkey);
-
-    test_validator.close();
 }
 
 #[test]
@@ -405,6 +401,4 @@ fn test_transfer_all() {
     process_command(&config).unwrap();
     check_recent_balance(0, &rpc_client, &sender_pubkey);
     check_recent_balance(49_999, &rpc_client, &recipient_pubkey);
-
-    test_validator.close();
 }

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -19,9 +19,10 @@ use std::sync::mpsc::channel;
 
 #[test]
 fn test_vote_authorize_and_withdraw() {
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
     let (sender, receiver) = channel();
-    run_local_faucet(test_validator.mint_keypair(), sender, None);
+    run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -125,6 +125,4 @@ fn test_vote_authorize_and_withdraw() {
         withdraw_authority: 1,
     };
     process_command(&config).unwrap();
-
-    test_validator.close();
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -58,6 +58,7 @@ solana-metrics = { path = "../metrics", version = "1.5.0" }
 solana-measure = { path = "../measure", version = "1.5.0" }
 solana-net-utils = { path = "../net-utils", version = "1.5.0" }
 solana-perf = { path = "../perf", version = "1.5.0" }
+solana-program-test = { path = "../program-test", version = "1.5.0" }
 solana-runtime = { path = "../runtime", version = "1.5.0" }
 solana-sdk = { path = "../sdk", version = "1.5.0" }
 solana-frozen-abi = { path = "../frozen-abi", version = "1.5.0" }

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -2,188 +2,279 @@ use {
     crate::{
         cluster_info::Node,
         gossip_service::discover_cluster,
+        rpc::JsonRpcConfig,
         validator::{Validator, ValidatorConfig},
     },
-    solana_ledger::create_new_tmp_ledger,
+    solana_ledger::{blockstore::create_new_ledger, create_new_tmp_ledger},
+    solana_runtime::{
+        bank_forks::{CompressionType, SnapshotConfig, SnapshotVersion},
+        genesis_utils::create_genesis_config_with_leader_ex,
+        hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+    },
     solana_sdk::{
         fee_calculator::FeeRateGovernor,
-        hash::Hash,
         native_token::sol_to_lamports,
         pubkey::Pubkey,
         rent::Rent,
-        signature::{Keypair, Signer},
+        signature::{read_keypair_file, write_keypair_file, Keypair, Signer},
     },
-    std::{fs::remove_dir_all, net::SocketAddr, path::PathBuf, sync::Arc},
+    std::{
+        fs::remove_dir_all,
+        net::SocketAddr,
+        path::{Path, PathBuf},
+        sync::Arc,
+    },
 };
 
-pub struct TestValidatorConfig {
+pub struct TestValidatorGenesisConfig {
     pub fee_rate_governor: FeeRateGovernor,
-    pub mint_lamports: u64,
+    pub mint_address: Pubkey,
     pub rent: Rent,
-    pub validator_identity_keypair: Keypair,
-    pub validator_identity_lamports: u64,
-    pub validator_stake_lamports: u64,
 }
 
-impl Default for TestValidatorConfig {
-    fn default() -> Self {
-        Self {
-            fee_rate_governor: FeeRateGovernor::default(),
-            mint_lamports: sol_to_lamports(500_000_000.),
-            rent: Rent::default(),
-            validator_identity_keypair: Keypair::new(),
-            validator_identity_lamports: sol_to_lamports(500.),
-            validator_stake_lamports: sol_to_lamports(1.),
-        }
-    }
+#[derive(Default)]
+pub struct TestValidatorStartConfig {
+    pub rpc_config: JsonRpcConfig,
+    pub rpc_ports: Option<(u16, u16)>, // (JsonRpc, JsonRpcPubSub), None == random ports
 }
 
 pub struct TestValidator {
-    validator: Validator,
     ledger_path: PathBuf,
-    preserve_ledger: bool,
-
-    genesis_hash: Hash,
-    mint_keypair: Keypair,
-    vote_account_address: Pubkey,
-
-    tpu: SocketAddr,
-    rpc_url: String,
     rpc_pubsub_url: String,
-}
-
-impl Default for TestValidator {
-    fn default() -> Self {
-        Self::new(TestValidatorConfig::default())
-    }
+    rpc_url: String,
+    tpu: SocketAddr,
+    gossip: SocketAddr,
+    validator: Validator,
+    vote_account_address: Pubkey,
 }
 
 impl TestValidator {
-    pub fn with_no_fees() -> Self {
-        Self::new(TestValidatorConfig {
-            fee_rate_governor: FeeRateGovernor::new(0, 0),
-            rent: Rent {
-                lamports_per_byte_year: 1,
-                exemption_threshold: 1.0,
-                ..Rent::default()
+    /// The default test validator is intended to be generically suitable for unit testing.
+    ///
+    /// It uses a unique temporary ledger that is deleted on `close` and randomly assigned ports.
+    /// All test tokens will be minted into `mint_address`
+    ///
+    /// This function panics on initialization failure.
+    pub fn new(mint_address: Pubkey) -> Self {
+        let ledger_path = Self::initialize_ledger(
+            None,
+            TestValidatorGenesisConfig {
+                fee_rate_governor: FeeRateGovernor::default(),
+                mint_address,
+                rent: Rent::default(),
             },
-            ..TestValidatorConfig::default()
-        })
+        )
+        .unwrap();
+        Self::start(&ledger_path, TestValidatorStartConfig::default()).unwrap()
     }
 
-    pub fn with_custom_fees(target_lamports_per_signature: u64) -> Self {
-        Self::new(TestValidatorConfig {
-            fee_rate_governor: FeeRateGovernor::new(target_lamports_per_signature, 0),
-            rent: Rent {
-                lamports_per_byte_year: 1,
-                exemption_threshold: 1.0,
-                ..Rent::default()
+    /// Create a `TestValidator` with no transaction fees and minimal rent.
+    ///
+    /// This function panics on initialization failure.
+    pub fn with_no_fees(mint_address: Pubkey) -> Self {
+        let ledger_path = Self::initialize_ledger(
+            None,
+            TestValidatorGenesisConfig {
+                fee_rate_governor: FeeRateGovernor::new(0, 0),
+                mint_address,
+                rent: Rent {
+                    lamports_per_byte_year: 1,
+                    exemption_threshold: 1.0,
+                    ..Rent::default()
+                },
             },
-            ..TestValidatorConfig::default()
-        })
+        )
+        .unwrap();
+        Self::start(&ledger_path, TestValidatorStartConfig::default()).unwrap()
     }
 
-    pub fn new(config: TestValidatorConfig) -> Self {
-        use solana_ledger::genesis_utils::{
-            create_genesis_config_with_leader_ex, GenesisConfigInfo,
-        };
+    /// Create a `TestValidator` with custom transaction fees and minimal rent.
+    ///
+    /// This function panics on initialization failure.
+    pub fn with_custom_fees(mint_address: Pubkey, target_lamports_per_signature: u64) -> Self {
+        let ledger_path = Self::initialize_ledger(
+            None,
+            TestValidatorGenesisConfig {
+                fee_rate_governor: FeeRateGovernor::new(target_lamports_per_signature, 0),
+                mint_address,
+                rent: Rent {
+                    lamports_per_byte_year: 1,
+                    exemption_threshold: 1.0,
+                    ..Rent::default()
+                },
+            },
+        )
+        .unwrap();
+        Self::start(&ledger_path, TestValidatorStartConfig::default()).unwrap()
+    }
 
-        let TestValidatorConfig {
+    /// Initialize the test validator's ledger directory
+    ///
+    /// If `ledger_path` is `None`, a temporary ledger will be created.  Otherwise the ledger will
+    /// be initialized in the provided directory.
+    ///
+    /// Returns the path to the ledger directory.
+    pub fn initialize_ledger(
+        ledger_path: Option<&Path>,
+        config: TestValidatorGenesisConfig,
+    ) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let TestValidatorGenesisConfig {
             fee_rate_governor,
-            mint_lamports,
+            mint_address,
             rent,
-            validator_identity_keypair,
-            validator_identity_lamports,
-            validator_stake_lamports,
         } = config;
-        let validator_identity_keypair = Arc::new(validator_identity_keypair);
 
-        let node = Node::new_localhost_with_pubkey(&validator_identity_keypair.pubkey());
+        let validator_identity_keypair = Keypair::new();
+        let validator_vote_account = Keypair::new();
+        let validator_stake_account = Keypair::new();
+        let validator_identity_lamports = sol_to_lamports(500.);
+        let validator_stake_lamports = sol_to_lamports(1_000_000.);
+        let mint_lamports = sol_to_lamports(500_000_000.);
 
-        let GenesisConfigInfo {
-            mut genesis_config,
-            mint_keypair,
-            voting_keypair: vote_account_keypair,
-        } = create_genesis_config_with_leader_ex(
+        let initial_accounts = solana_program_test::programs::spl_programs(&rent);
+        let genesis_config = create_genesis_config_with_leader_ex(
             mint_lamports,
-            &node.info.id,
-            &Keypair::new(),
-            &Keypair::new().pubkey(),
+            &mint_address,
+            &validator_identity_keypair.pubkey(),
+            &validator_vote_account.pubkey(),
+            &validator_stake_account.pubkey(),
             validator_stake_lamports,
             validator_identity_lamports,
+            fee_rate_governor,
+            rent,
             solana_sdk::genesis_config::ClusterType::Development,
+            initial_accounts,
         );
 
-        genesis_config.rent = rent;
-        genesis_config.fee_rate_governor = fee_rate_governor;
-
-        let (ledger_path, blockhash) = create_new_tmp_ledger!(&genesis_config);
-
-        let config = ValidatorConfig {
-            rpc_addrs: Some((node.info.rpc, node.info.rpc_pubsub)),
-            ..ValidatorConfig::default()
+        let ledger_path = match ledger_path {
+            None => create_new_tmp_ledger!(&genesis_config).0,
+            Some(ledger_path) => {
+                let _ = create_new_ledger(
+                    ledger_path,
+                    &genesis_config,
+                    MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+                    solana_ledger::blockstore_db::AccessType::PrimaryOnly,
+                )
+                .map_err(|err| {
+                    format!(
+                        "Failed to create ledger at {}: {}",
+                        ledger_path.display(),
+                        err
+                    )
+                })?;
+                ledger_path.to_path_buf()
+            }
         };
 
-        let vote_account_address = vote_account_keypair.pubkey();
+        write_keypair_file(
+            &validator_identity_keypair,
+            ledger_path.join("validator-keypair.json").to_str().unwrap(),
+        )?;
+        write_keypair_file(
+            &validator_vote_account,
+            ledger_path
+                .join("vote-account-keypair.json")
+                .to_str()
+                .unwrap(),
+        )?;
+
+        Ok(ledger_path)
+    }
+
+    /// Starts a TestValidator at the provided ledger directory
+    pub fn start(
+        ledger_path: &Path,
+        config: TestValidatorStartConfig,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let validator_identity_keypair =
+            read_keypair_file(ledger_path.join("validator-keypair.json").to_str().unwrap())?;
+        let validator_vote_account = read_keypair_file(
+            ledger_path
+                .join("vote-account-keypair.json")
+                .to_str()
+                .unwrap(),
+        )?;
+
+        let mut node = Node::new_localhost_with_pubkey(&validator_identity_keypair.pubkey());
+        if let Some((rpc, rpc_pubsub)) = config.rpc_ports {
+            node.info.rpc = SocketAddr::new(node.info.gossip.ip(), rpc);
+            node.info.rpc_pubsub = SocketAddr::new(node.info.gossip.ip(), rpc_pubsub);
+        }
+
+        let vote_account_address = validator_vote_account.pubkey();
         let rpc_url = format!("http://{}:{}", node.info.rpc.ip(), node.info.rpc.port());
         let rpc_pubsub_url = format!("ws://{}/", node.info.rpc_pubsub);
         let tpu = node.info.tpu;
         let gossip = node.info.gossip;
 
+        let validator_config = ValidatorConfig {
+            rpc_addrs: Some((node.info.rpc, node.info.rpc_pubsub)),
+            rpc_config: config.rpc_config,
+            accounts_hash_interval_slots: 100,
+            account_paths: vec![ledger_path.join("accounts")],
+            poh_verify: false, // Skip PoH verification of ledger on startup for speed
+            snapshot_config: Some(SnapshotConfig {
+                snapshot_interval_slots: 100,
+                snapshot_path: ledger_path.join("snapshot"),
+                snapshot_package_output_path: ledger_path.to_path_buf(),
+                compression: CompressionType::NoCompression,
+                snapshot_version: SnapshotVersion::default(),
+            }),
+            ..ValidatorConfig::default()
+        };
+
         let validator = Validator::new(
             node,
-            &validator_identity_keypair,
+            &Arc::new(validator_identity_keypair),
             &ledger_path,
-            &vote_account_keypair.pubkey(),
-            vec![Arc::new(vote_account_keypair)],
+            &validator_vote_account.pubkey(),
+            vec![Arc::new(validator_vote_account)],
             None,
-            &config,
+            &validator_config,
         );
 
         // Needed to avoid panics in `solana-responder-gossip` in tests that create a number of
         // test validators concurrently...
         discover_cluster(&gossip, 1).expect("TestValidator startup failed");
 
-        TestValidator {
+        Ok(TestValidator {
+            ledger_path: ledger_path.to_path_buf(),
+            rpc_pubsub_url,
+            rpc_url,
+            gossip,
+            tpu,
             validator,
             vote_account_address,
-            mint_keypair,
-            ledger_path,
-            genesis_hash: blockhash,
-            tpu,
-            rpc_url,
-            rpc_pubsub_url,
-            preserve_ledger: false,
-        }
+        })
     }
 
+    /// Stop the test validator and delete its ledger directory
     pub fn close(self) {
         self.validator.close().unwrap();
-        if !self.preserve_ledger {
-            remove_dir_all(&self.ledger_path).unwrap();
-        }
+        remove_dir_all(&self.ledger_path).unwrap();
     }
 
+    /// Return the test validator's TPU address
     pub fn tpu(&self) -> &SocketAddr {
         &self.tpu
     }
 
-    pub fn mint_keypair(&self) -> Keypair {
-        Keypair::from_bytes(&self.mint_keypair.to_bytes()).unwrap()
+    /// Return the test validator's Gossip address
+    pub fn gossip(&self) -> &SocketAddr {
+        &self.gossip
     }
 
+    /// Return the test validator's JSON RPC URL
     pub fn rpc_url(&self) -> String {
         self.rpc_url.clone()
     }
 
+    /// Return the test validator's JSON RPC PubSub URL
     pub fn rpc_pubsub_url(&self) -> String {
         self.rpc_pubsub_url.clone()
     }
 
-    pub fn genesis_hash(&self) -> Hash {
-        self.genesis_hash
-    }
-
+    /// Return the vote account address of the validator
     pub fn vote_account_address(&self) -> Pubkey {
         self.vote_account_address
     }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -65,7 +65,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
     sync::mpsc::Receiver,
     sync::{mpsc::channel, Arc, Mutex, RwLock},
-    thread::{sleep, Result},
+    thread::sleep,
     time::Duration,
 };
 
@@ -635,9 +635,9 @@ impl Validator {
         }
     }
 
-    pub fn close(mut self) -> Result<()> {
+    pub fn close(mut self) {
         self.exit();
-        self.join()
+        self.join();
     }
 
     fn print_node_info(node: &Node) {
@@ -665,7 +665,7 @@ impl Validator {
         );
     }
 
-    pub fn join(self) -> Result<()> {
+    pub fn join(self) {
         self.poh_service.join().expect("poh_service");
         drop(self.poh_recorder);
         if let Some(RpcServices {
@@ -718,8 +718,6 @@ impl Validator {
             .join()
             .expect("completed_data_sets_service");
         self.ip_echo_server.shutdown_now();
-
-        Ok(())
     }
 }
 
@@ -1267,7 +1265,7 @@ mod tests {
             Some(&leader_node.info),
             &config,
         );
-        validator.close().unwrap();
+        validator.close();
         remove_dir_all(validator_ledger_path).unwrap();
     }
 
@@ -1345,7 +1343,7 @@ mod tests {
         // While join is called sequentially, the above exit call notified all the
         // validators to exit from all their threads
         validators.into_iter().for_each(|validator| {
-            validator.join().unwrap();
+            validator.join();
         });
 
         for path in ledger_paths {

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -12,8 +12,11 @@ use solana_runtime::{
     genesis_utils::{create_genesis_config, GenesisConfigInfo},
 };
 use solana_sdk::{
-    commitment_config::CommitmentConfig, native_token::sol_to_lamports, rpc_port,
-    signature::Signer, system_transaction,
+    commitment_config::CommitmentConfig,
+    native_token::sol_to_lamports,
+    rpc_port,
+    signature::{Keypair, Signer},
+    system_transaction,
 };
 use std::{
     net::{IpAddr, SocketAddr},
@@ -30,8 +33,8 @@ use systemstat::Ipv4Addr;
 fn test_rpc_client() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_no_fees();
-    let alice = test_validator.mint_keypair();
+    let alice = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(alice.pubkey());
 
     let bob_pubkey = solana_sdk::pubkey::new_rand();
 

--- a/core/tests/client.rs
+++ b/core/tests/client.rs
@@ -82,7 +82,6 @@ fn test_rpc_client() {
         client.get_balance(&alice.pubkey()).unwrap(),
         original_alice_balance - sol_to_lamports(20.0)
     );
-    test_validator.close();
 }
 
 #[test]

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -109,7 +109,6 @@ fn test_rpc_send_tx() {
     );
     let json: Value = post_rpc(req, &rpc_url);
     info!("{:?}", json["result"]["value"]);
-    test_validator.close();
 }
 
 #[test]
@@ -142,7 +141,6 @@ fn test_rpc_invalid_requests() {
 
     let the_value = &json["result"]["value"];
     assert!(the_value.is_null());
-    test_validator.close();
 }
 
 #[test]
@@ -317,5 +315,4 @@ fn test_rpc_subscriptions() {
     }
 
     rt.shutdown_now().wait().unwrap();
-    test_validator.close();
 }

--- a/ledger/src/genesis_utils.rs
+++ b/ledger/src/genesis_utils.rs
@@ -1,6 +1,5 @@
 pub use solana_runtime::genesis_utils::{
-    bootstrap_validator_stake_lamports, create_genesis_config_with_leader,
-    create_genesis_config_with_leader_ex, GenesisConfigInfo,
+    bootstrap_validator_stake_lamports, create_genesis_config_with_leader, GenesisConfigInfo,
 };
 
 // same as genesis_config::create_genesis_config, but with bootstrap_validator staking logic

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -285,7 +285,7 @@ impl LocalCluster {
         self.exit();
         for (_, node) in self.validators.iter_mut() {
             if let Some(v) = node.validator.take() {
-                v.join().expect("Validator join failed");
+                v.join();
             }
         }
     }
@@ -609,7 +609,7 @@ impl Cluster for LocalCluster {
         // Shut down the validator
         let mut validator = node.validator.take().expect("Validator must be running");
         validator.exit();
-        validator.join().unwrap();
+        validator.join();
         node
     }
 

--- a/program-test/src/programs.rs
+++ b/program-test/src/programs.rs
@@ -1,0 +1,38 @@
+use solana_sdk::{account::Account, pubkey::Pubkey, rent::Rent};
+
+mod spl_token {
+    solana_sdk::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+}
+mod spl_memo {
+    solana_sdk::declare_id!("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo");
+}
+mod spl_associated_token_account {
+    solana_sdk::declare_id!("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL");
+}
+
+static SPL_PROGRAMS: &[(Pubkey, &[u8])] = &[
+    (spl_token::ID, include_bytes!("programs/spl_token-2.0.6.so")),
+    (spl_memo::ID, include_bytes!("programs/spl_memo-1.0.0.so")),
+    (
+        spl_associated_token_account::ID,
+        include_bytes!("programs/spl_associated-token-account-1.0.1.so"),
+    ),
+];
+
+pub fn spl_programs(rent: &Rent) -> Vec<(Pubkey, Account)> {
+    SPL_PROGRAMS
+        .iter()
+        .map(|(program_id, elf)| {
+            (
+                *program_id,
+                Account {
+                    lamports: rent.minimum_balance(elf.len()).min(1),
+                    data: elf.to_vec(),
+                    owner: solana_program::bpf_loader::id(),
+                    executable: true,
+                    rent_epoch: 0,
+                },
+            )
+        })
+        .collect()
+}

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -95,6 +95,7 @@ else
     solana-stake-monitor
     solana-stake-o-matic
     solana-sys-tuner
+    solana-test-validator
     solana-tokens
     solana-validator
     solana-watchtower

--- a/sdk/src/rpc_port.rs
+++ b/sdk/src/rpc_port.rs
@@ -3,6 +3,3 @@ pub const DEFAULT_RPC_PORT: u16 = 8899;
 
 /// Default port number for JSON RPC pubsub
 pub const DEFAULT_RPC_PUBSUB_PORT: u16 = 8900;
-
-/// Default port number for Banks RPC API
-pub const DEFAULT_RPC_BANKS_PORT: u16 = 8901;

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1038,7 +1038,7 @@ mod tests {
     use solana_core::test_validator::TestValidator;
     use solana_sdk::{
         clock::DEFAULT_MS_PER_SLOT,
-        signature::{read_keypair_file, write_keypair_file},
+        signature::{read_keypair_file, write_keypair_file, Signer},
     };
     use solana_stake_program::stake_instruction::StakeInstruction;
 
@@ -1057,8 +1057,8 @@ mod tests {
 
     #[test]
     fn test_process_token_allocations() {
-        let test_validator = TestValidator::with_no_fees();
-        let alice = test_validator.mint_keypair();
+        let alice = Keypair::new();
+        let test_validator = TestValidator::with_no_fees(alice.pubkey());
         let url = test_validator.rpc_url();
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
@@ -1069,8 +1069,8 @@ mod tests {
 
     #[test]
     fn test_process_transfer_amount_allocations() {
-        let test_validator = TestValidator::with_no_fees();
-        let alice = test_validator.mint_keypair();
+        let alice = Keypair::new();
+        let test_validator = TestValidator::with_no_fees(alice.pubkey());
         let url = test_validator.rpc_url();
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
@@ -1081,8 +1081,8 @@ mod tests {
 
     #[test]
     fn test_process_stake_allocations() {
-        let test_validator = TestValidator::with_no_fees();
-        let alice = test_validator.mint_keypair();
+        let alice = Keypair::new();
+        let test_validator = TestValidator::with_no_fees(alice.pubkey());
         let url = test_validator.rpc_url();
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
@@ -1398,8 +1398,8 @@ mod tests {
         let fees = 10_000;
         let fees_in_sol = lamports_to_sol(fees);
 
-        let test_validator = TestValidator::with_custom_fees(fees);
-        let alice = test_validator.mint_keypair();
+        let alice = Keypair::new();
+        let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
@@ -1485,8 +1485,8 @@ mod tests {
     fn test_check_payer_balances_distribute_tokens_separate_payers() {
         let fees = 10_000;
         let fees_in_sol = lamports_to_sol(fees);
-        let test_validator = TestValidator::with_custom_fees(fees);
-        let alice = test_validator.mint_keypair();
+        let alice = Keypair::new();
+        let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
@@ -1598,8 +1598,8 @@ mod tests {
     fn test_check_payer_balances_distribute_stakes_single_payer() {
         let fees = 10_000;
         let fees_in_sol = lamports_to_sol(fees);
-        let test_validator = TestValidator::with_custom_fees(fees);
-        let alice = test_validator.mint_keypair();
+        let alice = Keypair::new();
+        let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
         test_validator_block_0_fee_workaround(&client);
@@ -1707,8 +1707,8 @@ mod tests {
     fn test_check_payer_balances_distribute_stakes_separate_payers() {
         let fees = 10_000;
         let fees_in_sol = lamports_to_sol(fees);
-        let test_validator = TestValidator::with_custom_fees(fees);
-        let alice = test_validator.mint_keypair();
+        let alice = Keypair::new();
+        let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
@@ -2025,8 +2025,8 @@ mod tests {
 
     #[test]
     fn test_distribute_allocations_dump_db() {
-        let test_validator = TestValidator::with_no_fees();
-        let sender_keypair = test_validator.mint_keypair();
+        let sender_keypair = Keypair::new();
+        let test_validator = TestValidator::with_no_fees(sender_keypair.pubkey());
         let url = test_validator.rpc_url();
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
 

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1063,8 +1063,6 @@ mod tests {
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
         test_process_distribute_tokens_with_client(&client, alice, None);
-
-        test_validator.close();
     }
 
     #[test]
@@ -1075,8 +1073,6 @@ mod tests {
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
         test_process_distribute_tokens_with_client(&client, alice, Some(sol_to_lamports(1.5)));
-
-        test_validator.close();
     }
 
     #[test]
@@ -1087,8 +1083,6 @@ mod tests {
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
         test_process_distribute_stake_with_client(&client, alice);
-
-        test_validator.close();
     }
 
     #[test]
@@ -1477,8 +1471,6 @@ mod tests {
         } else {
             panic!("check_payer_balances should have errored");
         }
-
-        test_validator.close();
     }
 
     #[test]
@@ -1550,8 +1542,6 @@ mod tests {
         } else {
             panic!("check_payer_balances should have errored");
         }
-
-        test_validator.close();
     }
 
     fn initialize_stake_account(
@@ -1699,8 +1689,6 @@ mod tests {
         } else {
             panic!("check_payer_balances should have errored");
         }
-
-        test_validator.close();
     }
 
     #[test]
@@ -1779,8 +1767,6 @@ mod tests {
         } else {
             panic!("check_payer_balances should have errored");
         }
-
-        test_validator.close();
     }
 
     #[test]
@@ -2076,8 +2062,6 @@ mod tests {
         let read_db = db::open_db(&db_file, true).unwrap();
         let transaction_info = db::read_transaction_infos(&read_db);
         assert_eq!(transaction_info.len(), 1);
-
-        test_validator.close();
     }
 
     #[test]

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1036,24 +1036,8 @@ pub fn test_process_distribute_stake_with_client(client: &RpcClient, sender_keyp
 mod tests {
     use super::*;
     use solana_core::test_validator::TestValidator;
-    use solana_sdk::{
-        clock::DEFAULT_MS_PER_SLOT,
-        signature::{read_keypair_file, write_keypair_file, Signer},
-    };
+    use solana_sdk::signature::{read_keypair_file, write_keypair_file, Signer};
     use solana_stake_program::stake_instruction::StakeInstruction;
-
-    // This is a quick hack until TestValidator can be initialized with fees from block 0
-    fn test_validator_block_0_fee_workaround(client: &RpcClient) {
-        while client
-            .get_recent_blockhash()
-            .unwrap()
-            .1
-            .lamports_per_signature
-            == 0
-        {
-            sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));
-        }
-    }
 
     #[test]
     fn test_process_token_allocations() {
@@ -1400,8 +1384,6 @@ mod tests {
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
         write_keypair_file(&alice, &sender_keypair_file).unwrap();
 
-        test_validator_block_0_fee_workaround(&client);
-
         let allocation_amount = 1000.0;
 
         // Fully funded payer
@@ -1482,7 +1464,6 @@ mod tests {
         let url = test_validator.rpc_url();
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
-        test_validator_block_0_fee_workaround(&client);
 
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
         write_keypair_file(&alice, &sender_keypair_file).unwrap();
@@ -1592,7 +1573,6 @@ mod tests {
         let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
-        test_validator_block_0_fee_workaround(&client);
 
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
         write_keypair_file(&alice, &sender_keypair_file).unwrap();
@@ -1700,7 +1680,6 @@ mod tests {
         let url = test_validator.rpc_url();
 
         let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
-        test_validator_block_0_fee_workaround(&client);
 
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
         write_keypair_file(&alice, &sender_keypair_file).unwrap();

--- a/tokens/tests/commands.rs
+++ b/tokens/tests/commands.rs
@@ -1,15 +1,17 @@
 use solana_client::rpc_client::RpcClient;
 use solana_core::test_validator::TestValidator;
+use solana_sdk::signature::{Keypair, Signer};
 use solana_tokens::commands::test_process_distribute_tokens_with_client;
 
 #[test]
 fn test_process_distribute_with_rpc_client() {
     solana_logger::setup();
 
-    let test_validator = TestValidator::with_no_fees();
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
 
     let client = RpcClient::new(test_validator.rpc_url());
-    test_process_distribute_tokens_with_client(&client, test_validator.mint_keypair(), None);
+    test_process_distribute_tokens_with_client(&client, mint_keypair, None);
 
     test_validator.close();
 }

--- a/tokens/tests/commands.rs
+++ b/tokens/tests/commands.rs
@@ -12,6 +12,4 @@ fn test_process_distribute_with_rpc_client() {
 
     let client = RpcClient::new(test_validator.rpc_url());
     test_process_distribute_tokens_with_client(&client, mint_keypair, None);
-
-    test_validator.close();
 }

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -7,15 +7,18 @@ version = "1.5.0"
 repository = "https://github.com/solana-labs/solana"
 license = "Apache-2.0"
 homepage = "https://solana.com/"
+default-run = "solana-validator"
 
 [dependencies]
 clap = "2.33.1"
 chrono = { version = "0.4.11", features = ["serde"] }
 console = "0.11.3"
+indicatif = "0.15.0"
 log = "0.4.8"
 rand = "0.7.0"
 serde_json = "1.0.56"
 solana-clap-utils = { path = "../clap-utils", version = "1.5.0" }
+solana-cli-config = { path = "../cli-config", version = "1.5.0" }
 solana-client = { path = "../client", version = "1.5.0" }
 solana-core = { path = "../core", version = "1.5.0" }
 solana-download-utils = { path = "../download-utils", version = "1.5.0" }
@@ -29,18 +32,11 @@ solana-runtime = { path = "../runtime", version = "1.5.0" }
 solana-sdk = { path = "../sdk", version = "1.5.0" }
 solana-version = { path = "../version", version = "1.5.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.5.0" }
-solana-vote-signer = { path = "../vote-signer", version = "1.5.0" }
+symlink = "0.1.0"
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.72"
 signal-hook = "0.1.15"
-
-#[[bin]]
-#name = "solana-validator"
-#path = "src/main.rs"
-#
-#[lib]
-#name = "solana_validator"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/validator/solana-test-validator
+++ b/validator/solana-test-validator
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+here="$(dirname "$0")"
+set -x
+exec cargo run --manifest-path="$here"/Cargo.toml --bin solana-test-validator -- "$@"

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -206,6 +206,7 @@ fn main() {
         TestValidator::start(
             &ledger_path,
             TestValidatorStartConfig {
+                preserve_ledger: true,
                 rpc_config: JsonRpcConfig {
                     enable_validator_exit: true,
                     enable_rpc_transaction_history: true,

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -1,0 +1,262 @@
+use {
+    clap::{value_t_or_exit, App, Arg},
+    console::style,
+    indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle},
+    solana_clap_utils::{input_parsers::pubkey_of, input_validators::is_pubkey},
+    solana_client::{client_error, rpc_client::RpcClient},
+    solana_core::rpc::JsonRpcConfig,
+    solana_sdk::{
+        clock::{Slot, DEFAULT_TICKS_PER_SLOT, MS_PER_TICK},
+        commitment_config::CommitmentConfig,
+        fee_calculator::FeeRateGovernor,
+        rent::Rent,
+        rpc_port,
+        signature::{read_keypair_file, Signer},
+    },
+    solana_validator::{start_logger, test_validator::*},
+    std::{
+        path::PathBuf,
+        process::exit,
+        thread::sleep,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    },
+};
+
+#[derive(PartialEq)]
+enum Output {
+    None,
+    Log,
+    Dashboard,
+}
+
+/// Creates a new process bar for processing that will take an unknown amount of time
+fn new_spinner_progress_bar() -> ProgressBar {
+    let progress_bar = ProgressBar::new(42);
+    progress_bar.set_draw_target(ProgressDrawTarget::stdout());
+    progress_bar
+        .set_style(ProgressStyle::default_spinner().template("{spinner:.green} {wide_msg}"));
+    progress_bar.enable_steady_tick(100);
+    progress_bar
+}
+
+/// Pretty print a "name value"
+fn println_name_value(name: &str, value: &str) {
+    println!("{} {}", style(name).bold(), value);
+}
+
+fn main() {
+    let default_rpc_port = rpc_port::DEFAULT_RPC_PORT.to_string();
+
+    let matches = App::new("solana-test-validator").about("Test Validator")
+        .version(solana_version::version!())
+        .arg({
+            let arg = Arg::with_name("config_file")
+                .short("C")
+                .long("config")
+                .value_name("PATH")
+                .takes_value(true)
+                .help("Configuration file to use");
+            if let Some(ref config_file) = *solana_cli_config::CONFIG_FILE {
+                arg.default_value(&config_file)
+            } else {
+                arg
+            }
+        })
+        .arg(
+            Arg::with_name("mint_address")
+                .long("mint")
+                .value_name("PUBKEY")
+                .validator(is_pubkey)
+                .takes_value(true)
+                .help("Address of the mint account that will receive all the initial tokens [default: client keypair]"),
+        )
+        .arg(
+            Arg::with_name("ledger_path")
+                .short("l")
+                .long("ledger")
+                .value_name("DIR")
+                .takes_value(true)
+                .required(true)
+                .default_value("test-ledger")
+                .help("Use DIR as ledger location"),
+        )
+        .arg(
+            Arg::with_name("quiet")
+                .short("q")
+                .long("quiet")
+                .takes_value(false)
+                .conflicts_with("log")
+                .help("Quiet mode: suppress normal output")
+        )
+        .arg(
+            Arg::with_name("log")
+                .long("log")
+                .takes_value(false)
+                .conflicts_with("quiet")
+                .help("Log mode: stream the validator log")
+        )
+        .arg(
+            Arg::with_name("rpc_port")
+                .long("rpc-port")
+                .value_name("PORT")
+                .takes_value(true)
+                .default_value(&default_rpc_port)
+                .validator(solana_validator::port_validator)
+                .help("Use this port for JSON RPC and the next port for the RPC websocket"),
+        )
+        .get_matches();
+
+    let cli_config = if let Some(config_file) = matches.value_of("config_file") {
+        solana_cli_config::Config::load(config_file).unwrap_or_default()
+    } else {
+        solana_cli_config::Config::default()
+    };
+
+    let mint_address = pubkey_of(&matches, "mint_address").unwrap_or_else(|| {
+        read_keypair_file(&cli_config.keypair_path)
+            .unwrap_or_else(|err| {
+                eprintln!(
+                    "Error: Unable to read keypair file {}: {}",
+                    cli_config.keypair_path, err
+                );
+                exit(1);
+            })
+            .pubkey()
+    });
+
+    let ledger_path = value_t_or_exit!(matches, "ledger_path", PathBuf);
+    let output = if matches.is_present("quiet") {
+        Output::None
+    } else if matches.is_present("log") {
+        Output::Log
+    } else {
+        Output::Dashboard
+    };
+
+    let rpc_ports = {
+        let rpc_port = value_t_or_exit!(matches, "rpc_port", u16);
+        (rpc_port, rpc_port + 1)
+    };
+
+    if !ledger_path.exists() {
+        let _progress_bar = if output == Output::Dashboard {
+            println_name_value("Mint address:", &mint_address.to_string());
+            let progress_bar = new_spinner_progress_bar();
+            progress_bar.set_message("Creating ledger...");
+            Some(progress_bar)
+        } else {
+            None
+        };
+
+        TestValidator::initialize_ledger(
+            Some(&ledger_path),
+            TestValidatorGenesisConfig {
+                mint_address,
+                fee_rate_governor: FeeRateGovernor::default(),
+                rent: Rent::default(),
+            },
+        )
+        .unwrap_or_else(|err| {
+            eprintln!(
+                "Error: failed to initialize ledger at {}: {}",
+                ledger_path.display(),
+                err
+            );
+            exit(1);
+        });
+    }
+
+    let validator_log_symlink = ledger_path.join("validator.log");
+    let logfile = if output != Output::Log {
+        let validator_log_with_timestamp = format!(
+            "validator-{}.log",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        );
+
+        let _ = std::fs::remove_file(&validator_log_symlink);
+        symlink::symlink_file(&validator_log_with_timestamp, &validator_log_symlink).unwrap();
+
+        Some(
+            ledger_path
+                .join(validator_log_with_timestamp)
+                .into_os_string()
+                .into_string()
+                .unwrap(),
+        )
+    } else {
+        None
+    };
+
+    let _logger_thread = start_logger(logfile);
+
+    let test_validator = {
+        let _progress_bar = if output == Output::Dashboard {
+            println_name_value("Ledger location:", &format!("{}", ledger_path.display()));
+            println_name_value("Log:", &format!("{}", validator_log_symlink.display()));
+            let progress_bar = new_spinner_progress_bar();
+            progress_bar.set_message("Initializing...");
+            Some(progress_bar)
+        } else {
+            None
+        };
+
+        TestValidator::start(
+            &ledger_path,
+            TestValidatorStartConfig {
+                rpc_config: JsonRpcConfig {
+                    enable_validator_exit: true,
+                    enable_rpc_transaction_history: true,
+                    ..JsonRpcConfig::default()
+                },
+                rpc_ports: Some(rpc_ports),
+            },
+        )
+    }
+    .unwrap_or_else(|err| {
+        eprintln!("Error: failed to start validator: {}", err);
+        exit(1);
+    });
+
+    if output == Output::Dashboard {
+        println_name_value("JSON RPC URL:", &test_validator.rpc_url());
+        println_name_value(
+            "JSON RPC PubSub Websocket:",
+            &test_validator.rpc_pubsub_url(),
+        );
+        println_name_value("Gossip Address:", &test_validator.gossip().to_string());
+        println_name_value("TPU Address:", &test_validator.tpu().to_string());
+
+        let progress_bar = new_spinner_progress_bar();
+        let rpc_client = RpcClient::new(test_validator.rpc_url());
+
+        fn get_validator_stats(rpc_client: &RpcClient) -> client_error::Result<(Slot, Slot, u64)> {
+            let max_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::max())?;
+            let recent_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::recent())?;
+            let transaction_count =
+                rpc_client.get_transaction_count_with_commitment(CommitmentConfig::recent())?;
+            Ok((recent_slot, max_slot, transaction_count))
+        }
+
+        loop {
+            match get_validator_stats(&rpc_client) {
+                Ok((recent_slot, max_slot, transaction_count)) => {
+                    progress_bar.set_message(&format!(
+                        "Recent slot: {} | Max confirmed slot: {} | Transaction count: {}",
+                        recent_slot, max_slot, transaction_count,
+                    ));
+                }
+                Err(err) => {
+                    progress_bar.set_message(&format!("{}", err));
+                }
+            }
+            sleep(Duration::from_millis(
+                MS_PER_TICK * DEFAULT_TICKS_PER_SLOT / 2,
+            ));
+        }
+    }
+
+    std::thread::park();
+}

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,0 +1,74 @@
+pub use solana_core::test_validator;
+use {
+    log::*,
+    std::{env, process::exit, thread::JoinHandle},
+};
+
+#[cfg(unix)]
+fn redirect_stderr(filename: &str) {
+    use std::{fs::OpenOptions, os::unix::io::AsRawFd};
+    match OpenOptions::new()
+        .write(true)
+        .create(true)
+        .append(true)
+        .open(filename)
+    {
+        Ok(file) => unsafe {
+            libc::dup2(file.as_raw_fd(), libc::STDERR_FILENO);
+        },
+        Err(err) => eprintln!("Unable to open {}: {}", filename, err),
+    }
+}
+
+pub fn start_logger(logfile: Option<String>) -> Option<JoinHandle<()>> {
+    // Default to RUST_BACKTRACE=1 for more informative validator logs
+    if env::var_os("RUST_BACKTRACE").is_none() {
+        env::set_var("RUST_BACKTRACE", "1")
+    }
+
+    let logger_thread = match logfile {
+        None => None,
+        Some(logfile) => {
+            #[cfg(unix)]
+            {
+                let signals = signal_hook::iterator::Signals::new(&[signal_hook::SIGUSR1])
+                    .unwrap_or_else(|err| {
+                        eprintln!("Unable to register SIGUSR1 handler: {:?}", err);
+                        exit(1);
+                    });
+
+                redirect_stderr(&logfile);
+                Some(std::thread::spawn(move || {
+                    for signal in signals.forever() {
+                        info!(
+                            "received SIGUSR1 ({}), reopening log file: {:?}",
+                            signal, logfile
+                        );
+                        redirect_stderr(&logfile);
+                    }
+                }))
+            }
+            #[cfg(not(unix))]
+            {
+                println!("logging to a file is not supported on this platform");
+                ()
+            }
+        }
+    };
+
+    solana_logger::setup_with_default(
+        &[
+            "solana=info,solana_runtime::message_processor=error", /* info logging for all solana modules */
+            "rpc=trace",   /* json_rpc request/response logging */
+        ]
+        .join(","),
+    );
+
+    logger_thread
+}
+
+pub fn port_validator(port: String) -> Result<(), String> {
+    port.parse::<u16>()
+        .map(|_| ())
+        .map_err(|e| format!("{:?}", e))
+}

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1740,6 +1740,6 @@ pub fn main() {
         });
     }
     info!("Validator initialized");
-    validator.join().expect("validator exit");
+    validator.join();
     info!("Validator exiting..");
 }


### PR DESCRIPTION
It's too hard to run a test validator for development.  Current options:
* solana-localnet -- needs docker, not installed by default, bash goo + docker
* `./run.sh` --  needs a git clone of the mono-repo, not installed by default, bash goo

The `TestValidator` struct is looking like the future for external client-side unit testing, wrap a cli around it.   

#### Basic usage:
```
$ solana-test-validator 
Mint address: vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg
Ledger location: test-ledger
Log: test-ledger/validator.log
JSON RPC URL: http://127.0.0.1:8899
JSON RPC PubSub Websocket: ws://127.0.0.1:8900/
Gossip Address: 127.0.0.1:1024
TPU Address: 127.0.0.1:54720
⠈ Recent slot: 12 | Max confirmed slot: 0 | Transaction count: 12
``` 

#### Interface
```
$ solana-test-validator --help
solana-test-validator 1.5.0 (src:devbuild; feat:569138916)
Test Validator

USAGE:
    solana-test-validator [FLAGS] [OPTIONS] --ledger <DIR>

FLAGS:
    -h, --help       Prints help information
        --log        Log mode: stream the validator log
    -q, --quiet      Quiet mode: suppress normal output
    -V, --version    Prints version information

OPTIONS:
    -C, --config <PATH>      Configuration file to use [default: /Users/mvines/.config/solana/cli/config.yml]
    -l, --ledger <DIR>       Use DIR as ledger location [default: test-ledger]
        --mint <PUBKEY>      Address of the mint account that will receive all the initial tokens [default: client
                             keypair]
        --rpc-port <PORT>    Use this port for JSON RPC and the next port for the RPC websocket [default: 8899]
```