### PR TITLE
Add StakeInstruction::Merge logging

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -227,6 +227,7 @@ impl RpcClient {
                         for (i, log) in logs.iter().enumerate() {
                             debug!("{:>3}: {}", i + 1, log);
                         }
+                        debug!("");
                     }
                 }
                 return Err(err);

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -449,7 +449,7 @@ pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     data: &[u8],
-    _invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
@@ -500,6 +500,7 @@ pub fn process_instruction(
         StakeInstruction::Merge => {
             let source_stake = &next_keyed_account(keyed_accounts)?;
             me.merge(
+                invoke_context,
                 source_stake,
                 &from_keyed_account::<Clock>(next_keyed_account(keyed_accounts)?)?,
                 &from_keyed_account::<StakeHistory>(next_keyed_account(keyed_accounts)?)?,


### PR DESCRIPTION
I was confused a while ago why a stake merge failed with StakeError::MergeMismatch, as that error is returned from multiple points.  Take the opportunity to build on the recently-added `ic_msg()` macro to plumb some logging through the stake merge code.  Adding full logging through all the stake instructions is for some future PR