### PR TITLE
validator: Add log message for when a local snapshot is too old

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -659,10 +659,21 @@ fn rpc_bootstrap(
                     get_highest_snapshot_archive_path(ledger_path)
                         .map(|(_path, (slot, _hash, _compression))| slot)
                 {
-                    if highest_local_snapshot_slot > snapshot_hash.0.saturating_sub(maximum_local_snapshot_age) {
-                        info!("Reusing local snapshot at slot {} instead of downloading a newer snapshot for slot {}",
-                              highest_local_snapshot_slot, snapshot_hash.0);
+                    if highest_local_snapshot_slot
+                        > snapshot_hash.0.saturating_sub(maximum_local_snapshot_age)
+                    {
+                        info!(
+                            "Reusing local snapshot at slot {} instead \
+                               of downloading a newer snapshot for slot {}",
+                            highest_local_snapshot_slot, snapshot_hash.0
+                        );
                         use_local_snapshot = true;
+                    } else {
+                        info!(
+                            "Local snapshot from slot {} is too old. \
+                              Downloading a newer snapshot for slot {}",
+                            highest_local_snapshot_slot, snapshot_hash.0
+                        );
                     }
                 }
 


### PR DESCRIPTION
A useful hint for somebody who's paying attention and is interested in tuning their `--maximum-local-snapshot-age`