### PR TITLE
Reject invalid --expected-shred-version

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -162,13 +162,6 @@ where
     is_parsable_generic::<u16, _>(port)
 }
 
-pub fn is_shred_version<T>(shred_version: T) -> Result<(), String>
-where
-    T: AsRef<str> + Display,
-{
-    is_parsable_generic::<u16, _>(shred_version)
-}
-
 pub fn is_valid_percentage<T>(percentage: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -162,6 +162,13 @@ where
     is_parsable_generic::<u16, _>(port)
 }
 
+pub fn is_shred_version<T>(shred_version: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    is_parsable_generic::<u16, _>(shred_version)
+}
+
 pub fn is_valid_percentage<T>(percentage: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -7,7 +7,8 @@ use rand::{thread_rng, Rng};
 use solana_clap_utils::{
     input_parsers::{keypair_of, keypairs_of, pubkey_of},
     input_validators::{
-        is_keypair_or_ask_keyword, is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot,
+        is_keypair_or_ask_keyword, is_parsable, is_pubkey, is_pubkey_or_keypair, is_shred_version,
+        is_slot,
     },
     keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
 };
@@ -1134,6 +1135,7 @@ pub fn main() {
                 .long("expected-shred-version")
                 .value_name("VERSION")
                 .takes_value(true)
+                .validator(is_shred_version)
                 .help("Require the shred version be this value"),
         )
         .arg(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -7,8 +7,7 @@ use rand::{thread_rng, Rng};
 use solana_clap_utils::{
     input_parsers::{keypair_of, keypairs_of, pubkey_of},
     input_validators::{
-        is_keypair_or_ask_keyword, is_parsable, is_pubkey, is_pubkey_or_keypair, is_shred_version,
-        is_slot,
+        is_keypair_or_ask_keyword, is_parsable, is_pubkey, is_pubkey_or_keypair, is_slot,
     },
     keypair::SKIP_SEED_PHRASE_VALIDATION_ARG,
 };
@@ -1135,7 +1134,7 @@ pub fn main() {
                 .long("expected-shred-version")
                 .value_name("VERSION")
                 .takes_value(true)
-                .validator(is_shred_version)
+                .validator(is_parsable::<u16>)
                 .help("Require the shred version be this value"),
         )
         .arg(


### PR DESCRIPTION
#### Problem

The value given to `--expected-shred-version` isn't validated at all. Any string value can be given like: `--expected-shread-version skip_any_corrupted_record` and validator works and the option is just ignored.
This confuses users and makes debugging/investigation/support hard.

This `ok()` causes this bug, squashing any parsing errors into `None`, which is same as if the option isn't given: https://github.com/solana-labs/solana/blob/593ad809541336da5790bfed9d5899a3bcc08e8f/validator/src/main.rs#L1426



#### Summary of Changes

Add appropriate clap `.validator()`.

BEFORE:

```
$ ps auxf
...
solana-validator ... --expected-shred-version 2323442344

$ ps auxf
...
solana-validator ... --expected-shred-version baddd
```

AFTER:

```
error: Invalid value for '--expected-shred-version <VERSION>': error parsing 'jajaj': invalid digit found in string
error: Invalid value for '--expected-shred-version <VERSION>': error parsing '2323442344': number too large to fit in target type
```


In the strictest sense, this breaks compatibility but I think this could sneak in v1.4 and v1.5, assuming we add appropriate small note in the next patch release note?



Fixes #
