### PR TITLE
Impl OutputFormat for solana program

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1466,6 +1466,60 @@ impl fmt::Display for CliTokenAccount {
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliProgramId {
+    pub program_id: String,
+}
+
+impl QuietDisplay for CliProgramId {}
+impl VerboseDisplay for CliProgramId {}
+
+impl fmt::Display for CliProgramId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln_name_value(f, "Program Id:", &self.program_id)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliProgramBuffer {
+    pub buffer: String,
+}
+
+impl QuietDisplay for CliProgramBuffer {}
+impl VerboseDisplay for CliProgramBuffer {}
+
+impl fmt::Display for CliProgramBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln_name_value(f, "Buffer:", &self.buffer)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CliProgramAccountType {
+    Buffer,
+    Program,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliProgramAuthority {
+    pub authority: String,
+    pub account_type: CliProgramAccountType,
+}
+
+impl QuietDisplay for CliProgramAuthority {}
+impl VerboseDisplay for CliProgramAuthority {}
+
+impl fmt::Display for CliProgramAuthority {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln_name_value(f, "Account Type:", &format!("{:?}", self.account_type))?;
+        writeln_name_value(f, "Authority:", &self.authority)
+    }
+}
+
 pub fn return_signers(
     tx: &Transaction,
     output_format: &OutputFormat,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2724,6 +2724,7 @@ mod tests {
             use_deprecated_loader: false,
             allow_excessive_balance: false,
         };
+        config.output_format = OutputFormat::JsonCompact;
         let result = process_command(&config);
         let json: Value = serde_json::from_str(&result.unwrap()).unwrap();
         let program_id = json

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -3,6 +3,7 @@ use solana_cli::{
     cli::{process_command, CliCommand, CliConfig},
     program::ProgramCliCommand,
 };
+use solana_cli_output::OutputFormat;
 use solana_client::rpc_client::RpcClient;
 use solana_core::test_validator::TestValidator;
 use solana_faucet::faucet::run_local_faucet;
@@ -58,6 +59,7 @@ fn test_cli_program_deploy_non_upgradeable() {
         use_deprecated_loader: false,
         allow_excessive_balance: false,
     };
+    config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
     let program_id_str = json
@@ -190,6 +192,7 @@ fn test_cli_program_deploy_no_authority() {
         is_final: true,
         max_len: None,
     });
+    config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
     let program_id_str = json
@@ -274,6 +277,7 @@ fn test_cli_program_deploy_with_authority() {
         is_final: false,
         max_len: Some(max_len),
     });
+    config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
     let program_pubkey_str = json
@@ -592,6 +596,7 @@ fn test_cli_program_write_buffer() {
         buffer_authority_signer_index: None,
         max_len: None,
     });
+    config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
     let buffer_pubkey_str = json
@@ -826,6 +831,7 @@ fn test_cli_program_set_buffer_authority() {
         buffer_authority_index: Some(0),
         new_buffer_authority: new_buffer_authority.pubkey(),
     });
+    config.output_format = OutputFormat::JsonCompact;
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
     let new_buffer_authority_str = json


### PR DESCRIPTION
#### Problem
`solana program ...` and `solana deploy` commands always return json objects. This is inconsistent with all our other cli subcommands, and forces horrible hand-casing of returned fields.

#### Summary of Changes
A more comprehensive (and breakier) version of #14907 for master, implementing OutputFormat for the solana program/deploy subcommands.
