### PR TITLE
explorer: Only report getBlockTime error under max confs

### DIFF
--- a/explorer/src/providers/transactions/index.tsx
+++ b/explorer/src/providers/transactions/index.tsx
@@ -75,22 +75,22 @@ export async function fetchTransactionStatus(
 
     let info = null;
     if (value !== null) {
-      let blockTime = null;
-      try {
-        blockTime = await connection.getBlockTime(value.slot);
-      } catch (error) {
-        if (cluster === Cluster.MainnetBeta) {
-          reportError(error, { slot: `${value.slot}` });
-        }
-      }
-      let timestamp: Timestamp = blockTime !== null ? blockTime : "unavailable";
-
       let confirmations: Confirmations;
       if (typeof value.confirmations === "number") {
         confirmations = value.confirmations;
       } else {
         confirmations = "max";
       }
+
+      let blockTime = null;
+      try {
+        blockTime = await connection.getBlockTime(value.slot);
+      } catch (error) {
+        if (cluster === Cluster.MainnetBeta && confirmations === "max") {
+          reportError(error, { slot: `${value.slot}` });
+        }
+      }
+      let timestamp: Timestamp = blockTime !== null ? blockTime : "unavailable";
 
       info = {
         slot: value.slot,


### PR DESCRIPTION
#### Problem
If a user lands on the transaction details page before maximum confirmations, an error most likely will be reported when the block time is attempted to be retrieved. 

#### Summary of Changes
Only report this error to Sentry if confirmations are max

