### PR TITLE
Cli: Implement OutputFormat for some missing subcommands

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1162,6 +1162,32 @@ impl fmt::Display for CliBlockTime {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliLeaderSchedule {
+    pub epoch: Epoch,
+    pub leader_schedule_entries: Vec<CliLeaderScheduleEntry>,
+}
+
+impl QuietDisplay for CliLeaderSchedule {}
+impl VerboseDisplay for CliLeaderSchedule {}
+
+impl fmt::Display for CliLeaderSchedule {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for entry in &self.leader_schedule_entries {
+            writeln!(f, "  {:<15} {:<44}", entry.slot, entry.leader)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliLeaderScheduleEntry {
+    pub slot: Slot,
+    pub leader: String,
+}
+
 #[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct CliSignOnlyData {

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -10,7 +10,8 @@ use serde_json::{Map, Value};
 use solana_account_decoder::parse_token::UiTokenAccount;
 use solana_clap_utils::keypair::SignOnly;
 use solana_client::rpc_response::{
-    RpcAccountBalance, RpcKeyedAccount, RpcSupply, RpcVoteAccountInfo,
+    RpcAccountBalance, RpcInflationGovernor, RpcInflationRate, RpcKeyedAccount, RpcSupply,
+    RpcVoteAccountInfo,
 };
 use solana_sdk::{
     clock::{self, Epoch, Slot, UnixTimestamp},
@@ -1186,6 +1187,78 @@ impl fmt::Display for CliLeaderSchedule {
 pub struct CliLeaderScheduleEntry {
     pub slot: Slot,
     pub leader: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliInflation {
+    pub governor: RpcInflationGovernor,
+    pub current_rate: RpcInflationRate,
+}
+
+impl QuietDisplay for CliInflation {}
+impl VerboseDisplay for CliInflation {}
+
+impl fmt::Display for CliInflation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "{}", style("Inflation Governor:").bold())?;
+        if (self.governor.initial - self.governor.terminal).abs() < f64::EPSILON {
+            writeln!(
+                f,
+                "Fixed APR:               {:>5.2}%",
+                self.governor.terminal * 100.
+            )?;
+        } else {
+            writeln!(
+                f,
+                "Initial APR:             {:>5.2}%",
+                self.governor.initial * 100.
+            )?;
+            writeln!(
+                f,
+                "Terminal APR:            {:>5.2}%",
+                self.governor.terminal * 100.
+            )?;
+            writeln!(
+                f,
+                "Rate reduction per year: {:>5.2}%",
+                self.governor.taper * 100.
+            )?;
+        }
+        if self.governor.foundation_term > 0. {
+            writeln!(
+                f,
+                "Foundation percentage:   {:>5.2}%",
+                self.governor.foundation
+            )?;
+            writeln!(
+                f,
+                "Foundation term:         {:.1} years",
+                self.governor.foundation_term
+            )?;
+        }
+
+        writeln!(
+            f,
+            "\n{}",
+            style(format!("Inflation for Epoch {}:", self.current_rate.epoch)).bold()
+        )?;
+        writeln!(
+            f,
+            "Total APR:               {:>5.2}%",
+            self.current_rate.total * 100.
+        )?;
+        writeln!(
+            f,
+            "Staking APR:             {:>5.2}%",
+            self.current_rate.validator * 100.
+        )?;
+        writeln!(
+            f,
+            "Foundation APR:          {:>5.2}%",
+            self.current_rate.foundation * 100.
+        )
+    }
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1178,7 +1178,9 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::Inflation(inflation_subcommand) => {
             process_inflation_subcommand(&rpc_client, config, inflation_subcommand)
         }
-        CliCommand::LeaderSchedule { epoch } => process_leader_schedule(&rpc_client, *epoch),
+        CliCommand::LeaderSchedule { epoch } => {
+            process_leader_schedule(&rpc_client, config, *epoch)
+        }
         CliCommand::LiveSlots => process_live_slots(&config),
         CliCommand::Logs { filter } => process_logs(&config, filter),
         CliCommand::Ping {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -837,7 +837,11 @@ pub fn parse_leader_schedule(matches: &ArgMatches<'_>) -> Result<CliCommandInfo,
     })
 }
 
-pub fn process_leader_schedule(rpc_client: &RpcClient, epoch: Option<Epoch>) -> ProcessResult {
+pub fn process_leader_schedule(
+    rpc_client: &RpcClient,
+    config: &CliConfig,
+    epoch: Option<Epoch>,
+) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info()?;
     let epoch = epoch.unwrap_or(epoch_info.epoch);
     if epoch > epoch_info.epoch {
@@ -867,15 +871,18 @@ pub fn process_leader_schedule(rpc_client: &RpcClient, epoch: Option<Epoch>) -> 
         }
     }
 
+    let mut leader_schedule_entries = vec![];
     for (slot_index, leader) in leader_per_slot_index.iter().enumerate() {
-        println!(
-            "  {:<15} {:<44}",
-            first_slot_in_epoch + slot_index as u64,
-            leader
-        );
+        leader_schedule_entries.push(CliLeaderScheduleEntry {
+            slot: first_slot_in_epoch + slot_index as u64,
+            leader: leader.to_string(),
+        });
     }
 
-    Ok("".to_string())
+    Ok(config.output_format.formatted_string(&CliLeaderSchedule {
+        epoch,
+        leader_schedule_entries,
+    }))
 }
 
 pub fn process_get_block(

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -1,7 +1,7 @@
 use crate::cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult};
 use clap::{App, ArgMatches, SubCommand};
-use console::style;
 use solana_clap_utils::keypair::*;
+use solana_cli_output::CliInflation;
 use solana_client::rpc_client::RpcClient;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use std::sync::Arc;
@@ -34,56 +34,18 @@ pub fn parse_inflation_subcommand(
 
 pub fn process_inflation_subcommand(
     rpc_client: &RpcClient,
-    _config: &CliConfig,
+    config: &CliConfig,
     inflation_subcommand: &InflationCliCommand,
 ) -> ProcessResult {
     assert_eq!(*inflation_subcommand, InflationCliCommand::Show);
 
     let governor = rpc_client.get_inflation_governor()?;
-    let current_inflation_rate = rpc_client.get_inflation_rate()?;
+    let current_rate = rpc_client.get_inflation_rate()?;
 
-    println!("{}", style("Inflation Governor:").bold());
-    if (governor.initial - governor.terminal).abs() < f64::EPSILON {
-        println!(
-            "Fixed APR:               {:>5.2}%",
-            governor.terminal * 100.
-        );
-    } else {
-        println!("Initial APR:             {:>5.2}%", governor.initial * 100.);
-        println!(
-            "Terminal APR:            {:>5.2}%",
-            governor.terminal * 100.
-        );
-        println!("Rate reduction per year: {:>5.2}%", governor.taper * 100.);
-    }
-    if governor.foundation_term > 0. {
-        println!("Foundation percentage:   {:>5.2}%", governor.foundation);
-        println!(
-            "Foundation term:         {:.1} years",
-            governor.foundation_term
-        );
-    }
+    let inflation = CliInflation {
+        governor,
+        current_rate,
+    };
 
-    println!(
-        "\n{}",
-        style(format!(
-            "Inflation for Epoch {}:",
-            current_inflation_rate.epoch
-        ))
-        .bold()
-    );
-    println!(
-        "Total APR:               {:>5.2}%",
-        current_inflation_rate.total * 100.
-    );
-    println!(
-        "Staking APR:             {:>5.2}%",
-        current_inflation_rate.validator * 100.
-    );
-    println!(
-        "Foundation APR:          {:>5.2}%",
-        current_inflation_rate.foundation * 100.
-    );
-
-    Ok("".to_string())
+    Ok(config.output_format.formatted_string(&inflation))
 }


### PR DESCRIPTION
#### Problem
Not all cli commands have been updated to produce properly formatted output.

#### Summary of Changes
- Implement OutputFormat for `solana leader-schedule` and `solana inflation

Toward #14509 
