### PR TITLE
explorer: display block time on cluster stats

### DIFF
--- a/explorer/src/pages/ClusterStatsPage.tsx
+++ b/explorer/src/pages/ClusterStatsPage.tsx
@@ -90,7 +90,7 @@ function StatsCardBody() {
         <tr>
           <td className="w-100">Block time</td>
           <td className="text-lg-right text-monospace">
-            {displayTimestamp(blockTime * 1000)}
+            {displayTimestamp(blockTime)}
           </td>
         </tr>
       )}

--- a/explorer/src/pages/ClusterStatsPage.tsx
+++ b/explorer/src/pages/ClusterStatsPage.tsx
@@ -10,6 +10,7 @@ import {
 import { slotsToHumanString } from "utils";
 import { useCluster } from "providers/cluster";
 import { TpsCard } from "components/TpsCard";
+import { displayTimestamp } from "utils/date";
 
 const CLUSTER_STATS_TIMEOUT = 10000;
 
@@ -52,7 +53,12 @@ function StatsCardBody() {
     return <StatsNotReady error={error} />;
   }
 
-  const { avgSlotTime_1h, avgSlotTime_1min, epochInfo } = dashboardInfo;
+  const {
+    avgSlotTime_1h,
+    avgSlotTime_1min,
+    epochInfo,
+    blockTime,
+  } = dashboardInfo;
   const hourlySlotTime = Math.round(1000 * avgSlotTime_1h);
   const averageSlotTime = Math.round(1000 * avgSlotTime_1min);
   const { slotIndex, slotsInEpoch } = epochInfo;
@@ -77,6 +83,14 @@ function StatsCardBody() {
           <td className="w-100">Block height</td>
           <td className="text-lg-right text-monospace">
             <Slot slot={blockHeight} />
+          </td>
+        </tr>
+      )}
+      {blockTime && (
+        <tr>
+          <td className="w-100">Block time</td>
+          <td className="text-lg-right text-monospace">
+            {displayTimestamp(blockTime * 1000)}
           </td>
         </tr>
       )}

--- a/explorer/src/providers/stats/solanaClusterStats.tsx
+++ b/explorer/src/providers/stats/solanaClusterStats.tsx
@@ -148,10 +148,19 @@ export function SolanaClusterStatsProvider({ children }: Props) {
     const getEpochInfo = async () => {
       try {
         const epochInfo = await connection.getEpochInfo();
+        const blockTime = await connection.getBlockTime(epochInfo.absoluteSlot);
+
         dispatchDashboardInfo({
           type: DashboardInfoActionType.SetEpochInfo,
           data: epochInfo,
         });
+
+        if (blockTime !== null) {
+          dispatchDashboardInfo({
+            type: DashboardInfoActionType.SetBlockTime,
+            data: blockTime,
+          });
+        }
       } catch (error) {
         if (cluster !== Cluster.Custom) {
           reportError(error, { url });

--- a/explorer/src/providers/stats/solanaDashboardInfo.tsx
+++ b/explorer/src/providers/stats/solanaDashboardInfo.tsx
@@ -108,10 +108,14 @@ export function dashboardInfoReducer(
           ? ClusterStatsStatus.Ready
           : ClusterStatsStatus.Loading;
 
-      let blockTime;
+      let blockTime = state.blockTime;
 
       // interpolate blocktime based on last known blocktime and average slot time
-      if (state.lastBlockTime && state.avgSlotTime_1h !== 0) {
+      if (
+        state.lastBlockTime &&
+        state.avgSlotTime_1h !== 0 &&
+        action.data.absoluteSlot >= state.lastBlockTime.slot
+      ) {
         blockTime =
           state.lastBlockTime.blockTime +
           (action.data.absoluteSlot - state.lastBlockTime.slot) *

--- a/explorer/src/providers/stats/solanaDashboardInfo.tsx
+++ b/explorer/src/providers/stats/solanaDashboardInfo.tsx
@@ -6,11 +6,13 @@ export type DashboardInfo = {
   avgSlotTime_1h: number;
   avgSlotTime_1min: number;
   epochInfo: EpochInfo;
+  blockTime?: number;
 };
 
 export enum DashboardInfoActionType {
   SetPerfSamples,
   SetEpochInfo,
+  SetBlockTime,
   SetError,
   Reset,
 }
@@ -35,17 +37,30 @@ export type DashboardInfoActionSetError = {
   data: string;
 };
 
+export type DashboardInfoActionSetBlockTime = {
+  type: DashboardInfoActionType.SetBlockTime;
+  data: number;
+};
+
 export type DashboardInfoAction =
   | DashboardInfoActionSetPerfSamples
   | DashboardInfoActionSetEpochInfo
   | DashboardInfoActionReset
-  | DashboardInfoActionSetError;
+  | DashboardInfoActionSetError
+  | DashboardInfoActionSetBlockTime;
 
 export function dashboardInfoReducer(
   state: DashboardInfo,
   action: DashboardInfoAction
 ) {
   switch (action.type) {
+    case DashboardInfoActionType.SetBlockTime: {
+      return {
+        ...state,
+        blockTime: action.data,
+      };
+    }
+
     case DashboardInfoActionType.SetPerfSamples: {
       if (action.data.length < 1) {
         return state;


### PR DESCRIPTION
#### Problem
Cluster stats should display the current block time.ie, every time we update the current slot,  include a call to getBlockTime, and display the current time (same local time format used for locked stake accounts).

#### Summary of Changes
Fetches blocktime when the absolute slot changes. Displayed with proper format on cluster stats page. 