### PR TITLE
Update bigtable confirm to use confirmation_status

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -106,14 +106,15 @@ async fn confirm(signature: &Signature, verbose: bool) -> Result<(), Box<dyn std
                     "  ",
                 );
             }
-            Ok(None) => println!("Confirmed transaction details not available"),
-            Err(err) => println!("Unable to get confirmed transaction details: {}", err),
+            Ok(None) => println!("Finalized transaction details not available"),
+            Err(err) => println!("Unable to get finalized transaction details: {}", err),
         }
         println!();
     }
-    match transaction_status.status {
-        Ok(_) => println!("Confirmed"),
-        Err(err) => println!("Transaction failed: {}", err),
+    if let Some(err) = &transaction_status.err {
+        println!("Transaction failed: {}", err);
+    } else {
+        println!("{:?}", transaction_status.confirmation_status());
     }
     Ok(())
 }


### PR DESCRIPTION
Just a tweak to keep `solana-ledger-tool bigtable confirm ...` output consistent with that from `solana confirm ...`