### PR TITLE
Add try_find_program_address syscall

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -155,6 +155,20 @@ extern uint64_t entrypoint(const uint8_t *input) {
       sol_assert(SolPubkey_same(&address, accounts[DERIVED_KEY1_INDEX].key));
     }
 
+    sol_log("Test try_find_program_address");
+    {
+      uint8_t seed[] = {'Y', 'o', 'u', ' ', 'p', 'a', 's', 's',
+                        ' ', 'b', 'u', 't', 't', 'e', 'r'};
+      const SolSignerSeed seeds[] = {{seed, SOL_ARRAY_SIZE(seed)}};
+      SolPubkey address;
+      uint8_t bump_seed;
+      sol_assert(SUCCESS == sol_try_find_program_address(
+                                seeds, SOL_ARRAY_SIZE(seeds), params.program_id,
+                                &address, &bump_seed));
+      sol_assert(SolPubkey_same(&address, accounts[DERIVED_KEY1_INDEX].key));
+      sol_assert(bump_seed == bump_seed1);
+    }
+
     sol_log("Test derived signers");
     {
       sol_assert(!accounts[DERIVED_KEY1_INDEX].is_signer);

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -259,6 +259,19 @@ fn process_instruction(
                 );
             }
 
+            msg!("Test try_find_program_address");
+            {
+                let (address, bump_seed) =
+                    Pubkey::try_find_program_address(&[b"You pass butter"], program_id).unwrap();
+                assert_eq!(&address, accounts[DERIVED_KEY1_INDEX].key);
+                assert_eq!(bump_seed, bump_seed1);
+                assert_eq!(
+                    Pubkey::create_program_address(&[b"You pass butter"], &Pubkey::default())
+                        .unwrap_err(),
+                    PubkeyError::InvalidSeeds
+                );
+            }
+
             msg!("Test derived signers");
             {
                 assert!(!accounts[DERIVED_KEY1_INDEX].is_signer);

--- a/sdk/bpf/c/inc/solana_sdk.h
+++ b/sdk/bpf/c/inc/solana_sdk.h
@@ -479,14 +479,31 @@ typedef struct {
  *
  * @param seeds Seed bytes used to sign program accounts
  * @param seeds_len Length of the seeds array
- * @param Progam id of the signer
- * @param Program address created, filled on return
+ * @param program_id Program id of the signer
+ * @param program_address Program address created, filled on return
  */
 static uint64_t sol_create_program_address(
     const SolSignerSeed *seeds,
     int seeds_len,
     const SolPubkey *program_id,
-    const SolPubkey *address
+    const SolPubkey *program_address
+);
+
+/**
+ * Try to find a program address and return corresponding bump seed
+ *
+ * @param seeds Seed bytes used to sign program accounts
+ * @param seeds_len Length of the seeds array
+ * @param program_id Program id of the signer
+ * @param program_address Program address created, filled on return
+ * @param bump_seed Bump seed required to create a valid program address
+ */
+static uint64_t sol_try_find_program_address(
+    const SolSignerSeed *seeds,
+    int seeds_len,
+    const SolPubkey *program_id,
+    const SolPubkey *program_address,
+    const uint8_t *bump_seed
 );
 
 /**

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -106,6 +106,10 @@ pub mod bpf_loader_upgradeable_program {
     solana_sdk::declare_id!("FbhK8HN9qvNHvJcoFVHAEUCNkagHvu7DTWzdnLuVQ5u4");
 }
 
+pub mod try_find_program_address_syscall_enabled {
+    solana_sdk::declare_id!("EMsMNadQNhCYDyGpYH5Tx6dGHxiUqKHk782PU5XaWfmi");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -134,6 +138,7 @@ lazy_static! {
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
         (simple_capitalization::id(), "simple capitalization"),
         (bpf_loader_upgradeable_program::id(), "upgradeable bpf loader"),
+        (try_find_program_address_syscall_enabled::id(), "add try_find_program_address syscall"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Finding a program address in BPF space can be very expensive due to repeated calls to create_program_address. 

#### Summary of Changes

Extend a syscall for `Pubkey::try_find_program_address'.

Fixes #
