### PR TITLE
Remove Testnet-specific old code

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -14,12 +14,7 @@ use fs_extra::dir::CopyOptions;
 use log::*;
 use regex::Regex;
 use solana_measure::measure::Measure;
-use solana_sdk::{
-    clock::Slot,
-    genesis_config::{ClusterType, GenesisConfig},
-    hash::Hash,
-    pubkey::Pubkey,
-};
+use solana_sdk::{clock::Slot, genesis_config::GenesisConfig, hash::Hash, pubkey::Pubkey};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::{
@@ -626,18 +621,6 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     if !bank.verify_snapshot_bank() {
         panic!("Snapshot bank for slot {} failed to verify", bank.slot());
     }
-    if genesis_config.cluster_type == ClusterType::Testnet {
-        // remove me after we transitions to the fixed rent distribution with no overflow
-        let old = bank.set_capitalization();
-        if old != bank.capitalization() {
-            warn!(
-                "Capitalization was recalculated: {} => {}",
-                old,
-                bank.capitalization()
-            )
-        }
-    }
-
     measure.stop();
     info!("{}", measure);
 


### PR DESCRIPTION
#### Problem

This isn't needed at all now that feature (`4kpdyrcj5jS47CZb2oJGfVxjYbsMm2Kx97gFyZrxxwXz no overflow rent distribution`) is activated across all live clusters.

#### Summary of Changes

Remove this. And catch any capitalization mismatch sooner if ever we introduce such a bug sooner on the testnet.

follow-up: #12112 (this is the basis for the chosen reviewer)
