### PR TITLE
calculate hash from store instead of index

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
                 .update_accounts_hash(0, &ancestors, true);
             time.stop();
             let mut time_store = Measure::start("hash using store");
-            let results_store = accounts.accounts_db.update_accounts_hash_with_store_option(
+            let results_store = accounts.accounts_db.update_accounts_hash_with_index_option(
                 true,
                 false,
                 solana_sdk::clock::Slot::default(),
@@ -135,6 +135,6 @@ fn main() {
         info!("update_accounts_hash(us),{}", x);
     }
     for x in elapsed_store {
-        info!("calculate_accounts_hash_using_stores(us),{}", x);
+        info!("calculate_accounts_hash_without_index(us),{}", x);
     }
 }

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate log;
 use clap::{crate_description, crate_name, value_t, App, Arg};
 use rayon::prelude::*;
 use solana_measure::measure::Measure;
@@ -51,6 +53,7 @@ fn main() {
 
     let path = PathBuf::from(env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_owned()))
         .join("accounts-bench");
+    println!("cleaning file system: {:?}", path);
     if fs::remove_dir_all(path.clone()).is_err() {
         println!("Warning: Couldn't remove {:?}", path);
     }
@@ -84,6 +87,8 @@ fn main() {
         ancestors.insert(i as u64, i - 1);
         accounts.add_root(i as u64);
     }
+    let mut elapsed = vec![0; iterations];
+    let mut elapsed_store = vec![0; iterations];
     for x in 0..iterations {
         if clean {
             let mut time = Measure::start("clean");
@@ -97,13 +102,35 @@ fn main() {
         } else {
             let mut pubkeys: Vec<Pubkey> = vec![];
             let mut time = Measure::start("hash");
-            let hash = accounts
+            let results = accounts
                 .accounts_db
-                .update_accounts_hash(0, &ancestors, true)
-                .0;
+                .update_accounts_hash(0, &ancestors, true);
             time.stop();
-            println!("hash: {} {}", hash, time);
+            let mut time_store = Measure::start("hash using store");
+            let results_store = accounts
+                .accounts_db
+                .update_accounts_hash_with_store_option(true, false, solana_sdk::clock::Slot::default(), &ancestors, true);
+            time_store.stop();
+            if results != results_store {
+                error!("results different: \n{:?}\n{:?}", results, results_store);
+            }
+            println!(
+                "hash,{},{},{},{}%",
+                results.0,
+                time,
+                time_store,
+                (time_store.as_us() as f64 / time.as_us() as f64 * 100.0f64) as u32
+            );
             create_test_accounts(&accounts, &mut pubkeys, 1, 0);
+            elapsed[x] = time.as_us();
+            elapsed_store[x] = time_store.as_us();
         }
+    }
+
+    for x in elapsed {
+        info!("update_accounts_hash(us),{}", x);
+    }
+    for x in elapsed_store {
+        info!("calculate_accounts_hash_using_stores(us),{}", x);
     }
 }

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -107,9 +107,13 @@ fn main() {
                 .update_accounts_hash(0, &ancestors, true);
             time.stop();
             let mut time_store = Measure::start("hash using store");
-            let results_store = accounts
-                .accounts_db
-                .update_accounts_hash_with_store_option(true, false, solana_sdk::clock::Slot::default(), &ancestors, true);
+            let results_store = accounts.accounts_db.update_accounts_hash_with_store_option(
+                true,
+                false,
+                solana_sdk::clock::Slot::default(),
+                &ancestors,
+                true,
+            );
             time_store.stop();
             if results != results_store {
                 error!("results different: \n{:?}\n{:?}", results, results_store);

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -8,7 +8,9 @@ use crate::{
     cluster_info::{ClusterInfo, MAX_SNAPSHOT_HASHES},
     snapshot_packager_service::PendingSnapshotPackage,
 };
-use solana_runtime::snapshot_package::{AccountsPackagePre, AccountsPackageReceiver};
+use solana_runtime::snapshot_package::{
+    AccountsPackage, AccountsPackagePre, AccountsPackageReceiver,
+};
 use solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey};
 use std::collections::{HashMap, HashSet};
 use std::{
@@ -49,7 +51,7 @@ impl AccountsHashVerifier {
 
                     match accounts_package_receiver.recv_timeout(Duration::from_secs(1)) {
                         Ok(accounts_package) => {
-                            Self::process_accounts_package(
+                            Self::process_accounts_package_pre(
                                 accounts_package,
                                 &cluster_info,
                                 &trusted_validators,
@@ -72,7 +74,7 @@ impl AccountsHashVerifier {
         }
     }
 
-    fn process_accounts_package(
+    fn process_accounts_package_pre(
         accounts_package: AccountsPackagePre,
         cluster_info: &ClusterInfo,
         trusted_validators: &Option<HashSet<Pubkey>>,
@@ -83,7 +85,32 @@ impl AccountsHashVerifier {
         fault_injection_rate_slots: u64,
         snapshot_interval_slots: u64,
     ) {
-        let accounts_package = solana_runtime::snapshot_utils::process_accounts_package_pre(accounts_package);
+        let accounts_package =
+            solana_runtime::snapshot_utils::process_accounts_package_pre(accounts_package);
+        Self::process_accounts_package(
+            accounts_package,
+            cluster_info,
+            trusted_validators,
+            halt_on_trusted_validator_accounts_hash_mismatch,
+            pending_snapshot_package,
+            hashes,
+            exit,
+            fault_injection_rate_slots,
+            snapshot_interval_slots,
+        );
+    }
+
+    fn process_accounts_package(
+        accounts_package: AccountsPackage,
+        cluster_info: &ClusterInfo,
+        trusted_validators: &Option<HashSet<Pubkey>>,
+        halt_on_trusted_validator_accounts_hash_mismatch: bool,
+        pending_snapshot_package: &Option<PendingSnapshotPackage>,
+        hashes: &mut Vec<(Slot, Hash)>,
+        exit: &Arc<AtomicBool>,
+        fault_injection_rate_slots: u64,
+        snapshot_interval_slots: u64,
+    ) {
         let hash = accounts_package.hash;
         if fault_injection_rate_slots != 0
             && accounts_package.slot % fault_injection_rate_slots == 0

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -98,7 +98,7 @@ impl AccountsHashVerifier {
             "accounts_hash_verifier",
             ("calculate_hash", time.as_us(), i64),
         );
-        assert_eq!(hash.0, accounts_package.hash); // TODO: don't calculate hash elsewhere
+        //assert_eq!(hash.0, accounts_package.hash); // TODO: don't calculate hash elsewhere
 
         if fault_injection_rate_slots != 0
             && accounts_package.slot % fault_injection_rate_slots == 0

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -88,7 +88,7 @@ impl AccountsHashVerifier {
         let mut time = Measure::start("hash");
 
         let simple_capitalization_enabled = true; // ??? TODO
-        let hash = AccountsDB::calculate_accounts_hash_using_stores_only(
+        let _hash = AccountsDB::calculate_accounts_hash_using_stores_only(
             accounts_package.storages.clone(),
             simple_capitalization_enabled,
         );

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2537,7 +2537,9 @@ pub(crate) mod tests {
         assert_matches!(
             res,
             Err(
-                BlockstoreProcessorError::FailedToLoadEntries(BlockstoreError::InvalidShredData(_)),
+                BlockstoreProcessorError::FailedToLoadEntries(
+                    BlockstoreError::InvalidShredData(_)
+                ),
             )
         );
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2537,9 +2537,7 @@ pub(crate) mod tests {
         assert_matches!(
             res,
             Err(
-                BlockstoreProcessorError::FailedToLoadEntries(
-                    BlockstoreError::InvalidShredData(_)
-                ),
+                BlockstoreProcessorError::FailedToLoadEntries(BlockstoreError::InvalidShredData(_)),
             )
         );
     }

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -156,7 +156,7 @@ mod tests {
 
         // Create a packageable snapshot
         let output_tar_path = snapshot_utils::get_snapshot_archive_path(
-            &snapshot_package_output_path,
+            snapshot_package_output_path.to_path_buf(),
             &(42, Hash::default()),
             ArchiveFormat::TarBzip2,
         );

--- a/core/src/snapshot_packager_service.rs
+++ b/core/src/snapshot_packager_service.rs
@@ -156,7 +156,7 @@ mod tests {
 
         // Create a packageable snapshot
         let output_tar_path = snapshot_utils::get_snapshot_archive_path(
-            snapshot_package_output_path.to_path_buf(),
+            snapshot_package_output_path,
             &(42, Hash::default()),
             ArchiveFormat::TarBzip2,
         );

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -79,6 +79,7 @@ pub struct TvuConfig {
     pub repair_validators: Option<HashSet<Pubkey>>,
     pub accounts_hash_fault_injection_slots: u64,
     pub accounts_db_caching_enabled: bool,
+    pub test_hash_calculation: bool,
 }
 
 impl Tvu {
@@ -274,6 +275,7 @@ impl Tvu {
             &exit,
             accounts_background_request_handler,
             tvu_config.accounts_db_caching_enabled,
+            tvu_config.test_hash_calculation,
         );
 
         Tvu {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -121,6 +121,7 @@ pub struct ValidatorConfig {
     pub account_indexes: HashSet<AccountIndex>,
     pub accounts_db_caching_enabled: bool,
     pub warp_slot: Option<Slot>,
+    pub accounts_db_test_hash_calculation: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -168,6 +169,7 @@ impl Default for ValidatorConfig {
             account_indexes: HashSet::new(),
             accounts_db_caching_enabled: false,
             warp_slot: None,
+            accounts_db_test_hash_calculation: false,
         }
     }
 }
@@ -641,6 +643,7 @@ impl Validator {
                 repair_validators: config.repair_validators.clone(),
                 accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
                 accounts_db_caching_enabled: config.accounts_db_caching_enabled,
+                test_hash_calculation: config.accounts_db_test_hash_calculation,
             },
         );
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -218,7 +218,7 @@ mod tests {
             if slot % set_root_interval == 0 || slot == last_slot - 1 {
                 // set_root should send a snapshot request
                 bank_forks.set_root(bank.slot(), &request_sender, None);
-                snapshot_request_handler.handle_snapshot_requests(false);
+                snapshot_request_handler.handle_snapshot_requests(false, false);
             }
         }
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -238,6 +238,7 @@ mod tests {
             last_bank.get_snapshot_storages(),
             ArchiveFormat::TarBzip2,
             snapshot_version,
+            None,
         )
         .unwrap();
         let snapshot_package = snapshot_utils::process_accounts_package_pre(snapshot_package);
@@ -359,6 +360,7 @@ mod tests {
                 &snapshot_package_output_path,
                 snapshot_config.snapshot_version,
                 &snapshot_config.archive_format,
+                None,
             )
             .unwrap();
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -218,6 +218,7 @@ mod tests {
             if slot % set_root_interval == 0 || slot == last_slot - 1 {
                 // set_root should send a snapshot request
                 bank_forks.set_root(bank.slot(), &request_sender, None);
+                bank.update_accounts_hash();
                 snapshot_request_handler.handle_snapshot_requests(false, false);
             }
         }

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -153,7 +153,7 @@ mod tests {
                 .unwrap()
                 .snapshot_path,
             snapshot_utils::get_snapshot_archive_path(
-                snapshot_package_output_path,
+                snapshot_package_output_path.to_path_buf(),
                 &(old_last_bank.slot(), old_last_bank.get_accounts_hash()),
                 ArchiveFormat::TarBzip2,
             ),
@@ -240,6 +240,7 @@ mod tests {
             snapshot_version,
         )
         .unwrap();
+        let snapshot_package = snapshot_utils::process_accounts_package_pre(snapshot_package);
         snapshot_utils::archive_snapshot_package(&snapshot_package).unwrap();
 
         // Restore bank from snapshot
@@ -383,7 +384,7 @@ mod tests {
                 fs_extra::dir::copy(&last_snapshot_path, &saved_snapshots_dir, &options).unwrap();
 
                 saved_archive_path = Some(snapshot_utils::get_snapshot_archive_path(
-                    snapshot_package_output_path,
+                    snapshot_package_output_path.to_path_buf(),
                     &(slot, accounts_hash),
                     ArchiveFormat::TarBzip2,
                 ));
@@ -425,6 +426,7 @@ mod tests {
                         snapshot_package = new_snapshot_package;
                     }
 
+                    let snapshot_package = solana_runtime::snapshot_utils::process_accounts_package_pre(snapshot_package);
                     *pending_snapshot_package.lock().unwrap() = Some(snapshot_package);
                 }
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -426,7 +426,10 @@ mod tests {
                         snapshot_package = new_snapshot_package;
                     }
 
-                    let snapshot_package = solana_runtime::snapshot_utils::process_accounts_package_pre(snapshot_package);
+                    let snapshot_package =
+                        solana_runtime::snapshot_utils::process_accounts_package_pre(
+                            snapshot_package,
+                        );
                     *pending_snapshot_package.lock().unwrap() = Some(snapshot_package);
                 }
 

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -180,7 +180,7 @@ pub fn download_snapshot(
         ArchiveFormat::TarBzip2,
     ] {
         let desired_snapshot_package = snapshot_utils::get_snapshot_archive_path(
-            ledger_path,
+            ledger_path.to_path_buf(),
             &desired_snapshot_hash,
             *compression,
         );

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1052,7 +1052,7 @@ fn test_snapshot_download() {
 
     trace!("found: {:?}", archive_filename);
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
-        &validator_snapshot_test_config.snapshot_output_path,
+        validator_snapshot_test_config.snapshot_output_path.path().to_path_buf(),
         &archive_snapshot_hash,
         ArchiveFormat::TarBzip2,
     );
@@ -1122,7 +1122,7 @@ fn test_snapshot_restart_tower() {
 
     // Copy archive to validator's snapshot output directory
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
-        &validator_snapshot_test_config.snapshot_output_path,
+        validator_snapshot_test_config.snapshot_output_path.path().to_path_buf(),
         &archive_snapshot_hash,
         ArchiveFormat::TarBzip2,
     );
@@ -1187,7 +1187,7 @@ fn test_snapshots_blockstore_floor() {
 
     // Copy archive to validator's snapshot output directory
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
-        &validator_snapshot_test_config.snapshot_output_path,
+        validator_snapshot_test_config.snapshot_output_path.path().to_path_buf(),
         &(archive_slot, archive_hash),
         ArchiveFormat::TarBzip2,
     );

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1052,7 +1052,10 @@ fn test_snapshot_download() {
 
     trace!("found: {:?}", archive_filename);
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
-        validator_snapshot_test_config.snapshot_output_path.path().to_path_buf(),
+        validator_snapshot_test_config
+            .snapshot_output_path
+            .path()
+            .to_path_buf(),
         &archive_snapshot_hash,
         ArchiveFormat::TarBzip2,
     );
@@ -1122,7 +1125,10 @@ fn test_snapshot_restart_tower() {
 
     // Copy archive to validator's snapshot output directory
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
-        validator_snapshot_test_config.snapshot_output_path.path().to_path_buf(),
+        validator_snapshot_test_config
+            .snapshot_output_path
+            .path()
+            .to_path_buf(),
         &archive_snapshot_hash,
         ArchiveFormat::TarBzip2,
     );
@@ -1187,7 +1193,10 @@ fn test_snapshots_blockstore_floor() {
 
     // Copy archive to validator's snapshot output directory
     let validator_archive_path = snapshot_utils::get_snapshot_archive_path(
-        validator_snapshot_test_config.snapshot_output_path.path().to_path_buf(),
+        validator_snapshot_test_config
+            .snapshot_output_path
+            .path()
+            .to_path_buf(),
         &(archive_slot, archive_hash),
         ArchiveFormat::TarBzip2,
     );

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,7 +14,7 @@ blake3 = "0.3.6"
 bv = { version = "0.11.1", features = ["serde"] }
 byteorder = "1.3.4"
 bzip2 = "0.3.3"
-dashmap = { version = "4.0.2", features = ["rayon"] }
+dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 crossbeam-channel = "0.4"
 dir-diff = "0.3.2"
 flate2 = "1.0.14"

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -77,7 +77,11 @@ pub struct SnapshotRequestHandler {
 
 impl SnapshotRequestHandler {
     // Returns the latest requested snapshot slot, if one exists
-    pub fn handle_snapshot_requests(&self, accounts_db_caching_enabled: bool) -> Option<u64> {
+    pub fn handle_snapshot_requests(
+        &self,
+        accounts_db_caching_enabled: bool,
+        test_hash_calculation: bool,
+    ) -> Option<u64> {
         self.snapshot_request_receiver
             .try_iter()
             .last()
@@ -87,10 +91,11 @@ impl SnapshotRequestHandler {
                     status_cache_slot_deltas,
                 } = snapshot_request;
 
-                // TODO - get rid of this as we move it to accounts_hash_verifier
-                let mut hash_time = Measure::start("hash_time");
-                snapshot_root_bank.update_accounts_hash();
-                hash_time.stop();
+                let mut hash_for_testing: Option<solana_sdk::hash::Hash> = None;
+                if test_hash_calculation {
+                    snapshot_root_bank.update_accounts_hash();
+                    hash_for_testing = Some(snapshot_root_bank.get_accounts_hash());
+                }
 
                 let mut shrink_time = Measure::start("shrink_time");
                 if !accounts_db_caching_enabled {
@@ -145,6 +150,7 @@ impl SnapshotRequestHandler {
                     &self.snapshot_config.snapshot_package_output_path,
                     self.snapshot_config.snapshot_version,
                     &self.snapshot_config.archive_format,
+                    hash_for_testing,
                 );
                 if r.is_err() {
                     warn!(
@@ -162,7 +168,6 @@ impl SnapshotRequestHandler {
 
                 datapoint_info!(
                     "handle_snapshot_requests-timing",
-                    ("hash_time", hash_time.as_us(), i64),
                     (
                         "flush_accounts_cache_time",
                         flush_accounts_cache_time.as_us(),
@@ -217,11 +222,11 @@ pub struct ABSRequestHandler {
 
 impl ABSRequestHandler {
     // Returns the latest requested snapshot block height, if one exists
-    pub fn handle_snapshot_requests(&self, accounts_db_caching_enabled: bool) -> Option<u64> {
+    pub fn handle_snapshot_requests(&self, accounts_db_caching_enabled: bool, test_hash_calculation: bool) -> Option<u64> {
         self.snapshot_request_handler
             .as_ref()
             .and_then(|snapshot_request_handler| {
-                snapshot_request_handler.handle_snapshot_requests(accounts_db_caching_enabled)
+                snapshot_request_handler.handle_snapshot_requests(accounts_db_caching_enabled, test_hash_calculation)
             })
     }
 
@@ -246,6 +251,7 @@ impl AccountsBackgroundService {
         exit: &Arc<AtomicBool>,
         request_handler: ABSRequestHandler,
         accounts_db_caching_enabled: bool,
+        test_hash_calculation: bool,
     ) -> Self {
         info!("AccountsBackgroundService active");
         let exit = exit.clone();
@@ -289,7 +295,7 @@ impl AccountsBackgroundService {
                 // snapshot_request_handler.handle_requests() will always look for the latest
                 // available snapshot in the channel.
                 let snapshot_block_height =
-                    request_handler.handle_snapshot_requests(accounts_db_caching_enabled);
+                    request_handler.handle_snapshot_requests(accounts_db_caching_enabled, test_hash_calculation);
                 if accounts_db_caching_enabled {
                     // Note that the flush will do an internal clean of the
                     // cache up to bank.slot(), so should be safe as long

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -222,11 +222,16 @@ pub struct ABSRequestHandler {
 
 impl ABSRequestHandler {
     // Returns the latest requested snapshot block height, if one exists
-    pub fn handle_snapshot_requests(&self, accounts_db_caching_enabled: bool, test_hash_calculation: bool) -> Option<u64> {
+    pub fn handle_snapshot_requests(
+        &self,
+        accounts_db_caching_enabled: bool,
+        test_hash_calculation: bool,
+    ) -> Option<u64> {
         self.snapshot_request_handler
             .as_ref()
             .and_then(|snapshot_request_handler| {
-                snapshot_request_handler.handle_snapshot_requests(accounts_db_caching_enabled, test_hash_calculation)
+                snapshot_request_handler
+                    .handle_snapshot_requests(accounts_db_caching_enabled, test_hash_calculation)
             })
     }
 
@@ -294,8 +299,8 @@ impl AccountsBackgroundService {
                 // request for `N` to the snapshot request channel before setting a root `R > N`, and
                 // snapshot_request_handler.handle_requests() will always look for the latest
                 // available snapshot in the channel.
-                let snapshot_block_height =
-                    request_handler.handle_snapshot_requests(accounts_db_caching_enabled, test_hash_calculation);
+                let snapshot_block_height = request_handler
+                    .handle_snapshot_requests(accounts_db_caching_enabled, test_hash_calculation);
                 if accounts_db_caching_enabled {
                     // Note that the flush will do an internal clean of the
                     // cache up to bank.slot(), so should be safe as long

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -87,8 +87,9 @@ impl SnapshotRequestHandler {
                     status_cache_slot_deltas,
                 } = snapshot_request;
 
+                // TODO - get rid of this as we move it to accounts_hash_verifier
                 let mut hash_time = Measure::start("hash_time");
-                snapshot_root_bank.update_accounts_hash();
+                snapshot_root_bank.update_accounts_hash_with_store_option(false, false);
                 hash_time.stop();
 
                 let mut shrink_time = Measure::start("shrink_time");

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -89,7 +89,7 @@ impl SnapshotRequestHandler {
 
                 // TODO - get rid of this as we move it to accounts_hash_verifier
                 let mut hash_time = Measure::start("hash_time");
-                snapshot_root_bank.update_accounts_hash_with_store_option(false, false);
+                snapshot_root_bank.update_accounts_hash();
                 hash_time.stop();
 
                 let mut shrink_time = Measure::start("shrink_time");

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5069,7 +5069,14 @@ pub mod tests {
                         true,
                     )
                     .0;
-                    assert_eq!(AccountsDB::accumulate_account_hashes(input.clone(), Slot::default(), false), result.0);
+                    assert_eq!(
+                        AccountsDB::accumulate_account_hashes(
+                            input.clone(),
+                            Slot::default(),
+                            false
+                        ),
+                        result.0
+                    );
                     AccountsDB::sort_hashes_by_pubkey(&mut input);
                 }
                 let mut expected = 0;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3672,7 +3672,7 @@ impl AccountsDB {
     pub fn rest_of_hash_calculation(
         accounts: (DashMap<Pubkey, CalculateHashIntermediate>, Measure, Measure),
     ) -> (Hash, u64) {
-        let (account_maps, time_scan, time_accumulate) = accounts;
+        let (account_maps, time_scan) = accounts;
 
         let len = account_maps.len();
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -290,9 +290,7 @@ impl<'a> LoadedAccount<'a> {
 
     pub fn lamports(&self) -> u64 {
         match self {
-            LoadedAccount::Stored(stored_account_meta) => {
-                stored_account_meta.account_meta.lamports
-            }
+            LoadedAccount::Stored(stored_account_meta) => stored_account_meta.account_meta.lamports,
             LoadedAccount::Cached((_, cached_account)) => match cached_account {
                 Cow::Owned(cached_account) => cached_account.account.lamports,
                 Cow::Borrowed(cached_account) => cached_account.account.lamports,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3691,10 +3691,6 @@ impl AccountsDB {
             ("sort", sort_time.as_us(), i64),
             ("hash_total", hash_total, i64),
         );
-        warn!(
-            "hashes including zeros: {}, after removal: {}, lamports: {}, hash: {}",
-            len, hash_total, ret.1, ret.0
-        );
 
         ret
     }
@@ -3744,15 +3740,10 @@ impl AccountsDB {
 
             assert_eq!(hash, hash_other);
             assert_eq!(total_lamports, total_lamports_other);
-            warn!("Verified: {}, {}", hash, total_lamports_other);
         }
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();
         bank_hash_info.snapshot_hash = hash;
-        warn!(
-            "maybe bank setting hash to: {}, slot: {}, lamports: {}, using_store: {}, debug: {}",
-            hash, slot, total_lamports, use_store, debug_verify_store
-        );
         (hash, total_lamports)
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -291,7 +291,7 @@ impl<'a> LoadedAccount<'a> {
     pub fn lamports(&self) -> u64 {
         match self {
             LoadedAccount::Stored(stored_account_meta) => {
-                stored_account_meta.clone_account().lamports
+                stored_account_meta.account_meta.lamports
             }
             LoadedAccount::Cached((_, cached_account)) => match cached_account {
                 Cow::Owned(cached_account) => cached_account.account.lamports,
@@ -3670,8 +3670,6 @@ impl AccountsDB {
         accounts: (DashMap<Pubkey, CalculateHashIntermediate>, Measure),
     ) -> (Hash, u64) {
         let (account_maps, time_scan) = accounts;
-
-        let len = account_maps.len();
 
         let mut zeros = Measure::start("eliminate zeros");
         let hashes = Self::remove_zero_balance_accounts(account_maps);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5130,7 +5130,7 @@ pub mod tests {
         let acc = Account::new(1, 48, &Account::default().owner);
         let sm = StoredMeta {
             data_len: 1,
-            pubkey: pubkey,
+            pubkey,
             write_version: 1,
         };
         storages[0][0]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6124,8 +6124,8 @@ pub mod tests {
 
         let ancestors = linear_ancestors(latest_slot);
         assert_eq!(
-            daccounts.update_accounts_hash_test(latest_slot, &ancestors, true),
-            accounts.update_accounts_hash_test(latest_slot, &ancestors, true)
+            daccounts.update_accounts_hash(latest_slot, &ancestors, true),
+            accounts.update_accounts_hash(latest_slot, &ancestors, true)
         );
     }
 
@@ -6400,7 +6400,7 @@ pub mod tests {
         accounts.add_root(current_slot);
 
         accounts.print_accounts_stats("pre_f");
-        accounts.update_accounts_hash_test(4, &HashMap::default(), true);
+        accounts.update_accounts_hash(4, &HashMap::default(), true);
 
         let accounts = f(accounts, current_slot);
 
@@ -7466,7 +7466,7 @@ pub mod tests {
         );
 
         let no_ancestors = HashMap::default();
-        accounts.update_accounts_hash_test(current_slot, &no_ancestors, true);
+        accounts.update_accounts_hash(current_slot, &no_ancestors, true);
         accounts
             .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300, true)
             .unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5015,7 +5015,7 @@ pub mod tests {
         solana_logger::setup();
 
         let key = Pubkey::new_unique();
-        let mut account_maps: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
+        let account_maps: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
         let hash = Hash::new(&[1u8; 32]);
         let val = (0, hash, 88, 490, Slot::default());
         account_maps.insert(key, val);
@@ -5035,7 +5035,7 @@ pub mod tests {
     fn test_accountsdb_handle_one_loaded_account() {
         solana_logger::setup();
 
-        let mut account_maps: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
+        let account_maps: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
         let key = Pubkey::new_unique();
         let hash = Hash::new_unique();
         let val = (1, hash, 1, 2, 1);
@@ -5057,7 +5057,7 @@ pub mod tests {
 
         // slot same, vers >
         let hash4 = Hash::new_unique();
-        let val4 = (2, hash3, 6, 7, 1);
+        let val4 = (2, hash4, 6, 7, 1);
         AccountsDB::handle_one_loaded_account(&key, val4, &account_maps);
         assert_eq!(*account_maps.get(&key).unwrap(), val4);
 
@@ -5074,7 +5074,7 @@ pub mod tests {
 
         let key = Pubkey::new_unique();
         let hash = Hash::new_unique();
-        let mut account_maps: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
+        let account_maps: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
         let val = (0, hash, 1, 2, Slot::default());
         account_maps.insert(key, val);
 
@@ -5082,7 +5082,7 @@ pub mod tests {
         assert_eq!(result, vec![(key, val.1, val.2)]);
 
         // zero original lamports
-        let mut account_maps: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
+        let account_maps: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
         let val = (0, hash, 1, 0, Slot::default());
         account_maps.insert(key, val);
 
@@ -5094,14 +5094,14 @@ pub mod tests {
     fn test_accountsdb_calculate_accounts_hash_using_stores_only_simple() {
         solana_logger::setup();
 
-        let (storages, size, slot_expected) = sample_storage();
+        let (storages, _size, _slot_expected) = sample_storage();
         let result = AccountsDB::calculate_accounts_hash_using_stores_only(storages, true);
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();
         assert_eq!(result, (expected_hash, 0));
     }
 
     fn sample_storage() -> (SnapshotStorages, usize, Slot) {
-        let (temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+        let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
         let slot_expected: Slot = 0;
         let size: usize = 123;
         let data = AccountStorageEntry::new(&paths[0], slot_expected, 0, size as u64);
@@ -5115,17 +5115,20 @@ pub mod tests {
     fn test_accountsdb_scan_account_storage_no_bank() {
         solana_logger::setup();
 
+        let expected = 1;
         let (storages, size, slot_expected) = sample_storage();
         let result = AccountsDB::scan_account_storage_no_bank(
             storages,
             |loaded_account: LoadedAccount,
              _store_id: AppendVecId,
-             accum: &mut Vec<(Pubkey, CalculateHashIntermediate)>,
+             accum: &mut Vec<u64>,
              slot: Slot| {
                 assert_eq!(loaded_account.stored_size(), size);
                 assert_eq!(slot_expected, slot);
+                accum.push(expected);
             },
         );
+        assert_eq!(result, vec![vec![expcted]]);
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5131,7 +5131,6 @@ pub mod tests {
             pubkey: pubkey,
             write_version: 1,
         };
-        let some_hash = Hash::new(&[0xca; HASH_BYTES]);
         storages[0][0]
             .accounts
             .append_accounts(&[(sm, &acc)], &[Hash::default()]);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3759,7 +3759,7 @@ impl AccountsDB {
         };
     }
 
-    fn scan_slot_using_snapshot(
+    fn scan_snapshot_stores(
         storage: SnapshotStorages,
         simple_capitalization_enabled: bool,
     ) -> (DashMap<Pubkey, CalculateHashIntermediate>, Measure) {
@@ -3771,7 +3771,6 @@ impl AccountsDB {
              _store_id: AppendVecId,
              _accum: &mut Vec<(Pubkey, CalculateHashIntermediate)>,
              slot: Slot| {
-                let public_key = loaded_account.pubkey();
                 let version = loaded_account.write_version();
                 let raw_lamports = loaded_account.lamports();
                 let balance = Self::account_balance_for_capitalization(
@@ -3781,7 +3780,6 @@ impl AccountsDB {
                     simple_capitalization_enabled,
                 );
 
-                let key = public_key;
                 let source_item = (
                     version,
                     *loaded_account.loaded_hash(),
@@ -3789,7 +3787,7 @@ impl AccountsDB {
                     raw_lamports,
                     slot,
                 );
-                Self::handle_one_loaded_account(key, source_item, &map);
+                Self::handle_one_loaded_account(loaded_account.pubkey(), source_item, &map);
             },
         );
         time.stop();
@@ -3803,7 +3801,7 @@ impl AccountsDB {
         storages: SnapshotStorages,
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
-        let result = Self::scan_slot_using_snapshot(storages, simple_capitalization_enabled);
+        let result = Self::scan_snapshot_stores(storages, simple_capitalization_enabled);
 
         Self::rest_of_hash_calculation(result)
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5117,7 +5117,9 @@ pub mod tests {
 
         let expected = 1;
         let slot_expected: Slot = 0;
-        let tf = crate::append_vec::test_utils::get_append_vec_path("test_accountsdb_scan_account_storage_no_bank");
+        let tf = crate::append_vec::test_utils::get_append_vec_path(
+            "test_accountsdb_scan_account_storage_no_bank",
+        );
         let mut data = AccountStorageEntry::new_empty_map(0, 10000);
         let av = AppendVec::new(&tf.path, true, 1024 * 1024);
         data.accounts = av;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5055,7 +5055,7 @@ pub mod tests {
         // 3rd key - with pubkey value before 1st key so it will be sorted first
         let key = Pubkey::new(&[10u8; 32]);
         let hash = Hash::new(&[2u8; 32]);
-        let val = (0, hash, 20, 20, Slot::default());
+        let val = CalculateHashIntermediate::new(0, hash, 20, 20, Slot::default());
         account_maps.insert(key, val);
 
         let result = AccountsDB::rest_of_hash_calculation((account_maps, Measure::start("")));

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3413,6 +3413,9 @@ impl AccountsDB {
         unstable_sort: bool,
     ) -> ((Hash, u64), (Measure, Measure)) {
         let mut sort_time = Measure::start("sort");
+        // Unstable and stable sorts produce the same results for the known callers.
+        // However, sort time performance can be very different for different callers.
+        // So, the option to specify which type of sort is provided.
         if unstable_sort {
             hashes.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
         } else {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3570,7 +3570,7 @@ impl AccountsDB {
         ancestors: &Ancestors,
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
-        self.update_accounts_hash_with_store_option(
+        self.update_accounts_hash_with_index_option(
             false,
             false,
             slot,
@@ -3585,7 +3585,7 @@ impl AccountsDB {
         ancestors: &Ancestors,
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
-        self.update_accounts_hash_with_store_option(
+        self.update_accounts_hash_with_index_option(
             false,
             true,
             slot,
@@ -3672,7 +3672,7 @@ impl AccountsDB {
             true,
         );
         datapoint_info!(
-            "calculate_accounts_hash_using_stores",
+            "calculate_accounts_hash_without_index",
             ("accounts_scan", time_scan.as_us(), i64),
             ("eliminate_zeros", zeros.as_us(), i64),
             ("hash", hash_time.as_us(), i64),
@@ -3685,15 +3685,15 @@ impl AccountsDB {
 
     fn calculate_accounts_hash_helper(
         &self,
-        use_store: bool,
+        do_not_use_index: bool,
         slot: Slot,
         ancestors: &Ancestors,
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
-        if use_store {
+        if do_not_use_index {
             let combined_maps = self.get_snapshot_storages(slot);
 
-            Self::calculate_accounts_hash_using_stores_only(
+            Self::calculate_accounts_hash_without_index(
                 combined_maps,
                 simple_capitalization_enabled,
             )
@@ -3703,24 +3703,24 @@ impl AccountsDB {
         }
     }
 
-    pub fn update_accounts_hash_with_store_option(
+    pub fn update_accounts_hash_with_index_option(
         &self,
-        use_store: bool,
-        debug_verify_store: bool,
+        do_not_use_index: bool,
+        debug_verify: bool,
         slot: Slot,
         ancestors: &Ancestors,
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
         let (hash, total_lamports) = self.calculate_accounts_hash_helper(
-            use_store,
+            do_not_use_index,
             slot,
             ancestors,
             simple_capitalization_enabled,
         );
-        if debug_verify_store {
+        if debug_verify {
             // calculate the other way (store or non-store) and verify results match.
             let (hash_other, total_lamports_other) = self.calculate_accounts_hash_helper(
-                !use_store,
+                !do_not_use_index,
                 slot,
                 ancestors,
                 simple_capitalization_enabled,
@@ -3796,7 +3796,7 @@ impl AccountsDB {
 
     // modeled after get_accounts_delta_hash
     // intended to be faster than calculate_accounts_hash
-    pub fn calculate_accounts_hash_using_stores_only(
+    pub fn calculate_accounts_hash_without_index(
         storages: SnapshotStorages,
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
@@ -5091,11 +5091,11 @@ pub mod tests {
     }
 
     #[test]
-    fn test_accountsdb_calculate_accounts_hash_using_stores_only_simple() {
+    fn test_accountsdb_calculate_accounts_hash_without_index_simple() {
         solana_logger::setup();
 
         let (storages, _size, _slot_expected) = sample_storage();
-        let result = AccountsDB::calculate_accounts_hash_using_stores_only(storages, true);
+        let result = AccountsDB::calculate_accounts_hash_without_index(storages, true);
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();
         assert_eq!(result, (expected_hash, 0));
     }
@@ -5128,7 +5128,7 @@ pub mod tests {
                 accum.push(expected);
             },
         );
-        assert_eq!(result, vec![vec![expcted]]);
+        assert_eq!(result, vec![vec![expected]]);
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5069,6 +5069,7 @@ pub mod tests {
                         true,
                     )
                     .0;
+                    assert_eq!(AccountsDB::accumulate_account_hashes(input.clone(), Slot::default(), false), result.0);
                     AccountsDB::sort_hashes_by_pubkey(&mut input);
                 }
                 let mut expected = 0;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5067,7 +5067,7 @@ pub mod tests {
         // slot same, version <
         let hash2 = Hash::new_unique();
         let val2 = CalculateHashIntermediate::new(0, hash2, 4, 5, 1);
-        AccountsDB::handle_one_loaded_account(&key, val2.clone(), &account_maps);
+        AccountsDB::handle_one_loaded_account(&key, val2, &account_maps);
         assert_eq!(*account_maps.get(&key).unwrap(), val);
 
         // slot same, vers =

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -167,7 +167,7 @@ type ReclaimResult = (AccountSlots, AppendVecOffsets);
 type StorageFinder<'a> = Box<dyn Fn(Slot, usize) -> Arc<AccountStorageEntry> + 'a>;
 type ShrinkCandidates = HashMap<Slot, HashMap<AppendVecId, Arc<AccountStorageEntry>>>;
 
-type CalculateHashIntermediate = (u64, Hash, u64, u64);
+type CalculateHashIntermediate = (u64, Hash, u64, u64, Slot);
 
 trait Versioned {
     fn version(&self) -> u64;
@@ -3600,7 +3600,7 @@ impl AccountsDB {
         scan_func: F,
     ) -> Vec<B>
     where
-        F: Fn(LoadedAccount, AppendVecId, &mut B) + Send + Sync,
+        F: Fn(LoadedAccount, AppendVecId, &mut B, Slot) + Send + Sync,
         B: Send + Default,
     {
         snapshot_storages
@@ -3614,6 +3614,7 @@ impl AccountsDB {
                         LoadedAccount::Stored(stored_account),
                         storage.append_vec_id(),
                         &mut retval,
+                        storage.slot(),
                     )
                 });
                 retval
@@ -3636,7 +3637,7 @@ impl AccountsDB {
         type ShardType = dashmap::lock::RwLock<
             std::collections::HashMap<
                 solana_sdk::pubkey::Pubkey,
-                dashmap::SharedValue<(u64, solana_sdk::hash::Hash, u64, u64)>,
+                dashmap::SharedValue<CalculateHashIntermediate>,
             >,
         >;
         let shards: &[ShardType] = account_maps.shards();
@@ -3649,7 +3650,7 @@ impl AccountsDB {
                     .iter()
                     .filter_map(|inp| {
                         let (pubkey, sv) = inp;
-                        let (_, hash, lamports, raw_lamports) = sv.get();
+                        let (_version, hash, lamports, raw_lamports, _slot) = sv.get();
                         if *raw_lamports != 0 {
                             Some((*pubkey, *hash, *lamports))
                         } else {
@@ -3753,7 +3754,8 @@ impl AccountsDB {
             storage,
             |loaded_account: LoadedAccount,
              _store_id: AppendVecId,
-             _accum: &mut Vec<(Pubkey, CalculateHashIntermediate)>| {
+             _accum: &mut Vec<(Pubkey, CalculateHashIntermediate)>,
+             slot: Slot| {
                 let public_key = loaded_account.pubkey();
                 let version = loaded_account.write_version();
                 let raw_lamports = loaded_account.lamports();
@@ -3770,10 +3772,14 @@ impl AccountsDB {
                     *loaded_account.loaded_hash(),
                     balance,
                     raw_lamports,
+                    slot,
                 );
                 match map.entry(*key) {
                     Occupied(mut dest_item) => {
-                        if dest_item.get_mut().version() <= source_item.version() {
+                        let contents = dest_item.get();
+                        if contents.4 < slot
+                            || (contents.4 == slot && contents.version() <= source_item.version())
+                        {
                             // replace the item
                             dest_item.insert(source_item);
                         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3629,9 +3629,6 @@ impl AccountsDB {
             .get_slot_stores(slot)
             .map(|res| res.read().unwrap().values().cloned().collect())
             .unwrap_or_default();
-        if storage_maps.len() > 10000 {
-            warn!("get_storage_maps, found slots: {}", storage_maps.len());
-        }
         storage_maps
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3670,7 +3670,7 @@ impl AccountsDB {
     }
 
     pub fn rest_of_hash_calculation(
-        accounts: (DashMap<Pubkey, CalculateHashIntermediate>, Measure, Measure),
+        accounts: (DashMap<Pubkey, CalculateHashIntermediate>, Measure),
     ) -> (Hash, u64) {
         let (account_maps, time_scan) = accounts;
 
@@ -3689,12 +3689,10 @@ impl AccountsDB {
         datapoint_info!(
             "calculate_accounts_hash_using_stores",
             ("accounts_scan", time_scan.as_us(), i64),
-            ("hash_accumulate", time_accumulate.as_us(), i64),
             ("eliminate_zeros", zeros.as_us(), i64),
             ("hash", hash_time.as_us(), i64),
             ("sort", sort_time.as_us(), i64),
             ("hash_total", hash_total, i64),
-            ("scan", time_scan.as_us(), i64),
         );
         warn!(
             "hashes including zeros: {}, after removal: {}, lamports: {}, hash: {}",
@@ -3764,7 +3762,7 @@ impl AccountsDB {
     fn scan_slot_using_snapshot(
         storage: SnapshotStorages,
         simple_capitalization_enabled: bool,
-    ) -> (DashMap<Pubkey, CalculateHashIntermediate>, Measure, Measure) {
+    ) -> (DashMap<Pubkey, CalculateHashIntermediate>, Measure) {
         let map: DashMap<Pubkey, CalculateHashIntermediate> = DashMap::new();
         let mut time = Measure::start("scan all accounts");
         Self::scan_account_storage_no_bank(
@@ -3804,9 +3802,7 @@ impl AccountsDB {
         );
         time.stop();
 
-        let mut time_accumulate = Measure::start("accumulate");
-        time_accumulate.stop();
-        (map, time, time_accumulate)
+        (map, time)
     }
 
     // modeled after get_accounts_delta_hash

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4299,18 +4299,18 @@ impl Bank {
         self.rc.accounts.accounts_db.get_accounts_hash(self.slot)
     }
 
-    pub fn update_accounts_hash_with_store_option(
+    pub fn update_accounts_hash_with_index_option(
         &self,
-        use_store: bool,
-        debug_verify_store: bool,
+        do_not_use_index: bool,
+        debug_verify: bool,
     ) -> Hash {
         let (hash, total_lamports) = self
             .rc
             .accounts
             .accounts_db
-            .update_accounts_hash_with_store_option(
-                use_store,
-                debug_verify_store,
+            .update_accounts_hash_with_index_option(
+                do_not_use_index,
+                debug_verify,
                 self.slot(),
                 &self.ancestors,
                 self.simple_capitalization_enabled(),
@@ -4320,11 +4320,11 @@ impl Bank {
     }
 
     pub fn update_accounts_hash(&self) -> Hash {
-        self.update_accounts_hash_with_store_option(false, false)
+        self.update_accounts_hash_with_index_option(false, false)
     }
 
     pub fn update_accounts_hash_with_store_test(&self) -> Hash {
-        self.update_accounts_hash_with_store_option(false, true)
+        self.update_accounts_hash_with_index_option(false, true)
     }
 
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7103,9 +7103,9 @@ pub(crate) mod tests {
         bank.freeze();
         bank.squash();
         bank.force_flush_accounts_cache();
-        let hash = bank.update_accounts_hash_with_store_test();
+        let hash = bank.update_accounts_hash();
         bank.clean_accounts(false);
-        assert_eq!(bank.update_accounts_hash_with_store_test(), hash);
+        assert_eq!(bank.update_accounts_hash(), hash);
 
         let bank0 = Arc::new(new_from_parent(&bank));
         let blockhash = bank.last_blockhash();
@@ -7123,9 +7123,9 @@ pub(crate) mod tests {
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
 
         info!("bank0 purge");
-        let hash = bank0.update_accounts_hash_with_store_test();
+        let hash = bank0.update_accounts_hash();
         bank0.clean_accounts(false);
-        assert_eq!(bank0.update_accounts_hash_with_store_test(), hash);
+        assert_eq!(bank0.update_accounts_hash(), hash);
 
         assert_eq!(bank0.get_account(&keypair.pubkey()).unwrap().lamports, 10);
         assert_eq!(bank1.get_account(&keypair.pubkey()), None);
@@ -7145,7 +7145,7 @@ pub(crate) mod tests {
 
         bank1.freeze();
         bank1.squash();
-        bank1.update_accounts_hash_with_store_test();
+        bank1.update_accounts_hash();
         assert!(bank1.verify_bank_hash());
 
         // keypair should have 0 tokens on both forks
@@ -7923,7 +7923,7 @@ pub(crate) mod tests {
         let pubkey2 = solana_sdk::pubkey::new_rand();
         info!("transfer 2 {}", pubkey2);
         bank2.transfer(10, &mint_keypair, &pubkey2).unwrap();
-        bank2.update_accounts_hash_with_store_test();
+        bank2.update_accounts_hash();
         assert!(bank2.verify_bank_hash());
     }
 
@@ -7947,18 +7947,18 @@ pub(crate) mod tests {
 
         // Checkpointing should never modify the checkpoint's state once frozen
         let bank0_state = bank0.hash_internal_state();
-        bank2.update_accounts_hash_with_store_test();
+        bank2.update_accounts_hash();
         assert!(bank2.verify_bank_hash());
         let bank3 = Bank::new_from_parent(&bank0, &solana_sdk::pubkey::new_rand(), 2);
         assert_eq!(bank0_state, bank0.hash_internal_state());
         assert!(bank2.verify_bank_hash());
-        bank3.update_accounts_hash_with_store_test();
+        bank3.update_accounts_hash();
         assert!(bank3.verify_bank_hash());
 
         let pubkey2 = solana_sdk::pubkey::new_rand();
         info!("transfer 2 {}", pubkey2);
         bank2.transfer(10, &mint_keypair, &pubkey2).unwrap();
-        bank2.update_accounts_hash_with_store_test();
+        bank2.update_accounts_hash();
         assert!(bank2.verify_bank_hash());
         assert!(bank3.verify_bank_hash());
     }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -9,11 +9,46 @@ use std::{
 };
 use tempfile::TempDir;
 
-pub type AccountsPackageSender = Sender<AccountsPackage>;
-pub type AccountsPackageReceiver = Receiver<AccountsPackage>;
-pub type AccountsPackageSendError = SendError<AccountsPackage>;
+pub type AccountsPackageSender = Sender<AccountsPackagePre>;
+pub type AccountsPackageReceiver = Receiver<AccountsPackagePre>;
+pub type AccountsPackageSendError = SendError<AccountsPackagePre>;
 
 #[derive(Debug)]
+pub struct AccountsPackagePre {
+    pub slot: Slot,
+    pub block_height: Slot,
+    pub slot_deltas: Vec<BankSlotDelta>,
+    pub snapshot_links: TempDir,
+    pub storages: SnapshotStorages,
+    pub archive_format: ArchiveFormat,
+    pub snapshot_version: SnapshotVersion,
+    pub snapshot_output_dir: PathBuf,
+}
+
+impl AccountsPackagePre {
+    pub fn new(
+        slot: Slot,
+        block_height: u64,
+        slot_deltas: Vec<BankSlotDelta>,
+        snapshot_links: TempDir,
+        storages: SnapshotStorages,
+        archive_format: ArchiveFormat,
+        snapshot_version: SnapshotVersion,
+        snapshot_output_dir: PathBuf,
+    ) -> Self {
+        Self {
+            slot,
+            block_height,
+            slot_deltas,
+            snapshot_links,
+            storages,
+            archive_format,
+            snapshot_version,
+            snapshot_output_dir,
+        }
+    }
+}
+
 pub struct AccountsPackage {
     pub slot: Slot,
     pub block_height: Slot,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -29,6 +29,7 @@ pub struct AccountsPackagePre {
 }
 
 impl AccountsPackagePre {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         slot: Slot,
         block_height: u64,

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -25,6 +25,7 @@ pub struct AccountsPackagePre {
     pub snapshot_output_dir: PathBuf,
     pub expected_capitalization: u64,
     pub hash_for_testing: Option<Hash>,
+    pub simple_capitalization_testing: bool,
 }
 
 impl AccountsPackagePre {
@@ -39,6 +40,7 @@ impl AccountsPackagePre {
         snapshot_output_dir: PathBuf,
         expected_capitalization: u64,
         hash_for_testing: Option<Hash>,
+        simple_capitalization_testing: bool,
     ) -> Self {
         Self {
             slot,
@@ -51,6 +53,7 @@ impl AccountsPackagePre {
             snapshot_output_dir,
             expected_capitalization,
             hash_for_testing,
+            simple_capitalization_testing,
         }
     }
 }

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -23,6 +23,8 @@ pub struct AccountsPackagePre {
     pub archive_format: ArchiveFormat,
     pub snapshot_version: SnapshotVersion,
     pub snapshot_output_dir: PathBuf,
+    pub expected_capitalization: u64,
+    pub hash_for_testing: Option<Hash>,
 }
 
 impl AccountsPackagePre {
@@ -35,6 +37,8 @@ impl AccountsPackagePre {
         archive_format: ArchiveFormat,
         snapshot_version: SnapshotVersion,
         snapshot_output_dir: PathBuf,
+        expected_capitalization: u64,
+        hash_for_testing: Option<Hash>,
     ) -> Self {
         Self {
             slot,
@@ -45,6 +49,8 @@ impl AccountsPackagePre {
             archive_format,
             snapshot_version,
             snapshot_output_dir,
+            expected_capitalization,
+            hash_for_testing,
         }
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -984,7 +984,6 @@ pub fn process_accounts_package_pre(accounts_package: AccountsPackagePre) -> Acc
     )
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -184,6 +184,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
         snapshot_package_output_path.as_ref().to_path_buf(),
         bank.capitalization(),
         hash_for_testing,
+        bank.simple_capitalization_enabled(),
     );
 
     Ok(package)
@@ -961,7 +962,7 @@ pub fn process_accounts_package_pre(accounts_package: AccountsPackagePre) -> Acc
 
     let (hash, lamports) = AccountsDB::calculate_accounts_hash_using_stores_only(
         accounts_package.storages.clone(),
-        false,
+        accounts_package.simple_capitalization_testing,
     );
     time.stop();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -960,7 +960,7 @@ pub fn bank_to_snapshot_archive<P: AsRef<Path>, Q: AsRef<Path>>(
 pub fn process_accounts_package_pre(accounts_package: AccountsPackagePre) -> AccountsPackage {
     let mut time = Measure::start("hash");
 
-    let (hash, lamports) = AccountsDB::calculate_accounts_hash_using_stores_only(
+    let (hash, lamports) = AccountsDB::calculate_accounts_hash_without_index(
         accounts_package.storages.clone(),
         accounts_package.simple_capitalization_testing,
     );

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -7,7 +7,9 @@ use crate::{
     serde_snapshot::{
         bank_from_stream, bank_to_stream, SerdeStyle, SnapshotStorage, SnapshotStorages,
     },
-    snapshot_package::{AccountsPackage, AccountsPackagePre, AccountsPackageSendError, AccountsPackageSender},
+    snapshot_package::{
+        AccountsPackage, AccountsPackagePre, AccountsPackageSendError, AccountsPackageSender,
+    },
 };
 use bincode::{config::Options, serialize_into};
 use bzip2::bufread::BzDecoder;
@@ -948,14 +950,14 @@ pub fn bank_to_snapshot_archive<P: AsRef<Path>, Q: AsRef<Path>>(
     Ok(package.tar_output_file)
 }
 
-pub fn process_accounts_package_pre(accounts_package: AccountsPackagePre) -> AccountsPackage
-{
+pub fn process_accounts_package_pre(accounts_package: AccountsPackagePre) -> AccountsPackage {
     let mut time = Measure::start("hash");
 
     let hash = AccountsDB::calculate_accounts_hash_using_stores_only(
         accounts_package.storages.clone(),
         false,
-    ).0;
+    )
+    .0;
     time.stop();
 
     datapoint_info!(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1419,6 +1419,11 @@ pub fn main() {
                 .help("Disables accounts caching"),
         )
         .arg(
+            Arg::with_name("accounts_db_test_hash_calculation")
+                .long("accounts-db-test-hash-calculation")
+                .help("Enables testing of hash calculation"),
+        )
+        .arg(
             // legacy nop argument
             Arg::with_name("accounts_db_caching_enabled")
                 .long("accounts-db-caching-enabled")
@@ -1623,6 +1628,7 @@ pub fn main() {
             .unwrap_or(poh_service::DEFAULT_PINNED_CPU_CORE),
         account_indexes,
         accounts_db_caching_enabled: !matches.is_present("no_accounts_db_caching"),
+        accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
         ..ValidatorConfig::default()
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1421,7 +1421,7 @@ pub fn main() {
         .arg(
             Arg::with_name("accounts_db_test_hash_calculation")
                 .long("accounts-db-test-hash-calculation")
-                .help("Enables testing of hash calculation"),
+                .help("Enables testing of hash calculation using stores in AccountsHashVerifier. This has a computational cost."),
         )
         .arg(
             // legacy nop argument


### PR DESCRIPTION
#### Problem
The number of accounts are growing.
There is value in moving operations out of the critical path. Some operations like clean and shrink are not able to complete effectively.
One such operation is calculating the hash of a bank.

#### Summary of Changes

Move the hash calculation out of accounts_background_service and into accounts_hash_verifier. The calculation also avoids using the index, reducing contention.
Add a command line option to calculate the hash using the index in the previous location and verify the hash calculation in ahv without using the index.

Fixes #
