### PR TITLE
ledger: Humanize the 'ledger processed...' time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,6 +4328,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "chrono",
+ "chrono-humanize",
  "crossbeam-channel",
  "dlopen",
  "dlopen_derive",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 bincode = "1.3.1"
 byteorder = "1.3.4"
 chrono = { version = "0.4.11", features = ["serde"] }
+chrono-humanize = "0.1.1"
 crossbeam-channel = "0.4"
 dlopen_derive = "0.1.4"
 dlopen = "0.1.8"

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -6,6 +6,7 @@ use crate::{
     entry::{create_ticks, Entry, EntrySlice, EntryVerificationStatus, VerifyRecyclers},
     leader_schedule_cache::LeaderScheduleCache,
 };
+use chrono_humanize::{Accuracy, HumanTime, Tense};
 use crossbeam_channel::Sender;
 use itertools::Itertools;
 use log::*;
@@ -34,7 +35,6 @@ use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
     signature::{Keypair, Signature},
-    timing::duration_as_ms,
     transaction::{Result, Transaction, TransactionError},
 };
 use solana_transaction_status::token_balances::{
@@ -479,8 +479,8 @@ fn do_process_blockstore_from_root(
     let bank_forks = BankForks::new_from_banks(&initial_forks, root);
 
     info!(
-        "ledger processed in {}ms. {} MB allocated. root={}, {} fork{} at {}, with {} frozen bank{}",
-        duration_as_ms(&now.elapsed()),
+        "ledger processed in {}. {} MB allocated. root slot is {}, {} fork{} at {}, with {} frozen bank{}",
+        HumanTime::from(chrono::Duration::from_std(now.elapsed()).unwrap()).to_text_en(Accuracy::Precise, Tense::Present),
         allocated.since(initial_allocation) / 1_000_000,
         bank_forks.root(),
         initial_forks.len(),


### PR DESCRIPTION
nit: "ledger processed in 3423432433432ms" isn't super helpful.  Use a format that humans can better understand at a glance