### PR TITLE
feature gates turbine retransmit peers patch

### DIFF
--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -252,7 +252,7 @@ fn enable_turbine_retransmit_peers_patch(shred_slot: Slot, root_bank: &Bank) -> 
             let epoch_schedule = root_bank.epoch_schedule();
             let feature_epoch = epoch_schedule.get_epoch(feature_slot);
             let shred_epoch = epoch_schedule.get_epoch(shred_slot);
-            feature_epoch + 1 < shred_epoch
+            feature_epoch < shred_epoch
         }
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -138,6 +138,10 @@ pub mod use_loaded_executables {
     solana_sdk::declare_id!("2SLL2KLakB83YAnF1TwFb1hpycrWeHAfHYyLhwk2JRGn");
 }
 
+pub mod turbine_retransmit_peers_patch {
+    solana_sdk::declare_id!("5Lu3JnWSFwRYpXzwDMkanWSk6XqSuF2i5fpnVhzB5CTc");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -174,6 +178,7 @@ lazy_static! {
         (use_loaded_program_accounts::id(), "Use loaded program accounts"),
         (abort_on_all_cpi_failures::id(), "Abort on all CPI failures"),
         (use_loaded_executables::id(), "Use loaded executable accounts"),
+        (turbine_retransmit_peers_patch::id(), "turbine retransmit peers patch #14631"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/14565 needs to be feature-gated before it is enabled on mainnet,
otherwise the cluster will be out of sync on how they compute turbine retransmit peers.

#### Summary of Changes
added a feature gate for the patch.