### PR TITLE
fill in timing gaps in replay_stage

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -296,7 +296,6 @@ impl ReplayStage {
                 let mut partition_exists = false;
                 let mut skipped_slots_info = SkippedSlotsInfo::default();
                 let mut replay_timing = ReplayTiming::default();
-
                 loop {
                     let allocated = thread_mem_usage::Allocatedp::default();
 
@@ -598,13 +597,13 @@ impl ReplayStage {
 
                         let timer = Duration::from_millis(100);
                         let result = ledger_signal_receiver.recv_timeout(timer);
-                        wait_receive_time.stop();
                         match result {
                             Err(RecvTimeoutError::Timeout) => (),
                             Err(_) => break,
                             Ok(_) => trace!("blockstore signal"),
                         };
                     }
+                    wait_receive_time.stop();
 
                     replay_timing.update(
                         collect_frozen_banks_time.as_us(),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -123,6 +123,7 @@ pub struct ReplayTiming {
     reset_duplicate_slots_elapsed: u64,
     wait_receive_elapsed: u64,
     heaviest_fork_failures_elapsed: u64,
+    bank_count: u64,
 }
 impl ReplayTiming {
     #[allow(clippy::too_many_arguments)]
@@ -140,6 +141,7 @@ impl ReplayTiming {
         reset_duplicate_slots_elapsed: u64,
         wait_receive_elapsed: u64,
         heaviest_fork_failures_elapsed: u64,
+        bank_count: u64,
     ) {
         self.compute_bank_stats_elapsed += compute_bank_stats_elapsed;
         self.select_vote_and_reset_forks_elapsed += select_vote_and_reset_forks_elapsed;
@@ -153,6 +155,7 @@ impl ReplayTiming {
         self.reset_duplicate_slots_elapsed += reset_duplicate_slots_elapsed;
         self.wait_receive_elapsed += wait_receive_elapsed;
         self.heaviest_fork_failures_elapsed += heaviest_fork_failures_elapsed;
+        self.bank_count += bank_count;
         let now = timestamp();
         let elapsed_ms = now - self.last_print;
         if elapsed_ms > 1000 {
@@ -209,6 +212,11 @@ impl ReplayTiming {
                 (
                     "heaviest_fork_failures_elapsed",
                     self.heaviest_fork_failures_elapsed as i64,
+                    i64
+                ),
+                (
+                    "bank_count",
+                    self.bank_count as i64,
                     i64
                 ),
             );
@@ -607,6 +615,7 @@ impl ReplayStage {
                         reset_duplicate_slots_time.as_us(),
                         wait_receive_time.as_us(),
                         heaviest_fork_failures_time.as_us(),
+                        if did_complete_bank {1} else {0},
                     );
                 }
                 Ok(())

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -214,11 +214,7 @@ impl ReplayTiming {
                     self.heaviest_fork_failures_elapsed as i64,
                     i64
                 ),
-                (
-                    "bank_count",
-                    self.bank_count as i64,
-                    i64
-                ),
+                ("bank_count", self.bank_count as i64, i64),
             );
 
             *self = ReplayTiming::default();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -111,6 +111,7 @@ pub struct ReplayStageConfig {
 #[derive(Default)]
 pub struct ReplayTiming {
     last_print: u64,
+    collect_frozen_banks_elapsed: u64,
     compute_bank_stats_elapsed: u64,
     select_vote_and_reset_forks_elapsed: u64,
     start_leader_elapsed: u64,
@@ -129,6 +130,7 @@ impl ReplayTiming {
     #[allow(clippy::too_many_arguments)]
     fn update(
         &mut self,
+        collect_frozen_banks_elapsed: u64,
         compute_bank_stats_elapsed: u64,
         select_vote_and_reset_forks_elapsed: u64,
         start_leader_elapsed: u64,
@@ -143,6 +145,7 @@ impl ReplayTiming {
         heaviest_fork_failures_elapsed: u64,
         bank_count: u64,
     ) {
+        self.collect_frozen_banks_elapsed += collect_frozen_banks_elapsed;
         self.compute_bank_stats_elapsed += compute_bank_stats_elapsed;
         self.select_vote_and_reset_forks_elapsed += select_vote_and_reset_forks_elapsed;
         self.start_leader_elapsed += start_leader_elapsed;
@@ -162,6 +165,11 @@ impl ReplayTiming {
             datapoint_info!(
                 "replay-loop-timing-stats",
                 ("total_elapsed_us", elapsed_ms * 1000, i64),
+                (
+                    "collect_frozen_banks_elapsed",
+                    self.collect_frozen_banks_elapsed as i64,
+                    i64
+                ),
                 (
                     "compute_bank_stats_elapsed",
                     self.compute_bank_stats_elapsed as i64,
@@ -599,6 +607,7 @@ impl ReplayStage {
                     }
 
                     replay_timing.update(
+                        collect_frozen_banks_time.as_us(),
                         compute_bank_stats_time.as_us(),
                         select_vote_and_reset_forks_time.as_us(),
                         start_leader_time.as_us(),


### PR DESCRIPTION
#### Problem
replay_stage is taking longer than desired. The current timing has gaps in coverage such that only 50% of the total elapsed time is itemized. This makes it difficult to get an accurate picture of the time spent in replay_stage.

#### Summary of Changes
Add 2 time measurement metrics to cover the gaps.

Fixes #
