### PR TITLE
Rework TestValidator API to be more like ProgramTest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5094,6 +5094,7 @@ dependencies = [
 name = "solana-validator"
 version = "1.5.0"
 dependencies = [
+ "base64 0.12.3",
  "chrono",
  "clap",
  "console",

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -256,14 +256,14 @@ pub fn request_airdrop_transaction(
     Ok(transaction)
 }
 
-// For integration tests. Listens on random open port and reports port to Sender.
-pub fn run_local_faucet(
+pub fn run_local_faucet_with_port(
     faucet_keypair: Keypair,
     sender: Sender<SocketAddr>,
     per_time_cap: Option<u64>,
+    port: u16,
 ) {
     thread::spawn(move || {
-        let faucet_addr = socketaddr!(0, 0);
+        let faucet_addr = socketaddr!(0, port);
         let faucet = Arc::new(Mutex::new(Faucet::new(
             faucet_keypair,
             None,
@@ -272,6 +272,15 @@ pub fn run_local_faucet(
         )));
         run_faucet(faucet, faucet_addr, Some(sender));
     });
+}
+
+// For integration tests. Listens on random open port and reports port to Sender.
+pub fn run_local_faucet(
+    faucet_keypair: Keypair,
+    sender: Sender<SocketAddr>,
+    per_time_cap: Option<u64>,
+) {
+    run_local_faucet_with_port(faucet_keypair, sender, per_time_cap, 0)
 }
 
 pub fn run_faucet(

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://solana.com/"
 default-run = "solana-validator"
 
 [dependencies]
+base64 = "0.12.3"
 clap = "2.33.1"
 chrono = { version = "0.4.11", features = ["serde"] }
 console = "0.11.3"

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -5,19 +5,25 @@ use {
     solana_clap_utils::{input_parsers::pubkey_of, input_validators::is_pubkey},
     solana_client::{client_error, rpc_client::RpcClient},
     solana_core::rpc::JsonRpcConfig,
+    solana_faucet::faucet::{run_local_faucet_with_port, FAUCET_PORT},
     solana_sdk::{
+        account::Account,
         clock::{Slot, DEFAULT_TICKS_PER_SLOT, MS_PER_TICK},
         commitment_config::CommitmentConfig,
-        fee_calculator::FeeRateGovernor,
-        rent::Rent,
+        native_token::sol_to_lamports,
+        pubkey::Pubkey,
         rpc_port,
-        signature::{read_keypair_file, Signer},
+        signature::{read_keypair_file, write_keypair_file, Keypair, Signer},
+        system_program,
     },
     solana_validator::{start_logger, test_validator::*},
     std::{
+        fs,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
         path::PathBuf,
         process::exit,
-        thread::sleep,
+        sync::mpsc::channel,
+        thread,
         time::{Duration, SystemTime, UNIX_EPOCH},
     },
 };
@@ -47,7 +53,8 @@ fn println_name_value(name: &str, value: &str) {
 fn main() {
     let default_rpc_port = rpc_port::DEFAULT_RPC_PORT.to_string();
 
-    let matches = App::new("solana-test-validator").about("Test Validator")
+    let matches = App::new("solana-test-validator")
+        .about("Test Validator")
         .version(solana_version::version!())
         .arg({
             let arg = Arg::with_name("config_file")
@@ -68,7 +75,10 @@ fn main() {
                 .value_name("PUBKEY")
                 .validator(is_pubkey)
                 .takes_value(true)
-                .help("Address of the mint account that will receive all the initial tokens [default: client keypair]"),
+                .help(
+                    "Address of the mint account that will receive tokens \
+                       created at genesis [default: client keypair]",
+                ),
         )
         .arg(
             Arg::with_name("ledger_path")
@@ -86,14 +96,14 @@ fn main() {
                 .long("quiet")
                 .takes_value(false)
                 .conflicts_with("log")
-                .help("Quiet mode: suppress normal output")
+                .help("Quiet mode: suppress normal output"),
         )
         .arg(
             Arg::with_name("log")
                 .long("log")
                 .takes_value(false)
                 .conflicts_with("quiet")
-                .help("Log mode: stream the validator log")
+                .help("Log mode: stream the validator log"),
         )
         .arg(
             Arg::with_name("rpc_port")
@@ -103,6 +113,15 @@ fn main() {
                 .default_value(&default_rpc_port)
                 .validator(solana_validator::port_validator)
                 .help("Use this port for JSON RPC and the next port for the RPC websocket"),
+        )
+        .arg(
+            Arg::with_name("bpf_program")
+                .long("bpf-program")
+                .value_name("ADDRESS BPF_PROGRAM.SO")
+                .takes_value(true)
+                .number_of_values(2)
+                .multiple(true)
+                .help("Add a BPF program to the genesis configuration"),
         )
         .get_matches();
 
@@ -132,42 +151,56 @@ fn main() {
     } else {
         Output::Dashboard
     };
+    let rpc_port = value_t_or_exit!(matches, "rpc_port", u16);
+    let faucet_addr = Some(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        FAUCET_PORT,
+    ));
 
-    let rpc_ports = {
-        let rpc_port = value_t_or_exit!(matches, "rpc_port", u16);
-        (rpc_port, rpc_port + 1)
-    };
+    let mut programs = vec![];
+    if let Some(values) = matches.values_of("bpf_program") {
+        let values: Vec<&str> = values.collect::<Vec<_>>();
+        for address_program in values.chunks(2) {
+            match address_program {
+                [address, program] => {
+                    let address = address.parse::<Pubkey>().unwrap_or_else(|err| {
+                        eprintln!("Error: invalid address {}: {}", address, err);
+                        exit(1);
+                    });
 
-    if !ledger_path.exists() {
-        let _progress_bar = if output == Output::Dashboard {
-            println_name_value("Mint address:", &mint_address.to_string());
-            let progress_bar = new_spinner_progress_bar();
-            progress_bar.set_message("Creating ledger...");
-            Some(progress_bar)
-        } else {
-            None
-        };
+                    let program_path = PathBuf::from(program);
+                    if !program_path.exists() {
+                        eprintln!(
+                            "Error: program file does not exist: {}",
+                            program_path.display()
+                        );
+                        exit(1);
+                    }
 
-        TestValidator::initialize_ledger(
-            Some(&ledger_path),
-            TestValidatorGenesisConfig {
-                mint_address,
-                fee_rate_governor: FeeRateGovernor::default(),
-                rent: Rent::default(),
-            },
-        )
-        .unwrap_or_else(|err| {
-            eprintln!(
-                "Error: failed to initialize ledger at {}: {}",
-                ledger_path.display(),
-                err
-            );
-            exit(1);
-        });
+                    programs.push(ProgramInfo {
+                        program_id: address,
+                        loader: solana_sdk::bpf_loader::id(),
+                        program_path,
+                    });
+                }
+                _ => unreachable!(),
+            }
+        }
     }
 
     let validator_log_symlink = ledger_path.join("validator.log");
     let logfile = if output != Output::Log {
+        if !ledger_path.exists() {
+            fs::create_dir(&ledger_path).unwrap_or_else(|err| {
+                eprintln!(
+                    "Error: Unable to create directory {}: {}",
+                    ledger_path.display(),
+                    err
+                );
+                exit(1);
+            })
+        }
+
         let validator_log_with_timestamp = format!(
             "validator-{}.log",
             SystemTime::now()
@@ -176,7 +209,7 @@ fn main() {
                 .as_millis()
         );
 
-        let _ = std::fs::remove_file(&validator_log_symlink);
+        let _ = fs::remove_file(&validator_log_symlink);
         symlink::symlink_file(&validator_log_with_timestamp, &validator_log_symlink).unwrap();
 
         Some(
@@ -189,11 +222,35 @@ fn main() {
     } else {
         None
     };
-
     let _logger_thread = start_logger(logfile);
+
+    let faucet_lamports = sol_to_lamports(1_000_000.);
+    let faucet_keypair_file = ledger_path.join("faucet-keypair.json");
+    if !faucet_keypair_file.exists() {
+        write_keypair_file(&Keypair::new(), faucet_keypair_file.to_str().unwrap()).unwrap_or_else(
+            |err| {
+                eprintln!(
+                    "Error: Failed to write {}: {}",
+                    faucet_keypair_file.display(),
+                    err
+                );
+                exit(1);
+            },
+        );
+    }
+    let faucet_keypair =
+        read_keypair_file(faucet_keypair_file.to_str().unwrap()).unwrap_or_else(|err| {
+            eprintln!(
+                "Error: Failed to read {}: {}",
+                faucet_keypair_file.display(),
+                err
+            );
+            exit(1);
+        });
 
     let test_validator = {
         let _progress_bar = if output == Output::Dashboard {
+            println_name_value("Mint address:", &mint_address.to_string());
             println_name_value("Ledger location:", &format!("{}", ledger_path.display()));
             println_name_value("Log:", &format!("{}", validator_log_symlink.display()));
             let progress_bar = new_spinner_progress_bar();
@@ -203,23 +260,32 @@ fn main() {
             None
         };
 
-        TestValidator::start(
-            &ledger_path,
-            TestValidatorStartConfig {
-                preserve_ledger: true,
-                rpc_config: JsonRpcConfig {
-                    enable_validator_exit: true,
-                    enable_rpc_transaction_history: true,
-                    ..JsonRpcConfig::default()
-                },
-                rpc_ports: Some(rpc_ports),
-            },
-        )
+        TestValidatorGenesis::default()
+            .ledger_path(ledger_path)
+            .add_account(
+                faucet_keypair.pubkey(),
+                Account::new(faucet_lamports, 0, &system_program::id()),
+            )
+            .rpc_config(JsonRpcConfig {
+                enable_validator_exit: true,
+                enable_rpc_transaction_history: true,
+                faucet_addr,
+                ..JsonRpcConfig::default()
+            })
+            .rpc_port(rpc_port)
+            .add_programs_with_path(&programs)
+            .start_with_mint_address(mint_address)
     }
     .unwrap_or_else(|err| {
         eprintln!("Error: failed to start validator: {}", err);
         exit(1);
     });
+
+    if let Some(faucet_addr) = &faucet_addr {
+        let (sender, receiver) = channel();
+        run_local_faucet_with_port(faucet_keypair, sender, None, faucet_addr.port());
+        receiver.recv().expect("run faucet");
+    }
 
     if output == Output::Dashboard {
         println_name_value("JSON RPC URL:", &test_validator.rpc_url());
@@ -229,9 +295,12 @@ fn main() {
         );
         println_name_value("Gossip Address:", &test_validator.gossip().to_string());
         println_name_value("TPU Address:", &test_validator.tpu().to_string());
+        if let Some(faucet_addr) = &faucet_addr {
+            println_name_value("Faucet Address:", &faucet_addr.to_string());
+        }
 
         let progress_bar = new_spinner_progress_bar();
-        let rpc_client = RpcClient::new(test_validator.rpc_url());
+        let rpc_client = test_validator.rpc_client().0;
 
         fn get_validator_stats(rpc_client: &RpcClient) -> client_error::Result<(Slot, Slot, u64)> {
             let max_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::max())?;
@@ -253,7 +322,7 @@ fn main() {
                     progress_bar.set_message(&format!("{}", err));
                 }
             }
-            sleep(Duration::from_millis(
+            thread::sleep(Duration::from_millis(
                 MS_PER_TICK * DEFAULT_TICKS_PER_SLOT / 2,
             ));
         }


### PR DESCRIPTION
`TestValidator` now provides an API to add BPF programs or other accounts to the genesis configuration, mimicking `ProgramTest`.   It also features a convenient API to easily get the payer keypair, an RpcClient and a blockhash to start with, which further reduces the test boilerplate.

Freebie: `solana-test-validator` now runs a faucet to make it a drop-in replacement for `solana-localnet`

Example`TestValidator`-based tests:
* https://github.com/mvines/solana-bpf-program-template/pull/5/files
* https://github.com/mvines/solana-cli-template/pull/1/files
