### PR TITLE
Upgradeable programs needs program account's program id

### DIFF
--- a/programs/bpf/rust/upgradeable/src/lib.rs
+++ b/programs/bpf/rust/upgradeable/src/lib.rs
@@ -2,16 +2,24 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
+    account_info::AccountInfo,
+    entrypoint,
+    entrypoint::ProgramResult,
+    msg,
+    pubkey::Pubkey,
+    sysvar::{clock, fees},
 };
 
 entrypoint!(process_instruction);
 fn process_instruction(
-    _program_id: &Pubkey,
+    program_id: &Pubkey,
     accounts: &[AccountInfo],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Upgradeable program");
-    assert_eq!(accounts.len(), 2);
+    assert_eq!(accounts.len(), 3);
+    assert_eq!(accounts[0].key, program_id);
+    assert_eq!(*accounts[1].key, clock::id());
+    assert_eq!(*accounts[2].key, fees::id());
     Err(42.into())
 }

--- a/programs/bpf/rust/upgraded/src/lib.rs
+++ b/programs/bpf/rust/upgraded/src/lib.rs
@@ -2,16 +2,24 @@
 
 extern crate solana_program;
 use solana_program::{
-    account_info::AccountInfo, entrypoint, entrypoint::ProgramResult, msg, pubkey::Pubkey,
+    account_info::AccountInfo,
+    entrypoint,
+    entrypoint::ProgramResult,
+    msg,
+    pubkey::Pubkey,
+    sysvar::{clock, fees},
 };
 
 entrypoint!(process_instruction);
 fn process_instruction(
-    _program_id: &Pubkey,
+    program_id: &Pubkey,
     accounts: &[AccountInfo],
     _instruction_data: &[u8],
 ) -> ProgramResult {
     msg!("Upgraded program");
-    assert_eq!(accounts.len(), 2);
+    assert_eq!(accounts.len(), 3);
+    assert_eq!(accounts[0].key, program_id);
+    assert_eq!(*accounts[1].key, clock::id());
+    assert_eq!(*accounts[2].key, fees::id());
     Err(43.into())
 }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1533,7 +1533,6 @@ fn test_program_bpf_test_use_latest_executor2() {
 fn test_program_bpf_upgrade() {
     solana_logger::setup();
 
-    let mut nonce = 0;
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -1548,17 +1547,18 @@ fn test_program_bpf_upgrade() {
     let (program_id, authority_keypair) =
         load_upgradeable_bpf_program(&bank_client, &mint_keypair, "solana_bpf_rust_upgradeable");
 
-    // Call upgrade program
-    nonce += 1;
-    let instruction = Instruction::new(
+    let mut instruction = Instruction::new(
         program_id,
-        &[nonce],
+        &[0],
         vec![
+            AccountMeta::new(program_id.clone(), false),
             AccountMeta::new(clock::id(), false),
             AccountMeta::new(fees::id(), false),
         ],
     );
-    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+
+    // Call upgrade program
+    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(0, InstructionError::Custom(42))
@@ -1574,16 +1574,8 @@ fn test_program_bpf_upgrade() {
     );
 
     // Call upgraded program
-    nonce += 1;
-    let instruction = Instruction::new(
-        program_id,
-        &[nonce],
-        vec![
-            AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
-        ],
-    );
-    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+    instruction.data[0] += 1;
+    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(0, InstructionError::Custom(43))
@@ -1609,15 +1601,7 @@ fn test_program_bpf_upgrade() {
     );
 
     // Call original program
-    nonce += 1;
-    let instruction = Instruction::new(
-        program_id,
-        &[nonce],
-        vec![
-            AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
-        ],
-    );
+    instruction.data[0] += 1;
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert_eq!(
         result.unwrap_err().unwrap(),
@@ -1630,7 +1614,6 @@ fn test_program_bpf_upgrade() {
 fn test_program_bpf_invoke_upgradeable_via_cpi() {
     solana_logger::setup();
 
-    let mut nonce = 0;
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -1653,18 +1636,20 @@ fn test_program_bpf_invoke_upgradeable_via_cpi() {
     let (program_id, authority_keypair) =
         load_upgradeable_bpf_program(&bank_client, &mint_keypair, "solana_bpf_rust_upgradeable");
 
-    // Call invoker program to invoke the upgradeable program
-    nonce += 1;
-    let instruction = Instruction::new(
+    let mut instruction = Instruction::new(
         invoke_and_return,
-        &[nonce],
+        &[0],
         vec![
+            AccountMeta::new(program_id, false),
             AccountMeta::new(program_id, false),
             AccountMeta::new(clock::id(), false),
             AccountMeta::new(fees::id(), false),
         ],
     );
-    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+
+    // Call invoker program to invoke the upgradeable program
+    instruction.data[0] += 1;
+    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(0, InstructionError::Custom(42))
@@ -1680,17 +1665,8 @@ fn test_program_bpf_invoke_upgradeable_via_cpi() {
     );
 
     // Call the upgraded program
-    nonce += 1;
-    let instruction = Instruction::new(
-        invoke_and_return,
-        &[nonce],
-        vec![
-            AccountMeta::new(program_id, false),
-            AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
-        ],
-    );
-    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+    instruction.data[0] += 1;
+    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(0, InstructionError::Custom(43))
@@ -1716,17 +1692,8 @@ fn test_program_bpf_invoke_upgradeable_via_cpi() {
     );
 
     // Call original program
-    nonce += 1;
-    let instruction = Instruction::new(
-        invoke_and_return,
-        &[nonce],
-        vec![
-            AccountMeta::new(program_id, false),
-            AccountMeta::new(clock::id(), false),
-            AccountMeta::new(fees::id(), false),
-        ],
-    );
-    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
+    instruction.data[0] += 1;
+    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
     assert_eq!(
         result.unwrap_err().unwrap(),
         TransactionError::InstructionError(0, InstructionError::Custom(42))

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -273,6 +273,7 @@ fn process_instruction_common(
         };
         executor.execute(
             loader_id,
+            first_account.unsigned_key(),
             keyed_accounts,
             instruction_data,
             invoke_context,
@@ -664,6 +665,7 @@ impl Executor for BPFExecutor {
     fn execute(
         &self,
         loader_id: &Pubkey,
+        program_id: &Pubkey,
         keyed_accounts: &[KeyedAccount],
         instruction_data: &[u8],
         invoke_context: &mut dyn InvokeContext,
@@ -676,12 +678,8 @@ impl Executor for BPFExecutor {
         let program = next_keyed_account(&mut keyed_accounts_iter)?;
 
         let parameter_accounts = keyed_accounts_iter.as_slice();
-        let mut parameter_bytes = serialize_parameters(
-            loader_id,
-            program.unsigned_key(),
-            parameter_accounts,
-            &instruction_data,
-        )?;
+        let mut parameter_bytes =
+            serialize_parameters(loader_id, program_id, parameter_accounts, &instruction_data)?;
         {
             let compute_meter = invoke_context.get_compute_meter();
             let mut vm = match create_vm(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10640,6 +10640,7 @@ pub(crate) mod tests {
     impl Executor for TestExecutor {
         fn execute(
             &self,
+            _loader_id: &Pubkey,
             _program_id: &Pubkey,
             _keyed_accounts: &[KeyedAccount],
             _instruction_data: &[u8],

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -248,6 +248,7 @@ pub trait Executor: Debug + Send + Sync {
     /// Execute the program
     fn execute(
         &self,
+        loader_id: &Pubkey,
         program_id: &Pubkey,
         keyed_accounts: &[KeyedAccount],
         instruction_data: &[u8],


### PR DESCRIPTION
#### Problem

Upgradeable programs get the address of the programdata account as the program id instead of the program account

#### Summary of Changes

Pass the program account's address

Fixes #
