### PR TITLE
snapshot_utils: Don't bother restoring snapshots, they're never used

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3156,9 +3156,8 @@ pub mod tests {
     };
     use assert_matches::assert_matches;
     use rand::{thread_rng, Rng};
-    use solana_sdk::pubkey::PUBKEY_BYTES;
-    use solana_sdk::{account::Account, hash::HASH_BYTES};
-    use std::{fs, iter::FromIterator, str::FromStr};
+    use solana_sdk::{account::Account, hash::HASH_BYTES, pubkey::PUBKEY_BYTES};
+    use std::{iter::FromIterator, str::FromStr};
 
     fn linear_ancestors(end_slot: u64) -> Ancestors {
         let mut ancestors: Ancestors = vec![(0, 0)].into_iter().collect();
@@ -4633,24 +4632,6 @@ pub mod tests {
         let ancestors = vec![(0, 0)].into_iter().collect();
         let ret = db.load_slow(&ancestors, &key).unwrap();
         assert_eq!(ret.0.data.len(), data_len);
-    }
-
-    pub fn copy_append_vecs<P: AsRef<Path>>(
-        accounts_db: &AccountsDB,
-        output_dir: P,
-    ) -> IOResult<()> {
-        let storage_entries = accounts_db.get_snapshot_storages(Slot::max_value());
-        for storage in storage_entries.iter().flatten() {
-            let storage_path = storage.get_path();
-            let output_path = output_dir.as_ref().join(AppendVec::new_relative_path(
-                storage.slot(),
-                storage.append_vec_id(),
-            ));
-
-            fs::copy(storage_path, output_path)?;
-        }
-
-        Ok(())
     }
 
     #[test]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,10 +34,6 @@ pub mod transaction_utils;
 pub mod vote_account;
 pub mod vote_sender_types;
 
-extern crate solana_config_program;
-extern crate solana_stake_program;
-extern crate solana_vote_program;
-
 #[macro_use]
 extern crate solana_metrics;
 #[macro_use]
@@ -45,6 +41,3 @@ extern crate serde_derive;
 
 #[macro_use]
 extern crate solana_frozen_abi_macro;
-
-extern crate fs_extra;
-extern crate tempfile;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -11,7 +11,6 @@ use crate::{
 use bincode::{config::Options, serialize_into};
 use bzip2::bufread::BzDecoder;
 use flate2::read::GzDecoder;
-use fs_extra::dir::CopyOptions;
 use log::*;
 use regex::Regex;
 use solana_measure::measure::Measure;
@@ -110,9 +109,6 @@ pub enum SnapshotError {
 
     #[error("serialization error: {0}")]
     Serialize(#[from] bincode::Error),
-
-    #[error("file system error: {0}")]
-    FsExtra(#[from] fs_extra::error::Error),
 
     #[error("archive generation failure {0}")]
     ArchiveGenerationFailure(ExitStatus),
@@ -547,7 +543,7 @@ pub fn add_snapshot<P: AsRef<Path>>(
     })
 }
 
-pub fn serialize_status_cache(
+fn serialize_status_cache(
     slot: Slot,
     slot_deltas: &[BankSlotDelta],
     snapshot_links: &TempDir,
@@ -626,20 +622,6 @@ pub fn bank_from_archive<P: AsRef<Path>>(
     }
     measure.stop();
     info!("{}", measure);
-
-    // Move the unpacked snapshots into `snapshot_path`
-    let dir_files = fs::read_dir(&unpacked_snapshots_dir).unwrap_or_else(|err| {
-        panic!(
-            "Invalid snapshot path {:?}: {}",
-            unpacked_snapshots_dir, err
-        )
-    });
-    let paths: Vec<PathBuf> = dir_files
-        .filter_map(|entry| entry.ok().map(|e| e.path()))
-        .collect();
-    let mut copy_options = CopyOptions::new();
-    copy_options.overwrite = true;
-    fs_extra::move_items(&paths, &snapshot_path, &copy_options)?;
 
     Ok(bank)
 }
@@ -800,7 +782,10 @@ where
         .pop()
         .ok_or_else(|| get_io_error("No snapshots found in snapshots directory"))?;
 
-    info!("Loading bank from {:?}", &root_paths.snapshot_file_path);
+    info!(
+        "Loading bank from {}",
+        &root_paths.snapshot_file_path.display()
+    );
     let bank = deserialize_snapshot_data_file(&root_paths.snapshot_file_path, |mut stream| {
         Ok(match snapshot_version_enum {
             SnapshotVersion::V1_2_0 => bank_from_stream(
@@ -819,7 +804,10 @@ where
 
     let status_cache_path = unpacked_snapshots_dir.join(SNAPSHOT_STATUS_CACHE_FILE_NAME);
     let slot_deltas = deserialize_snapshot_data_file(&status_cache_path, |stream| {
-        info!("Rebuilding status cache...");
+        info!(
+            "Rebuilding status cache from {}",
+            status_cache_path.display()
+        );
         let slot_deltas: Vec<BankSlotDelta> = bincode::options()
             .with_limit(MAX_SNAPSHOT_DATA_FILE_SIZE)
             .with_fixint_encoding()


### PR DESCRIPTION
When extracting a snapshot archive, the `snapshot/` directory is re-populated with the bank snapshot and status cache.  But nobody cares.  Remove the useless copy.

Also remove some dead test code (`copy_append_vecs()`).