### PR TITLE
Fix race between setting tick height and calculating accounts hash

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -41,7 +41,7 @@ use solana_sdk::{
 use std::convert::TryFrom;
 use std::{
     boxed::Box,
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     convert::TryInto,
     io::{Error as IOError, Result as IOResult},
     ops::RangeBounds,
@@ -465,8 +465,6 @@ pub struct AccountsDB {
     stats: AccountsStats,
 
     pub cluster_type: Option<ClusterType>,
-
-    pub frozen_slots: RwLock<BTreeSet<Slot>>,
 }
 
 #[derive(Debug, Default)]
@@ -544,7 +542,6 @@ impl Default for AccountsDB {
             frozen_accounts: HashMap::new(),
             stats: AccountsStats::default(),
             cluster_type: None,
-            frozen_slots: RwLock::new(BTreeSet::new()),
         }
     }
 }
@@ -2643,18 +2640,8 @@ impl AccountsDB {
         }
     }
 
-    pub fn mark_slot_frozen(&self, slot: Slot) {
-        self.frozen_slots.write().unwrap().insert(slot);
-    }
-
     /// Store the account update.
     pub fn store(&self, slot: Slot, accounts: &[(&Pubkey, &Account)]) {
-        if self.frozen_slots.read().unwrap().contains(&slot) {
-            panic!(
-                "Trying to modify frozen slot {} with accounts: {:?}",
-                slot, accounts
-            );
-        }
         // If all transactions in a batch are errored,
         // it's possible to get a store with no accounts.
         if accounts.is_empty() {
@@ -2843,12 +2830,7 @@ impl AccountsDB {
     }
 
     pub fn add_root(&self, slot: Slot) {
-        self.accounts_index.add_root(slot);
-        {
-            let mut w_frozen_slots = self.frozen_slots.write().unwrap();
-            let mut new_unrooted_slots = w_frozen_slots.split_off(&slot);
-            std::mem::swap(&mut *w_frozen_slots, &mut new_unrooted_slots);
-        }
+        self.accounts_index.add_root(slot)
     }
 
     pub fn get_snapshot_storages(&self, snapshot_slot: Slot) -> SnapshotStorages {
@@ -5746,21 +5728,6 @@ pub mod tests {
         assert_eq!(
             db.load_slow(&HashMap::new(), &account_key),
             Some((zero_lamport_account, 1))
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_store_frozen_slot() {
-        let db = AccountsDB::new(Vec::new(), &ClusterType::Development);
-        let frozen_slot = 1;
-        db.mark_slot_frozen(frozen_slot);
-        db.store(
-            frozen_slot,
-            &[(
-                &Pubkey::new_unique(),
-                &Account::new(0, 0, &Account::default().owner),
-            )],
         );
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2281,13 +2281,13 @@ impl Bank {
         // not attempt to freeze after observing the last tick and before blockhash is
         // updated
         let mut w_blockhash_queue = self.blockhash_queue.write().unwrap();
-        let current_tick_height = self.tick_height.fetch_add(1, Relaxed) as u64;
-        if self.is_block_boundary(current_tick_height + 1) {
+        if self.is_block_boundary(self.tick_height.load(Relaxed) + 1) {
             w_blockhash_queue.register_hash(hash, &self.fee_calculator);
             if self.fix_recent_blockhashes_sysvar_delay() {
                 self.update_recent_blockhashes_locked(&w_blockhash_queue);
             }
         }
+        let current_tick_height = self.tick_height.fetch_add(1, Relaxed) as u64;
     }
 
     pub fn is_complete(&self) -> bool {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -867,6 +867,8 @@ pub struct Bank {
     pub feature_set: Arc<FeatureSet>,
 
     pub drop_callback: RwLock<OptionalDropCallback>,
+
+    pub freeze_started: AtomicBool,
 }
 
 impl Default for BlockhashQueue {
@@ -1022,6 +1024,7 @@ impl Bank {
                     .as_ref()
                     .map(|drop_callback| drop_callback.clone_box()),
             )),
+            freeze_started: AtomicBool::new(false),
         };
 
         datapoint_info!(
@@ -1145,6 +1148,7 @@ impl Bank {
             transaction_log_collector: new(),
             feature_set: new(),
             drop_callback: RwLock::new(OptionalDropCallback(None)),
+            freeze_started: AtomicBool::new(fields.hash != Hash::default()),
         };
         bank.finish_init(genesis_config, additional_builtins);
 
@@ -1246,6 +1250,10 @@ impl Bank {
 
     pub fn is_frozen(&self) -> bool {
         *self.hash.read().unwrap() != Hash::default()
+    }
+
+    pub fn freeze_started(&self) -> bool {
+        self.freeze_started.load(Relaxed)
     }
 
     pub fn status_cache_ancestors(&self) -> Vec<u64> {
@@ -1941,6 +1949,17 @@ impl Bank {
     }
 
     pub fn freeze(&self) {
+        // This lock prevents any new commits from BankingStage
+        // `process_and_record_transactions_locked()` from coming
+        // in after the last tick is observed. This is because in
+        // BankingStage, any transaction successfully recorded in
+        // `record_transactions()` is recorded after this `hash` lock
+        // is grabbed. At the time of the successful record,
+        // this means the PoH has not yet reached the last tick,
+        // so this means freeze() hasn't been called yet. And because
+        // BankingStage doesn't release this hash lock until both
+        // record and commit are finished, those transactions will be
+        // committed before this write lock can be obtained here.
         let mut hash = self.hash.write().unwrap();
 
         if *hash == Hash::default() {
@@ -1952,6 +1971,7 @@ impl Bank {
             self.run_incinerator();
 
             // freeze is a one-way trip, idempotent
+            self.freeze_started.store(true, Relaxed);
             *hash = self.hash_internal_state();
         }
     }
@@ -2145,7 +2165,7 @@ impl Bank {
         }
 
         assert!(
-            !self.is_frozen(),
+            !self.freeze_started(),
             "Can't change frozen bank by adding not-existing new native program ({}, {}). \
             Maybe, inconsistent program activation is detected on snapshot restore?",
             name,
@@ -2272,8 +2292,8 @@ impl Bank {
     /// bank will reject transactions using that `hash`.
     pub fn register_tick(&self, hash: &Hash) {
         assert!(
-            !self.is_frozen(),
-            "register_tick() working on a frozen bank!"
+            !self.freeze_started(),
+            "register_tick() working on a bank that is already frozen or is undergoing freezing!"
         );
 
         inc_new_counter_debug!("bank-register_tick-registered", 1);
@@ -3055,8 +3075,8 @@ impl Bank {
         signature_count: u64,
     ) -> TransactionResults {
         assert!(
-            !self.is_frozen(),
-            "commit_transactions() working on a frozen bank!"
+            !self.freeze_started(),
+            "commit_transactions() working on a bank that is already frozen or is undergoing freezing!"
         );
 
         self.increment_transaction_count(tx_count);
@@ -3770,6 +3790,7 @@ impl Bank {
     }
 
     pub fn store_account(&self, pubkey: &Pubkey, account: &Account) {
+        assert!(!self.freeze_started());
         self.rc.accounts.store_slow(self.slot(), pubkey, account);
 
         if Stakes::is_stake(account) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1952,7 +1952,6 @@ impl Bank {
             self.run_incinerator();
 
             // freeze is a one-way trip, idempotent
-            self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());
             *hash = self.hash_internal_state();
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1952,6 +1952,7 @@ impl Bank {
             self.run_incinerator();
 
             // freeze is a one-way trip, idempotent
+            self.rc.accounts.accounts_db.mark_slot_frozen(self.slot());
             *hash = self.hash_internal_state();
         }
     }


### PR DESCRIPTION
#### Problem
Freeze in ReplayStage only checks the tick height: https://github.com/solana-labs/solana/blob/master/core/src/replay_stage.rs#L1339-L1348), so it's possible that the the accounts diff hash is calculated after freeze, but before the block hash sysvar is updated. Like this:
```
let current_tick_height = self.tick_height.fetch_add(1, Relaxed) as u64;
<<< Freeze happens here>>>
if self.is_block_boundary(current_tick_height + 1) {
            w_blockhash_queue.register_hash(hash, &self.fee_calculator);
            if self.fix_recent_blockhashes_sysvar_delay() {
                self.update_recent_blockhashes_locked(&w_blockhash_queue);
            }
        }
```

#### Summary of Changes
Move blockhash registration before tick registration.

TODO: Testing and double checking subtleties in old related PR's that I may have forgotten about:

1) https://github.com/solana-labs/solana/pull/6013
2) https://github.com/solana-labs/solana/pull/6799

Fixes #
