### PR TITLE
[rfc] Tune linux vm for reduced io by delayed writes

### DIFF
--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -94,6 +94,16 @@ fn tune_kernel_udp_buffers_and_vmmap() {
 
     // increase mmap counts for many append_vecs
     sysctl_write("vm.max_map_count", "500000");
+
+    // Delay writes (and thereby reduce them by being overlapping and discarded)
+    // actually hitting the hardware as much as possible.
+    // This is mainly for AccountsDB and snapshot creation IO.
+    // Moreover, we don't generally care about durability not much.
+    // Reference: https://unix.stackexchange.com/a/41831/364236
+    sysctl_write("vm.dirty_ratio", "90");
+    sysctl_write("vm.dirty_background_ratio", "90");
+    sysctl_write("vm.dirty_expire_centisecs", "36000");
+    sysctl_write("vm.dirty_writeback_centisecs", "36000");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
#### Problem

Unless, tmpfs is setup, solana-validator's IO is generally too high, wearing hardware too much.

#### Summary of Changes

Delay writes.

The basic idea here is that currently ./accounts is heavily rewritten itself (well, we're baking fixes, ref #13140 ). As a temporary fix, these tuning very aggressively delays writing to disk while buffering written data on ram as much as possible. In that way, most of rewrites only happen on ram and then this ultimately avoids meaningless (re)writes hitting on ssd/nvme.

This is really effective on small machines, making n2-standard-16 16 vCPUs, 64 GB memory (no tmpfs possible) validator realizable again for the mainnet-beta. Also, some external similar validator operators managed to catch up with this.

Put differentially, this super large dirty page buffer effectively works like a dynamically sizing `tmpfs`.

It also seems to benefit for large-sized instances as well to some extent, I'm gueesing this due to snapshot creation? I've observed this when I've applied this settings manually all over the api backend instances.

For example, io reduced like this (50% down IO throughput/10% down IO reqs):

![image](https://user-images.githubusercontent.com/117807/103242534-deb28f00-4999-11eb-8772-112a24dbe255.png)

Also, api nodes reduced the frequency to lag behind the cluster significantly.


The downside is that this really delays the writes. I've seen very long `apt full-upgrade` along side running `solana-validator`. But I think it's acceptable.

related discord discussions:

https://discord.com/channels/428295358100013066/689412830075551748/792013915717632011
https://discord.com/channels/428295358100013066/689412830075551748/792959495726432288

