### PR TITLE
Fix the occasional stuck RPC request

### DIFF
--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -358,6 +358,14 @@ impl JsonRpcService {
 
         let ledger_path = ledger_path.to_path_buf();
 
+        let runtime01 = {
+            use tokio_01::runtime::{Builder as RuntimeBuilder, Runtime, TaskExecutor};
+            RuntimeBuilder::new()
+                .name_prefix("rpc")
+                .build()
+                .unwrap()
+        };
+
         let (close_handle_sender, close_handle_receiver) = channel();
         let thread_hdl = Builder::new()
             .name("solana-jsonrpc".to_string())
@@ -376,7 +384,8 @@ impl JsonRpcService {
                     io,
                     move |_req: &hyper::Request<hyper::Body>| request_processor.clone(),
                 )
-                .threads(rpc_threads)
+                .event_loop_executor(runtime01.executor())
+                .threads(1)
                 .cors(DomainsValidation::AllowOnly(vec![
                     AccessControlAllowOrigin::Any,
                 ]))


### PR DESCRIPTION
#### Problem

Finally fixed the odd rpc timeout issue.

If the rpc_service encounters a possibly-resource-intensive request like this:

```
Jan 16 22:20:47 api-europe-west4-c haproxy[1493]: 130.211.2.14:62282 [16/Jan/2021:22:20:17.920] http jsonrpc/rpc 0/0/0/-1/30000 504 203 - - sH-- 150/150/1/1/0 0/0 "POST / HTTP/1.1" 116.202.85.179, {"jsonrpc":"2.0","method":"getProgramAccounts","params":["TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"],"id":1}
```

It starts to stuck other future (even normal) requests sometimes.

The reason is that our event loop structure doesn't even `accept()` the incoming requests:

```
$ sudo ss --tcp --process --numeric -o state listening '( sport = 8899 )' | cat
Recv-Q      Send-Q           Local Address:Port           Peer Address:Port     Process                                                                         
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1238))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1234))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1230))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1226))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1222))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1218))                                
96          1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1214))                                
74          1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1210))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1206))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1202))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1198))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1194))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1190))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1186))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1182))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1178))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1174))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1170))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1166))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1162))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1158))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1154))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1150))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1146))                                

```

(To make the situation worse, linux kernel doesn't evenly load-balance requests across all listening same `SO_REUSEPORT` sockets for some reason)

Normally all recv queue is empty:

```
$ sudo ss --tcp --process --numeric -o state listening '( sport = 8899 )' | cat
Recv-Q      Send-Q           Local Address:Port           Peer Address:Port     Process                                                                         
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1238))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1234))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1230))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1226))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1222))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1218))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1214))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1210))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1206))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1202))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1198))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1194))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1190))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1186))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1182))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1178))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1174))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1170))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1166))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1162))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1158))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1154))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1150))                                
0           1024                   0.0.0.0:8899                0.0.0.0:*         users:(("solana-validato",pid=3038185,fd=1146))                                

```

#### Summary of Changes

Change the event loop arrangement. This isn't ultimate fix, though.. More like a work-around.

This makes 8899 listening socket is only one. But I think this is safe assuming there is backing N-multithread event loop to fetch more requests. And our rps isn't designed for the likes of 10,000 rps or more so there is no disadvantage for forgoing kernel-land load balancing possibility.
Also, this doesn't increase/decrease our susceptability to general DOS. As was before, malicious user can just request purposedly-chosen heavy requests as before.

Fixes #
