### PR TITLE
Improve docs around bigtable read limit

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -313,7 +313,8 @@ impl BigTable {
     /// Otherwise the listing will start from the start of the table.
     ///
     /// If `end_at` is provided, the row key listing will end at the key. Otherwise it will
-    /// continue until the `limit` is reached or the end of the table, whichever comes first.
+    /// continue until the `rows_limit` is reached or the end of the table, whichever comes first.
+    /// If `rows_limit` is zero, the listing will continue until the end of the table.
     pub async fn get_row_keys(
         &mut self,
         table_name: &str,
@@ -374,7 +375,8 @@ impl BigTable {
     /// of the table.
     ///
     /// If `end_at` is provided, the row key listing will end at the key. Otherwise it will
-    /// continue until the `limit` is reached or the end of the table, whichever comes first.
+    /// continue until the `rows_limit` is reached or the end of the table, whichever comes first.
+    /// If `rows_limit` is zero, the listing will continue until the end of the table.
     pub async fn get_row_data(
         &mut self,
         table_name: &str,

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -297,7 +297,8 @@ impl LedgerStorage {
     /// Fetch the next slots after the provided slot that contains a block
     ///
     /// start_slot: slot to start the search from (inclusive)
-    /// limit: stop after this many slots have been found.
+    /// limit: stop after this many slots have been found; if limit==0, all records in the table
+    /// after start_slot will be read
     pub async fn get_confirmed_blocks(&self, start_slot: Slot, limit: usize) -> Result<Vec<Slot>> {
         let mut bigtable = self.connection.client();
         let blocks = bigtable
@@ -371,7 +372,8 @@ impl LedgerStorage {
     ///
     /// address: address to search for
     /// before_signature: start with the first signature older than this one
-    /// limit: stop after this many signatures.
+    /// until_signature: end with the last signature more recent than this one
+    /// limit: stop after this many signatures; if limit==0, all records in the table will be read
     pub async fn get_confirmed_signatures_for_address(
         &self,
         address: &Pubkey,


### PR DESCRIPTION
#### Problem
Prior to https://github.com/solana-labs/solana/pull/14651, `getConfirmedBlocks` could erroneously request a BigTable read with `limit: 0`. Rather than quickly returning zero records, as might be expected, this would cause the thread to hang, as BigTable attempted to read every row after in the table after `start_slot` (many millions of records).

#### Summary of Changes
- Make BigTable's `limit: 0` behavior more obvious in storage-bigtable method documentation