### PR TITLE
Nonce address doesn't sign AdvanceNonceAccount

### DIFF
--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -115,7 +115,7 @@ pub enum SystemInstruction {
     /// Consumes a stored nonce, replacing it with a successor
     ///
     /// # Account references
-    ///   0. [WRITE, SIGNER] Nonce account
+    ///   0. [WRITE] Nonce account
     ///   1. [] RecentBlockhashes sysvar
     ///   2. [SIGNER] Nonce authority
     AdvanceNonceAccount,


### PR DESCRIPTION
#### Problem

Doc comment for `SystemInstruction::AdvanceNonceAccount` incorrectly specifies the account address as a signer

#### Summary of Changes

Fix it