### PR TITLE
v1.4: Update timestamp max allowable drift to 50% of PoH

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2894,7 +2894,7 @@ pub mod tests {
     };
     use solana_vote_program::{
         vote_instruction,
-        vote_state::{Vote, VoteInit, MAX_LOCKOUT_HISTORY},
+        vote_state::{BlockTimestamp, Vote, VoteInit, VoteStateVersions, MAX_LOCKOUT_HISTORY},
     };
     use spl_token_v2_0::{
         solana_program::{program_option::COption, pubkey::Pubkey as SplTokenPubkey},
@@ -2929,6 +2929,18 @@ pub mod tests {
     ) -> RpcHandler {
         let (bank_forks, alice, leader_vote_keypair) = new_bank_forks();
         let bank = bank_forks.read().unwrap().working_bank();
+
+        let vote_pubkey = leader_vote_keypair.pubkey();
+        let mut vote_account = bank.get_account(&vote_pubkey).unwrap_or_default();
+        let mut vote_state = VoteState::from(&vote_account).unwrap_or_default();
+        vote_state.last_timestamp = BlockTimestamp {
+            slot: bank.slot(),
+            timestamp: bank.clock().unix_timestamp,
+        };
+        let versioned = VoteStateVersions::new_current(vote_state);
+        VoteState::to(&versioned, &mut vote_account).unwrap();
+        bank.store_account(&vote_pubkey, &vote_account);
+
         let ledger_path = get_tmp_ledger_path!();
         let blockstore = Blockstore::open(&ledger_path).unwrap();
         let blockstore = Arc::new(blockstore);
@@ -5118,7 +5130,7 @@ pub mod tests {
         let res = io.handle_request_sync(&req, meta.clone());
         let expected = format!(
             r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#,
-            base_timestamp + (5 * slot_duration).as_secs() as i64
+            base_timestamp + (7 * slot_duration).as_secs() as i64
         );
         let expected: Response =
             serde_json::from_str(&expected).expect("expected response deserialization");

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -60,7 +60,9 @@ use solana_sdk::{
     slot_hashes::SlotHashes,
     slot_history::SlotHistory,
     stake_weighted_timestamp::{
-        calculate_stake_weighted_timestamp, EstimateType, DEPRECATED_TIMESTAMP_SLOT_RANGE,
+        calculate_stake_weighted_timestamp, EstimateType,
+        DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE, DEPRECATED_TIMESTAMP_SLOT_RANGE,
+        MAX_ALLOWABLE_DRIFT_PERCENTAGE,
     },
     system_transaction,
     sysvar::{self},
@@ -1304,7 +1306,18 @@ impl Bank {
                     } else {
                         None
                     };
-                    (EstimateType::Bounded, epoch_start_timestamp)
+                    let max_allowable_drift = if self
+                        .feature_set
+                        .is_active(&feature_set::warp_timestamp::id())
+                    {
+                        MAX_ALLOWABLE_DRIFT_PERCENTAGE
+                    } else {
+                        DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE
+                    };
+                    (
+                        EstimateType::Bounded(max_allowable_drift),
+                        epoch_start_timestamp,
+                    )
                 } else {
                     (EstimateType::Unbounded, None)
                 };
@@ -11064,6 +11077,10 @@ pub(crate) mod tests {
         genesis_config
             .accounts
             .remove(&feature_set::timestamp_bounding::id())
+            .unwrap();
+        genesis_config
+            .accounts
+            .remove(&feature_set::warp_timestamp::id())
             .unwrap();
         genesis_config.epoch_schedule = EpochSchedule::new(slots_in_epoch);
         let bank = Bank::new(&genesis_config);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1286,14 +1286,21 @@ impl Bank {
                     // needed for timestamp bounding, but isn't yet corrected for the activation slot
                     let epoch_start_timestamp = if self.slot() > timestamp_bounding_activation_slot
                     {
-                        let epoch = if let Some(epoch) = parent_epoch {
-                            epoch
+                        let warp_timestamp = self
+                            .feature_set
+                            .activated_slot(&feature_set::warp_timestamp::id());
+                        if warp_timestamp == Some(self.slot()) {
+                            None
                         } else {
-                            self.epoch()
-                        };
-                        let first_slot_in_epoch =
-                            self.epoch_schedule.get_first_slot_in_epoch(epoch);
-                        Some((first_slot_in_epoch, self.clock().epoch_start_timestamp))
+                            let epoch = if let Some(epoch) = parent_epoch {
+                                epoch
+                            } else {
+                                self.epoch()
+                            };
+                            let first_slot_in_epoch =
+                                self.epoch_schedule.get_first_slot_in_epoch(epoch);
+                            Some((first_slot_in_epoch, self.clock().epoch_start_timestamp))
+                        }
                     } else {
                         None
                     };

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -130,6 +130,10 @@ pub mod abort_on_all_cpi_failures {
     solana_sdk::declare_id!("ED5D5a2hQaECHaMmKpnU48GdsfafdCjkb3pgAw5RKbb2");
 }
 
+pub mod warp_timestamp {
+    solana_sdk::declare_id!("Bfqm7fGk5MBptqa2WHXWFLH7uJvq8hkJcAQPipy2bAMk");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -164,6 +168,7 @@ lazy_static! {
         (limit_cpi_loader_invoke::id(), "Loader not authorized via CPI"),
         (use_loaded_program_accounts::id(), "Use loaded program accounts"),
         (abort_on_all_cpi_failures::id(), "Abort on all CPI failures"),
+        (warp_timestamp::id(), "warp timestamp to current, adjust bounding to 50% #TODO"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -168,7 +168,7 @@ lazy_static! {
         (limit_cpi_loader_invoke::id(), "Loader not authorized via CPI"),
         (use_loaded_program_accounts::id(), "Use loaded program accounts"),
         (abort_on_all_cpi_failures::id(), "Abort on all CPI failures"),
-        (warp_timestamp::id(), "warp timestamp to current, adjust bounding to 50% #TODO"),
+        (warp_timestamp::id(), "warp timestamp to current, adjust bounding to 50% #14532"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
v1.4 version of #14531 

- Update max allowable drift to 50%, and make it easier to rolled changes to this value in the future (as must be feature-gated)
- Add `warp_timestamp` feature to bump timestamp and feature-gate percentage change
