### PR TITLE
Bump RBPF version to v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5205,9 +5205,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f14c9649bc6c2dfc205b3450007ef02ec7331c1ea8f109468d53d159a09f3a"
+checksum = "77cd2bce0b970bcc90210d005d838cd37745899f41f4d096edc58b49d8bb6094"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,7 +37,7 @@ solana-config-program = { path = "../programs/config", version = "1.6.0" }
 solana-faucet = { path = "../faucet", version = "1.6.0" }
 solana-logger = { path = "../logger", version = "1.6.0" }
 solana-net-utils = { path = "../net-utils", version = "1.6.0" }
-solana_rbpf = "=0.2.2"
+solana_rbpf = "=0.2.3"
 solana-remote-wallet = { path = "../remote-wallet", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.6.0" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2418,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f14c9649bc6c2dfc205b3450007ef02ec7331c1ea8f109468d53d159a09f3a"
+checksum = "77cd2bce0b970bcc90210d005d838cd37745899f41f4d096edc58b49d8bb6094"
 dependencies = [
  "byteorder 1.3.4",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -29,7 +29,7 @@ solana-logger = { path = "../../logger", version = "1.6.0" }
 solana-measure = { path = "../../measure", version = "1.6.0" }
 solana-runtime = { path = "../../runtime", version = "1.6.0" }
 solana-sdk = { path = "../../sdk", version = "1.6.0" }
-solana_rbpf = "=0.2.2"
+solana_rbpf = "=0.2.3"
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-runtime = { path = "../../runtime", version = "1.6.0" }
 solana-sdk = { path = "../../sdk", version = "1.6.0" }
-solana_rbpf = "=0.2.2"
+solana_rbpf = "=0.2.3"
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
#### Summary of Changes
See https://github.com/solana-labs/rbpf/releases/tag/v0.2.3
