### PR TITLE
Deinit zero-lamport account data

### DIFF
--- a/account-decoder/src/parse_account_data.rs
+++ b/account-decoder/src/parse_account_data.rs
@@ -118,7 +118,7 @@ mod test {
 
         let vote_state = VoteState::default();
         let mut vote_account_data: Vec<u8> = vec![0; VoteState::size_of()];
-        let versioned = VoteStateVersions::Current(Box::new(vote_state));
+        let versioned = VoteStateVersions::new_current(vote_state);
         VoteState::serialize(&versioned, &mut vote_account_data).unwrap();
         let parsed = parse_account_data(
             &account_pubkey,

--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -128,7 +128,7 @@ mod test {
     fn test_parse_vote() {
         let vote_state = VoteState::default();
         let mut vote_account_data: Vec<u8> = vec![0; VoteState::size_of()];
-        let versioned = VoteStateVersions::Current(Box::new(vote_state));
+        let versioned = VoteStateVersions::new_current(vote_state);
         VoteState::serialize(&versioned, &mut vote_account_data).unwrap();
         let expected_vote_state = UiVoteState {
             node_pubkey: Pubkey::default().to_string(),

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -434,26 +434,26 @@ mod tests {
         let mut vote_state1 = VoteState::from(&vote_account1).unwrap();
         vote_state1.process_slot_vote_unchecked(3);
         vote_state1.process_slot_vote_unchecked(5);
-        let versioned = VoteStateVersions::Current(Box::new(vote_state1));
+        let versioned = VoteStateVersions::new_current(vote_state1);
         VoteState::to(&versioned, &mut vote_account1).unwrap();
         bank.store_account(&pk1, &vote_account1);
 
         let mut vote_state2 = VoteState::from(&vote_account2).unwrap();
         vote_state2.process_slot_vote_unchecked(9);
         vote_state2.process_slot_vote_unchecked(10);
-        let versioned = VoteStateVersions::Current(Box::new(vote_state2));
+        let versioned = VoteStateVersions::new_current(vote_state2);
         VoteState::to(&versioned, &mut vote_account2).unwrap();
         bank.store_account(&pk2, &vote_account2);
 
         let mut vote_state3 = VoteState::from(&vote_account3).unwrap();
         vote_state3.root_slot = Some(1);
-        let versioned = VoteStateVersions::Current(Box::new(vote_state3));
+        let versioned = VoteStateVersions::new_current(vote_state3);
         VoteState::to(&versioned, &mut vote_account3).unwrap();
         bank.store_account(&pk3, &vote_account3);
 
         let mut vote_state4 = VoteState::from(&vote_account4).unwrap();
         vote_state4.root_slot = Some(2);
-        let versioned = VoteStateVersions::Current(Box::new(vote_state4));
+        let versioned = VoteStateVersions::new_current(vote_state4);
         VoteState::to(&versioned, &mut vote_account4).unwrap();
         bank.store_account(&pk4, &vote_account4);
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1583,7 +1583,7 @@ pub mod test {
                 vote_state.process_slot_vote_unchecked(*slot);
             }
             VoteState::serialize(
-                &VoteStateVersions::Current(Box::new(vote_state)),
+                &VoteStateVersions::new_current(vote_state),
                 &mut account.data,
             )
             .expect("serialize state");

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2562,7 +2562,7 @@ pub(crate) mod tests {
             let mut leader_vote_account = bank.get_account(&pubkey).unwrap();
             let mut vote_state = VoteState::from(&leader_vote_account).unwrap();
             vote_state.process_slot_vote_unchecked(vote_slot);
-            let versioned = VoteStateVersions::Current(Box::new(vote_state));
+            let versioned = VoteStateVersions::new_current(vote_state);
             VoteState::to(&versioned, &mut leader_vote_account).unwrap();
             bank.store_account(&pubkey, &leader_vote_account);
         }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3217,7 +3217,7 @@ pub mod tests {
                         vote_state.root_slot = Some(root);
                         let mut vote_account =
                             Account::new(1, VoteState::size_of(), &solana_vote_program::id());
-                        let versioned = VoteStateVersions::Current(Box::new(vote_state));
+                        let versioned = VoteStateVersions::new_current(vote_state);
                         VoteState::serialize(&versioned, &mut vote_account.data).unwrap();
                         (
                             solana_sdk::pubkey::new_rand(),

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -311,7 +311,7 @@ pub(crate) mod tests {
         let vote_accounts = stakes.into_iter().map(|(stake, vote_state)| {
             let account = Account::new_data(
                 rng.gen(), // lamports
-                &VoteStateVersions::Current(Box::new(vote_state)),
+                &VoteStateVersions::new_current(vote_state),
                 &Pubkey::new_unique(), // owner
             )
             .unwrap();

--- a/programs/stake/src/legacy_stake_state.rs
+++ b/programs/stake/src/legacy_stake_state.rs
@@ -1004,7 +1004,7 @@ mod tests {
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         let vote_state_credits = vote_state.credits();
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(vote_state)))
+            .set_state(&VoteStateVersions::new_current(vote_state))
             .unwrap();
 
         let stake_pubkey = solana_sdk::pubkey::new_rand();
@@ -1902,7 +1902,7 @@ mod tests {
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
         assert_eq!(
             stake_keyed_account.delegate(
@@ -1993,7 +1993,7 @@ mod tests {
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
 
         stake_keyed_account
@@ -2235,7 +2235,7 @@ mod tests {
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
         let signers = vec![stake_pubkey].into_iter().collect();
         assert_eq!(
@@ -2351,7 +2351,7 @@ mod tests {
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
         let signers = vec![stake_pubkey].into_iter().collect();
         assert_eq!(

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1641,7 +1641,7 @@ mod tests {
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         let vote_state_credits = vote_state.credits();
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(vote_state)))
+            .set_state(&VoteStateVersions::new_current(vote_state))
             .unwrap();
 
         let stake_pubkey = solana_sdk::pubkey::new_rand();
@@ -2539,7 +2539,7 @@ mod tests {
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
         assert_eq!(
             stake_keyed_account.delegate(
@@ -2630,7 +2630,7 @@ mod tests {
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
 
         stake_keyed_account
@@ -2872,7 +2872,7 @@ mod tests {
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
         let signers = vec![stake_pubkey].into_iter().collect();
         assert_eq!(
@@ -2988,7 +2988,7 @@ mod tests {
         ));
         let vote_keyed_account = KeyedAccount::new(&vote_pubkey, false, &vote_account);
         vote_keyed_account
-            .set_state(&VoteStateVersions::Current(Box::new(VoteState::default())))
+            .set_state(&VoteStateVersions::new_current(VoteState::default()))
             .unwrap();
         let signers = vec![stake_pubkey].into_iter().collect();
         assert_eq!(

--- a/programs/vote/src/vote_state/vote_state_versions.rs
+++ b/programs/vote/src/vote_state/vote_state_versions.rs
@@ -8,6 +8,10 @@ pub enum VoteStateVersions {
 }
 
 impl VoteStateVersions {
+    pub fn new_current(vote_state: VoteState) -> Self {
+        Self::Current(Box::new(vote_state))
+    }
+
     pub fn convert_to_current(self) -> VoteState {
         match self {
             VoteStateVersions::V0_23_5(state) => {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -236,6 +236,8 @@ impl Accounts {
                         })? {
                         SystemAccountKind::System => 0,
                         SystemAccountKind::Nonce => {
+                            // Should we ever allow a fees charge to zero a nonce account's
+                            // balance. The state MUST be set to uninitialized in that case
                             rent_collector.rent.minimum_balance(nonce::State::size())
                         }
                     };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10829,7 +10829,7 @@ pub(crate) mod tests {
         let mut vote_account = bank.get_account(vote_pubkey).unwrap_or_default();
         let mut vote_state = VoteState::from(&vote_account).unwrap_or_default();
         vote_state.last_timestamp = timestamp;
-        let versioned = VoteStateVersions::Current(Box::new(vote_state));
+        let versioned = VoteStateVersions::new_current(vote_state);
         VoteState::to(&versioned, &mut vote_account).unwrap();
         bank.store_account(vote_pubkey, &vote_account);
     }

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -316,7 +316,7 @@ mod tests {
         let vote_state = VoteState::new(&vote_init, &clock);
         let account = Account::new_data(
             rng.gen(), // lamports
-            &VoteStateVersions::Current(Box::new(vote_state.clone())),
+            &VoteStateVersions::new_current(vote_state.clone()),
             &Pubkey::new_unique(), // owner
         )
         .unwrap();


### PR DESCRIPTION
#### Problem

Native programs don't deinitialize their state once the balance reaches zero lamports

#### Summary of Changes

Deinitialize native program states upon zero-lamport balance
Update tests


This builds atop #14232. 