### PR TITLE
test-validator: Add ability to clone accounts from an RPC endpoint

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -164,8 +164,8 @@ where
     }
 }
 
-pub fn normalize_to_url_if_moniker(url_or_moniker: &str) -> String {
-    match url_or_moniker {
+pub fn normalize_to_url_if_moniker<T: AsRef<str>>(url_or_moniker: T) -> String {
+    match url_or_moniker.as_ref() {
         "m" | "mainnet-beta" => "https://api.mainnet-beta.solana.com",
         "t" | "testnet" => "https://testnet.solana.com",
         "d" | "devnet" => "https://devnet.solana.com",

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -84,6 +84,30 @@ impl TestValidatorGenesis {
         self
     }
 
+    pub fn add_accounts<T>(&mut self, accounts: T) -> &mut Self
+    where
+        T: IntoIterator<Item = (Pubkey, Account)>,
+    {
+        for (address, account) in accounts {
+            self.add_account(address, account);
+        }
+        self
+    }
+
+    pub fn clone_accounts<T>(&mut self, addresses: T, rpc_client: &RpcClient) -> &mut Self
+    where
+        T: IntoIterator<Item = Pubkey>,
+    {
+        for address in addresses {
+            info!("Fetching {}...", address);
+            let account = rpc_client.get_account(&address).unwrap_or_else(|err| {
+                panic!("Failed to fetch {}: {}", address, err);
+            });
+            self.add_account(address, account);
+        }
+        self
+    }
+
     /// Add an account to the test environment with the account data in the provided `filename`
     pub fn add_account_with_file_data(
         &mut self,


### PR DESCRIPTION
Add an easy way to copy accounts of interest from mainnet-beta or elsewhere into a local test validator.

Illustrative example:
```
$ solana-test-validator --reset \
  --clone SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8 \
  --clone FV9WWFWYzWHDpAc8oxiFKV1LmFUyWw7HGdo4GK19MiZ \
  --url http://api.mainnet-beta.solana.com
```
or more concisely
```
$ solana-test-validator -r -c SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8 \
  -c FV9WWFWYzWHDpAc8oxiFKV1LmFUyWw7HGdo4GK19MiZ -u m
```
boots my local test-validator with the program that @joncinque just deployed to mainnet-beta
```
$ solana account --verbose SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8
RPC URL: http://127.0.0.1:8899
Default Signer Path: /Users/mvines/.config/solana/id.json
Commitment: singleGossip

Public Key: SwaPpA9LAaLfeLi3a68M4DjnLqgtticKg6CnyNwgAC8
Balance: 0.00114144 SOL
Owner: BPFLoaderUpgradeab1e11111111111111111111111
Executable: true
Rent Epoch: 142
Length: 36 (0x24) bytes
0000:   02 00 00 00  d7 39 80 1c  85 84 a4 cc  4b 84 a2 c1   .....9......K...
0010:   c6 00 31 d0  2f 06 ba 8a  07 52 4c 2e  00 a8 31 44   ..1./....RL...1D
0020:   a8 26 ba c1                                          .&..
```
