### PR TITLE
Rotate feature key: use loaded executable accounts

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -155,7 +155,7 @@ pub mod abort_on_all_cpi_failures {
 }
 
 pub mod use_loaded_executables {
-    solana_sdk::declare_id!("2SLL2KLakB83YAnF1TwFb1hpycrWeHAfHYyLhwk2JRGn");
+    solana_sdk::declare_id!("3Jq7mE2chDpf6oeEDsuGK7orTYEgyQjCPvaRppTNdVGK");
 }
 
 pub mod turbine_retransmit_peers_patch {


### PR DESCRIPTION
#### Problem

Activated on mainnet before the feature was available there which could cause the v1.5 nodes where the feature is available to be forked off.

#### Summary of Changes

Rotate the key and re-activate at another epoch

Fixes #
