### PR TITLE
removes &Arc<Self> receivers

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1731,7 +1731,7 @@ impl ClusterInfo {
         Ok(())
     }
 
-    fn handle_adopt_shred_version(self: &Arc<Self>, adopt_shred_version: &mut bool) {
+    fn handle_adopt_shred_version(&self, adopt_shred_version: &mut bool) {
         // Adopt the entrypoint's `shred_version` if ours is unset
         if *adopt_shred_version {
             // If gossip was given an entrypoint, look up the ContactInfo by the given
@@ -1765,7 +1765,7 @@ impl ClusterInfo {
     }
 
     fn handle_purge(
-        self: &Arc<Self>,
+        &self,
         thread_pool: &ThreadPool,
         bank_forks: &Option<Arc<RwLock<BankForks>>>,
         stakes: &HashMap<Pubkey, u64>,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3808,10 +3808,10 @@ impl Bank {
     }
 
     /// Compute all the parents of the bank including this bank itself
-    pub fn parents_inclusive(self: &Arc<Self>) -> Vec<Arc<Bank>> {
-        let mut all = vec![self.clone()];
-        all.extend(self.parents().into_iter());
-        all
+    pub fn parents_inclusive(self: Arc<Self>) -> Vec<Arc<Bank>> {
+        let mut parents = self.parents();
+        parents.insert(0, self);
+        parents
     }
 
     pub fn store_account(&self, pubkey: &Pubkey, account: &Account) {
@@ -4018,7 +4018,7 @@ impl Bank {
     }
 
     pub fn get_largest_accounts(
-        self: &Arc<Self>,
+        &self,
         num: usize,
         filter_by_address: &HashSet<Pubkey>,
         filter: AccountAddressFilter,
@@ -11573,7 +11573,7 @@ pub(crate) mod tests {
                     // are currently discoverable, previous parents should have
                     // been squashed
                     assert_eq!(
-                        current_minor_fork_bank.parents_inclusive().len(),
+                        current_minor_fork_bank.clone().parents_inclusive().len(),
                         num_new_banks + 1,
                     );
 


### PR DESCRIPTION
#### Problem
This came up during a conversation with @jeffwashington.

`&Arc<Self>` does not seem to be useful as a receiver:
https://doc.rust-lang.org/reference/items/associated-items.html#methods

If `Arc` is not necessary, then the receiver can simply be `&self`.  Using
`&Arc<Self>` instead, will make the method inaccessible to a `&Self`, or other
methods with a `&Self` receiver.

If `Arc` is necessary, then the receiver can be `Arc<Self>`.  Using
`&Arc<Self>` instead, will force a redundant `.clone` even in instances that we
already have an `Arc<Self>` which can be consumed.

#### Summary of Changes
Removed instances of `&Arc<Self>`, replacing with `&self` or `Arc<Self>`.