### PR TITLE
net/net.sh: Quite pre-emptible instance status check

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -723,8 +723,7 @@ checkPremptibleInstances() {
   # immediately after its successfully pinged.
   for ipAddress in "${validatorIpList[@]}"; do
     (
-      set -x
-      timeout 5s ping -c 1 "$ipAddress" | tr - _
+      timeout 5s ping -c 1 "$ipAddress" | tr - _ &>/dev/null
     ) || {
       cat <<EOF
 


### PR DESCRIPTION
#### Problem

Running `net/net.sh` with an active config spams a bunch of ping output during the preemptible instance check

#### Summary of Changes

Blackhole its output