### PR TITLE
install: Add version envvar to `info --eval` output

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -584,6 +584,16 @@ pub fn info(
             "SOLANA_INSTALL_ACTIVE_RELEASE={}",
             &config.active_release_dir().to_str().unwrap_or("")
         );
+        config
+            .explicit_release
+            .map(|er| match er {
+                ExplicitRelease::Semver(semver) => semver,
+                ExplicitRelease::Channel(channel) => channel,
+            })
+            .and_then(|channel| {
+                println!("SOLANA_INSTALL_ACTIVE_CHANNEL={}", channel,);
+                Option::<String>::None
+            });
         return Ok(None);
     }
 


### PR DESCRIPTION
#### Problem

No easy way to get the version of the `solana-install` active release in shell scripts

#### Summary of Changes

Add a `SOLANA_INSTALL_ACTIVE_CHANNEL` envvar to the output of `solana-install info --eval`