### PR TITLE
CLI: Reinstate logging, disabled by default

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -245,6 +245,7 @@ pub fn parse_args<'a>(
 }
 
 fn main() -> Result<(), Box<dyn error::Error>> {
+    solana_logger::setup_with_default("off");
     let matches = app(
         crate_name!(),
         crate_description!(),


### PR DESCRIPTION
#### Problem

@mvines actually uses CLI logging

#### Summary of Changes

Re-enable it