### PR TITLE
Enable program-id account index for supply calculations

### DIFF
--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -30,6 +30,10 @@ pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> NonCirculatingSuppl
     {
         bank.get_filtered_indexed_accounts(
             &IndexKey::ProgramId(solana_stake_program::id()),
+            // The program-id account index checks for Account owner on inclusion. However, due to
+            // the current AccountsDB implementation, an account may remain in storage as a
+            // zero-lamport Account::Default() after being wiped and reinitialized in later
+            // updates. We include the redundant filter here to avoid returning these accounts.
             |account| account.owner == solana_stake_program::id(),
         )
     } else {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -1313,6 +1313,11 @@ impl JsonRpcRequestProcessor {
             .contains(&AccountIndex::ProgramId)
         {
             bank.get_filtered_indexed_accounts(&IndexKey::ProgramId(*program_id), |account| {
+                // The program-id account index checks for Account owner on inclusion. However, due
+                // to the current AccountsDB implementation, an account may remain in storage as a
+                // zero-lamport Account::Default() after being wiped and reinitialized in later
+                // updates. We include the redundant filters here to avoid returning these
+                // accounts.
                 account.owner == *program_id && filter_closure(account)
             })
         } else {
@@ -1327,10 +1332,10 @@ impl JsonRpcRequestProcessor {
         owner_key: &Pubkey,
         mut filters: Vec<RpcFilterType>,
     ) -> Vec<(Pubkey, Account)> {
-        // The by-owner accounts index checks for Token Account state and Owner address on inclusion.
-        // However, due to the current AccountsDB implementation, accounts may remain in storage as
-        // be zero-lamport Account::Default() after being wiped and reinitialized in a later updates.
-        // We include the redundant filters here to avoid returning these accounts.
+        // The by-owner accounts index checks for Token Account state and Owner address on
+        // inclusion. However, due to the current AccountsDB implementation, an account may remain
+        // in storage as a zero-lamport Account::Default() after being wiped and reinitialized in
+        // later updates. We include the redundant filters here to avoid returning these accounts.
         //
         // Filter on Token Account state
         filters.push(RpcFilterType::DataSize(
@@ -1368,9 +1373,9 @@ impl JsonRpcRequestProcessor {
         mut filters: Vec<RpcFilterType>,
     ) -> Vec<(Pubkey, Account)> {
         // The by-mint accounts index checks for Token Account state and Mint address on inclusion.
-        // However, due to the current AccountsDB implementation, accounts may remain in storage as
-        // be zero-lamport Account::Default() after being wiped and reinitialized in a later updates.
-        // We include the redundant filters here to avoid returning these accounts.
+        // However, due to the current AccountsDB implementation, an account may remain in storage
+        // as be zero-lamport Account::Default() after being wiped and reinitialized in later
+        // updates. We include the redundant filters here to avoid returning these accounts.
         //
         // Filter on Token Account state
         filters.push(RpcFilterType::DataSize(


### PR DESCRIPTION
#### Problem
`rpc::calculate_non_circulating_supply()` uses `Bank::get_program_accounts()` under the hood, which doesn't make use of the program-id account index.

#### Summary of Changes
- Update method to use program-id account index, if present.
- Also fix grammar in previous comments, and include on program-id-index calls

@mvines , fyi this should help the explorer's `getSupply` calls, if we roll it out to the mainnet-beta api nodes and also enable account indexes. It will also help `getLargestAccounts` for circulating or non-circulating accounts some, by reducing from 2 accounts scans to 1, but I wouldn't expect those to become sprightly.
