### PR TITLE
camelCase json field labels

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1144,12 +1144,12 @@ fn do_process_program_write_and_deploy(
 
     if let Some(program_signer) = program_signer {
         Ok(json!({
-            "ProgramId": format!("{}", program_signer.pubkey()),
+            "programId": format!("{}", program_signer.pubkey()),
         })
         .to_string())
     } else {
         Ok(json!({
-            "Buffer": format!("{}", buffer_pubkey),
+            "buffer": format!("{}", buffer_pubkey),
         })
         .to_string())
     }


### PR DESCRIPTION
#### Problem
`solana program deploy` returns json, but isn't consistent with camel-casing field labels.

#### Summary of Changes
- Fix it
In the future, consider fixing these commands to use OutputFormat to be consistent with other cli commands, instead of json all the time.

Fixes #14830

cc @jackcmay 
