### PR TITLE
Cli: default to single gossip

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -522,7 +522,7 @@ impl Default for CliConfig<'_> {
             rpc_timeout: Duration::from_secs(u64::from_str(DEFAULT_RPC_TIMEOUT_SECONDS).unwrap()),
             verbose: false,
             output_format: OutputFormat::Display,
-            commitment: CommitmentConfig::default(),
+            commitment: CommitmentConfig::single_gossip(),
             send_transaction_config: RpcSendTransactionConfig::default(),
             address_labels: HashMap::new(),
         }
@@ -1123,8 +1123,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
 
     let mut _rpc_client;
     let rpc_client = if config.rpc_client.is_none() {
-        _rpc_client =
-            RpcClient::new_with_timeout(config.json_rpc_url.to_string(), config.rpc_timeout);
+        _rpc_client = RpcClient::new_with_timeout_and_commitment(
+            config.json_rpc_url.to_string(),
+            config.rpc_timeout,
+            config.commitment,
+        );
         &_rpc_client
     } else {
         // Primarily for testing
@@ -1856,7 +1859,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(false)
                         .help("Display balance in lamports instead of SOL"),
                 )
-                .arg(commitment_arg_with_default("max")),
+                .arg(commitment_arg_with_default("singleGossip")),
         )
         .subcommand(
             SubCommand::with_name("confirm")

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -934,9 +934,7 @@ fn process_balance(
     } else {
         config.pubkey()?
     };
-    let balance = rpc_client
-        .get_balance_with_commitment(&pubkey, config.commitment)?
-        .value;
+    let balance = rpc_client.get_balance(&pubkey)?;
     Ok(build_balance_message(balance, use_lamports_unit, true))
 }
 
@@ -1102,11 +1100,7 @@ fn process_transfer(
         let result = if no_wait {
             rpc_client.send_transaction(&tx)
         } else {
-            rpc_client.send_and_confirm_transaction_with_spinner_and_config(
-                &tx,
-                config.commitment,
-                config.send_transaction_config,
-            )
+            rpc_client.send_and_confirm_transaction_with_spinner(&tx)
         };
         log_instruction_custom_error::<SystemError>(result, &config)
     }
@@ -1755,8 +1749,7 @@ pub fn request_and_confirm_airdrop(
         }
     }?;
     let tx = keypair.airdrop_transaction();
-    let result =
-        rpc_client.send_and_confirm_transaction_with_spinner_and_commitment(&tx, config.commitment);
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,6 +19,7 @@ use solana_cli_config::{Config, CONFIG_FILE};
 use solana_cli_output::{display::println_name_value, OutputFormat};
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
+use solana_sdk::commitment_config::CommitmentConfig;
 use std::{collections::HashMap, error, path::PathBuf, sync::Arc, time::Duration};
 
 pub fn println_name_value_or(name: &str, value: &str, setting_type: SettingType) {
@@ -191,7 +192,7 @@ pub fn parse_args<'a>(
         }
         commitment_of(sub_matches, COMMITMENT_ARG.long)
     }
-    .unwrap_or_default();
+    .unwrap_or_else(CommitmentConfig::single_gossip);
 
     let address_labels = if matches.is_present("no_address_labels") {
         HashMap::new()

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -332,9 +332,7 @@ pub fn process_authorize_nonce_account(
     nonce_authority: SignerIndex,
     new_authority: &Pubkey,
 ) -> ProcessResult {
-    let (recent_blockhash, fee_calculator, _) = rpc_client
-        .get_recent_blockhash_with_commitment(config.commitment)?
-        .value;
+    let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let nonce_authority = config.signers[nonce_authority];
     let ix = authorize_nonce_account(nonce_account, &nonce_authority.pubkey(), new_authority);
@@ -349,11 +347,7 @@ pub fn process_authorize_nonce_account(
         &tx.message,
         config.commitment,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
-        &tx,
-        config.commitment,
-        config.send_transaction_config,
-    );
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<NonceError>(result, &config)
 }
 
@@ -400,9 +394,7 @@ pub fn process_create_nonce_account(
         Message::new(&ixs, Some(&config.signers[0].pubkey()))
     };
 
-    let (recent_blockhash, fee_calculator, _) = rpc_client
-        .get_recent_blockhash_with_commitment(config.commitment)?
-        .value;
+    let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let (message, lamports) = resolve_spend_tx_and_check_account_balance(
         rpc_client,
@@ -414,9 +406,7 @@ pub fn process_create_nonce_account(
         config.commitment,
     )?;
 
-    if let Ok(nonce_account) =
-        get_account_with_commitment(rpc_client, &nonce_account_address, config.commitment)
-    {
+    if let Ok(nonce_account) = get_account(rpc_client, &nonce_account_address) {
         let err_msg = if state_from_account(&nonce_account).is_ok() {
             format!("Nonce account {} already exists", nonce_account_address)
         } else {
@@ -439,11 +429,7 @@ pub fn process_create_nonce_account(
 
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
-        &tx,
-        config.commitment,
-        config.send_transaction_config,
-    );
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 
@@ -471,9 +457,8 @@ pub fn process_new_nonce(
         (&nonce_account, "nonce_account_pubkey".to_string()),
     )?;
 
-    let nonce_account_check =
-        rpc_client.get_account_with_commitment(&nonce_account, config.commitment);
-    if nonce_account_check.is_err() || nonce_account_check.unwrap().value.is_none() {
+    let nonce_account_check = rpc_client.get_account(&nonce_account);
+    if nonce_account_check.is_err() {
         return Err(CliError::BadParameter(
             "Unable to create new nonce, no nonce account found".to_string(),
         )
@@ -482,9 +467,7 @@ pub fn process_new_nonce(
 
     let nonce_authority = config.signers[nonce_authority];
     let ix = advance_nonce_account(&nonce_account, &nonce_authority.pubkey());
-    let (recent_blockhash, fee_calculator, _) = rpc_client
-        .get_recent_blockhash_with_commitment(config.commitment)?
-        .value;
+    let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
     let message = Message::new(&[ix], Some(&config.signers[0].pubkey()));
     let mut tx = Transaction::new_unsigned(message);
     tx.try_sign(&config.signers, recent_blockhash)?;
@@ -495,11 +478,7 @@ pub fn process_new_nonce(
         &tx.message,
         config.commitment,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
-        &tx,
-        config.commitment,
-        config.send_transaction_config,
-    );
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<SystemError>(result, &config)
 }
 
@@ -541,9 +520,7 @@ pub fn process_withdraw_from_nonce_account(
     destination_account_pubkey: &Pubkey,
     lamports: u64,
 ) -> ProcessResult {
-    let (recent_blockhash, fee_calculator, _) = rpc_client
-        .get_recent_blockhash_with_commitment(config.commitment)?
-        .value;
+    let (recent_blockhash, fee_calculator) = rpc_client.get_recent_blockhash()?;
 
     let nonce_authority = config.signers[nonce_authority];
     let ix = withdraw_nonce_account(
@@ -562,11 +539,7 @@ pub fn process_withdraw_from_nonce_account(
         &tx.message,
         config.commitment,
     )?;
-    let result = rpc_client.send_and_confirm_transaction_with_spinner_and_config(
-        &tx,
-        config.commitment,
-        config.send_transaction_config,
-    );
+    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
     log_instruction_custom_error::<NonceError>(result, &config)
 }
 

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -20,7 +20,6 @@ use solana_config_program::{config_instruction, get_config_data, ConfigKeys, Con
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
 use solana_sdk::{
     account::Account,
-    commitment_config::CommitmentConfig,
     message::Message,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
@@ -288,9 +287,7 @@ pub fn process_set_validator_info(
     };
 
     // Check existence of validator-info account
-    let balance = rpc_client
-        .poll_get_balance_with_commitment(&info_pubkey, CommitmentConfig::default())
-        .unwrap_or(0);
+    let balance = rpc_client.get_balance(&info_pubkey).unwrap_or(0);
 
     let lamports =
         rpc_client.get_minimum_balance_for_rent_exemption(ValidatorInfo::max_space() as usize)?;

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -63,7 +63,8 @@ fn full_battery_tests(
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let json_rpc_url = test_validator.rpc_url();
 
     let mut config_payer = CliConfig::recent_for_tests();
@@ -228,7 +229,8 @@ fn test_create_account_with_seed() {
     let config = CliConfig::recent_for_tests();
 
     // Setup accounts
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -33,7 +33,8 @@ fn test_cli_program_deploy_non_upgradeable() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -70,11 +71,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         .as_str()
         .unwrap();
     let program_id = Pubkey::from_str(&program_id_str).unwrap();
-    let account0 = rpc_client
-        .get_account_with_commitment(&program_id, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let account0 = rpc_client.get_account(&program_id).unwrap();
     assert_eq!(account0.lamports, minimum_balance_for_rent_exemption);
     assert_eq!(account0.owner, bpf_loader::id());
     assert_eq!(account0.executable, true);
@@ -94,9 +91,7 @@ fn test_cli_program_deploy_non_upgradeable() {
     };
     process_command(&config).unwrap();
     let account1 = rpc_client
-        .get_account_with_commitment(&custom_address_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
+        .get_account(&custom_address_keypair.pubkey())
         .unwrap();
     assert_eq!(account1.lamports, minimum_balance_for_rent_exemption);
     assert_eq!(account1.owner, bpf_loader::id());
@@ -134,9 +129,7 @@ fn test_cli_program_deploy_non_upgradeable() {
     };
     process_command(&config).unwrap();
     let account2 = rpc_client
-        .get_account_with_commitment(&custom_address_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
+        .get_account(&custom_address_keypair.pubkey())
         .unwrap();
     assert_eq!(account2.lamports, 2 * minimum_balance_for_rent_exemption);
     assert_eq!(account2.owner, bpf_loader::id());
@@ -161,7 +154,8 @@ fn test_cli_program_deploy_no_authority() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -248,7 +242,8 @@ fn test_cli_program_deploy_with_authority() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -304,11 +299,7 @@ fn test_cli_program_deploy_with_authority() {
         program_keypair.pubkey(),
         Pubkey::from_str(&program_pubkey_str).unwrap()
     );
-    let program_account = rpc_client
-        .get_account_with_commitment(&program_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let program_account = rpc_client.get_account(&program_keypair.pubkey()).unwrap();
     assert_eq!(program_account.lamports, minimum_balance_for_program);
     assert_eq!(program_account.owner, bpf_loader_upgradeable::id());
     assert_eq!(program_account.executable, true);
@@ -316,11 +307,7 @@ fn test_cli_program_deploy_with_authority() {
         &[program_keypair.pubkey().as_ref()],
         &bpf_loader_upgradeable::id(),
     );
-    let programdata_account = rpc_client
-        .get_account_with_commitment(&programdata_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
     assert_eq!(
         programdata_account.lamports,
         minimum_balance_for_programdata
@@ -356,21 +343,13 @@ fn test_cli_program_deploy_with_authority() {
         .as_str()
         .unwrap();
     let program_pubkey = Pubkey::from_str(&program_pubkey_str).unwrap();
-    let program_account = rpc_client
-        .get_account_with_commitment(&program_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let program_account = rpc_client.get_account(&program_pubkey).unwrap();
     assert_eq!(program_account.lamports, minimum_balance_for_program);
     assert_eq!(program_account.owner, bpf_loader_upgradeable::id());
     assert_eq!(program_account.executable, true);
     let (programdata_pubkey, _) =
         Pubkey::find_program_address(&[program_pubkey.as_ref()], &bpf_loader_upgradeable::id());
-    let programdata_account = rpc_client
-        .get_account_with_commitment(&programdata_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
     assert_eq!(
         programdata_account.lamports,
         minimum_balance_for_programdata
@@ -397,21 +376,13 @@ fn test_cli_program_deploy_with_authority() {
         max_len: Some(max_len),
     });
     process_command(&config).unwrap();
-    let program_account = rpc_client
-        .get_account_with_commitment(&program_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let program_account = rpc_client.get_account(&program_pubkey).unwrap();
     assert_eq!(program_account.lamports, minimum_balance_for_program);
     assert_eq!(program_account.owner, bpf_loader_upgradeable::id());
     assert_eq!(program_account.executable, true);
     let (programdata_pubkey, _) =
         Pubkey::find_program_address(&[program_pubkey.as_ref()], &bpf_loader_upgradeable::id());
-    let programdata_account = rpc_client
-        .get_account_with_commitment(&programdata_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
     assert_eq!(
         programdata_account.lamports,
         minimum_balance_for_programdata
@@ -460,21 +431,13 @@ fn test_cli_program_deploy_with_authority() {
         max_len: None,
     });
     process_command(&config).unwrap();
-    let program_account = rpc_client
-        .get_account_with_commitment(&program_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let program_account = rpc_client.get_account(&program_pubkey).unwrap();
     assert_eq!(program_account.lamports, minimum_balance_for_program);
     assert_eq!(program_account.owner, bpf_loader_upgradeable::id());
     assert_eq!(program_account.executable, true);
     let (programdata_pubkey, _) =
         Pubkey::find_program_address(&[program_pubkey.as_ref()], &bpf_loader_upgradeable::id());
-    let programdata_account = rpc_client
-        .get_account_with_commitment(&programdata_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
     assert_eq!(
         programdata_account.lamports,
         minimum_balance_for_programdata
@@ -565,11 +528,7 @@ fn test_cli_program_deploy_with_authority() {
     let program_pubkey = Pubkey::from_str(&program_pubkey_str).unwrap();
     let (programdata_pubkey, _) =
         Pubkey::find_program_address(&[program_pubkey.as_ref()], &bpf_loader_upgradeable::id());
-    let programdata_account = rpc_client
-        .get_account_with_commitment(&programdata_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let programdata_account = rpc_client.get_account(&programdata_pubkey).unwrap();
     if let UpgradeableLoaderState::ProgramData {
         slot: _,
         upgrade_authority_address,
@@ -614,7 +573,8 @@ fn test_cli_program_write_buffer() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -663,11 +623,7 @@ fn test_cli_program_write_buffer() {
         .as_str()
         .unwrap();
     let new_buffer_pubkey = Pubkey::from_str(&buffer_pubkey_str).unwrap();
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&new_buffer_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&new_buffer_pubkey).unwrap();
     assert_eq!(buffer_account.lamports, minimum_balance_for_buffer_default);
     assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
@@ -704,11 +660,7 @@ fn test_cli_program_write_buffer() {
         buffer_keypair.pubkey(),
         Pubkey::from_str(&buffer_pubkey_str).unwrap()
     );
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&buffer_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     assert_eq!(buffer_account.lamports, minimum_balance_for_buffer);
     assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
@@ -765,11 +717,7 @@ fn test_cli_program_write_buffer() {
         buffer_keypair.pubkey(),
         Pubkey::from_str(&buffer_pubkey_str).unwrap()
     );
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&buffer_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     assert_eq!(buffer_account.lamports, minimum_balance_for_buffer_default);
     assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
@@ -804,11 +752,7 @@ fn test_cli_program_write_buffer() {
         .as_str()
         .unwrap();
     let buffer_pubkey = Pubkey::from_str(&buffer_pubkey_str).unwrap();
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&buffer_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&buffer_pubkey).unwrap();
     assert_eq!(buffer_account.lamports, minimum_balance_for_buffer_default);
     assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
@@ -843,11 +787,7 @@ fn test_cli_program_write_buffer() {
         .as_str()
         .unwrap();
     let buffer_pubkey = Pubkey::from_str(&buffer_pubkey_str).unwrap();
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&buffer_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&buffer_pubkey).unwrap();
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
         assert_eq!(authority_address, None);
     } else {
@@ -888,7 +828,8 @@ fn test_cli_program_set_buffer_authority() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -924,11 +865,7 @@ fn test_cli_program_set_buffer_authority() {
         max_len: None,
     });
     process_command(&config).unwrap();
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&buffer_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
         assert_eq!(authority_address, Some(keypair.pubkey()));
     } else {
@@ -956,11 +893,7 @@ fn test_cli_program_set_buffer_authority() {
         Pubkey::from_str(&new_buffer_authority_str).unwrap(),
         new_buffer_authority.pubkey()
     );
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&buffer_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
         assert_eq!(authority_address, Some(new_buffer_authority.pubkey()));
     } else {
@@ -987,11 +920,7 @@ fn test_cli_program_set_buffer_authority() {
         Pubkey::from_str(&buffer_authority_str).unwrap(),
         buffer_keypair.pubkey()
     );
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&buffer_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
         assert_eq!(authority_address, Some(buffer_keypair.pubkey()));
     } else {
@@ -1015,11 +944,7 @@ fn test_cli_program_set_buffer_authority() {
         .as_str()
         .unwrap();
     assert_eq!(buffer_authority_str, "None");
-    let buffer_account = rpc_client
-        .get_account_with_commitment(&buffer_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
         assert_eq!(authority_address, None);
     } else {

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -31,11 +31,11 @@ fn test_cli_request_airdrop() {
     let sig_response = process_command(&bob_config);
     sig_response.unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let balance = rpc_client
-        .get_balance_with_commitment(&bob_config.signers[0].pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value;
+        .get_balance(&bob_config.signers[0].pubkey())
+        .unwrap();
     assert_eq!(balance, 50);
 }

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -32,7 +32,8 @@ fn test_stake_delegation_force() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let default_signer = Keypair::new();
 
     let mut config = CliConfig::recent_for_tests();
@@ -120,7 +121,8 @@ fn test_seed_stake_delegation_and_deactivation() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let validator_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
     let mut config_validator = CliConfig::recent_for_tests();
@@ -199,7 +201,8 @@ fn test_stake_delegation_and_deactivation() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let validator_keypair = Keypair::new();
 
     let mut config_validator = CliConfig::recent_for_tests();
@@ -274,7 +277,8 @@ fn test_offline_stake_delegation_and_deactivation() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let mut config_validator = CliConfig::recent_for_tests();
     config_validator.json_rpc_url = test_validator.rpc_url();
@@ -406,7 +410,8 @@ fn test_nonced_stake_delegation_and_deactivation() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let config_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
     let mut config = CliConfig::recent_for_tests();
@@ -520,7 +525,8 @@ fn test_stake_authorize() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let default_signer = Keypair::new();
 
     let mut config = CliConfig::recent_for_tests();
@@ -588,11 +594,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-    let stake_account = rpc_client
-        .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
     let current_authority = match stake_state {
         StakeState::Initialized(meta) => meta.authorized.staker,
@@ -619,11 +621,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-    let stake_account = rpc_client
-        .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
     let (current_staker, current_withdrawer) = match stake_state {
         StakeState::Initialized(meta) => (meta.authorized.staker, meta.authorized.withdrawer),
@@ -645,11 +643,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-    let stake_account = rpc_client
-        .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
     let current_authority = match stake_state {
         StakeState::Initialized(meta) => meta.authorized.staker,
@@ -660,10 +654,7 @@ fn test_stake_authorize() {
     // Offline assignment of new nonced stake authority
     let nonced_authority = Keypair::new();
     let nonced_authority_pubkey = nonced_authority.pubkey();
-    let (blockhash, _, _) = rpc_client
-        .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
-        .unwrap()
-        .value;
+    let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorizations: vec![(StakeAuthorize::Staker, nonced_authority_pubkey, 0)],
@@ -689,11 +680,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-    let stake_account = rpc_client
-        .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
     let current_authority = match stake_state {
         StakeState::Initialized(meta) => meta.authorized.staker,
@@ -758,11 +745,7 @@ fn test_stake_authorize() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-    let stake_account = rpc_client
-        .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
     let current_authority = match stake_state {
         StakeState::Initialized(meta) => meta.authorized.staker,
@@ -792,7 +775,8 @@ fn test_stake_authorize_with_fee_payer() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let default_signer = Keypair::new();
     let default_pubkey = default_signer.pubkey();
 
@@ -870,10 +854,7 @@ fn test_stake_authorize_with_fee_payer() {
     check_recent_balance(100_000 - SIG_FEE - SIG_FEE, &rpc_client, &payer_pubkey);
 
     // Assign authority with offline fee payer
-    let (blockhash, _, _) = rpc_client
-        .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
-        .unwrap()
-        .value;
+    let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     config_offline.command = CliCommand::StakeAuthorize {
         stake_account_pubkey,
         new_authorizations: vec![(StakeAuthorize::Staker, payer_pubkey, 0)],
@@ -916,7 +897,8 @@ fn test_stake_split() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let default_signer = Keypair::new();
     let offline_signer = Keypair::new();
 
@@ -1059,7 +1041,8 @@ fn test_stake_set_lockup() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let default_signer = Keypair::new();
     let offline_signer = Keypair::new();
 
@@ -1142,11 +1125,7 @@ fn test_stake_set_lockup() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-    let stake_account = rpc_client
-        .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
     let current_lockup = match stake_state {
         StakeState::Initialized(meta) => meta.lockup,
@@ -1197,11 +1176,7 @@ fn test_stake_set_lockup() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-    let stake_account = rpc_client
-        .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
     let current_lockup = match stake_state {
         StakeState::Initialized(meta) => meta.lockup,
@@ -1294,11 +1269,7 @@ fn test_stake_set_lockup() {
         fee_payer: 0,
     };
     process_command(&config).unwrap();
-    let stake_account = rpc_client
-        .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent())
-        .unwrap()
-        .value
-        .unwrap();
+    let stake_account = rpc_client.get_account(&stake_account_pubkey).unwrap();
     let stake_state: StakeState = stake_account.state().unwrap();
     let current_lockup = match stake_state {
         StakeState::Initialized(meta) => meta.lockup,
@@ -1322,7 +1293,8 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let mut config = CliConfig::recent_for_tests();
     let default_signer = keypair_from_seed(&[1u8; 32]).unwrap();
     config.signers = vec![&default_signer];

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -29,7 +29,8 @@ fn test_transfer() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let default_signer = Keypair::new();
     let default_offline_signer = Keypair::new();
@@ -92,10 +93,7 @@ fn test_transfer() {
     check_recent_balance(50, &rpc_client, &offline_pubkey);
 
     // Offline transfer
-    let (blockhash, _, _) = rpc_client
-        .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
-        .unwrap()
-        .value;
+    let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
     offline.command = CliCommand::Transfer {
         amount: SpendAmount::Some(10),
         to: recipient_pubkey,
@@ -256,7 +254,8 @@ fn test_transfer_multisession_signing() {
     let config = CliConfig::recent_for_tests();
 
     // Setup accounts
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
@@ -279,10 +278,7 @@ fn test_transfer_multisession_signing() {
 
     check_ready(&rpc_client);
 
-    let (blockhash, _, _) = rpc_client
-        .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
-        .unwrap()
-        .value;
+    let (blockhash, _) = rpc_client.get_recent_blockhash().unwrap();
 
     // Offline fee-payer signs first
     let mut fee_payer_config = CliConfig::recent_for_tests();
@@ -368,7 +364,8 @@ fn test_transfer_all() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
 
     let default_signer = Keypair::new();
 

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -25,7 +25,8 @@ fn test_vote_authorize_and_withdraw() {
     run_local_faucet(mint_keypair, sender, None);
     let faucet_addr = receiver.recv().unwrap();
 
-    let rpc_client = RpcClient::new(test_validator.rpc_url());
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
     let default_signer = Keypair::new();
 
     let mut config = CliConfig::recent_for_tests();
@@ -55,9 +56,7 @@ fn test_vote_authorize_and_withdraw() {
     };
     process_command(&config).unwrap();
     let vote_account = rpc_client
-        .get_account_with_commitment(&vote_account_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
+        .get_account(&vote_account_keypair.pubkey())
         .unwrap();
     let vote_state: VoteStateVersions = vote_account.state().unwrap();
     let authorized_withdrawer = vote_state.convert_to_current().authorized_withdrawer;
@@ -95,9 +94,7 @@ fn test_vote_authorize_and_withdraw() {
     };
     process_command(&config).unwrap();
     let vote_account = rpc_client
-        .get_account_with_commitment(&vote_account_keypair.pubkey(), CommitmentConfig::recent())
-        .unwrap()
-        .value
+        .get_account(&vote_account_keypair.pubkey())
         .unwrap();
     let vote_state: VoteStateVersions = vote_account.state().unwrap();
     let authorized_withdrawer = vote_state.convert_to_current().authorized_withdrawer;

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -97,6 +97,17 @@ impl RpcClient {
         )
     }
 
+    pub fn new_with_timeout_and_commitment(
+        url: String,
+        timeout: Duration,
+        commitment_config: CommitmentConfig,
+    ) -> Self {
+        Self::new_sender(
+            HttpSender::new_with_timeout(url, timeout),
+            commitment_config,
+        )
+    }
+
     pub fn new_mock(url: String) -> Self {
         Self::new_sender(MockSender::new(url), CommitmentConfig::default())
     }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -361,6 +361,10 @@ impl RpcClient {
         self.send(RpcRequest::GetSlot, json!([commitment_config]))
     }
 
+    pub fn supply(&self) -> RpcResult<RpcSupply> {
+        self.supply_with_commitment(self.commitment_config)
+    }
+
     pub fn supply_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
@@ -782,6 +786,7 @@ impl RpcClient {
                 filters: None,
                 account_config: RpcAccountInfoConfig {
                     encoding: Some(UiAccountEncoding::Base64),
+                    commitment: Some(self.commitment_config),
                     ..RpcAccountInfoConfig::default()
                 },
             },

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -323,7 +323,7 @@ fn check_vote_account(
     authorized_voter_pubkeys: &[Pubkey],
 ) -> Result<(), String> {
     let vote_account = rpc_client
-        .get_account_with_commitment(vote_account_address, CommitmentConfig::root())
+        .get_account_with_commitment(vote_account_address, CommitmentConfig::single_gossip())
         .map_err(|err| format!("failed to fetch vote account: {}", err.to_string()))?
         .value
         .ok_or_else(|| format!("vote account does not exist: {}", vote_account_address))?;
@@ -336,7 +336,7 @@ fn check_vote_account(
     }
 
     let identity_account = rpc_client
-        .get_account_with_commitment(identity_pubkey, CommitmentConfig::root())
+        .get_account_with_commitment(identity_pubkey, CommitmentConfig::single_gossip())
         .map_err(|err| format!("failed to fetch identity account: {}", err.to_string()))?
         .value
         .ok_or_else(|| format!("identity account does not exist: {}", identity_pubkey))?;


### PR DESCRIPTION
#### Problem
The Cli waits for any transaction to be finalized, but single-gossip commitment is sufficient for most actions.

#### Summary of Changes
- Default cli to single gossip by initializing RpcClient commitment: https://github.com/solana-labs/solana/pull/14673/commits/7ce63605a90b7099ec051ebfc79104e94ebc4c3d
- Simplify rpc-client calls to use RpcClient's configured commitment; remaining `_with_commitment` calls are because of the different return signatures for get_recent_blockhash and get_account. (Incidentally, there is a lot more work that could be done here, especially the methods in `cli/src/checks.rs` and `client/src/nonce_utils.rs`. But this seemed like enough churn for one PR)

Fixes #14589 
