### PR TITLE
Add CPI support for upgradeable loader

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -1986,6 +1986,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-invoke-and-return"
+version = "1.6.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
 name = "solana-bpf-rust-invoked"
 version = "1.6.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "rust/invoke",
     "rust/invoke_and_error",
     "rust/invoke_and_ok",
+    "rust/invoke_and_return",
     "rust/invoked",
     "rust/iter",
     "rust/many_args",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -72,6 +72,7 @@ fn main() {
             "invoke",
             "invoke_and_error",
             "invoke_and_ok",
+            "invoke_and_return",
             "invoked",
             "iter",
             "many_args",

--- a/programs/bpf/rust/invoke_and_return/Cargo.toml
+++ b/programs/bpf/rust/invoke_and_return/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "solana-bpf-rust-invoke-and-return"
+version = "1.6.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "1.6.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/invoke_and_return/Xargo.toml
+++ b/programs/bpf/rust/invoke_and_return/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/bpf/rust/invoke_and_return/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_return/src/lib.rs
@@ -1,0 +1,36 @@
+//! @brief Invokes an instruction and returns an error, the instruction invoked
+//! uses the instruction data provided and all the accounts
+
+use solana_program::{
+    account_info::AccountInfo, bpf_loader_upgradeable, entrypoint, entrypoint::ProgramResult,
+    instruction::AccountMeta, instruction::Instruction, program::invoke, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+#[allow(clippy::unnecessary_wraps)]
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    let to_call = accounts[0].key;
+    let infos = accounts;
+    let last = if bpf_loader_upgradeable::check_id(accounts[0].owner) {
+        accounts.len() - 1
+    } else {
+        accounts.len()
+    };
+    let instruction = Instruction {
+        accounts: accounts[1..last]
+            .iter()
+            .map(|acc| AccountMeta {
+                pubkey: *acc.key,
+                is_signer: acc.is_signer,
+                is_writable: acc.is_writable,
+            })
+            .collect(),
+        data: instruction_data.to_owned(),
+        program_id: *to_call,
+    };
+    invoke(&instruction, &infos)
+}

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -61,6 +61,8 @@ pub trait InvokeContext {
     fn record_instruction(&self, instruction: &Instruction);
     /// Get the bank's active feature set
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
+    /// Get an account from a pre-account
+    fn get_account(&self, pubkey: &Pubkey) -> Option<Account>;
 }
 
 #[derive(Clone, Copy, Debug, AbiExample)]
@@ -339,5 +341,8 @@ impl InvokeContext for MockInvokeContext {
     fn record_instruction(&self, _instruction: &Instruction) {}
     fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
         true
+    }
+    fn get_account(&self, _pubkey: &Pubkey) -> Option<Account> {
+        None
     }
 }


### PR DESCRIPTION
#### Problem

CPI does not support calling upgradeable programs

#### Summary of Changes

- Add support by pulling the upgradable programs `ProgramData` account from pre-accounts
  - The current CPI behavior requires that all programs being invoked by a program must be passed to the invoking program.  This stems from the fact that the runtime only knows about accounts described in the original transaction and the runtime does not currently reach back and load more accounts from the account db during instruction processing.
  - When invoking an upgradeable program the matching ProgramData account must also be passed to the invoking program in order for it to be available to the runtime.
  - A new transaction definition where all invoked programs are listed would allow the runtime to preload all the accounts required by the transaction without requiring the program accounts be passed to each invoking program.
- This change also now pulls the executable from pre-accounts as well which means that the programs being executed no longer travel through the user's program which reduces the attack surface considerably.

Fixes #
