### PR TITLE
Partial shred deserialize cleanup and shred type differentiation

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod local_vote_signer_service;
 pub mod non_circulating_supply;
 pub mod optimistic_confirmation_verifier;
 pub mod optimistically_confirmed_bank_tracker;
+pub mod packet_hasher;
 pub mod ping_pong;
 pub mod poh_recorder;
 pub mod poh_service;

--- a/core/src/packet_hasher.rs
+++ b/core/src/packet_hasher.rs
@@ -1,0 +1,34 @@
+// Get a unique hash value for a packet
+// Used in retransmit and shred fetch to prevent dos with same packet data.
+
+use ahash::AHasher;
+use rand::{thread_rng, Rng};
+use solana_perf::packet::Packet;
+use std::hash::Hasher;
+
+#[derive(Clone)]
+pub struct PacketHasher {
+    seed1: u128,
+    seed2: u128,
+}
+
+impl Default for PacketHasher {
+    fn default() -> Self {
+        Self {
+            seed1: thread_rng().gen::<u128>(),
+            seed2: thread_rng().gen::<u128>(),
+        }
+    }
+}
+
+impl PacketHasher {
+    pub fn hash_packet(&self, packet: &Packet) -> u64 {
+        let mut hasher = AHasher::new_with_keys(self.seed1, self.seed2);
+        hasher.write(&packet.data[0..packet.meta.size]);
+        hasher.finish()
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -1,7 +1,5 @@
 //! The `retransmit_stage` retransmits shreds between validators
 
-use crate::shred_fetch_stage::ShredFetchStage;
-use crate::shred_fetch_stage::ShredFetchStats;
 use crate::{
     cluster_info::{compute_retransmit_peers, ClusterInfo, DATA_PLANE_FANOUT},
     cluster_info_vote_listener::VerifiedVoteReceiver,
@@ -18,6 +16,7 @@ use ahash::AHasher;
 use crossbeam_channel::Receiver;
 use lru::LruCache;
 use rand::{thread_rng, Rng};
+use solana_ledger::shred::{get_shred_slot_index_type, ShredFetchStats};
 use solana_ledger::{
     blockstore::{Blockstore, CompletedSlotsReceiver},
     leader_schedule_cache::LeaderScheduleCache,
@@ -25,7 +24,7 @@ use solana_ledger::{
 };
 use solana_measure::measure::Measure;
 use solana_metrics::inc_new_counter_error;
-use solana_perf::packet::Packets;
+use solana_perf::packet::{Packet, Packets};
 use solana_runtime::bank_forks::BankForks;
 use solana_sdk::clock::{Epoch, Slot};
 use solana_sdk::epoch_schedule::EpochSchedule;
@@ -205,7 +204,46 @@ struct EpochStakesCache {
     stakes_and_index: Vec<(u64, usize)>,
 }
 
-pub type ShredFilterAndSeeds = (LruCache<(Slot, u32), Vec<u64>>, u128, u128);
+// Map of shred (slot, index, is_data) => list of hash values seen for that key.
+pub type ShredFilter = LruCache<(Slot, u32, bool), Vec<u64>>;
+
+pub type ShredFilterAndSeeds = (ShredFilter, u128, u128);
+
+// Return true if shred is already received and should skip retransmit
+fn check_if_already_received(
+    packet: &Packet,
+    shreds_received: &Arc<Mutex<ShredFilterAndSeeds>>,
+) -> bool {
+    match get_shred_slot_index_type(packet, &mut ShredFetchStats::default()) {
+        Some(slot_index) => {
+            let mut received = shreds_received.lock().unwrap();
+            let seed1 = received.1;
+            let seed2 = received.2;
+            if let Some(sent) = received.0.get_mut(&slot_index) {
+                if sent.len() < MAX_DUPLICATE_COUNT {
+                    let mut hasher = AHasher::new_with_keys(seed1, seed2);
+                    hasher.write(&packet.data[0..packet.meta.size]);
+                    let hash = hasher.finish();
+                    if sent.contains(&hash) {
+                        return true;
+                    }
+
+                    sent.push(hash);
+                } else {
+                    return true;
+                }
+            } else {
+                let mut hasher = AHasher::new_with_keys(seed1, seed2);
+                hasher.write(&packet.data[0..packet.meta.size]);
+                let hash = hasher.finish();
+                received.0.put(slot_index, vec![hash]);
+            }
+
+            false
+        }
+        None => true,
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 fn retransmit(
@@ -298,33 +336,10 @@ fn retransmit(
                 continue;
             }
 
-            match ShredFetchStage::get_slot_index(packet, &mut ShredFetchStats::default()) {
-                Some(slot_index) => {
-                    let mut received = shreds_received.lock().unwrap();
-                    let seed1 = received.1;
-                    let seed2 = received.2;
-                    if let Some(sent) = received.0.get_mut(&slot_index) {
-                        if sent.len() < MAX_DUPLICATE_COUNT {
-                            let mut hasher = AHasher::new_with_keys(seed1, seed2);
-                            hasher.write(&packet.data[0..packet.meta.size]);
-                            let hash = hasher.finish();
-                            if sent.contains(&hash) {
-                                continue;
-                            }
-
-                            sent.push(hash);
-                        } else {
-                            continue;
-                        }
-                    } else {
-                        let mut hasher = AHasher::new_with_keys(seed1, seed2);
-                        hasher.write(&packet.data[0..packet.meta.size]);
-                        let hash = hasher.finish();
-                        received.0.put(slot_index, vec![hash]);
-                    }
-                }
-                None => continue,
+            if check_if_already_received(packet, shreds_received) {
+                continue;
             }
+
             let mut compute_turbine_peers = Measure::start("turbine_start");
             let (my_index, mut shuffled_stakes_and_index) = ClusterInfo::shuffle_peers_and_index(
                 &my_id,
@@ -567,6 +582,7 @@ mod tests {
     use solana_ledger::blockstore_processor::{process_blockstore, ProcessOptions};
     use solana_ledger::create_new_tmp_ledger;
     use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
+    use solana_ledger::shred::Shred;
     use solana_net_utils::find_available_port_in_range;
     use solana_perf::packet::{Packet, Packets};
     use std::net::{IpAddr, Ipv4Addr};
@@ -615,8 +631,7 @@ mod tests {
         );
         let _thread_hdls = vec![t_retransmit];
 
-        let mut shred =
-            solana_ledger::shred::Shred::new_from_data(0, 0, 0, None, true, true, 0, 0x20, 0);
+        let mut shred = Shred::new_from_data(0, 0, 0, None, true, true, 0, 0x20, 0);
         let mut packet = Packet::default();
         shred.copy_to_packet(&mut packet);
 
@@ -640,5 +655,53 @@ mod tests {
         solana_streamer::packet::recv_from(&mut packets, &me_retransmit, 1).unwrap();
         assert_eq!(packets.packets.len(), 1);
         assert_eq!(packets.packets[0].meta.repair, false);
+    }
+
+    #[test]
+    fn test_already_received() {
+        let mut packet = Packet::default();
+        let slot = 1;
+        let index = 5;
+        let version = 0x40;
+        let shred = Shred::new_from_data(slot, index, 0, None, true, true, 0, version, 0);
+        shred.copy_to_packet(&mut packet);
+        let shreds_received = Arc::new(Mutex::new((LruCache::new(100), 0, 0)));
+        // unique shred for (1, 5) should pass
+        assert!(!check_if_already_received(&packet, &shreds_received));
+        // duplicate shred for (1, 5) blocked
+        assert!(check_if_already_received(&packet, &shreds_received));
+
+        let shred = Shred::new_from_data(slot, index, 2, None, true, true, 0, version, 0);
+        shred.copy_to_packet(&mut packet);
+        // first duplicate shred for (1, 5) passed
+        assert!(!check_if_already_received(&packet, &shreds_received));
+        // then blocked
+        assert!(check_if_already_received(&packet, &shreds_received));
+
+        let shred = Shred::new_from_data(slot, index, 8, None, true, true, 0, version, 0);
+        shred.copy_to_packet(&mut packet);
+        // 2nd duplicate shred for (1, 5) blocked
+        assert!(check_if_already_received(&packet, &shreds_received));
+        assert!(check_if_already_received(&packet, &shreds_received));
+
+        let shred = Shred::new_empty_coding(slot, index, 0, 1, 1, 0, version);
+        shred.copy_to_packet(&mut packet);
+        // Coding at (1, 5) passes
+        assert!(!check_if_already_received(&packet, &shreds_received));
+        // then blocked
+        assert!(check_if_already_received(&packet, &shreds_received));
+
+        let shred = Shred::new_empty_coding(slot, index, 2, 1, 1, 0, version);
+        shred.copy_to_packet(&mut packet);
+        // 2nd unique coding at (1, 5) passes
+        assert!(!check_if_already_received(&packet, &shreds_received));
+        // same again is blocked
+        assert!(check_if_already_received(&packet, &shreds_received));
+
+        let shred = Shred::new_empty_coding(slot, index, 3, 1, 1, 0, version);
+        shred.copy_to_packet(&mut packet);
+        // Another unique at (1, 5) always blocked
+        assert!(check_if_already_received(&packet, &shreds_received));
+        assert!(check_if_already_received(&packet, &shreds_received));
     }
 }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1,5 +1,6 @@
 //! The `shred` module defines data structures and methods to pull MTU sized data frames from the network.
 use crate::{
+    blockstore::MAX_DATA_SHREDS_PER_SLOT,
     entry::{create_ticks, Entry},
     erasure::Session,
 };
@@ -12,7 +13,7 @@ use rayon::{
 };
 use serde::{Deserialize, Serialize};
 use solana_measure::measure::Measure;
-use solana_perf::packet::Packet;
+use solana_perf::packet::{limited_deserialize, Packet};
 use solana_rayon_threadlimit::get_thread_count;
 use solana_sdk::{
     clock::Slot,
@@ -307,6 +308,27 @@ impl Shred {
         };
 
         Ok(shred)
+    }
+
+    pub fn new_empty_coding(
+        slot: Slot,
+        index: u32,
+        fec_set_index: u32,
+        num_data: usize,
+        num_code: usize,
+        position: usize,
+        version: u16,
+    ) -> Self {
+        let (header, coding_header) = Shredder::new_coding_shred_header(
+            slot,
+            index,
+            fec_set_index,
+            num_data,
+            num_code,
+            position,
+            version,
+        );
+        Shred::new_empty_from_header(header, DataShredHeader::default(), coding_header)
     }
 
     pub fn new_empty_from_header(
@@ -698,7 +720,7 @@ impl Shredder {
             // Create empty coding shreds, with correctly populated headers
             let mut coding_shreds = Vec::with_capacity(num_coding);
             (0..num_coding).for_each(|i| {
-                let (header, coding_header) = Self::new_coding_shred_header(
+                let shred = Shred::new_empty_coding(
                     slot,
                     start_index + i as u32,
                     start_index,
@@ -707,8 +729,6 @@ impl Shredder {
                     i,
                     version,
                 );
-                let shred =
-                    Shred::new_empty_from_header(header, DataShredHeader::default(), coding_header);
                 coding_shreds.push(shred.payload);
             });
 
@@ -729,7 +749,7 @@ impl Shredder {
                 .into_iter()
                 .enumerate()
                 .map(|(i, payload)| {
-                    let (common_header, coding_header) = Self::new_coding_shred_header(
+                    let mut shred = Shred::new_empty_coding(
                         slot,
                         start_index + i as u32,
                         start_index,
@@ -738,12 +758,8 @@ impl Shredder {
                         i,
                         version,
                     );
-                    Shred {
-                        common_header,
-                        data_header: DataShredHeader::default(),
-                        coding_header,
-                        payload,
-                    }
+                    shred.payload = payload;
+                    shred
                 })
                 .collect()
         } else {
@@ -960,6 +976,71 @@ impl Shredder {
 
         Ok(())
     }
+}
+
+#[derive(Default, Debug, Eq, PartialEq)]
+pub struct ShredFetchStats {
+    pub index_overrun: usize,
+    pub shred_count: usize,
+    pub index_bad_deserialize: usize,
+    pub index_out_of_bounds: usize,
+    pub slot_bad_deserialize: usize,
+    pub duplicate_shred: usize,
+    pub slot_out_of_range: usize,
+    pub bad_shred_type: usize,
+}
+
+// Get slot, index, and type from a packet with partial deserialize
+pub fn get_shred_slot_index_type(
+    p: &Packet,
+    stats: &mut ShredFetchStats,
+) -> Option<(Slot, u32, bool)> {
+    let index_start = OFFSET_OF_SHRED_INDEX;
+    let index_end = index_start + SIZE_OF_SHRED_INDEX;
+    let slot_start = OFFSET_OF_SHRED_SLOT;
+    let slot_end = slot_start + SIZE_OF_SHRED_SLOT;
+
+    debug_assert!(index_end > slot_end);
+    debug_assert!(index_end > OFFSET_OF_SHRED_TYPE);
+
+    if index_end > p.meta.size {
+        stats.index_overrun += 1;
+        return None;
+    }
+
+    let index;
+    match limited_deserialize::<u32>(&p.data[index_start..index_end]) {
+        Ok(x) => index = x,
+        Err(_e) => {
+            stats.index_bad_deserialize += 1;
+            return None;
+        }
+    }
+
+    if index >= MAX_DATA_SHREDS_PER_SLOT as u32 {
+        stats.index_out_of_bounds += 1;
+        return None;
+    }
+
+    let slot;
+    match limited_deserialize::<Slot>(&p.data[slot_start..slot_end]) {
+        Ok(x) => {
+            slot = x;
+        }
+        Err(_e) => {
+            stats.slot_bad_deserialize += 1;
+            return None;
+        }
+    }
+
+    let shred_type = p.data[OFFSET_OF_SHRED_TYPE];
+    if shred_type == DATA_SHRED || shred_type == CODING_SHRED {
+        return Some((slot, index, shred_type == DATA_SHRED));
+    } else {
+        stats.bad_shred_type += 1;
+    }
+
+    None
 }
 
 pub fn max_ticks_per_n_shreds(num_shreds: u64, shred_data_size: Option<usize>) -> u64 {
@@ -1705,5 +1786,61 @@ pub mod tests {
                 parent_offset: 1000
             })
         );
+    }
+
+    #[test]
+    fn test_shred_offsets() {
+        solana_logger::setup();
+        let mut packet = Packet::default();
+        let shred = Shred::new_from_data(1, 3, 0, None, true, true, 0, 0, 0);
+        shred.copy_to_packet(&mut packet);
+        let mut stats = ShredFetchStats::default();
+        let ret = get_shred_slot_index_type(&packet, &mut stats);
+        assert_eq!(Some((1, 3, true)), ret);
+        assert_eq!(stats, ShredFetchStats::default());
+
+        packet.meta.size = OFFSET_OF_SHRED_TYPE;
+        assert_eq!(None, get_shred_slot_index_type(&packet, &mut stats));
+        assert_eq!(stats.index_overrun, 1);
+
+        packet.meta.size = OFFSET_OF_SHRED_INDEX;
+        assert_eq!(None, get_shred_slot_index_type(&packet, &mut stats));
+        assert_eq!(stats.index_overrun, 2);
+
+        packet.meta.size = OFFSET_OF_SHRED_INDEX + 1;
+        assert_eq!(None, get_shred_slot_index_type(&packet, &mut stats));
+        assert_eq!(stats.index_overrun, 3);
+
+        packet.meta.size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX - 1;
+        assert_eq!(None, get_shred_slot_index_type(&packet, &mut stats));
+        assert_eq!(stats.index_overrun, 4);
+
+        packet.meta.size = OFFSET_OF_SHRED_INDEX + SIZE_OF_SHRED_INDEX;
+        assert_eq!(
+            Some((1, 3, true)),
+            get_shred_slot_index_type(&packet, &mut stats)
+        );
+        assert_eq!(stats.index_overrun, 4);
+
+        let shred = Shred::new_empty_coding(8, 2, 10, 30, 4, 7, 200);
+        shred.copy_to_packet(&mut packet);
+        assert_eq!(
+            Some((8, 2, false)),
+            get_shred_slot_index_type(&packet, &mut stats)
+        );
+
+        let shred = Shred::new_from_data(1, std::u32::MAX - 10, 0, None, true, true, 0, 0, 0);
+        shred.copy_to_packet(&mut packet);
+        assert_eq!(None, get_shred_slot_index_type(&packet, &mut stats));
+        assert_eq!(1, stats.index_out_of_bounds);
+
+        let (mut header, coding_header) =
+            Shredder::new_coding_shred_header(8, 2, 10, 30, 4, 7, 200);
+        header.shred_type = ShredType(u8::MAX);
+        let shred = Shred::new_empty_from_header(header, DataShredHeader::default(), coding_header);
+        shred.copy_to_packet(&mut packet);
+
+        assert_eq!(None, get_shred_slot_index_type(&packet, &mut stats));
+        assert_eq!(1, stats.bad_shred_type);
     }
 }


### PR DESCRIPTION
#### Problem

Retransmit should differentiate between data/coding index spaces for duplicate hashes and code relating to shred deserialize should be in shred module.

#### Summary of Changes

Rearrange shred code, and dedupe based on coding/data in retransmit.

Fixes #
