### PR TITLE
Switch `solana deploy` commitment default from "max" to "singleGossip"

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2792,7 +2792,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(false)
                         .help("Use the designated program id, even if the account already holds a large balance of SOL")
                 )
-                .arg(commitment_arg_with_default("max")),
+                .arg(commitment_arg_with_default("singleGossip")),
         )
         .subcommand(
             SubCommand::with_name("program-upgrade")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -206,7 +206,10 @@ pub fn parse_args<'a>(
             verbose,
             output_format,
             commitment,
-            send_transaction_config: RpcSendTransactionConfig::default(),
+            send_transaction_config: RpcSendTransactionConfig {
+                preflight_commitment: Some(commitment.commitment),
+                ..RpcSendTransactionConfig::default()
+            },
             address_labels,
         },
         signers,


### PR DESCRIPTION
On a `solana-test-validator` running locally, elapsed time for `solana deploy spl_token-2.0.6.so` drops from ~35 seconds to ~5 seconds