### PR TITLE
Filter out stake and vote accounts with incorrect owners

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1644,6 +1644,16 @@ impl Bank {
                             && (stake_account.owner != solana_stake_program::id()
                                 || vote_account.owner != solana_vote_program::id())
                         {
+                            datapoint_warn!(
+                                "bank-stake_delegation_accounts-invalid-account",
+                                ("slot", self.slot() as i64, i64),
+                                ("stake-address", format!("{:?}", stake_pubkey), String),
+                                (
+                                    "vote-address",
+                                    format!("{:?}", delegation.voter_pubkey),
+                                    String
+                                ),
+                            );
                             return;
                         }
                         let entry = accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1638,8 +1638,11 @@ impl Bank {
                                 ),
                             ));
                         }
-                        if stake_account.owner != solana_stake_program::id()
-                            || vote_account.owner != solana_vote_program::id()
+                        if self
+                            .feature_set
+                            .is_active(&feature_set::filter_stake_delegation_accounts::id())
+                            && (stake_account.owner != solana_stake_program::id()
+                                || vote_account.owner != solana_vote_program::id())
                         {
                             return;
                         }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -94,6 +94,10 @@ pub mod rewrite_stake {
     solana_sdk::declare_id!("6ap2eGy7wx5JmsWUmQ5sHwEWrFSDUxSti2k5Hbfv5BZG");
 }
 
+pub mod filter_stake_delegation_accounts {
+    solana_sdk::declare_id!("GE7fRxmW46K6EmCD9AMZSbnaJ2e3LfqCZzdHi9hmYAgi");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -119,6 +123,7 @@ lazy_static! {
         (timestamp_bounding::id(), "add timestamp-correction bounding #13120"),
         (stake_program_v2::id(), "solana_stake_program v2"),
         (rewrite_stake::id(), "rewrite stake"),
+        (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Follow up to #13615
While the stake program now checks whether a vote account is correctly owned on Delegation, the runtime method to collect stake and vote accounts doesn't verify whether this is still the case.

#### Summary of Changes
Filter out invalid stake and vote accounts
