### PR TITLE
stake-o-matic fixing++

### DIFF
--- a/stake-o-matic/src/main.rs
+++ b/stake-o-matic/src/main.rs
@@ -372,7 +372,7 @@ fn classify_block_producers(
             }
         );
 
-        confirmed_blocks.push(retry_rpc_operation(10, || {
+        confirmed_blocks.push(retry_rpc_operation(42, || {
             rpc_client.get_confirmed_blocks(next_slot, Some(last_slot))
         })?);
         next_slot = last_slot + 1;


### PR DESCRIPTION
1. Transaction simulation is timing out blockhashes.   Fetch a new blockhash each time
2. Retry getting confirmed blocks harder