### PR TITLE
Persist gossip contact info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5101,6 +5101,7 @@ name = "solana-validator"
 version = "1.6.0"
 dependencies = [
  "base64 0.12.3",
+ "bincode",
  "chrono",
  "clap",
  "console",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -11,6 +11,7 @@ default-run = "solana-validator"
 
 [dependencies]
 base64 = "0.12.3"
+bincode = "1.3.1"
 clap = "2.33.1"
 chrono = { version = "0.4.11", features = ["serde"] }
 console = "0.11.3"


### PR DESCRIPTION
Cold starts for gossip can take a while, and node IP addresses really don't change often.  Save gossip contact info for faster validator restarts