### PR TITLE
Modernize GCE testnet machines

### DIFF
--- a/net/gce.sh
+++ b/net/gce.sh
@@ -12,7 +12,7 @@ gce)
   # shellcheck source=net/scripts/gce-provider.sh
   source "$here"/scripts/gce-provider.sh
 
-  cpuBootstrapLeaderMachineType="--custom-cpu 12 --custom-memory 32GB --min-cpu-platform Intel%20Skylake"
+  cpuBootstrapLeaderMachineType="--custom-cpu 24 --custom-memory 64GB --min-cpu-platform Intel%20Skylake"
   gpuBootstrapLeaderMachineType="$cpuBootstrapLeaderMachineType --accelerator count=1,type=nvidia-tesla-p100"
   clientMachineType="--custom-cpu 16 --custom-memory 20GB"
   blockstreamerMachineType="--machine-type n1-standard-8"

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -174,10 +174,10 @@ cloud_CreateInstances() {
     # the stock Ubuntu 18.04 image and programmatically install CUDA after the
     # instance boots
     #
-    imageName="ubuntu-1804-bionic-v20181029-with-cuda-10-and-cuda-9-2 --image-project principal-lane-200702"
+    imageName="ubuntu-2004-focal-v20201211-with-cuda-10-2 --image-project principal-lane-200702"
   else
-    # Upstream Ubuntu 18.04 LTS image
-    imageName="ubuntu-1804-bionic-v20190813a --image-project ubuntu-os-cloud"
+    # Upstream Ubuntu 20.04 LTS image
+    imageName="ubuntu-2004-focal-v20201201 --image-project ubuntu-os-cloud"
   fi
 
   declare -a nodes

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -162,7 +162,7 @@ cloud_CreateInstances() {
   declare optionalBootDiskSize="$7"
   declare optionalStartupScript="$8"
   declare optionalAddress="$9"
-  declare optionalBootDiskType="${10}"
+  declare optionalBootDiskType="${10:-pd-ssd}"
   declare optionalAdditionalDiskSize="${11}"
   declare optionalPreemptible="${12}"
   #declare sshPrivateKey="${13}"  # unused

--- a/net/scripts/install-certbot.sh
+++ b/net/scripts/install-certbot.sh
@@ -4,9 +4,11 @@ set -ex
 [[ $(uname) = Linux ]] || exit 1
 [[ $USER = root ]] || exit 1
 
-apt-get update
-add-apt-repository --yes ppa:certbot/certbot
-apt-get --assume-yes install certbot
+snap install core
+snap refresh core
+
+snap install --classic certbot
+ln -sf /snap/bin/certbot /usr/bin/certbot
 
 cat > /certbot-restore.sh <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
#### Problem

Our net scripts create GCE test-clusters using machines spec'd well below our current recommendations

#### Summary of Changes

- 24-core, 64GB RAM
- Switch to SSD boot disk
- Upgrade Ubuntu 20.04