### PR TITLE
Rpc: Add custom error for BigTable data not found

### DIFF
--- a/client/src/rpc_custom_error.rs
+++ b/client/src/rpc_custom_error.rs
@@ -12,7 +12,7 @@ pub const JSON_RPC_SERVER_ERROR_NODE_UNHEALTHLY: i64 = -32005;
 pub const JSON_RPC_SERVER_ERROR_TRANSACTION_PRECOMPILE_VERIFICATION_FAILURE: i64 = -32006;
 pub const JSON_RPC_SERVER_ERROR_SLOT_SKIPPED: i64 = -32007;
 pub const JSON_RPC_SERVER_ERROR_NO_SNAPSHOT: i64 = -32008;
-pub const JSON_RPC_SERVER_ERROR_BIGTABLE_SLOT_SKIPPED: i64 = -32009;
+pub const JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED: i64 = -32009;
 
 pub enum RpcCustomError {
     BlockCleanedUp {
@@ -35,7 +35,7 @@ pub enum RpcCustomError {
         slot: Slot,
     },
     NoSnapshot,
-    BigTableSlotSkipped {
+    LongTermStorageSlotSkipped {
         slot: Slot,
     },
 }
@@ -110,9 +110,9 @@ impl From<RpcCustomError> for Error {
                 message: "No snapshot".to_string(),
                 data: None,
             },
-            RpcCustomError::BigTableSlotSkipped { slot } => Self {
-                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_BIGTABLE_SLOT_SKIPPED),
-                message: format!("Slot {} was skipped, or missing in BigTable", slot),
+            RpcCustomError::LongTermStorageSlotSkipped { slot } => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED),
+                message: format!("Slot {} was skipped, or missing in long-term storage", slot),
                 data: None,
             },
         }

--- a/client/src/rpc_custom_error.rs
+++ b/client/src/rpc_custom_error.rs
@@ -12,6 +12,7 @@ pub const JSON_RPC_SERVER_ERROR_NODE_UNHEALTHLY: i64 = -32005;
 pub const JSON_RPC_SERVER_ERROR_TRANSACTION_PRECOMPILE_VERIFICATION_FAILURE: i64 = -32006;
 pub const JSON_RPC_SERVER_ERROR_SLOT_SKIPPED: i64 = -32007;
 pub const JSON_RPC_SERVER_ERROR_NO_SNAPSHOT: i64 = -32008;
+pub const JSON_RPC_SERVER_ERROR_BIGTABLE_SLOT_SKIPPED: i64 = -32009;
 
 pub enum RpcCustomError {
     BlockCleanedUp {
@@ -34,6 +35,9 @@ pub enum RpcCustomError {
         slot: Slot,
     },
     NoSnapshot,
+    BigTableSlotSkipped {
+        slot: Slot,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -104,6 +108,11 @@ impl From<RpcCustomError> for Error {
             RpcCustomError::NoSnapshot => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_NO_SNAPSHOT),
                 message: "No snapshot".to_string(),
+                data: None,
+            },
+            RpcCustomError::BigTableSlotSkipped { slot } => Self {
+                code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_BIGTABLE_SLOT_SKIPPED),
+                message: format!("Slot {} was skipped, or missing in BigTable", slot),
                 data: None,
             },
         }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -670,6 +670,22 @@ impl JsonRpcRequestProcessor {
         Ok(())
     }
 
+    fn check_bigtable_result<T>(
+        &self,
+        result: &std::result::Result<T, solana_storage_bigtable::Error>,
+    ) -> Result<()>
+    where
+        T: std::fmt::Debug,
+    {
+        if result.is_err() {
+            let err = result.as_ref().unwrap_err();
+            if let solana_storage_bigtable::Error::BlockNotFound(slot) = err {
+                return Err(RpcCustomError::BigTableSlotSkipped { slot: *slot }.into());
+            }
+        }
+        Ok(())
+    }
+
     pub fn get_confirmed_block(
         &self,
         slot: Slot,
@@ -688,9 +704,11 @@ impl JsonRpcRequestProcessor {
             self.check_blockstore_root(&result, slot)?;
             if result.is_err() {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
-                    return Ok(self
+                    let bigtable_result = self
                         .runtime_handle
-                        .block_on(bigtable_ledger_storage.get_confirmed_block(slot))
+                        .block_on(bigtable_ledger_storage.get_confirmed_block(slot));
+                    self.check_bigtable_result(&bigtable_result)?;
+                    return Ok(bigtable_result
                         .ok()
                         .map(|confirmed_block| confirmed_block.encode(encoding)));
                 }
@@ -803,9 +821,11 @@ impl JsonRpcRequestProcessor {
             self.check_blockstore_root(&result, slot)?;
             if result.is_err() || matches!(result, Ok(None)) {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
-                    return Ok(self
+                    let bigtable_result = self
                         .runtime_handle
-                        .block_on(bigtable_ledger_storage.get_confirmed_block(slot))
+                        .block_on(bigtable_ledger_storage.get_confirmed_block(slot));
+                    self.check_bigtable_result(&bigtable_result)?;
+                    return Ok(bigtable_result
                         .ok()
                         .and_then(|confirmed_block| confirmed_block.block_time));
                 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -680,7 +680,7 @@ impl JsonRpcRequestProcessor {
         if result.is_err() {
             let err = result.as_ref().unwrap_err();
             if let solana_storage_bigtable::Error::BlockNotFound(slot) = err {
-                return Err(RpcCustomError::BigTableSlotSkipped { slot: *slot }.into());
+                return Err(RpcCustomError::LongTermStorageSlotSkipped { slot: *slot }.into());
             }
         }
         Ok(())


### PR DESCRIPTION
#### Problem
Rpc apis that query BigTable do not distinguish between BigTable errors and successful queries that do not find data; they return `null` for all these cases. This is problematic in the case of `getConfirmedBlock`; if a block is in range of Blockstore, the api returns a specific error for skipped blocks and `null` for read errors, and users are used to distinguishing these cases. But for an old slot, this pattern doesn't hold.

#### Summary of Changes
- Expose specific data NotFound errors from storage-bigtable
- Return a custom rpc error when BigTable block is not found
