### PR TITLE
Aggregate purge and shrink metrics

### DIFF
--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -70,6 +70,11 @@ impl SlotCacheInner {
     pub fn is_frozen(&self) -> bool {
         self.is_frozen.load(Ordering::SeqCst)
     }
+
+    pub fn total_bytes(&self) -> u64 {
+        self.unique_account_writes_size.load(Ordering::Relaxed)
+            + self.same_account_writes_size.load(Ordering::Relaxed)
+    }
 }
 
 impl Deref for SlotCacheInner {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -907,7 +907,7 @@ impl ShrinkStats {
                     i64
                 ),
                 (
-                    "drop_storage_entries_elapsed",
+                    "accounts_removed",
                     self.accounts_removed.swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
@@ -2862,7 +2862,7 @@ impl AccountsDB {
         self.do_purge_slots_from_cache_and_store(
             true,
             non_roots.into_iter(),
-            &self.clean_accounts_stats.purge_stats,
+            &self.external_purge_slots_stats,
         );
         self.external_purge_slots_stats
             .report("external_purge_slots_stats", Some(1000));

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -646,7 +646,7 @@ pub struct AccountsDB {
     clean_accounts_stats: CleanAccountsStats,
 
     // Stats for purges called outside of clean_accounts()
-    purge_slots_stats: PurgeStats,
+    external_purge_slots_stats: PurgeStats,
 
     shrink_stats: ShrinkStats,
 
@@ -698,14 +698,14 @@ struct PurgeStats {
 }
 
 impl PurgeStats {
-    fn report(&self, metric_name: &'static str, report_interval_ms: Option<usize>) {
+    fn report(&self, metric_name: &'static str, report_interval_ms: Option<u64>) {
         let should_report = report_interval_ms
-            .map(|report_interval| {
+            .map(|report_interval_ms| {
                 let last = self.last_report.load(Ordering::Relaxed);
                 let now = solana_sdk::timing::timestamp();
                 now.saturating_sub(last) > report_interval_ms
                     && self
-                        .last_store_report
+                        .last_report
                         .compare_and_swap(last, now, Ordering::Relaxed)
                         == last
             })
@@ -899,6 +899,7 @@ impl Default for AccountsDB {
             min_num_stores: num_threads,
             bank_hashes: RwLock::new(bank_hashes),
             frozen_accounts: HashMap::new(),
+            external_purge_slots_stats: PurgeStats::default(),
             clean_accounts_stats: CleanAccountsStats::default(),
             shrink_stats: ShrinkStats::default(),
             stats: AccountsStats::default(),
@@ -1490,7 +1491,7 @@ impl AccountsDB {
         clean_dead_slots.stop();
 
         let mut purge_removed_slots = Measure::start("reclaims::purge_removed_slots");
-        self.purge_removed_slots_from_store(&dead_slots);
+        self.purge_storage_slots(&dead_slots);
         purge_removed_slots.stop();
 
         // If the slot is dead, remove the need to shrink the storages as
@@ -1654,9 +1655,9 @@ impl AccountsDB {
         }
         rewrite_elapsed.stop();
 
-        let mut recycle_stores_write_time = Measure::start("recycle_stores_write_time");
+        let mut recycle_stores_write_elapsed = Measure::start("recycle_stores_write_time");
         let mut recycle_stores = self.recycle_stores.write().unwrap();
-        recycle_stores_write_time.stop();
+        recycle_stores_write_elapsed.stop();
 
         let mut drop_storage_entries_elapsed = Measure::start("drop_storage_entries_elapsed");
         if recycle_stores.len() < MAX_RECYCLE_STORES {
@@ -1703,8 +1704,8 @@ impl AccountsDB {
                 i64
             ),
             (
-                "recycle_stores_write_time",
-                recycle_stores_write_time.as_us(),
+                "recycle_stores_write_elapsed",
+                recycle_stores_write_elapsed.as_us(),
                 i64
             ),
             ("total_starting_accounts", total_starting_accounts, i64),
@@ -1921,9 +1922,9 @@ impl AccountsDB {
         }
         rewrite_elapsed.stop();
 
-        let mut recycle_stores_write_time = Measure::start("recycle_stores_write_time");
+        let mut recycle_stores_write_elapsed = Measure::start("recycle_stores_write_elapsed");
         let mut recycle_stores = self.recycle_stores.write().unwrap();
-        recycle_stores_write_time.stop();
+        recycle_stores_write_elapsed.stop();
 
         let mut drop_storage_entries_elapsed = Measure::start("drop_storage_entries_elapsed");
         if recycle_stores.len() < MAX_RECYCLE_STORES {
@@ -1971,8 +1972,8 @@ impl AccountsDB {
                 i64
             ),
             (
-                "recycle_stores_write_time",
-                recycle_stores_write_time.as_us(),
+                "recycle_stores_write_elapsed",
+                recycle_stores_write_elapsed.as_us(),
                 i64
             ),
         );
@@ -2623,9 +2624,9 @@ impl AccountsDB {
     ) -> u64 {
         let mut recycled_count = 0;
 
-        let mut recycle_stores_write_time = Measure::start("recycle_stores_write_time");
+        let mut recycle_stores_write_elapsed = Measure::start("recycle_stores_write_elapsed");
         let mut recycle_stores = self.recycle_stores.write().unwrap();
-        recycle_stores_write_time.stop();
+        recycle_stores_write_elapsed.stop();
 
         for slot_entries in slot_stores {
             let entry = slot_entries.read().unwrap();
@@ -2635,34 +2636,44 @@ impl AccountsDB {
                     self.stats
                         .dropped_stores
                         .fetch_add(dropped_count as u64, Ordering::Relaxed);
-                    return recycle_stores_write_time.as_us();
+                    return recycle_stores_write_elapsed.as_us();
                 }
                 recycle_stores.push(stores.clone());
                 recycled_count += 1;
             }
         }
-        recycle_stores_write_time.as_us()
+        recycle_stores_write_elapsed.as_us()
     }
 
-    /// # Arguments
-    /// * `removed_slots` - Slots that were previously rooted but just removed
-    fn purge_removed_slots_from_store(&self, removed_slots: &HashSet<Slot>) {
-        // Check all slots `removed_slots` are no longer rooted
-        let mut safety_checks_elapsed = Measure::start("safety_checks_elapsed");
-        for slot in removed_slots.iter() {
-            assert!(!self.accounts_index.is_root(*slot))
-        }
-        safety_checks_elapsed.stop();
-
-        // Purge the storage entries of the removed slots
+    fn do_purge_slots_from_cache_and_store<'a>(
+        &'a self,
+        can_exist_in_cache: bool,
+        removed_slots: impl Iterator<Item = &'a Slot>,
+        purge_stats: &PurgeStats,
+    ) {
         let mut remove_storages_elapsed = Measure::start("remove_storages_elapsed");
         let mut all_removed_slot_storages = vec![];
         let mut total_removed_storage_entries = 0;
         let mut total_removed_bytes = 0;
-        for slot in removed_slots {
-            // The removed slot must alrady have been flushed from the cache
-            assert!(self.accounts_cache.slot_cache(*slot).is_none());
-            if let Some((_, slot_removed_storages)) = self.storage.0.remove(&slot) {
+        for remove_slot in removed_slots {
+            if let Some(slot_cache) = self.accounts_cache.remove_slot(*remove_slot) {
+                // If the slot is still in the cache, remove the backing storages for
+                // the slot and from the Accounts Index
+                if !can_exist_in_cache {
+                    panic!("The removed slot must alrady have been flushed from the cache");
+                }
+                self.purge_slot_cache(*remove_slot, slot_cache);
+            } else if let Some((_, slot_removed_storages)) = self.storage.0.remove(&remove_slot) {
+                // Because AccountsBackgroundService synchronously flushes from the accounts cache
+                // and handles all Bank::drop() (the cleanup function that leads to this
+                // function call), then we don't need to worry above an overlapping cache flush
+                // with this function call. This means, if we get into this case, we can be
+                // confident that the entire state for this slot has been flushed to the storage
+                // already.
+
+                // Note this only cleans up the storage entries. The accounts index cleaning
+                // (removing from the slot list, decrementing the account ref count), is handled in
+                // clean_accounts() -> purge_older_root_entries()
                 {
                     let r_slot_removed_storages = slot_removed_storages.read().unwrap();
                     total_removed_storage_entries += r_slot_removed_storages.len();
@@ -2673,12 +2684,19 @@ impl AccountsDB {
                 }
                 all_removed_slot_storages.push(slot_removed_storages.clone());
             }
+
+            // It should not be possible that a slot is neither in the cache or storage. Even in
+            // a slot with all ticks, `Bank::new_from_parent()` immediately stores some sysvars
+            // on bank creation.
+
+            // Remove any delta pubkey set if existing.
+            self.uncleaned_pubkeys.remove(remove_slot);
         }
         remove_storages_elapsed.stop();
 
         let num_slots_removed = all_removed_slot_storages.len();
 
-        let recycle_stores_write_time =
+        let recycle_stores_write_elapsed =
             self.recycle_slot_stores(total_removed_storage_entries, &all_removed_slot_storages);
 
         let mut drop_storage_entries_elapsed = Measure::start("drop_storage_entries_elapsed");
@@ -2687,34 +2705,42 @@ impl AccountsDB {
         drop(all_removed_slot_storages);
         drop_storage_entries_elapsed.stop();
 
+        purge_stats
+            .remove_storages_elapsed
+            .fetch_add(remove_storages_elapsed.as_us(), Ordering::Relaxed);
+        purge_stats
+            .drop_storage_entries_elapsed
+            .fetch_add(drop_storage_entries_elapsed.as_us(), Ordering::Relaxed);
+        purge_stats
+            .num_slots_removed
+            .fetch_add(num_slots_removed, Ordering::Relaxed);
+        purge_stats
+            .total_removed_storage_entries
+            .fetch_add(total_removed_storage_entries, Ordering::Relaxed);
+        purge_stats
+            .total_removed_bytes
+            .fetch_add(total_removed_bytes, Ordering::Relaxed);
+        purge_stats
+            .recycle_stores_write_elapsed
+            .fetch_add(recycle_stores_write_elapsed, Ordering::Relaxed);
+    }
+
+    fn purge_storage_slots(&self, removed_slots: &HashSet<Slot>) {
+        // Check all slots `removed_slots` are no longer rooted
+        let mut safety_checks_elapsed = Measure::start("safety_checks_elapsed");
+        for slot in removed_slots.iter() {
+            assert!(!self.accounts_index.is_root(*slot))
+        }
+        safety_checks_elapsed.stop();
         self.clean_accounts_stats
             .purge_stats
             .safety_checks_elapsed
             .fetch_add(safety_checks_elapsed.as_us(), Ordering::Relaxed);
-        self.clean_accounts_stats
-            .purge_stats
-            .remove_storages_elapsed
-            .fetch_add(remove_storages_elapsed.as_us(), Ordering::Relaxed);
-        self.clean_accounts_stats
-            .purge_stats
-            .drop_storage_entries_elapsed
-            .fetch_add(drop_storage_entries_elapsed.as_us(), Ordering::Relaxed);
-        self.clean_accounts_stats
-            .purge_stats
-            .num_slots_removed
-            .fetch_add(num_slots_removed, Ordering::Relaxed);
-        self.clean_accounts_stats
-            .purge_stats
-            .total_removed_storage_entries
-            .fetch_add(total_removed_storage_entries, Ordering::Relaxed);
-        self.clean_accounts_stats
-            .purge_stats
-            .total_removed_bytes
-            .fetch_add(total_removed_bytes, Ordering::Relaxed);
-        self.clean_accounts_stats
-            .purge_stats
-            .recycle_stores_write_elapsed
-            .fetch_add(recycle_stores_write_time, Ordering::Relaxed);
+        self.do_purge_slots_from_cache_and_store(
+            false,
+            removed_slots.iter(),
+            &self.clean_accounts_stats.purge_stats,
+        );
     }
 
     fn purge_slot_cache(&self, purged_slot: Slot, slot_cache: SlotCache) {
@@ -2751,81 +2777,23 @@ impl AccountsDB {
     }
 
     fn purge_slots(&self, slots: &HashSet<Slot>) {
-        //add_root should be called first
-        let non_roots: Vec<_> = slots
+        // `add_root()` should be called first
+        let mut safety_checks_elapsed = Measure::start("safety_checks_elapsed");
+        let non_roots: Vec<&Slot> = slots
             .iter()
             .filter(|slot| !self.accounts_index.is_root(**slot))
             .collect();
-        let mut all_removed_slot_storages = vec![];
-        let mut total_removed_storage_entries = 0;
-        let mut total_removed_bytes = 0;
-
-        let mut remove_storages_elapsed = Measure::start("remove_storages_elapsed");
-
-        for remove_slot in non_roots {
-            if let Some(slot_cache) = self.accounts_cache.remove_slot(*remove_slot) {
-                // If the slot is still in the cache, remove the backing storages for
-                // the slot. The accounts index cleaning (removing from the slot list,
-                // decrementing the account ref count), is handled in
-                // clean_accounts() -> purge_older_root_entries()
-                self.purge_slot_cache(*remove_slot, slot_cache);
-            } else if let Some((_, slot_removed_storages)) = self.storage.0.remove(&remove_slot) {
-                // Because AccountsBackgroundService synchronously flushes from the accounts cache
-                // and handles all Bank::drop() (the cleanup function that leads to this
-                // function call), then we don't need to worry above an overlapping cache flush
-                // with this function call. This means, if we get into this case, we can be
-                // confident that the entire state for this slot has been flushed to the storage
-                // already.
-
-                // Note this only cleans up the storage entries. The accounts index cleaning
-                // (removing from the slot list, decrementing the account ref count), is handled in
-                // clean_accounts() -> purge_older_root_entries()
-                {
-                    let r_slot_removed_storages = slot_removed_storages.read().unwrap();
-                    total_removed_storage_entries += r_slot_removed_storages.len();
-                    total_removed_bytes += r_slot_removed_storages
-                        .values()
-                        .map(|i| i.accounts.capacity())
-                        .sum::<u64>();
-                }
-                all_removed_slot_storages.push(slot_removed_storages.clone());
-            }
-            // It should not be possible that a slot is neither in the cache or storage. Even in
-            // a slot with all ticks, `Bank::new_from_parent()` immediately stores some sysvars
-            // on bank creation.
-
-            // Remove any delta pubkey set if existing.
-            self.uncleaned_pubkeys.remove(remove_slot);
-        }
-        remove_storages_elapsed.stop();
-
-        let num_slots_removed = all_removed_slot_storages.len();
-
-        let recycle_stores_write_time =
-            self.recycle_slot_stores(total_removed_storage_entries, &all_removed_slot_storages);
-
-        let mut drop_storage_entries_elapsed = Measure::start("drop_storage_entries_elapsed");
-        // Backing mmaps for removed storages entries explicitly dropped here outside
-        // of any locks
-        drop(all_removed_slot_storages);
-        drop_storage_entries_elapsed.stop();
-
-        self.external_purge_slots
+        safety_checks_elapsed.stop();
+        self.external_purge_slots_stats
+            .safety_checks_elapsed
             .fetch_add(safety_checks_elapsed.as_us(), Ordering::Relaxed);
-        self.external_purge_slots
-            .fetch_add(remove_storages_elapsed.as_us(), Ordering::Relaxed);
-        self.external_purge_slots
-            .fetch_add(drop_storage_entries_elapsed.as_us(), Ordering::Relaxed);
-        self.external_purge_slots
-            .fetch_add(num_slots_removed, Ordering::Relaxed);
-        self.external_purge_slots
-            .fetch_add(total_removed_storage_entries, Ordering::Relaxed);
-        self.external_purge_slots
-            .fetch_add(total_removed_bytes, Ordering::Relaxed);
-        self.external_purge_slots
-            .fetch_add(recycle_stores_write_time, Ordering::Relaxed);
-
-        self.external_purge_slots.report();
+        self.do_purge_slots_from_cache_and_store(
+            true,
+            non_roots.into_iter(),
+            &self.clean_accounts_stats.purge_stats,
+        );
+        self.external_purge_slots_stats
+            .report("external_purge_slots_stats", Some(1000));
     }
 
     // TODO: This is currently:

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -694,7 +694,8 @@ struct PurgeStats {
     num_cached_slots_removed: AtomicUsize,
     num_stored_slots_removed: AtomicUsize,
     total_removed_storage_entries: AtomicUsize,
-    total_removed_bytes: AtomicU64,
+    total_removed_cached_bytes: AtomicU64,
+    total_removed_stored_bytes: AtomicU64,
     recycle_stores_write_elapsed: AtomicU64,
 }
 
@@ -705,10 +706,12 @@ impl PurgeStats {
                 let last = self.last_report.load(Ordering::Relaxed);
                 let now = solana_sdk::timing::timestamp();
                 now.saturating_sub(last) > report_interval_ms
-                    && self
-                        .last_report
-                        .compare_and_swap(last, now, Ordering::Relaxed)
-                        == last
+                    && self.last_report.compare_exchange(
+                        last,
+                        now,
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    ) == Ok(last)
             })
             .unwrap_or(true);
 
@@ -747,8 +750,13 @@ impl PurgeStats {
                     i64
                 ),
                 (
-                    "total_removed_bytes",
-                    self.total_removed_bytes.swap(0, Ordering::Relaxed) as i64,
+                    "total_removed_cached_bytes",
+                    self.total_removed_cached_bytes.swap(0, Ordering::Relaxed) as i64,
+                    i64
+                ),
+                (
+                    "total_removed_stored_bytes",
+                    self.total_removed_stored_bytes.swap(0, Ordering::Relaxed) as i64,
                     i64
                 ),
                 (
@@ -835,7 +843,7 @@ struct ShrinkStats {
     drop_storage_entries_elapsed: AtomicU64,
     recycle_stores_write_elapsed: AtomicU64,
     accounts_removed: AtomicUsize,
-    bytes_removed: AtomicUsize,
+    bytes_removed: AtomicU64,
 }
 
 impl ShrinkStats {
@@ -846,8 +854,8 @@ impl ShrinkStats {
         let should_report = now.saturating_sub(last) > 1000
             && self
                 .last_report
-                .compare_and_swap(last, now, Ordering::Relaxed)
-                == last;
+                .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+                == Ok(last);
 
         if should_report {
             datapoint_info!(
@@ -1601,7 +1609,7 @@ impl AccountsDB {
         let mut original_bytes = 0;
         for store in stores {
             let mut start = 0;
-            original_bytes += store.alive_bytes();
+            original_bytes += store.total_bytes();
             while let Some((account, next)) = store.accounts.get_account(start) {
                 stored_accounts.push((
                     account.meta.pubkey,
@@ -1798,7 +1806,7 @@ impl AccountsDB {
             Ordering::Relaxed,
         );
         self.shrink_stats.bytes_removed.fetch_add(
-            original_bytes.saturating_sub(aligned_total as usize),
+            original_bytes.saturating_sub(aligned_total),
             Ordering::Relaxed,
         );
         self.shrink_stats.report();
@@ -2744,8 +2752,9 @@ impl AccountsDB {
         let mut remove_storages_elapsed = Measure::start("remove_storages_elapsed");
         let mut all_removed_slot_storages = vec![];
         let mut num_cached_slots_removed = 0;
+        let mut total_removed_cached_bytes = 0;
         let mut total_removed_storage_entries = 0;
-        let mut total_removed_bytes = 0;
+        let mut total_removed_stored_bytes = 0;
         for remove_slot in removed_slots {
             if let Some(slot_cache) = self.accounts_cache.remove_slot(*remove_slot) {
                 // If the slot is still in the cache, remove the backing storages for
@@ -2754,6 +2763,7 @@ impl AccountsDB {
                     panic!("The removed slot must alrady have been flushed from the cache");
                 }
                 num_cached_slots_removed += 1;
+                total_removed_cached_bytes += slot_cache.total_bytes();
                 self.purge_slot_cache(*remove_slot, slot_cache);
             } else if let Some((_, slot_removed_storages)) = self.storage.0.remove(&remove_slot) {
                 // Because AccountsBackgroundService synchronously flushes from the accounts cache
@@ -2769,7 +2779,7 @@ impl AccountsDB {
                 {
                     let r_slot_removed_storages = slot_removed_storages.read().unwrap();
                     total_removed_storage_entries += r_slot_removed_storages.len();
-                    total_removed_bytes += r_slot_removed_storages
+                    total_removed_stored_bytes += r_slot_removed_storages
                         .values()
                         .map(|i| i.accounts.capacity())
                         .sum::<u64>();
@@ -2807,14 +2817,17 @@ impl AccountsDB {
             .num_cached_slots_removed
             .fetch_add(num_cached_slots_removed, Ordering::Relaxed);
         purge_stats
+            .total_removed_cached_bytes
+            .fetch_add(total_removed_cached_bytes, Ordering::Relaxed);
+        purge_stats
             .num_stored_slots_removed
             .fetch_add(num_stored_slots_removed, Ordering::Relaxed);
         purge_stats
             .total_removed_storage_entries
             .fetch_add(total_removed_storage_entries, Ordering::Relaxed);
         purge_stats
-            .total_removed_bytes
-            .fetch_add(total_removed_bytes, Ordering::Relaxed);
+            .total_removed_stored_bytes
+            .fetch_add(total_removed_stored_bytes, Ordering::Relaxed);
         purge_stats
             .recycle_stores_write_elapsed
             .fetch_add(recycle_stores_write_elapsed, Ordering::Relaxed);
@@ -4268,13 +4281,13 @@ impl AccountsDB {
         let last = self.stats.last_store_report.load(Ordering::Relaxed);
         let now = solana_sdk::timing::timestamp();
 
-        #[allow(deprecated)]
         if now.saturating_sub(last) > 1000
-            && self
-                .stats
-                .last_store_report
-                .compare_and_swap(last, now, Ordering::Relaxed)
-                == last
+            && self.stats.last_store_report.compare_exchange(
+                last,
+                now,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) == Ok(last)
         {
             datapoint_info!(
                 "accounts_db_store_timings",


### PR DESCRIPTION
#### Problem
1) Shrink + purge metrics can be spammy when a lot of slots are cleaned up at once
2) Also noticed that `purge_slots()` and `purge_removed_slots_from_store()` shared basically the same code 😝 
 
#### Summary of Changes
1) Aggregate purge-related logic per call to `clean_accounts()` under `clean_accounts_stats`
2) Aggregate Bank::drop() purge into separate `external_purge_slots_stats`
3) Aggregate shrink metrics and report every second
4) Extract shared body of `purge_slots()` and `purge_removed_slots_from_store()` into common function
 `do_purge_slots_from_cache_and_store()`

Fixes #
