### PR TITLE
patches crds vote-index assignment bug

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1085,8 +1085,9 @@ impl ClusterInfo {
         // deque, or recent vote which has expired before getting enough
         // confirmations.
         // If all votes are still in the tower, add a new vote-index. If more
-        // than one vote is evicted, the one with most recent wallclock is
-        // returned because that had got fewer confirmations.
+        // than one vote is evicted, the oldest one by wallclock is returned in
+        // order to allow more recent votes more time to propagate through
+        // gossip.
         // TODO: When there are more than one vote evicted from the tower, only
         // one crds vote is overwritten here. Decide what to do with the rest.
         let mut num_crds_votes = 0;
@@ -1117,7 +1118,7 @@ impl ClusterInfo {
                         _ => panic!("this should not happen!"),
                     }
                 })
-                .max() // Take the evicted vote with the most recent wallclock.
+                .min() // Boot the oldest evicted vote by wallclock.
                 .map(|(_ /*wallclock*/, ix)| ix)
         };
         let vote_index = vote_index.unwrap_or(num_crds_votes);

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -63,6 +63,7 @@ use solana_sdk::{
 };
 use solana_streamer::sendmmsg::multicast;
 use solana_streamer::streamer::{PacketReceiver, PacketSender};
+use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::{
     borrow::Cow,
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
@@ -1076,22 +1077,59 @@ impl ClusterInfo {
         self.push_message(CrdsValue::new_signed(message, &self.keypair));
     }
 
-    pub fn push_vote(&self, tower_index: usize, vote: Transaction) {
+    pub fn push_vote(&self, tower: &[Slot], vote: Transaction) {
+        debug_assert!(tower.iter().tuple_windows().all(|(a, b)| a < b));
         let now = timestamp();
-        let vote = Vote::new(&self.id(), vote, now);
-        let vote_ix = {
-            let r_gossip =
-                self.time_gossip_read_lock("gossip_read_push_vote", &self.stats.push_vote_read);
-            let current_votes: Vec<_> = (0..crds_value::MAX_VOTES)
-                .filter_map(|ix| r_gossip.crds.lookup(&CrdsValueLabel::Vote(ix, self.id())))
-                .collect();
-            CrdsValue::compute_vote_index(tower_index, current_votes)
+        // Find a crds vote which is evicted from the tower, and recycle its
+        // vote-index. This can be either an old vote which is popped off the
+        // deque, or recent vote which has expired before getting enough
+        // confirmations.
+        // If all votes are still in the tower, add a new vote-index. If more
+        // than one vote is evicted, the one with most recent wallclock is
+        // returned because that had got fewer confirmations.
+        // TODO: When there are more than one vote evicted from the tower, only
+        // one crds vote is overwritten here. Decide what to do with the rest.
+        let mut num_crds_votes = 0;
+        let self_pubkey = self.id();
+        // Returns true if the tower does not contain the vote.slot.
+        let should_evict_vote = |vote: &Vote| -> bool {
+            match vote.slot() {
+                Some(slot) => !tower.contains(&slot),
+                None => {
+                    error!("crds vote with no slots!");
+                    true
+                }
+            }
         };
-        let entry = CrdsValue::new_signed(CrdsData::Vote(vote_ix, vote), &self.keypair);
-        self.local_message_pending_push_queue
+        let vote_index = {
+            let gossip =
+                self.time_gossip_read_lock("gossip_read_push_vote", &self.stats.push_vote_read);
+            (0..MAX_LOCKOUT_HISTORY as u8)
+                .filter_map(|ix| {
+                    let vote = CrdsValueLabel::Vote(ix, self_pubkey);
+                    let vote = gossip.crds.lookup(&vote)?;
+                    num_crds_votes += 1;
+                    match &vote.data {
+                        CrdsData::Vote(_, vote) if should_evict_vote(vote) => {
+                            Some((vote.wallclock, ix))
+                        }
+                        CrdsData::Vote(_, _) => None,
+                        _ => panic!("this should not happen!"),
+                    }
+                })
+                .max() // Take the evicted vote with the most recent wallclock.
+                .map(|(_ /*wallclock*/, ix)| ix)
+        };
+        let vote_index = vote_index.unwrap_or(num_crds_votes);
+        assert!((vote_index as usize) < MAX_LOCKOUT_HISTORY);
+        let vote = Vote::new(self_pubkey, vote, now);
+        debug_assert_eq!(vote.slot().unwrap(), *tower.last().unwrap());
+        let vote = CrdsData::Vote(vote_index, vote);
+        let vote = CrdsValue::new_signed(vote, &self.keypair);
+        self.gossip
             .write()
             .unwrap()
-            .push((entry, now));
+            .process_push_message(&self_pubkey, vec![vote], now);
     }
 
     pub fn send_vote(&self, vote: &Transaction) -> Result<()> {
@@ -1116,7 +1154,7 @@ impl ClusterInfo {
             .map(|vote| {
                 max_ts = std::cmp::max(vote.insert_timestamp, max_ts);
                 let transaction = match &vote.value.data {
-                    CrdsData::Vote(_, vote) => vote.transaction.clone(),
+                    CrdsData::Vote(_, vote) => vote.transaction().clone(),
                     _ => panic!("this should not happen!"),
                 };
                 (vote.value.label(), transaction)
@@ -3146,7 +3184,6 @@ mod tests {
     use crate::crds_value::{CrdsValue, CrdsValueLabel, Vote as CrdsVote};
     use itertools::izip;
     use rand::seq::SliceRandom;
-    use solana_perf::test_tx::test_tx;
     use solana_sdk::signature::{Keypair, Signer};
     use solana_vote_program::{vote_instruction, vote_state::Vote};
     use std::iter::repeat_with;
@@ -3632,6 +3669,7 @@ mod tests {
 
     #[test]
     fn test_push_vote() {
+        let mut rng = rand::thread_rng();
         let keys = Keypair::new();
         let contact_info = ContactInfo::new_localhost(&keys.pubkey(), 0);
         let cluster_info = ClusterInfo::new_with_invalid_keypair(contact_info);
@@ -3643,9 +3681,21 @@ mod tests {
         assert_eq!(max_ts, now);
 
         // add a vote
-        let tx = test_tx();
-        let index = 1;
-        cluster_info.push_vote(index, tx.clone());
+        let vote = Vote::new(
+            vec![1, 3, 7], // slots
+            solana_sdk::hash::new_rand(&mut rng),
+        );
+        let ix = vote_instruction::vote(
+            &Pubkey::new_unique(), // vote_pubkey
+            &Pubkey::new_unique(), // authorized_voter_pubkey
+            vote,
+        );
+        let tx = Transaction::new_with_payer(
+            &[ix], // instructions
+            None,  // payer
+        );
+        let tower = vec![7]; // Last slot in the vote.
+        cluster_info.push_vote(&tower, tx.clone());
         cluster_info.flush_push_queue();
 
         // -1 to make sure that the clock is strictly lower then when insert occurred
@@ -4029,11 +4079,11 @@ mod tests {
         vote_tx.partial_sign(&[keypair.as_ref()], Hash::default());
         vote_tx.partial_sign(&[keypair.as_ref()], Hash::default());
 
-        let vote = CrdsVote {
-            from: keypair.pubkey(),
-            transaction: vote_tx,
-            wallclock: 0,
-        };
+        let vote = CrdsVote::new(
+            keypair.pubkey(),
+            vote_tx,
+            0, // wallclock
+        );
         let vote = CrdsValue::new_signed(CrdsData::Vote(1, vote), &Keypair::new());
         assert!(bincode::serialized_size(&vote).unwrap() <= PUSH_MESSAGE_MAX_PAYLOAD_SIZE as u64);
     }

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -1428,7 +1428,7 @@ mod test {
 
         // construct something that's not a contact info
         let peer_vote =
-            CrdsValue::new_unsigned(CrdsData::Vote(0, Vote::new(&peer_pubkey, test_tx(), 0)));
+            CrdsValue::new_unsigned(CrdsData::Vote(0, Vote::new(peer_pubkey, test_tx(), 0)));
         // check that older CrdsValues (non-ContactInfos) infos pass even if are too old,
         // but a recent contact info (inserted above) exists
         assert_eq!(

--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use bincode::{serialize, serialized_size};
 use rand::{CryptoRng, Rng};
+use serde::de::{Deserialize, Deserializer};
 use solana_sdk::sanitize::{Sanitize, SanitizeError};
 use solana_sdk::timing::timestamp;
 use solana_sdk::{
@@ -16,9 +17,10 @@ use solana_sdk::{
     signature::{Keypair, Signable, Signature, Signer},
     transaction::Transaction,
 };
+use solana_vote_program::vote_transaction::parse_vote_transaction;
 use std::{
     borrow::{Borrow, Cow},
-    collections::{hash_map::Entry, BTreeSet, HashMap, HashSet},
+    collections::{hash_map::Entry, BTreeSet, HashMap},
     fmt,
 };
 
@@ -26,6 +28,8 @@ pub const MAX_WALLCLOCK: u64 = 1_000_000_000_000_000;
 pub const MAX_SLOT: u64 = 1_000_000_000_000_000;
 
 pub type VoteIndex = u8;
+// TODO: Remove this in favor of vote_state::MAX_LOCKOUT_HISTORY once
+// the fleet is updated to the new ClusterInfo::push_vote code.
 pub const MAX_VOTES: VoteIndex = 32;
 
 pub type EpochSlotsIndex = u8;
@@ -241,11 +245,13 @@ impl Sanitize for LowestSlot {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, AbiExample)]
+#[derive(Clone, Debug, PartialEq, AbiExample, Serialize)]
 pub struct Vote {
-    pub from: Pubkey,
-    pub transaction: Transaction,
-    pub wallclock: u64,
+    pub(crate) from: Pubkey,
+    transaction: Transaction,
+    pub(crate) wallclock: u64,
+    #[serde(skip_serializing)]
+    slot: Option<Slot>,
 }
 
 impl Sanitize for Vote {
@@ -257,11 +263,14 @@ impl Sanitize for Vote {
 }
 
 impl Vote {
-    pub fn new(from: &Pubkey, transaction: Transaction, wallclock: u64) -> Self {
+    pub fn new(from: Pubkey, transaction: Transaction, wallclock: u64) -> Self {
+        let slot = parse_vote_transaction(&transaction)
+            .and_then(|(_, vote, _)| vote.slots.last().copied());
         Self {
-            from: *from,
+            from,
             transaction,
             wallclock,
+            slot,
         }
     }
 
@@ -271,7 +280,41 @@ impl Vote {
             from: pubkey.unwrap_or_else(pubkey::new_rand),
             transaction: Transaction::default(),
             wallclock: new_rand_timestamp(rng),
+            slot: None,
         }
+    }
+
+    pub(crate) fn transaction(&self) -> &Transaction {
+        &self.transaction
+    }
+
+    pub(crate) fn slot(&self) -> Option<Slot> {
+        self.slot
+    }
+}
+
+impl<'de> Deserialize<'de> for Vote {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Vote {
+            from: Pubkey,
+            transaction: Transaction,
+            wallclock: u64,
+        };
+        let vote = Vote::deserialize(deserializer)?;
+        let vote = match vote.transaction.sanitize() {
+            Ok(_) => Self::new(vote.from, vote.transaction, vote.wallclock),
+            Err(_) => Self {
+                from: vote.from,
+                transaction: vote.transaction,
+                wallclock: vote.wallclock,
+                slot: None,
+            },
+        };
+        Ok(vote)
     }
 }
 
@@ -529,16 +572,11 @@ impl CrdsValue {
             _ => None,
         }
     }
-    pub fn vote(&self) -> Option<&Vote> {
+
+    #[cfg(test)]
+    fn vote(&self) -> Option<&Vote> {
         match &self.data {
             CrdsData::Vote(_, vote) => Some(vote),
-            _ => None,
-        }
-    }
-
-    pub fn vote_index(&self) -> Option<VoteIndex> {
-        match &self.data {
-            CrdsData::Vote(ix, _) => Some(*ix),
             _ => None,
         }
     }
@@ -590,33 +628,6 @@ impl CrdsValue {
         serialized_size(&self).expect("unable to serialize contact info")
     }
 
-    pub fn compute_vote_index(tower_index: usize, mut votes: Vec<&CrdsValue>) -> VoteIndex {
-        let mut available: HashSet<VoteIndex> = (0..MAX_VOTES).collect();
-        votes.iter().filter_map(|v| v.vote_index()).for_each(|ix| {
-            available.remove(&ix);
-        });
-
-        // free index
-        if !available.is_empty() {
-            return *available.iter().next().unwrap();
-        }
-
-        assert!(votes.len() == MAX_VOTES as usize);
-        votes.sort_by_key(|v| v.vote().expect("all values must be votes").wallclock);
-
-        // If Tower is full, oldest removed first
-        if tower_index + 1 == MAX_VOTES as usize {
-            return votes[0].vote_index().expect("all values must be votes");
-        }
-
-        // If Tower is not full, the early votes have expired
-        assert!(tower_index < MAX_VOTES as usize);
-
-        votes[tower_index]
-            .vote_index()
-            .expect("all values must be votes")
-    }
-
     /// Returns true if, regardless of prunes, this crds-value
     /// should be pushed to the receiving node.
     pub fn should_force_push(&self, peer: &Pubkey) -> bool {
@@ -663,10 +674,11 @@ pub(crate) fn sanitize_wallclock(wallclock: u64) -> Result<(), SanitizeError> {
 mod test {
     use super::*;
     use crate::contact_info::ContactInfo;
-    use bincode::deserialize;
+    use bincode::{deserialize, Options};
     use solana_perf::test_tx::test_tx;
     use solana_sdk::signature::{Keypair, Signer};
     use solana_sdk::timing::timestamp;
+    use solana_vote_program::{vote_instruction, vote_state};
     use std::cmp::Ordering;
     use std::iter::repeat_with;
 
@@ -679,7 +691,7 @@ mod test {
 
         let v = CrdsValue::new_unsigned(CrdsData::Vote(
             0,
-            Vote::new(&Pubkey::default(), test_tx(), 0),
+            Vote::new(Pubkey::default(), test_tx(), 0),
         ));
         assert_eq!(v.wallclock(), 0);
         let key = v.vote().unwrap().from;
@@ -731,7 +743,7 @@ mod test {
         verify_signatures(&mut v, &keypair, &wrong_keypair);
         v = CrdsValue::new_unsigned(CrdsData::Vote(
             0,
-            Vote::new(&keypair.pubkey(), test_tx(), timestamp()),
+            Vote::new(keypair.pubkey(), test_tx(), timestamp()),
         ));
         verify_signatures(&mut v, &keypair, &wrong_keypair);
         v = CrdsValue::new_unsigned(CrdsData::LowestSlot(
@@ -747,11 +759,43 @@ mod test {
         let vote = CrdsValue::new_signed(
             CrdsData::Vote(
                 MAX_VOTES,
-                Vote::new(&keypair.pubkey(), test_tx(), timestamp()),
+                Vote::new(keypair.pubkey(), test_tx(), timestamp()),
             ),
             &keypair,
         );
         assert!(vote.sanitize().is_err());
+    }
+
+    #[test]
+    fn test_vote_round_trip() {
+        let mut rng = rand::thread_rng();
+        let vote = vote_state::Vote::new(
+            vec![1, 3, 7], // slots
+            solana_sdk::hash::new_rand(&mut rng),
+        );
+        let ix = vote_instruction::vote(
+            &Pubkey::new_unique(), // vote_pubkey
+            &Pubkey::new_unique(), // authorized_voter_pubkey
+            vote,
+        );
+        let tx = Transaction::new_with_payer(
+            &[ix],                       // instructions
+            Some(&Pubkey::new_unique()), // payer
+        );
+        let vote = Vote::new(
+            Pubkey::new_unique(), // from
+            tx,
+            rng.gen(), // wallclock
+        );
+        assert_eq!(vote.slot, Some(7));
+        let bytes = bincode::serialize(&vote).unwrap();
+        let other = bincode::deserialize(&bytes[..]).unwrap();
+        assert_eq!(vote, other);
+        assert_eq!(other.slot, Some(7));
+        let bytes = bincode::options().serialize(&vote).unwrap();
+        let other = bincode::options().deserialize(&bytes[..]).unwrap();
+        assert_eq!(vote, other);
+        assert_eq!(other.slot, Some(7));
     }
 
     #[test]
@@ -765,49 +809,6 @@ mod test {
             &keypair,
         );
         assert_eq!(item.sanitize(), Err(SanitizeError::ValueOutOfBounds));
-    }
-    #[test]
-    fn test_compute_vote_index_empty() {
-        for i in 0..MAX_VOTES {
-            let votes = vec![];
-            assert!(CrdsValue::compute_vote_index(i as usize, votes) < MAX_VOTES);
-        }
-    }
-
-    #[test]
-    fn test_compute_vote_index_one() {
-        let keypair = Keypair::new();
-        let vote = CrdsValue::new_unsigned(CrdsData::Vote(
-            0,
-            Vote::new(&keypair.pubkey(), test_tx(), 0),
-        ));
-        for i in 0..MAX_VOTES {
-            let votes = vec![&vote];
-            assert!(CrdsValue::compute_vote_index(i as usize, votes) > 0);
-            let votes = vec![&vote];
-            assert!(CrdsValue::compute_vote_index(i as usize, votes) < MAX_VOTES);
-        }
-    }
-
-    #[test]
-    fn test_compute_vote_index_full() {
-        let keypair = Keypair::new();
-        let votes: Vec<_> = (0..MAX_VOTES)
-            .map(|x| {
-                CrdsValue::new_unsigned(CrdsData::Vote(
-                    x,
-                    Vote::new(&keypair.pubkey(), test_tx(), x as u64),
-                ))
-            })
-            .collect();
-        let vote_refs = votes.iter().collect();
-        //pick the oldest vote when full
-        assert_eq!(CrdsValue::compute_vote_index(31, vote_refs), 0);
-        //pick the index
-        let vote_refs = votes.iter().collect();
-        assert_eq!(CrdsValue::compute_vote_index(0, vote_refs), 0);
-        let vote_refs = votes.iter().collect();
-        assert_eq!(CrdsValue::compute_vote_index(30, vote_refs), 30);
     }
 
     fn serialize_deserialize_value(value: &mut CrdsValue, keypair: &Keypair) {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1088,7 +1088,7 @@ impl ReplayStage {
             inc_new_counter_info!("replay_stage-voted_empty_bank", 1);
         }
         trace!("handle votable bank {}", bank.slot());
-        let (vote, tower_index) = tower.new_vote_from_bank(bank, vote_account_pubkey);
+        let (vote, tower_slots) = tower.new_vote_from_bank(bank, vote_account_pubkey);
         let new_root = tower.record_bank_vote(vote);
         let last_vote = tower.last_vote_and_timestamp();
 
@@ -1163,7 +1163,7 @@ impl ReplayStage {
             vote_account_pubkey,
             authorized_voter_keypairs,
             last_vote,
-            tower_index,
+            &tower_slots,
             switch_fork_decision,
         );
     }
@@ -1174,7 +1174,7 @@ impl ReplayStage {
         vote_account_pubkey: &Pubkey,
         authorized_voter_keypairs: &[Arc<Keypair>],
         vote: Vote,
-        tower_index: usize,
+        tower: &[Slot],
         switch_fork_decision: &SwitchForkDecision,
     ) {
         if authorized_voter_keypairs.is_empty() {
@@ -1249,7 +1249,7 @@ impl ReplayStage {
         vote_tx.partial_sign(&[node_keypair.as_ref()], blockhash);
         vote_tx.partial_sign(&[authorized_voter_keypair.as_ref()], blockhash);
         let _ = cluster_info.send_vote(&vote_tx);
-        cluster_info.push_vote(tower_index, vote_tx);
+        cluster_info.push_vote(tower, vote_tx);
     }
 
     fn update_commitment_cache(

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -429,6 +429,12 @@ impl VoteState {
         self.last_lockout().map(|v| v.slot)
     }
 
+    // Upto MAX_LOCKOUT_HISTORY many recent unexpired
+    // vote slots pushed onto the stack.
+    pub fn tower(&self) -> Vec<Slot> {
+        self.votes.iter().map(|v| v.slot).collect()
+    }
+
     fn current_epoch(&self) -> Epoch {
         if self.epoch_credits.is_empty() {
             0


### PR DESCRIPTION
#### Problem
If tower is full, old votes are evicted from the front of the deque:
https://github.com/solana-labs/solana/blob/2074e407c/programs/vote/src/vote_state/mod.rs#L367-L373
whereas recent votes if expire are evicted from the back:
https://github.com/solana-labs/solana/blob/2074e407c/programs/vote/src/vote_state/mod.rs#L529-L537

As a result, from a single tower_index scalar, we cannot infer which crds-vote
should be overwritten:
https://github.com/solana-labs/solana/blob/2074e407c/core/src/crds_value.rs#L576

In addition there is an off by one bug in the existing code. tower_index is
bounded by MAX_LOCKOUT_HISTORY - 1:
https://github.com/solana-labs/solana/blob/2074e407c/core/src/consensus.rs#L382
So, it is at most 30, whereas MAX_VOTES is 32:
https://github.com/solana-labs/solana/blob/2074e407c/core/src/crds_value.rs#L29
Which means that this branch is never taken:
https://github.com/solana-labs/solana/blob/2074e407c/core/src/crds_value.rs#L590-L593
so crds table alwasys keeps 29 **oldest** votes by wallclock, and then
only overrides the 30st one each time. (i.e a tally of only two most
recent votes).

#### Summary of Changes
* Pass current state of tower to push-vote.
* Find which crds vote is evicted from the tower, and override that one.