### PR TITLE
Configure Bigtable's timeout, enabling by default

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -116,7 +116,7 @@ pub struct JsonRpcConfig {
     pub max_multiple_accounts: Option<usize>,
     pub account_indexes: HashSet<AccountIndex>,
     pub rpc_threads: usize,
-    pub rpc_timeout: Option<Duration>,
+    pub rpc_bigtable_timeout: Option<Duration>,
 }
 
 #[derive(Clone)]
@@ -740,7 +740,12 @@ impl JsonRpcRequestProcessor {
                         bigtable_blocks.retain(|&slot| slot <= end_slot);
                         bigtable_blocks
                     })
-                    .unwrap_or_else(|_| vec![]));
+                    .map_err(|_| {
+                        Error::invalid_params(
+                            "BigTable query failed (maybe timeout due to too large range?)"
+                                .to_string(),
+                        )
+                    })?);
             }
         }
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -81,6 +81,7 @@ use std::{
         mpsc::{channel, Receiver, Sender},
         Arc, Mutex, RwLock,
     },
+    time::Duration,
 };
 use tokio::runtime;
 
@@ -115,6 +116,7 @@ pub struct JsonRpcConfig {
     pub max_multiple_accounts: Option<usize>,
     pub account_indexes: HashSet<AccountIndex>,
     pub rpc_threads: usize,
+    pub rpc_timeout: Option<Duration>,
 }
 
 #[derive(Clone)]

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -297,7 +297,7 @@ impl JsonRpcService {
                 runtime
                     .block_on(solana_storage_bigtable::LedgerStorage::new(
                         !config.enable_bigtable_ledger_upload,
-                        config.rpc_timeout,
+                        config.rpc_bigtable_timeout,
                     ))
                     .map(|bigtable_ledger_storage| {
                         info!("BigTable ledger storage initialized");

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -297,6 +297,7 @@ impl JsonRpcService {
                 runtime
                     .block_on(solana_storage_bigtable::LedgerStorage::new(
                         !config.enable_bigtable_ledger_upload,
+                        config.rpc_timeout,
                     ))
                     .map(|bigtable_ledger_storage| {
                         info!("BigTable ledger storage initialized");

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -21,7 +21,7 @@ async fn upload(
     ending_slot: Option<Slot>,
     allow_missing_metadata: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let bigtable = solana_storage_bigtable::LedgerStorage::new(false)
+    let bigtable = solana_storage_bigtable::LedgerStorage::new(false, None)
         .await
         .map_err(|err| format!("Failed to connect to storage: {:?}", err))?;
 
@@ -37,7 +37,7 @@ async fn upload(
 }
 
 async fn first_available_block() -> Result<(), Box<dyn std::error::Error>> {
-    let bigtable = solana_storage_bigtable::LedgerStorage::new(true).await?;
+    let bigtable = solana_storage_bigtable::LedgerStorage::new(true, None).await?;
     match bigtable.get_first_available_block().await? {
         Some(block) => println!("{}", block),
         None => println!("No blocks available"),
@@ -47,7 +47,7 @@ async fn first_available_block() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn block(slot: Slot) -> Result<(), Box<dyn std::error::Error>> {
-    let bigtable = solana_storage_bigtable::LedgerStorage::new(false)
+    let bigtable = solana_storage_bigtable::LedgerStorage::new(false, None)
         .await
         .map_err(|err| format!("Failed to connect to storage: {:?}", err))?;
 
@@ -75,7 +75,7 @@ async fn block(slot: Slot) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn blocks(starting_slot: Slot, limit: usize) -> Result<(), Box<dyn std::error::Error>> {
-    let bigtable = solana_storage_bigtable::LedgerStorage::new(false)
+    let bigtable = solana_storage_bigtable::LedgerStorage::new(false, None)
         .await
         .map_err(|err| format!("Failed to connect to storage: {:?}", err))?;
 
@@ -87,7 +87,7 @@ async fn blocks(starting_slot: Slot, limit: usize) -> Result<(), Box<dyn std::er
 }
 
 async fn confirm(signature: &Signature, verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let bigtable = solana_storage_bigtable::LedgerStorage::new(false)
+    let bigtable = solana_storage_bigtable::LedgerStorage::new(false, None)
         .await
         .map_err(|err| format!("Failed to connect to storage: {:?}", err))?;
 
@@ -127,7 +127,7 @@ pub async fn transaction_history(
     show_transactions: bool,
     query_chunk_size: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let bigtable = solana_storage_bigtable::LedgerStorage::new(true).await?;
+    let bigtable = solana_storage_bigtable::LedgerStorage::new(true, None).await?;
 
     let mut loaded_block: Option<(Slot, ConfirmedBlock)> = None;
     while limit > 0 {

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -152,13 +152,7 @@ impl BigTableConnection {
                         )?;
 
                     if let Some(timeout) = timeout {
-                        if read_only {
-                            // apply timeout only when thre is no write queries!
-                            endpoint.timeout(timeout)
-                        } else {
-                            warn!("BigTableConnection's requested timeout configuration is ignored because it's not read-only.");
-                            endpoint
-                        }
+                        endpoint.timeout(timeout)
                     } else {
                         endpoint
                     }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -279,8 +279,9 @@ pub struct LedgerStorage {
 }
 
 impl LedgerStorage {
-    pub async fn new(read_only: bool) -> Result<Self> {
-        let connection = bigtable::BigTableConnection::new("solana-ledger", read_only).await?;
+    pub async fn new(read_only: bool, timeout: Option<std::time::Duration>) -> Result<Self> {
+        let connection =
+            bigtable::BigTableConnection::new("solana-ledger", read_only, timeout).await?;
         Ok(Self { connection })
     }
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1288,6 +1288,14 @@ pub fn main() {
                 .help("Number of threads to use for servicing RPC requests"),
         )
         .arg(
+            Arg::with_name("rpc_timeout")
+                .long("rpc-timeout")
+                .value_name("NUMBER")
+                .validator(is_parsable::<u64>)
+                .takes_value(true)
+                .help("Number of seconds to time out rpc requests (not applied to all kinds of methods)"),
+        )
+        .arg(
             Arg::with_name("rpc_pubsub_enable_vote_subscription")
                 .long("rpc-pubsub-enable-vote-subscription")
                 .takes_value(false)
@@ -1561,6 +1569,9 @@ pub fn main() {
                 u64
             ),
             rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),
+            rpc_timeout: value_t!(matches, "rpc_timeout", u64)
+                .ok()
+                .map(Duration::from_secs),
             account_indexes: account_indexes.clone(),
         },
         rpc_addrs: value_t!(matches, "rpc_port", u16).ok().map(|rpc_port| {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1288,12 +1288,13 @@ pub fn main() {
                 .help("Number of threads to use for servicing RPC requests"),
         )
         .arg(
-            Arg::with_name("rpc_timeout")
-                .long("rpc-timeout")
+            Arg::with_name("rpc_bigtable_timeout")
+                .long("rpc-bigtable-timeout")
                 .value_name("NUMBER")
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
-                .help("Number of seconds to time out rpc requests (not applied to all kinds of methods)"),
+                .default_value("30")
+                .help("Number of seconds to time out rpc requests backed by BigTable"),
         )
         .arg(
             Arg::with_name("rpc_pubsub_enable_vote_subscription")
@@ -1569,7 +1570,7 @@ pub fn main() {
                 u64
             ),
             rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),
-            rpc_timeout: value_t!(matches, "rpc_timeout", u64)
+            rpc_bigtable_timeout: value_t!(matches, "rpc_bigtable_timeout", u64)
                 .ok()
                 .map(Duration::from_secs),
             account_indexes: account_indexes.clone(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1290,11 +1290,11 @@ pub fn main() {
         .arg(
             Arg::with_name("rpc_bigtable_timeout")
                 .long("rpc-bigtable-timeout")
-                .value_name("NUMBER")
+                .value_name("SECONDS")
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
                 .default_value("30")
-                .help("Number of seconds to time out rpc requests backed by BigTable"),
+                .help("Number of seconds before timing out RPC requests backed by BigTable"),
         )
         .arg(
             Arg::with_name("rpc_pubsub_enable_vote_subscription")


### PR DESCRIPTION
#### Problem

There is two known indefinitely-processing places which can called from the RPC service codepath (getConfirmedBlocks)

#### Summary of Changes

Introduce timeouts.
