### PR TITLE
explorer: Add timestamps to transaction history

### DIFF
--- a/explorer/src/components/account/TransactionHistoryCard.tsx
+++ b/explorer/src/components/account/TransactionHistoryCard.tsx
@@ -7,6 +7,7 @@ import { Signature } from "components/common/Signature";
 import { ErrorCard } from "components/common/ErrorCard";
 import { LoadingCard } from "components/common/LoadingCard";
 import { Slot } from "components/common/Slot";
+import { displayTimestampUtc } from "utils/date";
 
 export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
   const address = pubkey.toBase58();
@@ -48,6 +49,7 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
     );
   }
 
+  const hasTimestamps = !!transactions.find((element) => !!element.blockTime);
   const detailsList: React.ReactNode[] = [];
   for (var i = 0; i < transactions.length; i++) {
     const slot = transactions[i].slot;
@@ -58,7 +60,7 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
       slotTransactions.push(transactions[++i]);
     }
 
-    slotTransactions.forEach(({ signature, err }) => {
+    slotTransactions.forEach(({ signature, err, blockTime }) => {
       let statusText;
       let statusClass;
       if (err) {
@@ -74,6 +76,12 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
           <td className="w-1">
             <Slot slot={slot} link />
           </td>
+
+          {hasTimestamps && (
+            <td className="text-muted">
+              {blockTime ? displayTimestampUtc(blockTime * 1000) : "---"}
+            </td>
+          )}
 
           <td>
             <span className={`badge badge-soft-${statusClass}`}>
@@ -118,6 +126,7 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
           <thead>
             <tr>
               <th className="text-muted w-1">Slot</th>
+              {hasTimestamps && <th className="text-muted">Timestamp</th>}
               <th className="text-muted">Result</th>
               <th className="text-muted">Transaction Signature</th>
             </tr>

--- a/explorer/src/components/account/TransactionHistoryCard.tsx
+++ b/explorer/src/components/account/TransactionHistoryCard.tsx
@@ -7,7 +7,7 @@ import { Signature } from "components/common/Signature";
 import { ErrorCard } from "components/common/ErrorCard";
 import { LoadingCard } from "components/common/LoadingCard";
 import { Slot } from "components/common/Slot";
-import { displayTimestampUtc } from "utils/date";
+import { displayTimestamp } from "utils/date";
 
 export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
   const address = pubkey.toBase58();
@@ -79,7 +79,7 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
 
           {hasTimestamps && (
             <td className="text-muted">
-              {blockTime ? displayTimestampUtc(blockTime * 1000) : "---"}
+              {blockTime ? displayTimestamp(blockTime * 1000, true) : "---"}
             </td>
           )}
 

--- a/explorer/src/utils/date.ts
+++ b/explorer/src/utils/date.ts
@@ -1,4 +1,7 @@
-export function displayTimestamp(unixTimestamp: number, shortTimezone = false): string {
+export function displayTimestamp(
+  unixTimestamp: number,
+  shortTimeZoneName = false
+): string {
   const expireDate = new Date(unixTimestamp);
   const dateString = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
@@ -10,12 +13,15 @@ export function displayTimestamp(unixTimestamp: number, shortTimezone = false): 
     minute: "numeric",
     second: "numeric",
     hour12: false,
-    timeZoneName: shortTimezone ? "short" : "long",
+    timeZoneName: shortTimeZoneName ? "short" : "long",
   }).format(expireDate);
   return `${dateString} at ${timeString}`;
 }
 
-export function displayTimestampUtc(unixTimestamp: number): string {
+export function displayTimestampUtc(
+  unixTimestamp: number,
+  shortTimeZoneName = false
+): string {
   const expireDate = new Date(unixTimestamp);
   const dateString = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
@@ -29,6 +35,7 @@ export function displayTimestampUtc(unixTimestamp: number): string {
     second: "numeric",
     hour12: false,
     timeZone: "UTC",
+    timeZoneName: shortTimeZoneName ? "short" : "long",
   }).format(expireDate);
   return `${dateString} at ${timeString}`;
 }

--- a/explorer/src/utils/date.ts
+++ b/explorer/src/utils/date.ts
@@ -1,4 +1,4 @@
-export function displayTimestamp(unixTimestamp: number): string {
+export function displayTimestamp(unixTimestamp: number, shortTimezone = false): string {
   const expireDate = new Date(unixTimestamp);
   const dateString = new Intl.DateTimeFormat("en-US", {
     year: "numeric",
@@ -10,7 +10,7 @@ export function displayTimestamp(unixTimestamp: number): string {
     minute: "numeric",
     second: "numeric",
     hour12: false,
-    timeZoneName: "long",
+    timeZoneName: shortTimezone ? "short" : "long",
   }).format(expireDate);
   return `${dateString} at ${timeString}`;
 }


### PR DESCRIPTION
#### Problem
In Explorer, transaction history doesn't show the newly available block times alongside transaction signatures. 

#### Summary of Changes
Display blocktime column if available. 
