### PR TITLE
Fix subtraction underflow in metrics

### DIFF
--- a/core/src/broadcast_stage.rs
+++ b/core/src/broadcast_stage.rs
@@ -347,7 +347,7 @@ fn update_peer_stats(
 ) {
     let now = timestamp();
     let last = last_datapoint_submit.load(Ordering::Relaxed);
-    if now - last > 1000
+    if now.saturating_sub(last) > 1000
         && last_datapoint_submit.compare_and_swap(last, now, Ordering::Relaxed) == last
     {
         datapoint_info!(

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -117,7 +117,9 @@ fn update_retransmit_stats(
 
     let now = timestamp();
     let last = stats.last_ts.load(Ordering::Relaxed);
-    if now - last > 2000 && stats.last_ts.compare_and_swap(last, now, Ordering::Relaxed) == last {
+    if now.saturating_sub(last) > 2000
+        && stats.last_ts.compare_and_swap(last, now, Ordering::Relaxed) == last
+    {
         datapoint_info!("retransmit-num_nodes", ("count", peers_len, i64));
         datapoint_info!(
             "retransmit-stage",
@@ -288,7 +290,8 @@ fn retransmit(
 
     let now = timestamp();
     let last = last_peer_update.load(Ordering::Relaxed);
-    if now - last > 1000 && last_peer_update.compare_and_swap(last, now, Ordering::Relaxed) == last
+    if now.saturating_sub(last) > 1000
+        && last_peer_update.compare_and_swap(last, now, Ordering::Relaxed) == last
     {
         drop(r_epoch_stakes_cache);
         let mut w_epoch_stakes_cache = epoch_stakes_cache.write().unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2723,7 +2723,7 @@ impl AccountsDB {
     fn report_store_timings(&self) {
         let last = self.stats.last_store_report.load(Ordering::Relaxed);
         let now = solana_sdk::timing::timestamp();
-        if now - last > 1000
+        if now.saturating_sub(last) > 1000
             && self
                 .stats
                 .last_store_report


### PR DESCRIPTION
#### Problem

Multiple threads could load/compare-swap in different order, debug-mode underflow could cause a panic and underflow in release would cause the metric to be reported more often than expected.

#### Summary of Changes

Use a saturating sub to avoid the panic.

Fixes #
