### PR TITLE
Only mmap file from snapshot once

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -381,13 +381,18 @@ impl AccountStorageEntry {
         }
     }
 
-    pub(crate) fn new_empty_map(id: AppendVecId, accounts_current_len: usize) -> Self {
+    pub(crate) fn new_existing(
+        slot: Slot,
+        id: AppendVecId,
+        accounts: AppendVec,
+        num_accounts: usize,
+    ) -> Self {
         Self {
             id: AtomicUsize::new(id),
-            slot: AtomicU64::new(0),
-            accounts: AppendVec::new_empty_map(accounts_current_len),
+            slot: AtomicU64::new(slot),
+            accounts,
             count_and_status: RwLock::new((0, AccountStorageStatus::Available)),
-            approx_store_count: AtomicUsize::new(0),
+            approx_store_count: AtomicUsize::new(num_accounts),
             alive_bytes: AtomicUsize::new(0),
         }
     }
@@ -519,13 +524,6 @@ impl AccountStorageEntry {
         count -= 1;
         *count_and_status = (count, status);
         count
-    }
-
-    pub fn set_file<P: AsRef<Path>>(&mut self, path: P) -> IOResult<()> {
-        let num_accounts = self.accounts.set_file(path)?;
-        self.approx_store_count
-            .store(num_accounts, Ordering::Relaxed);
-        Ok(())
     }
 
     pub fn get_relative_path(&self) -> Option<PathBuf> {

--- a/runtime/src/serde_snapshot/future.rs
+++ b/runtime/src/serde_snapshot/future.rs
@@ -12,6 +12,20 @@ pub(super) struct SerializableAccountStorageEntry {
     accounts_current_len: usize,
 }
 
+pub trait SerializableStorage {
+    fn id(&self) -> AppendVecId;
+    fn current_len(&self) -> usize;
+}
+
+impl SerializableStorage for SerializableAccountStorageEntry {
+    fn id(&self) -> AppendVecId {
+        self.id
+    }
+    fn current_len(&self) -> usize {
+        self.accounts_current_len
+    }
+}
+
 #[cfg(all(test, RUSTC_WITH_SPECIALIZATION))]
 impl solana_frozen_abi::abi_example::IgnoreAsHelper for SerializableAccountStorageEntry {}
 
@@ -21,12 +35,6 @@ impl From<&AccountStorageEntry> for SerializableAccountStorageEntry {
             id: rhs.append_vec_id(),
             accounts_current_len: rhs.accounts.len(),
         }
-    }
-}
-
-impl From<SerializableAccountStorageEntry> for AccountStorageEntry {
-    fn from(s: SerializableAccountStorageEntry) -> Self {
-        AccountStorageEntry::new_empty_map(s.id, s.accounts_current_len)
     }
 }
 

--- a/runtime/store-tool/src/main.rs
+++ b/runtime/store-tool/src/main.rs
@@ -25,15 +25,13 @@ fn main() {
 
     let file = value_t_or_exit!(matches, "file", String);
     let len = value_t_or_exit!(matches, "len", usize);
-    let mut store = AppendVec::new_empty_map(len);
+    let (mut store, num_accounts) = AppendVec::new_from_file(file, len).expect("should succeed");
     store.set_no_remove_on_drop();
-    store.set_file(file).expect("set_file failed");
-    let accounts = store.accounts(0);
     info!(
         "store: len: {} capacity: {} accounts: {}",
         store.len(),
         store.capacity(),
-        accounts.len()
+        num_accounts,
     );
     for account in store.accounts(0) {
         info!(


### PR DESCRIPTION
#### Problem

Two mmaps are created for each append-vec in a snapshot, first an anonymous map which is then dropped, and then the real map. Creating and destroying the anonymous map is quite expensive and slows down snapshot ingestion.

#### Summary of Changes

Don't create anonymous map initially, and just map directly the real mmap that should be used.

Takes about 3 seconds off the `reconstruct_accountsdb_from_fields` function to ingest a mainnet-beta snapshot.

Fixes #
