### PR TITLE
Improve solana-test-validator output

### DIFF
--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -338,6 +338,9 @@ impl TestValidator {
         let tpu = node.info.tpu;
         let gossip = node.info.gossip;
 
+        let mut rpc_config = config.rpc_config.clone();
+        rpc_config.identity_pubkey = validator_identity.pubkey();
+
         let validator_config = ValidatorConfig {
             rpc_addrs: Some((
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), node.info.rpc.port()),
@@ -346,7 +349,7 @@ impl TestValidator {
                     node.info.rpc_pubsub.port(),
                 ),
             )),
-            rpc_config: config.rpc_config.clone(),
+            rpc_config,
             accounts_hash_interval_slots: 100,
             account_paths: vec![ledger_path.join("accounts")],
             poh_verify: false, // Skip PoH verification of ledger on startup for speed


### PR DESCRIPTION
At startup, include:
* validator identity
* validator version

The progress bar now includes:
* time the validator has been running
* the processed, confirmed, finalized and snapshot slot
* validator identity balance

I'm going ahead with the new slot terminology still under discussion at https://github.com/solana-labs/solana/pull/14430, if we end up settling on different terms then I'll make the necessary edits here if this PR lands first
