### PR TITLE
Add solana-test-validator --warp-slot argument

### DIFF
--- a/ci/nits.sh
+++ b/ci/nits.sh
@@ -19,6 +19,7 @@ declare prints=(
 # Parts of the tree that are expected to be print free
 declare print_free_tree=(
   ':core/src/**.rs'
+  ':^core/src/validator.rs'
   ':faucet/src/**.rs'
   ':ledger/src/**.rs'
   ':metrics/src/**.rs'

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -158,7 +158,7 @@ mod tests {
         let output_tar_path = snapshot_utils::get_snapshot_archive_path(
             &snapshot_package_output_path,
             &(42, Hash::default()),
-            &ArchiveFormat::TarBzip2,
+            ArchiveFormat::TarBzip2,
         );
         let snapshot_package = AccountsPackage::new(
             5,

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -14,7 +14,7 @@ use {
     },
     solana_sdk::{
         account::Account,
-        clock::DEFAULT_MS_PER_SLOT,
+        clock::{Slot, DEFAULT_MS_PER_SLOT},
         commitment_config::CommitmentConfig,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
         hash::Hash,
@@ -48,6 +48,7 @@ pub struct TestValidatorGenesis {
     rent: Rent,
     rpc_config: JsonRpcConfig,
     rpc_ports: Option<(u16, u16)>, // (JsonRpc, JsonRpcPubSub), None == random ports
+    warp_slot: Option<Slot>,
     accounts: HashMap<Pubkey, Account>,
     programs: Vec<ProgramInfo>,
 }
@@ -78,6 +79,11 @@ impl TestValidatorGenesis {
         self
     }
 
+    pub fn warp_slot(&mut self, warp_slot: Slot) -> &mut Self {
+        self.warp_slot = Some(warp_slot);
+        self
+    }
+
     /// Add an account to the test environment
     pub fn add_account(&mut self, address: Pubkey, account: Account) -> &mut Self {
         self.accounts.insert(address, account);
@@ -99,9 +105,10 @@ impl TestValidatorGenesis {
         T: IntoIterator<Item = Pubkey>,
     {
         for address in addresses {
-            info!("Fetching {}...", address);
+            info!("Fetching {} over RPC...", address);
             let account = rpc_client.get_account(&address).unwrap_or_else(|err| {
-                panic!("Failed to fetch {}: {}", address, err);
+                error!("Failed to fetch {}: {}", address, err);
+                crate::validator::abort();
             });
             self.add_account(address, account);
         }
@@ -280,7 +287,7 @@ impl TestValidator {
             );
         }
 
-        let genesis_config = create_genesis_config_with_leader_ex(
+        let mut genesis_config = create_genesis_config_with_leader_ex(
             mint_lamports,
             &mint_address,
             &validator_identity.pubkey(),
@@ -293,6 +300,7 @@ impl TestValidator {
             solana_sdk::genesis_config::ClusterType::Development,
             accounts.into_iter().collect(),
         );
+        genesis_config.epoch_schedule = solana_sdk::epoch_schedule::EpochSchedule::without_warmup();
 
         let ledger_path = match &config.ledger_path {
             None => create_new_tmp_ledger!(&genesis_config).0,
@@ -385,6 +393,7 @@ impl TestValidator {
                 snapshot_version: SnapshotVersion::default(),
             }),
             enforce_ulimit_nofile: false,
+            warp_slot: config.warp_slot,
             ..ValidatorConfig::default()
         };
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -155,7 +155,7 @@ mod tests {
             snapshot_utils::get_snapshot_archive_path(
                 snapshot_package_output_path,
                 &(old_last_bank.slot(), old_last_bank.get_accounts_hash()),
-                &ArchiveFormat::TarBzip2,
+                ArchiveFormat::TarBzip2,
             ),
             ArchiveFormat::TarBzip2,
             old_genesis_config,
@@ -385,7 +385,7 @@ mod tests {
                 saved_archive_path = Some(snapshot_utils::get_snapshot_archive_path(
                     snapshot_package_output_path,
                     &(slot, accounts_hash),
-                    &ArchiveFormat::TarBzip2,
+                    ArchiveFormat::TarBzip2,
                 ));
             }
         }

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -182,7 +182,7 @@ pub fn download_snapshot(
         let desired_snapshot_package = snapshot_utils::get_snapshot_archive_path(
             ledger_path,
             &desired_snapshot_hash,
-            compression,
+            *compression,
         );
 
         if desired_snapshot_package.is_file() {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1918,6 +1918,7 @@ fn main() {
                         &bank,
                         Some(snapshot_version),
                         output_directory,
+                        ArchiveFormat::TarZstd,
                     )
                     .unwrap_or_else(|err| {
                         eprintln!("Unable to create snapshot: {}", err);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1131,13 +1131,6 @@ fn main() {
             )
             .arg(&hashes_per_tick)
             .arg(
-                Arg::with_name("rehash")
-                    .required(false)
-                    .long("rehash")
-                    .takes_value(false)
-                    .help("Re-calculate the bank hash and overwrite the original bank hash."),
-            )
-            .arg(
                 Arg::with_name("accounts_to_remove")
                     .required(false)
                     .long("remove-account")
@@ -1712,7 +1705,6 @@ fn main() {
             let snapshot_slot = value_t_or_exit!(arg_matches, "snapshot_slot", Slot);
             let output_directory = value_t_or_exit!(arg_matches, "output_directory", String);
             let mut warp_slot = value_t!(arg_matches, "warp_slot", Slot).ok();
-            let mut rehash = arg_matches.is_present("rehash");
             let remove_stake_accounts = arg_matches.is_present("remove_stake_accounts");
             let new_hard_forks = hardforks_of(arg_matches, "hard_forks");
 
@@ -1790,7 +1782,6 @@ fn main() {
                     }
 
                     if let Some(faucet_pubkey) = faucet_pubkey {
-                        rehash = true;
                         bank.store_account(
                             &faucet_pubkey,
                             &Account::new(faucet_lamports, 0, &system_program::id()),
@@ -1809,15 +1800,12 @@ fn main() {
 
                     for address in accounts_to_remove {
                         if let Some(mut account) = bank.get_account(&address) {
-                            rehash = true;
                             account.lamports = 0;
                             bank.store_account(&address, &account);
                         }
                     }
 
                     if let Some(bootstrap_validator_pubkeys) = bootstrap_validator_pubkeys {
-                        rehash = true;
-
                         assert_eq!(bootstrap_validator_pubkeys.len() % 3, 0);
 
                         // Ensure there are no duplicated pubkeys in the --bootstrap-validator list
@@ -1924,56 +1912,31 @@ fn main() {
                         snapshot_version,
                         bank.slot(),
                     );
-                    assert!(bank.is_complete());
-                    bank.squash();
-                    bank.force_flush_accounts_cache();
-                    bank.clean_accounts(true);
-                    bank.update_accounts_hash();
-                    if rehash {
-                        bank.rehash();
-                    }
 
-                    let temp_dir = tempfile::tempdir_in(ledger_path).unwrap_or_else(|err| {
-                        eprintln!("Unable to create temporary directory: {}", err);
+                    let archive_file = snapshot_utils::bank_to_snapshot_archive(
+                        ledger_path,
+                        &bank,
+                        Some(snapshot_version),
+                        output_directory,
+                    )
+                    .unwrap_or_else(|err| {
+                        eprintln!("Unable to create snapshot: {}", err);
                         exit(1);
                     });
 
-                    let storages: Vec<_> = bank.get_snapshot_storages();
-                    snapshot_utils::add_snapshot(&temp_dir, &bank, &storages, snapshot_version)
-                        .and_then(|slot_snapshot_paths| {
-                            snapshot_utils::package_snapshot(
-                                &bank,
-                                &slot_snapshot_paths,
-                                &temp_dir,
-                                bank.src.slot_deltas(&bank.src.roots()),
-                                output_directory,
-                                storages,
-                                ArchiveFormat::TarZstd,
-                                snapshot_version,
-                            )
-                        })
-                        .and_then(|package| {
-                            snapshot_utils::archive_snapshot_package(&package).map(|ok| {
-                                println!(
-                                    "Successfully created snapshot for slot {}, hash {}: {:?}",
-                                    bank.slot(),
-                                    bank.hash(),
-                                    package.tar_output_file
-                                );
-                                println!(
-                                    "Shred version: {}",
-                                    compute_shred_version(
-                                        &genesis_config.hash(),
-                                        Some(&bank.hard_forks().read().unwrap())
-                                    )
-                                );
-                                ok
-                            })
-                        })
-                        .unwrap_or_else(|err| {
-                            eprintln!("Unable to create snapshot archive: {}", err);
-                            exit(1);
-                        });
+                    println!(
+                        "Successfully created snapshot for slot {}, hash {}: {}",
+                        bank.slot(),
+                        bank.hash(),
+                        archive_file.display(),
+                    );
+                    println!(
+                        "Shred version: {}",
+                        compute_shred_version(
+                            &genesis_config.hash(),
+                            Some(&bank.hard_forks().read().unwrap())
+                        )
+                    );
                 }
                 Err(err) => {
                     eprintln!("Failed to load ledger: {:?}", err);

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1054,7 +1054,7 @@ fn test_snapshot_download() {
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
         &validator_snapshot_test_config.snapshot_output_path,
         &archive_snapshot_hash,
-        &ArchiveFormat::TarBzip2,
+        ArchiveFormat::TarBzip2,
     );
 
     // Download the snapshot, then boot a validator from it.
@@ -1124,7 +1124,7 @@ fn test_snapshot_restart_tower() {
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
         &validator_snapshot_test_config.snapshot_output_path,
         &archive_snapshot_hash,
-        &ArchiveFormat::TarBzip2,
+        ArchiveFormat::TarBzip2,
     );
     fs::hard_link(archive_filename, &validator_archive_path).unwrap();
 
@@ -1189,7 +1189,7 @@ fn test_snapshots_blockstore_floor() {
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
         &validator_snapshot_test_config.snapshot_output_path,
         &(archive_slot, archive_hash),
-        &ArchiveFormat::TarBzip2,
+        ArchiveFormat::TarBzip2,
     );
     fs::hard_link(archive_filename, &validator_archive_path).unwrap();
     let slot_floor = archive_slot;

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -17,7 +17,7 @@ use std::{
 
 pub use crate::snapshot_utils::SnapshotVersion;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ArchiveFormat {
     TarBzip2,
     TarGzip,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -172,7 +172,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
     let snapshot_package_output_file = get_snapshot_archive_path(
         &snapshot_package_output_path,
         &(bank.slot(), bank.get_accounts_hash()),
-        &archive_format,
+        archive_format,
     );
 
     let package = AccountsPackage::new(
@@ -190,7 +190,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
     Ok(package)
 }
 
-fn get_archive_ext(archive_format: &ArchiveFormat) -> &'static str {
+fn get_archive_ext(archive_format: ArchiveFormat) -> &'static str {
     match archive_format {
         ArchiveFormat::TarBzip2 => ".tar.bz2",
         ArchiveFormat::TarGzip => ".tar.gz",
@@ -291,7 +291,7 @@ pub fn archive_snapshot_package(snapshot_package: &AccountsPackage) -> Result<()
         f.write_all(snapshot_package.snapshot_version.as_str().as_bytes())?;
     }
 
-    let file_ext = get_archive_ext(&snapshot_package.archive_format);
+    let file_ext = get_archive_ext(snapshot_package.archive_format);
 
     // Tar the staging directory into the archive at `archive_path`
     //
@@ -633,7 +633,7 @@ pub fn bank_from_archive<P: AsRef<Path>>(
 pub fn get_snapshot_archive_path<P: AsRef<Path>>(
     snapshot_output_dir: P,
     snapshot_hash: &(Slot, Hash),
-    archive_format: &ArchiveFormat,
+    archive_format: ArchiveFormat,
 ) -> PathBuf {
     snapshot_output_dir.as_ref().join(format!(
         "snapshot-{}-{}{}",
@@ -906,7 +906,7 @@ pub fn snapshot_bank(
         status_cache_slot_deltas,
         snapshot_package_output_path,
         storages,
-        archive_format.clone(),
+        *archive_format,
         snapshot_version,
     )?;
 
@@ -922,6 +922,7 @@ pub fn bank_to_snapshot_archive<P: AsRef<Path>, Q: AsRef<Path>>(
     bank: &Bank,
     snapshot_version: Option<SnapshotVersion>,
     snapshot_package_output_path: Q,
+    archive_format: ArchiveFormat,
 ) -> Result<PathBuf> {
     let snapshot_version = snapshot_version.unwrap_or_default();
 
@@ -943,7 +944,7 @@ pub fn bank_to_snapshot_archive<P: AsRef<Path>, Q: AsRef<Path>>(
         bank.src.slot_deltas(&bank.src.roots()),
         snapshot_package_output_path,
         storages,
-        ArchiveFormat::TarZstd,
+        archive_format,
         snapshot_version,
     )?;
 

--- a/sdk/program/src/epoch_schedule.rs
+++ b/sdk/program/src/epoch_schedule.rs
@@ -51,6 +51,13 @@ impl EpochSchedule {
     pub fn new(slots_per_epoch: u64) -> Self {
         Self::custom(slots_per_epoch, slots_per_epoch, true)
     }
+    pub fn without_warmup() -> Self {
+        Self::custom(
+            DEFAULT_SLOTS_PER_EPOCH,
+            DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET,
+            false,
+        )
+    }
     pub fn custom(slots_per_epoch: u64, leader_schedule_slot_offset: u64, warmup: bool) -> Self {
         assert!(slots_per_epoch >= MINIMUM_SLOTS_PER_EPOCH as u64);
         let (first_normal_epoch, first_normal_slot) = if warmup {


### PR DESCRIPTION
Building on #14755, when accounts are copied from another cluster it's convenient for your `solana-test-validator` to boot from the current slot of that cluster.   Add `--warp-slot` for this.

Example 1:  Boot a test validator from slot 1234 instead of slot 0
```
$ solana-test-validator --reset --warp-slot 1234
```

Example 2:  Boot a test validator from the current slot that mainnet-beta is on
```
$ solana-test-validator --reset --url mainnet-beta --warp-slot
```