### PR TITLE
chore: fix flaky web3 stake-program test

### DIFF
--- a/web3.js/test/stake-program.test.js
+++ b/web3.js/test/stake-program.test.js
@@ -414,7 +414,7 @@ test('live staking actions', async () => {
       connection,
       deactivateNotAuthorized,
       [authorized],
-      {commitment: 'singleGossip', skipPreflight: true},
+      {commitment: 'singleGossip'},
     ),
   ).rejects.toThrow();
 

--- a/web3.js/test/stake-program.test.js
+++ b/web3.js/test/stake-program.test.js
@@ -378,6 +378,13 @@ test('live staking actions', async () => {
     commitment: 'singleGossip',
   });
 
+  let stakeActivationState;
+  do {
+    stakeActivationState = await connection.getStakeActivation(
+      newAccountPubkey,
+    );
+  } while (stakeActivationState.state != 'inactive');
+
   // Test that withdraw succeeds after deactivation
   withdraw = StakeProgram.withdraw({
     stakePubkey: newAccountPubkey,

--- a/web3.js/test/stake-program.test.js
+++ b/web3.js/test/stake-program.test.js
@@ -369,6 +369,29 @@ test('live staking actions', async () => {
     }),
   ).rejects.toThrow();
 
+  // Deactivate stake
+  let deactivate = StakeProgram.deactivate({
+    stakePubkey: newAccountPubkey,
+    authorizedPubkey: authorized.publicKey,
+  });
+  await sendAndConfirmTransaction(connection, deactivate, [authorized], {
+    commitment: 'singleGossip',
+  });
+
+  // Test that withdraw succeeds after deactivation
+  withdraw = StakeProgram.withdraw({
+    stakePubkey: newAccountPubkey,
+    authorizedPubkey: authorized.publicKey,
+    toPubkey: recipient.publicKey,
+    lamports: minimumAmount + 20,
+  });
+
+  await sendAndConfirmTransaction(connection, withdraw, [authorized], {
+    commitment: 'singleGossip',
+  });
+  const recipientBalance = await connection.getBalance(recipient.publicKey);
+  expect(recipientBalance).toEqual(minimumAmount + 20);
+
   // Split stake
   const newStake = new Account();
   let split = StakeProgram.split({
@@ -380,6 +403,8 @@ test('live staking actions', async () => {
   await sendAndConfirmTransaction(connection, split, [authorized, newStake], {
     commitment: 'singleGossip',
   });
+  const balance = await connection.getBalance(newAccountPubkey);
+  expect(balance).toEqual(minimumAmount + 2);
 
   // Authorize to new account
   const newAuthorized = new Account();
@@ -404,44 +429,17 @@ test('live staking actions', async () => {
     commitment: 'singleGossip',
   });
 
-  // Test old authorized can't deactivate
-  let deactivateNotAuthorized = StakeProgram.deactivate({
+  // Test old authorized can't delegate
+  let delegateNotAuthorized = StakeProgram.delegate({
     stakePubkey: newAccountPubkey,
     authorizedPubkey: authorized.publicKey,
+    votePubkey,
   });
   await expect(
-    sendAndConfirmTransaction(
-      connection,
-      deactivateNotAuthorized,
-      [authorized],
-      {commitment: 'singleGossip'},
-    ),
+    sendAndConfirmTransaction(connection, delegateNotAuthorized, [authorized], {
+      commitment: 'singleGossip',
+    }),
   ).rejects.toThrow();
-
-  // Deactivate stake
-  let deactivate = StakeProgram.deactivate({
-    stakePubkey: newAccountPubkey,
-    authorizedPubkey: newAuthorized.publicKey,
-  });
-  await sendAndConfirmTransaction(connection, deactivate, [newAuthorized], {
-    commitment: 'singleGossip',
-  });
-
-  // Test that withdraw succeeds after deactivation
-  withdraw = StakeProgram.withdraw({
-    stakePubkey: newAccountPubkey,
-    authorizedPubkey: newAuthorized.publicKey,
-    toPubkey: recipient.publicKey,
-    lamports: minimumAmount + 20,
-  });
-
-  await sendAndConfirmTransaction(connection, withdraw, [newAuthorized], {
-    commitment: 'singleGossip',
-  });
-  const balance = await connection.getBalance(newAccountPubkey);
-  expect(balance).toEqual(minimumAmount + 2);
-  const recipientBalance = await connection.getBalance(recipient.publicKey);
-  expect(recipientBalance).toEqual(minimumAmount + 20);
 
   // Authorize a derived address
   authorize = StakeProgram.authorize({


### PR DESCRIPTION
#### Problem
`stake-program.test.js` runs Deactivate and assumes that the stake account is whithdraw-able immediately. As it happens, an epoch boundary falls between Delegate and Deactivate very often in CI, making the Withdraw attempt throw an error because the stake is not cooled down.

#### Summary of Changes
- Rearrange stake test so that deactivation happens immediately after delegation to minimize chances of epoch boundary falling between these actions. Change invalid-authority action from Deactivate to Delegate.
- Add a loop to ensure stake is `inactive` before attempting to Withdraw in the very unlucky off-chance that we do still hit the epoch boundary
- Also remove dangling `skipPreflight`. I think there are others in other tests, but that's work for another time.
