### PR TITLE
Wrong rpc inflation rate

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -347,13 +347,12 @@ impl JsonRpcRequestProcessor {
         let bank = self.bank(None);
         let epoch = bank.epoch();
         let inflation = bank.inflation();
-        let year =
-            (bank.epoch_schedule().get_last_slot_in_epoch(epoch)) as f64 / bank.slots_per_year();
+        let slot_in_year = bank.slot_in_year_for_inflation();
 
         RpcInflationRate {
-            total: inflation.total(year),
-            validator: inflation.validator(year),
-            foundation: inflation.foundation(year),
+            total: inflation.total(slot_in_year),
+            validator: inflation.validator(slot_in_year),
+            foundation: inflation.foundation(slot_in_year),
             epoch,
         }
     }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -3306,12 +3306,11 @@ pub mod tests {
         };
         let inflation = bank.inflation();
         let epoch = bank.epoch();
-        let year =
-            (bank.epoch_schedule().get_last_slot_in_epoch(epoch)) as f64 / bank.slots_per_year();
+        let slot_in_year = bank.slot_in_year_for_inflation();
         let expected_inflation_rate = RpcInflationRate {
-            total: inflation.total(year),
-            validator: inflation.validator(year),
-            foundation: inflation.foundation(year),
+            total: inflation.total(slot_in_year),
+            validator: inflation.validator(slot_in_year),
+            foundation: inflation.foundation(slot_in_year),
             epoch,
         };
         assert_eq!(inflation_rate, expected_inflation_rate);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1529,8 +1529,8 @@ impl Bank {
         }
         // if I'm the first Bank in an epoch, count, claim, disburse rewards from Inflation
 
-        let epoch_duration_in_years = self.epoch_duration_in_years(prev_epoch);
         let slot_in_year = self.slot_in_year_for_inflation();
+        let epoch_duration_in_years = self.epoch_duration_in_years(prev_epoch);
 
         let (validator_rate, foundation_rate) = {
             let inflation = self.inflation.read().unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1511,6 +1511,13 @@ impl Bank {
         self.epoch_schedule.get_first_slot_in_epoch(self.epoch()) - inflation_start_slot
     }
 
+    pub fn slot_in_year_for_inflation(&self) -> f64 {
+        let num_slots = self.get_inflation_num_slots();
+
+        // calculated as: num_slots / (slots / year)
+        num_slots as f64 / self.slots_per_year
+    }
+
     // update rewards based on the previous epoch
     fn update_rewards(
         &mut self,
@@ -1522,11 +1529,8 @@ impl Bank {
         }
         // if I'm the first Bank in an epoch, count, claim, disburse rewards from Inflation
 
-        // calculated as: num_slots / (slots / year)
-        let num_slots = self.get_inflation_num_slots();
-        let slot_in_year = num_slots as f64 / self.slots_per_year;
-
         let epoch_duration_in_years = self.epoch_duration_in_years(prev_epoch);
+        let slot_in_year = self.slot_in_year_for_inflation();
 
         let (validator_rate, foundation_rate) = {
             let inflation = self.inflation.read().unwrap();


### PR DESCRIPTION
#### Problem

#13671 forget to update the duplicate code in the rpc land, which needed to be updated as well.

Also note that `pico_inflation` didn't expose this because it had no taper:

```
$ ./target/release/solana  --url  http://devnet.solana.com inflation
Inflation Governor:
Fixed APR:                0.01%

Inflation for Epoch 52:
Total APR:                0.01%
Staking APR:              0.01%
Foundation APR:           0.00%

```

#### Summary of Changes

Update it by de-duplicating to prevent it to re-occur in the future. :)
