### PR TITLE
feat: publish more docker ports in localnet script (bp #12788)

### DIFF
--- a/web3.js/bin/localnet.sh
+++ b/web3.js/bin/localnet.sh
@@ -84,9 +84,21 @@ up)
       --detach
       --name solana-localnet
       --rm
-      --publish 8899:8899
-      --publish 8900:8900
-      --publish 9900:9900
+      --publish 8001:8001/tcp # entrypoint
+      --publish 8899:8899/tcp # rpc http
+      --publish 8900:8900/tcp # rpc pubsub
+      --publish 8901:8901/tcp # (future) bank service
+      --publish 8902:8902/tcp # bank service
+      --publish 9900:9900/tcp # faucet
+      --publish 8000:8000/udp # tvu
+      --publish 8001:8001/udp # gossip
+      --publish 8002:8002/udp # tvu_forwards
+      --publish 8003:8003/udp # tpu
+      --publish 8004:8004/udp # tpu_forwards
+      --publish 8005:8005/udp # retransmit
+      --publish 8006:8006/udp # repair
+      --publish 8007:8007/udp # serve_repair
+      --publish 8008:8008/udp # broadcast
       --tty
       --ulimit "nofile=500000"
       --env "RUST_LOG=$RUST_LOG"


### PR DESCRIPTION
#### Problem

This is a backport of #12788

The localnet script manages a docker container for a local node but it doesn't publish the udp port for the node's TPU. For performance reasons, developers may wish to directly send transactions to the TPU so it's useful to have the localnet dev environment expose this port.

#### Summary of Changes
- Publish all validator ports (tcp and udp)

Fixes #