### PR TITLE
fixes test_filter_current flakiness

### DIFF
--- a/core/src/crds_value.rs
+++ b/core/src/crds_value.rs
@@ -870,8 +870,11 @@ mod test {
             match value.wallclock().cmp(&current_value.wallclock()) {
                 Ordering::Less => (),
                 Ordering::Equal => {
-                    assert_eq!(value, *current_value);
-                    count += 1;
+                    // There is a chance that two randomly generated
+                    // crds-values have the same label and wallclock.
+                    if value == *current_value {
+                        count += 1;
+                    }
                 }
                 Ordering::Greater => panic!("this should not happen!"),
             }


### PR DESCRIPTION
#### Problem
`new_rand_timestamp` is using current system time:
https://github.com/solana-labs/solana/blob/e1021d9f8/core/src/crds_value.rs#L134
which causes `test_filter_current` to be flaky despite fixing random seed in https://github.com/solana-labs/solana/pull/14749 


#### Summary of Changes
Updated test assertions to taking into account that two randomly generated crds-values have the same label and wallclock.

Fixes #14744
