### PR TITLE
web3.js: support blockTime on getConfirmedSignaturesForAddress2

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -190,6 +190,12 @@ declare module '@solana/web3.js' {
       transaction: Transaction;
       meta: ConfirmedTransactionMeta | null;
     }>;
+    rewards: Array<{
+      pubkey: string,
+      lamports: number,
+      postBalance: number | null,
+      rewardType: string | null,
+    }>;
   };
 
   export type PerfSample = {

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -203,6 +203,7 @@ declare module '@solana/web3.js' {
     slot: number;
     transaction: Transaction;
     meta: ConfirmedTransactionMeta | null;
+    blockTime?: number | null;
   };
 
   export type ParsedMessageAccount = {

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -110,6 +110,7 @@ declare module '@solana/web3.js' {
     slot: number;
     err: TransactionError | null;
     memo: string | null;
+    blockTime?: number | null;
   };
 
   export type BlockhashAndFeeCalculator = {

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -191,10 +191,10 @@ declare module '@solana/web3.js' {
       meta: ConfirmedTransactionMeta | null;
     }>;
     rewards: Array<{
-      pubkey: string,
-      lamports: number,
-      postBalance: number | null,
-      rewardType: string | null,
+      pubkey: string;
+      lamports: number;
+      postBalance: number | null;
+      rewardType: string | null;
     }>;
   };
 

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -125,6 +125,7 @@ declare module '@solana/web3.js' {
     slot: number,
     err: TransactionError | null,
     memo: string | null,
+    blockTime?: number | null,
   };
 
   declare export type BlockhashAndFeeCalculator = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -205,6 +205,12 @@ declare module '@solana/web3.js' {
       transaction: Transaction,
       meta: ConfirmedTransactionMeta | null,
     }>,
+    rewards: Array<{
+      pubkey: string,
+      lamports: number,
+      postBalance: number | null,
+      rewardType: string | null,
+    }>,
   };
 
   declare export type PerfSample = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -218,6 +218,7 @@ declare module '@solana/web3.js' {
     slot: number,
     transaction: Transaction,
     meta: ConfirmedTransactionMeta | null,
+    blockTime?: number | null,
   };
 
   declare export type ParsedAccountData = {

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -438,11 +438,13 @@ type ConfirmedTransactionMeta = {
  * @property {number} slot The slot during which the transaction was processed
  * @property {Transaction} transaction The details of the transaction
  * @property {ConfirmedTransactionMeta|null} meta Metadata produced from the transaction
+ * @property {number} blockTime The unix timestamp of when the transaction was processed
  */
 type ConfirmedTransaction = {
   slot: number,
   transaction: Transaction,
   meta: ConfirmedTransactionMeta | null,
+  blockTime?: number | null,
 };
 
 /**
@@ -520,11 +522,13 @@ type ParsedTransaction = {
  * @property {number} slot The slot during which the transaction was processed
  * @property {ParsedTransaction} transaction The details of the transaction
  * @property {ConfirmedTransactionMeta|null} meta Metadata produced from the transaction
+ * @property {number} blockTime The unix timestamp of when the transaction was processed
  */
 type ParsedConfirmedTransaction = {
   slot: number,
   transaction: ParsedTransaction,
   meta: ParsedConfirmedTransactionMeta | null,
+  blockTime?: number | null,
 };
 
 /**
@@ -1333,6 +1337,7 @@ const GetConfirmedTransactionRpcResult = jsonRpcResult(
       slot: 'number',
       transaction: ConfirmedTransactionResult,
       meta: ConfirmedTransactionMetaResult,
+      blockTime: struct.union(['number', 'null', 'undefined']),
     }),
   ]),
 );
@@ -1347,6 +1352,7 @@ const GetParsedConfirmedTransactionRpcResult = jsonRpcResult(
       slot: 'number',
       transaction: ParsedConfirmedTransactionResult,
       meta: ParsedConfirmedTransactionMetaResult,
+      blockTime: struct.union(['number', 'null', 'undefined']),
     }),
   ]),
 );

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -438,7 +438,7 @@ type ConfirmedTransactionMeta = {
  * @property {number} slot The slot during which the transaction was processed
  * @property {Transaction} transaction The details of the transaction
  * @property {ConfirmedTransactionMeta|null} meta Metadata produced from the transaction
- * @property {number} blockTime The unix timestamp of when the transaction was processed
+ * @property {number|null|undefined} blockTime The unix timestamp of when the transaction was processed
  */
 type ConfirmedTransaction = {
   slot: number,

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -522,7 +522,7 @@ type ParsedTransaction = {
  * @property {number} slot The slot during which the transaction was processed
  * @property {ParsedTransaction} transaction The details of the transaction
  * @property {ConfirmedTransactionMeta|null} meta Metadata produced from the transaction
- * @property {number} blockTime The unix timestamp of when the transaction was processed
+ * @property {number|null|undefined} blockTime The unix timestamp of when the transaction was processed
  */
 type ParsedConfirmedTransaction = {
   slot: number,
@@ -1602,7 +1602,7 @@ export type SignatureStatus = {
  * @property {number} slot when the transaction was processed
  * @property {TransactionError | null} err error, if any
  * @property {string | null} memo memo associated with the transaction, if any
- * @property {number | null | undefined} blockTime the blockTime when the transaction was processed
+ * @property {number | null | undefined} blockTime The unix timestamp of when the transaction was processed
  */
 export type ConfirmedSignatureInfo = {
   signature: string,

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -930,11 +930,12 @@ const GetConfirmedSignaturesForAddressRpcResult = jsonRpcResult(
 
 const GetConfirmedSignaturesForAddress2RpcResult = jsonRpcResult(
   struct.array([
-    struct({
+    struct.pick({
       signature: 'string',
       slot: 'number',
       err: TransactionErrorResult,
       memo: struct.union(['null', 'string']),
+      blockTime: struct.union(['undefined', 'null', 'number']),
     }),
   ]),
 );
@@ -1595,12 +1596,14 @@ export type SignatureStatus = {
  * @property {number} slot when the transaction was processed
  * @property {TransactionError | null} err error, if any
  * @property {string | null} memo memo associated with the transaction, if any
+ * @property {number | null | undefined} blockTime the blockTime when the transaction was processed
  */
 export type ConfirmedSignatureInfo = {
   signature: string,
   slot: number,
   err: TransactionError | null,
   memo: string | null,
+  blockTime?: number | null,
 };
 
 /**


### PR DESCRIPTION
#### Problem
Web3.js should support blockTime on getConfirmedSignaturesForAddress2.

#### Summary of Changes
* Add blockTime to appropriate types. 
* Add missing rewards typings under ConfirmedBlock