### PR TITLE
Bail on all CPI errors

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -14,6 +14,7 @@ static const uint8_t TEST_CAP_SIGNERS = 7;
 static const uint8_t TEST_ALLOC_ACCESS_VIOLATION = 8;
 static const uint8_t TEST_INSTRUCTION_DATA_TOO_LARGE = 9;
 static const uint8_t TEST_INSTRUCTION_META_TOO_LARGE = 10;
+static const uint8_t TEST_RETURN_ERROR = 11;
 
 static const int MINT_INDEX = 0;
 static const int ARGUMENT_INDEX = 1;
@@ -112,7 +113,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
           {accounts[INVOKED_ARGUMENT_INDEX].key, true, true},
           {accounts[INVOKED_PROGRAM_INDEX].key, false, false},
           {accounts[INVOKED_PROGRAM_DUP_INDEX].key, false, false}};
-      uint8_t data[] = {TEST_VERIFY_TRANSLATIONS, 1, 2, 3, 4, 5};
+      uint8_t data[] = {VERIFY_TRANSLATIONS, 1, 2, 3, 4, 5};
       const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                           arguments, SOL_ARRAY_SIZE(arguments),
                                           data, SOL_ARRAY_SIZE(data)};
@@ -130,18 +131,6 @@ extern uint64_t entrypoint(const uint8_t *input) {
                                           data, SOL_ARRAY_SIZE(data)};
 
       sol_assert(SUCCESS ==
-                 sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
-    }
-
-    sol_log("Test return error");
-    {
-      SolAccountMeta arguments[] = {{accounts[ARGUMENT_INDEX].key, true, true}};
-      uint8_t data[] = {TEST_RETURN_ERROR};
-      const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
-                                          arguments, SOL_ARRAY_SIZE(arguments),
-                                          data, SOL_ARRAY_SIZE(data)};
-
-      sol_assert(42 ==
                  sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
     }
 
@@ -183,7 +172,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
           {accounts[DERIVED_KEY1_INDEX].key, true, true},
           {accounts[DERIVED_KEY2_INDEX].key, true, false},
           {accounts[DERIVED_KEY3_INDEX].key, false, false}};
-      uint8_t data[] = {TEST_DERIVED_SIGNERS, bump_seed2, bump_seed3};
+      uint8_t data[] = {DERIVED_SIGNERS, bump_seed2, bump_seed3};
       const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                           arguments, SOL_ARRAY_SIZE(arguments),
                                           data, SOL_ARRAY_SIZE(data)};
@@ -202,7 +191,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
     {
       SolAccountMeta arguments[] = {
           {accounts[INVOKED_ARGUMENT_INDEX].key, true, false}};
-      uint8_t data[] = {TEST_VERIFY_WRITER};
+      uint8_t data[] = {VERIFY_WRITER};
       const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                           arguments, SOL_ARRAY_SIZE(arguments),
                                           data, SOL_ARRAY_SIZE(data)};
@@ -222,7 +211,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
           {accounts[INVOKED_ARGUMENT_INDEX].key, true, true},
           {accounts[ARGUMENT_INDEX].key, true, true},
           {accounts[INVOKED_PROGRAM_DUP_INDEX].key, false, false}};
-      uint8_t data[] = {TEST_NESTED_INVOKE};
+      uint8_t data[] = {NESTED_INVOKE};
       const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                           arguments, SOL_ARRAY_SIZE(arguments),
                                           data, SOL_ARRAY_SIZE(data)};
@@ -252,7 +241,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_log("Test privilege escalation signer");
     SolAccountMeta arguments[] = {
         {accounts[DERIVED_KEY3_INDEX].key, false, false}};
-    uint8_t data[] = {TEST_VERIFY_PRIVILEGE_ESCALATION};
+    uint8_t data[] = {VERIFY_PRIVILEGE_ESCALATION};
     const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                         arguments, SOL_ARRAY_SIZE(arguments),
                                         data, SOL_ARRAY_SIZE(data)};
@@ -268,7 +257,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_log("Test privilege escalation writable");
     SolAccountMeta arguments[] = {
         {accounts[DERIVED_KEY3_INDEX].key, false, false}};
-    uint8_t data[] = {TEST_VERIFY_PRIVILEGE_ESCALATION};
+    uint8_t data[] = {VERIFY_PRIVILEGE_ESCALATION};
     const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                         arguments, SOL_ARRAY_SIZE(arguments),
                                         data, SOL_ARRAY_SIZE(data)};
@@ -284,7 +273,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_log("Test program not executable");
     SolAccountMeta arguments[] = {
         {accounts[DERIVED_KEY3_INDEX].key, false, false}};
-    uint8_t data[] = {TEST_VERIFY_PRIVILEGE_ESCALATION};
+    uint8_t data[] = {VERIFY_PRIVILEGE_ESCALATION};
     const SolInstruction instruction = {accounts[ARGUMENT_INDEX].key, arguments,
                                         SOL_ARRAY_SIZE(arguments), data,
                                         SOL_ARRAY_SIZE(data)};
@@ -435,6 +424,16 @@ extern uint64_t entrypoint(const uint8_t *input) {
                               &instruction, accounts, SOL_ARRAY_SIZE(accounts),
                               signers_seeds, SOL_ARRAY_SIZE(signers_seeds)));
 
+    break;
+  }
+  case TEST_RETURN_ERROR: {
+    SolAccountMeta arguments[] = {{accounts[ARGUMENT_INDEX].key, true, true}};
+    uint8_t data[] = {RETURN_ERROR};
+    const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+                                        arguments, SOL_ARRAY_SIZE(arguments),
+                                        data, SOL_ARRAY_SIZE(data)};
+
+    sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
     break;
   }
   default:

--- a/programs/bpf/c/src/invoked/instruction.h
+++ b/programs/bpf/c/src/invoked/instruction.h
@@ -4,10 +4,12 @@
 
 #include <solana_sdk.h>
 
-const uint8_t TEST_VERIFY_TRANSLATIONS = 0;
-const uint8_t TEST_RETURN_ERROR = 1;
-const uint8_t TEST_DERIVED_SIGNERS = 2;
-const uint8_t TEST_VERIFY_NESTED_SIGNERS = 3;
-const uint8_t TEST_VERIFY_WRITER = 4;
-const uint8_t TEST_VERIFY_PRIVILEGE_ESCALATION = 5;
-const uint8_t TEST_NESTED_INVOKE = 6;
+const uint8_t VERIFY_TRANSLATIONS = 0;
+const uint8_t RETURN_ERROR = 1;
+const uint8_t DERIVED_SIGNERS = 2;
+const uint8_t VERIFY_NESTED_SIGNERS = 3;
+const uint8_t VERIFY_WRITER = 4;
+const uint8_t VERIFY_PRIVILEGE_ESCALATION = 5;
+const uint8_t NESTED_INVOKE = 6;
+const uint8_t RETURN_OK = 7;
+

--- a/programs/bpf/c/src/invoked/instruction.h
+++ b/programs/bpf/c/src/invoked/instruction.h
@@ -12,4 +12,3 @@ const uint8_t VERIFY_WRITER = 4;
 const uint8_t VERIFY_PRIVILEGE_ESCALATION = 5;
 const uint8_t NESTED_INVOKE = 6;
 const uint8_t RETURN_OK = 7;
-

--- a/programs/bpf/c/src/invoked/invoked.c
+++ b/programs/bpf/c/src/invoked/invoked.c
@@ -17,7 +17,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
   }
 
   switch (params.data[0]) {
-  case TEST_VERIFY_TRANSLATIONS: {
+  case VERIFY_TRANSLATIONS: {
     sol_log("verify data translations");
 
     static const int ARGUMENT_INDEX = 0;
@@ -85,11 +85,15 @@ extern uint64_t entrypoint(const uint8_t *input) {
                accounts[INVOKED_PROGRAM_DUP_INDEX].executable);
     break;
   }
-  case TEST_RETURN_ERROR: {
+  case RETURN_OK: {
+    sol_log("return Ok");
+    return SUCCESS;
+  }
+  case RETURN_ERROR: {
     sol_log("return error");
     return 42;
   }
-  case TEST_DERIVED_SIGNERS: {
+  case DERIVED_SIGNERS: {
     sol_log("verify derived signers");
     static const int INVOKED_PROGRAM_INDEX = 0;
     static const int DERIVED_KEY1_INDEX = 1;
@@ -108,7 +112,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
         {accounts[DERIVED_KEY1_INDEX].key, true, false},
         {accounts[DERIVED_KEY2_INDEX].key, true, true},
         {accounts[DERIVED_KEY3_INDEX].key, false, true}};
-    uint8_t data[] = {TEST_VERIFY_NESTED_SIGNERS};
+    uint8_t data[] = {VERIFY_NESTED_SIGNERS};
     const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                         arguments, SOL_ARRAY_SIZE(arguments),
                                         data, SOL_ARRAY_SIZE(data)};
@@ -130,7 +134,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
     break;
   }
 
-  case TEST_VERIFY_NESTED_SIGNERS: {
+  case VERIFY_NESTED_SIGNERS: {
     sol_log("verify derived nested signers");
     static const int DERIVED_KEY1_INDEX = 0;
     static const int DERIVED_KEY2_INDEX = 1;
@@ -144,7 +148,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
     break;
   }
 
-  case TEST_VERIFY_WRITER: {
+  case VERIFY_WRITER: {
     sol_log("verify writable");
     static const int ARGUMENT_INDEX = 0;
     sol_assert(sol_deserialize(input, &params, 1));
@@ -152,11 +156,11 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_assert(accounts[ARGUMENT_INDEX].is_writable);
     break;
   }
-  case TEST_VERIFY_PRIVILEGE_ESCALATION: {
+  case VERIFY_PRIVILEGE_ESCALATION: {
     sol_log("Success");
     break;
   }
-  case TEST_NESTED_INVOKE: {
+  case NESTED_INVOKE: {
     sol_log("invoke");
 
     static const int INVOKED_ARGUMENT_INDEX = 0;
@@ -179,7 +183,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
       SolAccountMeta arguments[] = {
           {accounts[INVOKED_ARGUMENT_INDEX].key, true, true},
           {accounts[ARGUMENT_INDEX].key, true, true}};
-      uint8_t data[] = {TEST_NESTED_INVOKE};
+      uint8_t data[] = {NESTED_INVOKE};
       const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
                                           arguments, SOL_ARRAY_SIZE(arguments),
                                           data, SOL_ARRAY_SIZE(data)};

--- a/programs/bpf/rust/invoked/src/instruction.rs
+++ b/programs/bpf/rust/invoked/src/instruction.rs
@@ -5,13 +5,14 @@ use solana_program::{
     pubkey::Pubkey,
 };
 
-pub const TEST_VERIFY_TRANSLATIONS: u8 = 0;
-pub const TEST_RETURN_ERROR: u8 = 1;
-pub const TEST_DERIVED_SIGNERS: u8 = 2;
-pub const TEST_VERIFY_NESTED_SIGNERS: u8 = 3;
-pub const TEST_VERIFY_WRITER: u8 = 4;
-pub const TEST_VERIFY_PRIVILEGE_ESCALATION: u8 = 5;
-pub const TEST_NESTED_INVOKE: u8 = 6;
+pub const VERIFY_TRANSLATIONS: u8 = 0;
+pub const RETURN_ERROR: u8 = 1;
+pub const DERIVED_SIGNERS: u8 = 2;
+pub const VERIFY_NESTED_SIGNERS: u8 = 3;
+pub const VERIFY_WRITER: u8 = 4;
+pub const VERIFY_PRIVILEGE_ESCALATION: u8 = 5;
+pub const NESTED_INVOKE: u8 = 6;
+pub const RETURN_OK: u8 = 7;
 
 pub fn create_instruction(
     program_id: Pubkey,

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -27,7 +27,7 @@ fn process_instruction(
     }
 
     match instruction_data[0] {
-        TEST_VERIFY_TRANSLATIONS => {
+        VERIFY_TRANSLATIONS => {
             msg!("verify data translations");
 
             const ARGUMENT_INDEX: usize = 0;
@@ -105,19 +105,15 @@ fn process_instruction(
                 msg!(data[0], 0, 0, 0, 0);
             }
         }
-        TEST_RETURN_ERROR => {
+        RETURN_OK => {
+            msg!("Ok");
+            return Ok(());
+        }
+        RETURN_ERROR => {
             msg!("return error");
-            const ARGUMENT_INDEX: usize = 0;
-
-            // modify lamports that should be dropped
-            assert_eq!(10, **accounts[ARGUMENT_INDEX].try_borrow_lamports()?);
-            **accounts[ARGUMENT_INDEX].try_borrow_mut_lamports()? += 1;
-            // modify data that should be dropped
-            assert_eq!(0, accounts[ARGUMENT_INDEX].try_borrow_mut_data()?[0]);
-            accounts[ARGUMENT_INDEX].try_borrow_mut_data()?[0] = 1;
             return Err(ProgramError::Custom(42));
         }
-        TEST_DERIVED_SIGNERS => {
+        DERIVED_SIGNERS => {
             msg!("verify derived signers");
             const INVOKED_PROGRAM_INDEX: usize = 0;
             const DERIVED_KEY1_INDEX: usize = 1;
@@ -137,7 +133,7 @@ fn process_instruction(
                     (accounts[DERIVED_KEY2_INDEX].key, true, true),
                     (accounts[DERIVED_KEY3_INDEX].key, false, true),
                 ],
-                vec![TEST_VERIFY_NESTED_SIGNERS],
+                vec![VERIFY_NESTED_SIGNERS],
             );
             invoke_signed(
                 &invoked_instruction,
@@ -148,7 +144,7 @@ fn process_instruction(
                 ],
             )?;
         }
-        TEST_VERIFY_NESTED_SIGNERS => {
+        VERIFY_NESTED_SIGNERS => {
             msg!("verify nested derived signers");
             const DERIVED_KEY1_INDEX: usize = 0;
             const DERIVED_KEY2_INDEX: usize = 1;
@@ -158,16 +154,16 @@ fn process_instruction(
             assert!(accounts[DERIVED_KEY2_INDEX].is_signer);
             assert!(accounts[DERIVED_KEY3_INDEX].is_signer);
         }
-        TEST_VERIFY_WRITER => {
+        VERIFY_WRITER => {
             msg!("verify writable");
             const ARGUMENT_INDEX: usize = 0;
 
             assert!(!accounts[ARGUMENT_INDEX].is_writable);
         }
-        TEST_VERIFY_PRIVILEGE_ESCALATION => {
+        VERIFY_PRIVILEGE_ESCALATION => {
             msg!("Success");
         }
-        TEST_NESTED_INVOKE => {
+        NESTED_INVOKE => {
             msg!("nested invoke");
 
             const ARGUMENT_INDEX: usize = 0;
@@ -186,7 +182,7 @@ fn process_instruction(
                         (accounts[ARGUMENT_INDEX].key, true, true),
                         (accounts[INVOKED_ARGUMENT_INDEX].key, true, true),
                     ],
-                    vec![TEST_NESTED_INVOKE],
+                    vec![NESTED_INVOKE],
                 );
                 invoke(&invoked_instruction, accounts)?;
             } else {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -130,6 +130,10 @@ pub mod use_loaded_program_accounts {
     solana_sdk::declare_id!("FLjgLeg1PJkZimQCVa5sVFtaq6VmSDPw3NvH8iQ3nyHn");
 }
 
+pub mod abort_on_all_cpi_failures {
+    solana_sdk::declare_id!("ED5D5a2hQaECHaMmKpnU48GdsfafdCjkb3pgAw5RKbb2");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -164,6 +168,7 @@ lazy_static! {
         (max_cpi_instruction_size_ipv6_mtu::id(), "Max cross-program invocation size 1280"),
         (limit_cpi_loader_invoke::id(), "Loader not authorized via CPI"),
         (use_loaded_program_accounts::id(), "Use loaded program accounts"),
+        (abort_on_all_cpi_failures::id(), "Abort on all CPI failures"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

A program called via CPI might call other programs and then fail gracefully.  If that happens the original caller will not have the updated account data from the other called programs and thus will fail runtime checks when it returns.

#### Summary of Changes

Bail immediately on all failed CPI invocations.

Fixes #
