### PR TITLE
Don't reset store accounts from accounts clean

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6776,24 +6776,20 @@ pub mod tests {
             }
 
             let mut count = 0;
-            snapshot
-                .clone()
-                .into_iter()
-                .flatten()
-                .for_each(|storage| {
-                    let accounts = storage.accounts.accounts(0);
-                    accounts.into_iter().for_each(|stored_account| {
-                        let l = stored_account.account_meta.lamports;
-                        let acct = LoadedAccount::Stored(stored_account);
-                        warn!(
-                            "lamports, slot: {}, {}",
-                            storage.slot.load(Ordering::Relaxed),
-                            l
-                        );
-                        assert_eq!(*acct.pubkey(), pubkey);
-                        count += 1;
-                    })
-                });
+            snapshot.clone().into_iter().flatten().for_each(|storage| {
+                let accounts = storage.accounts.accounts(0);
+                accounts.into_iter().for_each(|stored_account| {
+                    let l = stored_account.account_meta.lamports;
+                    let acct = LoadedAccount::Stored(stored_account);
+                    warn!(
+                        "lamports, slot: {}, {}",
+                        storage.slot.load(Ordering::Relaxed),
+                        l
+                    );
+                    assert_eq!(*acct.pubkey(), pubkey);
+                    count += 1;
+                })
+            });
             assert_eq!(count, 1);
         });
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6754,20 +6754,22 @@ pub mod tests {
             assert!(snapshot[0].len() == 1);
             let _store_id = &snapshot[0][0].id;
             let mut count = 0;
-            snapshot.clone()
-            .into_iter()
-            .flatten()
-            .map(|storage| {
-                storage.set_status(AccountStorageStatus::Full);
-                let accounts = storage.accounts.accounts(0);
-                accounts.into_iter().for_each(|stored_account| {
-                    let acct = LoadedAccount::Stored(stored_account);
-                    //assert_eq!(accounts.slot(), slot_orig);
-                    assert_eq!(*acct.pubkey(), pubkey);
-                    assert_eq!(acct.account().lamports, lamports);
-                    count += 1;
-            })
-            }).count();
+            snapshot
+                .clone()
+                .into_iter()
+                .flatten()
+                .map(|storage| {
+                    storage.set_status(AccountStorageStatus::Full);
+                    let accounts = storage.accounts.accounts(0);
+                    accounts.into_iter().for_each(|stored_account| {
+                        let acct = LoadedAccount::Stored(stored_account);
+                        //assert_eq!(accounts.slot(), slot_orig);
+                        assert_eq!(*acct.pubkey(), pubkey);
+                        assert_eq!(acct.account().lamports, lamports);
+                        count += 1;
+                    })
+                })
+                .count();
             assert_eq!(count, 1);
 
             slot += 1;
@@ -6788,19 +6790,25 @@ pub mod tests {
             // assert_eq!(storage_entry.status(), AccountStorageStatus::Full);
 
             let mut count = 0;
-            snapshot.clone()
-            .into_iter()
-            .flatten()
-            .map(|storage| {
-                let accounts = storage.accounts.accounts(0);
-                accounts.into_iter().for_each(|stored_account| {
-                    let l = stored_account.account_meta.lamports;
-                    let acct = LoadedAccount::Stored(stored_account);
-                    warn!("lamports, slot: {}, {}", storage.slot.load(Ordering::Relaxed), l);
-                assert_eq!(*acct.pubkey(), pubkey);
-                count += 1;
-            })
-            }).count();
+            snapshot
+                .clone()
+                .into_iter()
+                .flatten()
+                .map(|storage| {
+                    let accounts = storage.accounts.accounts(0);
+                    accounts.into_iter().for_each(|stored_account| {
+                        let l = stored_account.account_meta.lamports;
+                        let acct = LoadedAccount::Stored(stored_account);
+                        warn!(
+                            "lamports, slot: {}, {}",
+                            storage.slot.load(Ordering::Relaxed),
+                            l
+                        );
+                        assert_eq!(*acct.pubkey(), pubkey);
+                        count += 1;
+                    })
+                })
+                .count();
             assert_eq!(count, 1);
         });
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6703,6 +6703,68 @@ pub mod tests {
 
     #[test]
     #[should_panic(expected = "double remove of account in slot: 0/store: 0!!")]
+    fn test_storage_remove_account_double_remove_with_reset() {
+        let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
+        let pubkey = solana_sdk::pubkey::new_rand();
+        let account = Account::new(1, 0, &Account::default().owner);
+        accounts.store_uncached(0, &[(&pubkey, &account)]);
+        let storage_entry = get_account_entry(&accounts);
+        storage_entry.remove_account(0, false);
+        storage_entry.remove_account(0, true);
+    }
+
+    fn get_account_entry(accounts: &AccountsDB) -> Arc<AccountStorageEntry> {
+        accounts
+            .storage
+            .get_slot_stores(0)
+            .unwrap()
+            .read()
+            .unwrap()
+            .values()
+            .next()
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn test_storage_remove_account_with_reset_then_access() {
+        solana_logger::setup();
+        (0..3).into_iter().for_each(|pass| {
+            info!("pass: {}", pass);
+            let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
+            let pubkey = solana_sdk::pubkey::new_rand();
+            let account = Account::new(1, 0, &Account::default().owner);
+            let slot = 0;
+            accounts.store_uncached(slot, &[(&pubkey, &account)]);
+            let storage_entry = get_account_entry(&accounts);
+            storage_entry.set_status(AccountStorageStatus::Full);
+            let store_id = storage_entry.append_vec_id();
+            let result = accounts
+                .storage
+                .get_account_storage_entry(slot, store_id)
+                .unwrap();
+            assert_eq!(result.slot.load(Ordering::Relaxed), slot);
+            assert_eq!(result.id.load(Ordering::Relaxed), store_id);
+            if pass == 0 {
+                storage_entry.remove_account(0, false);
+            } else if pass == 1 {
+                storage_entry.remove_account(0, false);
+                accounts.shrink_all_slots();
+            } else if pass == 2 {
+                accounts.clean_accounts(None);
+            }
+            let result = accounts
+                .storage
+                .get_account_storage_entry(slot, store_id)
+                .unwrap();
+            assert_eq!(result.slot.load(Ordering::Relaxed), slot);
+            assert_eq!(result.id.load(Ordering::Relaxed), store_id);
+            assert_eq!(storage_entry.status(), AccountStorageStatus::Full);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "double remove of account in slot: 0/store: 0!!")]
     fn test_storage_remove_account_double_remove() {
         let accounts = AccountsDB::new(Vec::new(), &ClusterType::Development);
         let pubkey = solana_sdk::pubkey::new_rand();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6758,6 +6758,7 @@ pub mod tests {
             .into_iter()
             .flatten()
             .map(|storage| {
+                storage.set_status(AccountStorageStatus::Full);
                 let accounts = storage.accounts.accounts(0);
                 accounts.into_iter().for_each(|stored_account| {
                     let acct = LoadedAccount::Stored(stored_account);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1111,7 +1111,7 @@ impl AccountsDB {
 
         let mut measure = Measure::start("clean_old_root_reclaims");
         let mut reclaim_result = (HashMap::new(), HashMap::new());
-        self.handle_reclaims(&reclaims, None, false, Some(&mut reclaim_result));
+        self.handle_reclaims(&reclaims, None, false, Some(&mut reclaim_result), false);
         measure.stop();
         debug!("{} {}", clean_rooted, measure);
         inc_new_counter_info!("clean-old-root-reclaim-ms", measure.as_ms() as usize);
@@ -1487,7 +1487,7 @@ impl AccountsDB {
 
         let reclaims = self.purge_keys_exact(&pubkey_to_slot_set);
 
-        self.handle_reclaims(&reclaims, None, false, None);
+        self.handle_reclaims(&reclaims, None, false, None, true);
 
         reclaims_time.stop();
 
@@ -1542,6 +1542,7 @@ impl AccountsDB {
         expected_single_dead_slot: Option<Slot>,
         no_dead_slot: bool,
         reclaim_result: Option<&mut ReclaimResult>,
+        reset_accounts: bool,
     ) {
         if reclaims.is_empty() {
             return;
@@ -1557,6 +1558,7 @@ impl AccountsDB {
             expected_single_dead_slot,
             reclaimed_offsets,
             no_dead_slot,
+            reset_accounts,
         );
         if no_dead_slot {
             assert!(dead_slots.is_empty());
@@ -1602,7 +1604,7 @@ impl AccountsDB {
         );
     }
 
-    fn do_shrink_slot_stores<'a, I>(&'a self, slot: Slot, stores: I)
+    fn do_shrink_slot_stores<'a, I>(&'a self, slot: Slot, stores: I, reset_accounts: bool)
     where
         I: Iterator<Item = &'a Arc<AccountStorageEntry>>,
     {
@@ -1726,6 +1728,7 @@ impl AccountsDB {
                 Some(Box::new(move |_, _| shrunken_store.clone())),
                 Some(Box::new(write_versions.into_iter())),
                 false,
+                reset_accounts,
             );
 
             // `store_accounts_custom()` above may have purged accounts from some
@@ -1837,7 +1840,7 @@ impl AccountsDB {
                 );
                 return 0;
             }
-            self.do_shrink_slot_stores(slot, stores.iter());
+            self.do_shrink_slot_stores(slot, stores.iter(), false);
             alive_count
         } else {
             0
@@ -2002,6 +2005,7 @@ impl AccountsDB {
                 &hashes,
                 Some(Box::new(move |_, _| shrunken_store.clone())),
                 Some(Box::new(write_versions.into_iter())),
+                false,
                 false,
             );
 
@@ -2194,7 +2198,7 @@ impl AccountsDB {
         let num_candidates = shrink_slots.len();
         for (slot, slot_shrink_candidates) in shrink_slots {
             let mut measure = Measure::start("shrink_candidate_slots-ms");
-            self.do_shrink_slot_stores(slot, slot_shrink_candidates.values());
+            self.do_shrink_slot_stores(slot, slot_shrink_candidates.values(), true);
             measure.stop();
             inc_new_counter_info!("shrink_candidate_slots-ms", measure.as_ms() as usize);
         }
@@ -2965,7 +2969,7 @@ impl AccountsDB {
 
         // 1) Remove old bank hash from self.bank_hashes
         // 2) Purge this slot's storage entries from self.storage
-        self.handle_reclaims(&reclaims, Some(remove_slot), false, None);
+        self.handle_reclaims(&reclaims, Some(remove_slot), false, None, false);
         assert!(self.storage.get_slot_stores(remove_slot).is_none());
     }
 
@@ -3476,6 +3480,7 @@ impl AccountsDB {
                     &hashes,
                     Some(Box::new(move |_, _| flushed_store.clone())),
                     None,
+                    false,
                     false,
                 );
                 // If the above sizing function is correct, just one AppendVec is enough to hold
@@ -4023,6 +4028,7 @@ impl AccountsDB {
         expected_slot: Option<Slot>,
         mut reclaimed_offsets: Option<&mut AppendVecOffsets>,
         no_dead_slot: bool,
+        reset_accounts: bool,
     ) -> HashSet<Slot> {
         let mut dead_slots = HashSet::new();
         let mut new_shrink_candidates: ShrinkCandidates = HashMap::new();
@@ -4047,7 +4053,8 @@ impl AccountsDB {
                     "AccountDB::accounts_index corrupted. Storage pointed to: {}, expected: {}, should only point to one slot",
                     store.slot(), *slot
                 );
-                let count = store.remove_account(account_info.stored_size, no_dead_slot);
+                let count =
+                    store.remove_account(account_info.stored_size, no_dead_slot || reset_accounts);
                 if count == 0 {
                     dead_slots.insert(*slot);
                 } else if self.caching_enabled
@@ -4381,6 +4388,7 @@ impl AccountsDB {
             None::<StorageFinder>,
             None::<Box<dyn Iterator<Item = u64>>>,
             is_cached_store,
+            false,
         );
     }
 
@@ -4392,6 +4400,7 @@ impl AccountsDB {
         storage_finder: Option<StorageFinder<'a>>,
         write_version_producer: Option<Box<dyn Iterator<Item = u64>>>,
         is_cached_store: bool,
+        reset_accounts: bool,
     ) -> StoreAccountsTiming {
         let storage_finder: StorageFinder<'a> = storage_finder
             .unwrap_or_else(|| Box::new(move |slot, size| self.find_storage_candidate(slot, size)));
@@ -4457,7 +4466,7 @@ impl AccountsDB {
         //
         // From 1) and 2) we guarantee passing Some(slot), true is safe
         let mut handle_reclaims_time = Measure::start("handle_reclaims");
-        self.handle_reclaims(&reclaims, Some(slot), true, None);
+        self.handle_reclaims(&reclaims, Some(slot), true, None, reset_accounts);
         handle_reclaims_time.stop();
         self.stats
             .store_handle_reclaims

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6834,7 +6834,7 @@ pub mod tests {
     }
 
     fn verify_accounts_in_stores(
-        storages: &SnapshotStorages,
+        storages: &[SnapshotStorage],
         num_accounts: usize,
         lamport_sum: u64,
     ) {
@@ -6842,7 +6842,7 @@ pub mod tests {
     }
 
     fn verify_accounts_in_stores_with_reset(
-        storages: &SnapshotStorages,
+        storages: &[SnapshotStorage],
         num_accounts: usize,
         lamport_sum: u64,
         reset: bool,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -491,11 +491,11 @@ impl AccountStorageEntry {
         }
     }
 
-    fn remove_account(&self, num_bytes: usize) -> usize {
+    fn remove_account(&self, num_bytes: usize, reset_accounts: bool) -> usize {
         let mut count_and_status = self.count_and_status.write().unwrap();
         let (mut count, mut status) = *count_and_status;
 
-        if count == 1 && status == AccountStorageStatus::Full {
+        if count == 1 && status == AccountStorageStatus::Full && reset_accounts {
             // this case arises when we remove the last account from the
             //  storage, but we've learned from previous write attempts that
             //  the storage is full
@@ -1552,8 +1552,12 @@ impl AccountsDB {
             } else {
                 (None, None)
             };
-        let dead_slots =
-            self.remove_dead_accounts(reclaims, expected_single_dead_slot, reclaimed_offsets);
+        let dead_slots = self.remove_dead_accounts(
+            reclaims,
+            expected_single_dead_slot,
+            reclaimed_offsets,
+            no_dead_slot,
+        );
         if no_dead_slot {
             assert!(dead_slots.is_empty());
         } else if let Some(expected_single_dead_slot) = expected_single_dead_slot {
@@ -4018,6 +4022,7 @@ impl AccountsDB {
         reclaims: SlotSlice<AccountInfo>,
         expected_slot: Option<Slot>,
         mut reclaimed_offsets: Option<&mut AppendVecOffsets>,
+        no_dead_slot: bool,
     ) -> HashSet<Slot> {
         let mut dead_slots = HashSet::new();
         let mut new_shrink_candidates: ShrinkCandidates = HashMap::new();
@@ -4042,7 +4047,7 @@ impl AccountsDB {
                     "AccountDB::accounts_index corrupted. Storage pointed to: {}, expected: {}, should only point to one slot",
                     store.slot(), *slot
                 );
-                let count = store.remove_account(account_info.stored_size);
+                let count = store.remove_account(account_info.stored_size, no_dead_slot);
                 if count == 0 {
                     dead_slots.insert(*slot);
                 } else if self.caching_enabled
@@ -6685,7 +6690,7 @@ pub mod tests {
             .values()
             .next()
             .unwrap()
-            .remove_account(0);
+            .remove_account(0, true);
         assert!(db.get_snapshot_storages(after_slot).is_empty());
     }
 
@@ -6706,8 +6711,8 @@ pub mod tests {
             .next()
             .unwrap()
             .clone();
-        storage_entry.remove_account(0);
-        storage_entry.remove_account(0);
+        storage_entry.remove_account(0, true);
+        storage_entry.remove_account(0, true);
     }
 
     #[test]
@@ -7892,7 +7897,7 @@ pub mod tests {
             assert_eq!(removed_data_size, account.stored_size);
             assert_eq!(account_info.0, slot);
             let reclaims = vec![account_info];
-            accounts_db.remove_dead_accounts(&reclaims, None, None);
+            accounts_db.remove_dead_accounts(&reclaims, None, None, true);
             let after_size = storage0.alive_bytes.load(Ordering::Relaxed);
             assert_eq!(before_size, after_size + account.stored_size);
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6780,7 +6780,7 @@ pub mod tests {
                 .clone()
                 .into_iter()
                 .flatten()
-                .map(|storage| {
+                .for_each(|storage| {
                     let accounts = storage.accounts.accounts(0);
                     accounts.into_iter().for_each(|stored_account| {
                         let l = stored_account.account_meta.lamports;
@@ -6793,8 +6793,7 @@ pub mod tests {
                         assert_eq!(*acct.pubkey(), pubkey);
                         count += 1;
                     })
-                })
-                .count();
+                });
             assert_eq!(count, 1);
         });
     }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6741,9 +6741,8 @@ pub mod tests {
         solana_logger::setup();
         // passes:
         // 0. clean
-        // 1. shrink (do_intra_cache_clean = false). If we don't flush, nothing goes into stores
+        // 1. shrink
         for pass in 0..2 {
-            let do_intra_cache_clean: bool = false;
             // Enable caching so that we use the straightforward implementation
             // of shrink that will shrink all candidate slots
             let caching_enabled = true;
@@ -6772,7 +6771,12 @@ pub mod tests {
             db.flush_accounts_cache(true, None);
 
             let snapshot = db.get_snapshot_storages(slot_orig);
-            verify_accounts_in_stores_with_reset(&snapshot, expected_account_count, lamports_sum, true);
+            verify_accounts_in_stores_with_reset(
+                &snapshot,
+                expected_account_count,
+                lamports_sum,
+                true,
+            );
 
             slot += 1;
             let lamports3 = 0;
@@ -6829,12 +6833,21 @@ pub mod tests {
         }
     }
 
-    fn verify_accounts_in_stores(storages: &SnapshotStorages, num_accounts: usize, lamport_sum: u64) {
+    fn verify_accounts_in_stores(
+        storages: &SnapshotStorages,
+        num_accounts: usize,
+        lamport_sum: u64,
+    ) {
         verify_accounts_in_stores_with_reset(storages, num_accounts, lamport_sum, false);
     }
 
-    fn verify_accounts_in_stores_with_reset(storages: &SnapshotStorages, num_accounts: usize, lamport_sum: u64, reset: bool) {
-            let mut count = 0;
+    fn verify_accounts_in_stores_with_reset(
+        storages: &SnapshotStorages,
+        num_accounts: usize,
+        lamport_sum: u64,
+        reset: bool,
+    ) {
+        let mut count = 0;
         let mut lamport_sum_found = 0;
         storages.iter().flatten().for_each(|storage| {
             if reset {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7906,7 +7906,7 @@ pub mod tests {
             assert_eq!(removed_data_size, account.stored_size);
             assert_eq!(account_info.0, slot);
             let reclaims = vec![account_info];
-            accounts_db.remove_dead_accounts(&reclaims, None, None, true);
+            accounts_db.remove_dead_accounts(&reclaims, None, None, true, false);
             let after_size = storage0.alive_bytes.load(Ordering::Relaxed);
             assert_eq!(before_size, after_size + account.stored_size);
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4396,7 +4396,7 @@ impl AccountsDB {
             None::<StorageFinder>,
             None::<Box<dyn Iterator<Item = u64>>>,
             is_cached_store,
-            false,
+            true,
         );
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1557,7 +1557,6 @@ impl AccountsDB {
             reclaims,
             expected_single_dead_slot,
             reclaimed_offsets,
-            no_dead_slot,
             reset_accounts,
         );
         if no_dead_slot {
@@ -4027,7 +4026,6 @@ impl AccountsDB {
         reclaims: SlotSlice<AccountInfo>,
         expected_slot: Option<Slot>,
         mut reclaimed_offsets: Option<&mut AppendVecOffsets>,
-        no_dead_slot: bool,
         reset_accounts: bool,
     ) -> HashSet<Slot> {
         let mut dead_slots = HashSet::new();
@@ -4054,7 +4052,7 @@ impl AccountsDB {
                     store.slot(), *slot
                 );
                 let count =
-                    store.remove_account(account_info.stored_size, no_dead_slot || reset_accounts);
+                    store.remove_account(account_info.stored_size, reset_accounts);
                 if count == 0 {
                     dead_slots.insert(*slot);
                 } else if self.caching_enabled
@@ -7906,7 +7904,7 @@ pub mod tests {
             assert_eq!(removed_data_size, account.stored_size);
             assert_eq!(account_info.0, slot);
             let reclaims = vec![account_info];
-            accounts_db.remove_dead_accounts(&reclaims, None, None, true, false);
+            accounts_db.remove_dead_accounts(&reclaims, None, None, true);
             let after_size = storage0.alive_bytes.load(Ordering::Relaxed);
             assert_eq!(before_size, after_size + account.stored_size);
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1487,7 +1487,7 @@ impl AccountsDB {
 
         let reclaims = self.purge_keys_exact(&pubkey_to_slot_set);
 
-        self.handle_reclaims(&reclaims, None, false, None, true);
+        self.handle_reclaims(&reclaims, None, false, None, false);
 
         reclaims_time.stop();
 
@@ -1604,7 +1604,7 @@ impl AccountsDB {
         );
     }
 
-    fn do_shrink_slot_stores<'a, I>(&'a self, slot: Slot, stores: I, reset_accounts: bool)
+    fn do_shrink_slot_stores<'a, I>(&'a self, slot: Slot, stores: I)
     where
         I: Iterator<Item = &'a Arc<AccountStorageEntry>>,
     {
@@ -1728,7 +1728,7 @@ impl AccountsDB {
                 Some(Box::new(move |_, _| shrunken_store.clone())),
                 Some(Box::new(write_versions.into_iter())),
                 false,
-                reset_accounts,
+                false,
             );
 
             // `store_accounts_custom()` above may have purged accounts from some
@@ -1840,7 +1840,7 @@ impl AccountsDB {
                 );
                 return 0;
             }
-            self.do_shrink_slot_stores(slot, stores.iter(), false);
+            self.do_shrink_slot_stores(slot, stores.iter());
             alive_count
         } else {
             0
@@ -2198,7 +2198,7 @@ impl AccountsDB {
         let num_candidates = shrink_slots.len();
         for (slot, slot_shrink_candidates) in shrink_slots {
             let mut measure = Measure::start("shrink_candidate_slots-ms");
-            self.do_shrink_slot_stores(slot, slot_shrink_candidates.values(), true);
+            self.do_shrink_slot_stores(slot, slot_shrink_candidates.values());
             measure.stop();
             inc_new_counter_info!("shrink_candidate_slots-ms", measure.as_ms() as usize);
         }

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6782,6 +6782,7 @@ pub mod tests {
 
             // this loads the newer account... assert_load_account(&db, slot_orig, pubkey, lamports);
             if pass == 0 {
+                db.clean_accounts(None);
                 db.shrink_all_slots();
             } else if pass == 1 {
                 db.clean_accounts(None);

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -296,6 +296,11 @@ impl AccountStorage {
         self.0.get(&slot).map(|result| result.value().clone())
     }
 
+    fn get_slot_storage_entries(&self, slot: Slot) -> Option<Vec<Arc<AccountStorageEntry>>> {
+        self.get_slot_stores(slot)
+            .map(|res| res.read().unwrap().values().cloned().collect())
+    }
+
     fn slot_store_count(&self, slot: Slot, store_id: AppendVecId) -> Option<usize> {
         self.get_account_storage_entry(slot, store_id)
             .map(|store| store.count_and_status.read().unwrap().0)
@@ -2360,8 +2365,7 @@ impl AccountsDB {
             // the cache *after* we've finished flushing in `flush_slot_cache`.
             let storage_maps: Vec<Arc<AccountStorageEntry>> = self
                 .storage
-                .get_slot_stores(slot)
-                .map(|res| res.read().unwrap().values().cloned().collect())
+                .get_slot_storage_entries(slot)
                 .unwrap_or_default();
             self.thread_pool.install(|| {
                 storage_maps
@@ -4520,8 +4524,7 @@ impl AccountsDB {
             }
             let storage_maps: Vec<Arc<AccountStorageEntry>> = self
                 .storage
-                .get_slot_stores(*slot)
-                .map(|res| res.read().unwrap().values().cloned().collect())
+                .get_slot_storage_entries(*slot)
                 .unwrap_or_default();
             let num_accounts = storage_maps
                 .iter()
@@ -7972,8 +7975,7 @@ pub mod tests {
 
         let mut storage_maps: Vec<Arc<AccountStorageEntry>> = accounts_db
             .storage
-            .get_slot_stores(slot)
-            .map(|res| res.read().unwrap().values().cloned().collect())
+            .get_slot_storage_entries(slot)
             .unwrap_or_default();
 
         // Flushing cache should only create one storage entry
@@ -8384,6 +8386,73 @@ pub mod tests {
     #[test]
     fn test_flush_rooted_accounts_cache_without_clean() {
         run_flush_rooted_accounts_cache(false);
+    }
+
+    #[test]
+    fn test_shrink_unref() {
+        // Enable caching so that we use the straightforward implementation
+        // of shrink that will shrink all candidate slots
+        let caching_enabled = true;
+        let db = AccountsDB::new_with_config(
+            Vec::new(),
+            &ClusterType::Development,
+            HashSet::default(),
+            caching_enabled,
+        );
+        let account_key1 = Pubkey::new_unique();
+        let account_key2 = Pubkey::new_unique();
+        let account1 = Account::new(1, 0, &Account::default().owner);
+
+        // Store into slot 0
+        db.store_cached(0, &[(&account_key1, &account1)]);
+        db.store_cached(0, &[(&account_key2, &account1)]);
+        db.add_root(0);
+        // Flushes all roots
+        db.flush_accounts_cache(true, None);
+
+        // Make account_key1 in slot 0 outdated by updating in rooted slot 1
+        db.store_cached(1, &[(&account_key1, &account1)]);
+        db.add_root(1);
+        // Flushes all roots
+        db.flush_accounts_cache(true, None);
+        db.get_accounts_delta_hash(0);
+        db.get_accounts_delta_hash(1);
+
+        // Clean to remove outdated entry from slot 0
+        db.clean_accounts(Some(1));
+
+        // Shrink Slot 0
+        let mut slot0_stores = db.storage.get_slot_storage_entries(0).unwrap();
+        assert_eq!(slot0_stores.len(), 1);
+        let slot0_store = slot0_stores.pop().unwrap();
+        {
+            let mut shrink_candidate_slots = db.shrink_candidate_slots.lock().unwrap();
+            shrink_candidate_slots
+                .entry(0)
+                .or_default()
+                .insert(slot0_store.append_vec_id(), slot0_store);
+        }
+        db.shrink_candidate_slots();
+
+        // Make slot 0 dead by updating the remaining key
+        db.store_cached(2, &[(&account_key2, &account1)]);
+        db.add_root(2);
+
+        // Flushes all roots
+        db.flush_accounts_cache(true, None);
+
+        // Should be one store before clean for slot 0
+        assert_eq!(db.storage.get_slot_storage_entries(0).unwrap().len(), 1);
+        db.get_accounts_delta_hash(2);
+        db.clean_accounts(Some(2));
+
+        // No stores should exist for slot 0 after clean
+        assert!(db.storage.get_slot_storage_entries(0).is_none());
+
+        // Ref count for `account_key1` (account removed earlier by shrink)
+        // should be 1, since it was only stored in slot 0 and 1, and slot 0
+        // is now dead
+        assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4051,8 +4051,7 @@ impl AccountsDB {
                     "AccountDB::accounts_index corrupted. Storage pointed to: {}, expected: {}, should only point to one slot",
                     store.slot(), *slot
                 );
-                let count =
-                    store.remove_account(account_info.stored_size, reset_accounts);
+                let count = store.remove_account(account_info.stored_size, reset_accounts);
                 if count == 0 {
                     dead_slots.insert(*slot);
                 } else if self.caching_enabled

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -100,6 +100,10 @@ impl<T: Clone> ReadAccountMapEntry<T> {
     pub fn ref_count(&self) -> &AtomicU64 {
         &self.borrow_owned_entry_contents().ref_count
     }
+
+    pub fn unref(&self) {
+        self.ref_count().fetch_sub(1, Ordering::Relaxed);
+    }
 }
 
 #[self_referencing]
@@ -109,7 +113,7 @@ pub struct WriteAccountMapEntry<T: 'static> {
     slot_list_guard: RwLockWriteGuard<'this, SlotList<T>>,
 }
 
-impl<T: 'static + Clone> WriteAccountMapEntry<T> {
+impl<T: 'static + Clone + IsCached> WriteAccountMapEntry<T> {
     pub fn from_account_map_entry(account_map_entry: AccountMapEntry<T>) -> Self {
         WriteAccountMapEntryBuilder {
             owned_entry: account_map_entry,
@@ -146,12 +150,18 @@ impl<T: 'static + Clone> WriteAccountMapEntry<T> {
             .collect();
         assert!(same_slot_previous_updates.len() <= 1);
         if let Some((list_index, (s, previous_update_value))) = same_slot_previous_updates.pop() {
+            let is_flush_from_cache =
+                previous_update_value.is_cached() && !account_info.is_cached();
             reclaims.push((*s, previous_update_value.clone()));
             self.slot_list_mut(|list| list.remove(list_index));
-        } else {
-            // Only increment ref count if the account was not prevously updated in this slot
+            if is_flush_from_cache {
+                self.ref_count().fetch_add(1, Ordering::Relaxed);
+            }
+        } else if !account_info.is_cached() {
+            // If it's the first non-cache insert, also bump the stored ref count
             self.ref_count().fetch_add(1, Ordering::Relaxed);
         }
+
         self.slot_list_mut(|list| list.push((slot, account_info)));
     }
 }
@@ -856,7 +866,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
 
     pub fn unref_from_storage(&self, pubkey: &Pubkey) {
         if let Some(locked_entry) = self.get_account_read_entry(pubkey) {
-            locked_entry.ref_count().fetch_sub(1, Ordering::Relaxed);
+            locked_entry.unref();
         }
     }
 


### PR DESCRIPTION
#### Problem

Stores can be reset while snapshots are being created.

#### Summary of Changes

Check if the store accounts are being removed from a clean on a rooted store, then don't reset the accounts if that is the case.

Fixes #
