### PR TITLE
Upgradeable programs called same as non-upgradeable

### DIFF
--- a/programs/bpf/rust/invoke_and_return/src/lib.rs
+++ b/programs/bpf/rust/invoke_and_return/src/lib.rs
@@ -2,8 +2,8 @@
 //! uses the instruction data provided and all the accounts
 
 use solana_program::{
-    account_info::AccountInfo, bpf_loader_upgradeable, entrypoint, entrypoint::ProgramResult,
-    instruction::AccountMeta, instruction::Instruction, program::invoke, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, instruction::AccountMeta,
+    instruction::Instruction, program::invoke, pubkey::Pubkey,
 };
 
 entrypoint!(process_instruction);
@@ -15,13 +15,8 @@ fn process_instruction(
 ) -> ProgramResult {
     let to_call = accounts[0].key;
     let infos = accounts;
-    let last = if bpf_loader_upgradeable::check_id(accounts[0].owner) {
-        accounts.len() - 1
-    } else {
-        accounts.len()
-    };
     let instruction = Instruction {
-        accounts: accounts[1..last]
+        accounts: accounts[1..]
             .iter()
             .map(|acc| AccountMeta {
                 pubkey: *acc.key,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1479,11 +1479,11 @@ fn test_program_bpf_upgrade() {
     bank.add_builtin(&name, id, entrypoint);
     let bank_client = BankClient::new(bank);
 
-    // deploy upgrade program
+    // Deploy upgrade program
     let (program_id, authority_keypair) =
         load_upgradeable_bpf_program(&bank_client, &mint_keypair, "solana_bpf_rust_upgradeable");
 
-    // call upgrade program
+    // Call upgrade program
     nonce += 1;
     let instruction = Instruction::new(
         program_id,
@@ -1499,7 +1499,7 @@ fn test_program_bpf_upgrade() {
         TransactionError::InstructionError(0, InstructionError::Custom(42))
     );
 
-    // upgrade program
+    // Upgrade program
     upgrade_bpf_program(
         &bank_client,
         &mint_keypair,
@@ -1508,7 +1508,7 @@ fn test_program_bpf_upgrade() {
         "solana_bpf_rust_upgraded",
     );
 
-    // call upgraded program
+    // Call upgraded program
     nonce += 1;
     let instruction = Instruction::new(
         program_id,
@@ -1524,7 +1524,7 @@ fn test_program_bpf_upgrade() {
         TransactionError::InstructionError(0, InstructionError::Custom(43))
     );
 
-    // upgrade back to the original program
+    // Set a new authority
     let new_authority_keypair = Keypair::new();
     set_upgrade_authority(
         &bank_client,
@@ -1534,7 +1534,7 @@ fn test_program_bpf_upgrade() {
         Some(&new_authority_keypair.pubkey()),
     );
 
-    // upgrade back to the original program
+    // Upgrade back to the original program
     upgrade_bpf_program(
         &bank_client,
         &mint_keypair,
@@ -1543,7 +1543,7 @@ fn test_program_bpf_upgrade() {
         "solana_bpf_rust_upgradeable",
     );
 
-    // call original program
+    // Call original program
     nonce += 1;
     let instruction = Instruction::new(
         program_id,
@@ -1562,9 +1562,10 @@ fn test_program_bpf_upgrade() {
 
 #[cfg(feature = "bpf_rust")]
 #[test]
-fn test_program_bpf_invoke_upgradeable() {
+fn test_program_bpf_invoke_upgradeable_via_cpi() {
     solana_logger::setup();
 
+    let mut nonce = 0;
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -1583,29 +1584,81 @@ fn test_program_bpf_invoke_upgradeable() {
         "solana_bpf_rust_invoke_and_return",
     );
 
-    // deploy upgrade program
-    let (program_id, _) =
+    // Deploy upgrade program
+    let (program_id, authority_keypair) =
         load_upgradeable_bpf_program(&bank_client, &mint_keypair, "solana_bpf_rust_upgradeable");
 
-    let data = bank_client.get_account(&program_id).unwrap().unwrap();
-    let programdata_address = if let UpgradeableLoaderState::Program {
-        programdata_address,
-    } = data.state().unwrap()
-    {
-        programdata_address
-    } else {
-        panic!("Not a program");
-    };
-
-    // call invoker program to invoke the upgradeable program
+    // Call invoker program to invoke the upgradeable program
+    nonce += 1;
     let instruction = Instruction::new(
         invoke_and_return,
-        &[0],
+        &[nonce],
         vec![
             AccountMeta::new(program_id, false),
             AccountMeta::new(clock::id(), false),
             AccountMeta::new(fees::id(), false),
-            AccountMeta::new(programdata_address, false),
+        ],
+    );
+    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        TransactionError::InstructionError(0, InstructionError::Custom(42))
+    );
+
+    // Upgrade program
+    upgrade_bpf_program(
+        &bank_client,
+        &mint_keypair,
+        &program_id,
+        &authority_keypair,
+        "solana_bpf_rust_upgraded",
+    );
+
+    // Call the upgraded program
+    nonce += 1;
+    let instruction = Instruction::new(
+        invoke_and_return,
+        &[nonce],
+        vec![
+            AccountMeta::new(program_id, false),
+            AccountMeta::new(clock::id(), false),
+            AccountMeta::new(fees::id(), false),
+        ],
+    );
+    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        TransactionError::InstructionError(0, InstructionError::Custom(43))
+    );
+
+    // Set a new authority
+    let new_authority_keypair = Keypair::new();
+    set_upgrade_authority(
+        &bank_client,
+        &mint_keypair,
+        &program_id,
+        &authority_keypair,
+        Some(&new_authority_keypair.pubkey()),
+    );
+
+    // Upgrade back to the original program
+    upgrade_bpf_program(
+        &bank_client,
+        &mint_keypair,
+        &program_id,
+        &new_authority_keypair,
+        "solana_bpf_rust_upgradeable",
+    );
+
+    // Call original program
+    nonce += 1;
+    let instruction = Instruction::new(
+        invoke_and_return,
+        &[nonce],
+        vec![
+            AccountMeta::new(program_id, false),
+            AccountMeta::new(clock::id(), false),
+            AccountMeta::new(fees::id(), false),
         ],
     );
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -21,9 +21,7 @@ use solana_runtime::{
 };
 use solana_sdk::{
     account::Account,
-    account_utils::StateMut,
     bpf_loader, bpf_loader_deprecated,
-    bpf_loader_upgradeable::UpgradeableLoaderState,
     client::SyncClient,
     clock::{DEFAULT_SLOTS_PER_EPOCH, MAX_PROCESSING_AGE},
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -993,6 +993,7 @@ mod tests {
             Rent::default(),
             vec![],
             &[],
+            &[],
             None,
             BpfComputeBudget {
                 max_units: 1,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4,8 +4,8 @@
 //! already been signed and verified.
 use crate::{
     accounts::{
-        AccountAddressFilter, Accounts, TransactionAccounts, TransactionLoadResult,
-        TransactionLoaders,
+        AccountAddressFilter, Accounts, TransactionAccountDeps, TransactionAccounts,
+        TransactionLoadResult, TransactionLoaders,
     },
     accounts_db::{ErrorCounters, SnapshotStorages},
     accounts_index::Ancestors,
@@ -117,6 +117,7 @@ type BankStatusCache = StatusCache<Result<()>>;
 #[frozen_abi(digest = "GSPuprru1pomsgvopKG7XRWiXdqdXJdLPkgJ2arPbkXM")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 type TransactionAccountRefCells = Vec<Rc<RefCell<Account>>>;
+type TransactionAccountDepRefCells = Vec<(Pubkey, RefCell<Account>)>;
 type TransactionLoaderRefCells = Vec<Vec<(Pubkey, RefCell<Account>)>>;
 
 // Eager rent collection repeats in cyclic manner.
@@ -2669,11 +2670,20 @@ impl Bank {
     /// ownership by draining the source
     fn accounts_to_refcells(
         accounts: &mut TransactionAccounts,
+        account_deps: &mut TransactionAccountDeps,
         loaders: &mut TransactionLoaders,
-    ) -> (TransactionAccountRefCells, TransactionLoaderRefCells) {
+    ) -> (
+        TransactionAccountRefCells,
+        TransactionAccountDepRefCells,
+        TransactionLoaderRefCells,
+    ) {
         let account_refcells: Vec<_> = accounts
             .drain(..)
             .map(|account| Rc::new(RefCell::new(account)))
+            .collect();
+        let account_dep_refcells: Vec<_> = account_deps
+            .drain(..)
+            .map(|(pubkey, account_dep)| (pubkey, RefCell::new(account_dep)))
             .collect();
         let loader_refcells: Vec<Vec<_>> = loaders
             .iter_mut()
@@ -2683,7 +2693,7 @@ impl Bank {
                     .collect()
             })
             .collect();
-        (account_refcells, loader_refcells)
+        (account_refcells, account_dep_refcells, loader_refcells)
     }
 
     /// Converts back from RefCell<Account> to Account, this involves moving
@@ -2835,13 +2845,13 @@ impl Bank {
             .zip(OrderedIterator::new(txs, batch.iteration_order()))
             .map(|(accs, (_, tx))| match accs {
                 (Err(e), _nonce_rollback) => (Err(e.clone()), None),
-                (Ok((accounts, loaders, _rents)), nonce_rollback) => {
+                (Ok((accounts, account_deps, loaders, _rents)), nonce_rollback) => {
                     signature_count += u64::from(tx.message().header.num_required_signatures);
 
                     let executors = self.get_executors(&tx.message, &loaders);
 
-                    let (account_refcells, loader_refcells) =
-                        Self::accounts_to_refcells(accounts, loaders);
+                    let (account_refcells, account_dep_refcells, loader_refcells) =
+                        Self::accounts_to_refcells(accounts, account_deps, loaders);
 
                     let instruction_recorders = if enable_cpi_recording {
                         let ix_count = tx.message.instructions.len();
@@ -2862,6 +2872,7 @@ impl Bank {
                         tx.message(),
                         &loader_refcells,
                         &account_refcells,
+                        &account_dep_refcells,
                         &self.rent_collector,
                         log_collector.clone(),
                         executors.clone(),
@@ -3279,7 +3290,7 @@ impl Bank {
 
             let acc = raccs.as_ref().unwrap();
 
-            collected_rent += acc.2;
+            collected_rent += acc.3;
         }
 
         self.collected_rent.fetch_add(collected_rent, Relaxed);

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -207,6 +207,7 @@ pub struct ThisInvokeContext<'a> {
     program_ids: Vec<Pubkey>,
     rent: Rent,
     pre_accounts: Vec<PreAccount>,
+    account_deps: &'a [(Pubkey, RefCell<Account>)],
     programs: &'a [(Pubkey, ProcessInstructionWithContext)],
     logger: Rc<RefCell<dyn Logger>>,
     bpf_compute_budget: BpfComputeBudget,
@@ -216,10 +217,12 @@ pub struct ThisInvokeContext<'a> {
     feature_set: Arc<FeatureSet>,
 }
 impl<'a> ThisInvokeContext<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         program_id: &Pubkey,
         rent: Rent,
         pre_accounts: Vec<PreAccount>,
+        account_deps: &'a [(Pubkey, RefCell<Account>)],
         programs: &'a [(Pubkey, ProcessInstructionWithContext)],
         log_collector: Option<Rc<LogCollector>>,
         bpf_compute_budget: BpfComputeBudget,
@@ -233,6 +236,7 @@ impl<'a> ThisInvokeContext<'a> {
             program_ids,
             rent,
             pre_accounts,
+            account_deps,
             programs,
             logger: Rc::new(RefCell::new(ThisLogger { log_collector })),
             bpf_compute_budget,
@@ -312,16 +316,25 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool {
         self.feature_set.is_active(feature_id)
     }
-    fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
+    fn get_account(&self, pubkey: &Pubkey) -> Option<RefCell<Account>> {
+        if let Some(account) = self.account_deps.iter().find_map(|(key, account)| {
+            if key == pubkey {
+                Some(account.clone())
+            } else {
+                None
+            }
+        }) {
+            return Some(account);
+        }
         self.pre_accounts.iter().find_map(|pre| {
             if pre.key == *pubkey {
-                Some(Account {
+                Some(RefCell::new(Account {
                     lamports: pre.lamports,
                     data: pre.data.clone(),
                     owner: pre.owner,
                     executable: pre.is_executable,
                     rent_epoch: pre.rent_epoch,
-                })
+                }))
             } else {
                 None
             }
@@ -641,26 +654,27 @@ impl MessageProcessor {
         let program_account = invoke_context
             .get_account(&callee_program_id)
             .ok_or(InstructionError::MissingAccount)?;
-        if !program_account.executable {
+        if !program_account.borrow().executable {
             return Err(InstructionError::AccountNotExecutable);
         }
-        let programdata_executable = if program_account.owner == bpf_loader_upgradeable::id() {
-            if let UpgradeableLoaderState::Program {
-                programdata_address,
-            } = program_account.state()?
-            {
-                if let Some(account) = invoke_context.get_account(&programdata_address) {
-                    Some((programdata_address, RefCell::new(account)))
+        let programdata_executable =
+            if program_account.borrow().owner == bpf_loader_upgradeable::id() {
+                if let UpgradeableLoaderState::Program {
+                    programdata_address,
+                } = program_account.borrow().state()?
+                {
+                    if let Some(account) = invoke_context.get_account(&programdata_address) {
+                        Some((programdata_address, account))
+                    } else {
+                        return Err(InstructionError::MissingAccount);
+                    }
                 } else {
                     return Err(InstructionError::MissingAccount);
                 }
             } else {
-                return Err(InstructionError::MissingAccount);
-            }
-        } else {
-            None
-        };
-        let mut executable_accounts = vec![(callee_program_id, RefCell::new(program_account))];
+                None
+            };
+        let mut executable_accounts = vec![(callee_program_id, program_account)];
         if let Some(programdata) = programdata_executable {
             executable_accounts.push(programdata);
         }
@@ -859,6 +873,7 @@ impl MessageProcessor {
         instruction: &CompiledInstruction,
         executable_accounts: &[(Pubkey, RefCell<Account>)],
         accounts: &[Rc<RefCell<Account>>],
+        account_deps: &[(Pubkey, RefCell<Account>)],
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
         executors: Rc<RefCell<Executors>>,
@@ -887,6 +902,7 @@ impl MessageProcessor {
             instruction.program_id(&message.account_keys),
             rent_collector.rent,
             pre_accounts,
+            account_deps,
             &self.programs,
             log_collector,
             bpf_compute_budget,
@@ -917,6 +933,7 @@ impl MessageProcessor {
         message: &Message,
         loaders: &[Vec<(Pubkey, RefCell<Account>)>],
         accounts: &[Rc<RefCell<Account>>],
+        account_deps: &[(Pubkey, RefCell<Account>)],
         rent_collector: &RentCollector,
         log_collector: Option<Rc<LogCollector>>,
         executors: Rc<RefCell<Executors>>,
@@ -933,6 +950,7 @@ impl MessageProcessor {
                 instruction,
                 &loaders[instruction_index],
                 accounts,
+                account_deps,
                 rent_collector,
                 log_collector.clone(),
                 executors.clone(),
@@ -987,6 +1005,7 @@ mod tests {
             &program_ids[0],
             Rent::default(),
             pre_accounts,
+            &[],
             &[],
             None,
             BpfComputeBudget::default(),
@@ -1540,6 +1559,7 @@ mod tests {
             &message,
             &loaders,
             &accounts,
+            &[],
             &rent_collector,
             None,
             executors.clone(),
@@ -1564,6 +1584,7 @@ mod tests {
             &message,
             &loaders,
             &accounts,
+            &[],
             &rent_collector,
             None,
             executors.clone(),
@@ -1592,6 +1613,7 @@ mod tests {
             &message,
             &loaders,
             &accounts,
+            &[],
             &rent_collector,
             None,
             executors,
@@ -1704,6 +1726,7 @@ mod tests {
             &message,
             &loaders,
             &accounts,
+            &[],
             &rent_collector,
             None,
             executors.clone(),
@@ -1732,6 +1755,7 @@ mod tests {
             &message,
             &loaders,
             &accounts,
+            &[],
             &rent_collector,
             None,
             executors.clone(),
@@ -1757,6 +1781,7 @@ mod tests {
             &message,
             &loaders,
             &accounts,
+            &[],
             &rent_collector,
             None,
             executors,
@@ -1842,6 +1867,7 @@ mod tests {
                 not_owned_preaccount,
                 executable_preaccount,
             ],
+            &[],
             programs.as_slice(),
             None,
             BpfComputeBudget::default(),

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -62,7 +62,7 @@ pub trait InvokeContext {
     /// Get the bank's active feature set
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
     /// Get an account from a pre-account
-    fn get_account(&self, pubkey: &Pubkey) -> Option<Account>;
+    fn get_account(&self, pubkey: &Pubkey) -> Option<RefCell<Account>>;
 }
 
 #[derive(Clone, Copy, Debug, AbiExample)]
@@ -342,7 +342,7 @@ impl InvokeContext for MockInvokeContext {
     fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
         true
     }
-    fn get_account(&self, _pubkey: &Pubkey) -> Option<Account> {
+    fn get_account(&self, _pubkey: &Pubkey) -> Option<RefCell<Account>> {
         None
     }
 }


### PR DESCRIPTION
#### Problem

Upgradable programs called via CPI need the `ProgramData` account but callers shouldn't have to be aware of it

#### Summary of Changes

The runtime now loads all `ProgramData` accounts associated with executable upgradeable programs that appear in a transaction so that if they are used via CPI the runtime can pull them up transparently.

Fixes #
