### PR TITLE
consolidate constants related to time for future refactoring

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -8,7 +8,7 @@ use solana_measure::measure::Measure;
 use solana_metrics::{self, datapoint_info};
 use solana_sdk::{
     client::Client,
-    clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, MAX_PROCESSING_AGE},
+    clock::{DEFAULT_S_PER_SLOT, MAX_PROCESSING_AGE},
     commitment_config::CommitmentConfig,
     fee_calculator::FeeCalculator,
     hash::Hash,
@@ -32,8 +32,7 @@ use std::{
 };
 
 // The point at which transactions become "too old", in seconds.
-const MAX_TX_QUEUE_AGE: u64 =
-    MAX_PROCESSING_AGE as u64 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
+const MAX_TX_QUEUE_AGE: u64 = (MAX_PROCESSING_AGE as f64 * DEFAULT_S_PER_SLOT) as u64;
 
 pub const MAX_SPENDS_PER_TX: u64 = 4;
 

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -284,10 +284,7 @@ impl fmt::Display for CliEpochInfo {
 }
 
 fn slot_to_human_time(slot: Slot) -> String {
-    humantime::format_duration(Duration::from_secs(
-        slot * clock::DEFAULT_TICKS_PER_SLOT / clock::DEFAULT_TICKS_PER_SECOND,
-    ))
-    .to_string()
+    humantime::format_duration(Duration::from_millis(slot * clock::DEFAULT_MS_PER_SLOT)).to_string()
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1327,9 +1327,7 @@ pub fn process_ping(
 
                     // Sleep for half a slot
                     if signal_receiver
-                        .recv_timeout(Duration::from_millis(
-                            500 * clock::DEFAULT_TICKS_PER_SLOT / clock::DEFAULT_TICKS_PER_SECOND,
-                        ))
+                        .recv_timeout(Duration::from_millis(clock::DEFAULT_MS_PER_SLOT / 2))
                         .is_ok()
                     {
                         break 'mainloop;

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -22,10 +22,7 @@ use solana_account_decoder::{
 };
 use solana_sdk::{
     account::Account,
-    clock::{
-        Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT,
-        MAX_HASH_AGE_IN_SECONDS,
-    },
+    clock::{Slot, UnixTimestamp, DEFAULT_MS_PER_SLOT, MAX_HASH_AGE_IN_SECONDS},
     commitment_config::{CommitmentConfig, CommitmentLevel},
     epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
@@ -903,9 +900,7 @@ impl RpcClient {
             debug!("Got same blockhash ({:?}), will retry...", blockhash);
 
             // Retry ~twice during a slot
-            sleep(Duration::from_millis(
-                500 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND,
-            ));
+            sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT / 2));
             num_retries += 1;
         }
         Err(RpcError::ForUser(format!(

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -15,9 +15,7 @@ use solana_ledger::{
 };
 use solana_sdk::{
     client::SyncClient,
-    clock::{
-        self, Slot, DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS,
-    },
+    clock::{self, Slot, DEFAULT_MS_PER_SLOT, NUM_CONSECUTIVE_LEADER_SLOTS},
     commitment_config::CommitmentConfig,
     epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     hash::Hash,
@@ -34,8 +32,6 @@ use std::{
     thread::sleep,
     time::{Duration, Instant},
 };
-
-const DEFAULT_SLOT_MILLIS: u64 = (DEFAULT_TICKS_PER_SLOT * 1000) / DEFAULT_TICKS_PER_SECOND;
 
 /// Spend and verify from every node in the network
 pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
@@ -131,7 +127,7 @@ pub fn validator_exit(entry_point_info: &ContactInfo, nodes: usize) {
         let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         assert!(client.validator_exit().unwrap());
     }
-    sleep(Duration::from_millis(DEFAULT_SLOT_MILLIS));
+    sleep(Duration::from_millis(DEFAULT_MS_PER_SLOT));
     for node in &cluster_nodes {
         let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         assert!(client.validator_exit().is_err());

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -25,6 +25,7 @@ pub const DEFAULT_SLOTS_PER_EPOCH: u64 = 2 * TICKS_PER_DAY / DEFAULT_TICKS_PER_S
 // leader schedule is governed by this
 pub const NUM_CONSECUTIVE_LEADER_SLOTS: u64 = 4;
 
+pub const DEFAULT_S_PER_SLOT: f64 = DEFAULT_TICKS_PER_SLOT as f64 / DEFAULT_TICKS_PER_SECOND as f64;
 pub const DEFAULT_MS_PER_SLOT: u64 = 1_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
 
 /// The time window of recent block hash values that the bank will track the signatures

--- a/sdk/program/src/fee_calculator.rs
+++ b/sdk/program/src/fee_calculator.rs
@@ -1,4 +1,4 @@
-use crate::clock::{DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT};
+use crate::clock::DEFAULT_MS_PER_SLOT;
 use crate::message::Message;
 use crate::secp256k1_program;
 use log::*;
@@ -87,8 +87,7 @@ pub struct FeeRateGovernor {
 }
 
 pub const DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE: u64 = 10_000;
-pub const DEFAULT_TARGET_SIGNATURES_PER_SLOT: u64 =
-    50_000 * DEFAULT_TICKS_PER_SLOT / DEFAULT_TICKS_PER_SECOND;
+pub const DEFAULT_TARGET_SIGNATURES_PER_SLOT: u64 = 50 * DEFAULT_MS_PER_SLOT;
 
 // Percentage of tx fees to burn
 pub const DEFAULT_BURN_PERCENT: u8 = 50;

--- a/sdk/program/src/rent.rs
+++ b/sdk/program/src/rent.rs
@@ -142,8 +142,7 @@ mod tests {
         use crate::{clock::*, sysvar::Sysvar};
 
         const SECONDS_PER_YEAR: f64 = 365.242_199 * 24.0 * 60.0 * 60.0;
-        const SLOTS_PER_YEAR: f64 =
-            SECONDS_PER_YEAR / (DEFAULT_TICKS_PER_SLOT as f64 / DEFAULT_TICKS_PER_SECOND as f64);
+        const SLOTS_PER_YEAR: f64 = SECONDS_PER_YEAR / DEFAULT_S_PER_SLOT;
 
         let rent = Rent::default();
         panic!(


### PR DESCRIPTION
#### Problem
Multiple places in the code perform calculations time per slot time in similar ways.

#### Summary of Changes
This change cleans up constant usage and consolidates calculations. This makes it more clear that the code is trying to use time per slot.

The concepts of:
default seconds per slot
default milliseconds per slot
are used instead of a calculation based on
ticks per slot
and
ticks per second.

Fixes #
