### PR TITLE
cli: Use max commitment when fetching epoch info for block production

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -911,7 +911,7 @@ pub fn process_show_block_production(
     slot_limit: Option<u64>,
 ) -> ProcessResult {
     let epoch_schedule = rpc_client.get_epoch_schedule()?;
-    let epoch_info = rpc_client.get_epoch_info_with_commitment(CommitmentConfig::root())?;
+    let epoch_info = rpc_client.get_epoch_info_with_commitment(CommitmentConfig::max())?;
 
     let epoch = epoch.unwrap_or(epoch_info.epoch);
     if epoch > epoch_info.epoch {


### PR DESCRIPTION
Root commitment was incorrectly being used to fetch the latest slot for `solana block-production`.   This could result in a slot that is 1 or 2 ahead of the current max commitment slot that is used as the max slot returned by the `getConfirmedBlocks` RPC method, giving the illusion that the last 1 or 2 blocks were skipped.

Fixes #14400
