### PR TITLE
Correctly show reward percent changes

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -800,8 +800,9 @@ pub fn process_get_block(
                     format!(
                         "◎{:<19.9}  {:>13.9}%",
                         lamports_to_sol(reward.post_balance),
-                        reward.lamports.abs() as f64
-                            / (reward.post_balance as f64 - reward.lamports as f64)
+                        (reward.lamports.abs() as f64
+                            / (reward.post_balance as f64 - reward.lamports as f64))
+                            * 100.0
                     )
                 }
             );

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1662,13 +1662,13 @@ pub(crate) fn fetch_epoch_rewards(
                 .find(|reward| reward.pubkey == address.to_string())
             {
                 if reward.post_balance > reward.lamports.try_into().unwrap_or(0) {
-                    let percent_change = reward.lamports.abs() as f64
+                    let rate_change = reward.lamports.abs() as f64
                         / (reward.post_balance as f64 - reward.lamports as f64);
 
                     let apr = wallclock_epoch_duration.map(|wallclock_epoch_duration| {
                         let wallclock_epochs_per_year =
                             (SECONDS_PER_DAY * 356) as f64 / wallclock_epoch_duration;
-                        percent_change * wallclock_epochs_per_year
+                        rate_change * wallclock_epochs_per_year
                     });
 
                     all_epoch_rewards.push(CliEpochReward {
@@ -1676,8 +1676,8 @@ pub(crate) fn fetch_epoch_rewards(
                         effective_slot,
                         amount: reward.lamports.abs() as u64,
                         post_balance: reward.post_balance,
-                        percent_change,
-                        apr,
+                        percent_change: rate_change * 100.0,
+                        apr: apr.map(|r| r * 100.0),
                     });
                 }
             }


### PR DESCRIPTION
#### Problem

What's expected to be multiplied by 100 is actually not done so, showing incorrect (apparently very small rewards).

#### Summary of Changes

Do `100x`.

```
BEFORE:
$ ./target/debug/solana  --url  http://testnet.solana.com block 52796261
  ...
  yrkgYPkeLVfuWt4xhDeLMUjcL3cjzarZ17Te6AYmFMU       staking      ◎334.637797223   ◎5378.363316903         0.066347345%

AFTER:
$ ./target/debug/solana  --url  http://testnet.solana.com block 52796261
  ...
  yrkgYPkeLVfuWt4xhDeLMUjcL3cjzarZ17Te6AYmFMU       staking      ◎334.637797223   ◎5378.363316903         6.634734502%


BEFORE:
$ ./target/debug/solana  --url  http://testnet.solana.com stake-account yrkgYPkeLVfuWt4xhDeLMUjcL3cjzarZ17Te6AYmFMU
  ...
  Epoch     Reward Slot  Amount           New Balance      Percent Change             APR
  134       52796261     ◎334.637797223   ◎5378.363316903    0.066347345%    9.447774451%

AFTER:
$ ./target/debug/solana  --url  http://testnet.solana.com stake-account yrkgYPkeLVfuWt4xhDeLMUjcL3cjzarZ17Te6AYmFMU
  ...
  Epoch     Reward Slot  Amount           New Balance      Percent Change             APR
  134       52796261     ◎334.637797223   ◎5378.363316903    6.634734502%  944.777445096%
```

APR looks broken; but this is correct because currently so few sols are staked compared to the total supply **on testnet**.