### PR TITLE
Improve ping for easier tx landing debugging

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -117,6 +117,9 @@ pub enum CliCommand {
         timeout: Duration,
         blockhash: Option<Hash>,
         print_timestamp: bool,
+        use_nonce: bool,
+        resubmit_interval: Duration,
+        blockhash_interval: Duration,
     },
     ShowBlockProduction {
         epoch: Option<Epoch>,
@@ -1176,6 +1179,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             timeout,
             blockhash,
             print_timestamp,
+            use_nonce,
+            resubmit_interval,
+            blockhash_interval,
         } => process_ping(
             &rpc_client,
             config,
@@ -1185,6 +1191,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             timeout,
             blockhash,
             *print_timestamp,
+            *use_nonce,
+            resubmit_interval,
+            blockhash_interval,
         ),
         CliCommand::ShowBlockProduction { epoch, slot_limit } => {
             process_show_block_production(&rpc_client, config, *epoch, *slot_limit)

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -53,7 +53,7 @@ pub fn resolve_spend_tx_and_check_account_balance<F>(
     commitment: CommitmentConfig,
 ) -> Result<(Message, u64), CliError>
 where
-    F: Fn(u64) -> Message,
+    F: FnMut(u64) -> Message,
 {
     resolve_spend_tx_and_check_account_balances(
         rpc_client,
@@ -78,7 +78,7 @@ pub fn resolve_spend_tx_and_check_account_balances<F>(
     commitment: CommitmentConfig,
 ) -> Result<(Message, u64), CliError>
 where
-    F: Fn(u64) -> Message,
+    F: FnMut(u64) -> Message,
 {
     if sign_only {
         let (message, SpendAndFee { spend, fee: _ }) = resolve_spend_message(
@@ -128,10 +128,10 @@ fn resolve_spend_message<F>(
     from_balance: u64,
     from_pubkey: &Pubkey,
     fee_pubkey: &Pubkey,
-    build_message: F,
+    mut build_message: F,
 ) -> (Message, SpendAndFee)
 where
-    F: Fn(u64) -> Message,
+    F: FnMut(u64) -> Message,
 {
     match amount {
         SpendAmount::Some(lamports) => {


### PR DESCRIPTION
#### Problem

There is no simple way to actually test the tx landing behavior from cli.

#### Summary of Changes

Improve ping for that purpose, following the spirit of https://github.com/solana-labs/solana/pull/13980
Also, really confirm nonced tx's not-expiring behavior

also, implement rerty at the client side (could split into a different pr)


Well, code is still dirty.

Needed proper exchange support and debugging.

Fixes #
