### PR TITLE
Add syscall feature activation test

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4655,6 +4655,20 @@ impl Bank {
         false
     }
 
+    pub fn deactivate_feature(&mut self, id: &Pubkey) {
+        let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
+        feature_set.active.remove(&id);
+        feature_set.inactive.insert(*id);
+        self.feature_set = Arc::new(feature_set);
+    }
+
+    pub fn activate_feature(&mut self, id: &Pubkey) {
+        let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
+        feature_set.inactive.remove(id);
+        feature_set.active.insert(*id, 0);
+        self.feature_set = Arc::new(feature_set);
+    }
+
     // This is called from snapshot restore AND for each epoch boundary
     // The entire code path herein must be idempotent
     fn apply_feature_activations(&mut self, init_finish_or_warp: bool) {


### PR DESCRIPTION
#### Problem

https://github.com/solana-labs/solana/issues/14887

in v1.5, syscall information is stored in the cached program executor and the VM attempts to bind to info upon load even if the program never calls it. Upon activation, the VM has a superset of syscalls and fails when it can't bind to the new syscall in the old executor.

#### Summary of Changes

This PR adds a test (ignored for now) to recreate the issue

Fixes #
