### PR TITLE
Manually camelCase solana program json

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2726,7 +2726,7 @@ mod tests {
         let program_id = json
             .as_object()
             .unwrap()
-            .get("ProgramId")
+            .get("programId")
             .unwrap()
             .as_str()
             .unwrap();

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -10,7 +10,7 @@ use bincode::serialize;
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use log::*;
-use serde_json::{self, json};
+use serde_json::{self, json, Value};
 use solana_bpf_loader_program::{bpf_verifier, BPFError, ThisInstructionMeter};
 use solana_clap_utils::{self, input_parsers::*, input_validators::*, keypair::*};
 use solana_cli_output::display::new_spinner_progress_bar;
@@ -888,7 +888,7 @@ fn process_set_authority(
         )
         .map_err(|e| format!("Setting authority failed: {}", e))?;
 
-    Ok(option_pubkey_to_string("Authority", new_authority))
+    Ok(option_pubkey_to_string("authority", new_authority).to_string())
 }
 
 fn process_get_authority(
@@ -914,10 +914,11 @@ fn process_get_authority(
                         ..
                     }) = account.state()
                     {
-                        Ok(option_pubkey_to_string(
-                            "Program upgrade authority",
-                            upgrade_authority_address,
-                        ))
+                        let mut value =
+                            option_pubkey_to_string("authority", upgrade_authority_address);
+                        let map = value.as_object_mut().unwrap();
+                        map.insert("accountType".to_string(), json!("program".to_string()));
+                        Ok(value.to_string())
                     } else {
                         Err("Invalid associated ProgramData account found for the program".into())
                     }
@@ -929,10 +930,10 @@ fn process_get_authority(
                 }
             } else if let Ok(UpgradeableLoaderState::Buffer { authority_address }) = account.state()
             {
-                Ok(option_pubkey_to_string(
-                    "Buffer authority",
-                    authority_address,
-                ))
+                let mut value = option_pubkey_to_string("authority", authority_address);
+                let map = value.as_object_mut().unwrap();
+                map.insert("accountType".to_string(), json!("buffer".to_string()));
+                Ok(value.to_string())
             } else {
                 Err("Not a buffer or program account".into())
             }
@@ -1144,12 +1145,12 @@ fn do_process_program_write_and_deploy(
 
     if let Some(program_signer) = program_signer {
         Ok(json!({
-            "ProgramId": format!("{}", program_signer.pubkey()),
+            "programId": format!("{}", program_signer.pubkey()),
         })
         .to_string())
     } else {
         Ok(json!({
-            "Buffer": format!("{}", buffer_pubkey),
+            "buffer": format!("{}", buffer_pubkey),
         })
         .to_string())
     }
@@ -1465,16 +1466,14 @@ fn report_ephemeral_mnemonic(words: usize, mnemonic: bip39::Mnemonic) {
     );
 }
 
-fn option_pubkey_to_string(tag: &str, option: Option<Pubkey>) -> String {
+fn option_pubkey_to_string(tag: &str, option: Option<Pubkey>) -> Value {
     match option {
         Some(pubkey) => json!({
             tag: format!("{:?}", pubkey),
-        })
-        .to_string(),
+        }),
         None => json!({
-            tag: "None",
-        })
-        .to_string(),
+            tag: "none",
+        }),
     }
 }
 
@@ -2388,7 +2387,7 @@ mod tests {
         let program_id = json
             .as_object()
             .unwrap()
-            .get("ProgramId")
+            .get("programId")
             .unwrap()
             .as_str()
             .unwrap();

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -66,7 +66,7 @@ fn test_cli_program_deploy_non_upgradeable() {
     let program_id_str = json
         .as_object()
         .unwrap()
-        .get("ProgramId")
+        .get("programId")
         .unwrap()
         .as_str()
         .unwrap();
@@ -202,7 +202,7 @@ fn test_cli_program_deploy_no_authority() {
     let program_id_str = json
         .as_object()
         .unwrap()
-        .get("ProgramId")
+        .get("programId")
         .unwrap()
         .as_str()
         .unwrap();
@@ -291,7 +291,7 @@ fn test_cli_program_deploy_with_authority() {
     let program_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("ProgramId")
+        .get("programId")
         .unwrap()
         .as_str()
         .unwrap();
@@ -338,7 +338,7 @@ fn test_cli_program_deploy_with_authority() {
     let program_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("ProgramId")
+        .get("programId")
         .unwrap()
         .as_str()
         .unwrap();
@@ -407,7 +407,7 @@ fn test_cli_program_deploy_with_authority() {
     let new_upgrade_authority_str = json
         .as_object()
         .unwrap()
-        .get("Authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
@@ -459,7 +459,7 @@ fn test_cli_program_deploy_with_authority() {
     let authority_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Program upgrade authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
@@ -480,11 +480,11 @@ fn test_cli_program_deploy_with_authority() {
     let new_upgrade_authority_str = json
         .as_object()
         .unwrap()
-        .get("Authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
-    assert_eq!(new_upgrade_authority_str, "None");
+    assert_eq!(new_upgrade_authority_str, "none");
 
     // Upgrade with no authority
     config.signers = vec![&keypair, &new_upgrade_authority];
@@ -521,7 +521,7 @@ fn test_cli_program_deploy_with_authority() {
     let program_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("ProgramId")
+        .get("programId")
         .unwrap()
         .as_str()
         .unwrap();
@@ -549,11 +549,11 @@ fn test_cli_program_deploy_with_authority() {
     let authority_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Program upgrade authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
-    assert_eq!("None", authority_pubkey_str);
+    assert_eq!("none", authority_pubkey_str);
 }
 
 #[test]
@@ -618,7 +618,7 @@ fn test_cli_program_write_buffer() {
     let buffer_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Buffer")
+        .get("buffer")
         .unwrap()
         .as_str()
         .unwrap();
@@ -652,7 +652,7 @@ fn test_cli_program_write_buffer() {
     let buffer_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Buffer")
+        .get("buffer")
         .unwrap()
         .as_str()
         .unwrap();
@@ -683,7 +683,7 @@ fn test_cli_program_write_buffer() {
     let authority_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Buffer authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
@@ -709,7 +709,7 @@ fn test_cli_program_write_buffer() {
     let buffer_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Buffer")
+        .get("buffer")
         .unwrap()
         .as_str()
         .unwrap();
@@ -747,7 +747,7 @@ fn test_cli_program_write_buffer() {
     let buffer_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Buffer")
+        .get("buffer")
         .unwrap()
         .as_str()
         .unwrap();
@@ -782,7 +782,7 @@ fn test_cli_program_write_buffer() {
     let buffer_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Buffer")
+        .get("buffer")
         .unwrap()
         .as_str()
         .unwrap();
@@ -804,11 +804,11 @@ fn test_cli_program_write_buffer() {
     let authority_pubkey_str = json
         .as_object()
         .unwrap()
-        .get("Buffer authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
-    assert_eq!("None", authority_pubkey_str);
+    assert_eq!("none", authority_pubkey_str);
 }
 
 #[test]
@@ -885,7 +885,7 @@ fn test_cli_program_set_buffer_authority() {
     let new_buffer_authority_str = json
         .as_object()
         .unwrap()
-        .get("Authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
@@ -912,7 +912,7 @@ fn test_cli_program_set_buffer_authority() {
     let buffer_authority_str = json
         .as_object()
         .unwrap()
-        .get("Authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
@@ -939,11 +939,11 @@ fn test_cli_program_set_buffer_authority() {
     let buffer_authority_str = json
         .as_object()
         .unwrap()
-        .get("Authority")
+        .get("authority")
         .unwrap()
         .as_str()
         .unwrap();
-    assert_eq!(buffer_authority_str, "None");
+    assert_eq!(buffer_authority_str, "none");
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
         assert_eq!(authority_address, None);


### PR DESCRIPTION
#### Problem
New upgradeable loader code for solana-cli changed the case of the json response from `solana deploy`

#### Summary of Changes
- Restore it
- Also manually camelCase all the other `solana program` json responses. Follow up work will implement DisplayOutput for `solana program`, but shipped with v1.6 since it is a breaking change (after that change, users who want json will need to pass the `--output json` arg)
