### PR TITLE
More generic accounts purge functions

### DIFF
--- a/core/src/repair_service.rs
+++ b/core/src/repair_service.rs
@@ -5,7 +5,6 @@ use crate::{
     cluster_info_vote_listener::VerifiedVoteReceiver,
     cluster_slots::ClusterSlots,
     repair_weight::RepairWeight,
-    repair_weighted_traversal::Contains,
     result::Result,
     serve_repair::{RepairType, ServeRepair, DEFAULT_NONCE},
 };
@@ -15,7 +14,9 @@ use solana_ledger::{
     shred::Nonce,
 };
 use solana_measure::measure::Measure;
-use solana_runtime::{bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE};
+use solana_runtime::{
+    bank::Bank, bank_forks::BankForks, commitment::VOTE_THRESHOLD_SIZE, contains::Contains,
+};
 use solana_sdk::{clock::Slot, epoch_schedule::EpochSchedule, pubkey::Pubkey, timing::timestamp};
 use std::{
     collections::{HashMap, HashSet},
@@ -402,12 +403,12 @@ impl RepairService {
     }
 
     /// Repairs any fork starting at the input slot
-    pub fn generate_repairs_for_fork(
+    pub fn generate_repairs_for_fork<'a>(
         blockstore: &Blockstore,
         repairs: &mut Vec<RepairType>,
         max_repairs: usize,
         slot: Slot,
-        duplicate_slot_repair_statuses: &dyn Contains<Slot>,
+        duplicate_slot_repair_statuses: &impl Contains<'a, Slot>,
     ) {
         let mut pending_slots = vec![slot];
         while repairs.len() < max_repairs && !pending_slots.is_empty() {

--- a/core/src/repair_weight.rs
+++ b/core/src/repair_weight.rs
@@ -1,13 +1,10 @@
 use crate::{
-    heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
-    repair_service::RepairTiming,
-    repair_weighted_traversal::{self, Contains},
-    serve_repair::RepairType,
-    tree_diff::TreeDiff,
+    heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice, repair_service::RepairTiming,
+    repair_weighted_traversal, serve_repair::RepairType, tree_diff::TreeDiff,
 };
 use solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore};
 use solana_measure::measure::Measure;
-use solana_runtime::epoch_stakes::EpochStakes;
+use solana_runtime::{contains::Contains, epoch_stakes::EpochStakes};
 use solana_sdk::{
     clock::Slot,
     epoch_schedule::{Epoch, EpochSchedule},
@@ -129,14 +126,14 @@ impl RepairWeight {
         }
     }
 
-    pub fn get_best_weighted_repairs(
+    pub fn get_best_weighted_repairs<'a>(
         &mut self,
         blockstore: &Blockstore,
         epoch_stakes: &HashMap<Epoch, EpochStakes>,
         epoch_schedule: &EpochSchedule,
         max_new_orphans: usize,
         max_new_shreds: usize,
-        ignore_slots: &dyn Contains<Slot>,
+        ignore_slots: &impl Contains<'a, Slot>,
         repair_timing: Option<&mut RepairTiming>,
     ) -> Vec<RepairType> {
         let mut repairs = vec![];
@@ -228,12 +225,12 @@ impl RepairWeight {
     }
 
     // Generate shred repairs for main subtree rooted at `self.slot`
-    fn get_best_shreds(
+    fn get_best_shreds<'a>(
         &mut self,
         blockstore: &Blockstore,
         repairs: &mut Vec<RepairType>,
         max_new_shreds: usize,
-        ignore_slots: &dyn Contains<Slot>,
+        ignore_slots: &impl Contains<'a, Slot>,
     ) {
         let root_tree = self.trees.get(&self.root).expect("Root tree must exist");
         repair_weighted_traversal::get_best_repair_shreds(

--- a/core/src/repair_weighted_traversal.rs
+++ b/core/src/repair_weighted_traversal.rs
@@ -3,27 +3,9 @@ use crate::{
     serve_repair::RepairType, tree_diff::TreeDiff,
 };
 use solana_ledger::blockstore::Blockstore;
+use solana_runtime::contains::Contains;
 use solana_sdk::clock::Slot;
-use std::{
-    cmp::Eq,
-    collections::{HashMap, HashSet},
-    hash::Hash,
-};
-
-pub trait Contains<T: Eq + Hash> {
-    fn contains(&self, key: &T) -> bool;
-}
-
-impl<T: Eq + Hash, U> Contains<T> for HashMap<T, U> {
-    fn contains(&self, key: &T) -> bool {
-        self.contains_key(key)
-    }
-}
-impl<T: Eq + Hash> Contains<T> for HashSet<T> {
-    fn contains(&self, key: &T) -> bool {
-        self.contains(key)
-    }
-}
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, PartialEq)]
 enum Visit {
@@ -84,12 +66,12 @@ impl<'a> Iterator for RepairWeightTraversal<'a> {
 }
 
 // Generate shred repairs for main subtree rooted at `self.slot`
-pub fn get_best_repair_shreds(
+pub fn get_best_repair_shreds<'a>(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
     repairs: &mut Vec<RepairType>,
     max_new_shreds: usize,
-    ignore_slots: &dyn Contains<Slot>,
+    ignore_slots: &impl Contains<'a, Slot>,
 ) {
     let initial_len = repairs.len();
     let max_repairs = initial_len + max_new_shreds;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -24,6 +24,7 @@ use crate::{
         AccountIndex, AccountsIndex, Ancestors, IndexKey, IsCached, SlotList, SlotSlice,
     },
     append_vec::{AppendVec, StoredAccountMeta, StoredMeta},
+    contains::Contains,
 };
 use blake3::traits::digest::Digest;
 use dashmap::DashMap;
@@ -893,17 +894,20 @@ impl AccountsDB {
         }
     }
 
-    fn purge_keys_exact(
-        &self,
-        pubkey_to_slot_set: Vec<(Pubkey, HashSet<Slot>)>,
-    ) -> Vec<(u64, AccountInfo)> {
+    fn purge_keys_exact<'a, C: 'a>(
+        &'a self,
+        pubkey_to_slot_set: &'a [(Pubkey, C)],
+    ) -> Vec<(u64, AccountInfo)>
+    where
+        C: Contains<'a, Slot>,
+    {
         let mut reclaims = Vec::new();
         let mut dead_keys = Vec::new();
 
         for (pubkey, slots_set) in pubkey_to_slot_set {
             let is_empty = self.accounts_index.purge_exact(
                 &pubkey,
-                &slots_set,
+                slots_set,
                 &mut reclaims,
                 &self.account_indexes,
             );
@@ -1079,11 +1083,18 @@ impl AccountsDB {
         let pubkey_to_slot_set: Vec<_> = purges
             .into_iter()
             .map(|(key, (slots_list, _ref_count))| {
-                (key, slots_list.into_iter().map(|(slot, _)| slot).collect())
+                (
+                    key,
+                    slots_list
+                        .into_iter()
+                        .map(|(slot, _)| slot)
+                        .collect::<HashSet<Slot>>(),
+                )
             })
             .collect();
 
-        let reclaims = self.purge_keys_exact(pubkey_to_slot_set);
+        let reclaims = self.purge_keys_exact(&pubkey_to_slot_set);
+
         self.handle_reclaims(&reclaims, None, false, None);
 
         reclaims_time.stop();
@@ -2385,22 +2396,26 @@ impl AccountsDB {
         );
     }
 
-    fn purge_slot_cache_keys(&self, dead_slot: Slot, slot_cache: SlotCache) {
+    fn purge_slot_cache_keys(
+        &self,
+        dead_slot: Slot,
+        slot_cache: SlotCache,
+    ) -> Vec<(u64, AccountInfo)> {
         // Slot purged from cache should not exist in the backing store
         assert!(self.storage.get_slot_stores(dead_slot).is_none());
-        let dead_slots: HashSet<Slot> = vec![dead_slot].into_iter().collect();
         let mut purged_slot_pubkeys: HashSet<(Slot, Pubkey)> = HashSet::new();
-        let pubkey_to_slot_set: Vec<(Pubkey, HashSet<Slot>)> = slot_cache
+        let pubkey_to_slot_set: Vec<(Pubkey, Slot)> = slot_cache
             .iter()
             .map(|account| {
                 purged_slot_pubkeys.insert((dead_slot, *account.key()));
-                (*account.key(), dead_slots.clone())
+                (*account.key(), dead_slot)
             })
             .collect();
         let num_purged_keys = pubkey_to_slot_set.len();
-        let reclaims = self.purge_keys_exact(pubkey_to_slot_set);
+        let reclaims = self.purge_keys_exact(&pubkey_to_slot_set);
         assert_eq!(reclaims.len(), num_purged_keys);
-        self.finalize_dead_slot_removal(&dead_slots, purged_slot_pubkeys, None);
+        self.finalize_dead_slot_removal(std::iter::once(&dead_slot), purged_slot_pubkeys, None);
+        reclaims
     }
 
     fn purge_slots(&self, slots: &HashSet<Slot>) {
@@ -3478,9 +3493,9 @@ impl AccountsDB {
         dead_slots
     }
 
-    fn finalize_dead_slot_removal(
-        &self,
-        dead_slots: &HashSet<Slot>,
+    fn finalize_dead_slot_removal<'a>(
+        &'a self,
+        dead_slots_iter: impl IntoIterator<Item = &'a Slot> + Clone,
         purged_slot_pubkeys: HashSet<(Slot, Pubkey)>,
         mut purged_account_slots: Option<&mut AccountSlots>,
     ) {
@@ -3491,12 +3506,13 @@ impl AccountsDB {
             self.accounts_index.unref_from_storage(&pubkey);
         }
 
-        for slot in dead_slots.iter() {
+        let dead_slots_iter_ = dead_slots_iter.clone();
+        for slot in dead_slots_iter {
             self.accounts_index.clean_dead_slot(*slot);
         }
         {
             let mut bank_hashes = self.bank_hashes.write().unwrap();
-            for slot in dead_slots.iter() {
+            for slot in dead_slots_iter_ {
                 bank_hashes.remove(slot);
             }
         }
@@ -5492,7 +5508,7 @@ pub mod tests {
 
         let slots: HashSet<Slot> = vec![1].into_iter().collect();
         let purge_keys = vec![(key1, slots)];
-        db.purge_keys_exact(purge_keys);
+        db.purge_keys_exact(&purge_keys);
 
         let account2 = Account::new(3, 0, &key);
         db.store_uncached(2, &[(&key1, &account2)]);

--- a/runtime/src/contains.rs
+++ b/runtime/src/contains.rs
@@ -1,0 +1,49 @@
+use std::{
+    borrow::Borrow,
+    cmp::Eq,
+    collections::{HashMap, HashSet},
+    hash::Hash,
+};
+
+pub trait Contains<'a, T: Eq + Hash> {
+    type Item: Borrow<T>;
+    type Iter: Iterator<Item = Self::Item>;
+    fn contains(&self, key: &T) -> bool;
+    fn contains_iter(&'a self) -> Self::Iter;
+}
+
+impl<'a, T: 'a + Eq + Hash, U: 'a> Contains<'a, T> for HashMap<T, U> {
+    type Item = &'a T;
+    type Iter = std::collections::hash_map::Keys<'a, T, U>;
+
+    fn contains(&self, key: &T) -> bool {
+        self.contains_key(key)
+    }
+    fn contains_iter(&'a self) -> Self::Iter {
+        self.keys()
+    }
+}
+
+impl<'a, T: 'a + Eq + Hash> Contains<'a, T> for HashSet<T> {
+    type Item = &'a T;
+    type Iter = std::collections::hash_set::Iter<'a, T>;
+
+    fn contains(&self, key: &T) -> bool {
+        <HashSet<T>>::contains(self, key)
+    }
+    fn contains_iter(&'a self) -> Self::Iter {
+        self.iter()
+    }
+}
+
+impl<'a, T: 'a + Eq + Hash + Copy> Contains<'a, T> for T {
+    type Item = &'a T;
+    type Iter = std::iter::Once<&'a T>;
+
+    fn contains(&self, key: &T) -> bool {
+        *key == *self
+    }
+    fn contains_iter(&'a self) -> Self::Iter {
+        std::iter::once(self)
+    }
+}

--- a/runtime/src/contains.rs
+++ b/runtime/src/contains.rs
@@ -17,7 +17,7 @@ impl<'a, T: 'a + Eq + Hash, U: 'a> Contains<'a, T> for HashMap<T, U> {
     type Iter = std::collections::hash_map::Keys<'a, T, U>;
 
     fn contains(&self, key: &T) -> bool {
-        self.contains_key(key)
+        <HashMap<T, U>>::contains_key(self, key)
     }
     fn contains_iter(&'a self) -> Self::Iter {
         self.keys()
@@ -41,7 +41,7 @@ impl<'a, T: 'a + Eq + Hash + Copy> Contains<'a, T> for T {
     type Iter = std::iter::Once<&'a T>;
 
     fn contains(&self, key: &T) -> bool {
-        *key == *self
+        key == self
     }
     fn contains_iter(&'a self) -> Self::Iter {
         std::iter::once(self)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,6 +13,7 @@ mod blockhash_queue;
 pub mod bloom;
 pub mod builtins;
 pub mod commitment;
+pub mod contains;
 pub mod epoch_stakes;
 pub mod genesis_utils;
 pub mod hardened_unpack;


### PR DESCRIPTION
#### Problem
`AccountsDb::purge_keys_exact() -> AccountsDb::purge_exact() -> AccountsDb::purge_secondary_indexes_by_inner_key()` requires a `HashSet` when sometimes a slot is all that is necessary

purge_slot_cache_keys() clones `dead_slot ` HashSet every time, only needs an iterator

#### Summary of Changes
Support more generic parameters, remove clones.

Fixes #
