### PR TITLE
Clean accounts dirs earlier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5126,6 +5126,7 @@ dependencies = [
  "solana-faucet",
  "solana-ledger",
  "solana-logger 1.6.0",
+ "solana-measure",
  "solana-metrics",
  "solana-net-utils",
  "solana-perf",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -42,7 +42,6 @@ use solana_ledger::{
     leader_schedule_cache::LeaderScheduleCache,
     poh::compute_hash_time_ns,
 };
-use solana_measure::measure::Measure;
 use solana_metrics::datapoint_info;
 use solana_runtime::{
     accounts_index::AccountIndex,
@@ -284,19 +283,6 @@ impl Validator {
                 );
             }
         }
-
-        info!("Cleaning accounts paths..");
-        let mut start = Measure::start("clean_accounts_paths");
-        for accounts_path in &config.account_paths {
-            cleanup_accounts_path(accounts_path);
-        }
-        if let Some(ref shrink_paths) = config.account_shrink_paths {
-            for accounts_path in shrink_paths {
-                cleanup_accounts_path(accounts_path);
-            }
-        }
-        start.stop();
-        info!("done. {}", start);
 
         let mut validator_exit = ValidatorExit::default();
         let exit = Arc::new(AtomicBool::new(false));
@@ -1289,16 +1275,6 @@ fn get_stake_percent_in_gossip(bank: &Bank, cluster_info: &ClusterInfo, log: boo
     }
 
     online_stake * 100 / total_activated_stake
-}
-
-// Cleanup anything that looks like an accounts append-vec
-fn cleanup_accounts_path(account_path: &std::path::Path) {
-    if std::fs::remove_dir_all(account_path).is_err() {
-        warn!(
-            "encountered error removing accounts path: {:?}",
-            account_path
-        );
-    }
 }
 
 pub fn is_snapshot_config_invalid(

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -29,9 +29,10 @@ solana-download-utils = { path = "../download-utils", version = "1.6.0" }
 solana-faucet = { path = "../faucet", version = "1.6.0" }
 solana-ledger = { path = "../ledger", version = "1.6.0" }
 solana-logger = { path = "../logger", version = "1.6.0" }
-solana-perf = { path = "../perf", version = "1.6.0" }
+solana-measure = { path = "../measure", version = "1.6.0" }
 solana-metrics = { path = "../metrics", version = "1.6.0" }
 solana-net-utils = { path = "../net-utils", version = "1.6.0" }
+solana-perf = { path = "../perf", version = "1.6.0" }
 solana-runtime = { path = "../runtime", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }


### PR DESCRIPTION
#### Problem

Accounts files can take significant resources when mapped into memory causing problems for validator startup.

#### Summary of Changes

Clean the accounts paths earlier in the validator startup.

Fixes #
