### PR TITLE
Use standard tmp-snapshot- file prefix for the "new_state" archive for better cleanup/consistency

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -220,6 +220,7 @@ fn main() {
             exit(1);
         })
     }
+    solana_runtime::snapshot_utils::remove_tmp_snapshot_archives(&ledger_path);
 
     let validator_log_symlink = ledger_path.join("validator.log");
     let logfile = if output != Output::Log {


### PR DESCRIPTION
The name `ledger/new_state.tar.zst` is confusing and doesn't get cleaned up if the validator aborts while producing it.  Instead:
* Call it `ledger/tmp-snapshot-{slot}.zst`, which has the added benefit of clearly indicating which slot the new snapshot is being produced for
* An interrupted archive will get cleaned up on validator restart as all `ledger/tmp-snapshot-*` files/directories get removed

(builds on https://github.com/solana-labs/solana/pull/14528)