### PR TITLE
Various snapshot-related code clean up

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -175,7 +175,7 @@ mod tests {
     use super::*;
     use crate::cluster_info::make_accounts_hashes_message;
     use crate::contact_info::ContactInfo;
-    use solana_runtime::bank_forks::CompressionType;
+    use solana_runtime::bank_forks::ArchiveFormat;
     use solana_runtime::snapshot_utils::SnapshotVersion;
     use solana_sdk::{
         hash::hash,
@@ -239,7 +239,7 @@ mod tests {
                 snapshot_links,
                 tar_output_file: PathBuf::from("."),
                 storages: vec![],
-                compression: CompressionType::Bzip2,
+                archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version: SnapshotVersion::default(),
             };
 

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -83,17 +83,17 @@ impl AccountsHashVerifier {
         snapshot_interval_slots: u64,
     ) {
         if fault_injection_rate_slots != 0
-            && accounts_package.root % fault_injection_rate_slots == 0
+            && accounts_package.slot % fault_injection_rate_slots == 0
         {
             // For testing, publish an invalid hash to gossip.
             use rand::{thread_rng, Rng};
             use solana_sdk::hash::extend_and_hash;
-            warn!("inserting fault at slot: {}", accounts_package.root);
+            warn!("inserting fault at slot: {}", accounts_package.slot);
             let rand = thread_rng().gen_range(0, 10);
             let hash = extend_and_hash(&accounts_package.hash, &[rand]);
-            hashes.push((accounts_package.root, hash));
+            hashes.push((accounts_package.slot, hash));
         } else {
-            hashes.push((accounts_package.root, accounts_package.hash));
+            hashes.push((accounts_package.slot, accounts_package.hash));
         }
 
         while hashes.len() > MAX_SNAPSHOT_HASHES {
@@ -234,7 +234,7 @@ mod tests {
             let accounts_package = AccountsPackage {
                 hash: hash(&[i as u8]),
                 block_height: 100 + i as u64,
-                root: 100 + i as u64,
+                slot: 100 + i as u64,
                 slot_deltas: vec![],
                 snapshot_links,
                 tar_output_file: PathBuf::from("."),

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -439,9 +439,7 @@ mod tests {
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         get_tmp_ledger_path,
     };
-    use solana_runtime::{
-        bank::Bank, bank_forks::CompressionType, snapshot_utils::SnapshotVersion,
-    };
+    use solana_runtime::{bank::Bank, bank_forks::ArchiveFormat, snapshot_utils::SnapshotVersion};
     use solana_sdk::{genesis_config::ClusterType, signature::Signer};
     use std::net::{IpAddr, Ipv4Addr};
 
@@ -534,7 +532,7 @@ mod tests {
                 snapshot_interval_slots: 0,
                 snapshot_package_output_path: PathBuf::from("/"),
                 snapshot_path: PathBuf::from("/"),
-                compression: CompressionType::Bzip2,
+                archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version: SnapshotVersion::default(),
             }),
             bank_forks,

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -51,7 +51,7 @@ impl SnapshotPackagerService {
                             {
                                 warn!("Failed to create snapshot archive: {}", err);
                             } else {
-                                hashes.push((snapshot_package.root, snapshot_package.hash));
+                                hashes.push((snapshot_package.slot, snapshot_package.hash));
                                 while hashes.len() > MAX_SNAPSHOT_HASHES {
                                     hashes.remove(0);
                                 }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -81,7 +81,7 @@ mod tests {
     use solana_runtime::{
         accounts_db::AccountStorageEntry,
         bank::BankSlotDelta,
-        bank_forks::CompressionType,
+        bank_forks::ArchiveFormat,
         snapshot_package::AccountsPackage,
         snapshot_utils::{self, SnapshotVersion, SNAPSHOT_STATUS_CACHE_FILE_NAME},
     };
@@ -163,7 +163,7 @@ mod tests {
         let output_tar_path = snapshot_utils::get_snapshot_archive_path(
             &snapshot_package_output_path,
             &(42, Hash::default()),
-            &CompressionType::Bzip2,
+            &ArchiveFormat::TarBzip2,
         );
         let snapshot_package = AccountsPackage::new(
             5,
@@ -173,7 +173,7 @@ mod tests {
             vec![storage_entries],
             output_tar_path.clone(),
             Hash::default(),
-            CompressionType::Bzip2,
+            ArchiveFormat::TarBzip2,
             SnapshotVersion::default(),
         );
 
@@ -198,7 +198,7 @@ mod tests {
             output_tar_path,
             snapshots_dir,
             accounts_dir,
-            CompressionType::Bzip2,
+            ArchiveFormat::TarBzip2,
         );
     }
 }

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -8,7 +8,7 @@ use {
     solana_client::rpc_client::RpcClient,
     solana_ledger::{blockstore::create_new_ledger, create_new_tmp_ledger},
     solana_runtime::{
-        bank_forks::{CompressionType, SnapshotConfig, SnapshotVersion},
+        bank_forks::{ArchiveFormat, SnapshotConfig, SnapshotVersion},
         genesis_utils::create_genesis_config_with_leader_ex,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     },
@@ -354,7 +354,7 @@ impl TestValidator {
                 snapshot_interval_slots: 100,
                 snapshot_path: ledger_path.join("snapshot"),
                 snapshot_package_output_path: ledger_path.to_path_buf(),
-                compression: CompressionType::NoCompression,
+                archive_format: ArchiveFormat::Tar,
                 snapshot_version: SnapshotVersion::default(),
             }),
             enforce_ulimit_nofile: false,

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -45,7 +45,7 @@ mod tests {
     use solana_runtime::{
         accounts_background_service::{ABSRequestSender, SnapshotRequestHandler},
         bank::{Bank, BankSlotDelta},
-        bank_forks::{BankForks, CompressionType, SnapshotConfig},
+        bank_forks::{ArchiveFormat, BankForks, SnapshotConfig},
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         snapshot_utils,
         snapshot_utils::SnapshotVersion,
@@ -106,7 +106,7 @@ mod tests {
                 snapshot_interval_slots,
                 snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
                 snapshot_path: PathBuf::from(snapshot_dir.path()),
-                compression: CompressionType::Bzip2,
+                archive_format: ArchiveFormat::TarBzip2,
                 snapshot_version,
             };
             bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
@@ -146,9 +146,9 @@ mod tests {
             snapshot_utils::get_snapshot_archive_path(
                 snapshot_package_output_path,
                 &(old_last_bank.slot(), old_last_bank.get_accounts_hash()),
-                &CompressionType::Bzip2,
+                &ArchiveFormat::TarBzip2,
             ),
-            CompressionType::Bzip2,
+            ArchiveFormat::TarBzip2,
             old_genesis_config,
             None,
             None,
@@ -226,7 +226,7 @@ mod tests {
             last_bank.src.slot_deltas(&last_bank.src.roots()),
             &snapshot_config.snapshot_package_output_path,
             last_bank.get_snapshot_storages(),
-            CompressionType::Bzip2,
+            ArchiveFormat::TarBzip2,
             snapshot_version,
         )
         .unwrap();
@@ -347,7 +347,7 @@ mod tests {
                 &snapshot_path,
                 &snapshot_package_output_path,
                 snapshot_config.snapshot_version,
-                &snapshot_config.compression,
+                &snapshot_config.archive_format,
             )
             .unwrap();
 
@@ -375,7 +375,7 @@ mod tests {
                 saved_archive_path = Some(snapshot_utils::get_snapshot_archive_path(
                     snapshot_package_output_path,
                     &(slot, accounts_hash),
-                    &CompressionType::Bzip2,
+                    &ArchiveFormat::TarBzip2,
                 ));
             }
         }
@@ -432,7 +432,7 @@ mod tests {
             saved_accounts_dir
                 .path()
                 .join(accounts_dir.path().file_name().unwrap()),
-            CompressionType::Bzip2,
+            ArchiveFormat::TarBzip2,
         );
     }
 

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -1,7 +1,7 @@
 use console::Emoji;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;
-use solana_runtime::{bank_forks::CompressionType, snapshot_utils};
+use solana_runtime::{bank_forks::ArchiveFormat, snapshot_utils};
 use solana_sdk::clock::Slot;
 use solana_sdk::hash::Hash;
 use std::fs::{self, File};
@@ -175,9 +175,9 @@ pub fn download_snapshot(
     snapshot_utils::purge_old_snapshot_archives(ledger_path);
 
     for compression in &[
-        CompressionType::Zstd,
-        CompressionType::Gzip,
-        CompressionType::Bzip2,
+        ArchiveFormat::TarZstd,
+        ArchiveFormat::TarGzip,
+        ArchiveFormat::TarBzip2,
     ] {
         let desired_snapshot_package = snapshot_utils::get_snapshot_archive_path(
             ledger_path,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -25,7 +25,7 @@ use solana_ledger::{
 };
 use solana_runtime::{
     bank::{Bank, RewardCalculationEvent},
-    bank_forks::{BankForks, CompressionType, SnapshotConfig},
+    bank_forks::{ArchiveFormat, BankForks, SnapshotConfig},
     hardened_unpack::{open_genesis_config, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
     snapshot_utils,
     snapshot_utils::SnapshotVersion,
@@ -667,7 +667,7 @@ fn load_bank_forks(
             snapshot_interval_slots: 0, // Value doesn't matter
             snapshot_package_output_path,
             snapshot_path,
-            compression: CompressionType::Bzip2,
+            archive_format: ArchiveFormat::TarBzip2,
             snapshot_version: SnapshotVersion::default(),
         })
     };
@@ -1947,7 +1947,7 @@ fn main() {
                                 bank.src.slot_deltas(&bank.src.roots()),
                                 output_directory,
                                 storages,
-                                CompressionType::Zstd,
+                                ArchiveFormat::TarZstd,
                                 snapshot_version,
                             )
                         })

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -32,7 +32,7 @@ use solana_local_cluster::{
     local_cluster::{ClusterConfig, LocalCluster},
 };
 use solana_runtime::{
-    bank_forks::{CompressionType, SnapshotConfig},
+    bank_forks::{ArchiveFormat, SnapshotConfig},
     snapshot_utils,
 };
 use solana_sdk::{
@@ -1054,7 +1054,7 @@ fn test_snapshot_download() {
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
         &validator_snapshot_test_config.snapshot_output_path,
         &archive_snapshot_hash,
-        &CompressionType::Bzip2,
+        &ArchiveFormat::TarBzip2,
     );
 
     // Download the snapshot, then boot a validator from it.
@@ -1124,7 +1124,7 @@ fn test_snapshot_restart_tower() {
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
         &validator_snapshot_test_config.snapshot_output_path,
         &archive_snapshot_hash,
-        &CompressionType::Bzip2,
+        &ArchiveFormat::TarBzip2,
     );
     fs::hard_link(archive_filename, &validator_archive_path).unwrap();
 
@@ -1189,7 +1189,7 @@ fn test_snapshots_blockstore_floor() {
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
         &validator_snapshot_test_config.snapshot_output_path,
         &(archive_slot, archive_hash),
-        &CompressionType::Bzip2,
+        &ArchiveFormat::TarBzip2,
     );
     fs::hard_link(archive_filename, &validator_archive_path).unwrap();
     let slot_floor = archive_slot;
@@ -2446,7 +2446,7 @@ fn setup_snapshot_validator_config(
         snapshot_interval_slots,
         snapshot_package_output_path: PathBuf::from(snapshot_output_path.path()),
         snapshot_path: PathBuf::from(snapshot_dir.path()),
-        compression: CompressionType::Bzip2,
+        archive_format: ArchiveFormat::TarBzip2,
         snapshot_version: snapshot_utils::SnapshotVersion::default(),
     };
 

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -112,7 +112,7 @@ impl SnapshotRequestHandler {
                     &self.snapshot_config.snapshot_path,
                     &self.snapshot_config.snapshot_package_output_path,
                     self.snapshot_config.snapshot_version,
-                    &self.snapshot_config.compression,
+                    &self.snapshot_config.archive_format,
                 );
                 if r.is_err() {
                     warn!(

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -18,11 +18,11 @@ use std::{
 pub use crate::snapshot_utils::SnapshotVersion;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum CompressionType {
-    Bzip2,
-    Gzip,
-    Zstd,
-    NoCompression,
+pub enum ArchiveFormat {
+    TarBzip2,
+    TarGzip,
+    TarZstd,
+    Tar,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -36,7 +36,7 @@ pub struct SnapshotConfig {
     // Where to place the snapshots for recent slots
     pub snapshot_path: PathBuf,
 
-    pub compression: CompressionType,
+    pub archive_format: ArchiveFormat,
 
     // Snapshot version to generate
     pub snapshot_version: SnapshotVersion,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -288,6 +288,12 @@ where
         map
     };
 
+    // Ensure all account paths exist
+    for path in &accounts_db.paths {
+        std::fs::create_dir_all(path)
+            .unwrap_or_else(|err| panic!("Failed to create directory {}: {}", path.display(), err));
+    }
+
     let mut last_log_update = Instant::now();
     let mut remaining_slots_to_process = storage.len();
 
@@ -306,8 +312,6 @@ where
             for (id, storage_entry) in slot_storage.drain() {
                 let path_index = thread_rng().gen_range(0, accounts_db.paths.len());
                 let local_dir = &accounts_db.paths[path_index];
-
-                std::fs::create_dir_all(local_dir).expect("Create directory failed");
 
                 // Move the corresponding AppendVec from the snapshot into the directory pointed
                 // at by `local_dir`

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -1,4 +1,4 @@
-use crate::bank_forks::CompressionType;
+use crate::bank_forks::ArchiveFormat;
 use crate::snapshot_utils::SnapshotVersion;
 use crate::{accounts_db::SnapshotStorages, bank::BankSlotDelta};
 use solana_sdk::clock::Slot;
@@ -22,7 +22,7 @@ pub struct AccountsPackage {
     pub storages: SnapshotStorages,
     pub tar_output_file: PathBuf,
     pub hash: Hash,
-    pub compression: CompressionType,
+    pub archive_format: ArchiveFormat,
     pub snapshot_version: SnapshotVersion,
 }
 
@@ -35,7 +35,7 @@ impl AccountsPackage {
         storages: SnapshotStorages,
         tar_output_file: PathBuf,
         hash: Hash,
-        compression: CompressionType,
+        archive_format: ArchiveFormat,
         snapshot_version: SnapshotVersion,
     ) -> Self {
         Self {
@@ -46,7 +46,7 @@ impl AccountsPackage {
             storages,
             tar_output_file,
             hash,
-            compression,
+            archive_format,
             snapshot_version,
         }
     }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -15,7 +15,7 @@ pub type AccountsPackageSendError = SendError<AccountsPackage>;
 
 #[derive(Debug)]
 pub struct AccountsPackage {
-    pub root: Slot,
+    pub slot: Slot,
     pub block_height: Slot,
     pub slot_deltas: Vec<BankSlotDelta>,
     pub snapshot_links: TempDir,
@@ -28,7 +28,7 @@ pub struct AccountsPackage {
 
 impl AccountsPackage {
     pub fn new(
-        root: Slot,
+        slot: Slot,
         block_height: u64,
         slot_deltas: Vec<BankSlotDelta>,
         snapshot_links: TempDir,
@@ -39,7 +39,7 @@ impl AccountsPackage {
         snapshot_version: SnapshotVersion,
     ) -> Self {
         Self {
-            root,
+            slot,
             block_height,
             slot_deltas,
             snapshot_links,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -229,11 +229,11 @@ pub fn remove_tmp_snapshot_archives(snapshot_path: &Path) {
 pub fn archive_snapshot_package(snapshot_package: &AccountsPackage) -> Result<()> {
     info!(
         "Generating snapshot archive for slot {}",
-        snapshot_package.root
+        snapshot_package.slot
     );
 
     serialize_status_cache(
-        snapshot_package.root,
+        snapshot_package.slot,
         &snapshot_package.slot_deltas,
         &snapshot_package.snapshot_links.path().join(SNAPSHOT_STATUS_CACHE_FILE_NAME),
     )?;
@@ -360,13 +360,13 @@ pub fn archive_snapshot_package(snapshot_package: &AccountsPackage) -> Result<()
     info!(
         "Successfully created {:?}. slot: {}, elapsed ms: {}, size={}",
         snapshot_package.tar_output_file,
-        snapshot_package.root,
+        snapshot_package.slot,
         timer.as_ms(),
         metadata.len()
     );
     datapoint_info!(
         "snapshot-package",
-        ("slot", snapshot_package.root, i64),
+        ("slot", snapshot_package.slot, i64),
         ("duration_ms", timer.as_ms(), i64),
         ("size", metadata.len(), i64)
     );

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -274,10 +274,10 @@ pub fn archive_snapshot_package(snapshot_package: &AccountsPackage) -> Result<()
             ));
 
         // `storage_path` - The file path where the AppendVec itself is located
-        // `output_path` - The directory where the AppendVec will be placed in the staging directory.
+        // `output_path` - The file path where the AppendVec will be placed in the staging directory.
         let storage_path =
             fs::canonicalize(storage_path).expect("Could not get absolute path for accounts");
-        symlink::symlink_dir(storage_path, &output_path)?;
+        symlink::symlink_file(storage_path, &output_path)?;
         if !output_path.is_file() {
             return Err(SnapshotError::StoragePathSymlinkInvalid);
         }


### PR DESCRIPTION
Minor code improvements and refactoring that I ran into while walking through the snapshot code
* Avoid excessive mkdir-ing of accounts directories
* Replace wrong `symlink_dir` usage with `symlink_file`
* Limit TempDir surface area
* Rename AccountsPackage::root to AccountsPackage::slot for more clarity
* Rename CompressionType to ArchiveFormat.   This makes room for other snapshot archive types that aren't tarball based  or aren't full snapshots