### PR TITLE
Use optimistic confirmation in getSignatureStatuses, and various downstream client methods

### DIFF
--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -12,9 +12,9 @@ use solana_sdk::{
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum TransactionConfirmationStatus {
-    Recent,
-    Optimistic,
-    Max,
+    Processed,
+    OptimisticallyConfirmed,
+    Finalized,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -15,6 +15,7 @@ pub struct TransactionStatus {
     pub slot: Slot,
     pub confirmations: Option<usize>, // None = rooted
     pub err: Option<TransactionError>,
+    pub optimistically_confirmed: Option<bool>,
 }
 
 #[tarpc::service]

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -11,11 +11,18 @@ use solana_sdk::{
 };
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TransactionConfirmationStatus {
+    Recent,
+    Optimistic,
+    Max,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TransactionStatus {
     pub slot: Slot,
     pub confirmations: Option<usize>, // None = rooted
     pub err: Option<TransactionError>,
-    pub optimistically_confirmed: Option<bool>,
+    pub confirmation_status: Option<TransactionConfirmationStatus>,
 }
 
 #[tarpc::service]

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -13,7 +13,7 @@ use solana_sdk::{
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum TransactionConfirmationStatus {
     Processed,
-    OptimisticallyConfirmed,
+    Confirmed,
     Finalized,
 }
 

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -189,11 +189,11 @@ impl Banks for BanksServer {
             confirmations,
             err: status.err(),
             confirmation_status: if confirmations.is_none() {
-                Some(TransactionConfirmationStatus::Max)
+                Some(TransactionConfirmationStatus::Finalized)
             } else if optimistically_confirmed.is_some() {
-                Some(TransactionConfirmationStatus::Optimistic)
+                Some(TransactionConfirmationStatus::OptimisticallyConfirmed)
             } else {
-                Some(TransactionConfirmationStatus::Recent)
+                Some(TransactionConfirmationStatus::Processed)
             },
         })
     }

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -191,7 +191,7 @@ impl Banks for BanksServer {
             confirmation_status: if confirmations.is_none() {
                 Some(TransactionConfirmationStatus::Finalized)
             } else if optimistically_confirmed.is_some() {
-                Some(TransactionConfirmationStatus::OptimisticallyConfirmed)
+                Some(TransactionConfirmationStatus::Confirmed)
             } else {
                 Some(TransactionConfirmationStatus::Processed)
             },

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -169,6 +169,11 @@ impl Banks for BanksServer {
         let (slot, status) = bank.get_signature_status_slot(&signature)?;
         let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
+        let optimistically_confirmed_bank = self.bank(CommitmentLevel::SingleGossip);
+        let optimistically_confirmed = optimistically_confirmed_bank
+            .get_signature_status_slot(&signature)
+            .map(|_| true);
+
         let confirmations = if r_block_commitment_cache.root() >= slot
             && r_block_commitment_cache.highest_confirmed_root() >= slot
         {
@@ -182,6 +187,7 @@ impl Banks for BanksServer {
             slot,
             confirmations,
             err: status.err(),
+            optimistically_confirmed,
         })
     }
 

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -4,7 +4,9 @@ use futures::{
     future,
     prelude::stream::{self, StreamExt},
 };
-use solana_banks_interface::{Banks, BanksRequest, BanksResponse, TransactionStatus};
+use solana_banks_interface::{
+    Banks, BanksRequest, BanksResponse, TransactionConfirmationStatus, TransactionStatus,
+};
 use solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache};
 use solana_sdk::{
     account::Account,
@@ -170,9 +172,8 @@ impl Banks for BanksServer {
         let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
         let optimistically_confirmed_bank = self.bank(CommitmentLevel::SingleGossip);
-        let optimistically_confirmed = optimistically_confirmed_bank
-            .get_signature_status_slot(&signature)
-            .map(|_| true);
+        let optimistically_confirmed =
+            optimistically_confirmed_bank.get_signature_status_slot(&signature);
 
         let confirmations = if r_block_commitment_cache.root() >= slot
             && r_block_commitment_cache.highest_confirmed_root() >= slot
@@ -187,7 +188,13 @@ impl Banks for BanksServer {
             slot,
             confirmations,
             err: status.err(),
-            optimistically_confirmed,
+            confirmation_status: if confirmations.is_none() {
+                Some(TransactionConfirmationStatus::Max)
+            } else if optimistically_confirmed.is_some() {
+                Some(TransactionConfirmationStatus::Optimistic)
+            } else {
+                Some(TransactionConfirmationStatus::Recent)
+            },
         })
     }
 

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -41,6 +41,7 @@ use solana_sdk::{
     system_program,
     transaction::Transaction,
 };
+use solana_transaction_status::TransactionConfirmationStatus;
 use std::{
     cmp::min, collections::HashMap, error, fs::File, io::Read, net::UdpSocket, path::PathBuf,
     sync::Arc, thread::sleep, time::Duration,
@@ -1578,11 +1579,11 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
 
             for (signature, status) in pending_signatures.into_iter().zip(statuses.into_iter()) {
                 if let Some(status) = status {
-                    if status.confirmations.is_none()
-                        || (status.optimistically_confirmed.is_some()
-                            && status.optimistically_confirmed.unwrap())
-                        || status.confirmations.unwrap() > 1
-                    {
+                    if let Some(confirmation_status) = &status.confirmation_status {
+                        if *confirmation_status != TransactionConfirmationStatus::Recent {
+                            let _ = pending_transactions.remove(&signature);
+                        }
+                    } else if status.confirmations.is_none() || status.confirmations.unwrap() > 1 {
                         let _ = pending_transactions.remove(&signature);
                     }
                 }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1578,7 +1578,11 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
 
             for (signature, status) in pending_signatures.into_iter().zip(statuses.into_iter()) {
                 if let Some(status) = status {
-                    if status.confirmations.is_none() || status.confirmations.unwrap() > 1 {
+                    if status.confirmations.is_none()
+                        || (status.optimistically_confirmed.is_some()
+                            && status.optimistically_confirmed.unwrap())
+                        || status.confirmations.unwrap() > 1
+                    {
                         let _ = pending_transactions.remove(&signature);
                     }
                 }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1580,7 +1580,7 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
             for (signature, status) in pending_signatures.into_iter().zip(statuses.into_iter()) {
                 if let Some(status) = status {
                     if let Some(confirmation_status) = &status.confirmation_status {
-                        if *confirmation_status != TransactionConfirmationStatus::Recent {
+                        if *confirmation_status != TransactionConfirmationStatus::Processed {
                             let _ = pending_transactions.remove(&signature);
                         }
                     } else if status.confirmations.is_none() || status.confirmations.unwrap() > 1 {

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -106,7 +106,7 @@ impl RpcSender for MockSender {
                         slot: 1,
                         confirmations: None,
                         err,
-                        confirmation_status: Some(TransactionConfirmationStatus::Max),
+                        confirmation_status: Some(TransactionConfirmationStatus::Finalized),
                     })
                 };
                 let statuses: Vec<Option<TransactionStatus>> = params.as_array().unwrap()[0]

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -12,7 +12,7 @@ use solana_sdk::{
     signature::Signature,
     transaction::{self, Transaction, TransactionError},
 };
-use solana_transaction_status::TransactionStatus;
+use solana_transaction_status::{TransactionConfirmationStatus, TransactionStatus};
 use solana_version::Version;
 use std::{collections::HashMap, sync::RwLock};
 
@@ -106,7 +106,7 @@ impl RpcSender for MockSender {
                         slot: 1,
                         confirmations: None,
                         err,
-                        optimistically_confirmed: Some(true),
+                        confirmation_status: Some(TransactionConfirmationStatus::Max),
                     })
                 };
                 let statuses: Vec<Option<TransactionStatus>> = params.as_array().unwrap()[0]

--- a/client/src/mock_sender.rs
+++ b/client/src/mock_sender.rs
@@ -106,6 +106,7 @@ impl RpcSender for MockSender {
                         slot: 1,
                         confirmations: None,
                         err,
+                        optimistically_confirmed: Some(true),
                     })
                 };
                 let statuses: Vec<Option<TransactionStatus>> = params.as_array().unwrap()[0]

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -37,6 +37,7 @@ use solana_transaction_status::{
 };
 use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::{
+    cmp::min,
     net::SocketAddr,
     sync::RwLock,
     thread::sleep,
@@ -1372,7 +1373,7 @@ impl RpcClient {
 
             progress_bar.set_message(&format!(
                 "[{}/{}] Finalizing transaction {}",
-                confirmations + 1,
+                min(confirmations + 1, desired_confirmations),
                 desired_confirmations,
                 signature,
             ));

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1359,26 +1359,17 @@ impl RpcClient {
         }
         let now = Instant::now();
         loop {
-            match commitment.commitment {
-                CommitmentLevel::Max | CommitmentLevel::Root =>
-                // Return when default (max) commitment is reached
-                // Failed transactions have already been eliminated, `is_some` check is sufficient
-                {
-                    if self.get_signature_status(&signature)?.is_some() {
-                        progress_bar.set_message("Transaction confirmed");
-                        progress_bar.finish_and_clear();
-                        return Ok(signature);
-                    }
-                }
-                _ => {
-                    // Return when one confirmation has been reached
-                    if confirmations >= desired_confirmations {
-                        progress_bar.set_message("Transaction reached commitment");
-                        progress_bar.finish_and_clear();
-                        return Ok(signature);
-                    }
-                }
+            // Return when specified commitment is reached
+            // Failed transactions have already been eliminated, `is_some` check is sufficient
+            if self
+                .get_signature_status_with_commitment(&signature, commitment)?
+                .is_some()
+            {
+                progress_bar.set_message("Transaction confirmed");
+                progress_bar.finish_and_clear();
+                return Ok(signature);
             }
+
             progress_bar.set_message(&format!(
                 "[{}/{}] Finalizing transaction {}",
                 confirmations + 1,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -62,7 +62,8 @@ use solana_sdk::{
 };
 use solana_stake_program::stake_state::StakeState;
 use solana_transaction_status::{
-    EncodedConfirmedBlock, EncodedConfirmedTransaction, TransactionStatus, UiTransactionEncoding,
+    EncodedConfirmedBlock, EncodedConfirmedTransaction, TransactionConfirmationStatus,
+    TransactionStatus, UiTransactionEncoding,
 };
 use solana_vote_program::vote_state::{VoteState, MAX_LOCKOUT_HISTORY};
 use spl_token_v2_0::{
@@ -858,7 +859,7 @@ impl JsonRpcRequestProcessor {
                             status: status_meta.status,
                             confirmations: None,
                             err,
-                            optimistically_confirmed: Some(true),
+                            confirmation_status: Some(TransactionConfirmationStatus::Max),
                         }
                     })
                     .or_else(|| {
@@ -888,9 +889,8 @@ impl JsonRpcRequestProcessor {
         let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
         let optimistically_confirmed_bank = self.bank(Some(CommitmentConfig::single_gossip()));
-        let optimistically_confirmed = optimistically_confirmed_bank
-            .get_signature_status_slot(&signature)
-            .map(|_| true);
+        let optimistically_confirmed =
+            optimistically_confirmed_bank.get_signature_status_slot(&signature);
 
         let confirmations = if r_block_commitment_cache.root() >= slot
             && is_confirmed_rooted(&r_block_commitment_cache, bank, &self.blockstore, slot)
@@ -907,7 +907,13 @@ impl JsonRpcRequestProcessor {
             status,
             confirmations,
             err,
-            optimistically_confirmed,
+            confirmation_status: if confirmations.is_none() {
+                Some(TransactionConfirmationStatus::Max)
+            } else if optimistically_confirmed.is_some() {
+                Some(TransactionConfirmationStatus::Optimistic)
+            } else {
+                Some(TransactionConfirmationStatus::Recent)
+            },
         })
     }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -910,7 +910,7 @@ impl JsonRpcRequestProcessor {
             confirmation_status: if confirmations.is_none() {
                 Some(TransactionConfirmationStatus::Finalized)
             } else if optimistically_confirmed.is_some() {
-                Some(TransactionConfirmationStatus::OptimisticallyConfirmed)
+                Some(TransactionConfirmationStatus::Confirmed)
             } else {
                 Some(TransactionConfirmationStatus::Processed)
             },

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -858,6 +858,7 @@ impl JsonRpcRequestProcessor {
                             status: status_meta.status,
                             confirmations: None,
                             err,
+                            optimistically_confirmed: Some(true),
                         }
                     })
                     .or_else(|| {
@@ -886,6 +887,11 @@ impl JsonRpcRequestProcessor {
         let (slot, status) = bank.get_signature_status_slot(&signature)?;
         let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
+        let optimistically_confirmed_bank = self.bank(Some(CommitmentConfig::single_gossip()));
+        let optimistically_confirmed = optimistically_confirmed_bank
+            .get_signature_status_slot(&signature)
+            .map(|_| true);
+
         let confirmations = if r_block_commitment_cache.root() >= slot
             && is_confirmed_rooted(&r_block_commitment_cache, bank, &self.blockstore, slot)
         {
@@ -901,6 +907,7 @@ impl JsonRpcRequestProcessor {
             status,
             confirmations,
             err,
+            optimistically_confirmed,
         })
     }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -859,7 +859,7 @@ impl JsonRpcRequestProcessor {
                             status: status_meta.status,
                             confirmations: None,
                             err,
-                            confirmation_status: Some(TransactionConfirmationStatus::Max),
+                            confirmation_status: Some(TransactionConfirmationStatus::Finalized),
                         }
                     })
                     .or_else(|| {
@@ -908,11 +908,11 @@ impl JsonRpcRequestProcessor {
             confirmations,
             err,
             confirmation_status: if confirmations.is_none() {
-                Some(TransactionConfirmationStatus::Max)
+                Some(TransactionConfirmationStatus::Finalized)
             } else if optimistically_confirmed.is_some() {
-                Some(TransactionConfirmationStatus::Optimistic)
+                Some(TransactionConfirmationStatus::OptimisticallyConfirmed)
             } else {
-                Some(TransactionConfirmationStatus::Recent)
+                Some(TransactionConfirmationStatus::Processed)
             },
         })
     }

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1945,7 +1945,7 @@ An array of:
   - `slot: <u64>` - The slot the transaction was processed
   - `confirmations: <usize | null>` - Number of blocks since signature confirmation, null if rooted, as well as finalized by a supermajority of the cluster
   - `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24)
-  - `confirmationStatus: <string | null>` - The transaction's cluster confirmation status; either `recent`, `optimistic`, or `max`. See [Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - `confirmationStatus: <string | null>` - The transaction's cluster confirmation status; either `processed`, `optimisticallyConfirmed`, or `finalized`. See [Commitment](jsonrpc-api.md#configuring-state-commitment) for more on optimistic confirmation.
   - DEPRECATED: `status: <object>` - Transaction status
     - `"Ok": <null>` - Transaction was successful
     - `"Err": <ERR>` - Transaction failed with TransactionError

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1945,7 +1945,7 @@ An array of:
   - `slot: <u64>` - The slot the transaction was processed
   - `confirmations: <usize | null>` - Number of blocks since signature confirmation, null if rooted, as well as finalized by a supermajority of the cluster
   - `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24)
-  - `confirmationStatus: <string | null>` - The transaction's cluster confirmation status; either `processed`, `optimisticallyConfirmed`, or `finalized`. See [Commitment](jsonrpc-api.md#configuring-state-commitment) for more on optimistic confirmation.
+  - `confirmationStatus: <string | null>` - The transaction's cluster confirmation status; either `processed`, `confirmed`, or `finalized`. See [Commitment](jsonrpc-api.md#configuring-state-commitment) for more on optimistic confirmation.
   - DEPRECATED: `status: <object>` - Transaction status
     - `"Ok": <null>` - Transaction was successful
     - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -1985,7 +1985,7 @@ Result:
         "status": {
           "Ok": null
         },
-        "confirmationStatus": "optimisticallyConfirmed",
+        "confirmationStatus": "confirmed",
       },
       null
     ]

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1945,7 +1945,7 @@ An array of:
   - `slot: <u64>` - The slot the transaction was processed
   - `confirmations: <usize | null>` - Number of blocks since signature confirmation, null if rooted, as well as finalized by a supermajority of the cluster
   - `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24)
-  - `optimisticallyConfirmed: <bool | null>` - Whether the transaction has been optimistically confirmed by the cluster. See [singleGossip Commitment](jsonrpc-api.md#configuring-state-commitment)
+  - `confirmationStatus: <string | null>` - The transaction's cluster confirmation status; either `recent`, `optimistic`, or `max`. See [Commitment](jsonrpc-api.md#configuring-state-commitment)
   - DEPRECATED: `status: <object>` - Transaction status
     - `"Ok": <null>` - Transaction was successful
     - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -1985,7 +1985,7 @@ Result:
         "status": {
           "Ok": null
         },
-        "optimisticallyConfirmed": true,
+        "confirmationStatus": "optimisticallyConfirmed",
       },
       null
     ]
@@ -2030,7 +2030,7 @@ Result:
         "status": {
           "Ok": null
         },
-        "optimisticallyConfirmed": true,
+        "confirmationStatus": "finalized",
       },
       null
     ]

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1945,6 +1945,7 @@ An array of:
   - `slot: <u64>` - The slot the transaction was processed
   - `confirmations: <usize | null>` - Number of blocks since signature confirmation, null if rooted, as well as finalized by a supermajority of the cluster
   - `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24)
+  - `optimisticallyConfirmed: <bool | null>` - Whether the transaction has been optimistically confirmed by the cluster. See [singleGossip Commitment](jsonrpc-api.md#configuring-state-commitment)
   - DEPRECATED: `status: <object>` - Transaction status
     - `"Ok": <null>` - Transaction was successful
     - `"Err": <ERR>` - Transaction failed with TransactionError
@@ -1983,7 +1984,8 @@ Result:
         "err": null,
         "status": {
           "Ok": null
-        }
+        },
+        "optimisticallyConfirmed": true,
       },
       null
     ]
@@ -2027,7 +2029,8 @@ Result:
         "err": null,
         "status": {
           "Ok": null
-        }
+        },
+        "optimisticallyConfirmed": true,
       },
       null
     ]

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -257,6 +257,7 @@ impl From<TransactionInfo> for TransactionStatus {
             confirmations: None,
             status,
             err,
+            optimistically_confirmed: Some(true),
         }
     }
 }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -10,7 +10,8 @@ use solana_sdk::{
 use solana_storage_proto::convert::generated;
 use solana_transaction_status::{
     ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature, Reward,
-    TransactionStatus, TransactionStatusMeta, TransactionWithStatusMeta,
+    TransactionConfirmationStatus, TransactionStatus, TransactionStatusMeta,
+    TransactionWithStatusMeta,
 };
 use std::{collections::HashMap, convert::TryInto};
 use thiserror::Error;
@@ -257,7 +258,7 @@ impl From<TransactionInfo> for TransactionStatus {
             confirmations: None,
             status,
             err,
-            optimistically_confirmed: Some(true),
+            confirmation_status: Some(TransactionConfirmationStatus::Max),
         }
     }
 }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -258,7 +258,7 @@ impl From<TransactionInfo> for TransactionStatus {
             confirmations: None,
             status,
             err,
-            confirmation_status: Some(TransactionConfirmationStatus::Max),
+            confirmation_status: Some(TransactionConfirmationStatus::Finalized),
         }
     }
 }

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -2105,6 +2105,7 @@ mod tests {
                 confirmations: Some(15),
                 status: Ok(()),
                 err: None,
+                optimistically_confirmed: Some(true),
             })],
             &mut confirmations,
         )
@@ -2124,6 +2125,7 @@ mod tests {
                 confirmations: None,
                 status: Ok(()),
                 err: None,
+                optimistically_confirmed: Some(true),
             })],
             &mut confirmations,
         )

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -2106,7 +2106,7 @@ mod tests {
                 confirmations: Some(15),
                 status: Ok(()),
                 err: None,
-                confirmation_status: Some(TransactionConfirmationStatus::Max),
+                confirmation_status: Some(TransactionConfirmationStatus::Finalized),
             })],
             &mut confirmations,
         )
@@ -2126,7 +2126,7 @@ mod tests {
                 confirmations: None,
                 status: Ok(()),
                 err: None,
-                confirmation_status: Some(TransactionConfirmationStatus::Max),
+                confirmation_status: Some(TransactionConfirmationStatus::Finalized),
             })],
             &mut confirmations,
         )

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1038,6 +1038,7 @@ mod tests {
     use solana_core::test_validator::TestValidator;
     use solana_sdk::signature::{read_keypair_file, write_keypair_file, Signer};
     use solana_stake_program::stake_instruction::StakeInstruction;
+    use solana_transaction_status::TransactionConfirmationStatus;
 
     #[test]
     fn test_process_token_allocations() {
@@ -2105,7 +2106,7 @@ mod tests {
                 confirmations: Some(15),
                 status: Ok(()),
                 err: None,
-                optimistically_confirmed: Some(true),
+                confirmation_status: Some(TransactionConfirmationStatus::Max),
             })],
             &mut confirmations,
         )
@@ -2125,7 +2126,7 @@ mod tests {
                 confirmations: None,
                 status: Ok(()),
                 err: None,
-                optimistically_confirmed: Some(true),
+                confirmation_status: Some(TransactionConfirmationStatus::Max),
             })],
             &mut confirmations,
         )

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -307,6 +307,7 @@ mod tests {
             confirmations: Some(1),
             err: None,
             status: Ok(()),
+            optimistically_confirmed: Some(true),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)
@@ -334,6 +335,7 @@ mod tests {
             confirmations: None,
             err: Some(TransactionError::AccountNotFound),
             status: Ok(()),
+            optimistically_confirmed: Some(true),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)
@@ -358,6 +360,7 @@ mod tests {
             confirmations: None,
             err: None,
             status: Ok(()),
+            optimistically_confirmed: Some(true),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -308,7 +308,7 @@ mod tests {
             confirmations: Some(1),
             err: None,
             status: Ok(()),
-            confirmation_status: Some(TransactionConfirmationStatus::Optimistic),
+            confirmation_status: Some(TransactionConfirmationStatus::OptimisticallyConfirmed),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)
@@ -336,7 +336,7 @@ mod tests {
             confirmations: None,
             err: Some(TransactionError::AccountNotFound),
             status: Ok(()),
-            confirmation_status: Some(TransactionConfirmationStatus::Max),
+            confirmation_status: Some(TransactionConfirmationStatus::Finalized),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)
@@ -361,7 +361,7 @@ mod tests {
             confirmations: None,
             err: None,
             status: Ok(()),
-            confirmation_status: Some(TransactionConfirmationStatus::Max),
+            confirmation_status: Some(TransactionConfirmationStatus::Finalized),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -308,7 +308,7 @@ mod tests {
             confirmations: Some(1),
             err: None,
             status: Ok(()),
-            confirmation_status: Some(TransactionConfirmationStatus::OptimisticallyConfirmed),
+            confirmation_status: Some(TransactionConfirmationStatus::Confirmed),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -211,6 +211,7 @@ mod tests {
     use super::*;
     use csv::{ReaderBuilder, Trim};
     use solana_sdk::transaction::TransactionError;
+    use solana_transaction_status::TransactionConfirmationStatus;
     use tempfile::NamedTempFile;
 
     #[test]
@@ -307,7 +308,7 @@ mod tests {
             confirmations: Some(1),
             err: None,
             status: Ok(()),
-            optimistically_confirmed: Some(true),
+            confirmation_status: Some(TransactionConfirmationStatus::Optimistic),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)
@@ -335,7 +336,7 @@ mod tests {
             confirmations: None,
             err: Some(TransactionError::AccountNotFound),
             status: Ok(()),
-            optimistically_confirmed: Some(true),
+            confirmation_status: Some(TransactionConfirmationStatus::Max),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)
@@ -360,7 +361,7 @@ mod tests {
             confirmations: None,
             err: None,
             status: Ok(()),
-            optimistically_confirmed: Some(true),
+            confirmation_status: Some(TransactionConfirmationStatus::Max),
         };
         assert_eq!(
             update_finalized_transaction(&mut db, &signature, Some(transaction_status), 0, 0)

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -264,7 +264,7 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
 #[serde(rename_all = "camelCase")]
 pub enum TransactionConfirmationStatus {
     Processed,
-    OptimisticallyConfirmed,
+    Confirmed,
     Finalized,
 }
 
@@ -583,7 +583,7 @@ mod test {
             confirmations: Some(10),
             status: Ok(()),
             err: None,
-            confirmation_status: Some(TransactionConfirmationStatus::OptimisticallyConfirmed),
+            confirmation_status: Some(TransactionConfirmationStatus::Confirmed),
         };
 
         assert!(!status.satisfies_commitment(CommitmentConfig::default()));

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -263,9 +263,9 @@ impl From<TransactionStatusMeta> for UiTransactionStatusMeta {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TransactionConfirmationStatus {
-    Recent,
-    Optimistic,
-    Max,
+    Processed,
+    OptimisticallyConfirmed,
+    Finalized,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -284,7 +284,7 @@ impl TransactionStatus {
             CommitmentLevel::Max | CommitmentLevel::Root => self.confirmations.is_none(),
             CommitmentLevel::SingleGossip => {
                 if let Some(status) = &self.confirmation_status {
-                    *status != TransactionConfirmationStatus::Recent
+                    *status != TransactionConfirmationStatus::Processed
                 } else {
                     // These fallback cases handle TransactionStatus RPC responses from older software
                     self.confirmations.is_some() && self.confirmations.unwrap() > 1
@@ -569,7 +569,7 @@ mod test {
             confirmations: None,
             status: Ok(()),
             err: None,
-            confirmation_status: Some(TransactionConfirmationStatus::Max),
+            confirmation_status: Some(TransactionConfirmationStatus::Finalized),
         };
 
         assert!(status.satisfies_commitment(CommitmentConfig::default()));
@@ -583,7 +583,7 @@ mod test {
             confirmations: Some(10),
             status: Ok(()),
             err: None,
-            confirmation_status: Some(TransactionConfirmationStatus::Optimistic),
+            confirmation_status: Some(TransactionConfirmationStatus::OptimisticallyConfirmed),
         };
 
         assert!(!status.satisfies_commitment(CommitmentConfig::default()));
@@ -597,7 +597,7 @@ mod test {
             confirmations: Some(1),
             status: Ok(()),
             err: None,
-            confirmation_status: Some(TransactionConfirmationStatus::Recent),
+            confirmation_status: Some(TransactionConfirmationStatus::Processed),
         };
 
         assert!(!status.satisfies_commitment(CommitmentConfig::default()));


### PR DESCRIPTION
#### Problem
`getSignatureStatuses` is our recommended api for confirming transactions, but it doesn't convey any information about optimistic confirmation.

#### Summary of Changes
- Add `confirmationStatus` field to TransactionStatus and populate as `recent/optimistic/max`. Adds in check of the latest optimistically-confirmed bank (which we already have in RPC)
- Use `confirmationStatus` in various client methods to offer more-precise determination of transaction confirmation for the requested commitment

Follow-up work (as part of #14414 ): enable use of singleGossip commitment for solana-cli operations, like `solana transfer`, which are currently locked to max