### PR TITLE
Don't use caller passed executable account

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -291,7 +291,8 @@ extern uint64_t entrypoint(const uint8_t *input) {
   case TEST_EMPTY_ACCOUNTS_SLICE: {
     sol_log("Empty accounts slice");
 
-    SolAccountMeta arguments[] = {};
+    SolAccountMeta arguments[] = {
+        {accounts[INVOKED_ARGUMENT_INDEX].key, false, false}};
     uint8_t data[] = {};
     const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                         arguments, SOL_ARRAY_SIZE(arguments),

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -385,7 +385,11 @@ fn process_instruction(
         }
         TEST_EMPTY_ACCOUNTS_SLICE => {
             msg!("Empty accounts slice");
-            let instruction = create_instruction(*accounts[INVOKED_PROGRAM_INDEX].key, &[], vec![]);
+            let instruction = create_instruction(
+                *accounts[INVOKED_PROGRAM_INDEX].key,
+                &[(accounts[INVOKED_ARGUMENT_INDEX].key, false, false)],
+                vec![],
+            );
             invoke(&instruction, &[])?;
         }
         TEST_CAP_SEEDS => {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -989,7 +989,7 @@ fn test_program_bpf_invoke() {
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
-            TransactionError::InstructionError(0, InstructionError::ModifiedProgramId)
+            TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature)
         );
         assert_eq!(10, bank.get_balance(&from_pubkey));
         assert_eq!(0, bank.get_balance(&to_pubkey));


### PR DESCRIPTION
#### Problem

CPI takes the executable account to run from the caller which requires the runtime to validate that account.  

#### Summary of Changes

The runtime already has the executable account so use it.  This change limits the attack surface of CPI calls.

Fixes #
