### PR TITLE
Save 7G mem on mainnet fixing AccIndex overalloc.

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -498,7 +498,7 @@ impl<T: 'static + Clone> AccountsIndex<T> {
         if w_account_entry.is_none() {
             let new_entry = Arc::new(AccountMapEntryInner {
                 ref_count: AtomicU64::new(0),
-                slot_list: RwLock::new(SlotList::with_capacity(32)),
+                slot_list: RwLock::new(SlotList::with_capacity(1)),
             });
             let mut w_account_maps = self.account_maps.write().unwrap();
             let account_entry = w_account_maps.entry(*pubkey).or_insert_with(|| {


### PR DESCRIPTION
#### Problem

mainnet-beta wastes too much memory, pressuring linux's page cache needlessly.

One of main reason for huge memory footprint is in very wasteful AccountIndex behavior. Firstly, its entry is 32 bytes. But, we currently unconditionally overallocate by 32x. (Maybe picked from MAX_LOCKOUT and remnant of tps benchmarking days..) So, as opposed to the intention of slim index entry design (slot + AccountInfo; 32 bytes), the reality is that each account consumes `1024 bytes` via `Vec::with_capacity()`.

Currently, there are around 7M accounts (and counting) on mainnet-beta. And ~99.999% of them are never updated. For these accounts, we should only consume 32 bytes for AccountsIndex (the minimum required).

Okay, let's do the fun math: **`7M accounts * ~1000bytes = 7G`** :)

Also note that periodic full account set hashing hampers swapping out them properly. Thus, this also deteriorate the overall validator performance like a pest. (but haven't evaluated this to greater degree still)

#### Summary of Changes

Reduce it to bare minimum 1 for now. I think realloc cost doesn't matter much compared to the overall indexing cost, assuming exponential overallocation strategy in (rust's) `Vec`. (somehow we cap this strategy to 32 as a bonus...)

found via `heaptrack`

BEFORE

```
7.36GB leaked over 7216856 calls from
  alloc::alloc::alloc::h42bff26f59c33bd6
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:86
    in /tmp/solana-validator.no-jemalloc7
  alloc::alloc::Global::alloc_impl::h6e8f952ef784c80f
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:166
  _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::hcd5aa98f8fdb82d8
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:226
  alloc::raw_vec::RawVec$LT$T$C$A$GT$::allocate_in::h0ed891fb915f107f
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:188
  alloc::raw_vec::RawVec$LT$T$C$A$GT$::with_capacity_in::h6bdf60b63e75db33
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:129
  alloc::vec::Vec$LT$T$C$A$GT$::with_capacity_in::h57cdfbb02640dd8c
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec.rs:498
  alloc::vec::Vec$LT$T$GT$::with_capacity::hc035000e45333ccd
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec.rs:364
  solana_runtime::accounts_index::AccountsIndex$LT$T$GT$::get_account_write_entry_else_create::he34b4a7626bf7d95
    at runtime/src/accounts_index.rs:414
  solana_runtime::accounts_index::AccountsIndex$LT$T$GT$::upsert::haf6530f9f16e046f
    at runtime/src/accounts_index.rs:603

```

AFTER

```
518.56MB leaked over 7225158 calls from
  alloc::alloc::alloc::h42bff26f59c33bd6
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:86
    in /tmp/solana-validator.no-jemalloc8
  alloc::alloc::Global::alloc_impl::h6e8f952ef784c80f
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:166
  _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::hcd5aa98f8fdb82d8
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:226
  alloc::alloc::exchange_malloc::h8373e57f5f7edca9
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:316
  std::sync::rwlock::RwLock$LT$T$GT$::new::h58d1c8ab8fa8baf0
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sync/rwlock.rs:131
  solana_runtime::accounts_index::AccountsIndex$LT$T$GT$::get_account_write_entry_else_create::he34b4a7626bf7d95
    at runtime/src/accounts_index.rs:414
    in /tmp/solana-validator.no-jemalloc8
  solana_runtime::accounts_index::AccountsIndex$LT$T$GT$::upsert::haf6530f9f16e046f
    at runtime/src/accounts_index.rs:603

```

related?: #14366 #14410 