### PR TITLE
Use highest-confirmed-root for max check

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -169,7 +169,9 @@ impl Banks for BanksServer {
         let (slot, status) = bank.get_signature_status_slot(&signature)?;
         let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
-        let confirmations = if r_block_commitment_cache.root() >= slot {
+        let confirmations = if r_block_commitment_cache.root() >= slot
+            && r_block_commitment_cache.highest_confirmed_root() >= slot
+        {
             None
         } else {
             r_block_commitment_cache


### PR DESCRIPTION
#### Problem
`BanksServer::get_transaction_status_with_context` mirrors Rpc `get_transaction_status()`. However, it returns `confirmations: None` for rooted transactions, where that value indicates a finalized (cluster-confirmed rooted) transaction in Rpc. This distinction is immaterial for BanksServer implementations using only one Bank (like ProgramTest, the only current usage I'm aware of). But it could be relevant if BanksServer is used in a framework representing multiple nodes (and modifying the BlockCommitmentCache accordingly).
Since we're enhancing confirmation-status information in #14430 , it'd be nice to get this correct.

#### Summary of Changes
- Check that transaction processing slot is also a cluster-confirmed root in `BanksServer::get_transaction_status_with_context()`
