### PR TITLE
explorer: Hide banner when lockup has expired

### DIFF
--- a/explorer/src/components/account/StakeAccountSection.tsx
+++ b/explorer/src/components/account/StakeAccountSection.tsx
@@ -48,9 +48,9 @@ export function StakeAccountSection({
 }
 
 function LockupCard({ stakeAccount }: { stakeAccount: StakeAccountInfo }) {
-  const unixTimestamp = stakeAccount.meta?.lockup.unixTimestamp;
-  if (unixTimestamp && unixTimestamp > 0) {
-    const prettyTimestamp = displayTimestampUtc(unixTimestamp * 1000);
+  const unixTimestamp = 1000 * (stakeAccount.meta?.lockup.unixTimestamp || 0);
+  if (Date.now() < unixTimestamp) {
+    const prettyTimestamp = displayTimestampUtc(unixTimestamp);
     return (
       <div className="alert alert-warning text-center">
         <strong>Account is locked!</strong> Lockup expires on {prettyTimestamp}


### PR DESCRIPTION
#### Problem
Lockup banner still shows for stake accounts with a lockup authority after lockup has expired

#### Summary of Changes
- Hide banner if lockup has expired

Fixes #
