### PR TITLE
Increase vm map limit recommendation to 700k

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -83,7 +83,7 @@ sudo sysctl -p /etc/sysctl.d/20-solana-udp-buffers.conf
 ```bash
 sudo bash -c "cat >/etc/sysctl.d/20-solana-mmaps.conf <<EOF
 # Increase memory mapped files limit
-vm.max_map_count = 500000
+vm.max_map_count = 700000
 EOF"
 ```
 ```bash

--- a/sys-tuner/src/main.rs
+++ b/sys-tuner/src/main.rs
@@ -93,7 +93,7 @@ fn tune_kernel_udp_buffers_and_vmmap() {
     sysctl_write("net.core.wmem_default", "134217728");
 
     // increase mmap counts for many append_vecs
-    sysctl_write("vm.max_map_count", "500000");
+    sysctl_write("vm.max_map_count", "700000");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
#### Problem

500k vm map limit doesn't give enough margin if clean/shrink is not keeping up to reduce the number of stores.

#### Summary of Changes

Increase limit to to 700k.

Fixes #
