### PR TITLE
program-test: Expose bank task to fix fuzzing

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -19,6 +19,7 @@ use {
     },
     solana_sdk::{
         account::Account,
+        genesis_config::GenesisConfig,
         keyed_account::KeyedAccount,
         process_instruction::{
             stable_log, BpfComputeBudget, InvokeContext, ProcessInstructionWithContext,
@@ -37,6 +38,10 @@ use {
         sync::{Arc, RwLock},
         time::{Duration, Instant},
     },
+    tokio::{
+        sync::mpsc::{self, Sender},
+        task::JoinHandle,
+    }
 };
 
 // Export types so test clients can limit their solana crate dependencies
@@ -351,6 +356,45 @@ pub fn read_file<P: AsRef<Path>>(path: P) -> Vec<u8> {
     file_data
 }
 
+fn setup_fee_calculator(bank: Bank) -> Bank {
+    // Realistic fee_calculator part 1: Fake a single signature by calling
+    // `bank.commit_transactions()` so that the fee calculator in the child bank will be
+    // initialized with a non-zero fee.
+    assert_eq!(bank.signature_count(), 0);
+    bank.commit_transactions(
+        &[],
+        None,
+        &mut [],
+        &[],
+        0,
+        1,
+        &mut ExecuteTimings::default(),
+    );
+    assert_eq!(bank.signature_count(), 1);
+
+    // Advance beyond slot 0 for a slightly more realistic test environment
+    let bank = Arc::new(bank);
+    let bank = Bank::new_from_parent(&bank, bank.collector_id(), bank.slot() + 1);
+    debug!("Bank slot: {}", bank.slot());
+
+    // Realistic fee_calculator part 2: Tick until a new blockhash is produced to pick up the
+    // non-zero fee calculator
+    let last_blockhash = bank.last_blockhash();
+    while last_blockhash == bank.last_blockhash() {
+        bank.register_tick(&Hash::new_unique());
+    }
+    let last_blockhash = bank.last_blockhash();
+    // Make sure the new last_blockhash now requires a fee
+    assert_ne!(
+        bank.get_fee_calculator(&last_blockhash)
+            .expect("fee_calculator")
+            .lamports_per_signature,
+        0
+    );
+
+    bank
+}
+
 pub struct ProgramTest {
     accounts: Vec<(Pubkey, Account)>,
     builtins: Vec<Builtin>,
@@ -539,7 +583,7 @@ impl ProgramTest {
     ///
     /// Returns a `BanksClient` interface into the test environment as well as a payer `Keypair`
     /// with SOL for sending transactions
-    pub async fn start(self) -> (BanksClient, Keypair, Hash) {
+    pub async fn start(self) -> ProgramTestState {
         {
             use std::sync::Once;
             static ONCE: Once = Once::new();
@@ -564,7 +608,6 @@ impl ProgramTest {
         let payer = gci.mint_keypair;
         debug!("Payer address: {}", payer.pubkey());
         debug!("Genesis config: {}", genesis_config);
-        let target_tick_duration = genesis_config.poh_config.target_tick_duration;
 
         let mut bank = Bank::new(&genesis_config);
 
@@ -603,62 +646,15 @@ impl ProgramTest {
             }));
         }
 
-        // Realistic fee_calculator part 1: Fake a single signature by calling
-        // `bank.commit_transactions()` so that the fee calculator in the child bank will be
-        // initialized with a non-zero fee.
-        assert_eq!(bank.signature_count(), 0);
-        bank.commit_transactions(
-            &[],
-            None,
-            &mut [],
-            &[],
-            0,
-            1,
-            &mut ExecuteTimings::default(),
-        );
-        assert_eq!(bank.signature_count(), 1);
-
-        // Advance beyond slot 0 for a slightly more realistic test environment
-        let bank = Arc::new(bank);
-        let bank = Bank::new_from_parent(&bank, bank.collector_id(), bank.slot() + 1);
-        debug!("Bank slot: {}", bank.slot());
-
-        // Realistic fee_calculator part 2: Tick until a new blockhash is produced to pick up the
-        // non-zero fee calculator
+        let bank = setup_fee_calculator(bank);
         let last_blockhash = bank.last_blockhash();
-        while last_blockhash == bank.last_blockhash() {
-            bank.register_tick(&Hash::new_unique());
-        }
-        let last_blockhash = bank.last_blockhash();
-        // Make sure the new last_blockhash now requires a fee
-        assert_ne!(
-            bank.get_fee_calculator(&last_blockhash)
-                .expect("fee_calculator")
-                .lamports_per_signature,
-            0
-        );
-
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
         let transport = start_local_server(&bank_forks).await;
         let banks_client = start_client(transport)
             .await
             .unwrap_or_else(|err| panic!("Failed to start banks client: {}", err));
 
-        // Run a simulated PohService to provide the client with new blockhashes.  New blockhashes
-        // are required when sending multiple otherwise identical transactions in series from a
-        // test
-        tokio::spawn(async move {
-            loop {
-                bank_forks
-                    .read()
-                    .unwrap()
-                    .working_bank()
-                    .register_tick(&Hash::new_unique());
-                tokio::time::sleep(target_tick_duration).await;
-            }
-        });
-
-        (banks_client, payer, last_blockhash)
+        ProgramTestState::new(bank_forks, banks_client, payer, last_blockhash, genesis_config)
     }
 }
 
@@ -698,3 +694,61 @@ impl ProgramTestBanksClientExt for BanksClient {
         ))
     }
 }
+
+struct DroppableTask<T>(Sender<()>, JoinHandle<T>);
+
+impl<T> Drop for DroppableTask<T> {
+    fn drop(&mut self) {
+        match self.0.try_send(()) {
+            Ok(_) => {},
+            Err(e) => {
+                debug!("Error cancelling task: {:?}", e);
+            }
+        }
+    }
+}
+
+pub struct ProgramTestState {
+    pub banks_client: BanksClient,
+    pub payer: Keypair,
+    pub last_blockhash: Hash,
+    _bank_task: DroppableTask<()>,
+}
+
+impl ProgramTestState {
+    pub fn new(bank_forks: Arc<RwLock<BankForks>>, banks_client: BanksClient, payer: Keypair, last_blockhash: Hash, genesis_config: GenesisConfig) -> Self {
+        // Run a simulated PohService to provide the client with new blockhashes.  New blockhashes
+        // are required when sending multiple otherwise identical transactions in series from a
+        // test
+        let target_tick_duration = genesis_config.poh_config.target_tick_duration;
+        let (tx, mut rx) = mpsc::channel(1);
+        let bank_task = DroppableTask(
+            tx,
+            tokio::spawn(async move {
+                loop {
+                    match rx.try_recv() {
+                        Ok(_) => {
+                            break;
+                        }
+                        // The channel is currently empty
+                        _ => {}
+                    }
+                    bank_forks
+                        .read()
+                        .unwrap()
+                        .working_bank()
+                        .register_tick(&Hash::new_unique());
+                    tokio::time::sleep(target_tick_duration).await;
+                }
+            })
+        );
+
+        Self {
+            banks_client,
+            payer,
+            last_blockhash,
+            _bank_task: bank_task,
+        }
+    }
+}
+

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -1,12 +1,17 @@
-use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, rent::Rent,
-};
-use solana_program_test::{processor, ProgramTest, ProgramTestState};
-use solana_sdk::{
-    signature::Keypair, signature::Signer, system_instruction, transaction::Transaction,
+use {
+    solana_banks_client::BanksClient,
+    solana_program::{
+        account_info::AccountInfo, entrypoint::ProgramResult, hash::Hash, pubkey::Pubkey,
+        rent::Rent,
+    },
+    solana_program_test::{processor, ProgramTest},
+    solana_sdk::{
+        signature::Keypair, signature::Signer, system_instruction, transaction::Transaction,
+    },
 };
 
 // Dummy process instruction required to instantiate ProgramTest
+#[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
     _accounts: &[AccountInfo],
@@ -26,18 +31,55 @@ fn simulate_fuzz() {
         processor!(process_instruction),
     );
 
-    let mut test_state = rt.block_on(async { program_test.start().await });
+    let (mut banks_client, payer, last_blockhash) =
+        rt.block_on(async { program_test.start().await });
 
     // the honggfuzz `fuzz!` macro does not allow for async closures,
     // so we have to use the runtime directly to run async functions
     rt.block_on(async {
-        run_fuzz_instructions(&[1, 2, 3, 4, 5], &mut test_state, &program_id).await
+        run_fuzz_instructions(
+            &[1, 2, 3, 4, 5],
+            &mut banks_client,
+            &payer,
+            last_blockhash,
+            &program_id,
+        )
+        .await
+    });
+}
+
+#[test]
+fn simulate_fuzz_with_context() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let program_id = Pubkey::new_unique();
+    // Initialize and start the test network
+    let program_test = ProgramTest::new(
+        "program-test-fuzz",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    let mut test_state = rt.block_on(async { program_test.start_with_context().await });
+
+    // the honggfuzz `fuzz!` macro does not allow for async closures,
+    // so we have to use the runtime directly to run async functions
+    rt.block_on(async {
+        run_fuzz_instructions(
+            &[1, 2, 3, 4, 5],
+            &mut test_state.banks_client,
+            &test_state.payer,
+            test_state.last_blockhash,
+            &program_id,
+        )
+        .await
     });
 }
 
 async fn run_fuzz_instructions(
     fuzz_instruction: &[u8],
-    test_state: &mut ProgramTestState,
+    banks_client: &mut BanksClient,
+    payer: &Keypair,
+    last_blockhash: Hash,
     program_id: &Pubkey,
 ) {
     let mut instructions = vec![];
@@ -45,7 +87,7 @@ async fn run_fuzz_instructions(
     for &i in fuzz_instruction {
         let keypair = Keypair::new();
         let instruction = system_instruction::create_account(
-            &test_state.payer.pubkey(),
+            &payer.pubkey(),
             &keypair.pubkey(),
             Rent::default().minimum_balance(i as usize),
             i as u64,
@@ -55,23 +97,17 @@ async fn run_fuzz_instructions(
         signer_keypairs.push(keypair);
     }
     // Process transaction on test network
-    let mut transaction =
-        Transaction::new_with_payer(&instructions, Some(&test_state.payer.pubkey()));
-    let signers = [&test_state.payer]
+    let mut transaction = Transaction::new_with_payer(&instructions, Some(&payer.pubkey()));
+    let signers = [payer]
         .iter()
         .copied()
         .chain(signer_keypairs.iter())
         .collect::<Vec<&Keypair>>();
-    transaction.partial_sign(&signers, test_state.last_blockhash);
+    transaction.partial_sign(&signers, last_blockhash);
 
-    test_state
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap();
+    banks_client.process_transaction(transaction).await.unwrap();
     for keypair in signer_keypairs {
-        let account = test_state
-            .banks_client
+        let account = banks_client
             .get_account(keypair.pubkey())
             .await
             .expect("account exists")

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -1,9 +1,17 @@
-use solana_program_test::{ProgramTest, ProgramTestState, processor};
-use solana_sdk::{signature::Keypair, signature::Signer, system_instruction, transaction::Transaction};
-use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, rent::Rent};
+use solana_program::{
+    account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, rent::Rent,
+};
+use solana_program_test::{processor, ProgramTest, ProgramTestState};
+use solana_sdk::{
+    signature::Keypair, signature::Signer, system_instruction, transaction::Transaction,
+};
 
 // Dummy process instruction required to instantiate ProgramTest
-fn process_instruction(_program_id: &Pubkey, _accounts: &[AccountInfo], _input: &[u8]) -> ProgramResult {
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _input: &[u8],
+) -> ProgramResult {
     Ok(())
 }
 
@@ -22,7 +30,9 @@ fn simulate_fuzz() {
 
     // the honggfuzz `fuzz!` macro does not allow for async closures,
     // so we have to use the runtime directly to run async functions
-    rt.block_on(async { run_fuzz_instructions(&[1, 2, 3, 4, 5], &mut test_state, &program_id).await });
+    rt.block_on(async {
+        run_fuzz_instructions(&[1, 2, 3, 4, 5], &mut test_state, &program_id).await
+    });
 }
 
 async fn run_fuzz_instructions(
@@ -35,32 +45,40 @@ async fn run_fuzz_instructions(
     for &i in fuzz_instruction {
         let keypair = Keypair::new();
         let instruction = system_instruction::create_account(
-                &test_state.payer.pubkey(),
-                &keypair.pubkey(),
-                Rent::default().minimum_balance(i as usize),
-                i as u64,
-                program_id,
-            );
+            &test_state.payer.pubkey(),
+            &keypair.pubkey(),
+            Rent::default().minimum_balance(i as usize),
+            i as u64,
+            program_id,
+        );
         instructions.push(instruction);
         signer_keypairs.push(keypair);
     }
     // Process transaction on test network
-    let mut transaction = Transaction::new_with_payer(
-        &instructions,
-        Some(&test_state.payer.pubkey()),
-    );
-    let signers = [&test_state.payer].iter().map(|&v| v).chain(signer_keypairs.iter()).collect::<Vec<&Keypair>>();
-    transaction.partial_sign(
-        &signers,
-        test_state.last_blockhash,
-    );
+    let mut transaction =
+        Transaction::new_with_payer(&instructions, Some(&test_state.payer.pubkey()));
+    let signers = [&test_state.payer]
+        .iter()
+        .copied()
+        .chain(signer_keypairs.iter())
+        .collect::<Vec<&Keypair>>();
+    transaction.partial_sign(&signers, test_state.last_blockhash);
 
-    test_state.banks_client.process_transaction(transaction).await.unwrap_or_else(|e| {
-        print!("{:?}", e);
-    });
+    test_state
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap_or_else(|e| {
+            print!("{:?}", e);
+        });
     for keypair in signer_keypairs {
-        let account = test_state.banks_client.get_account(keypair.pubkey()).await.expect("account exists").unwrap();
+        let account = test_state
+            .banks_client
+            .get_account(keypair.pubkey())
+            .await
+            .expect("account exists")
+            .unwrap();
         assert!(account.lamports > 0);
-        assert!(account.data.len() > 0);
+        assert!(!account.data.is_empty());
     }
 }

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -68,9 +68,7 @@ async fn run_fuzz_instructions(
         .banks_client
         .process_transaction(transaction)
         .await
-        .unwrap_or_else(|e| {
-            print!("{:?}", e);
-        });
+        .unwrap();
     for keypair in signer_keypairs {
         let account = test_state
             .banks_client

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -1,0 +1,66 @@
+use solana_program_test::{ProgramTest, ProgramTestState, processor};
+use solana_sdk::{signature::Keypair, signature::Signer, system_instruction, transaction::Transaction};
+use solana_program::{account_info::AccountInfo, entrypoint::ProgramResult, pubkey::Pubkey, rent::Rent};
+
+// Dummy process instruction required to instantiate ProgramTest
+fn process_instruction(_program_id: &Pubkey, _accounts: &[AccountInfo], _input: &[u8]) -> ProgramResult {
+    Ok(())
+}
+
+#[test]
+fn simulate_fuzz() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let program_id = Pubkey::new_unique();
+    // Initialize and start the test network
+    let program_test = ProgramTest::new(
+        "program-test-fuzz",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    let mut test_state = rt.block_on(async { program_test.start().await });
+
+    // the honggfuzz `fuzz!` macro does not allow for async closures,
+    // so we have to use the runtime directly to run async functions
+    rt.block_on(async { run_fuzz_instructions(&[1, 2, 3, 4, 5], &mut test_state, &program_id).await });
+}
+
+async fn run_fuzz_instructions(
+    fuzz_instruction: &[u8],
+    test_state: &mut ProgramTestState,
+    program_id: &Pubkey,
+) {
+    let mut instructions = vec![];
+    let mut signer_keypairs = vec![];
+    for &i in fuzz_instruction {
+        let keypair = Keypair::new();
+        let instruction = system_instruction::create_account(
+                &test_state.payer.pubkey(),
+                &keypair.pubkey(),
+                Rent::default().minimum_balance(i as usize),
+                i as u64,
+                program_id,
+            );
+        instructions.push(instruction);
+        signer_keypairs.push(keypair);
+    }
+    // Process transaction on test network
+    let mut transaction = Transaction::new_with_payer(
+        &instructions,
+        Some(&test_state.payer.pubkey()),
+    );
+    let signers = [&test_state.payer].iter().map(|&v| v).chain(signer_keypairs.iter()).collect::<Vec<&Keypair>>();
+    transaction.partial_sign(
+        &signers,
+        test_state.last_blockhash,
+    );
+
+    test_state.banks_client.process_transaction(transaction).await.unwrap_or_else(|e| {
+        print!("{:?}", e);
+    });
+    for keypair in signer_keypairs {
+        let account = test_state.banks_client.get_account(keypair.pubkey()).await.expect("account exists").unwrap();
+        assert!(account.lamports > 0);
+        assert!(account.data.len() > 0);
+    }
+}


### PR DESCRIPTION
#### Problem

Program-test creates a running task to register ticks on the bank, but does not expose this task.  For most cases, this works great, but in a fuzzing environment, not closing the thread properly blows up `/tmp` with all sorts of directories like `/tmp/.tmp0000`, perhaps related to rocksdb?  I'm not too familiar with that side of it.

#### Summary of Changes

Expose the running task on the bank through a new return type, `ProgramTestState`, and allow it to be stopped on `drop`.  This changes the API on `ProgramTest.start()`, which seems reasonable considering most of these are tests users.  If needed, I can spin off a new / old function and mark this as deprecated.

One thing to note is that we can't simply destructure this as:
```
let ProgramTestState { mut banks_client, payer, last_blockhash, .. } = program_test.start().await;
```
Because the task gets dropped at that point.

The other nice part of this approach is that we can start to support a lot of functions that have been asked for by devs.  My next idea is to add a `warp_to_slot` on `ProgramTestState`.  We'll just need to keep track of the `BankForks` and use `Bank::warp_from_parent`.

This approach gets much more consistent performance from fuzzing as well.  For the test, we can't easily use the `fuzz!` macro because then we need to build with `cargo hfuzz build`, so instead it's simulating what a fuzz run would look like with arbitrary `&[u8]` data.

Fixes #14707 