### PR TITLE
Add metrics panel to show slot production

### DIFF
--- a/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
+++ b/metrics/scripts/grafana-provisioning/dashboards/cluster-monitor.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 2075,
-  "iteration": 1607116926093,
+  "id": 2194,
+  "iteration": 1610479516268,
   "links": [
     {
       "asDropdown": true,
@@ -3078,8 +3078,8 @@
       "scroll": true,
       "showHeader": true,
       "sort": {
-        "col": null,
-        "desc": false
+        "col": 1,
+        "desc": true
       },
       "styles": [
         {
@@ -8611,7 +8611,7 @@
         "x": 0,
         "y": 71
       },
-      "id": 78,
+      "id": 50,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -8727,7 +8727,7 @@
         "x": 8,
         "y": 71
       },
-      "id": 50,
+      "id": 51,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9048,7 +9048,7 @@
         "x": 16,
         "y": 71
       },
-      "id": 51,
+      "id": 52,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9320,7 +9320,7 @@
         "x": 0,
         "y": 77
       },
-      "id": 52,
+      "id": 53,
       "panels": [],
       "title": "Tower Consensus",
       "type": "row"
@@ -9343,7 +9343,7 @@
         "x": 0,
         "y": 78
       },
-      "id": 53,
+      "id": 54,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9503,7 +9503,7 @@
         "x": 8,
         "y": 78
       },
-      "id": 54,
+      "id": 55,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9602,6 +9602,43 @@
             ]
           ],
           "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT max(\"root\") AS \"cluster-root\" FROM \"$testnet\".\"autogen\".\"tower-observed\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
         }
       ],
       "thresholds": [],
@@ -9663,7 +9700,7 @@
         "x": 16,
         "y": 78
       },
-      "id": 55,
+      "id": 56,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9859,7 +9896,7 @@
         "x": 0,
         "y": 83
       },
-      "id": 56,
+      "id": 57,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -9982,7 +10019,7 @@
         "x": 8,
         "y": 83
       },
-      "id": 57,
+      "id": 58,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -10105,7 +10142,7 @@
         "x": 16,
         "y": 83
       },
-      "id": 58,
+      "id": 59,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -10210,14 +10247,254 @@
       }
     },
     {
+      "aliasColors": {
+        "cluster-info.repair": "#ba43a9",
+        "replay_stage-new_leader.last": "#00ffbb",
+        "tower-vote.last": "#00ffbb",
+        "window-service.receive": "#b7dbab",
+        "window-stage.consumed": "#5195ce"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 88
+      },
+      "id": 79,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT max(\"slot_height\") FROM \"$testnet\".\"autogen\".\"bank-new_from_parent-heights\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT mean(\"slot_height\") AS \"cluster-height\" FROM \"$testnet\".\"autogen\".\"bank-new_from_parent-heights\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT max(\"slot\") AS \"cluster-replay-slot\" FROM \"$testnet\".\"autogen\".\"replay-slot-stats\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        },
+        {
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "cluster_info-vote-count",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "SELECT max(\"slot\") FROM \"$testnet\".\"autogen\".\"replay-slot-stats\" WHERE host_id::tag =~ /$hostid/ AND $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "count"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "sum"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Slot Production ($hostid)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 88
+        "y": 93
       },
-      "id": 59,
+      "id": 60,
       "panels": [],
       "repeat": null,
       "title": "IP Network",
@@ -10234,9 +10511,9 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 89
+        "y": 94
       },
-      "id": 60,
+      "id": 61,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -10467,9 +10744,9 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 89
+        "y": 94
       },
-      "id": 61,
+      "id": 62,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -10620,9 +10897,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 99
       },
-      "id": 62,
+      "id": 63,
       "panels": [],
       "title": "Signature Verification",
       "type": "row"
@@ -10638,9 +10915,9 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 95
+        "y": 100
       },
-      "id": 63,
+      "id": 64,
       "legend": {
         "avg": false,
         "current": false,
@@ -10840,9 +11117,9 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 95
+        "y": 100
       },
-      "id": 64,
+      "id": 65,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -10989,9 +11266,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 100
+        "y": 105
       },
-      "id": 65,
+      "id": 66,
       "panels": [],
       "title": "Snapshots",
       "type": "row"
@@ -11007,9 +11284,9 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 101
+        "y": 106
       },
-      "id": 66,
+      "id": 67,
       "legend": {
         "avg": false,
         "current": false,
@@ -11199,9 +11476,9 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 101
+        "y": 106
       },
-      "id": 67,
+      "id": 68,
       "legend": {
         "avg": false,
         "current": false,
@@ -11467,9 +11744,9 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 101
+        "y": 106
       },
-      "id": 68,
+      "id": 69,
       "legend": {
         "avg": false,
         "current": false,
@@ -11661,9 +11938,9 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 107
+        "y": 112
       },
-      "id": 69,
+      "id": 70,
       "legend": {
         "avg": false,
         "current": false,
@@ -11852,9 +12129,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 113
+        "y": 118
       },
-      "id": 70,
+      "id": 71,
       "panels": [],
       "title": "RPC Send Transaction Service",
       "type": "row"
@@ -11870,9 +12147,9 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 114
+        "y": 119
       },
-      "id": 71,
+      "id": 72,
       "legend": {
         "avg": false,
         "current": false,
@@ -11988,9 +12265,9 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 114
+        "y": 119
       },
-      "id": 72,
+      "id": 73,
       "legend": {
         "avg": false,
         "current": false,
@@ -12251,9 +12528,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 120
+        "y": 125
       },
-      "id": 73,
+      "id": 74,
       "panels": [],
       "title": "Bench TPS",
       "type": "row"
@@ -12269,9 +12546,9 @@
         "h": 5,
         "w": 7,
         "x": 0,
-        "y": 121
+        "y": 126
       },
-      "id": 74,
+      "id": 75,
       "legend": {
         "avg": false,
         "current": false,
@@ -12384,9 +12661,9 @@
         "h": 5,
         "w": 7,
         "x": 7,
-        "y": 121
+        "y": 126
       },
-      "id": 75,
+      "id": 76,
       "legend": {
         "alignAsTable": false,
         "avg": false,
@@ -12609,9 +12886,9 @@
         "h": 5,
         "w": 10,
         "x": 14,
-        "y": 121
+        "y": 126
       },
-      "id": 76,
+      "id": 77,
       "links": [],
       "pageSize": null,
       "scroll": true,
@@ -12697,9 +12974,9 @@
         "h": 4,
         "w": 10,
         "x": 0,
-        "y": 126
+        "y": 131
       },
-      "id": 77,
+      "id": 78,
       "legend": {
         "avg": false,
         "current": false,


### PR DESCRIPTION
#### Problem

No easy way to use the dashboard to track individual node performance vs. the cluster in terms of slots replayed.

#### Summary of Changes

Add a panel for slot production on both new bank and replay-slot-stats which compares a node against the cluster:
![slot-production-graph](https://user-images.githubusercontent.com/1024962/104769161-b78ee800-5723-11eb-9691-054d235624c8.png)

Fixes #
