### PR TITLE
Cli block, block-time: Default to highest finalized block if no slot provided

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -880,7 +880,7 @@ pub fn process_get_block(
     let slot = if let Some(slot) = slot {
         slot
     } else {
-        rpc_client.get_slot()?
+        rpc_client.get_slot_with_commitment(CommitmentConfig::max())?
     };
 
     let mut block =
@@ -958,7 +958,7 @@ pub fn process_get_block_time(
     let slot = if let Some(slot) = slot {
         slot
     } else {
-        rpc_client.get_slot()?
+        rpc_client.get_slot_with_commitment(CommitmentConfig::max())?
     };
     let timestamp = rpc_client.get_block_time(slot)?;
     let block_time = CliBlockTime { slot, timestamp };


### PR DESCRIPTION
#### Problem
Solana cli was recently updated to use `singleGossip` commitment by default. However, some data is only available once finalized. In a couple of these places, the cli uses `RpcClient::get_slot()` to chose the slot to query if no slot is provided; this returns an error because the returned slot (of `singleGossip` commitment) isn't yet finalized.

#### Summary of Changes
- `solana block-time` and `solana block`: default to highest finalized block if no slot provided
