### PR TITLE
ClusterInfo: Leave the entrypoint alone when adopting a shred version

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1756,7 +1756,6 @@ impl ClusterInfo {
                             .unwrap()
                             .set_shred_version(entrypoint.shred_version);
                         self.insert_self();
-                        *self.entrypoint.write().unwrap() = Some(entrypoint);
                         *adopt_shred_version = false;
                     }
                 }
@@ -4249,10 +4248,6 @@ mod tests {
 
         // Adopt the entrypoint's gossiped contact info and verify
         ClusterInfo::handle_adopt_shred_version(&cluster_info, &mut true);
-        assert_eq!(
-            cluster_info.entrypoint.read().unwrap().as_ref().unwrap(),
-            &gossiped_entrypoint_info
-        );
         assert_eq!(cluster_info.my_shred_version(), 1);
     }
 }


### PR DESCRIPTION
As a side-effect of shred adoption, ClusterInfo's entrypoint contact info is updated.   It's unclear why this is necessary, and the PR that introduced this change doesn't offer any hints, https://github.com/solana-labs/solana/pull/11620, nor does the PR's author remember.

Problems with this behavior: it's magical, unknown.

That is, it *only* executes when `--expected-shred-version` is not provided.  Why is the original entrypoint ok when `--expected-shred-version` is provided?

The only place where any entrypoint field other than the gossip SocketAddr (which is already valid without the code this PR removes) is accessed is [here](https://github.com/solana-labs/solana/blob/3316e7166c1b31ad6fa74064c452a9491076bebd/core/src/cluster_info.rs#L1536), where the entrypoint's id is read and then later used to dedup pull requests [here](https://github.com/solana-labs/solana/blob/3316e7166c1b31ad6fa74064c452a9491076bebd/core/src/cluster_info.rs#L1638).  But that code also has problems because there's no guarantee that the pull requests are sorted so that `.dedup()` probably doesn't even most of the time -- is this another bug?    However when `--expected-shred-version` is provided the entrypoint's id will always be `Pubkey::default()`.  So the value of the entrypoint's id doesn't seem to actually matter.

----
Why remove it then?  I'm adding multiple gossip entrypoint support and code is getting in the way.