### PR TITLE
Add `getHealth` RPC method

### DIFF
--- a/client/src/http_sender.rs
+++ b/client/src/http_sender.rs
@@ -85,6 +85,14 @@ impl RpcSender for HttpSender {
                                             }
                                         }
                                     },
+                                    rpc_custom_error::JSON_RPC_SERVER_ERROR_NODE_UNHEALTHLY => {
+                                        match serde_json::from_value::<rpc_custom_error::RpcNodeUnhealthyErrorData>(json["error"]["data"].clone()) {
+                                            Ok(rpc_custom_error::RpcNodeUnhealthyErrorData { num_slots_behind}) => RpcResponseErrorData::NodeUnhealthy {num_slots_behind},
+                                            Err(_err) => {
+                                                RpcResponseErrorData::Empty
+                                            }
+                                        }
+                                    },
                                     _ => RpcResponseErrorData::Empty
                                 };
 

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -928,6 +928,11 @@ impl RpcClient {
         Ok(hash)
     }
 
+    pub fn get_health(&self) -> ClientResult<()> {
+        self.send::<String>(RpcRequest::GetHealth, Value::Null)
+            .map(|_| ())
+    }
+
     pub fn get_token_account(&self, pubkey: &Pubkey) -> ClientResult<Option<UiTokenAccount>> {
         Ok(self
             .get_token_account_with_commitment(pubkey, self.commitment_config)?

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -1,6 +1,6 @@
 use crate::rpc_response::RpcSimulateTransactionResult;
 use serde_json::{json, Value};
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{clock::Slot, pubkey::Pubkey};
 use std::fmt;
 use thiserror::Error;
 
@@ -25,6 +25,7 @@ pub enum RpcRequest {
     GetFees,
     GetFirstAvailableBlock,
     GetGenesisHash,
+    GetHealth,
     GetIdentity,
     GetInflationGovernor,
     GetInflationRate,
@@ -80,6 +81,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetFees => "getFees",
             RpcRequest::GetFirstAvailableBlock => "getFirstAvailableBlock",
             RpcRequest::GetGenesisHash => "getGenesisHash",
+            RpcRequest::GetHealth => "getHealth",
             RpcRequest::GetIdentity => "getIdentity",
             RpcRequest::GetInflationGovernor => "getInflationGovernor",
             RpcRequest::GetInflationRate => "getInflationRate",
@@ -143,6 +145,7 @@ impl RpcRequest {
 pub enum RpcResponseErrorData {
     Empty,
     SendTransactionPreflightFailure(RpcSimulateTransactionResult),
+    NodeUnhealthy { num_slots_behind: Slot },
 }
 
 impl fmt::Display for RpcResponseErrorData {

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -159,7 +159,7 @@ impl RpcRequestMiddleware {
     fn health_check(&self) -> &'static str {
         let response = match self.health.check() {
             RpcHealthStatus::Ok => "ok",
-            RpcHealthStatus::Behind => "behind",
+            RpcHealthStatus::Behind { num_slots: _ } => "behind",
         };
         info!("health check: {}", response);
         response

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -36,6 +36,7 @@ gives a convenient interface for the RPC methods.
 - [getFees](jsonrpc-api.md#getfees)
 - [getFirstAvailableBlock](jsonrpc-api.md#getfirstavailableblock)
 - [getGenesisHash](jsonrpc-api.md#getgenesishash)
+- [getHealth](jsonrpc-api.md#gethealth)
 - [getIdentity](jsonrpc-api.md#getidentity)
 - [getInflationGovernor](jsonrpc-api.md#getinflationgovernor)
 - [getInflationRate](jsonrpc-api.md#getinflationrate)
@@ -1274,6 +1275,54 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
 Result:
 ```json
 {"jsonrpc":"2.0","result":"GH7ome3EiwEr7tu9JuTh2dpYWBJK3z69Xm1ZE3MEE6JC","id":1}
+```
+
+### getHealth
+
+Returns the current health of the node.
+
+If one or more `--trusted-validator` arguments are provided to
+`solana-validator`, "ok" is returned when the node has within
+`HEALTH_CHECK_SLOT_DISTANCE` slots of the highest trusted validator, otherwise
+an error is returned.  "ok" is always returned if no trusted validators are
+provided.
+
+#### Parameters:
+
+None
+
+#### Results:
+
+If the node is healthy: "ok"
+If the node is unhealthy, a JSON RPC error response is returned indicating how far behind the node is.
+
+#### Example:
+
+Request:
+```bash
+curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+  {"jsonrpc":"2.0","id":1, "method":"getHealth"}
+'
+```
+
+Healthy Result:
+```json
+{"jsonrpc":"2.0","result": "ok","id":1}
+```
+
+Unhealthy Result:
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32005,
+    "message": "RPC node is behind by 42 slots",
+    "data": {
+      "numSlotsBehind": 42
+    }
+  },
+  "id": 1
+}
 ```
 
 ### getIdentity


### PR DESCRIPTION
The `/health` REST endpoint doesn't include how far behind the validator is, which can be very useful information.  For now avoid disturbing `/health` and add a `getHealth` RPC method that provides this extra information.   

`getHealth` is structured so that it can easily replace `/health` with https://docs.rs/jsonrpc-http-server/16.0.0/jsonrpc_http_server/struct.ServerBuilder.html#method.health_api in the future.  Doing so would mean that it's no longer necessary to parse the `/health` response body for "ok", making it easier to integrate with some load balancers.   But dropping "behind" could potentially disturb some users, so I'm not going to pick at it for now.

`solana-test-validator` now uses `getHealth` in its dashboard, a stepping stone to refactoring the `solana-test-validator` dashboard such that it also works for `solana-validator`.  Stay tuned...

