### PR TITLE
Add accounts shrink paths

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -694,6 +694,7 @@ fn load_bank_forks(
         &genesis_config,
         &blockstore,
         account_paths,
+        None,
         snapshot_config.as_ref(),
         process_options,
         None,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -33,6 +33,7 @@ pub fn load(
     genesis_config: &GenesisConfig,
     blockstore: &Blockstore,
     account_paths: Vec<PathBuf>,
+    shrink_paths: Option<Vec<PathBuf>>,
     snapshot_config: Option<&SnapshotConfig>,
     process_options: ProcessOptions,
     transaction_status_sender: Option<TransactionStatusSender>,
@@ -69,6 +70,9 @@ pub fn load(
                     Some(&crate::builtins::get(process_options.bpf_jit)),
                 )
                 .expect("Load from snapshot failed");
+                if let Some(shrink_paths) = shrink_paths {
+                    deserialized_bank.set_shrink_paths(shrink_paths);
+                }
 
                 let deserialized_snapshot_hash = (
                     deserialized_bank.slot(),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -925,7 +925,7 @@ fn load_frozen_forks(
                 leader_schedule_cache.set_root(&new_root_bank);
                 new_root_bank.squash();
 
-                if last_free.elapsed() > Duration::from_secs(30) {
+                if last_free.elapsed() > Duration::from_secs(10) {
                     // This could take few secs; so update last_free later
                     new_root_bank.exhaustively_free_unused_resource();
                     last_free = Instant::now();

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -712,6 +712,10 @@ impl<T: 'static + Clone> AccountsIndex<T> {
             .contains(&slot)
     }
 
+    pub fn num_roots(&self) -> usize {
+        self.roots_tracker.read().unwrap().roots.len()
+    }
+
     pub fn all_roots(&self) -> Vec<Slot> {
         self.roots_tracker
             .read()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2432,6 +2432,10 @@ impl Bank {
         self.rc.accounts.accounts_db.remove_unrooted_slot(slot)
     }
 
+    pub fn set_shrink_paths(&self, paths: Vec<PathBuf>) {
+        self.rc.accounts.accounts_db.set_shrink_paths(paths);
+    }
+
     fn load_accounts(
         &self,
         txs: &[Transaction],
@@ -10100,12 +10104,11 @@ pub(crate) mod tests {
             22
         );
 
-        let mut consumed_budgets = (0..3)
+        let consumed_budgets: usize = (0..3)
             .map(|_| bank.process_stale_slot_with_budget(0, force_to_return_alive_account))
-            .collect::<Vec<_>>();
-        consumed_budgets.sort_unstable();
+            .sum();
         // consumed_budgets represents the count of alive accounts in the three slots 0,1,2
-        assert_eq!(consumed_budgets, vec![0, 1, 9]);
+        assert_eq!(consumed_budgets, 10);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Accounts works well on ramdisk, but can have spikes outside the size of a ramdisk.

#### Summary of Changes

Add an option for a slower-moving shrink path to shrink rooted stores into and also make shrinking slightly more aggressive.

Fixes #
