### PR TITLE
Cli: Return actual confirmation-status from solana confirm

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -298,6 +298,23 @@ impl TransactionStatus {
             CommitmentLevel::Recent => true,
         }
     }
+
+    // Returns `confirmation_status`, or if is_none, determines the status from confirmations.
+    // Facilitates querying nodes on older software
+    pub fn confirmation_status(&self) -> TransactionConfirmationStatus {
+        match &self.confirmation_status {
+            Some(status) => status.clone(),
+            None => {
+                if self.confirmations.is_none() {
+                    TransactionConfirmationStatus::Finalized
+                } else if self.confirmations.unwrap() > 0 {
+                    TransactionConfirmationStatus::Confirmed
+                } else {
+                    TransactionConfirmationStatus::Processed
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
#### Problem
`solana confirm` currently returns yes/no whether the transaction has been finalized. But we can now query the transaction's more-precised confirmation status: processed, confirmed, or finalized

#### Summary of Changes
- Return actual confirmation-status
- Also, spruce up error message when user requests verbose, but the transaction is not yet finalized. (In the future, we may be able to return transaction details for optimistically confirmed transactions, but right now, the rpc is limited to those that are finalized.)