### PR TITLE
cli: Use singleGossip for program deployment

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1939,7 +1939,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(false)
                         .help("Use the designated program id, even if the account already holds a large balance of SOL")
                 )
-                .arg(commitment_arg_with_default("max")),
+                .arg(commitment_arg_with_default("singleGossip")),
         )
         .subcommand(
             SubCommand::with_name("pay")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -182,11 +182,16 @@ pub fn parse_args<'a>(
             OutputFormat::Display
         });
 
-    let commitment = matches
-        .subcommand_name()
-        .and_then(|name| matches.subcommand_matches(name))
-        .and_then(|sub_matches| commitment_of(sub_matches, COMMITMENT_ARG.long))
-        .unwrap_or_default();
+    let commitment = {
+        let mut sub_matches = matches;
+        while let Some(subcommand_name) = sub_matches.subcommand_name() {
+            sub_matches = sub_matches
+                .subcommand_matches(subcommand_name)
+                .expect("subcommand_matches");
+        }
+        commitment_of(sub_matches, COMMITMENT_ARG.long)
+    }
+    .unwrap_or_default();
 
     let address_labels = if matches.is_present("no_address_labels") {
         HashMap::new()

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -94,7 +94,8 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Intermediate buffer account to write data to, can be used to resume a failed deploy [default: new random address]")
+                                .help("Intermediate buffer account to write data to, which can be used to resume a failed deploy \
+                                      [default: random address]")
                         )
                         .arg(
                             pubkey!(Arg::with_name("upgrade_authority")
@@ -106,7 +107,8 @@ impl ProgramSubCommands for App<'_, '_> {
                             pubkey!(Arg::with_name("program_id")
                                 .long("program-id")
                                 .value_name("PROGRAM_ID"),
-                                "Executable program's address, must be a signer for initial deploys, can be a pubkey for upgrades [default: new random address or the address of keypair file /path/to/program.json]"),
+                                "Executable program's address, must be a signer for initial deploys, can be a pubkey for upgrades \
+                                [default: address of keypair at /path/to/program-keypair.json if present, otherwise a random address]"),
                         )
                         .arg(
                             Arg::with_name("final")
@@ -119,13 +121,14 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("max_len")
                                 .takes_value(true)
                                 .required(false)
-                                .help("Maximum length of the upgradeable program, [default: twice the length of the original deployed program]")
+                                .help("Maximum length of the upgradeable program \
+                                      [default: twice the length of the original deployed program]")
                         )
                         .arg(
                             Arg::with_name("allow_excessive_balance")
                                 .long("allow-excessive-deploy-account-balance")
                                 .takes_value(false)
-                                .help("Use the designated program id, even if the account already holds a large balance of SOL")
+                                .help("Use the designated program id even if the account already holds a large balance of SOL")
                         )
                         .arg(commitment_arg_with_default("singleGossip")),
                 )
@@ -161,7 +164,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .conflicts_with("new_upgrade_authority")
                                 .help("The program will not be upgradeable")
                         )
-                        .arg(commitment_arg_with_default("max")),
+                        .arg(commitment_arg_with_default("singleGossip")),
                 )
         )
     }


### PR DESCRIPTION
1. Upgradable loader support in the cli caused #14141 to get lost
2. `solana program deploy` default commitment was really "max" instead of "singleGossip", fix it
3. `solana program set-upgrade-authority` now uses "singleGossip" by default, don't want to wait for "max"
4. Minor help tweaks