### PR TITLE
Don't stop to find newer cluster-confirmed roots

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -830,11 +830,11 @@ fn load_frozen_forks(
     let mut last_status_report = Instant::now();
     let mut last_free = Instant::now();
     let mut pending_slots = vec![];
-    let mut last_root_slot = root_bank.slot();
+    let mut last_root = root_bank.slot();
     let mut slots_elapsed = 0;
     let mut txs = 0;
     let blockstore_max_root = blockstore.max_root();
-    let max_root = std::cmp::max(root_bank.slot(), blockstore_max_root);
+    let mut max_root = std::cmp::max(root_bank.slot(), blockstore_max_root);
     info!(
         "load_frozen_forks() latest root from blockstore: {}, max_root: {}",
         blockstore_max_root, max_root,
@@ -859,7 +859,7 @@ fn load_frozen_forks(
                 info!(
                     "processing ledger: slot={}, last root slot={} slots={} slots/s={:?} txs/s={}",
                     slot,
-                    last_root_slot,
+                    last_root,
                     slots_elapsed,
                     slots_elapsed as f32 / secs,
                     txs as f32 / secs,
@@ -925,8 +925,11 @@ fn load_frozen_forks(
             };
 
             if let Some(new_root_bank) = new_root_bank {
+                // update various kinds of roots
                 *root = new_root_bank.slot();
-                last_root_slot = new_root_bank.slot();
+                last_root = new_root_bank.slot();
+                max_root = new_root_bank.slot();
+
                 leader_schedule_cache.set_root(&new_root_bank);
                 new_root_bank.squash();
 
@@ -949,7 +952,7 @@ fn load_frozen_forks(
 
             trace!(
                 "Bank for {}slot {} is complete. {} bytes allocated",
-                if last_root_slot == slot { "root " } else { "" },
+                if last_root == slot { "root " } else { "" },
                 slot,
                 allocated.since(initial_allocation)
             );

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -834,7 +834,7 @@ fn load_frozen_forks(
     let mut slots_elapsed = 0;
     let mut txs = 0;
     let blockstore_max_root = blockstore.max_root();
-    let mut max_root = std::cmp::max(root_bank.slot(), blockstore_max_root);
+    let max_root = std::cmp::max(root_bank.slot(), blockstore_max_root);
     info!(
         "load_frozen_forks() latest root from blockstore: {}, max_root: {}",
         blockstore_max_root, max_root,
@@ -896,7 +896,7 @@ fn load_frozen_forks(
             // If we've reached the last known root in blockstore, start looking
             // for newer cluster confirmed roots
             let new_root_bank = {
-                if *root == max_root {
+                if *root >= max_root {
                     supermajority_root_from_vote_accounts(
                         bank.slot(),
                         bank.total_epoch_stake(),
@@ -925,10 +925,8 @@ fn load_frozen_forks(
             };
 
             if let Some(new_root_bank) = new_root_bank {
-                // update various kinds of roots
                 *root = new_root_bank.slot();
                 last_root = new_root_bank.slot();
-                max_root = new_root_bank.slot();
 
                 leader_schedule_cache.set_root(&new_root_bank);
                 new_root_bank.squash();
@@ -3120,6 +3118,8 @@ pub mod tests {
                   ...    minor fork
                   /
             `last_slot`
+                 |
+            `really_last_slot`
         */
         let starting_fork_slot = 5;
         let mut main_fork = tr(starting_fork_slot);
@@ -3127,10 +3127,12 @@ pub mod tests {
 
         // Make enough slots to make a root slot > blockstore_root
         let expected_root_slot = starting_fork_slot + blockstore_root.unwrap_or(0);
+        let really_expected_root_slot = expected_root_slot + 1;
         let last_main_fork_slot = expected_root_slot + MAX_LOCKOUT_HISTORY as u64 + 1;
+        let really_last_main_fork_slot = last_main_fork_slot + 1;
 
         // Make `minor_fork`
-        let last_minor_fork_slot = last_main_fork_slot + 1;
+        let last_minor_fork_slot = last_main_fork_slot + 2;
         let minor_fork = tr(last_minor_fork_slot);
 
         // Make 'main_fork`
@@ -3165,6 +3167,7 @@ pub mod tests {
         let (bank_forks, _leader_schedule) =
             process_blockstore(&genesis_config, &blockstore, Vec::new(), opts.clone()).unwrap();
 
+        // prepare to add votes
         let last_vote_bank_hash = bank_forks.get(last_main_fork_slot - 1).unwrap().hash();
         let last_vote_blockhash = bank_forks
             .get(last_main_fork_slot - 1)
@@ -3194,12 +3197,12 @@ pub mod tests {
         );
 
         let (bank_forks, _leader_schedule) =
-            process_blockstore(&genesis_config, &blockstore, Vec::new(), opts).unwrap();
+            process_blockstore(&genesis_config, &blockstore, Vec::new(), opts.clone()).unwrap();
 
         assert_eq!(bank_forks.root(), expected_root_slot);
         assert_eq!(
             bank_forks.frozen_banks().len() as u64,
-            last_minor_fork_slot - expected_root_slot + 1
+            last_minor_fork_slot - really_expected_root_slot + 1
         );
 
         // Minor fork at `last_main_fork_slot + 1` was above the `expected_root_slot`
@@ -3207,6 +3210,10 @@ pub mod tests {
         //
         // Fork at slot 2 was purged because it was below the `expected_root_slot`
         for slot in 0..=last_minor_fork_slot {
+            // this slot will be created below
+            if slot == really_last_main_fork_slot {
+                continue;
+            }
             if slot >= expected_root_slot {
                 let bank = bank_forks.get(slot).unwrap();
                 assert_eq!(bank.slot(), slot);
@@ -3215,11 +3222,48 @@ pub mod tests {
                 assert!(bank_forks.get(slot).is_none());
             }
         }
+
+        // really prepare to add votes
+        let last_vote_bank_hash = bank_forks.get(last_main_fork_slot).unwrap().hash();
+        let last_vote_blockhash = bank_forks
+            .get(last_main_fork_slot)
+            .unwrap()
+            .last_blockhash();
+        let slots: Vec<_> = vec![last_main_fork_slot];
+        let vote_tx = vote_transaction::new_vote_transaction(
+            slots,
+            last_vote_bank_hash,
+            last_vote_blockhash,
+            &leader_keypair,
+            &validator_keypairs.vote_keypair,
+            &validator_keypairs.vote_keypair,
+            None,
+        );
+
+        // Add votes to `really_last_slot` so that `root` will be confirmed again
+        make_slot_with_vote_tx(
+            &blockstore,
+            ticks_per_slot,
+            really_last_main_fork_slot,
+            last_main_fork_slot,
+            &last_vote_blockhash,
+            vote_tx,
+            &leader_keypair,
+        );
+
+        let (bank_forks, _leader_schedule) =
+            process_blockstore(&genesis_config, &blockstore, Vec::new(), opts).unwrap();
+
+        assert_eq!(bank_forks.root(), really_expected_root_slot);
     }
 
     #[test]
-    fn test_process_blockstore_with_supermajority_root() {
+    fn test_process_blockstore_with_supermajority_root_without_blockstore_root() {
         run_test_process_blockstore_with_supermajority_root(None);
+    }
+
+    #[test]
+    fn test_process_blockstore_with_supermajority_root_with_blockstore_root() {
         run_test_process_blockstore_with_supermajority_root(Some(1))
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3132,7 +3132,7 @@ pub mod tests {
         let really_last_main_fork_slot = last_main_fork_slot + 1;
 
         // Make `minor_fork`
-        let last_minor_fork_slot = last_main_fork_slot + 2;
+        let last_minor_fork_slot = really_last_main_fork_slot + 1;
         let minor_fork = tr(last_minor_fork_slot);
 
         // Make 'main_fork`


### PR DESCRIPTION
#### Problem

ledger processing are too prone to OOM with `--no-snapshot-fetch`.

Well, sadly, detection of cluster-confirmed root is done only once..... So, after that, it'll soon no `exhaustively_free_unused_resource()`, grow accounts db many banks and no squash because of no roots and killing validator via OOM and looping over and over. This confuses some partners very seriously:

This also means this also causes validator resumes with very unoptimized way because cleaning is stopped at latter part of blockstore_processor.

```
[2021-01-12T14:55:07.993768788Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257516, last root slot=60257515 slots=2 slots/s=0.2 txs/s=77.4
[2021-01-12T14:55:10.152211962Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257520, last root slot=60257519 slots=4 slots/s=2.0 txs/s=1033
[2021-01-12T14:55:12.219953425Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257527, last root slot=60257526 slots=7 slots/s=3.5 txs/s=1772
[2021-01-12T14:55:14.397713615Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257532, last root slot=60257531 slots=5 slots/s=2.5 txs/s=1121.5
[2021-01-12T14:55:16.617987351Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257539, last root slot=60257538 slots=4 slots/s=2.0 txs/s=953
[2021-01-12T14:55:27.241800066Z INFO  solana_runtime::bank] exhaustively_free_unused_resource()
[2021-01-12T14:55:27.243694525Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257543, last root slot=60257542 slots=4 slots/s=0.4 txs/s=250.2
[2021-01-12T14:55:29.978999830Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257548, last root slot=60257547 slots=5 slots/s=2.5 txs/s=1333.5
[2021-01-12T14:55:32.699707231Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257553, last root slot=60257552 slots=5 slots/s=2.5 txs/s=1448.5
[2021-01-12T14:55:34.777933322Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257558, last root slot=60257557 slots=5 slots/s=2.5 txs/s=1425.5
[2021-01-12T14:55:36.972528582Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257562, last root slot=60257561 slots=4 slots/s=2.0 txs/s=1151
[2021-01-12T14:55:46.327910050Z INFO  solana_runtime::bank] exhaustively_free_unused_resource()
[2021-01-12T14:55:46.331777880Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257563, last root slot=60257562 slots=1 slots/s=0.11111111 txs/s=51.555557
[2021-01-12T14:55:49.147052147Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257569, last root slot=60257568 slots=6 slots/s=3.0 txs/s=1801.5
[2021-01-12T14:55:51.746842686Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257573, last root slot=60257572 slots=4 slots/s=2.0 txs/s=1241
[2021-01-12T14:55:54.246564314Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257578, last root slot=60257577 slots=5 slots/s=2.5 txs/s=1120
[2021-01-12T14:56:05.493506448Z INFO  solana_runtime::bank] exhaustively_free_unused_resource()
[2021-01-12T14:56:05.498745039Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257585, last root slot=60257584 slots=7 slots/s=0.6363636 txs/s=360.54544
[2021-01-12T14:56:07.799532238Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257589, last root slot=60257588 slots=4 slots/s=2.0 txs/s=1152.5
[2021-01-12T14:56:10.199182731Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257594, last root slot=60257593 slots=5 slots/s=2.5 txs/s=1174.5
[2021-01-12T14:56:12.211459602Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257600, last root slot=60257599 slots=6 slots/s=3.0 txs/s=1560
[2021-01-12T14:56:14.861738827Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257605, last root slot=60257600 slots=5 slots/s=2.5 txs/s=1270.5
[2021-01-12T14:56:16.895314865Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257611, last root slot=60257600 slots=6 slots/s=3.0 txs/s=1496.5
[2021-01-12T14:56:19.048199086Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257617, last root slot=60257600 slots=6 slots/s=3.0 txs/s=1363
[2021-01-12T14:56:21.198167869Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257623, last root slot=60257600 slots=6 slots/s=3.0 txs/s=1167
[2021-01-12T14:56:23.244259183Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257629, last root slot=60257600 slots=6 slots/s=3.0 txs/s=1593.5
[2021-01-12T14:56:25.566602033Z INFO  solana_ledger::blockstore_processor] blockstore processor found new cluster confirmed root: 60257601, observed in bank: 60257633
[2021-01-12T14:56:36.165297892Z INFO  solana_runtime::bank] exhaustively_free_unused_resource()
[2021-01-12T14:56:36.167401175Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257634, last root slot=60257601 slots=5 slots/s=0.41666666 txs/s=219.16667
[2021-01-12T14:56:37.018403634Z WARN  solana_ledger::blockstore_processor] slot 60257638 failed to verify: failed to load entries
[2021-01-12T14:56:38.592820989Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257641, last root slot=60257601 slots=5 slots/s=2.5 txs/s=850.5
[2021-01-12T14:56:40.784811195Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257647, last root slot=60257601 slots=6 slots/s=3.0 txs/s=1465.5
[2021-01-12T14:56:43.153875389Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257652, last root slot=60257601 slots=5 slots/s=2.5 txs/s=1321
[2021-01-12T14:56:45.917459794Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257657, last root slot=60257601 slots=5 slots/s=2.5 txs/s=1406.5
[2021-01-12T14:56:48.023700608Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257661, last root slot=60257601 slots=4 slots/s=2.0 txs/s=1103.5
[2021-01-12T14:56:50.933719919Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257665, last root slot=60257601 slots=4 slots/s=2.0 txs/s=1596
[2021-01-12T14:56:53.214754508Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257673, last root slot=60257601 slots=4 slots/s=2.0 txs/s=1023
[2021-01-12T14:56:55.525049560Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257678, last root slot=60257601 slots=5 slots/s=2.5 txs/s=1567
[2021-01-12T14:56:57.994518535Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257683, last root slot=60257601 slots=5 slots/s=2.5 txs/s=1226.5
[2021-01-12T14:57:00.218047200Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257687, last root slot=60257601 slots=4 slots/s=2.0 txs/s=1051.5
[2021-01-12T14:57:02.469701641Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257691, last root slot=60257601 slots=4 slots/s=2.0 txs/s=1084.5
[2021-01-12T14:57:04.911886367Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257695, last root slot=60257601 slots=4 slots/s=2.0 txs/s=1314
[2021-01-12T14:57:06.960446040Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257697, last root slot=60257601 slots=2 slots/s=1.0 txs/s=1033
[2021-01-12T14:57:09.168088415Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257699, last root slot=60257601 slots=2 slots/s=1.0 txs/s=913
[2021-01-12T14:57:11.199076937Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257708, last root slot=60257601 slots=6 slots/s=3.0 txs/s=1508
[2021-01-12T14:57:13.615039025Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257712, last root slot=60257601 slots=4 slots/s=2.0 txs/s=1282.5
[2021-01-12T14:57:15.893448249Z INFO  solana_ledger::blockstore_processor] processing ledger: slot=60257716, last root slot=60257601 slots=4 slots/s=2.0 txs/s=1191

```

#### Summary of Changes

I'll add a test soon.

Fixes #
