### PR TITLE
Add experimental knob for tuning PoH pinned CPU core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5099,6 +5099,7 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "core_affinity",
  "fd-lock",
  "indicatif",
  "libc",

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -4,7 +4,7 @@
 use crate::{
     cluster_info::ClusterInfo,
     poh_recorder::{PohRecorder, PohRecorderError, WorkingBankEntry},
-    poh_service::PohService,
+    poh_service::{self, PohService},
 };
 use crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError};
 use itertools::Itertools;
@@ -1093,6 +1093,7 @@ pub fn create_test_recorder(
         &poh_config,
         &exit,
         bank.ticks_per_slot(),
+        poh_service::DEFAULT_PINNED_CPU_CORE,
     );
 
     (exit, poh_recorder, poh_service, entry_receiver)

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -16,7 +16,7 @@ use crate::{
         OptimisticallyConfirmedBank, OptimisticallyConfirmedBankTracker,
     },
     poh_recorder::{PohRecorder, GRACE_TICKS_FACTOR, MAX_GRACE_SLOTS},
-    poh_service::PohService,
+    poh_service::{self, PohService},
     rewards_recorder_service::{RewardsRecorderSender, RewardsRecorderService},
     rpc::JsonRpcConfig,
     rpc_pubsub_service::{PubSubConfig, PubSubService},
@@ -116,6 +116,7 @@ pub struct ValidatorConfig {
     pub send_transaction_retry_ms: u64,
     pub send_transaction_leader_forward_count: u64,
     pub no_poh_speed_test: bool,
+    pub poh_pinned_cpu_core: usize,
 }
 
 impl Default for ValidatorConfig {
@@ -159,6 +160,7 @@ impl Default for ValidatorConfig {
             send_transaction_retry_ms: 2000,
             send_transaction_leader_forward_count: 2,
             no_poh_speed_test: true,
+            poh_pinned_cpu_core: poh_service::DEFAULT_PINNED_CPU_CORE,
         }
     }
 }
@@ -547,6 +549,7 @@ impl Validator {
             &poh_config,
             &exit,
             bank.ticks_per_slot(),
+            config.poh_pinned_cpu_core,
         );
         assert_eq!(
             blockstore.new_shreds_signals.len(),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -787,7 +787,7 @@ fn check_poh_speed(genesis_config: &GenesisConfig, maybe_hash_samples: Option<u6
             info!("PoH speed check: Will sleep {}ns per slot.", extra_ns);
         } else {
             error!(
-                "PoH is slower than cluster target tick rate! mine: {} cluster: {}. If you wish to continue, try --ignore-poh-speed",
+                "PoH is slower than cluster target tick rate! mine: {} cluster: {}. If you wish to continue, try --no-poh-speed-test",
                 my_ns_per_slot, target_ns_per_slot,
             );
             abort();

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -15,6 +15,7 @@ bincode = "1.3.1"
 clap = "2.33.1"
 chrono = { version = "0.4.11", features = ["serde"] }
 console = "0.11.3"
+core_affinity = "0.5.10"
 fd-lock = "1.1.1"
 indicatif = "0.15.0"
 log = "0.4.11"


### PR DESCRIPTION
#### Problem

No easy way to experiment with which core PoH is pinned to

#### Summary of Changes

Add a (hidden) flag to `solana-validator` that allows for selecting the PoH pinned CPU core