### PR TITLE
Enable program upgrades via CPI

### DIFF
--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -172,6 +172,10 @@ pub fn upgrade(
     )
 }
 
+pub fn is_upgrade_instruction(instruction_data: &[u8]) -> bool {
+    3 == instruction_data[0]
+}
+
 /// Returns the instructions required to set a program's authority.
 pub fn set_authority(
     program_address: &Pubkey,


### PR DESCRIPTION
#### Problem

All access to loaders via CPI is blocked but for multisig program upgrades, the `Upgrade` instruction must be performed from the governance program.

#### Summary of Changes

Open up CPI to allow upgradeable loader `Upgrade` instructions

Fixes #
