### PR TITLE
Update-executable flag in pre-accounts

### DIFF
--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -155,6 +155,7 @@ impl PreAccount {
 
         pre.lamports = account.lamports;
         pre.owner = account.owner;
+        pre.executable = account.executable;
         if pre.data.len() != account.data.len() {
             // Only system account can change data size, copy with alloc
             pre.data = account.data.clone();


### PR DESCRIPTION
#### Problem

During a CPI call flow, an account's executable flag is not updated in the pre-accounts. If an account is marked as executable and then again passed to invoke the verifier will reject it because it was not made aware that the account is now executable.

#### Summary of Changes

Update the pre-account executable flag

Fixes #13907
