### PR TITLE
JSON RPC: Add transactionCount field to GetEpochInfo

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -241,6 +241,9 @@ impl fmt::Display for CliEpochInfo {
         )?;
         writeln_name_value(f, "Slot:", &self.epoch_info.absolute_slot.to_string())?;
         writeln_name_value(f, "Epoch:", &self.epoch_info.epoch.to_string())?;
+        if let Some(transaction_count) = &self.epoch_info.transaction_count {
+            writeln_name_value(f, "Transaction Count:", &transaction_count.to_string())?;
+        }
         let start_slot = self.epoch_info.absolute_slot - self.epoch_info.slot_index;
         let end_slot = start_slot + self.epoch_info.slots_in_epoch;
         writeln_name_value(

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -65,6 +65,7 @@ impl RpcSender for MockSender {
                 slots_in_epoch: 32,
                 absolute_slot: 34,
                 block_height: 34,
+                transaction_count: Some(123),
             })?,
             RpcRequest::GetFeeCalculatorForBlockhash => {
                 let value = if self.url == "blockhash_expired" {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4386,12 +4386,14 @@ impl Bank {
         let block_height = self.block_height();
         let (epoch, slot_index) = self.get_epoch_and_slot_index(absolute_slot);
         let slots_in_epoch = self.get_slots_in_epoch(epoch);
+        let transaction_count = Some(self.transaction_count());
         EpochInfo {
             epoch,
             slot_index,
             slots_in_epoch,
             absolute_slot,
             block_height,
+            transaction_count,
         }
     }
 

--- a/sdk/src/epoch_info.rs
+++ b/sdk/src/epoch_info.rs
@@ -17,4 +17,7 @@ pub struct EpochInfo {
 
     /// The current block height
     pub block_height: u64,
+
+    /// Total number of transactions processed without error since genesis
+    pub transaction_count: Option<u64>,
 }

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -276,6 +276,7 @@ const GetInflationGovernorResult = struct({
  * @property {number} slotsInEpoch
  * @property {number} absoluteSlot
  * @property {number} blockHeight
+ * @property {number} transactionCount
  */
 type EpochInfo = {
   epoch: number,
@@ -283,6 +284,7 @@ type EpochInfo = {
   slotsInEpoch: number,
   absoluteSlot: number,
   blockHeight: number | null,
+  transactionCount: number | null,
 };
 
 const GetEpochInfoResult = struct({
@@ -291,6 +293,7 @@ const GetEpochInfoResult = struct({
   slotsInEpoch: 'number',
   absoluteSlot: 'number',
   blockHeight: 'number?',
+  transactionCount: 'number?',
 });
 
 /**


### PR DESCRIPTION
The `getTransactionCount` RPC API provides no context regarding the slot that the count was returned for, and adding context would break backwards compatibility.

Instead add a new transactionCount field to GetEpochInfo, which already includes a slot context