### PR TITLE
solana-test-simulator fixes to pacify Travis CI

### DIFF
--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -346,6 +346,7 @@ impl TestValidator {
                 compression: CompressionType::NoCompression,
                 snapshot_version: SnapshotVersion::default(),
             }),
+            enforce_ulimit_nofile: false,
             ..ValidatorConfig::default()
         };
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -341,7 +341,7 @@ pub mod tests {
             ledger_signal_receiver,
             completed_slots_receiver,
             ..
-        } = Blockstore::open_with_signal(&blockstore_path, None)
+        } = Blockstore::open_with_signal(&blockstore_path, None, true)
             .expect("Expected to successfully open ledger");
         let blockstore = Arc::new(blockstore);
         let bank = bank_forks.working_bank();

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -615,7 +615,7 @@ fn open_blockstore(
     access_type: AccessType,
     wal_recovery_mode: Option<BlockstoreRecoveryMode>,
 ) -> Blockstore {
-    match Blockstore::open_with_access_type(ledger_path, access_type, wal_recovery_mode) {
+    match Blockstore::open_with_access_type(ledger_path, access_type, wal_recovery_mode, true) {
         Ok(blockstore) => blockstore,
         Err(err) => {
             eprintln!("Failed to open ledger at {:?}: {:?}", ledger_path, err);

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1663,11 +1663,10 @@ fn test_validator_saves_tower() {
 }
 
 fn open_blockstore(ledger_path: &Path) -> Blockstore {
-    Blockstore::open_with_access_type(ledger_path, AccessType::PrimaryOnly, None).unwrap_or_else(
-        |e| {
+    Blockstore::open_with_access_type(ledger_path, AccessType::PrimaryOnly, None, true)
+        .unwrap_or_else(|e| {
             panic!("Failed to open ledger at {:?}, err: {}", ledger_path, e);
-        },
-    )
+        })
 }
 
 fn purge_slots(blockstore: &Blockstore, start_slot: Slot, slot_count: Slot) {
@@ -1887,6 +1886,7 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
                 &val_a_ledger_path,
                 AccessType::TryPrimaryThenSecondary,
                 None,
+                true,
             )
             .unwrap();
             let mut ancestors = AncestorIterator::new(last_vote, &blockstore);

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -143,14 +143,8 @@ fn main() {
     };
 
     let mint_address = pubkey_of(&matches, "mint_address").unwrap_or_else(|| {
-        read_keypair_file(&cli_config.keypair_path)
-            .unwrap_or_else(|err| {
-                eprintln!(
-                    "Error: Unable to read keypair file {}: {}",
-                    cli_config.keypair_path, err
-                );
-                exit(1);
-            })
+        read_keypair_file(dbg!(&cli_config.keypair_path))
+            .unwrap_or_else(|_| Keypair::new())
             .pubkey()
     });
 


### PR DESCRIPTION
Hopefully this unblocks https://github.com/solana-labs/solana/pull/14135...

Changes:
* Use an ephemeral mint address if the client keypair is not available to avoid having to add a bogus `solana-keygen new --silent --no-passphrase` in the Travis setup script
* Travis CI has `ulimit -n` fixed at 30000, can't increase it.  `solana-localnet` avoids this limitation by running in docker.   But for `solana-test-simulator`, 30000 open files ought to be fine so don't hard fail in this case 