### PR TITLE
uses ValidatorExit to stop when observing duplicate instances

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -493,6 +493,7 @@ impl Validator {
             node.sockets.gossip,
             config.gossip_validators.clone(),
             &exit,
+            validator_exit.clone(),
         );
         cluster_info.set_entrypoints(cluster_entrypoints);
 

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -19,8 +19,14 @@ fn test_node(exit: &Arc<AtomicBool>) -> (Arc<ClusterInfo>, GossipService, UdpSoc
     let keypair = Arc::new(Keypair::new());
     let mut test_node = Node::new_localhost_with_pubkey(&keypair.pubkey());
     let cluster_info = Arc::new(ClusterInfo::new(test_node.info.clone(), keypair));
-    let gossip_service =
-        GossipService::new(&cluster_info, None, test_node.sockets.gossip, None, exit);
+    let gossip_service = GossipService::new(
+        &cluster_info,
+        None,
+        test_node.sockets.gossip,
+        None,
+        exit,
+        Arc::default(), // validator exit
+    );
     let _ = cluster_info.my_contact_info();
     (
         cluster_info,
@@ -42,6 +48,7 @@ fn test_node_with_bank(
         test_node.sockets.gossip,
         None,
         exit,
+        Arc::default(), // validator exit
     );
     let _ = cluster_info.my_contact_info();
     (

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -131,6 +131,7 @@ fn start_gossip_node(
         gossip_socket,
         gossip_validators,
         &gossip_exit_flag,
+        Arc::default(), // validator exit
     );
     (cluster_info, gossip_exit_flag, gossip_service)
 }


### PR DESCRIPTION
#### Problem
`ClusterInfo::listen` does `std::process::exit` when it identifies duplicate instances:
https://github.com/solana-labs/solana/blob/87eb924d2/core/src/cluster_info.rs#L2940

#### Summary of Changes
* Passed through `ValidatorExit` instead to stop the validator.
* Added test coverage.
