### PR TITLE
Add cli command to query upgradeable account authorities

### DIFF
--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -486,6 +486,25 @@ fn test_cli_program_deploy_with_authority() {
         program_data[..]
     );
 
+    // Get upgrade authority
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Program(ProgramCliCommand::GetAuthority {
+        account_pubkey: Some(program_pubkey),
+    });
+    let response = process_command(&config);
+    let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
+    let authority_pubkey_str = json
+        .as_object()
+        .unwrap()
+        .get("Program upgrade authority")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    assert_eq!(
+        new_upgrade_authority.pubkey(),
+        Pubkey::from_str(&authority_pubkey_str).unwrap()
+    );
+
     // Set no authority
     config.signers = vec![&keypair, &new_upgrade_authority];
     config.command = CliCommand::Program(ProgramCliCommand::SetUpgradeAuthority {
@@ -560,6 +579,22 @@ fn test_cli_program_deploy_with_authority() {
     } else {
         panic!("not a buffer account");
     }
+
+    // Get buffer authority
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Program(ProgramCliCommand::GetAuthority {
+        account_pubkey: Some(program_pubkey),
+    });
+    let response = process_command(&config);
+    let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
+    let authority_pubkey_str = json
+        .as_object()
+        .unwrap()
+        .get("Program upgrade authority")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    assert_eq!("None", authority_pubkey_str);
 }
 
 #[test]
@@ -686,6 +721,25 @@ fn test_cli_program_write_buffer() {
         program_data[..]
     );
 
+    // Get buffer authority
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Program(ProgramCliCommand::GetAuthority {
+        account_pubkey: Some(buffer_keypair.pubkey()),
+    });
+    let response = process_command(&config);
+    let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
+    let authority_pubkey_str = json
+        .as_object()
+        .unwrap()
+        .get("Buffer authority")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    assert_eq!(
+        keypair.pubkey(),
+        Pubkey::from_str(&authority_pubkey_str).unwrap()
+    );
+
     // Specify buffer authority
     let buffer_keypair = Keypair::new();
     let authority_keypair = Keypair::new();
@@ -799,6 +853,22 @@ fn test_cli_program_write_buffer() {
     } else {
         panic!("not a buffer account");
     }
+
+    // Get buffer authority
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Program(ProgramCliCommand::GetAuthority {
+        account_pubkey: Some(buffer_pubkey),
+    });
+    let response = process_command(&config);
+    let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
+    let authority_pubkey_str = json
+        .as_object()
+        .unwrap()
+        .get("Buffer authority")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    assert_eq!("None", authority_pubkey_str);
 }
 
 #[test]


### PR DESCRIPTION
#### Problem

No explicit way to confirm the authority on an upgradeable account via the CLI

#### Summary of Changes

Add a query command to the CLI that returns a buffer or program authority

Fixes #
