### PR TITLE
Load executable accounts from invoke context

### DIFF
--- a/programs/bpf/c/src/invoked/invoked.c
+++ b/programs/bpf/c/src/invoked/invoked.c
@@ -127,9 +127,9 @@ extern uint64_t entrypoint(const uint8_t *input) {
     const SolSignerSeeds signers_seeds[] = {{seeds1, SOL_ARRAY_SIZE(seeds1)},
                                             {seeds2, SOL_ARRAY_SIZE(seeds2)}};
 
-    sol_assert(SUCCESS == sol_invoke_signed(
-                              &instruction, accounts, SOL_ARRAY_SIZE(accounts),
-                              signers_seeds, SOL_ARRAY_SIZE(signers_seeds)));
+    sol_assert(SUCCESS == sol_invoke_signed(&instruction, accounts,
+                                            params.ka_num, signers_seeds,
+                                            SOL_ARRAY_SIZE(signers_seeds)));
 
     break;
   }
@@ -189,8 +189,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
                                           data, SOL_ARRAY_SIZE(data)};
 
       sol_log("Invoke again");
-      sol_assert(SUCCESS ==
-                 sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
+      sol_assert(SUCCESS == sol_invoke(&instruction, accounts, params.ka_num));
     } else {
       sol_log("Last invoked");
       for (int i = 0; i < accounts[INVOKED_ARGUMENT_INDEX].data_len; i++) {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -804,7 +804,7 @@ fn test_program_bpf_invoke() {
             .iter()
             .map(|ix| message.account_keys[ix.program_id_index as usize].clone())
             .collect();
-        assert_eq!(invoked_programs, vec![argument_keypair.pubkey().clone()]);
+        assert_eq!(invoked_programs, vec![]);
         assert_eq!(
             result.unwrap_err(),
             TransactionError::InstructionError(0, InstructionError::AccountNotExecutable)

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -134,6 +134,10 @@ pub mod abort_on_all_cpi_failures {
     solana_sdk::declare_id!("ED5D5a2hQaECHaMmKpnU48GdsfafdCjkb3pgAw5RKbb2");
 }
 
+pub mod use_loaded_executables {
+    solana_sdk::declare_id!("2SLL2KLakB83YAnF1TwFb1hpycrWeHAfHYyLhwk2JRGn");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -169,6 +173,7 @@ lazy_static! {
         (limit_cpi_loader_invoke::id(), "Loader not authorized via CPI"),
         (use_loaded_program_accounts::id(), "Use loaded program accounts"),
         (abort_on_all_cpi_failures::id(), "Abort on all CPI failures"),
+        (use_loaded_executables::id(), "Use loaded executable accounts"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Unnecessary copies of executable accounts when making a cross-program invocation.  When a program calls a CPI that will then call another program it passes along the executable accounts required.  These are currently being copied from user space even though they are immutable and invoke context already has them available for use.  These accounts can be large.

#### Summary of Changes

- Remove the extra copy of the executable accounts and completes the effort fence off the program from attempting to modify  or spoof an executable account via CPI
- Limit the number of accounts that can be passed to `invoke`
- Cleans up the CPI code by breaking out common code between C and Rust

Fixes #
