### PR TITLE
Bumps RBPF to v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5300,9 +5300,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cd2bce0b970bcc90210d005d838cd37745899f41f4d096edc58b49d8bb6094"
+checksum = "cef52e1b7993b49ea5c2f65b1363bdc6f38046e467585d08094f54bf55db5ccc"
 dependencies = [
  "byteorder",
  "combine",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,7 +37,7 @@ solana-config-program = { path = "../programs/config", version = "1.6.0" }
 solana-faucet = { path = "../faucet", version = "1.6.0" }
 solana-logger = { path = "../logger", version = "1.6.0" }
 solana-net-utils = { path = "../net-utils", version = "1.6.0" }
-solana_rbpf = "=0.2.3"
+solana_rbpf = "=0.2.4"
 solana-remote-wallet = { path = "../remote-wallet", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.6.0" }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3329,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "solana_rbpf"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cd2bce0b970bcc90210d005d838cd37745899f41f4d096edc58b49d8bb6094"
+checksum = "cef52e1b7993b49ea5c2f65b1363bdc6f38046e467585d08094f54bf55db5ccc"
 dependencies = [
  "byteorder 1.3.4",
  "combine",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -29,7 +29,7 @@ solana-bpf-loader-program = { path = "../bpf_loader", version = "1.6.0" }
 solana-cli-output = { path = "../../cli-output", version = "1.6.0" }
 solana-logger = { path = "../../logger", version = "1.6.0" }
 solana-measure = { path = "../../measure", version = "1.6.0" }
-solana_rbpf = "=0.2.3"
+solana_rbpf = "=0.2.4"
 solana-runtime = { path = "../../runtime", version = "1.6.0" }
 solana-sdk = { path = "../../sdk", version = "1.6.0" }
 solana-transaction-status = { path = "../../transaction-status", version = "1.6.0" }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -16,7 +16,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-runtime = { path = "../../runtime", version = "1.6.0" }
 solana-sdk = { path = "../../sdk", version = "1.6.0" }
-solana_rbpf = "=0.2.3"
+solana_rbpf = "=0.2.4"
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
#### Problem
`unwrap` in RBPF `vm::bind_syscall_context_object()` causes crash

#### Summary of Changes
Replaces `unwrap` by `return Err`

Fixes #
