### PR TITLE
Include Clock sysvar in StakeInstruction::AuthorizeWithSeed instruction

### DIFF
--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -66,7 +66,7 @@ pub enum StakeInstruction {
     ///
     /// # Account references
     ///   0. [WRITE] Stake account to be updated
-    ///   1. [] (reserved for future use) Clock sysvar
+    ///   1. [] Clock sysvar
     ///   2. [SIGNER] The stake or withdraw authority
     Authorize(Pubkey, StakeAuthorize),
 
@@ -138,6 +138,7 @@ pub enum StakeInstruction {
     /// # Account references
     ///   0. [WRITE] Stake account to be updated
     ///   1. [SIGNER] Base key of stake or withdraw authority
+    ///   2. [] Clock sysvar
     AuthorizeWithSeed(AuthorizeWithSeedArgs),
 }
 
@@ -368,6 +369,7 @@ pub fn authorize_with_seed(
     let account_metas = vec![
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new_readonly(*authority_base, true),
+        AccountMeta::new_readonly(sysvar::clock::id(), false),
     ];
 
     let args = AuthorizeWithSeedArgs {

--- a/transaction-status/src/parse_stake.rs
+++ b/transaction-status/src/parse_stake.rs
@@ -354,7 +354,7 @@ mod test {
         );
         let message = Message::new(&[instruction], None);
         assert_eq!(
-            parse_stake(&message.instructions[0], &keys[0..2]).unwrap(),
+            parse_stake(&message.instructions[0], &keys[0..3]).unwrap(),
             ParsedInstructionEnum {
                 instruction_type: "authorizeWithSeed".to_string(),
                 info: json!({

--- a/web3.js/src/stake-program.js
+++ b/web3.js/src/stake-program.js
@@ -646,6 +646,7 @@ export class StakeProgram {
       keys: [
         {pubkey: stakePubkey, isSigner: false, isWritable: true},
         {pubkey: authorityBase, isSigner: true, isWritable: false},
+        {pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false},
       ],
       programId: this.programId,
       data,

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -411,7 +411,8 @@ test('get epoch info', async () => {
     'epoch',
     'slotIndex',
     'slotsInEpoch',
-    'absoluteSlot' /*, 'blockHeight'*/, // Uncomment blockHeight after 1.1.20 ships
+    'absoluteSlot',
+    'blockHeight',
   ]) {
     expect(epochInfo).toHaveProperty(key);
     expect(epochInfo[key]).toBeGreaterThanOrEqual(0);

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -2012,7 +2012,7 @@ test('transaction failure', async () => {
     url,
     {
       method: 'requestAirdrop',
-      params: [account.publicKey.toBase58(), minimumAmount + 100010],
+      params: [account.publicKey.toBase58(), 3 * minimumAmount],
     },
     {
       error: null,
@@ -2022,7 +2022,7 @@ test('transaction failure', async () => {
   ]);
   const airdropSignature = await connection.requestAirdrop(
     account.publicKey,
-    minimumAmount + 100010,
+    3 * minimumAmount,
   );
 
   mockConfirmTransaction(airdropSignature);
@@ -2040,12 +2040,12 @@ test('transaction failure', async () => {
         context: {
           slot: 11,
         },
-        value: minimumAmount + 100010,
+        value: 3 * minimumAmount,
       },
     },
   ]);
   expect(await connection.getBalance(account.publicKey)).toBe(
-    minimumAmount + 100010,
+    3 * minimumAmount,
   );
 
   mockGetRecentBlockhash('max');
@@ -2066,7 +2066,7 @@ test('transaction failure', async () => {
     SystemProgram.createAccount({
       fromPubkey: account.publicKey,
       newAccountPubkey: newAccount.publicKey,
-      lamports: 1000,
+      lamports: minimumAmount,
       space: 0,
       programId: SystemProgram.programId,
     }),
@@ -2099,7 +2099,7 @@ test('transaction failure', async () => {
     SystemProgram.createAccount({
       fromPubkey: account.publicKey,
       newAccountPubkey: newAccount.publicKey,
-      lamports: 10,
+      lamports: minimumAmount + 1,
       space: 0,
       programId: SystemProgram.programId,
     }),


### PR DESCRIPTION
Unlike `StakeInstruction::Authorize`, the `StakeInstruction::AuthorizeWithSeed` instruction is missing the clock sysvar.  This will make it impossible to implement https://github.com/solana-labs/solana/issues/14587

To prepare for a future where #14587 exists, add the Clock sysvar to `StakeInstruction::AuthorizeWithSeed` instruction construction in the Rust and Javascript clients.  