### PR TITLE
Make it possible to opt-out jemalloc for heaptrack

### DIFF
--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -19,5 +19,12 @@ solana-metrics = { path = "../metrics", version = "1.6.0" }
 jemallocator = "0.3.2"
 jemalloc-ctl = "0.3.2"
 
+[features]
+# mainly for heaptrack, which seems to be incompatible with jemalloc
+# opt-out ("no-" prefix) is chosen for convenience for the default case
+# (= with jemalloc), considering complexies of proper opt-in (default)
+# feature plumbing
+no-jemalloc = []
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/measure/src/lib.rs
+++ b/measure/src/lib.rs
@@ -4,6 +4,7 @@ pub mod thread_mem_usage;
 #[cfg(unix)]
 extern crate jemallocator;
 
+#[cfg(not(feature = "no-jemalloc"))]
 #[cfg(unix)]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;

--- a/measure/src/thread_mem_usage.rs
+++ b/measure/src/thread_mem_usage.rs
@@ -1,7 +1,9 @@
+#[cfg(not(feature = "no-jemalloc"))]
 #[cfg(unix)]
 use jemalloc_ctl::thread;
 
 pub fn datapoint(_name: &'static str) {
+    #[cfg(not(feature = "no-jemalloc"))]
     #[cfg(unix)]
     {
         let allocated = thread::allocatedp::mib().unwrap();
@@ -12,29 +14,32 @@ pub fn datapoint(_name: &'static str) {
 }
 
 pub struct Allocatedp {
+    #[cfg(not(feature = "no-jemalloc"))]
     #[cfg(unix)]
     allocated: thread::ThreadLocal<u64>,
 }
 
 impl Allocatedp {
     pub fn default() -> Self {
+        #[cfg(not(feature = "no-jemalloc"))]
         #[cfg(unix)]
         {
             let allocated = thread::allocatedp::mib().unwrap();
             let allocated = allocated.read().unwrap();
             Self { allocated }
         }
-        #[cfg(not(unix))]
+        #[cfg(any(feature = "no-jemalloc", not(unix)))]
         Self {}
     }
 
     /// Return current thread heap usage
     pub fn get(&self) -> u64 {
+        #[cfg(not(feature = "no-jemalloc"))]
         #[cfg(unix)]
         {
             self.allocated.get()
         }
-        #[cfg(not(unix))]
+        #[cfg(any(feature = "no-jemalloc", not(unix)))]
         0
     }
 


### PR DESCRIPTION
#### Problem

Out-of-tree patch for heaptrack build (ie = no jemalloc) is inconvenient.

#### Summary of Changes

Tidy up the patch and include into the master

For nightly rustc, building for heaptrack is easily turned on like this:

```bash
$ cargo run -Zpackage-features --features solana-measure/no-jemalloc ...
```