### PR TITLE
Limit CPI instruction size

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -12,6 +12,8 @@ static const uint8_t TEST_EMPTY_ACCOUNTS_SLICE = 5;
 static const uint8_t TEST_CAP_SEEDS = 6;
 static const uint8_t TEST_CAP_SIGNERS = 7;
 static const uint8_t TEST_ALLOC_ACCESS_VIOLATION = 8;
+static const uint8_t TEST_INSTRUCTION_DATA_TOO_LARGE = 9;
+static const uint8_t TEST_INSTRUCTION_META_TOO_LARGE = 10;
 
 static const int MINT_INDEX = 0;
 static const int ARGUMENT_INDEX = 1;
@@ -403,6 +405,36 @@ extern uint64_t entrypoint(const uint8_t *input) {
                sol_invoke_signed(&instruction,
                                  (const SolAccountInfo *)invoke_accounts, 3,
                                  signers_seeds, SOL_ARRAY_SIZE(signers_seeds)));
+    break;
+  }
+  case TEST_INSTRUCTION_DATA_TOO_LARGE: {
+    sol_log("Test instruction data too large");
+    SolAccountMeta arguments[] = {};
+    uint8_t *data = sol_calloc(1500, 1);
+    const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+                                        arguments, SOL_ARRAY_SIZE(arguments),
+                                        data, 1500};
+    const SolSignerSeeds signers_seeds[] = {};
+    sol_assert(SUCCESS == sol_invoke_signed(
+                              &instruction, accounts, SOL_ARRAY_SIZE(accounts),
+                              signers_seeds, SOL_ARRAY_SIZE(signers_seeds)));
+
+    break;
+  }
+  case TEST_INSTRUCTION_META_TOO_LARGE: {
+    sol_log("Test instruction meta too large");
+    SolAccountMeta *arguments = sol_calloc(40, sizeof(SolAccountMeta));
+    sol_log_64(0, 0, 0, 0, (uint64_t)arguments);
+    sol_assert(0 != arguments);
+    uint8_t data[] = {};
+    const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+                                        arguments, 40, data,
+                                        SOL_ARRAY_SIZE(data)};
+    const SolSignerSeeds signers_seeds[] = {};
+    sol_assert(SUCCESS == sol_invoke_signed(
+                              &instruction, accounts, SOL_ARRAY_SIZE(accounts),
+                              signers_seeds, SOL_ARRAY_SIZE(signers_seeds)));
+
     break;
   }
   default:

--- a/programs/bpf/rust/invoke/src/lib.rs
+++ b/programs/bpf/rust/invoke/src/lib.rs
@@ -24,6 +24,8 @@ const TEST_EMPTY_ACCOUNTS_SLICE: u8 = 5;
 const TEST_CAP_SEEDS: u8 = 6;
 const TEST_CAP_SIGNERS: u8 = 7;
 const TEST_ALLOC_ACCESS_VIOLATION: u8 = 8;
+const TEST_INSTRUCTION_DATA_TOO_LARGE: u8 = 9;
+const TEST_INSTRUCTION_META_TOO_LARGE: u8 = 10;
 
 // const MINT_INDEX: usize = 0;
 const ARGUMENT_INDEX: usize = 1;
@@ -496,6 +498,21 @@ fn process_instruction(
                 &[system_info.clone(), from_info.clone(), derived_info.clone()],
                 &[&[b"You pass butter", &[bump_seed1]]],
             )?;
+        }
+        TEST_INSTRUCTION_DATA_TOO_LARGE => {
+            msg!("Test instruction data too large");
+            let instruction =
+                create_instruction(*accounts[INVOKED_PROGRAM_INDEX].key, &[], vec![0; 1500]);
+            invoke_signed(&instruction, &[], &[])?;
+        }
+        TEST_INSTRUCTION_META_TOO_LARGE => {
+            msg!("Test instruction metas too large");
+            let instruction = create_instruction(
+                *accounts[INVOKED_PROGRAM_INDEX].key,
+                &[(&Pubkey::default(), false, false); 40],
+                vec![],
+            );
+            invoke_signed(&instruction, &[], &[])?;
         }
         _ => panic!(),
     }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1018,6 +1018,7 @@ mod tests {
                 max_call_depth: 20,
                 stack_frame_size: 4096,
                 log_pubkey_units: 100,
+                max_cpi_instruction_size: usize::MAX,
             },
             Rc::new(RefCell::new(Executors::default())),
             None,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -118,6 +118,10 @@ pub mod stake_program_v3 {
     solana_sdk::declare_id!("Ego6nTu7WsBcZBvVqJQKp6Yku2N3mrfG8oYCfaLZkAeK");
 }
 
+pub mod max_cpi_instruction_size_ipv6_mtu {
+    solana_sdk::declare_id!("5WLtuUJA5VVA1Cc28qULPfGs8anhoBev8uNqaaXeasnf");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -149,6 +153,7 @@ lazy_static! {
         (try_find_program_address_syscall_enabled::id(), "add try_find_program_address syscall"),
         (warp_testnet_timestamp::id(), "warp testnet timestamp to current #14210"),
         (stake_program_v3::id(), "solana_stake_program v3"),
+        (max_cpi_instruction_size_ipv6_mtu::id(), "Max cross-program invocation size 1280"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

CPI instructions have no size bounds

#### Summary of Changes

Limit the max size of an instruction invoked via CPI.  Featurized and limited to Ipv6 packet size to roughly correlate to Solana's current transaction size limit

Fixes #
