### PR TITLE
Ignore long/hanging test

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5156,6 +5156,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_shrink_and_clean() {
         solana_logger::setup();
 


### PR DESCRIPTION
#### Problem
CI coverage jobs are timing out regularly. It appears that after #14208  , `AccountsDB::test_shrink_and_clean` is taking a really long time, or sometimes not completing at all. This loop is not exiting: https://github.com/solana-labs/solana/blob/7042f11791371f9c6d05c76f1b3bfa89dafaa295/runtime/src/accounts_db.rs#L1023

#### Summary of Changes
Ignore test

Closes #14259
