### PR TITLE
Support account on tmpfs via net/ scripts

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -66,6 +66,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --expected-bank-hash ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --accounts ]]; then
+      args+=("$1" "$2")
+      shift 2
     else
       echo "Unknown argument: $1"
       $program --help

--- a/net/gce.sh
+++ b/net/gce.sh
@@ -68,6 +68,7 @@ externalNodes=false
 failOnValidatorBootupFailure=true
 preemptible=true
 evalInfo=false
+tmpfsAccounts=false
 
 publicNetwork=false
 letsEncryptDomainName=
@@ -154,6 +155,7 @@ Manage testnet instances
                     - Specify validator boot disk size in gb.
    --client-machine-type [type]
                     - custom client machine type
+   --tmpfs-accounts - Put accounts directory on a swap-backed tmpfs volume
 
  config-specific options:
    -P               - Use public network IP addresses (default: $publicNetwork)
@@ -228,6 +230,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --reclaim-all-reservations ]]; then
       reclaimAllReservations=true
       shift
+    elif [[ $1 == --tmpfs-accounts ]]; then
+      tmpfsAccounts=true
+      shift
     else
       usage "Unknown long option: $1"
     fi
@@ -298,12 +303,20 @@ fi
 case $cloudProvider in
 gce)
   customMemoryGB="$(cloud_DefaultCustomMemoryGB)"
+  if [[ "$tmpfsAccounts" = "true" ]]; then
+    customMemoryGB=$(( customMemoryGB * 2 ))
+    cpuBootstrapLeaderMachineType+=" --local-ssd interface=nvme"
+    gpuBootstrapLeaderMachineType+=" --local-ssd interface=nvme"
+  fi
   cpuBootstrapLeaderMachineType+=" --custom-memory ${customMemoryGB}GB"
   gpuBootstrapLeaderMachineType+=" --custom-memory ${customMemoryGB}GB"
   ;;
 ec2|azure|colo)
   if [[ -n $validatorAdditionalDiskSizeInGb ]] ; then
     usage "Error: --validator-additional-disk-size-gb currently only supported with cloud provider: gce"
+  fi
+  if [[ "$tmpfsAccounts" = "true" ]]; then
+    usage "Error: --tmpfs-accounts only supported on cloud provider: gce"
   fi
   ;;
 *)
@@ -445,6 +458,7 @@ netBasename=$prefix
 publicNetwork=$publicNetwork
 sshPrivateKey=$sshPrivateKey
 letsEncryptDomainName=$letsEncryptDomainName
+export TMPFS_ACCOUNTS=$tmpfsAccounts
 EOF
   fi
   touch "$geoipConfigFile"
@@ -832,6 +846,24 @@ See startup script log messages in /var/log/syslog for status:
 $(printNetworkInfo)
 $(creationInfo)
 EOM
+
+$(
+  if [[ "$tmpfsAccounts" = "true" ]]; then
+    cat <<'EOSWAP'
+
+# Setup swap/tmpfs for accounts
+tmpfsMountPoint=/mnt/solana-accounts
+swapDevice="/dev/nvme0n1"
+swapUUID="43076c54-7840-4e59-a368-2d164f8984fb"
+mkswap --uuid "$swapUUID" "$swapDevice"
+echo "UUID=$swapUUID swap swap defaults 0 0" >> /etc/fstab
+swapon "UUID=$swapUUID"
+mkdir -p -m 0777 "$tmpfsMountPoint"
+echo "tmpfs $tmpfsMountPoint tmpfs defaults,size=300G 0 0" >> /etc/fstab
+mount "$tmpfsMountPoint"
+EOSWAP
+  fi
+)
 
 touch /solana-scratch/.instance-startup-complete
 

--- a/net/net.sh
+++ b/net/net.sh
@@ -294,6 +294,7 @@ startBootstrapLeader() {
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
          \"$extraPrimordialStakes\" \
+         \"$TMPFS_ACCOUNTS\" \
       "
 
   ) >> "$logFile" 2>&1 || {
@@ -365,6 +366,7 @@ startNode() {
          \"$maybeWarpSlot\" \
          \"$waitForNodeInit\" \
          \"$extraPrimordialStakes\" \
+         \"$TMPFS_ACCOUNTS\" \
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -28,6 +28,7 @@ gpuMode="${19:-auto}"
 maybeWarpSlot="${20}"
 waitForNodeInit="${21}"
 extraPrimordialStakes="${22:=0}"
+tmpfsAccounts="${23:false}"
 set +x
 
 missing() {
@@ -275,6 +276,10 @@ EOF
       --init-complete-file "$initCompleteFile"
     )
 
+    if [[ "$tmpfsAccounts" = "true" ]]; then
+      args+=(--accounts /mnt/solana-accounts)
+    fi
+
     if [[ $airdropsEnabled = true ]]; then
 cat >> ~/solana/on-reboot <<EOF
       ./multinode-demo/faucet.sh > faucet.log 2>&1 &
@@ -390,6 +395,10 @@ EOF
     maybeSkipAccountsCreation=
     if [[ $nodeIndex -le $extraPrimordialStakes ]]; then
       maybeSkipAccountsCreation="export SKIP_ACCOUNTS_CREATION=1"
+    fi
+
+    if [[ "$tmpfsAccounts" = "true" ]]; then
+      args+=(--accounts /mnt/solana-accounts)
     fi
 
 cat >> ~/solana/on-reboot <<EOF

--- a/net/scripts/azure-provider.sh
+++ b/net/scripts/azure-provider.sh
@@ -8,6 +8,10 @@ cloud_DefaultZone() {
   echo "westus"
 }
 
+cloud_DefaultCustomMemoryGB() {
+  : # Not implemented
+}
+
 cloud_RestartPreemptedInstances() {
   : # Not implemented
 }

--- a/net/scripts/colo-provider.sh
+++ b/net/scripts/colo-provider.sh
@@ -17,6 +17,10 @@ cloud_DefaultZone() {
   echo "Denver"
 }
 
+cloud_DefaultCustomMemoryGB() {
+  : # Not implemented
+}
+
 cloud_RestartPreemptedInstances() {
   : # Not implemented
 }

--- a/net/scripts/ec2-provider.sh
+++ b/net/scripts/ec2-provider.sh
@@ -7,6 +7,10 @@ cloud_DefaultZone() {
   echo "us-east-1b"
 }
 
+cloud_DefaultCustomMemoryGB() {
+  : # Not implemented
+}
+
 cloud_RestartPreemptedInstances() {
   : # Not implemented
 }

--- a/net/scripts/gce-provider.sh
+++ b/net/scripts/gce-provider.sh
@@ -8,6 +8,10 @@ cloud_DefaultZone() {
   echo "us-west1-b"
 }
 
+cloud_DefaultCustomMemoryGB() {
+  echo 64
+}
+
 #
 # cloud_RestartPreemptedInstances [namePrefix]
 #


### PR DESCRIPTION
#### Problem

Can't specify accounts on a tmpfs volume when deploying test clusters on GCP

#### Summary of Changes

Add a `--tmpfs-accounts` flag to `net/gce.sh`
Plumb it through to multinode-demo

cc/ @CriesofCarrots 