### PR TITLE
Limit CPI from calling loader or native programs

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1337,6 +1337,7 @@ fn test_program_bpf_test_use_latest_executor() {
         .is_ok());
 }
 
+#[ignore] // Invoking BPF loaders from CPI not allowed
 #[cfg(feature = "bpf_rust")]
 #[test]
 fn test_program_bpf_test_use_latest_executor2() {


### PR DESCRIPTION
#### Problem

Calling BPF loaders or native programs from CPI opens up a large attack surface with insufficient coverage

#### Summary of Changes

Limit CPI from calling these types of programs

Fixes #
