### PR TITLE
Richer runtime failure logging

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -915,13 +915,13 @@ fn test_program_bpf_invoke_sanity() {
 
         do_invoke_failure_test_local(
             TEST_INSTRUCTION_DATA_TOO_LARGE,
-            TransactionError::InstructionError(0, InstructionError::ComputationalBudgetExceeded),
+            TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete),
             &[],
         );
 
         do_invoke_failure_test_local(
             TEST_INSTRUCTION_META_TOO_LARGE,
-            TransactionError::InstructionError(0, InstructionError::ComputationalBudgetExceeded),
+            TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete),
             &[],
         );
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -779,17 +779,15 @@ impl Executor for BPFExecutor {
                     }
                 }
                 Err(error) => {
-                    ic_logger_msg!(logger, "Program {} BPF VM error: {}", program_id, error);
                     let error = match error {
                         EbpfError::UserError(BPFError::SyscallError(
                             SyscallError::InstructionError(error),
                         )) => error,
                         err => {
-                            ic_logger_msg!(logger, "Program failed to complete: {:?}", err);
+                            ic_logger_msg!(logger, "Program failed to complete: {}", err);
                             InstructionError::ProgramFailedToComplete
                         }
                     };
-
                     stable_log::program_failure(&logger, program_id, &error);
                     return Err(error);
                 }


### PR DESCRIPTION
#### Problem

Multiple failure paths produce the same error signature which doesn't tell developers much about why their program failed

#### Summary of Changes

Add more failure logging and logs with more information

Fixes #14522
