### PR TITLE
Add poh speed test and calibration logic

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1088,7 +1088,12 @@ pub fn create_test_recorder(
     poh_recorder.set_bank(&bank);
 
     let poh_recorder = Arc::new(Mutex::new(poh_recorder));
-    let poh_service = PohService::new(poh_recorder.clone(), &poh_config, &exit);
+    let poh_service = PohService::new(
+        poh_recorder.clone(),
+        &poh_config,
+        &exit,
+        bank.ticks_per_slot(),
+    );
 
     (exit, poh_recorder, poh_service, entry_receiver)
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -37,6 +37,7 @@ use solana_ledger::{
     blockstore_processor::{self, TransactionStatusSender},
     leader_schedule::FixedSchedule,
     leader_schedule_cache::LeaderScheduleCache,
+    poh::compute_hash_time_ns,
 };
 use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
@@ -110,6 +111,7 @@ pub struct ValidatorConfig {
     pub bpf_jit: bool,
     pub send_transaction_retry_ms: u64,
     pub send_transaction_leader_forward_count: u64,
+    pub no_poh_speed_test: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -151,6 +153,7 @@ impl Default for ValidatorConfig {
             bpf_jit: false,
             send_transaction_retry_ms: 2000,
             send_transaction_leader_forward_count: 2,
+            no_poh_speed_test: true,
         }
     }
 }
@@ -526,11 +529,20 @@ impl Validator {
                 (None, None)
             };
 
+        if !config.no_poh_speed_test {
+            check_poh_speed(&genesis_config, None);
+        }
+
         if wait_for_supermajority(config, &bank, &cluster_info, rpc_override_health_check) {
             abort();
         }
 
-        let poh_service = PohService::new(poh_recorder.clone(), &poh_config, &exit);
+        let poh_service = PohService::new(
+            poh_recorder.clone(),
+            &poh_config,
+            &exit,
+            bank.ticks_per_slot(),
+        );
         assert_eq!(
             blockstore.new_shreds_signals.len(),
             1,
@@ -747,6 +759,35 @@ fn active_vote_account_exists_in_bank(bank: &Arc<Bank>, vote_account: &Pubkey) -
         }
     }
     false
+}
+
+fn check_poh_speed(genesis_config: &GenesisConfig, maybe_hash_samples: Option<u64>) {
+    if let Some(hashes_per_tick) = genesis_config.hashes_per_tick() {
+        let ticks_per_slot = genesis_config.ticks_per_slot();
+        let hashes_per_slot = hashes_per_tick * ticks_per_slot;
+
+        let hash_samples = maybe_hash_samples.unwrap_or(hashes_per_slot);
+        let hash_time_ns = compute_hash_time_ns(hash_samples);
+
+        let my_ns_per_slot = (hash_time_ns * hashes_per_slot) / hash_samples;
+        debug!("computed: ns_per_slot: {}", my_ns_per_slot);
+        let target_ns_per_slot = genesis_config.ns_per_slot() as u64;
+        debug!(
+            "cluster ns_per_hash: {}ns ns_per_slot: {}",
+            target_ns_per_slot / hashes_per_slot,
+            target_ns_per_slot
+        );
+        if my_ns_per_slot < target_ns_per_slot {
+            let extra_ns = target_ns_per_slot - my_ns_per_slot;
+            info!("PoH speed check: Will sleep {}ns per slot.", extra_ns);
+        } else {
+            error!(
+                "PoH is slower than cluster target tick rate! mine: {} cluster: {}. If you wish to continue, try --ignore-poh-speed",
+                my_ns_per_slot, target_ns_per_slot,
+            );
+            abort();
+        }
+    }
 }
 
 fn post_process_restored_tower(
@@ -1261,6 +1302,8 @@ pub fn is_snapshot_config_invalid(
 mod tests {
     use super::*;
     use solana_ledger::{create_new_tmp_ledger, genesis_utils::create_genesis_config_with_leader};
+    use solana_sdk::genesis_config::create_genesis_config;
+    use solana_sdk::poh_config::PohConfig;
     use std::fs::remove_dir_all;
 
     #[test]
@@ -1379,7 +1422,6 @@ mod tests {
     #[test]
     fn test_wait_for_supermajority() {
         solana_logger::setup();
-        use solana_sdk::genesis_config::create_genesis_config;
         use solana_sdk::hash::hash;
         let node_keypair = Arc::new(Keypair::new());
         let cluster_info = ClusterInfo::new(
@@ -1435,5 +1477,39 @@ mod tests {
         assert!(is_snapshot_config_invalid(230, 100));
         assert!(!is_snapshot_config_invalid(500, 100));
         assert!(!is_snapshot_config_invalid(5, 5));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_poh_speed() {
+        solana_logger::setup();
+        let poh_config = PohConfig {
+            target_tick_duration: Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
+            // make PoH rate really fast to cause the panic condition
+            hashes_per_tick: Some(
+                100 * solana_sdk::clock::DEFAULT_HASHES_PER_SECOND
+                    / solana_sdk::clock::DEFAULT_TICKS_PER_SECOND,
+            ),
+            ..PohConfig::default()
+        };
+        let genesis_config = GenesisConfig {
+            poh_config,
+            ..GenesisConfig::default()
+        };
+        check_poh_speed(&genesis_config, Some(10_000));
+    }
+
+    #[test]
+    fn test_poh_speed_no_hashes_per_tick() {
+        let poh_config = PohConfig {
+            target_tick_duration: Duration::from_millis(solana_sdk::clock::MS_PER_TICK),
+            hashes_per_tick: None,
+            ..PohConfig::default()
+        };
+        let genesis_config = GenesisConfig {
+            poh_config,
+            ..GenesisConfig::default()
+        };
+        check_poh_speed(&genesis_config, Some(10_000));
     }
 }

--- a/ledger/src/poh.rs
+++ b/ledger/src/poh.rs
@@ -82,18 +82,18 @@ impl Poh {
     }
 }
 
-pub fn compute_hashes_per_tick(duration: Duration, hashes_sample_size: u64) -> u64 {
-    // calculate hash rate with the system under maximum load
-    info!(
-        "Running {} hashes in parallel on all threads...",
-        hashes_sample_size
-    );
+pub fn compute_hash_time_ns(hashes_sample_size: u64) -> u64 {
+    info!("Running {} hashes...", hashes_sample_size);
     let mut v = Hash::default();
     let start = Instant::now();
     for _ in 0..hashes_sample_size {
         v = hash(&v.as_ref());
     }
-    let elapsed = start.elapsed().as_millis() as u64;
+    start.elapsed().as_nanos() as u64
+}
+
+pub fn compute_hashes_per_tick(duration: Duration, hashes_sample_size: u64) -> u64 {
+    let elapsed = compute_hash_time_ns(hashes_sample_size) / (1000 * 1000);
     duration.as_millis() as u64 * hashes_sample_size / elapsed
 }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1100,6 +1100,11 @@ pub fn main() {
                 .help("Milliseconds between printing contact debug from gossip."),
         )
         .arg(
+            Arg::with_name("no_poh_speed_test")
+                .long("no-poh-speed-test")
+                .help("Skip the check for PoH speed."),
+        )
+        .arg(
             Arg::with_name("accounts_hash_interval_slots")
                 .long("accounts-hash-slots")
                 .value_name("ACCOUNTS_HASH_INTERVAL_SLOTS")
@@ -1539,6 +1544,7 @@ pub fn main() {
             "rpc_send_transaction_leader_forward_count",
             u64
         ),
+        no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

PoH time is not calibrated between nodes resulting in skip slots and bad network synchronization

#### Summary of Changes

Add busy-wait to meet PoH goal time.
Add a check for PoH speed to detect slow PoH generation at boot.

Fixes #