### PR TITLE
watchtower: Add --ignore-http-bad-gateway flag

### DIFF
--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -5,6 +5,8 @@ use solana_sdk::{
 use std::io;
 use thiserror::Error;
 
+pub use reqwest; // export `reqwest` for clients
+
 #[derive(Error, Debug)]
 pub enum ClientErrorKind {
     #[error(transparent)]


### PR DESCRIPTION
502 Bad Gateway errors can generate unhelpful noise for some validators.  Add a `--ignore-http-bad-gateway` flag to opt into suppressing that error, at the expense of not knowing when your monitoring is not actually working due to an RPC failure.