### PR TITLE
Add buffer authority to upgradeable loader

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2665,7 +2665,7 @@ mod tests {
         let program_id = json
             .as_object()
             .unwrap()
-            .get("programId")
+            .get("ProgramId")
             .unwrap()
             .as_str()
             .unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -92,7 +92,7 @@ pub const SECONDS_PER_YEAR: f64 = 365.25 * 24.0 * 60.0 * 60.0;
 pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 5;
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "GSPuprru1pomsgvopKG7XRWiXdqdXJdLPkgJ2arPbkXM")]
+#[frozen_abi(digest = "MUmkgPsCRrWL2HEsMEvpkWMis35kbBnaEZtrph5P6bk")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 type TransactionAccountRefCells = Vec<Rc<RefCell<Account>>>;
 type TransactionAccountDepRefCells = Vec<(Pubkey, RefCell<Account>)>;

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -69,6 +69,7 @@ pub fn load_buffer_account<T: Client>(
                 &bpf_loader_upgradeable::create_buffer(
                     &from_keypair.pubkey(),
                     &buffer_pubkey,
+                    Some(&buffer_pubkey),
                     1.max(
                         bank_client
                             .get_minimum_balance_for_rent_exemption(program.len())
@@ -88,6 +89,7 @@ pub fn load_buffer_account<T: Client>(
         let message = Message::new(
             &[bpf_loader_upgradeable::write(
                 &buffer_pubkey,
+                None,
                 offset,
                 chunk.to_vec(),
             )],
@@ -168,7 +170,7 @@ pub fn set_upgrade_authority<T: Client>(
     new_authority_pubkey: Option<&Pubkey>,
 ) {
     let message = Message::new(
-        &[bpf_loader_upgradeable::set_authority(
+        &[bpf_loader_upgradeable::set_upgrade_authority(
             program_pubkey,
             &current_authority_keypair.pubkey(),
             new_authority_pubkey,

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -180,6 +180,12 @@ pub enum InstructionError {
 
     #[error("Program failed to compile")]
     ProgramFailedToCompile,
+
+    #[error("Account is immutable")]
+    Immutable,
+
+    #[error("Incorrect authority provided")]
+    IncorrectAuthority,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/sdk/program/src/loader_upgradeable_instruction.rs
+++ b/sdk/program/src/loader_upgradeable_instruction.rs
@@ -16,12 +16,15 @@ pub enum UpgradeableLoaderInstruction {
     ///
     /// # Account references
     ///   0. [writable] source account to initialize.
+    ///   1. [] Buffer authority, optional, if omitted then the buffer will be
+    ///      immutable.
     InitializeBuffer,
 
     /// Write program data into a Buffer account.
     ///
     /// # Account references
-    ///   0. [writable, signer] Buffer account to write program data to.
+    ///   0. [writable] Buffer account to write program data to.
+    ///   1. [signer] Buffer authority
     Write {
         /// Offset at which to write the given bytes.
         offset: u32,
@@ -92,11 +95,13 @@ pub enum UpgradeableLoaderInstruction {
     ///   6. [signer] The program's authority.
     Upgrade,
 
-    /// Set a new authority that is allowed to upgrade the program.  To
-    /// permanently disable program updates omit the new authority.
+    /// Set a new authority that is allowed to write the buffer or upgrade the
+    /// program.  To permanently make the buffer immutable or disable program
+    /// updates omit the new authority.
     ///
     /// # Account references
-    ///   0. `[writable]` The ProgramData account to change the authority of.
+    ///   0. `[writable]` The Buffer or ProgramData account to change the
+    ///      authority of.
     ///   1. `[signer]` The current authority.
     ///   2. `[]` The new authority, optional, if omitted then the program will
     ///      not be upgradeable.


### PR DESCRIPTION
#### Problem

When upgrading a program via a multisig governance program, the participants need to know that the data used in the upgrade is immutable before they sign.  The current upgradeable loader does not enforce any signing requirement on the buffer account.

#### Summary of Changes

- Add an authority to the buffer account that once set to `None` leaves the buffer account immutable
- Update the CLI to load buffer accounts, set buffer account authorities, and enable `deploy` to optionally take a buffer account instead of a program location

Fixes #
