### PR TITLE
Shrink slots by sparseness of written data size

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -162,10 +162,15 @@ impl AccountsBackgroundService {
                     assert!(last_cleaned_block_height <= snapshot_block_height);
                     last_cleaned_block_height = snapshot_block_height;
                 } else {
-                    consumed_budget = bank.process_stale_slot_with_budget(
-                        consumed_budget,
-                        SHRUNKEN_ACCOUNT_PER_INTERVAL,
-                    );
+                    // under sustained writes, shrink can lag behind so cap to
+                    // SHRUNKEN_ACCOUNT_PER_INTERVAL (which is based on INTERVAL_MS,
+                    // which in turn roughly asscociated block time)
+                    consumed_budget = bank
+                        .process_stale_slot_with_budget(
+                            consumed_budget,
+                            SHRUNKEN_ACCOUNT_PER_INTERVAL,
+                        )
+                        .min(SHRUNKEN_ACCOUNT_PER_INTERVAL);
 
                     if bank.block_height() - last_cleaned_block_height
                         > (CLEAN_INTERVAL_BLOCKS + thread_rng().gen_range(0, 10))


### PR DESCRIPTION
#### Problem

Shrinker doesn't trigger and causes indefinite AppendVec leaks when there is consistent write-once only transactions...

Eventually, this causes max_mmap_count. Also, this makes snapshots contain very large number of sparse files; so snapshot is bloated and snapshot creation takes more processing.

#### Summary of Changes

Be more aggressive by also considering the bytes sparseness.

Also note that this is a quick and dirty band aid;  The root problem is soon be solved by @carllin 's different pr.

follow up: #10099