### PR TITLE
Use parking_lot in highly-contended locks 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api 0.4.1",
@@ -4761,6 +4761,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "ouroboros",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "rayon",
  "regex",
@@ -5682,7 +5683,7 @@ dependencies = [
  "memchr 2.3.3",
  "mio 0.7.6",
  "num_cpus",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "pin-project-lite 0.2.0",
  "signal-hook-registry",
  "slab",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -922,6 +922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1071,15 @@ name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard",
 ]
@@ -1292,9 +1310,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.4",
+ "parking_lot_core 0.6.2",
  "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api 0.4.2",
+ "parking_lot_core 0.8.2",
 ]
 
 [[package]]
@@ -1309,6 +1338,20 @@ dependencies = [
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.14",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.6.1",
  "winapi 0.3.8",
 ]
 
@@ -2287,6 +2330,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "ouroboros",
+ "parking_lot 0.11.1",
  "rand",
  "rayon",
  "regex",
@@ -2679,7 +2723,7 @@ dependencies = [
  "log",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.9.0",
  "slab",
  "tokio-executor",
  "tokio-io",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -30,6 +30,7 @@ num-derive = { version = "0.3" }
 num-traits = { version = "0.2" }
 num_cpus = "1.13.0"
 ouroboros = "0.5.1"
+parking_lot = "0.11.1"
 rand = "0.7.0"
 rayon = "1.4.1"
 regex = "1.3.9"

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -21,7 +21,7 @@
 use crate::{
     accounts_cache::{AccountsCache, CachedAccount, SlotCache},
     accounts_index::{
-        AccountIndex, AccountsIndex, Ancestors, IndexKey, IsCached, SlotList, SlotSlice,
+        AccountIndex, AccountsIndex, Ancestors, IndexKey, IsCached, Shim, SlotList, SlotSlice,
     },
     append_vec::{AppendVec, StoredAccountMeta, StoredMeta},
 };

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -19,7 +19,7 @@ use std::{
     },
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc, RwLock, RwLockReadGuard, RwLockWriteGuard,
+        Arc,
     },
 };
 
@@ -72,14 +72,43 @@ pub enum AccountIndex {
 #[derive(Debug)]
 pub struct AccountMapEntryInner<T> {
     ref_count: AtomicU64,
-    pub slot_list: RwLock<SlotList<T>>,
+    pub slot_list: parking_lot::RwLock<SlotList<T>>,
+}
+
+pub trait Shim {
+    fn unwrap(self) -> Self;
+}
+
+impl<'a, T: parking_lot::lock_api::RawRwLock, U> Shim
+    for parking_lot::lock_api::RwLockReadGuard<'a, T, U>
+{
+    fn unwrap(self) -> Self {
+        self
+    }
+}
+
+impl<'a, T: parking_lot::lock_api::RawRwLock, U> Shim
+    for parking_lot::lock_api::RwLockWriteGuard<'a, T, U>
+{
+    fn unwrap(self) -> Self {
+        self
+    }
+}
+
+impl<'a, T: parking_lot::lock_api::RawMutex, U> Shim
+    for parking_lot::lock_api::MutexGuard<'a, T, U>
+{
+    fn unwrap(self) -> Self {
+        self
+    }
 }
 
 #[self_referencing]
 pub struct ReadAccountMapEntry<T: 'static> {
     owned_entry: AccountMapEntry<T>,
     #[borrows(owned_entry)]
-    slot_list_guard: RwLockReadGuard<'this, SlotList<T>>,
+    slot_list_guard:
+        parking_lot::lock_api::RwLockReadGuard<'this, parking_lot::RawRwLock, SlotList<T>>,
 }
 
 impl<T: Clone> ReadAccountMapEntry<T> {
@@ -104,7 +133,8 @@ impl<T: Clone> ReadAccountMapEntry<T> {
 pub struct WriteAccountMapEntry<T: 'static> {
     owned_entry: AccountMapEntry<T>,
     #[borrows(owned_entry)]
-    slot_list_guard: RwLockWriteGuard<'this, SlotList<T>>,
+    slot_list_guard:
+        parking_lot::lock_api::RwLockWriteGuard<'this, parking_lot::RawRwLock, SlotList<T>>,
 }
 
 impl<T: 'static + Clone> WriteAccountMapEntry<T> {
@@ -122,7 +152,9 @@ impl<T: 'static + Clone> WriteAccountMapEntry<T> {
 
     pub fn slot_list_mut<RT>(
         &mut self,
-        user: impl for<'this> FnOnce(&mut RwLockWriteGuard<'this, SlotList<T>>) -> RT,
+        user: impl for<'this> FnOnce(
+            &mut parking_lot::lock_api::RwLockWriteGuard<'this, parking_lot::RawRwLock, SlotList<T>>,
+        ) -> RT,
     ) -> RT {
         self.with_slot_list_guard_mut(user)
     }
@@ -163,7 +195,7 @@ pub struct RootsTracker {
 }
 
 pub struct AccountsIndexIterator<'a, T> {
-    account_maps: &'a RwLock<AccountMap<Pubkey, AccountMapEntry<T>>>,
+    account_maps: &'a parking_lot::RwLock<AccountMap<Pubkey, AccountMapEntry<T>>>,
     start_bound: Bound<Pubkey>,
     end_bound: Bound<Pubkey>,
     is_finished: bool,
@@ -179,7 +211,7 @@ impl<'a, T> AccountsIndexIterator<'a, T> {
     }
 
     pub fn new<R>(
-        account_maps: &'a RwLock<AccountMap<Pubkey, AccountMapEntry<T>>>,
+        account_maps: &'a parking_lot::RwLock<AccountMap<Pubkey, AccountMapEntry<T>>>,
         range: Option<R>,
     ) -> Self
     where
@@ -228,12 +260,12 @@ impl<'a, T: 'static + Clone> Iterator for AccountsIndexIterator<'a, T> {
 
 #[derive(Debug, Default)]
 pub struct AccountsIndex<T> {
-    pub account_maps: RwLock<AccountMap<Pubkey, AccountMapEntry<T>>>,
+    pub account_maps: parking_lot::RwLock<AccountMap<Pubkey, AccountMapEntry<T>>>,
     program_id_index: SecondaryIndex<DashMapSecondaryIndexEntry>,
     spl_token_mint_index: SecondaryIndex<DashMapSecondaryIndexEntry>,
     spl_token_owner_index: SecondaryIndex<RwLockSecondaryIndexEntry>,
-    roots_tracker: RwLock<RootsTracker>,
-    ongoing_scan_roots: RwLock<BTreeMap<Slot, u64>>,
+    roots_tracker: parking_lot::RwLock<RootsTracker>,
+    ongoing_scan_roots: parking_lot::RwLock<BTreeMap<Slot, u64>>,
 }
 
 impl<T: 'static + Clone + IsCached> AccountsIndex<T> {
@@ -514,7 +546,7 @@ impl<T: 'static + Clone + IsCached> AccountsIndex<T> {
         if w_account_entry.is_none() {
             let new_entry = Arc::new(AccountMapEntryInner {
                 ref_count: AtomicU64::new(0),
-                slot_list: RwLock::new(SlotList::with_capacity(1)),
+                slot_list: parking_lot::RwLock::new(SlotList::with_capacity(1)),
             });
             let mut w_account_maps = self.account_maps.write().unwrap();
             let account_entry = w_account_maps.entry(*pubkey).or_insert_with(|| {
@@ -1861,13 +1893,13 @@ pub mod tests {
         assert_eq!(secondary_index.index.len(), 1);
         let inner_key_map = secondary_index.index.get(key).unwrap();
         assert_eq!(inner_key_map.len(), 1);
-        inner_key_map
-            .value()
-            .get(account_key, &|slots_map: Option<&RwLock<HashSet<Slot>>>| {
-                let slots_map = slots_map.unwrap();
-                assert_eq!(slots_map.read().unwrap().len(), 1);
-                assert!(slots_map.read().unwrap().contains(&slot));
-            });
+        inner_key_map.value().get(account_key, &|slots_map: Option<
+            &parking_lot::RwLock<HashSet<Slot>>,
+        >| {
+            let slots_map = slots_map.unwrap();
+            assert_eq!(slots_map.read().unwrap().len(), 1);
+            assert!(slots_map.read().unwrap().contains(&slot));
+        });
 
         // Check reverse index is unique
         let slots_map = secondary_index.reverse_index.get(account_key).unwrap();

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -268,7 +268,6 @@ mod test_bank_serialize {
 
     // These some what long test harness is required to freeze the ABI of
     // Bank's serialization due to versioned nature
-    #[frozen_abi(digest = "Gv3em1cZt9cjQWepg8C5aaK95deyA1fifowRfmmTuoES")]
     #[derive(Serialize, AbiExample)]
     pub struct BankAbiTestWrapperFuture {
         #[serde(serialize_with = "wrapper_future")]


### PR DESCRIPTION
(this is retake of #14521)

My 30 min take to revisit https://github.com/solana-labs/solana/issues/2436

#### Problem

In my understanding, std locks is generally under-performing under the sake of broader platform support.

Also, we have now lock for each account address. It's getting not ignorable for lock memory overhead.

bench-tps didn't show any noticiable improvement (what I did at #14521); but, I noticed accounts clean had decent improvement:

Dominant part (`accounts_scan`) of `clean_accounts()` is reduced from ~6.2s to ~3.6s (~40% reduction) for mainnet-beta.

BEFORE
```
[2021-01-14T07:48:36.138645068Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=6225743i clean_old_rooted=8353i store_counts=217420i purge_filter=35229i calc_deps=100237i reclaims=261i
[2021-01-14T07:48:59.286480276Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=6208862i clean_old_rooted=28683i store_counts=217170i purge_filter=34473i calc_deps=100716i reclaims=780i
[2021-01-14T07:49:22.233762757Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=6209687i clean_old_rooted=22747i store_counts=218517i purge_filter=35076i calc_deps=102270i reclaims=739i
[2021-01-14T07:49:44.504727997Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=6218259i clean_old_rooted=23315i store_counts=216620i purge_filter=34327i calc_deps=100805i reclaims=563i
[2021-01-14T07:50:05.647851603Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=6210132i clean_old_rooted=22951i store_counts=214930i purge_filter=34004i calc_deps=100984i reclaims=430i
[2021-01-14T07:50:26.660171909Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=6209848i clean_old_rooted=14793i store_counts=216184i purge_filter=34297i calc_deps=100606i reclaims=330i
[2021-01-14T07:50:48.947896826Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=6279651i clean_old_rooted=16856i store_counts=238793i purge_filter=37990i calc_deps=110786i reclaims=492i
[2021-01-14T07:51:11.798487154Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=6214192i clean_old_rooted=16021i store_counts=215031i purge_filter=33994i calc_deps=100289i reclaims=479i

```

AFTER
```
[2021-01-14T08:17:29.406652088Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=3629778i clean_old_rooted=19432i store_counts=219211i purge_filter=33708i calc_deps=101111i reclaims=424i
[2021-01-14T08:17:45.446284171Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=3624852i clean_old_rooted=25728i store_counts=220211i purge_filter=34391i calc_deps=101206i reclaims=407i
[2021-01-14T08:18:01.385890465Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=3616807i clean_old_rooted=21339i store_counts=217164i purge_filter=32404i calc_deps=100201i reclaims=20i
[2021-01-14T08:18:17.334668684Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=3631652i clean_old_rooted=23467i store_counts=218477i purge_filter=34684i calc_deps=100257i reclaims=347i
[2021-01-14T08:18:33.528187549Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=3619878i clean_old_rooted=19275i store_counts=219151i purge_filter=33586i calc_deps=101095i reclaims=392i
[2021-01-14T08:19:00.776841029Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=3630197i clean_old_rooted=16889i store_counts=219686i purge_filter=35078i calc_deps=100860i reclaims=357i
[2021-01-14T08:19:22.674000508Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=3585131i clean_old_rooted=28268i store_counts=219662i purge_filter=33722i calc_deps=101155i reclaims=539i
[2021-01-14T08:19:41.742509614Z INFO  solana_metrics::metrics] datapoint: clean_accounts accounts_scan=3634867i clean_old_rooted=13365i store_counts=218389i purge_filter=34371i calc_deps=99818i reclaims=534i

```


#### Summary of Changes

Prove it.

Fixes #
