### PR TITLE
Fix program account rent exemption

### DIFF
--- a/programs/bpf/rust/upgradeable/src/lib.rs
+++ b/programs/bpf/rust/upgradeable/src/lib.rs
@@ -8,9 +8,10 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    accounts: &[AccountInfo],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Upgradeable program");
+    assert_eq!(accounts.len(), 2);
     Err(42.into())
 }

--- a/programs/bpf/rust/upgraded/src/lib.rs
+++ b/programs/bpf/rust/upgraded/src/lib.rs
@@ -8,9 +8,10 @@ use solana_program::{
 entrypoint!(process_instruction);
 fn process_instruction(
     _program_id: &Pubkey,
-    _accounts: &[AccountInfo],
+    accounts: &[AccountInfo],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Upgraded program");
+    assert_eq!(accounts.len(), 2);
     Err(43.into())
 }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1483,7 +1483,14 @@ fn test_program_bpf_upgrade() {
 
     // call upgrade program
     nonce += 1;
-    let instruction = Instruction::new(program_id, &[nonce], vec![]);
+    let instruction = Instruction::new(
+        program_id,
+        &[nonce],
+        vec![
+            AccountMeta::new(clock::id(), false),
+            AccountMeta::new(fees::id(), false),
+        ],
+    );
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert_eq!(
         result.unwrap_err().unwrap(),
@@ -1501,7 +1508,14 @@ fn test_program_bpf_upgrade() {
 
     // call upgraded program
     nonce += 1;
-    let instruction = Instruction::new(program_id, &[nonce], vec![]);
+    let instruction = Instruction::new(
+        program_id,
+        &[nonce],
+        vec![
+            AccountMeta::new(clock::id(), false),
+            AccountMeta::new(fees::id(), false),
+        ],
+    );
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert_eq!(
         result.unwrap_err().unwrap(),
@@ -1529,7 +1543,14 @@ fn test_program_bpf_upgrade() {
 
     // call original program
     nonce += 1;
-    let instruction = Instruction::new(program_id, &[nonce], vec![]);
+    let instruction = Instruction::new(
+        program_id,
+        &[nonce],
+        vec![
+            AccountMeta::new(clock::id(), false),
+            AccountMeta::new(fees::id(), false),
+        ],
+    );
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert_eq!(
         result.unwrap_err().unwrap(),


### PR DESCRIPTION
#### Problem

The program account is created by the user who could have overallocated it thus resulting in the account not being rent exempt

#### Summary of Changes

- Update the check for rent-exemption
- Add an explicit check for size
- Zero out any extra bytes for good measure during an upgrade
- Strip off ProgramData account

Thanks @jstarry !

Fixes #
