### PR TITLE
CLI: Strive for at least one signer

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1165,7 +1165,11 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         println_name_value("RPC URL:", &config.json_rpc_url);
         println_name_value("Default Signer Path:", &config.keypair_path);
         if config.keypair_path.starts_with("usb://") {
-            println_name_value("Pubkey:", &format!("{:?}", config.pubkey()?));
+            let pubkey = config
+                .pubkey()
+                .map(|pubkey| format!("{:?}", pubkey))
+                .unwrap_or_else(|_| "Unavailable".to_string());
+            println_name_value("Pubkey:", &pubkey);
         }
         println_name_value("Commitment:", &config.commitment.commitment.to_string());
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -245,7 +245,6 @@ pub fn parse_args<'a>(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    solana_logger::setup();
     let matches = app(
         crate_name!(),
         crate_description!(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -184,8 +184,18 @@ pub fn parse_args<'a>(
         path: default_signer_path.clone(),
     };
 
-    let CliCommandInfo { command, signers } =
-        parse_command(&matches, &default_signer, &mut wallet_manager)?;
+    let CliCommandInfo {
+        command,
+        mut signers,
+    } = parse_command(&matches, &default_signer, &mut wallet_manager)?;
+
+    if signers.is_empty() {
+        if let Ok(signer_info) =
+            default_signer.generate_unique_signers(vec![None], matches, &mut wallet_manager)
+        {
+            signers.extend(signer_info.signers);
+        }
+    }
 
     let verbose = matches.is_present("verbose");
     let output_format = matches


### PR DESCRIPTION
#### Problem

Passing `--verbose` to CLI subcommands that do not require signing, while the default signer is configured as a hardware wallet, fails unnecessarily

```
$ solana epoch-info --verbose -k usb://ledger
RPC URL: https://api.mainnet-beta.solana.com
Default Signer Path: usb://ledger
Error: custom error: Default keypair must be set if pubkey arg not provided
```

#### Summary of Changes

Try to initialize the default signer if no signers have been configured, eat the error when we fail.
Don't setup the logger
