### PR TITLE
Log error from AppendVec removal & a panic clean

### DIFF
--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -117,7 +117,10 @@ pub struct AppendVec {
 impl Drop for AppendVec {
     fn drop(&mut self) {
         if self.remove_on_drop {
-            let _ignored = remove_file(&self.path);
+            if let Err(e) = remove_file(&self.path) {
+                // promote this to panic soon.
+                error!("AppendVec failed to remove {:?}: {:?}", &self.path, e);
+            }
         }
     }
 }
@@ -138,19 +141,11 @@ impl AppendVec {
             .create(create)
             .open(file)
             .map_err(|e| {
-                let mut msg = format!("in current dir {:?}\n", std::env::current_dir());
-                for ancestor in file.ancestors() {
-                    msg.push_str(&format!(
-                        "{:?} is {:?}\n",
-                        ancestor,
-                        std::fs::metadata(ancestor)
-                    ));
-                }
                 panic!(
-                    "{}Unable to {} data file {}, err {:?}",
-                    msg,
+                    "Unable to {} data file {} in current dir({:?}): {:?}",
                     if create { "create" } else { "open" },
                     file.display(),
+                    std::env::current_dir(),
                     e
                 );
             })


### PR DESCRIPTION
#### Problem

Basically, AppendVec::Drop should never fail to remove its backing file. But it's not checking the removal error.

Not that I've found a real issue in this. But I think we're better off not ignoring the error if ever should it fail.

I've suspected odd thing from this while investigating the accounts leak. (well, it turned out unbounded work queue growth of AccountsBackgroundService.

#### Summary of Changes

- make it `error!` first.
- also tweaked too-verbose panic error while we're at it.

Fixes #
