### PR TITLE
docs: Add stake programming documentation

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -45,6 +45,7 @@ module.exports = {
     "Staking": [
       "staking",
       "staking/stake-accounts",
+      "staking/stake-programming",
     ],
     "Command Line": [
       "cli",

--- a/docs/src/staking/stake-programming.md
+++ b/docs/src/staking/stake-programming.md
@@ -9,7 +9,7 @@ stakes easier to manage.
 
 #### Stake-o-matic aka Auto-delegation Bots
 This off-chain program manages a large population of validators staked by a
-central authority. The Solana Foundation uses it to regularaly delegate its
+central authority. The Solana Foundation uses an auto-delegation bot to regularly delegate its
 stake to "non-delinquent" validators. More information can be found on the
 [official announcement](https://forums.solana.com/t/stake-o-matic-delegation-matching-program/790).
 

--- a/docs/src/staking/stake-programming.md
+++ b/docs/src/staking/stake-programming.md
@@ -1,0 +1,25 @@
+---
+title: Stake Programming
+---
+
+To maximize stake distribution, decentralization, and censorship resistance on 
+the Solana network, staking can be performed programmatically. The team
+and community have developed several on-chain and off-chain programs to make
+stakes easier to manage.
+
+#### Stake-o-matic
+This off-chain program manages a large population of validators staked by a
+central authority. The Solana Foundation uses it to regularaly delegate its
+stake to "non-delinquent" validators. More information can be found on the
+[official announcement](https://forums.solana.com/t/stake-o-matic-delegation-matching-program/790).
+
+#### Stake Pools
+This on-chain program pools together SOL to be staked by a manager, allowing SOL
+holders to stake and earn rewards without managing stakes.
+Users deposit SOL in exchange for tokens representing ownership in the pool. The pool
+manager stakes deposited SOL according to their strategy, perhaps using a variant
+of the Stake-o-matic program. As stakes earn rewards, the pool and pool tokens 
+grow proportionally in value. Finally, pool token holders can provide pool
+tokens in exchange for SOL, thereby participating in decentralization with much
+less work required. More information can be found at the
+[SPL stake pool documentation](https://spl.solana.com/stake-pool).

--- a/docs/src/staking/stake-programming.md
+++ b/docs/src/staking/stake-programming.md
@@ -10,7 +10,7 @@ stakes easier to manage.
 #### Stake-o-matic aka Auto-delegation Bots
 This off-chain program manages a large population of validators staked by a
 central authority. The Solana Foundation uses an auto-delegation bot to regularly delegate its
-stake to "non-delinquent" validators. More information can be found on the
+stake to "non-delinquent" validators that meet specified performance requirements. More information can be found on the
 [official announcement](https://forums.solana.com/t/stake-o-matic-delegation-matching-program/790).
 
 #### Stake Pools

--- a/docs/src/staking/stake-programming.md
+++ b/docs/src/staking/stake-programming.md
@@ -2,7 +2,7 @@
 title: Stake Programming
 ---
 
-To maximize stake distribution, decentralization, and censorship resistance on 
+To maximize stake distribution, decentralization, and censorship resistance on
 the Solana network, staking can be performed programmatically. The team
 and community have developed several on-chain and off-chain programs to make
 stakes easier to manage.
@@ -18,7 +18,7 @@ This on-chain program pools together SOL to be staked by a manager, allowing SOL
 holders to stake and earn rewards without managing stakes.
 Users deposit SOL in exchange for SPL tokens (staking derivatives) that represent their ownership in the stake pool. The pool
 manager stakes deposited SOL according to their strategy, perhaps using a variant
-of an auto-delegation bot as described above. As stakes earn rewards, the pool and pool tokens 
+of an auto-delegation bot as described above. As stakes earn rewards, the pool and pool tokens
 grow proportionally in value. Finally, pool token holders can send SPL tokens
 back to the stake pool to redeem SOL, thereby participating in decentralization with much
 less work required. More information can be found at the

--- a/docs/src/staking/stake-programming.md
+++ b/docs/src/staking/stake-programming.md
@@ -16,7 +16,7 @@ stake to "non-delinquent" validators that meet specified performance requirement
 #### Stake Pools
 This on-chain program pools together SOL to be staked by a manager, allowing SOL
 holders to stake and earn rewards without managing stakes.
-Users deposit SOL in exchange for tokens representing ownership in the pool. The pool
+Users deposit SOL in exchange for SPL tokens (staking derivatives) that represent their ownership in the stake pool. The pool
 manager stakes deposited SOL according to their strategy, perhaps using a variant
 of the Stake-o-matic program. As stakes earn rewards, the pool and pool tokens 
 grow proportionally in value. Finally, pool token holders can provide pool

--- a/docs/src/staking/stake-programming.md
+++ b/docs/src/staking/stake-programming.md
@@ -7,7 +7,7 @@ the Solana network, staking can be performed programmatically. The team
 and community have developed several on-chain and off-chain programs to make
 stakes easier to manage.
 
-#### Stake-o-matic
+#### Stake-o-matic aka Auto-delegation Bots
 This off-chain program manages a large population of validators staked by a
 central authority. The Solana Foundation uses it to regularaly delegate its
 stake to "non-delinquent" validators. More information can be found on the

--- a/docs/src/staking/stake-programming.md
+++ b/docs/src/staking/stake-programming.md
@@ -19,7 +19,7 @@ holders to stake and earn rewards without managing stakes.
 Users deposit SOL in exchange for SPL tokens (staking derivatives) that represent their ownership in the stake pool. The pool
 manager stakes deposited SOL according to their strategy, perhaps using a variant
 of an auto-delegation bot as described above. As stakes earn rewards, the pool and pool tokens 
-grow proportionally in value. Finally, pool token holders can provide pool
-tokens in exchange for SOL, thereby participating in decentralization with much
+grow proportionally in value. Finally, pool token holders can send SPL tokens
+back to the stake pool to redeem SOL, thereby participating in decentralization with much
 less work required. More information can be found at the
 [SPL stake pool documentation](https://spl.solana.com/stake-pool).

--- a/docs/src/staking/stake-programming.md
+++ b/docs/src/staking/stake-programming.md
@@ -18,7 +18,7 @@ This on-chain program pools together SOL to be staked by a manager, allowing SOL
 holders to stake and earn rewards without managing stakes.
 Users deposit SOL in exchange for SPL tokens (staking derivatives) that represent their ownership in the stake pool. The pool
 manager stakes deposited SOL according to their strategy, perhaps using a variant
-of the Stake-o-matic program. As stakes earn rewards, the pool and pool tokens 
+of an auto-delegation bot as described above. As stakes earn rewards, the pool and pool tokens 
 grow proportionally in value. Finally, pool token holders can provide pool
 tokens in exchange for SOL, thereby participating in decentralization with much
 less work required. More information can be found at the


### PR DESCRIPTION
#### Problem

We had a question on Discord about stake programming documentation, and there
wasn't a place that contained information about the stake-o-matic and
other stake development in one place.

#### Summary of Changes

Add a new docs page with that information.  Comments are welcome if there's a better place for this information, or if more information from the official announcements need to be included, or if the wording needs to be improved.  This PR can at least get the conversation started about how to document them in one place.

Fixes #
