### PR TITLE
Clean accounts cache before flush

### DIFF
--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -275,6 +275,10 @@ impl AccountsBackgroundService {
                 let snapshot_block_height =
                     request_handler.handle_snapshot_requests(accounts_db_caching_enabled);
                 if accounts_db_caching_enabled {
+                    // Note that the flush will do an internal clean of the
+                    // cache up to bank.slot(), so should be safe as long
+                    // as any later snapshots that are taken are of
+                    // slots >= bank.slot()
                     bank.flush_accounts_cache_if_needed();
                 }
 
@@ -300,6 +304,10 @@ impl AccountsBackgroundService {
                         > (CLEAN_INTERVAL_BLOCKS + thread_rng().gen_range(0, 10))
                     {
                         if accounts_db_caching_enabled {
+                            // Note that the flush will do an internal clean of the
+                            // cache up to bank.slot(), so should be safe as long
+                            // as any later snapshots that are taken are of
+                            // slots >= bank.slot()
                             bank.force_flush_accounts_cache();
                         }
                         bank.clean_accounts(true);

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
 use solana_sdk::{account::Account, clock::Slot, hash::Hash, pubkey::Pubkey};
 use std::{
-    collections::HashSet,
+    collections::BTreeSet,
     ops::Deref,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -90,7 +90,7 @@ pub struct AccountsCache {
     cache: DashMap<Slot, SlotCache>,
     // Queue of potentially unflushed roots. Random eviction + cache too large
     // could have triggered a flush of this slot already
-    maybe_unflushed_roots: RwLock<HashSet<Slot>>,
+    maybe_unflushed_roots: RwLock<BTreeSet<Slot>>,
     max_flushed_root: AtomicU64,
 }
 
@@ -147,14 +147,25 @@ impl AccountsCache {
     }
 
     pub fn add_root(&self, root: Slot) {
-        self.maybe_unflushed_roots.write().unwrap().insert(root);
+        let max_flushed_root = self.fetch_max_flush_root();
+        if root > max_flushed_root || (root == max_flushed_root && root == 0) {
+            self.maybe_unflushed_roots.write().unwrap().insert(root);
+        }
     }
 
-    pub fn clear_roots(&self) -> HashSet<Slot> {
-        std::mem::replace(
-            &mut self.maybe_unflushed_roots.write().unwrap(),
-            HashSet::new(),
-        )
+    pub fn clear_roots(&self, max_root: Option<Slot>) -> BTreeSet<Slot> {
+        let mut w_maybe_unflushed_roots = self.maybe_unflushed_roots.write().unwrap();
+        if let Some(max_root) = max_root {
+            // `greater_than_max_root` contains all slots >= `max_root + 1`, or alternatively,
+            // all slots > `max_root`. Meanwhile, `w_maybe_unflushed_roots` is left with all slots
+            // <= `max_root`.
+            let greater_than_max_root = w_maybe_unflushed_roots.split_off(&(max_root + 1));
+            // After the replace, `w_maybe_unflushed_roots` contains slots > `max_root`, and
+            // we return all slots <= `max_root`
+            std::mem::replace(&mut w_maybe_unflushed_roots, greater_than_max_root)
+        } else {
+            std::mem::replace(&mut *w_maybe_unflushed_roots, BTreeSet::new())
+        }
     }
 
     // Removes slots less than or equal to `max_root`. Only safe to pass in a rooted slot,


### PR DESCRIPTION
#### Problem
Accounts cache flushes a lot of outdated keys from earlier roots that have already been updated by later roots, which bloats AppendVecs

#### Summary of Changes
Note, builds on top of some refactoring done here: https://github.com/solana-labs/solana/pull/14595

Remove outdated updates from earlier roots

Results: Significantly less bloat in AppendVecs, which means much smaller shrink and flush times (note before 18:00 is with this change, after is without these changes)

<img width="1075" alt="Screen Shot 2021-01-14 at 6 31 57 PM" src="https://user-images.githubusercontent.com/3374799/104677133-bb782700-569d-11eb-9f14-0dd2b70ad66d.png">
<img width="1652" alt="Screen Shot 2021-01-14 at 6 31 45 PM" src="https://user-images.githubusercontent.com/3374799/104677135-bdda8100-569d-11eb-8d9a-af1d8a613893.png">

Can view the number of bytes/accounts removed from the cache here: 

https://metrics.solana.com:8888/sources/3/chronograf/data-explorer?query=SELECT%20mean%28%22account_bytes_saved%22%29%20AS%20%22mean_account_bytes_saved%22%2C%20mean%28%22num_accounts_saved%22%29%20AS%20%22mean_num_accounts_saved%22%20FROM%20%22mainnet-beta%22.%22autogen%22.%22accounts_db-flush_accounts_cache%22%20WHERE%20time%20%3E%20now%28%29%20-%2012h%20GROUP%20BY%20time%28%3Ainterval%3A%29%20FILL%28null%29
Fixes #
