### PR TITLE
fixes test_filter_current flakiness

### DIFF
--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -675,6 +675,8 @@ mod test {
     use super::*;
     use crate::contact_info::ContactInfo;
     use bincode::{deserialize, Options};
+    use rand::SeedableRng;
+    use rand_chacha::ChaChaRng;
     use solana_perf::test_tx::test_tx;
     use solana_sdk::signature::{Keypair, Signer};
     use solana_sdk::timing::timestamp;
@@ -843,7 +845,8 @@ mod test {
 
     #[test]
     fn test_filter_current() {
-        let mut rng = rand::thread_rng();
+        let seed = [48u8; 32];
+        let mut rng = ChaChaRng::from_seed(seed);
         let keys: Vec<_> = repeat_with(Keypair::new).take(16).collect();
         let values: Vec<_> = repeat_with(|| {
             let index = rng.gen_range(0, keys.len());


### PR DESCRIPTION
#### Problem
There is a tiny chance that two randomly generated crds-values have the same label and wallclock, in which case `test_filter_current` does not take into account.

#### Summary of Changes
Fixed the random seed.

Fixes #14744
