### PR TITLE
fix the typo in developing-rust.md

### DIFF
--- a/docs/src/developing/deployed-programs/developing-rust.md
+++ b/docs/src/developing/deployed-programs/developing-rust.md
@@ -31,7 +31,7 @@ to instruction helpers when making [cross-program
 invocations](developing/../../programming-model/calling-between-programs.md#cross-program-invocations).
 When doing so it's important to not pull in the dependent program's entrypoint
 symbols because they may conflict with the program's own.  To avoid this
-,programs should define an `exclude_entrypoint` feature in `Cargo.toml`j and use
+,programs should define an `exclude_entrypoint` feature in `Cargo.toml` and use
 to exclude the entrypoint.
 
 - [Define the


### PR DESCRIPTION
remove the redundant character