### PR TITLE
Deprecate commitment variants

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -122,7 +122,7 @@ impl BanksClient {
     pub fn get_fees(
         &mut self,
     ) -> impl Future<Output = io::Result<(FeeCalculator, Hash, Slot)>> + '_ {
-        self.get_fees_with_commitment_and_context(context::current(), CommitmentLevel::Root)
+        self.get_fees_with_commitment_and_context(context::current(), CommitmentLevel::default())
     }
 
     /// Return the cluster rent
@@ -196,7 +196,7 @@ impl BanksClient {
     /// Return the most recent rooted slot height. All transactions at or below this height
     /// are said to be finalized. The cluster will not fork to a higher slot height.
     pub fn get_root_slot(&mut self) -> impl Future<Output = io::Result<Slot>> + '_ {
-        self.get_slot_with_context(context::current(), CommitmentLevel::Root)
+        self.get_slot_with_context(context::current(), CommitmentLevel::default())
     }
 
     /// Return the account at the given address at the slot corresponding to the given

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -167,11 +167,11 @@ impl Banks for BanksServer {
         _: Context,
         signature: Signature,
     ) -> Option<TransactionStatus> {
-        let bank = self.bank(CommitmentLevel::Recent);
+        let bank = self.bank(CommitmentLevel::Processed);
         let (slot, status) = bank.get_signature_status_slot(&signature)?;
         let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
-        let optimistically_confirmed_bank = self.bank(CommitmentLevel::SingleGossip);
+        let optimistically_confirmed_bank = self.bank(CommitmentLevel::Confirmed);
         let optimistically_confirmed =
             optimistically_confirmed_bank.get_signature_status_slot(&signature);
 

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -390,7 +390,7 @@ fn swapper<T>(
             while client
                 .get_balance_with_commitment(
                     &trade_infos[trade_index].trade_account,
-                    CommitmentConfig::recent(),
+                    CommitmentConfig::processed(),
                 )
                 .unwrap_or(0)
                 == 0
@@ -445,7 +445,7 @@ fn swapper<T>(
             account_group = (account_group + 1) % account_groups as usize;
 
             let (blockhash, _fee_calculator, _last_valid_slot) = client
-                .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
                 .expect("Failed to get blockhash");
             let to_swap_txs: Vec<_> = to_swap
                 .par_iter()
@@ -571,7 +571,7 @@ fn trader<T>(
         account_group = (account_group + 1) % account_groups as usize;
 
         let (blockhash, _fee_calculator, _last_valid_slot) = client
-            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
             .expect("Failed to get blockhash");
 
         trades.chunks(chunk_size).for_each(|chunk| {
@@ -658,7 +658,7 @@ where
 {
     for s in &tx.signatures {
         if let Ok(Some(r)) =
-            sync_client.get_signature_status_with_commitment(s, CommitmentConfig::recent())
+            sync_client.get_signature_status_with_commitment(s, CommitmentConfig::processed())
         {
             match r {
                 Ok(_) => {
@@ -681,7 +681,7 @@ fn verify_funding_transfer<T: SyncClient + ?Sized>(
     if verify_transaction(client, tx) {
         for a in &tx.message().account_keys[1..] {
             if client
-                .get_balance_with_commitment(a, CommitmentConfig::recent())
+                .get_balance_with_commitment(a, CommitmentConfig::processed())
                 .unwrap_or(0)
                 >= amount
             {
@@ -764,7 +764,7 @@ pub fn fund_keys<T: Client>(client: &T, source: &Keypair, dests: &[Arc<Keypair>]
                 );
 
                 let (blockhash, _fee_calculator, _last_valid_slot) = client
-                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
                     .expect("blockhash");
                 to_fund_txs.par_iter_mut().for_each(|(k, tx)| {
                     tx.sign(&[*k], blockhash);
@@ -803,7 +803,7 @@ pub fn fund_keys<T: Client>(client: &T, source: &Keypair, dests: &[Arc<Keypair>]
         funded.append(&mut new_funded);
         funded.retain(|(k, b)| {
             client
-                .get_balance_with_commitment(&k.pubkey(), CommitmentConfig::recent())
+                .get_balance_with_commitment(&k.pubkey(), CommitmentConfig::processed())
                 .unwrap_or(0)
                 > lamports
                 && *b > lamports
@@ -857,7 +857,7 @@ pub fn create_token_accounts<T: Client>(
             let mut retries = 0;
             while !to_create_txs.is_empty() {
                 let (blockhash, _fee_calculator, _last_valid_slot) = client
-                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
                     .expect("Failed to get blockhash");
                 to_create_txs
                     .par_iter_mut()
@@ -903,7 +903,7 @@ pub fn create_token_accounts<T: Client>(
         let mut new_notfunded: Vec<(&Arc<Keypair>, &Keypair)> = vec![];
         for f in &notfunded {
             if client
-                .get_balance_with_commitment(&f.1.pubkey(), CommitmentConfig::recent())
+                .get_balance_with_commitment(&f.1.pubkey(), CommitmentConfig::processed())
                 .unwrap_or(0)
                 == 0
             {
@@ -968,7 +968,7 @@ pub fn airdrop_lamports<T: Client>(
     id: &Keypair,
     amount: u64,
 ) {
-    let balance = client.get_balance_with_commitment(&id.pubkey(), CommitmentConfig::recent());
+    let balance = client.get_balance_with_commitment(&id.pubkey(), CommitmentConfig::processed());
     let balance = balance.unwrap_or(0);
     if balance >= amount {
         return;
@@ -986,7 +986,7 @@ pub fn airdrop_lamports<T: Client>(
     let mut tries = 0;
     loop {
         let (blockhash, _fee_calculator, _last_valid_slot) = client
-            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
             .expect("Failed to get blockhash");
         match request_airdrop_transaction(&faucet_addr, &id.pubkey(), amount_to_drop, blockhash) {
             Ok(transaction) => {
@@ -995,14 +995,14 @@ pub fn airdrop_lamports<T: Client>(
                 for _ in 0..30 {
                     if let Ok(Some(_)) = client.get_signature_status_with_commitment(
                         &signature,
-                        CommitmentConfig::recent(),
+                        CommitmentConfig::processed(),
                     ) {
                         break;
                     }
                     sleep(Duration::from_millis(100));
                 }
                 if client
-                    .get_balance_with_commitment(&id.pubkey(), CommitmentConfig::recent())
+                    .get_balance_with_commitment(&id.pubkey(), CommitmentConfig::processed())
                     .unwrap_or(0)
                     >= amount
                 {

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -47,7 +47,7 @@ pub type SharedTransactions = Arc<RwLock<VecDeque<Vec<(Transaction, u64)>>>>;
 
 fn get_recent_blockhash<T: Client>(client: &T) -> (Hash, FeeCalculator) {
     loop {
-        match client.get_recent_blockhash_with_commitment(CommitmentConfig::recent()) {
+        match client.get_recent_blockhash_with_commitment(CommitmentConfig::processed()) {
             Ok((blockhash, fee_calculator, _last_valid_slot)) => {
                 return (blockhash, fee_calculator)
             }
@@ -496,7 +496,7 @@ fn do_tx_transfers<T: Client>(
 
 fn verify_funding_transfer<T: Client>(client: &Arc<T>, tx: &Transaction, amount: u64) -> bool {
     for a in &tx.message().account_keys[1..] {
-        match client.get_balance_with_commitment(a, CommitmentConfig::recent()) {
+        match client.get_balance_with_commitment(a, CommitmentConfig::processed()) {
             Ok(balance) => return balance >= amount,
             Err(err) => error!("failed to get balance {:?}", err),
         }
@@ -761,7 +761,7 @@ pub fn airdrop_lamports<T: Client>(
         };
 
         let current_balance = client
-            .get_balance_with_commitment(&id.pubkey(), CommitmentConfig::recent())
+            .get_balance_with_commitment(&id.pubkey(), CommitmentConfig::processed())
             .unwrap_or_else(|e| {
                 info!("airdrop error {}", e);
                 starting_balance
@@ -966,7 +966,7 @@ mod tests {
         for kp in &keypairs {
             assert_eq!(
                 client
-                    .get_balance_with_commitment(&kp.pubkey(), CommitmentConfig::recent())
+                    .get_balance_with_commitment(&kp.pubkey(), CommitmentConfig::processed())
                     .unwrap(),
                 lamports
             );

--- a/cli-config/src/config.rs
+++ b/cli-config/src/config.rs
@@ -42,7 +42,7 @@ impl Default for Config {
             "System Program".to_string(),
         );
 
-        let commitment = "singleGossip".to_string();
+        let commitment = "confirmed".to_string();
 
         Self {
             json_rpc_url,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -437,7 +437,7 @@ impl CliConfig<'_> {
     }
 
     fn default_commitment() -> CommitmentConfig {
-        CommitmentConfig::single_gossip()
+        CommitmentConfig::confirmed()
     }
 
     fn first_nonempty_setting(
@@ -532,10 +532,10 @@ impl CliConfig<'_> {
 
     pub fn recent_for_tests() -> Self {
         Self {
-            commitment: CommitmentConfig::recent(),
+            commitment: CommitmentConfig::processed(),
             send_transaction_config: RpcSendTransactionConfig {
                 skip_preflight: true,
-                preflight_commitment: Some(CommitmentConfig::recent().commitment),
+                preflight_commitment: Some(CommitmentConfig::processed().commitment),
                 ..RpcSendTransactionConfig::default()
             },
             ..Self::default()
@@ -558,7 +558,7 @@ impl Default for CliConfig<'_> {
             rpc_timeout: Duration::from_secs(u64::from_str(DEFAULT_RPC_TIMEOUT_SECONDS).unwrap()),
             verbose: false,
             output_format: OutputFormat::Display,
-            commitment: CommitmentConfig::single_gossip(),
+            commitment: CommitmentConfig::confirmed(),
             send_transaction_config: RpcSendTransactionConfig::default(),
             address_labels: HashMap::new(),
         }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -902,7 +902,7 @@ pub fn process_get_block(
     let slot = if let Some(slot) = slot {
         slot
     } else {
-        rpc_client.get_slot_with_commitment(CommitmentConfig::max())?
+        rpc_client.get_slot_with_commitment(CommitmentConfig::finalized())?
     };
 
     let mut block =
@@ -980,7 +980,7 @@ pub fn process_get_block_time(
     let slot = if let Some(slot) = slot {
         slot
     } else {
-        rpc_client.get_slot_with_commitment(CommitmentConfig::max())?
+        rpc_client.get_slot_with_commitment(CommitmentConfig::finalized())?
     };
     let timestamp = rpc_client.get_block_time(slot)?;
     let block_time = CliBlockTime { slot, timestamp };
@@ -1029,7 +1029,7 @@ pub fn process_show_block_production(
     slot_limit: Option<u64>,
 ) -> ProcessResult {
     let epoch_schedule = rpc_client.get_epoch_schedule()?;
-    let epoch_info = rpc_client.get_epoch_info_with_commitment(CommitmentConfig::max())?;
+    let epoch_info = rpc_client.get_epoch_info_with_commitment(CommitmentConfig::finalized())?;
 
     let epoch = epoch.unwrap_or(epoch_info.epoch);
     if epoch > epoch_info.epoch {
@@ -1088,7 +1088,7 @@ pub fn process_show_block_production(
 
     progress_bar.set_message(&format!("Fetching leader schedule for epoch {}...", epoch));
     let leader_schedule = rpc_client
-        .get_leader_schedule_with_commitment(Some(start_slot), CommitmentConfig::root())?;
+        .get_leader_schedule_with_commitment(Some(start_slot), CommitmentConfig::finalized())?;
     if leader_schedule.is_none() {
         return Err(format!("Unable to fetch leader schedule for slot {}", start_slot).into());
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -311,8 +311,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 "max",
             ])
             .value_name("COMMITMENT_LEVEL")
+            .hide_possible_values(true)
             .global(true)
-            .help("Return information at the selected commitment level"),
+            .help("Return information at the selected commitment level [possible values: processed, confirmed, finalized]"),
     )
     .arg(
         Arg::with_name("verbose")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -304,11 +304,11 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 "processed",
                 "confirmed",
                 "finalized",
-                "recent",
-                "single",
-                "singleGossip",
-                "root",
-                "max",
+                "recent", // Deprecated as of v1.5.5
+                "single", // Deprecated as of v1.5.5
+                "singleGossip", // Deprecated as of v1.5.5
+                "root", // Deprecated as of v1.5.5
+                "max", // Deprecated as of v1.5.5
             ])
             .value_name("COMMITMENT_LEVEL")
             .hide_possible_values(true)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -300,7 +300,16 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         Arg::with_name("commitment")
             .long("commitment")
             .takes_value(true)
-            .possible_values(&["recent", "single", "singleGossip", "root", "max"])
+            .possible_values(&[
+                "processed",
+                "confirmed",
+                "finalized",
+                "recent",
+                "single",
+                "singleGossip",
+                "root",
+                "max",
+            ])
             .value_name("COMMITMENT_LEVEL")
             .global(true)
             .help("Return information at the selected commitment level"),

--- a/cli/src/test_utils.rs
+++ b/cli/src/test_utils.rs
@@ -5,7 +5,7 @@ use std::{thread::sleep, time::Duration};
 pub fn check_recent_balance(expected_balance: u64, client: &RpcClient, pubkey: &Pubkey) {
     (0..5).for_each(|tries| {
         let balance = client
-            .get_balance_with_commitment(pubkey, CommitmentConfig::recent())
+            .get_balance_with_commitment(pubkey, CommitmentConfig::processed())
             .unwrap()
             .value;
         if balance == expected_balance {
@@ -20,7 +20,7 @@ pub fn check_recent_balance(expected_balance: u64, client: &RpcClient, pubkey: &
 
 pub fn check_ready(rpc_client: &RpcClient) {
     while rpc_client
-        .get_slot_with_commitment(CommitmentConfig::recent())
+        .get_slot_with_commitment(CommitmentConfig::processed())
         .unwrap()
         < 5
     {

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -64,7 +64,7 @@ fn full_battery_tests(
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let json_rpc_url = test_validator.rpc_url();
 
     let mut config_payer = CliConfig::recent_for_tests();
@@ -230,7 +230,7 @@ fn test_create_account_with_seed() {
 
     // Setup accounts
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
@@ -280,7 +280,7 @@ fn test_create_account_with_seed() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_address,
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -34,7 +34,7 @@ fn test_cli_program_deploy_non_upgradeable() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -155,7 +155,7 @@ fn test_cli_program_deploy_no_authority() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -243,7 +243,7 @@ fn test_cli_program_deploy_with_authority() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -574,7 +574,7 @@ fn test_cli_program_write_buffer() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();
@@ -829,7 +829,7 @@ fn test_cli_program_set_buffer_authority() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
     let mut program_data = Vec::new();

--- a/cli/tests/request_airdrop.rs
+++ b/cli/tests/request_airdrop.rs
@@ -32,7 +32,7 @@ fn test_cli_request_airdrop() {
     sig_response.unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let balance = rpc_client
         .get_balance(&bob_config.signers[0].pubkey())

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -33,7 +33,7 @@ fn test_stake_delegation_force() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let default_signer = Keypair::new();
 
     let mut config = CliConfig::recent_for_tests();
@@ -122,7 +122,7 @@ fn test_seed_stake_delegation_and_deactivation() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let validator_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
     let mut config_validator = CliConfig::recent_for_tests();
@@ -202,7 +202,7 @@ fn test_stake_delegation_and_deactivation() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let validator_keypair = Keypair::new();
 
     let mut config_validator = CliConfig::recent_for_tests();
@@ -278,7 +278,7 @@ fn test_offline_stake_delegation_and_deactivation() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let mut config_validator = CliConfig::recent_for_tests();
     config_validator.json_rpc_url = test_validator.rpc_url();
@@ -411,7 +411,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let config_keypair = keypair_from_seed(&[0u8; 32]).unwrap();
     let mut config = CliConfig::recent_for_tests();
@@ -465,7 +465,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -493,7 +493,7 @@ fn test_nonced_stake_delegation_and_deactivation() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -526,7 +526,7 @@ fn test_stake_authorize() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let default_signer = Keypair::new();
 
     let mut config = CliConfig::recent_for_tests();
@@ -706,7 +706,7 @@ fn test_stake_authorize() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -756,7 +756,7 @@ fn test_stake_authorize() {
     let new_nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -776,7 +776,7 @@ fn test_stake_authorize_with_fee_payer() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let default_signer = Keypair::new();
     let default_pubkey = default_signer.pubkey();
 
@@ -898,7 +898,7 @@ fn test_stake_split() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let default_signer = Keypair::new();
     let offline_signer = Keypair::new();
 
@@ -975,7 +975,7 @@ fn test_stake_split() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -1042,7 +1042,7 @@ fn test_stake_set_lockup() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let default_signer = Keypair::new();
     let offline_signer = Keypair::new();
 
@@ -1227,7 +1227,7 @@ fn test_stake_set_lockup() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -1294,7 +1294,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let mut config = CliConfig::recent_for_tests();
     let default_signer = keypair_from_seed(&[1u8; 32]).unwrap();
     config.signers = vec![&default_signer];
@@ -1342,7 +1342,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -1397,7 +1397,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -1445,7 +1445,7 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -30,7 +30,7 @@ fn test_transfer() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let default_signer = Keypair::new();
     let default_offline_signer = Keypair::new();
@@ -145,7 +145,7 @@ fn test_transfer() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -173,7 +173,7 @@ fn test_transfer() {
     let new_nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -194,7 +194,7 @@ fn test_transfer() {
     let nonce_hash = nonce_utils::get_account_with_commitment(
         &rpc_client,
         &nonce_account.pubkey(),
-        CommitmentConfig::recent(),
+        CommitmentConfig::processed(),
     )
     .and_then(|ref a| nonce_utils::data_from_account(a))
     .unwrap()
@@ -255,7 +255,7 @@ fn test_transfer_multisession_signing() {
 
     // Setup accounts
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
@@ -365,7 +365,7 @@ fn test_transfer_all() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
 
     let default_signer = Keypair::new();
 

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -26,7 +26,7 @@ fn test_vote_authorize_and_withdraw() {
     let faucet_addr = receiver.recv().unwrap();
 
     let rpc_client =
-        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::recent());
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
     let default_signer = Keypair::new();
 
     let mut config = CliConfig::recent_for_tests();

--- a/client/src/perf_utils.rs
+++ b/client/src/perf_utils.rs
@@ -33,7 +33,7 @@ pub fn sample_txs<T>(
     let mut now = Instant::now();
     let start_time = now;
     let initial_txs = client
-        .get_transaction_count_with_commitment(CommitmentConfig::recent())
+        .get_transaction_count_with_commitment(CommitmentConfig::processed())
         .expect("transaction count");
     let mut last_txs = initial_txs;
 
@@ -42,7 +42,7 @@ pub fn sample_txs<T>(
         let elapsed = now.elapsed();
         now = Instant::now();
         let mut txs;
-        match client.get_transaction_count_with_commitment(CommitmentConfig::recent()) {
+        match client.get_transaction_count_with_commitment(CommitmentConfig::processed()) {
             Err(e) => {
                 // ThinClient with multiple options should pick a better one now.
                 info!("Couldn't get transaction count {:?}", e);

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -23,7 +23,7 @@ use solana_account_decoder::{
 use solana_sdk::{
     account::Account,
     clock::{Slot, UnixTimestamp, DEFAULT_MS_PER_SLOT, MAX_HASH_AGE_IN_SECONDS},
-    commitment_config::CommitmentConfig,
+    commitment_config::{CommitmentConfig, CommitmentLevel},
     epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
     fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -48,6 +48,7 @@ pub struct RpcClient {
     sender: Box<dyn RpcSender + Send + Sync + 'static>,
     commitment_config: CommitmentConfig,
     default_cluster_transaction_encoding: RwLock<Option<UiTransactionEncoding>>,
+    use_deprecated_commitment: RwLock<Option<bool>>,
 }
 
 fn serialize_encode_transaction(
@@ -78,6 +79,7 @@ impl RpcClient {
         Self {
             sender: Box::new(sender),
             default_cluster_transaction_encoding: RwLock::new(None),
+            use_deprecated_commitment: RwLock::new(None),
             commitment_config,
         }
     }
@@ -128,14 +130,49 @@ impl RpcClient {
         Self::new_with_timeout(url, timeout)
     }
 
+    pub fn commitment(&self) -> CommitmentConfig {
+        self.commitment_config
+    }
+
+    fn use_deprecated_commitment(&self) -> Result<bool, RpcError> {
+        let use_deprecated_commitment = self.use_deprecated_commitment.read().unwrap();
+        if let Some(use_deprecated_commitment) = *use_deprecated_commitment {
+            Ok(use_deprecated_commitment)
+        } else {
+            drop(use_deprecated_commitment);
+            let cluster_version = self.get_version().map_err(|e| {
+                RpcError::RpcRequestError(format!("cluster version query failed: {}", e))
+            })?;
+            let cluster_version =
+                semver::Version::parse(&cluster_version.solana_core).map_err(|e| {
+                    RpcError::RpcRequestError(format!("failed to parse cluster version: {}", e))
+                })?;
+            let use_deprecated_commitment = cluster_version < semver::Version::new(1, 5, 5);
+            *self.use_deprecated_commitment.write().unwrap() = Some(use_deprecated_commitment);
+            Ok(use_deprecated_commitment)
+        }
+    }
+
+    fn maybe_map_commitment(
+        &self,
+        requested_commitment: CommitmentConfig,
+    ) -> Result<CommitmentConfig, RpcError> {
+        if matches!(
+            requested_commitment.commitment,
+            CommitmentLevel::Finalized | CommitmentLevel::Confirmed | CommitmentLevel::Processed
+        ) && self.use_deprecated_commitment()?
+        {
+            return Ok(CommitmentConfig::use_deprecated_commitment(
+                requested_commitment,
+            ));
+        }
+        Ok(requested_commitment)
+    }
+
     pub fn confirm_transaction(&self, signature: &Signature) -> ClientResult<bool> {
         Ok(self
             .confirm_transaction_with_commitment(signature, self.commitment_config)?
             .value)
-    }
-
-    pub fn commitment(&self) -> CommitmentConfig {
-        self.commitment_config
     }
 
     pub fn confirm_transaction_with_commitment(
@@ -159,7 +196,10 @@ impl RpcClient {
         self.send_transaction_with_config(
             transaction,
             RpcSendTransactionConfig {
-                preflight_commitment: Some(self.commitment_config.commitment),
+                preflight_commitment: Some(
+                    self.maybe_map_commitment(self.commitment_config)?
+                        .commitment,
+                ),
                 ..RpcSendTransactionConfig::default()
             },
         )
@@ -200,8 +240,13 @@ impl RpcClient {
         } else {
             self.default_cluster_transaction_encoding()?
         };
+        let preflight_commitment = CommitmentConfig {
+            commitment: config.preflight_commitment.unwrap_or_default(),
+        };
+        let preflight_commitment = self.maybe_map_commitment(preflight_commitment)?;
         let config = RpcSendTransactionConfig {
             encoding: Some(encoding),
+            preflight_commitment: Some(preflight_commitment.commitment),
             ..config
         };
         let serialized_encoded = serialize_encode_transaction(transaction, encoding)?;
@@ -274,8 +319,11 @@ impl RpcClient {
         } else {
             self.default_cluster_transaction_encoding()?
         };
+        let commitment = config.commitment.unwrap_or_default();
+        let commitment = self.maybe_map_commitment(commitment)?;
         let config = RpcSimulateTransactionConfig {
             encoding: Some(encoding),
+            commitment: Some(commitment),
             ..config
         };
         let serialized_encoded = serialize_encode_transaction(transaction, encoding)?;
@@ -358,7 +406,10 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Slot> {
-        self.send(RpcRequest::GetSlot, json!([commitment_config]))
+        self.send(
+            RpcRequest::GetSlot,
+            json!([self.maybe_map_commitment(commitment_config)?]),
+        )
     }
 
     pub fn supply(&self) -> RpcResult<RpcSupply> {
@@ -369,7 +420,10 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<RpcSupply> {
-        self.send(RpcRequest::GetSupply, json!([commitment_config]))
+        self.send(
+            RpcRequest::GetSupply,
+            json!([self.maybe_map_commitment(commitment_config)?]),
+        )
     }
 
     pub fn total_supply(&self) -> ClientResult<u64> {
@@ -380,13 +434,22 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
-        self.send(RpcRequest::GetTotalSupply, json!([commitment_config]))
+        self.send(
+            RpcRequest::GetTotalSupply,
+            json!([self.maybe_map_commitment(commitment_config)?]),
+        )
     }
 
     pub fn get_largest_accounts_with_config(
         &self,
         config: RpcLargestAccountsConfig,
     ) -> RpcResult<Vec<RpcAccountBalance>> {
+        let commitment = config.commitment.unwrap_or_default();
+        let commitment = self.maybe_map_commitment(commitment)?;
+        let config = RpcLargestAccountsConfig {
+            commitment: Some(commitment),
+            ..config
+        };
         self.send(RpcRequest::GetLargestAccounts, json!([config]))
     }
 
@@ -398,7 +461,10 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<RpcVoteAccountStatus> {
-        self.send(RpcRequest::GetVoteAccounts, json!([commitment_config]))
+        self.send(
+            RpcRequest::GetVoteAccounts,
+            json!([self.maybe_map_commitment(commitment_config)?]),
+        )
     }
 
     pub fn wait_for_max_stake(
@@ -558,7 +624,10 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<EpochInfo> {
-        self.send(RpcRequest::GetEpochInfo, json!([commitment_config]))
+        self.send(
+            RpcRequest::GetEpochInfo,
+            json!([self.maybe_map_commitment(commitment_config)?]),
+        )
     }
 
     pub fn get_leader_schedule(
@@ -575,7 +644,7 @@ impl RpcClient {
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
         self.send(
             RpcRequest::GetLeaderSchedule,
-            json!([slot, commitment_config]),
+            json!([slot, self.maybe_map_commitment(commitment_config)?]),
         )
     }
 
@@ -674,7 +743,7 @@ impl RpcClient {
     ) -> RpcResult<Option<Account>> {
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::Base64),
-            commitment: Some(commitment_config),
+            commitment: Some(self.maybe_map_commitment(commitment_config)?),
             data_slice: None,
         };
         let response = self.sender.send(
@@ -721,7 +790,7 @@ impl RpcClient {
     ) -> RpcResult<Vec<Option<Account>>> {
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::Base64),
-            commitment: Some(commitment_config),
+            commitment: Some(self.maybe_map_commitment(commitment_config)?),
             data_slice: None,
         };
         let pubkeys: Vec<_> = pubkeys.iter().map(|pubkey| pubkey.to_string()).collect();
@@ -775,7 +844,10 @@ impl RpcClient {
     ) -> RpcResult<u64> {
         self.send(
             RpcRequest::GetBalance,
-            json!([pubkey.to_string(), commitment_config]),
+            json!([
+                pubkey.to_string(),
+                self.maybe_map_commitment(commitment_config)?
+            ]),
         )
     }
 
@@ -798,6 +870,16 @@ impl RpcClient {
         pubkey: &Pubkey,
         config: RpcProgramAccountsConfig,
     ) -> ClientResult<Vec<(Pubkey, Account)>> {
+        let commitment = config.account_config.commitment.unwrap_or_default();
+        let commitment = self.maybe_map_commitment(commitment)?;
+        let account_config = RpcAccountInfoConfig {
+            commitment: Some(commitment),
+            ..config.account_config
+        };
+        let config = RpcProgramAccountsConfig {
+            account_config,
+            ..config
+        };
         let accounts: Vec<RpcKeyedAccount> = self.send(
             RpcRequest::GetProgramAccounts,
             json!([pubkey.to_string(), config]),
@@ -814,7 +896,10 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
-        self.send(RpcRequest::GetTransactionCount, json!([commitment_config]))
+        self.send(
+            RpcRequest::GetTransactionCount,
+            json!([self.maybe_map_commitment(commitment_config)?]),
+        )
     }
 
     pub fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
@@ -836,9 +921,11 @@ impl RpcClient {
                     fee_calculator,
                     last_valid_slot,
                 },
-        }) =
-            self.send::<Response<RpcFees>>(RpcRequest::GetFees, json!([commitment_config]))
-        {
+        }) = self
+            .send::<Response<RpcFees>>(
+                RpcRequest::GetFees,
+                json!([self.maybe_map_commitment(commitment_config)?]),
+            ) {
             (context, blockhash, fee_calculator, last_valid_slot)
         } else if let Ok(Response {
             context,
@@ -849,7 +936,7 @@ impl RpcClient {
                 },
         }) = self.send::<Response<RpcBlockhashFeeCalculator>>(
             RpcRequest::GetRecentBlockhash,
-            json!([commitment_config]),
+            json!([self.maybe_map_commitment(commitment_config)?]),
         ) {
             (context, blockhash, fee_calculator, 0)
         } else {
@@ -887,7 +974,10 @@ impl RpcClient {
     ) -> RpcResult<Option<FeeCalculator>> {
         let Response { context, value } = self.send::<Response<Option<RpcFeeCalculator>>>(
             RpcRequest::GetFeeCalculatorForBlockhash,
-            json!([blockhash.to_string(), commitment_config]),
+            json!([
+                blockhash.to_string(),
+                self.maybe_map_commitment(commitment_config)?
+            ]),
         )?;
 
         Ok(Response {
@@ -966,7 +1056,7 @@ impl RpcClient {
     ) -> RpcResult<Option<UiTokenAccount>> {
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::JsonParsed),
-            commitment: Some(commitment_config),
+            commitment: Some(self.maybe_map_commitment(commitment_config)?),
             data_slice: None,
         };
         let response = self.sender.send(
@@ -1027,7 +1117,10 @@ impl RpcClient {
     ) -> RpcResult<UiTokenAmount> {
         self.send(
             RpcRequest::GetTokenAccountBalance,
-            json!([pubkey.to_string(), commitment_config]),
+            json!([
+                pubkey.to_string(),
+                self.maybe_map_commitment(commitment_config)?
+            ]),
         )
     }
 
@@ -1060,7 +1153,7 @@ impl RpcClient {
 
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::JsonParsed),
-            commitment: Some(commitment_config),
+            commitment: Some(self.maybe_map_commitment(commitment_config)?),
             data_slice: None,
         };
 
@@ -1099,7 +1192,7 @@ impl RpcClient {
 
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::JsonParsed),
-            commitment: Some(commitment_config),
+            commitment: Some(self.maybe_map_commitment(commitment_config)?),
             data_slice: None,
         };
 
@@ -1122,7 +1215,10 @@ impl RpcClient {
     ) -> RpcResult<UiTokenAmount> {
         self.send(
             RpcRequest::GetTokenSupply,
-            json!([mint.to_string(), commitment_config]),
+            json!([
+                mint.to_string(),
+                self.maybe_map_commitment(commitment_config)?
+            ]),
         )
     }
 

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn test_build_request_json_config_options() {
         let commitment_config = CommitmentConfig {
-            commitment: CommitmentLevel::Max,
+            commitment: CommitmentLevel::Finalized,
         };
         let addr = json!("deadbeefXjn8o3yroDHxUtKsZZgoy4GPkPPXfouKNHhx");
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -139,16 +139,19 @@ pub struct JsonRpcRequestProcessor {
 impl Metadata for JsonRpcRequestProcessor {}
 
 impl JsonRpcRequestProcessor {
+    #[allow(deprecated)]
     fn bank(&self, commitment: Option<CommitmentConfig>) -> Arc<Bank> {
         debug!("RPC commitment_config: {:?}", commitment);
         let r_bank_forks = self.bank_forks.read().unwrap();
 
         let commitment_level = match commitment {
-            None => CommitmentLevel::Max,
+            None => CommitmentLevel::Finalized,
             Some(config) => config.commitment,
         };
 
-        if commitment_level == CommitmentLevel::SingleGossip {
+        if commitment_level == CommitmentLevel::SingleGossip || // SingleGossip variant is deprecated
+            commitment_level == CommitmentLevel::Confirmed
+        {
             let bank = self
                 .optimistically_confirmed_bank
                 .read()
@@ -166,19 +169,23 @@ impl JsonRpcRequestProcessor {
             .slot_with_commitment(commitment_level);
 
         match commitment_level {
-            CommitmentLevel::Recent => {
+            // Recent variant is deprecated
+            CommitmentLevel::Recent | CommitmentLevel::Processed => {
                 debug!("RPC using the heaviest slot: {:?}", slot);
             }
+            // Root variant is deprecated
             CommitmentLevel::Root => {
                 debug!("RPC using node root: {:?}", slot);
             }
+            // Single variant is deprecated
             CommitmentLevel::Single => {
                 debug!("RPC using confirmed slot: {:?}", slot);
             }
-            CommitmentLevel::Max => {
+            // Max variant is deprecated
+            CommitmentLevel::Max | CommitmentLevel::Finalized => {
                 debug!("RPC using block: {:?}", slot);
             }
-            CommitmentLevel::SingleGossip => unreachable!(),
+            CommitmentLevel::SingleGossip | CommitmentLevel::Confirmed => unreachable!(), // SingleGossip variant is deprecated
         };
 
         r_bank_forks.get(slot).cloned().unwrap_or_else(|| {
@@ -380,7 +387,7 @@ impl JsonRpcRequestProcessor {
     pub fn get_epoch_schedule(&self) -> EpochSchedule {
         // Since epoch schedule data comes from the genesis config, any commitment level should be
         // fine
-        let bank = self.bank(Some(CommitmentConfig::root()));
+        let bank = self.bank(Some(CommitmentConfig::finalized()));
         *bank.epoch_schedule()
     }
 
@@ -873,7 +880,7 @@ impl JsonRpcRequestProcessor {
         let search_transaction_history = config
             .map(|x| x.search_transaction_history)
             .unwrap_or(false);
-        let bank = self.bank(Some(CommitmentConfig::recent()));
+        let bank = self.bank(Some(CommitmentConfig::processed()));
 
         for signature in signatures {
             let status = if let Some(status) = self.get_transaction_status(signature, &bank) {
@@ -925,7 +932,7 @@ impl JsonRpcRequestProcessor {
         let (slot, status) = bank.get_signature_status_slot(&signature)?;
         let r_block_commitment_cache = self.block_commitment_cache.read().unwrap();
 
-        let optimistically_confirmed_bank = self.bank(Some(CommitmentConfig::single_gossip()));
+        let optimistically_confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
         let optimistically_confirmed =
             optimistically_confirmed_bank.get_signature_status_slot(&signature);
 
@@ -5376,7 +5383,7 @@ pub mod tests {
 
         let req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"getVoteAccounts","params":{}}}"#,
-            json!([CommitmentConfig::recent()])
+            json!([CommitmentConfig::processed()])
         );
 
         let res = io.handle_request_sync(&req, meta.clone());
@@ -5422,7 +5429,7 @@ pub mod tests {
         {
             let req = format!(
                 r#"{{"jsonrpc":"2.0","id":1,"method":"getVoteAccounts","params":{}}}"#,
-                json!([CommitmentConfig::recent()])
+                json!([CommitmentConfig::processed()])
             );
 
             let res = io.handle_request_sync(&req, meta);
@@ -6110,7 +6117,8 @@ pub mod tests {
         let mut io = MetaIoHandler::default();
         io.extend_with(RpcSolImpl.to_delegate());
 
-        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment":"singleGossip"}]}"#;
+        let req =
+            r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment":"confirmed"}]}"#;
         let res = io.handle_request_sync(req, meta.clone());
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
         let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
@@ -6123,7 +6131,8 @@ pub mod tests {
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
         );
-        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "singleGossip"}]}"#;
+        let req =
+            r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
         let res = io.handle_request_sync(&req, meta.clone());
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
         let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
@@ -6137,7 +6146,8 @@ pub mod tests {
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
         );
-        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "singleGossip"}]}"#;
+        let req =
+            r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
         let res = io.handle_request_sync(&req, meta.clone());
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
         let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
@@ -6151,7 +6161,8 @@ pub mod tests {
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
         );
-        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "singleGossip"}]}"#;
+        let req =
+            r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
         let res = io.handle_request_sync(&req, meta.clone());
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
         let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
@@ -6166,7 +6177,8 @@ pub mod tests {
             &subscriptions,
             &mut pending_optimistically_confirmed_banks,
         );
-        let req = r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "singleGossip"}]}"#;
+        let req =
+            r#"{"jsonrpc":"2.0","id":1,"method":"getSlot","params":[{"commitment": "confirmed"}]}"#;
         let res = io.handle_request_sync(&req, meta);
         let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
         let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();

--- a/core/src/rpc_pubsub.rs
+++ b/core/src/rpc_pubsub.rs
@@ -579,7 +579,7 @@ mod tests {
             subscriber,
             tx.signatures[0].to_string(),
             Some(RpcSignatureSubscribeConfig {
-                commitment: Some(CommitmentConfig::single()),
+                commitment: Some(CommitmentConfig::finalized()),
                 ..RpcSignatureSubscribeConfig::default()
             }),
         );
@@ -612,7 +612,7 @@ mod tests {
             subscriber,
             tx.signatures[0].to_string(),
             Some(RpcSignatureSubscribeConfig {
-                commitment: Some(CommitmentConfig::single()),
+                commitment: Some(CommitmentConfig::finalized()),
                 enable_received_notification: Some(true),
             }),
         );
@@ -721,7 +721,7 @@ mod tests {
             subscriber,
             stake_account.pubkey().to_string(),
             Some(RpcAccountInfoConfig {
-                commitment: Some(CommitmentConfig::recent()),
+                commitment: Some(CommitmentConfig::processed()),
                 encoding: None,
                 data_slice: None,
             }),
@@ -830,7 +830,7 @@ mod tests {
             subscriber,
             nonce_account.pubkey().to_string(),
             Some(RpcAccountInfoConfig {
-                commitment: Some(CommitmentConfig::recent()),
+                commitment: Some(CommitmentConfig::processed()),
                 encoding: Some(UiAccountEncoding::JsonParsed),
                 data_slice: None,
             }),
@@ -952,7 +952,7 @@ mod tests {
             subscriber,
             bob.pubkey().to_string(),
             Some(RpcAccountInfoConfig {
-                commitment: Some(CommitmentConfig::root()),
+                commitment: Some(CommitmentConfig::finalized()),
                 encoding: None,
                 data_slice: None,
             }),
@@ -1006,7 +1006,7 @@ mod tests {
             subscriber,
             bob.pubkey().to_string(),
             Some(RpcAccountInfoConfig {
-                commitment: Some(CommitmentConfig::root()),
+                commitment: Some(CommitmentConfig::finalized()),
                 encoding: None,
                 data_slice: None,
             }),

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -416,7 +416,7 @@ impl TestValidator {
         //  due to a bug in the Bank)
         {
             let rpc_client =
-                RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::recent());
+                RpcClient::new_with_commitment(rpc_url.clone(), CommitmentConfig::processed());
             let fee_rate_governor = rpc_client
                 .get_fee_rate_governor()
                 .expect("get_fee_rate_governor")
@@ -475,7 +475,7 @@ impl TestValidator {
     /// associated fee calculator
     pub fn rpc_client(&self) -> (RpcClient, Hash, FeeCalculator) {
         let rpc_client =
-            RpcClient::new_with_commitment(self.rpc_url.clone(), CommitmentConfig::recent());
+            RpcClient::new_with_commitment(self.rpc_url.clone(), CommitmentConfig::processed());
         let (recent_blockhash, fee_calculator) = rpc_client
             .get_recent_blockhash()
             .expect("get_recent_blockhash");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -498,7 +498,7 @@ impl Validator {
         };
 
         if config.dev_halt_at_slot.is_some() {
-            // Simulate a confirmed root to avoid RPC errors with CommitmentConfig::max() and
+            // Simulate a confirmed root to avoid RPC errors with CommitmentConfig::finalized() and
             // to ensure RPC endpoints like getConfirmedBlock, which require a confirmed root, work
             block_commitment_cache
                 .write()

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -247,7 +247,7 @@ fn test_rpc_subscriptions() {
 
     let rpc_client = RpcClient::new(test_validator.rpc_url());
     let mut mint_balance = rpc_client
-        .get_balance_with_commitment(&alice.pubkey(), CommitmentConfig::recent())
+        .get_balance_with_commitment(&alice.pubkey(), CommitmentConfig::processed())
         .unwrap()
         .value;
     assert!(mint_balance >= transactions.len() as u64);
@@ -264,7 +264,7 @@ fn test_rpc_subscriptions() {
     let expected_mint_balance = mint_balance - transactions.len() as u64;
     while mint_balance != expected_mint_balance && now.elapsed() < Duration::from_secs(5) {
         mint_balance = rpc_client
-            .get_balance_with_commitment(&alice.pubkey(), CommitmentConfig::recent())
+            .get_balance_with_commitment(&alice.pubkey(), CommitmentConfig::processed())
             .unwrap()
             .value;
         sleep(Duration::from_millis(100));

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -134,22 +134,20 @@ to report progress and higher levels to ensure the state will not be rolled back
 In descending order of commitment (most finalized to least finalized), clients
 may specify:
 
-- `"max"` - the node will query the most recent block confirmed by supermajority
+- `"finalized"` - the node will query the most recent block confirmed by supermajority
 of the cluster as having reached maximum lockout, meaning the cluster has
 recognized this block as finalized
-- `"root"` - the node will query the most recent block having reached maximum
-lockout on this node, meaning the node has recognized this block as finalized
-- `"singleGossip"` - the node will query the most recent block that has been voted on by supermajority of the cluster.
+- `"confirmed"` - the node will query the most recent block that has been voted on by supermajority of the cluster.
   - It incorporates votes from gossip and replay.
   - It does not count votes on descendants of a block, only direct votes on that block.
   - This confirmation level also upholds "optimistic confirmation" guarantees in
     release 1.3 and onwards.
-- `"recent"` - the node will query its most recent block.  Note that the block
+- `"processed"` - the node will query its most recent block.  Note that the block
 may not be complete.
 
 For processing many dependent transactions in series, it's recommended to use
-`"singleGossip"` commitment, which balances speed with rollback safety.
-For total safety, it's recommended to use`"max"` commitment.
+`"confirmed"` commitment, which balances speed with rollback safety.
+For total safety, it's recommended to use`"finalized"` commitment.
 
 #### Example
 
@@ -2966,7 +2964,7 @@ After connecting to the RPC PubSub websocket at `ws://<ADDRESS>/`:
 
 - Submit subscription requests to the websocket using the methods below
 - Multiple subscriptions may be active at once
-- Many subscriptions take the optional [`commitment` parameter](jsonrpc-api.md#configuring-state-commitment), defining how finalized a change should be to trigger a notification. For subscriptions, if commitment is unspecified, the default value is `"singleGossip"`.
+- Many subscriptions take the optional [`commitment` parameter](jsonrpc-api.md#configuring-state-commitment), defining how finalized a change should be to trigger a notification. For subscriptions, if commitment is unspecified, the default value is `"confirmed"`.
 
 ### accountSubscribe
 

--- a/docs/src/proposals/simple-payment-and-state-verification.md
+++ b/docs/src/proposals/simple-payment-and-state-verification.md
@@ -149,7 +149,7 @@ vote, and vote account pubkey responsible for the vote.
 
 Together, the transaction merkle and optimistic confirmation proofs can be
 provided over RPC to subscribers by extending the existing signature
-subscrption logic. Clients who subscribe to the "SingleGossip" confirmation
+subscrption logic. Clients who subscribe to the "Confirmed" confirmation
 level are already notified when optimistic confirmation is detected, a flag
 can be provided to signal the two proofs above should also be returned.
 

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -49,11 +49,14 @@ pub fn spend_and_verify_all_nodes<S: ::std::hash::BuildHasher>(
         let random_keypair = Keypair::new();
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let bal = client
-            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
+            .poll_get_balance_with_commitment(
+                &funding_keypair.pubkey(),
+                CommitmentConfig::processed(),
+            )
             .expect("balance in source");
         assert!(bal > 0);
         let (blockhash, _fee_calculator, _last_valid_slot) = client
-            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
             .unwrap();
         let mut transaction =
             system_transaction::transfer(&funding_keypair, &random_keypair.pubkey(), 1, blockhash);
@@ -78,7 +81,7 @@ pub fn verify_balances<S: ::std::hash::BuildHasher>(
     let client = create_client(node.client_facing_addr(), VALIDATOR_PORT_RANGE);
     for (pk, b) in expected_balances {
         let bal = client
-            .poll_get_balance_with_commitment(&pk, CommitmentConfig::recent())
+            .poll_get_balance_with_commitment(&pk, CommitmentConfig::processed())
             .expect("balance in source");
         assert_eq!(bal, b);
     }
@@ -95,11 +98,14 @@ pub fn send_many_transactions(
     for _ in 0..num_txs {
         let random_keypair = Keypair::new();
         let bal = client
-            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
+            .poll_get_balance_with_commitment(
+                &funding_keypair.pubkey(),
+                CommitmentConfig::processed(),
+            )
             .expect("balance in source");
         assert!(bal > 0);
         let (blockhash, _fee_calculator, _last_valid_slot) = client
-            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
             .unwrap();
         let transfer_amount = thread_rng().gen_range(1, max_tokens_per_transfer);
 
@@ -195,7 +201,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
     for ingress_node in &cluster_nodes {
         client
-            .poll_get_balance_with_commitment(&ingress_node.id, CommitmentConfig::recent())
+            .poll_get_balance_with_commitment(&ingress_node.id, CommitmentConfig::processed())
             .unwrap_or_else(|err| panic!("Node {} has no balance: {}", ingress_node.id, err));
     }
 
@@ -219,7 +225,10 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
         let client = create_client(ingress_node.client_facing_addr(), VALIDATOR_PORT_RANGE);
         let balance = client
-            .poll_get_balance_with_commitment(&funding_keypair.pubkey(), CommitmentConfig::recent())
+            .poll_get_balance_with_commitment(
+                &funding_keypair.pubkey(),
+                CommitmentConfig::processed(),
+            )
             .expect("balance in source");
         assert_ne!(balance, 0);
 
@@ -233,7 +242,7 @@ pub fn kill_entry_and_spend_and_verify_rest(
 
             let random_keypair = Keypair::new();
             let (blockhash, _fee_calculator, _last_valid_slot) = client
-                .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
                 .unwrap();
             let mut transaction = system_transaction::transfer(
                 &funding_keypair,
@@ -311,7 +320,7 @@ pub fn check_no_new_roots(
                 .unwrap_or_else(|_| panic!("get_slot for {} failed", ingress_node.id));
             roots[i] = initial_root;
             client
-                .get_slot_with_commitment(CommitmentConfig::recent())
+                .get_slot_with_commitment(CommitmentConfig::processed())
                 .unwrap_or_else(|_| panic!("get_slot for {} failed", ingress_node.id))
         })
         .max()
@@ -325,7 +334,7 @@ pub fn check_no_new_roots(
         for contact_info in contact_infos {
             let client = create_client(contact_info.client_facing_addr(), VALIDATOR_PORT_RANGE);
             current_slot = client
-                .get_slot_with_commitment(CommitmentConfig::recent())
+                .get_slot_with_commitment(CommitmentConfig::processed())
                 .unwrap_or_else(|_| panic!("get_slot for {} failed", contact_infos[0].id));
             if current_slot > end_slot {
                 reached_end_slot = true;

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -435,7 +435,7 @@ impl LocalCluster {
     ) -> u64 {
         trace!("getting leader blockhash");
         let (blockhash, _fee_calculator, _last_valid_slot) = client
-            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
             .unwrap();
         let mut tx =
             system_transaction::transfer(&source_keypair, dest_pubkey, lamports, blockhash);
@@ -452,7 +452,7 @@ impl LocalCluster {
             .wait_for_balance_with_commitment(
                 dest_pubkey,
                 Some(lamports),
-                CommitmentConfig::recent(),
+                CommitmentConfig::processed(),
             )
             .expect("get balance")
     }
@@ -474,7 +474,7 @@ impl LocalCluster {
 
         // Create the vote account if necessary
         if client
-            .poll_get_balance_with_commitment(&vote_account_pubkey, CommitmentConfig::recent())
+            .poll_get_balance_with_commitment(&vote_account_pubkey, CommitmentConfig::processed())
             .unwrap_or(0)
             == 0
         {
@@ -496,7 +496,7 @@ impl LocalCluster {
                 &[from_account.as_ref(), vote_account],
                 message,
                 client
-                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
                     .unwrap()
                     .0,
             );
@@ -507,7 +507,7 @@ impl LocalCluster {
                 .wait_for_balance_with_commitment(
                     &vote_account_pubkey,
                     Some(amount),
-                    CommitmentConfig::recent(),
+                    CommitmentConfig::processed(),
                 )
                 .expect("get balance");
 
@@ -524,7 +524,7 @@ impl LocalCluster {
                 &[from_account.as_ref(), &stake_account_keypair],
                 message,
                 client
-                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
                     .unwrap()
                     .0,
             );
@@ -541,7 +541,7 @@ impl LocalCluster {
                 .wait_for_balance_with_commitment(
                     &stake_account_pubkey,
                     Some(amount),
-                    CommitmentConfig::recent(),
+                    CommitmentConfig::processed(),
                 )
                 .expect("get balance");
         } else {
@@ -552,8 +552,9 @@ impl LocalCluster {
         }
         info!("Checking for vote account registration of {}", node_pubkey);
         match (
-            client.get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::recent()),
-            client.get_account_with_commitment(&vote_account_pubkey, CommitmentConfig::recent()),
+            client
+                .get_account_with_commitment(&stake_account_pubkey, CommitmentConfig::processed()),
+            client.get_account_with_commitment(&vote_account_pubkey, CommitmentConfig::processed()),
         ) {
             (Ok(Some(stake_account)), Ok(Some(vote_account))) => {
                 match (

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1584,7 +1584,10 @@ fn test_validator_saves_tower() {
 
     // Wait for the first root
     loop {
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::finalized()) {
+        #[allow(deprecated)]
+        // This test depends on knowing the immediate root, without any delay from the commitment
+        // service, so the deprecated CommitmentConfig::root() is retained
+        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
             trace!("current root: {}", root);
             if root > last_replayed_root + 1 {
                 last_replayed_root = root;
@@ -1613,7 +1616,10 @@ fn test_validator_saves_tower() {
 
     // Wait for a new root, demonstrating the validator was able to make progress from the older `tower1`
     loop {
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::finalized()) {
+        #[allow(deprecated)]
+        // This test depends on knowing the immediate root, without any delay from the commitment
+        // service, so the deprecated CommitmentConfig::root() is retained
+        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
             trace!(
                 "current root: {}, last_replayed_root: {}",
                 root,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -168,7 +168,7 @@ fn test_local_cluster_signature_subscribe() {
         VALIDATOR_PORT_RANGE,
     );
     let (blockhash, _fee_calculator, _last_valid_slot) = tx_client
-        .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+        .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
         .unwrap();
 
     let mut transaction = system_transaction::transfer(
@@ -182,7 +182,7 @@ fn test_local_cluster_signature_subscribe() {
         &format!("ws://{}", &non_bootstrap_info.rpc_pubsub.to_string()),
         &transaction.signatures[0],
         Some(RpcSignatureSubscribeConfig {
-            commitment: Some(CommitmentConfig::recent()),
+            commitment: Some(CommitmentConfig::processed()),
             enable_received_notification: Some(true),
         }),
     )
@@ -791,7 +791,7 @@ fn test_mainnet_beta_cluster_type() {
             (
                 program_id,
                 client
-                    .get_account_with_commitment(program_id, CommitmentConfig::recent())
+                    .get_account_with_commitment(program_id, CommitmentConfig::processed())
                     .unwrap()
             ),
             (_program_id, Some(_))
@@ -809,7 +809,7 @@ fn test_mainnet_beta_cluster_type() {
             (
                 program_id,
                 client
-                    .get_account_with_commitment(program_id, CommitmentConfig::recent())
+                    .get_account_with_commitment(program_id, CommitmentConfig::processed())
                     .unwrap()
             ),
             (program_id, None)
@@ -826,7 +826,7 @@ fn generate_frozen_account_panic(mut cluster: LocalCluster, frozen_account: Arc<
     trace!(
         "validator slot: {}",
         client
-            .get_slot_with_commitment(CommitmentConfig::recent())
+            .get_slot_with_commitment(CommitmentConfig::processed())
             .expect("get slot")
     );
 
@@ -838,7 +838,7 @@ fn generate_frozen_account_panic(mut cluster: LocalCluster, frozen_account: Arc<
     while !solana_runtime::accounts_db::FROZEN_ACCOUNT_PANIC.load(Ordering::Relaxed) {
         // Transfer from frozen account
         let (blockhash, _fee_calculator, _last_valid_slot) = client
-            .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+            .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
             .unwrap();
         client
             .async_transfer(
@@ -1222,7 +1222,7 @@ fn test_snapshots_blockstore_floor() {
     let target_slot = slot_floor + 40;
     while current_slot <= target_slot {
         trace!("current_slot: {}", current_slot);
-        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::recent()) {
+        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::processed()) {
             current_slot = slot;
         } else {
             continue;
@@ -1402,7 +1402,7 @@ fn test_no_voting() {
         .unwrap();
     loop {
         let last_slot = client
-            .get_slot_with_commitment(CommitmentConfig::recent())
+            .get_slot_with_commitment(CommitmentConfig::processed())
             .expect("Couldn't get slot");
         if last_slot > 4 * VOTE_THRESHOLD_DEPTH as u64 {
             break;
@@ -1460,7 +1460,7 @@ fn test_optimistic_confirmation_violation_detection() {
     let mut prev_voted_slot = 0;
     loop {
         let last_voted_slot = client
-            .get_slot_with_commitment(CommitmentConfig::recent())
+            .get_slot_with_commitment(CommitmentConfig::processed())
             .unwrap();
         if last_voted_slot > 50 {
             if prev_voted_slot == 0 {
@@ -1498,7 +1498,7 @@ fn test_optimistic_confirmation_violation_detection() {
     let client = cluster.get_validator_client(&entry_point_id).unwrap();
     loop {
         let last_root = client
-            .get_slot_with_commitment(CommitmentConfig::max())
+            .get_slot_with_commitment(CommitmentConfig::finalized())
             .unwrap();
         if last_root > prev_voted_slot {
             break;
@@ -1561,7 +1561,7 @@ fn test_validator_saves_tower() {
     // Wait for some votes to be generated
     let mut last_replayed_root;
     loop {
-        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::recent()) {
+        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::processed()) {
             trace!("current slot: {}", slot);
             if slot > 2 {
                 // this will be the root next time a validator starts
@@ -1584,7 +1584,7 @@ fn test_validator_saves_tower() {
 
     // Wait for the first root
     loop {
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
+        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::finalized()) {
             trace!("current root: {}", root);
             if root > last_replayed_root + 1 {
                 last_replayed_root = root;
@@ -1596,7 +1596,7 @@ fn test_validator_saves_tower() {
 
     // Stop validator, and check saved tower
     let recent_slot = validator_client
-        .get_slot_with_commitment(CommitmentConfig::recent())
+        .get_slot_with_commitment(CommitmentConfig::processed())
         .unwrap();
     let validator_info = cluster.exit_node(&validator_id);
     let tower2 = Tower::restore(&ledger_path, &validator_id).unwrap();
@@ -1613,7 +1613,7 @@ fn test_validator_saves_tower() {
 
     // Wait for a new root, demonstrating the validator was able to make progress from the older `tower1`
     loop {
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
+        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::finalized()) {
             trace!(
                 "current root: {}, last_replayed_root: {}",
                 root,
@@ -1642,10 +1642,10 @@ fn test_validator_saves_tower() {
 
     // Wait for a couple more slots to pass so another vote occurs
     let current_slot = validator_client
-        .get_slot_with_commitment(CommitmentConfig::recent())
+        .get_slot_with_commitment(CommitmentConfig::processed())
         .unwrap();
     loop {
-        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::recent()) {
+        if let Ok(slot) = validator_client.get_slot_with_commitment(CommitmentConfig::processed()) {
             trace!("current_slot: {}, slot: {}", current_slot, slot);
             if slot > current_slot + 1 {
                 break;
@@ -2157,13 +2157,13 @@ fn test_optimistic_confirmation_violation_without_tower() {
 #[test]
 #[serial]
 fn test_run_test_load_program_accounts_root() {
-    run_test_load_program_accounts(CommitmentConfig::root());
+    run_test_load_program_accounts(CommitmentConfig::finalized());
 }
 
 #[test]
 #[serial]
 fn test_run_test_load_program_accounts_partition_root() {
-    run_test_load_program_accounts_partition(CommitmentConfig::root());
+    run_test_load_program_accounts_partition(CommitmentConfig::finalized());
 }
 
 fn run_test_load_program_accounts_partition(scan_commitment: CommitmentConfig) {
@@ -2245,7 +2245,7 @@ fn setup_transfer_scan_threads(
                     return;
                 }
                 let (blockhash, _fee_calculator, _last_valid_slot) = client
-                    .get_recent_blockhash_with_commitment(CommitmentConfig::recent())
+                    .get_recent_blockhash_with_commitment(CommitmentConfig::processed())
                     .unwrap();
                 for i in 0..starting_keypairs_.len() {
                     client
@@ -2388,7 +2388,7 @@ fn wait_for_next_snapshot(
         .get_validator_client(&cluster.entry_point_info.id)
         .unwrap();
     let last_slot = client
-        .get_slot_with_commitment(CommitmentConfig::recent())
+        .get_slot_with_commitment(CommitmentConfig::processed())
         .expect("Couldn't get slot");
 
     // Wait for a snapshot for a bank >= last_slot to be made so we know that the snapshot

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -109,13 +109,16 @@ impl BlockCommitmentCache {
         self.highest_confirmed_slot()
     }
 
+    #[allow(deprecated)]
     pub fn slot_with_commitment(&self, commitment_level: CommitmentLevel) -> Slot {
         match commitment_level {
-            CommitmentLevel::Recent => self.slot(),
+            CommitmentLevel::Recent | CommitmentLevel::Processed => self.slot(),
             CommitmentLevel::Root => self.root(),
             CommitmentLevel::Single => self.highest_confirmed_slot(),
-            CommitmentLevel::SingleGossip => self.highest_gossip_confirmed_slot(),
-            CommitmentLevel::Max => self.highest_confirmed_root(),
+            CommitmentLevel::SingleGossip | CommitmentLevel::Confirmed => {
+                self.highest_gossip_confirmed_slot()
+            }
+            CommitmentLevel::Max | CommitmentLevel::Finalized => self.highest_confirmed_root(),
         }
     }
 

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -8,30 +10,50 @@ pub struct CommitmentConfig {
 }
 
 impl CommitmentConfig {
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentConfig::processed() instead"
+    )]
     pub fn recent() -> Self {
         Self {
             commitment: CommitmentLevel::Recent,
         }
     }
 
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentConfig::finalized() instead"
+    )]
     pub fn max() -> Self {
         Self {
             commitment: CommitmentLevel::Max,
         }
     }
 
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentConfig::finalized() instead"
+    )]
     pub fn root() -> Self {
         Self {
             commitment: CommitmentLevel::Root,
         }
     }
 
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentConfig::confirmed() instead"
+    )]
     pub fn single() -> Self {
         Self {
             commitment: CommitmentLevel::Single,
         }
     }
 
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentConfig::confirmed() instead"
+    )]
     pub fn single_gossip() -> Self {
         Self {
             commitment: CommitmentLevel::SingleGossip,
@@ -62,32 +84,67 @@ impl FromStr for CommitmentConfig {
 /// finalized. When querying the ledger state, use lower levels of commitment to report progress and higher
 /// levels to ensure state changes will not be rolled back.
 pub enum CommitmentLevel {
-    /// The highest slot having reached max vote lockout, as recognized by a supermajority of the cluster.
+    /// (DEPRECATED) The highest slot having reached max vote lockout, as recognized by a supermajority of the cluster.
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentLevel::Finalized instead"
+    )]
     Max,
 
-    /// The highest slot of the heaviest fork. Ledger state at this slot is not derived from a finalized
+    /// (DEPRECATED) The highest slot of the heaviest fork. Ledger state at this slot is not derived from a finalized
     /// block, but if multiple forks are present, is from the fork the validator believes is most likely
     /// to finalize.
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentLevel::Processed instead"
+    )]
     Recent,
 
-    /// The highest slot having reached max vote lockout.
+    /// (DEPRECATED) The highest slot having reached max vote lockout.
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentLevel::Finalized instead"
+    )]
     Root,
 
     /// (DEPRECATED) The highest slot having reached 1 confirmation by supermajority of the cluster.
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentLevel::Confirmed instead"
+    )]
     Single,
 
-    /// The highest slot that has been voted on by supermajority of the cluster
+    /// (DEPRECATED) The highest slot that has been voted on by supermajority of the cluster
     /// This differs from `single` in that:
     /// 1) It incorporates votes from gossip and replay.
     /// 2) It does not count votes on descendants of a block, only direct votes on that block.
     /// 3) This confirmation level also upholds "optimistic confirmation" guarantees in
     /// release 1.3 and onwards.
+    #[deprecated(
+        since = "1.5.5",
+        note = "Please use CommitmentLevel::Confirmed instead"
+    )]
     SingleGossip,
+
+    /// The highest slot of the heaviest fork processed by the node. Ledger state at this slot is
+    /// not derived from a confirmed or finalized block, but if multiple forks are present, is from
+    /// the fork the validator believes is most likely to finalize.
+    Processed,
+
+    /// The highest slot that has been voted on by supermajority of the cluster, ie. is confirmed.
+    /// Confirmation incorporates votes from gossip and replay. It does not count votes on
+    /// descendants of a block, only direct votes on that block, and upholds "optimistic
+    /// confirmation" guarantees in release 1.3 and onwards.
+    Confirmed,
+
+    /// The highest slot having reached max vote lockout, as recognized by a supermajority of the
+    /// cluster.
+    Finalized,
 }
 
 impl Default for CommitmentLevel {
     fn default() -> Self {
-        Self::Max
+        Self::Finalized
     }
 }
 
@@ -101,6 +158,9 @@ impl FromStr for CommitmentLevel {
             "root" => Ok(CommitmentLevel::Root),
             "single" => Ok(CommitmentLevel::Single),
             "singleGossip" => Ok(CommitmentLevel::SingleGossip),
+            "processed" => Ok(CommitmentLevel::Processed),
+            "confirmed" => Ok(CommitmentLevel::Confirmed),
+            "finalized" => Ok(CommitmentLevel::Finalized),
             _ => Err(ParseCommitmentLevelError::Invalid),
         }
     }
@@ -114,6 +174,9 @@ impl std::fmt::Display for CommitmentLevel {
             CommitmentLevel::Root => "root",
             CommitmentLevel::Single => "single",
             CommitmentLevel::SingleGossip => "singleGossip",
+            CommitmentLevel::Processed => "processed",
+            CommitmentLevel::Confirmed => "confirmed",
+            CommitmentLevel::Finalized => "finalized",
         };
         write!(f, "{}", s)
     }

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -85,6 +85,36 @@ impl CommitmentConfig {
             Some(self)
         }
     }
+
+    pub fn is_finalized(&self) -> bool {
+        matches!(
+            &self.commitment,
+            CommitmentLevel::Finalized | CommitmentLevel::Max | CommitmentLevel::Root
+        )
+    }
+
+    pub fn is_confirmed(&self) -> bool {
+        matches!(
+            &self.commitment,
+            CommitmentLevel::Confirmed | CommitmentLevel::SingleGossip | CommitmentLevel::Single
+        )
+    }
+
+    pub fn is_processed(&self) -> bool {
+        matches!(
+            &self.commitment,
+            CommitmentLevel::Processed | CommitmentLevel::Recent
+        )
+    }
+
+    pub fn use_deprecated_commitment(commitment: CommitmentConfig) -> Self {
+        match commitment.commitment {
+            CommitmentLevel::Finalized => CommitmentConfig::max(),
+            CommitmentLevel::Confirmed => CommitmentConfig::single_gossip(),
+            CommitmentLevel::Processed => CommitmentConfig::recent(),
+            _ => commitment,
+        }
+    }
 }
 
 impl FromStr for CommitmentConfig {

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated)]
+#![cfg(feature = "full")]
 
 use std::str::FromStr;
 use thiserror::Error;

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -60,6 +60,24 @@ impl CommitmentConfig {
         }
     }
 
+    pub fn finalized() -> Self {
+        Self {
+            commitment: CommitmentLevel::Finalized,
+        }
+    }
+
+    pub fn confirmed() -> Self {
+        Self {
+            commitment: CommitmentLevel::Confirmed,
+        }
+    }
+
+    pub fn processed() -> Self {
+        Self {
+            commitment: CommitmentLevel::Processed,
+        }
+    }
+
     pub fn ok(self) -> Option<Self> {
         if self == Self::default() {
             None

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -418,7 +418,7 @@ mod test {
             .unwrap();
 
         rpc_client
-            .poll_for_signature_with_commitment(&stake1_signature, CommitmentConfig::recent())
+            .poll_for_signature_with_commitment(&stake1_signature, CommitmentConfig::processed())
             .unwrap();
 
         // A balance increase by system transfer is ignored
@@ -473,7 +473,7 @@ mod test {
         rpc_client
             .poll_for_signature_with_commitment(
                 &stake3_initialize_signature,
-                CommitmentConfig::recent(),
+                CommitmentConfig::processed(),
             )
             .unwrap();
 
@@ -504,7 +504,7 @@ mod test {
         rpc_client
             .poll_for_signature_with_commitment(
                 &stake3_withdraw_signature,
-                CommitmentConfig::recent(),
+                CommitmentConfig::processed(),
             )
             .unwrap();
 
@@ -529,7 +529,7 @@ mod test {
         rpc_client
             .poll_for_signature_with_commitment(
                 &stake4_initialize_signature,
-                CommitmentConfig::recent(),
+                CommitmentConfig::processed(),
             )
             .unwrap();
 
@@ -560,7 +560,7 @@ mod test {
         rpc_client
             .poll_for_signature_with_commitment(
                 &stake45_split_signature,
-                CommitmentConfig::recent(),
+                CommitmentConfig::processed(),
             )
             .unwrap();
 
@@ -577,12 +577,15 @@ mod test {
             ))
             .unwrap();
         rpc_client
-            .poll_for_signature_with_commitment(&fund_system1_signature, CommitmentConfig::recent())
+            .poll_for_signature_with_commitment(
+                &fund_system1_signature,
+                CommitmentConfig::processed(),
+            )
             .unwrap();
         accounts_info.enroll_system_account(
             &system1_keypair.pubkey(),
             rpc_client
-                .get_slot_with_commitment(CommitmentConfig::recent())
+                .get_slot_with_commitment(CommitmentConfig::processed())
                 .unwrap(),
             2 * one_sol,
         );
@@ -616,12 +619,15 @@ mod test {
             ))
             .unwrap();
         rpc_client
-            .poll_for_signature_with_commitment(&fund_system2_signature, CommitmentConfig::recent())
+            .poll_for_signature_with_commitment(
+                &fund_system2_signature,
+                CommitmentConfig::processed(),
+            )
             .unwrap();
         accounts_info.enroll_system_account(
             &system2_keypair.pubkey(),
             rpc_client
-                .get_slot_with_commitment(CommitmentConfig::recent())
+                .get_slot_with_commitment(CommitmentConfig::processed())
                 .unwrap(),
             2 * one_sol,
         );
@@ -644,7 +650,7 @@ mod test {
 
         // Process all the transactions
         let current_slot = rpc_client
-            .get_slot_with_commitment(CommitmentConfig::recent())
+            .get_slot_with_commitment(CommitmentConfig::processed())
             .unwrap();
         process_slots(&rpc_client, &mut accounts_info, current_slot + 1);
 

--- a/stake-o-matic/src/main.rs
+++ b/stake-o-matic/src/main.rs
@@ -534,7 +534,7 @@ fn transact(
             break;
         }
 
-        let slot = rpc_client.get_slot_with_commitment(CommitmentConfig::max())?;
+        let slot = rpc_client.get_slot_with_commitment(CommitmentConfig::finalized())?;
         info!(
             "Current slot={}, last_valid_slot={} (slots remaining: {}) ",
             slot,

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1046,7 +1046,7 @@ mod tests {
         let test_validator = TestValidator::with_no_fees(alice.pubkey());
         let url = test_validator.rpc_url();
 
-        let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
+        let client = RpcClient::new_with_commitment(url, CommitmentConfig::processed());
         test_process_distribute_tokens_with_client(&client, alice, None);
     }
 
@@ -1056,7 +1056,7 @@ mod tests {
         let test_validator = TestValidator::with_no_fees(alice.pubkey());
         let url = test_validator.rpc_url();
 
-        let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
+        let client = RpcClient::new_with_commitment(url, CommitmentConfig::processed());
         test_process_distribute_tokens_with_client(&client, alice, Some(sol_to_lamports(1.5)));
     }
 
@@ -1066,7 +1066,7 @@ mod tests {
         let test_validator = TestValidator::with_no_fees(alice.pubkey());
         let url = test_validator.rpc_url();
 
-        let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
+        let client = RpcClient::new_with_commitment(url, CommitmentConfig::processed());
         test_process_distribute_stake_with_client(&client, alice);
     }
 
@@ -1381,7 +1381,7 @@ mod tests {
         let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
 
-        let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
+        let client = RpcClient::new_with_commitment(url, CommitmentConfig::processed());
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
         write_keypair_file(&alice, &sender_keypair_file).unwrap();
 
@@ -1464,7 +1464,7 @@ mod tests {
         let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
 
-        let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
+        let client = RpcClient::new_with_commitment(url, CommitmentConfig::processed());
 
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
         write_keypair_file(&alice, &sender_keypair_file).unwrap();
@@ -1573,7 +1573,7 @@ mod tests {
         let alice = Keypair::new();
         let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
-        let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
+        let client = RpcClient::new_with_commitment(url, CommitmentConfig::processed());
 
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
         write_keypair_file(&alice, &sender_keypair_file).unwrap();
@@ -1680,7 +1680,7 @@ mod tests {
         let test_validator = TestValidator::with_custom_fees(alice.pubkey(), fees);
         let url = test_validator.rpc_url();
 
-        let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
+        let client = RpcClient::new_with_commitment(url, CommitmentConfig::processed());
 
         let sender_keypair_file = tmp_file_path("keypair_file", &alice.pubkey());
         write_keypair_file(&alice, &sender_keypair_file).unwrap();
@@ -1994,7 +1994,7 @@ mod tests {
         let sender_keypair = Keypair::new();
         let test_validator = TestValidator::with_no_fees(sender_keypair.pubkey());
         let url = test_validator.rpc_url();
-        let client = RpcClient::new_with_commitment(url, CommitmentConfig::recent());
+        let client = RpcClient::new_with_commitment(url, CommitmentConfig::processed());
 
         let fee_payer = Keypair::new();
         let transaction = transfer(

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -435,14 +435,16 @@ fn main() {
             rpc_client: &RpcClient,
             identity: &Pubkey,
         ) -> client_error::Result<(Slot, Slot, Slot, u64, Sol, String)> {
-            let processed_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::recent())?;
+            let processed_slot =
+                rpc_client.get_slot_with_commitment(CommitmentConfig::processed())?;
             let confirmed_slot =
-                rpc_client.get_slot_with_commitment(CommitmentConfig::single_gossip())?;
-            let finalized_slot = rpc_client.get_slot_with_commitment(CommitmentConfig::max())?;
+                rpc_client.get_slot_with_commitment(CommitmentConfig::confirmed())?;
+            let finalized_slot =
+                rpc_client.get_slot_with_commitment(CommitmentConfig::finalized())?;
             let transaction_count =
-                rpc_client.get_transaction_count_with_commitment(CommitmentConfig::recent())?;
+                rpc_client.get_transaction_count_with_commitment(CommitmentConfig::processed())?;
             let identity_balance = rpc_client
-                .get_balance_with_commitment(identity, CommitmentConfig::single_gossip())?
+                .get_balance_with_commitment(identity, CommitmentConfig::confirmed())?
                 .value;
 
             let health = match rpc_client.get_health() {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -323,7 +323,7 @@ fn check_vote_account(
     authorized_voter_pubkeys: &[Pubkey],
 ) -> Result<(), String> {
     let vote_account = rpc_client
-        .get_account_with_commitment(vote_account_address, CommitmentConfig::single_gossip())
+        .get_account_with_commitment(vote_account_address, CommitmentConfig::confirmed())
         .map_err(|err| format!("failed to fetch vote account: {}", err.to_string()))?
         .value
         .ok_or_else(|| format!("vote account does not exist: {}", vote_account_address))?;
@@ -336,7 +336,7 @@ fn check_vote_account(
     }
 
     let identity_account = rpc_client
-        .get_account_with_commitment(identity_pubkey, CommitmentConfig::single_gossip())
+        .get_account_with_commitment(identity_pubkey, CommitmentConfig::confirmed())
         .map_err(|err| format!("failed to fetch identity account: {}", err.to_string()))?
         .value
         .ok_or_else(|| format!("identity account does not exist: {}", identity_pubkey))?;
@@ -690,7 +690,7 @@ fn rpc_bootstrap(
                     Ok(())
                 } else {
                     rpc_client
-                        .get_slot_with_commitment(CommitmentConfig::root())
+                        .get_slot_with_commitment(CommitmentConfig::finalized())
                         .map_err(|err| format!("Failed to get RPC node slot: {}", err))
                         .and_then(|slot| {
                             info!("RPC node root slot: {}", slot);


### PR DESCRIPTION
#### Problem
#14430 introduced new, more clear and correct commitment terminology. Time to use it everywhere, adding the new variants to `CommitmentLevel` and deprecating the old ones.

#### Summary of Changes
- Add new variants to structs and methods in `sdk/src/commitment_config.rs`, including helpers to allow removal of deprecated code in downstream crates now (and no changes later when deprecated variants are removed)
- Remove or update lots of deprecated code
- Add methods to RpcClient to check version of rpc node and map commitment config to old variants when necessary. This preserves compatibility between new cli/clients and old nodes.

Fixes #14414 

Follow-up work:
- [ ] Fix up solana-web3 to support new terminology (separate pr)
