### PR TITLE
getBlockTime RPC method now falls back to BigTable in all cases

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -772,7 +772,7 @@ impl JsonRpcRequestProcessor {
         {
             let result = self.blockstore.get_block_time(slot);
             self.check_blockstore_root(&result, slot)?;
-            if result.is_err() {
+            if result.is_err() || matches!(result, Ok(None)) {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
                     return Ok(self
                         .runtime_handle


### PR DESCRIPTION
We still want to fallback to BigTable if available when `blockstore.get_block_time()` returns `Ok(None)`