### PR TITLE
chore: bpf-loader test, don't match specific error text

### DIFF
--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -105,7 +105,7 @@ describe('load BPF Rust program', () => {
       programData,
       BPF_LOADER_PROGRAM_ID,
     );
-    await expect(failedLoad).rejects.toThrow('Transaction was not confirmed');
+    await expect(failedLoad).rejects.toThrow();
 
     // Second load will succeed
     await BpfLoader.load(


### PR DESCRIPTION
#### Problem
As of https://github.com/solana-labs/solana/pull/14286, Loader doesn't skip preflight checks. That means that the `failedLoad` in `bpf-loader.test.js` will more often than not fail on a preflight simulation, rather than the confirmation. This fails the expect, which is looking for the specific thrown confirmation error, and subsequently all the following tests.

#### Summary of Changes
Don't match specific error text in expect case
