### PR TITLE
Make Bigtable::get_confirmed_blocks inclusive of requested start_slot and end_slot

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -732,7 +732,7 @@ impl JsonRpcRequestProcessor {
                     .runtime_handle
                     .block_on(
                         bigtable_ledger_storage
-                            .get_confirmed_blocks(start_slot, (end_slot - start_slot) as usize),
+                            .get_confirmed_blocks(start_slot, (end_slot - start_slot) as usize + 1), // increment limit by 1 to return range inclusive of both start_slot and end_slot
                     )
                     .unwrap_or_else(|_| vec![]));
             }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -732,8 +732,12 @@ impl JsonRpcRequestProcessor {
                     .runtime_handle
                     .block_on(
                         bigtable_ledger_storage
-                            .get_confirmed_blocks(start_slot, (end_slot - start_slot) as usize + 1), // increment limit by 1 to return range inclusive of both start_slot and end_slot
+                            .get_confirmed_blocks(start_slot, (end_slot - start_slot) as usize + 1), // increment limit by 1 to ensure returned range is inclusive of both start_slot and end_slot
                     )
+                    .map(|mut bigtable_blocks| {
+                        bigtable_blocks.retain(|&slot| slot <= end_slot);
+                        bigtable_blocks
+                    })
                     .unwrap_or_else(|_| vec![]));
             }
         }


### PR DESCRIPTION
#### Problem
`Blockstore::get_confirmed_blocks` returns values inclusive of both the start_slot and end_slot provided. The BigTable analog is not necessarily inclusive of the end-slot, as it calculates limit as `end_slot - start_slot`. This is particularly problematic when a user queries for the same start_slot and end_slot, since our code attempts to return `limit: 0` cells from BigTable, and this hangs for some reason.

Also, regardless of the math, BigTable::get_confirmed_blocks can return blocks after end_slot, if not all slots produced a block, because it continues pulling Slots up to the limit. eg:
```
$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedBlocks", "params":[39368303,39368311]}' testnet.solana.com
{"jsonrpc":"2.0","result":[39368303,39368304,39368305,39368306,39368307,39368308,39368316,39368317],"id":1}
```

#### Summary of Changes
- Fix BigTable blocks limit math to be inclusive of end_slot, even when all slots produce blocks
- Add filter to remove blocks greater than end_slot
