### PR TITLE
Make exchange listening-for-deposits language stronger

### DIFF
--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -177,9 +177,9 @@ transfer to the appropriate deposit address.
 
 ### Poll for Blocks
 
-The easiest way to track all the deposit accounts for your exchange is to poll
-for each confirmed block and inspect for addresses of interest, using the
-JSON-RPC service of your Solana api node.
+To track all the deposit accounts for your exchange, poll for each confirmed
+block and inspect for addresses of interest, using the JSON-RPC service of your
+Solana api node.
 
 - To identify which blocks are available, send a [`getConfirmedBlocks` request](developing/clients/jsonrpc-api.md#getconfirmedblocks),
   passing the last block you have already processed as the start-slot parameter:
@@ -273,7 +273,10 @@ can request the block from RPC in binary format, and parse it using either our
 
 ### Address History
 
-You can also query the transaction history of a specific address.
+You can also query the transaction history of a specific address. This is
+generally *not* a viable method for tracking all your deposit addresses over all
+slots, but may be useful for examining a few accounts for a specific period of
+time.
 
 - Send a [`getConfirmedSignaturesForAddress`](developing/clients/jsonrpc-api.md#getconfirmedsignaturesforaddress)
   request to the api node, specifying a range of recent slots:

--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -179,7 +179,7 @@ transfer to the appropriate deposit address.
 
 To track all the deposit accounts for your exchange, poll for each confirmed
 block and inspect for addresses of interest, using the JSON-RPC service of your
-Solana api node.
+Solana API node.
 
 - To identify which blocks are available, send a [`getConfirmedBlocks` request](developing/clients/jsonrpc-api.md#getconfirmedblocks),
   passing the last block you have already processed as the start-slot parameter:

--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -278,18 +278,33 @@ generally *not* a viable method for tracking all your deposit addresses over all
 slots, but may be useful for examining a few accounts for a specific period of
 time.
 
-- Send a [`getConfirmedSignaturesForAddress`](developing/clients/jsonrpc-api.md#getconfirmedsignaturesforaddress)
-  request to the api node, specifying a range of recent slots:
+- Send a [`getConfirmedSignaturesForAddress2`](developing/clients/jsonrpc-api.md#getconfirmedsignaturesforaddress2)
+  request to the api node:
 
 ```bash
-curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedSignaturesForAddress","params":["6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC", 0, 10]}' localhost:8899
+curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0","id":1,"method":"getConfirmedSignaturesForAddress2","params":["6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC", {"limit": 3}]}' localhost:8899
 
 {
   "jsonrpc": "2.0",
   "result": [
-    "35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby",
-    "4bJdGN8Tt2kLWZ3Fa1dpwPSEkXWWTSszPSf1rRVsCwNjxbbUdwTeiWtmi8soA26YmwnKD4aAxNp8ci1Gjpdv4gsr",
-    "dhjhJp2V2ybQGVfELWM1aZy98guVVsxRCB5KhNiXFjCBMK5KEyzV8smhkVvs3xwkAug31KnpzJpiNPtcD5bG1t6"
+    {
+      "err": null,
+      "memo": null,
+      "signature": "35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby",
+      "slot": 114
+    },
+    {
+      "err": null,
+      "memo": null,
+      "signature": "4bJdGN8Tt2kLWZ3Fa1dpwPSEkXWWTSszPSf1rRVsCwNjxbbUdwTeiWtmi8soA26YmwnKD4aAxNp8ci1Gjpdv4gsr",
+      "slot": 112
+    },
+    {
+      "err": null,
+      "memo": null,
+      "signature": "dhjhJp2V2ybQGVfELWM1aZy98guVVsxRCB5KhNiXFjCBMK5KEyzV8smhkVvs3xwkAug31KnpzJpiNPtcD5bG1t6",
+      "slot": 108
+    }
   ],
   "id": 1
 }


### PR DESCRIPTION
#### Problem
Some exchanges may interpret the "Listening for Deposits" methods as equally viable. But for exchanges with large quantities of deposit addresses, polling the address history of every one is prohibitively slow, particularly if they are targeted our public, rate-limited api nodes.

#### Summary of Changes
- Make language recommending polling `getConfirmedBlocks`/`getConfirmedBlock` stronger
