### PR TITLE
Introduce rpc url monikers for cli

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -166,10 +166,10 @@ where
 
 pub fn normalize_to_url_if_moniker(url_or_moniker: &str) -> String {
     match url_or_moniker {
-        "mainnet-beta" => "http://api.mainnet-beta.solana.com",
-        "testnet" => "http://testnet.solana.com",
-        "devnet" => "http://devnet.solana.com",
-        "localnet" => "http://localhost:8899",
+        "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
+        "t" | "testnet" => "https://testnet.solana.com",
+        "d" | "devnet" => "https://devnet.solana.com",
+        "l" | "localhost" => "http://localhost:8899",
         url => url,
     }
     .to_string()

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -148,6 +148,33 @@ where
     }
 }
 
+pub fn is_url_or_moniker<T>(string: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    match url::Url::parse(&normalize_to_url_if_moniker(string.as_ref())) {
+        Ok(url) => {
+            if url.has_host() {
+                Ok(())
+            } else {
+                Err("no host provided".to_string())
+            }
+        }
+        Err(err) => Err(format!("{}", err)),
+    }
+}
+
+pub fn normalize_to_url_if_moniker(url_or_moniker: &str) -> String {
+    match url_or_moniker {
+        "mainnet-beta" => "http://api.mainnet-beta.solana.com",
+        "testnet" => "http://testnet.solana.com",
+        "devnet" => "http://devnet.solana.com",
+        "localnet" => "http://localhost:8899",
+        url => url,
+    }
+    .to_string()
+}
+
 pub fn is_epoch<T>(epoch: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -463,11 +463,12 @@ impl CliConfig<'_> {
         json_rpc_cmd_url: &str,
         json_rpc_cfg_url: &str,
     ) -> (SettingType, String) {
-        Self::first_nonempty_setting(vec![
+        let (setting_type, url_or_moniker) = Self::first_nonempty_setting(vec![
             (SettingType::Explicit, json_rpc_cmd_url.to_string()),
             (SettingType::Explicit, json_rpc_cfg_url.to_string()),
             (SettingType::SystemDefault, Self::default_json_rpc_url()),
-        ])
+        ]);
+        (setting_type, normalize_to_url_if_moniker(&url_or_moniker))
     }
 
     pub fn compute_keypair_path_setting(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,7 @@ use console::style;
 use solana_clap_utils::{
     commitment::COMMITMENT_ARG,
     input_parsers::commitment_of,
-    input_validators::is_url,
+    input_validators::{is_url, is_url_or_moniker},
     keypair::{CliSigners, DefaultSigner, SKIP_SEED_PHRASE_VALIDATION_ARG},
     DisplayError,
 };
@@ -246,11 +246,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Arg::with_name("json_rpc_url")
             .short("u")
             .long("url")
-            .value_name("URL")
+            .value_name("URL_OR_MONIKER")
             .takes_value(true)
             .global(true)
-            .validator(is_url)
-            .help("JSON RPC URL for the solana cluster"),
+            .validator(is_url_or_moniker)
+            .help("JSON RPC URL or some monikers (\"mainnet-beta\", \"testnet\", \"devnet\", \"localnet\")"),
     )
     .arg(
         Arg::with_name("websocket_url")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -250,7 +250,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             .takes_value(true)
             .global(true)
             .validator(is_url_or_moniker)
-            .help("JSON RPC URL or some monikers (\"mainnet-beta\", \"testnet\", \"devnet\", \"localnet\")"),
+            .help(
+                "URL for Solana's JSON RPC or moniker (or their first letter): \
+                   [mainnet-beta, testnet, devnet, localhost]",
+            ),
     )
     .arg(
         Arg::with_name("websocket_url")


### PR DESCRIPTION
#### Problem

I'm tired of typing `--url blabla...`.

Also, I can't instantly parse which cluster `--url` is pointing to when searching through shell history.

#### Summary of Changes

Introduce sensible defaults named after also sensible `ClusterType`.

Fixes #
