### PR TITLE
Fix timestamp handling on ledger warp

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1347,11 +1347,12 @@ impl Bank {
                 } else {
                     (EstimateType::Unbounded, None)
                 };
+
+            let ancestor_timestamp = self.clock().unix_timestamp;
             if let Some(timestamp_estimate) =
                 self.get_timestamp_estimate(estimate_type, epoch_start_timestamp)
             {
                 unix_timestamp = timestamp_estimate;
-                let ancestor_timestamp = self.clock().unix_timestamp;
                 if self
                     .feature_set
                     .is_active(&feature_set::timestamp_bounding::id())
@@ -1359,14 +1360,14 @@ impl Bank {
                 {
                     unix_timestamp = ancestor_timestamp;
                 }
-                datapoint_info!(
-                    "bank-timestamp-correction",
-                    ("slot", self.slot(), i64),
-                    ("from_genesis", self.unix_timestamp_from_genesis(), i64),
-                    ("corrected", timestamp_estimate, i64),
-                    ("ancestor_timestamp", ancestor_timestamp, i64),
-                );
             }
+            datapoint_info!(
+                "bank-timestamp-correction",
+                ("slot", self.slot(), i64),
+                ("from_genesis", self.unix_timestamp_from_genesis(), i64),
+                ("corrected", unix_timestamp, i64),
+                ("ancestor_timestamp", ancestor_timestamp, i64),
+            );
         }
         let epoch_start_timestamp = if self
             .feature_set

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1332,14 +1332,24 @@ impl Bank {
                     // needed for timestamp bounding, but isn't yet corrected for the activation slot
                     let epoch_start_timestamp = if self.slot() > timestamp_bounding_activation_slot
                     {
-                        let epoch = if let Some(epoch) = parent_epoch {
-                            epoch
+                        let warp_testnet_timestamp = self
+                            .feature_set
+                            .activated_slot(&feature_set::warp_testnet_timestamp::id());
+                        if warp_testnet_timestamp.is_some()
+                            && warp_testnet_timestamp.unwrap() == self.slot()
+                            && self.cluster_type() == ClusterType::Testnet
+                        {
+                            None
                         } else {
-                            self.epoch()
-                        };
-                        let first_slot_in_epoch =
-                            self.epoch_schedule.get_first_slot_in_epoch(epoch);
-                        Some((first_slot_in_epoch, self.clock().epoch_start_timestamp))
+                            let epoch = if let Some(epoch) = parent_epoch {
+                                epoch
+                            } else {
+                                self.epoch()
+                            };
+                            let first_slot_in_epoch =
+                                self.epoch_schedule.get_first_slot_in_epoch(epoch);
+                            Some((first_slot_in_epoch, self.clock().epoch_start_timestamp))
+                        }
                     } else {
                         None
                     };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1362,7 +1362,7 @@ impl Bank {
                     datapoint_info!(
                         "bank-timestamp-correction",
                         ("slot", self.slot(), i64),
-                        ("from_genesis", unix_timestamp, i64),
+                        ("from_genesis", self.unix_timestamp_from_genesis(), i64),
                         ("corrected", timestamp_estimate, i64),
                         ("ancestor_timestamp", ancestor_timestamp, i64),
                     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1335,8 +1335,7 @@ impl Bank {
                         let warp_testnet_timestamp = self
                             .feature_set
                             .activated_slot(&feature_set::warp_testnet_timestamp::id());
-                        if warp_testnet_timestamp.is_some()
-                            && warp_testnet_timestamp.unwrap() == self.slot()
+                        if warp_testnet_timestamp == Some(self.slot())
                             && self.cluster_type() == ClusterType::Testnet
                         {
                             None

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -110,6 +110,10 @@ pub mod try_find_program_address_syscall_enabled {
     solana_sdk::declare_id!("EMsMNadQNhCYDyGpYH5Tx6dGHxiUqKHk782PU5XaWfmi");
 }
 
+pub mod warp_testnet_timestamp {
+    solana_sdk::declare_id!("Bfqm7fGk5MBptqa2WHXWFLH7uJvq8hkJcAQPipy2bAMk");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -139,6 +143,7 @@ lazy_static! {
         (simple_capitalization::id(), "simple capitalization"),
         (bpf_loader_upgradeable_program::id(), "upgradeable bpf loader"),
         (try_find_program_address_syscall_enabled::id(), "add try_find_program_address syscall"),
+        (warp_testnet_timestamp::id(), "warp testnet timestamp to current #TODO"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
Testnet was recently rebooted from a snapshot that had warped forward 2 epochs. On a warp, the new Bank doesn't have populated epoch-stakes, so the timestamp calculation falls back to the genesis-estimate. For testnet, this was 2 months in the past (although on a cluster that is proceeding at very close to poh time, this fallback would be in the future). The cluster is slowly correcting the timestamp, but with only 25% change allowed each epoch, this will take a while.

#### Summary of Changes
- Rewrite Bank unix_timestamp and epoch_start_timestamp on Bank::warp_from_parent() so these values are close to realistic. There will still be some variation from real time, depending on how close the warp is to the start of an epoch, but should be < 1 epoch's worth of time.
- Fix up `update_clock` so that unix_timestamp defaults to the ancestor timestamp when no recent vote timestamps are found (as in a big warp)
- Fix timestamp-correction metrics to report on warp slots, and report the correct genesis-estimate
- Warp the current timestamp on testnet forward, feature-gated and only for ClusterType::Testnet
