### PR TITLE
Rewrite faucet with tokio v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,8 +4144,9 @@ version = "1.6.0"
 dependencies = [
  "bincode",
  "byteorder",
- "bytes 0.4.12",
+ "bytes 0.6.0",
  "clap",
+ "futures 0.3.8",
  "log 0.4.11",
  "serde",
  "serde_derive",
@@ -4155,8 +4156,8 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-version",
- "tokio 0.1.22",
- "tokio-codec",
+ "tokio 0.3.5",
+ "tokio-util 0.5.1",
 ]
 
 [[package]]
@@ -5935,6 +5936,20 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite 0.1.5",
+ "tokio 0.3.5",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3137de2b078e95274b696cc522e87f22c9a753fe3ef3344116ffb94f104f10a3"
+dependencies = [
+ "bytes 0.6.0",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.11",
+ "pin-project-lite 0.2.0",
  "tokio 0.3.5",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4144,9 +4144,7 @@ version = "1.6.0"
 dependencies = [
  "bincode",
  "byteorder",
- "bytes 0.6.0",
  "clap",
- "futures 0.3.8",
  "log 0.4.11",
  "serde",
  "serde_derive",
@@ -4157,7 +4155,6 @@ dependencies = [
  "solana-sdk",
  "solana-version",
  "tokio 0.3.5",
- "tokio-util 0.5.1",
 ]
 
 [[package]]
@@ -5936,20 +5933,6 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite 0.1.5",
- "tokio 0.3.5",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3137de2b078e95274b696cc522e87f22c9a753fe3ef3344116ffb94f104f10a3"
-dependencies = [
- "bytes 0.6.0",
- "futures-core",
- "futures-sink",
- "log 0.4.11",
- "pin-project-lite 0.2.0",
  "tokio 0.3.5",
 ]
 

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -11,8 +11,9 @@ edition = "2018"
 [dependencies]
 bincode = "1.3.1"
 byteorder = "1.3.4"
-bytes = "0.4"
+bytes = "0.6"
 clap = "2.33"
+futures = "0.3"
 log = "0.4.11"
 serde = "1.0.112"
 serde_derive = "1.0.103"
@@ -22,8 +23,8 @@ solana-logger = { path = "../logger", version = "1.6.0" }
 solana-metrics = { path = "../metrics", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }
-tokio = "0.1"
-tokio-codec = "0.1"
+tokio = { version = "0.3", features = ["full"] }
+tokio-util = { version = "0.5.1", features = ["codec"] }
 
 [lib]
 crate-type = ["lib"]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -11,9 +11,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.3.1"
 byteorder = "1.3.4"
-bytes = "0.6"
 clap = "2.33"
-futures = "0.3"
 log = "0.4.11"
 serde = "1.0.112"
 serde_derive = "1.0.103"
@@ -24,7 +22,6 @@ solana-metrics = { path = "../metrics", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }
 tokio = { version = "0.3", features = ["full"] }
-tokio-util = { version = "0.5.1", features = ["codec"] }
 
 [lib]
 crate-type = ["lib"]

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -11,7 +11,8 @@ use std::{
     thread,
 };
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let default_keypair = solana_cli_config::Config::default().keypair_path;
 
     solana_logger::setup_with_default("solana=info");
@@ -76,5 +77,5 @@ fn main() {
         faucet1.lock().unwrap().clear_request_count();
     });
 
-    run_faucet(faucet, faucet_addr, None);
+    run_faucet(faucet, faucet_addr, None).await;
 }

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -4,10 +4,8 @@
 //! checking requests against a request cap for a given time time_slice
 //! and (to come) an IP rate limit.
 
-use bincode::{deserialize, serialize};
+use bincode::{deserialize, serialize, serialized_size};
 use byteorder::{ByteOrder, LittleEndian};
-use bytes::{Bytes, BytesMut};
-use futures::{SinkExt, StreamExt};
 use log::*;
 use serde_derive::{Deserialize, Serialize};
 use solana_metrics::datapoint_info;
@@ -28,10 +26,10 @@ use std::{
     time::Duration,
 };
 use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream as TokioTcpStream},
     runtime::Runtime,
 };
-use tokio_util::codec::{BytesCodec, Decoder};
 
 #[macro_export]
 macro_rules! socketaddr {
@@ -56,6 +54,16 @@ pub enum FaucetRequest {
         to: Pubkey,
         blockhash: Hash,
     },
+}
+
+impl Default for FaucetRequest {
+    fn default() -> Self {
+        Self::GetAirdrop {
+            lamports: u64::default(),
+            to: Pubkey::default(),
+            blockhash: Hash::default(),
+        }
+    }
 }
 
 pub struct Faucet {
@@ -154,7 +162,7 @@ impl Faucet {
             }
         }
     }
-    pub fn process_faucet_request(&mut self, bytes: &BytesMut) -> Result<Bytes, io::Error> {
+    pub fn process_faucet_request(&mut self, bytes: &[u8]) -> Result<Vec<u8>, io::Error> {
         let req: FaucetRequest = deserialize(bytes).map_err(|err| {
             io::Error::new(
                 io::ErrorKind::Other,
@@ -177,9 +185,8 @@ impl Faucet {
                 LittleEndian::write_u16(&mut response_vec_with_length, response_vec.len() as u16);
                 response_vec_with_length.extend_from_slice(&response_vec);
 
-                let response_bytes = Bytes::from(response_vec_with_length);
                 info!("Airdrop transaction granted");
-                Ok(response_bytes)
+                Ok(response_vec_with_length)
             }
             Err(err) => {
                 warn!("Airdrop transaction failed: {:?}", err);
@@ -315,29 +322,24 @@ pub async fn run_faucet(
 }
 
 async fn process(
-    stream: TokioTcpStream,
+    mut stream: TokioTcpStream,
     faucet: Arc<Mutex<Faucet>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let framed = BytesCodec::new().framed(stream);
-    let (mut writer, mut reader) = framed.split();
+    let mut request = vec![0u8; serialized_size(&FaucetRequest::default()).unwrap() as usize];
+    while stream.read_exact(&mut request).await.is_ok() {
+        trace!("{:?}", request);
 
-    while let Some(request) = reader.next().await {
-        match request {
-            Ok(bytes) => {
-                let response = match faucet.lock().unwrap().process_faucet_request(&bytes) {
-                    Ok(response_bytes) => {
-                        trace!("Airdrop response_bytes: {:?}", response_bytes.to_vec());
-                        response_bytes
-                    }
-                    Err(e) => {
-                        info!("Error in request: {:?}", e);
-                        Bytes::from(0u16.to_le_bytes().to_vec())
-                    }
-                };
-                writer.send(response).await?;
+        let response = match faucet.lock().unwrap().process_faucet_request(&request) {
+            Ok(response_bytes) => {
+                trace!("Airdrop response_bytes: {:?}", response_bytes);
+                response_bytes
             }
-            Err(e) => return Err(e.into()),
-        }
+            Err(e) => {
+                info!("Error in request: {:?}", e);
+                0u16.to_le_bytes().to_vec()
+            }
+        };
+        stream.write_all(&response).await?;
     }
 
     Ok(())
@@ -346,7 +348,6 @@ async fn process(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::BufMut;
     use solana_sdk::system_instruction::SystemInstruction;
     use std::time::Duration;
 
@@ -458,8 +459,6 @@ mod tests {
             to,
         };
         let req = serialize(&req).unwrap();
-        let mut bytes = BytesMut::with_capacity(req.len());
-        bytes.put(&req[..]);
 
         let keypair = Keypair::new();
         let expected_instruction = system_instruction::transfer(&keypair.pubkey(), &to, lamports);
@@ -471,11 +470,11 @@ mod tests {
         expected_vec_with_length.extend_from_slice(&expected_bytes);
 
         let mut faucet = Faucet::new(keypair, None, None, None);
-        let response = faucet.process_faucet_request(&bytes);
+        let response = faucet.process_faucet_request(&req);
         let response_vec = response.unwrap().to_vec();
         assert_eq!(expected_vec_with_length, response_vec);
 
-        let bad_bytes = BytesMut::from("bad bytes");
+        let bad_bytes = "bad bytes".as_bytes();
         assert!(faucet.process_faucet_request(&bad_bytes).is_err());
     }
 }


### PR DESCRIPTION
#### Problem
Faucet code still depends on tokio v0.1

#### Summary of Changes
Rewrite using tokio v0.3 to synchronize with the majority of the code base
~~Upgrading to tokio v1.0 will require bumping `bytes` and `tokio-util` as well~~ 🎉 

Toward #10187 
