### PR TITLE
run.sh: add env knob for solana-validor

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -106,7 +106,8 @@ args=(
   --snapshot-compression none
   --require-tower
 )
-solana-validator "${args[@]}" &
+# shellcheck disable=SC2086
+solana-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS &
 validator=$!
 
 wait "$validator"


### PR DESCRIPTION
#### Problem

There is no handy way to mangle run.sh's `solana-validator` options like `--snapshot-interval-slots` and `--expected-shred-version` `--account-shrink-paths` or the like.

#### Summary of Changes

Add it. I know this is ugly but is handy. I'm still reserving the run.sh itself's `"$@"` for `run.sh`'s special command options, not starting directly forwarding to `solana-validator` yet.

Fixes #
