### PR TITLE
Reduce ~2 GBs mem by avoiding another overalloc.

### DIFF
--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -65,7 +65,7 @@ impl Packets {
 pub fn to_packets_chunked<T: Serialize>(xs: &[T], chunks: usize) -> Vec<Packets> {
     let mut out = vec![];
     for x in xs.chunks(chunks) {
-        let mut p = Packets::with_capacity(chunks);
+        let mut p = Packets::with_capacity(x.len());
         p.packets.resize(x.len(), Packet::default());
         for (i, o) in x.iter().zip(p.packets.iter_mut()) {
             Packet::populate_packet(o, None, i).expect("serialize request");

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -19,8 +19,7 @@ pub struct Packets {
 //auto derive doesn't support large arrays
 impl Default for Packets {
     fn default() -> Packets {
-        let packets = PinnedVec::with_capacity(NUM_RCVMMSGS);
-        Packets { packets }
+        Self::with_capacity(NUM_RCVMMSGS)
     }
 }
 
@@ -30,6 +29,11 @@ impl Packets {
     pub fn new(packets: Vec<Packet>) -> Self {
         let packets = PinnedVec::from_vec(packets);
         Self { packets }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let packets = PinnedVec::with_capacity(capacity);
+        Packets { packets }
     }
 
     pub fn new_with_recycler(recycler: PacketsRecycler, size: usize, name: &'static str) -> Self {
@@ -61,7 +65,7 @@ impl Packets {
 pub fn to_packets_chunked<T: Serialize>(xs: &[T], chunks: usize) -> Vec<Packets> {
     let mut out = vec![];
     for x in xs.chunks(chunks) {
-        let mut p = Packets::default();
+        let mut p = Packets::with_capacity(chunks);
         p.packets.resize(x.len(), Packet::default());
         for (i, o) in x.iter().zip(p.packets.iter_mut()) {
             Packet::populate_packet(o, None, i).expect("serialize request");


### PR DESCRIPTION
#### Problem

Currently, `ClusterInfoVoteListener` over-allocates (unrecycled) `Packets` by factor of 128. Ultimately, this results in approximately ~2G consistent unneeded memory use  both on testnet and mainnet-beta, which is not easily swappable because of quick create and destroy.

##### Details

Firstly, about the the overallocation:

`ClusterInfoVoteListener` calls `to_packets_chunked` and in turn it calls `Packets::Default()`, which surprisingly creates PinnedVec with capacity of `128`. (I have a draft cleaning pr for this)

https://github.com/solana-labs/solana/blob/cbffab7850e3c3d1545c688da76ee636306b16fa/core/src/cluster_info_vote_listener.rs#L344

https://github.com/solana-labs/solana/blob/cbffab7850e3c3d1545c688da76ee636306b16fa/perf/src/packet.rs#L61-L64

https://github.com/solana-labs/solana/blob/cbffab7850e3c3d1545c688da76ee636306b16fa/perf/src/packet.rs#L21-L22

https://github.com/solana-labs/solana/blob/cbffab7850e3c3d1545c688da76ee636306b16fa/perf/src/packet.rs#L11

Then, `Packet`'s memory size is a `1304`:

https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=adfaa40101d596d9e372f96b20f1a9df

And finally, `VerifiedVotePakcets` retains those `Packets` keyed by `CrdsValueLabel::Vote(VoteIndex, Pubkey)`:

https://github.com/solana-labs/solana/blob/cbffab7850e3c3d1545c688da76ee636306b16fa/core/src/verified_vote_packets.rs#L9

https://github.com/solana-labs/solana/blob/cbffab7850e3c3d1545c688da76ee636306b16fa/core/src/verified_vote_packets.rs#L28-L32


Also, combined with the fact that there are 300~400 validators both on testnet and mainnet-beta, and x32 votes per validator, we allocate 2G mem, only for 15M worth data (x 128):


```
[4] pry(main)> 1304 * 32 * 400 * 128 / (1024 * 1024)
=> 2037
[5] pry(main)> 1304 * 32 * 400 / (1024 * 1024)
=> 15
```


And this is found by anallyzing the following `heaptrack` info:


```
1.99GB leaked over 259982 calls from
  alloc::alloc::alloc::h42bff26f59c33bd6
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:86
    in /home/sol/.local/share/solana/install/releases/1.4.23/solana-release/bin/solana-validator
  alloc::alloc::Global::alloc_impl::h6e8f952ef784c80f
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:166
  _$LT$alloc..alloc..Global$u20$as$u20$core..alloc..Allocator$GT$::allocate::hcd5aa98f8fdb82d8
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:226
  alloc::raw_vec::RawVec$LT$T$C$A$GT$::allocate_in::h35baa41fee755df6
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:188
  alloc::raw_vec::RawVec$LT$T$C$A$GT$::with_capacity_in::hb6938eb2e8af4afe
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/raw_vec.rs:129
  alloc::vec::Vec$LT$T$C$A$GT$::with_capacity_in::h6fb314e1783cedc5
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec.rs:498
  alloc::vec::Vec$LT$T$GT$::with_capacity::hc736c0b130ffbed8
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/vec.rs:364
  solana_perf::cuda_runtime::PinnedVec$LT$T$GT$::with_capacity::h0e9b629a9ac237cd
    at perf/src/cuda_runtime.rs:235
  _$LT$solana_perf..packet..Packets$u20$as$u20$core..default..Default$GT$::default::h713f4e6119bb937f
    at perf/src/packet.rs:22
  solana_perf::packet::to_packets_chunked::hfc385ec0d9e6a87f
    at /home/ryoqun/work/solana/solana/perf/src/packet.rs:64
    in /home/sol/.local/share/solana/install/releases/1.4.23/solana-release/bin/solana-validator
  solana_core::cluster_info_vote_listener::ClusterInfoVoteListener::verify_votes::hb7280041ea55ff2d
    at core/src/cluster_info_vote_listener.rs:344
    in /home/sol/.local/share/solana/install/releases/1.4.23/solana-release/bin/solana-validator
  solana_core::cluster_info_vote_listener::ClusterInfoVoteListener::recv_loop::h89d6a22bbe2764cc
    at core/src/cluster_info_vote_listener.rs:331
  solana_core::cluster_info_vote_listener::ClusterInfoVoteListener::new::_$u7b$$u7b$closure$u7d$$u7d$::h29f58de0cb36359c
    at core/src/cluster_info_vote_listener.rs:262
    in /home/sol/.local/share/solana/install/releases/1.4.23/solana-release/bin/solana-validator
  std::sys_common::backtrace::__rust_begin_short_backtrace::h9b49012839beba4e
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys_common/backtrace.rs:125
  std::thread::Builder::spawn_unchecked::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h3041e870e79d8d0a
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:474
    in /home/sol/.local/share/solana/install/releases/1.4.23/solana-release/bin/solana-validator
  _$LT$std..panic..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::h3acac363628da548
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:322
  std::panicking::try::do_call::h5442c435157cc750
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:379
  std::panicking::try::h0687aaf903e83c62
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:343
  std::panic::catch_unwind::h9eed9da9fa29a1cc
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:396
  std::thread::Builder::spawn_unchecked::_$u7b$$u7b$closure$u7d$$u7d$::hd72846f01979a93e
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/thread/mod.rs:473
  core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h6aedf8cd756546ae
    at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:227
  _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::hea1090dbdcecbf5a
    at /rustc/7efc097c4fe6e97f54a44cee91c56189e9ddb41c/library/alloc/src/boxed.rs:1328
    in /home/sol/.local/share/solana/install/releases/1.4.23/solana-release/bin/solana-validator
  _$LT$alloc..boxed..Box$LT$F$C$A$GT$$u20$as$u20$core..ops..function..FnOnce$LT$Args$GT$$GT$::call_once::h8d5723d3912bd325
    at /rustc/7efc097c4fe6e97f54a44cee91c56189e9ddb41c/library/alloc/src/boxed.rs:1328
  std::sys::unix::thread::Thread::new::thread_start::hc17a425ca2995724
    at library/std/src/sys/unix/thread.rs:71
  start_thread
    in /lib/x86_64-linux-gnu/libpthread.so.0
  __clone
    in /lib/x86_64-linux-gnu/libc.so.6

```

#### Changes

Just don't overallocate. In this case, `Packets` with capacity of `1` seems to be correct.

Also, as this was such an instance, I think `Packets::default` should be changed. I'll do that as a follow-up PR; I first want to land this pretty low-risk memory saving pr to ship it to both v1.4 & v1.5.

Found via: #14366 
related to in that this is overallocation bug: #14435 
started to overallocate maybe at?: #9694