### PR TITLE
Upgrade sha2 to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +795,16 @@ name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array 0.14.3",
+ "subtle 2.2.2",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array 0.14.3",
  "subtle 2.2.2",
@@ -1000,7 +1016,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.8.2",
  "zeroize",
 ]
 
@@ -1539,6 +1555,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.0",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,7 +1572,7 @@ checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
 dependencies = [
  "digest 0.8.1",
  "generic-array 0.12.3",
- "hmac",
+ "hmac 0.7.1",
 ]
 
 [[package]]
@@ -2072,7 +2098,7 @@ dependencies = [
  "digest 0.8.1",
  "hmac-drbg",
  "rand 0.7.3",
- "sha2",
+ "sha2 0.8.2",
  "subtle 2.2.2",
  "typenum",
 ]
@@ -2661,6 +2687,15 @@ checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "byteorder",
  "crypto-mac 0.7.0",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
+dependencies = [
+ "crypto-mac 0.10.0",
 ]
 
 [[package]]
@@ -3562,6 +3597,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,7 +4264,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.8.2",
  "solana-frozen-abi-macro 1.4.17",
  "solana-logger 1.4.17",
  "thiserror",
@@ -4234,7 +4282,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.9.2",
  "solana-frozen-abi-macro 1.6.0",
  "solana-logger 1.6.0",
  "thiserror",
@@ -4383,7 +4431,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.9.2",
  "solana-bpf-loader-program",
  "solana-budget-program",
  "solana-frozen-abi 1.6.0",
@@ -4661,7 +4709,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2",
+ "sha2 0.8.2",
  "solana-frozen-abi 1.4.17",
  "solana-frozen-abi-macro 1.4.17",
  "solana-logger 1.4.17",
@@ -4691,7 +4739,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.9.2",
  "solana-frozen-abi 1.6.0",
  "solana-frozen-abi-macro 1.6.0",
  "solana-logger 1.6.0",
@@ -4841,7 +4889,7 @@ dependencies = [
  "ed25519-dalek",
  "generic-array 0.14.3",
  "hex",
- "hmac",
+ "hmac 0.10.1",
  "itertools 0.9.0",
  "lazy_static",
  "libsecp256k1",
@@ -4849,7 +4897,7 @@ dependencies = [
  "memmap2",
  "num-derive",
  "num-traits",
- "pbkdf2",
+ "pbkdf2 0.6.0",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rustc_version",
@@ -4858,7 +4906,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.9.2",
  "sha3",
  "solana-crate-features",
  "solana-frozen-abi 1.6.0",
@@ -5644,12 +5692,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
 dependencies = [
  "failure",
- "hmac",
+ "hmac 0.7.1",
  "once_cell",
- "pbkdf2",
+ "pbkdf2 0.3.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2",
+ "sha2 0.8.2",
  "unicode-normalization",
 ]
 

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -14,7 +14,7 @@ bv = { version = "0.11.1", features = ["serde"] }
 log = "0.4.11"
 serde = "1.0.112"
 serde_derive = "1.0.103"
-sha2 = "0.8.2"
+sha2 = "0.9.2"
 solana-frozen-abi-macro = { path = "macro", version = "1.6.0" }
 thiserror = "1.0"
 

--- a/frozen-abi/src/hash.rs
+++ b/frozen-abi/src/hash.rs
@@ -12,12 +12,12 @@ pub struct Hasher {
 
 impl Hasher {
     pub fn hash(&mut self, val: &[u8]) {
-        self.hasher.input(val);
+        self.hasher.update(val);
     }
     pub fn result(self) -> Hash {
         // At the time of this writing, the sha2 library is stuck on an old version
         // of generic_array (0.9.0). Decouple ourselves with a clone to our version.
-        Hash(<[u8; HASH_BYTES]>::try_from(self.hasher.result().as_slice()).unwrap())
+        Hash(<[u8; HASH_BYTES]>::try_from(self.hasher.finalize().as_slice()).unwrap())
     }
 }
 

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -32,7 +32,7 @@ rayon = "1.5.0"
 reed-solomon-erasure = { version = "4.0.2", features = ["simd-accel"] }
 serde = "1.0.112"
 serde_bytes = "0.11.4"
-sha2 = "0.8.2"
+sha2 = "0.9.2"
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "1.6.0" }
 solana-frozen-abi = { path = "../frozen-abi", version = "1.6.0" }
 solana-frozen-abi-macro = { path = "../frozen-abi/macro", version = "1.6.0" }

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -336,8 +336,8 @@ pub fn sign_shreds_gpu_pinned_keypair(keypair: &Keypair, cache: &RecyclerCache) 
     let pubkey = keypair.pubkey().to_bytes();
     let secret = keypair.secret().to_bytes();
     let mut hasher = Sha512::default();
-    hasher.input(&secret);
-    let mut result = hasher.result();
+    hasher.update(&secret);
+    let mut result = hasher.finalize();
     result[0] &= 248;
     result[31] &= 63;
     result[31] |= 64;

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -409,6 +409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array 0.14.3",
+ "subtle 2.2.2",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,7 +675,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.8.2",
  "zeroize",
 ]
 
@@ -1019,6 +1035,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.0",
+ "digest 0.9.0",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,7 +1052,7 @@ checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
 dependencies = [
  "digest 0.8.1",
  "generic-array 0.12.3",
- "hmac",
+ "hmac 0.7.1",
 ]
 
 [[package]]
@@ -1311,7 +1337,7 @@ dependencies = [
  "digest 0.8.1",
  "hmac-drbg",
  "rand 0.7.3",
- "sha2",
+ "sha2 0.8.2",
  "subtle 2.2.2",
  "typenum",
 ]
@@ -1791,6 +1817,15 @@ checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "byteorder 1.3.4",
  "crypto-mac 0.7.0",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
+dependencies = [
+ "crypto-mac 0.10.0",
 ]
 
 [[package]]
@@ -2395,6 +2430,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2882,7 +2930,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.8.2",
  "solana-frozen-abi-macro 1.5.3",
  "solana-logger 1.5.3",
  "thiserror",
@@ -2900,7 +2948,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.9.2",
  "solana-frozen-abi-macro 1.6.0",
  "solana-logger 1.6.0",
  "thiserror",
@@ -3014,7 +3062,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2",
+ "sha2 0.8.2",
  "solana-frozen-abi 1.5.3",
  "solana-frozen-abi-macro 1.5.3",
  "solana-logger 1.5.3",
@@ -3042,7 +3090,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2",
+ "sha2 0.9.2",
  "solana-frozen-abi 1.6.0",
  "solana-frozen-abi-macro 1.6.0",
  "solana-logger 1.6.0",
@@ -3139,7 +3187,7 @@ dependencies = [
  "ed25519-dalek",
  "generic-array 0.14.3",
  "hex",
- "hmac",
+ "hmac 0.10.1",
  "itertools 0.9.0",
  "lazy_static",
  "libsecp256k1",
@@ -3147,7 +3195,7 @@ dependencies = [
  "memmap2",
  "num-derive 0.3.0",
  "num-traits",
- "pbkdf2",
+ "pbkdf2 0.6.0",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rustc_version",
@@ -3156,7 +3204,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.9.2",
  "sha3",
  "solana-crate-features",
  "solana-frozen-abi 1.6.0",
@@ -3499,12 +3547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
 dependencies = [
  "failure",
- "hmac",
+ "hmac 0.7.1",
  "once_cell",
- "pbkdf2",
+ "pbkdf2 0.3.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2",
+ "sha2 0.8.2",
  "unicode-normalization",
 ]
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -44,21 +44,21 @@ chrono = { version = "0.4", optional = true }
 curve25519-dalek = { version = "2.1.0", optional = true }
 generic-array = { version = "0.14.3", default-features = false, features = ["serde", "more_lengths"], optional = true }
 hex = "0.4.2"
-hmac = "0.7.0"
+hmac = "0.10.1"
 itertools =  "0.9.0"
 lazy_static = "1.4.0"
 log = "0.4.11"
 memmap2 = { version = "0.1.0", optional = true }
 num-derive = "0.3"
 num-traits = "0.2"
-pbkdf2 = { version = "0.3.0", default-features = false }
+pbkdf2 = { version = "0.6.0", default-features = false }
 rand = { version = "0.7.0", optional = true }
 rand_chacha = { version = "0.2.2", optional = true }
 serde = "1.0.112"
 serde_bytes = "0.11"
 serde_derive = "1.0.103"
 serde_json = { version = "1.0.56", optional = true }
-sha2 = "0.8.2"
+sha2 = "0.9.2"
 thiserror = "1.0"
 ed25519-dalek = { version = "=1.0.0-pre.4", optional = true }
 solana-crate-features = { path = "../crate-features", version = "1.6.0", optional = true }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -22,7 +22,7 @@ rustversion = "1.0.3"
 serde = "1.0.112"
 serde_bytes = "0.11"
 serde_derive = "1.0.103"
-sha2 = "0.8.2"
+sha2 = "0.9.2"
 solana-frozen-abi = { path = "../../frozen-abi", version = "1.6.0" }
 solana-frozen-abi-macro = { path = "../../frozen-abi/macro", version = "1.6.0" }
 solana-sdk-macro = { path = "../macro", version = "1.6.0" }

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -19,7 +19,7 @@ pub struct Hasher {
 
 impl Hasher {
     pub fn hash(&mut self, val: &[u8]) {
-        self.hasher.input(val);
+        self.hasher.update(val);
     }
     pub fn hashv(&mut self, vals: &[&[u8]]) {
         for val in vals {
@@ -29,7 +29,7 @@ impl Hasher {
     pub fn result(self) -> Hash {
         // At the time of this writing, the sha2 library is stuck on an old version
         // of generic_array (0.9.0). Decouple ourselves with a clone to our version.
-        Hash(<[u8; HASH_BYTES]>::try_from(self.hasher.result().as_slice()).unwrap())
+        Hash(<[u8; HASH_BYTES]>::try_from(self.hasher.finalize().as_slice()).unwrap())
     }
 }
 

--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -400,7 +400,7 @@ pub fn keypair_from_seed_phrase_and_passphrase(
     seed_phrase: &str,
     passphrase: &str,
 ) -> Result<Keypair, Box<dyn error::Error>> {
-    const PBKDF2_ROUNDS: usize = 2048;
+    const PBKDF2_ROUNDS: u32 = 2048;
     const PBKDF2_BYTES: usize = 64;
 
     let salt = format!("mnemonic{}", passphrase);


### PR DESCRIPTION
#### Problem

sha2 crate older and slower than could be.

#### Summary of Changes

Upgrade to the latest.

Fixes #
