### PR TITLE
Do not download and execute binaries via HTTP

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -507,7 +507,7 @@ prepareDeploy() {
     if [[ -n $releaseChannel ]]; then
       echo "Downloading release from channel: $releaseChannel"
       rm -f "$SOLANA_ROOT"/solana-release.tar.bz2
-      declare updateDownloadUrl=http://release.solana.com/"$releaseChannel"/solana-release-x86_64-unknown-linux-gnu.tar.bz2
+      declare updateDownloadUrl=https://release.solana.com/"$releaseChannel"/solana-release-x86_64-unknown-linux-gnu.tar.bz2
       (
         set -x
         curl -L -I "$updateDownloadUrl"

--- a/scripts/solana-install-deploy.sh
+++ b/scripts/solana-install-deploy.sh
@@ -57,7 +57,7 @@ esac
 
 case $TAG in
 edge|beta)
-  DOWNLOAD_URL=http://release.solana.com/"$TAG"/solana-release-$TARGET.tar.bz2
+  DOWNLOAD_URL=https://release.solana.com/"$TAG"/solana-release-$TARGET.tar.bz2
   ;;
 *)
   DOWNLOAD_URL=https://github.com/solana-labs/solana/releases/download/"$TAG"/solana-release-$TARGET.tar.bz2

--- a/web3.js/bin/bpf-sdk-install.sh
+++ b/web3.js/bin/bpf-sdk-install.sh
@@ -29,7 +29,7 @@ echo "Installing $channel BPF SDK into $installDir"
 set -x
 cd "$installDir/"
 curl -L  --retry 5 --retry-delay 2 -o bpf-sdk.tar.bz2 \
-  http://solana-sdk.s3.amazonaws.com/"$channel"/bpf-sdk.tar.bz2
+  https://solana-sdk.s3.amazonaws.com/"$channel"/bpf-sdk.tar.bz2
 rm -rf bpf-sdk
 mkdir -p bpf-sdk
 tar jxf bpf-sdk.tar.bz2


### PR DESCRIPTION
This fixes a couple of trivial remote code execution opportunities.