### PR TITLE
Add validator flag to opt in to cpi and logs storage

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -593,7 +593,7 @@ impl BankingStage {
             );
 
             bank_utils::find_and_send_votes(txs, &tx_results, Some(gossip_vote_sender));
-            if let Some(sender) = transaction_status_sender {
+            if let Some(transaction_status_sender) = transaction_status_sender {
                 let post_balances = bank.collect_balances(batch);
                 let post_token_balances = collect_token_balances(&bank, &batch, &mut mint_decimals);
                 send_transaction_status_batch(
@@ -605,7 +605,7 @@ impl BankingStage {
                     TransactionTokenBalancesSet::new(pre_token_balances, post_token_balances),
                     inner_instructions,
                     transaction_logs,
-                    sender,
+                    transaction_status_sender,
                 );
             }
         }
@@ -2074,7 +2074,10 @@ mod tests {
                 &transactions,
                 &poh_recorder,
                 0,
-                Some(transaction_status_sender),
+                Some(TransactionStatusSender {
+                    sender: transaction_status_sender,
+                    enable_cpi_and_log_storage: false,
+                }),
                 &gossip_vote_sender,
             );
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2746,7 +2746,10 @@ pub(crate) mod tests {
             &bank,
             &entries,
             true,
-            Some(transaction_status_sender),
+            Some(TransactionStatusSender {
+                sender: transaction_status_sender,
+                enable_cpi_and_log_storage: false,
+            }),
             Some(&replay_vote_sender),
         );
 

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -109,6 +109,7 @@ pub struct JsonRpcConfig {
     pub enable_validator_exit: bool,
     pub enable_set_log_filter: bool,
     pub enable_rpc_transaction_history: bool,
+    pub enable_cpi_and_log_storage: bool,
     pub identity_pubkey: Pubkey,
     pub faucet_addr: Option<SocketAddr>,
     pub health_check_slot_distance: u64,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -136,7 +136,7 @@ fn execute_batch(
         ..
     } = tx_results;
 
-    if let Some(sender) = transaction_status_sender {
+    if let Some(transaction_status_sender) = transaction_status_sender {
         let post_token_balances = if record_token_balances {
             collect_token_balances(&bank, &batch, &mut mint_decimals)
         } else {
@@ -155,7 +155,7 @@ fn execute_batch(
             token_balances,
             inner_instructions,
             transaction_logs,
-            sender,
+            transaction_status_sender,
         );
     }
 
@@ -1097,7 +1097,11 @@ pub struct TransactionStatusBatch {
     pub transaction_logs: Vec<TransactionLogMessages>,
 }
 
-pub type TransactionStatusSender = Sender<TransactionStatusBatch>;
+#[derive(Clone)]
+pub struct TransactionStatusSender {
+    pub sender: Sender<TransactionStatusBatch>,
+    pub enable_cpi_and_log_storage: bool,
+}
 
 pub fn send_transaction_status_batch(
     bank: Arc<Bank>,
@@ -1106,21 +1110,28 @@ pub fn send_transaction_status_batch(
     statuses: Vec<TransactionExecutionResult>,
     balances: TransactionBalancesSet,
     token_balances: TransactionTokenBalancesSet,
-    inner_instructions: Vec<Option<InnerInstructionsList>>,
-    transaction_logs: Vec<TransactionLogMessages>,
+    mut inner_instructions: Vec<Option<InnerInstructionsList>>,
+    mut transaction_logs: Vec<TransactionLogMessages>,
     transaction_status_sender: TransactionStatusSender,
 ) {
     let slot = bank.slot();
-    if let Err(e) = transaction_status_sender.send(TransactionStatusBatch {
-        bank,
-        transactions: transactions.to_vec(),
-        iteration_order,
-        statuses,
-        balances,
-        token_balances,
-        inner_instructions,
-        transaction_logs,
-    }) {
+    if !transaction_status_sender.enable_cpi_and_log_storage {
+        inner_instructions = inner_instructions.iter().map(|_| None).collect();
+        transaction_logs = transaction_logs.iter().map(|_| vec![]).collect();
+    }
+    if let Err(e) = transaction_status_sender
+        .sender
+        .send(TransactionStatusBatch {
+            bank,
+            transactions: transactions.to_vec(),
+            iteration_order,
+            statuses,
+            balances,
+            token_balances,
+            inner_instructions,
+            transaction_logs,
+        })
+    {
         trace!(
             "Slot {} transaction_status send batch failed: {:?}",
             slot,

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -48,6 +48,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-rpc-transaction-history ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --enable-cpi-and-log-storage ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --enable-rpc-bigtable-ledger-storage ]]; then
       args+=("$1")
       shift

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -130,6 +130,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --enable-rpc-transaction-history ]]; then
       args+=("$1")
       shift
+    elif [[ $1 = --enable-cpi-and-log-storage ]]; then
+      args+=("$1")
+      shift
     elif [[ $1 = --skip-poh-verify ]]; then
       args+=("$1")
       shift

--- a/run.sh
+++ b/run.sh
@@ -102,6 +102,7 @@ args=(
   --log -
   --enable-rpc-exit
   --enable-rpc-transaction-history
+  --enable-cpi-and-log-storage
   --init-complete-file "$dataDir"/init-completed
   --snapshot-compression none
   --require-tower

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -376,6 +376,7 @@ fn main() {
             .rpc_config(JsonRpcConfig {
                 enable_validator_exit: true,
                 enable_rpc_transaction_history: true,
+                enable_cpi_and_log_storage: false,
                 faucet_addr,
                 ..JsonRpcConfig::default()
             })

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -999,6 +999,14 @@ pub fn main() {
                 .help("Upload new confirmed blocks into a BigTable instance"),
         )
         .arg(
+            Arg::with_name("enable_cpi_and_log_storage")
+                .long("enable-cpi-and-log-storage")
+                .requires("enable_rpc_transaction_history")
+                .takes_value(false)
+                .help("Include CPI inner instructions and logs in the \
+                        historical transaction info stored"),
+        )
+        .arg(
             Arg::with_name("rpc_max_multiple_accounts")
                 .long("rpc-max-multiple-accounts")
                 .value_name("MAX ACCOUNTS")
@@ -1559,6 +1567,7 @@ pub fn main() {
             enable_validator_exit: matches.is_present("enable_rpc_exit"),
             enable_set_log_filter: matches.is_present("enable_rpc_set_log_filter"),
             enable_rpc_transaction_history: matches.is_present("enable_rpc_transaction_history"),
+            enable_cpi_and_log_storage: matches.is_present("enable_cpi_and_log_storage"),
             enable_bigtable_ledger_storage: matches
                 .is_present("enable_rpc_bigtable_ledger_storage"),
             enable_bigtable_ledger_upload: matches.is_present("enable_bigtable_ledger_upload"),


### PR DESCRIPTION
#### Problem
Some api nodes are experiencing stalls while rocksdb compaction is running. Compaction of the TransactionStatus columns seems to take a particularly long time, and seems related to the extremely large sizes of some transaction meta, esp logs.

#### Summary of Changes
As a short-term fix, add a parameter to `solana-validator` to allow nodes to opt-in to storing the transaction meta that isn't critical for exchange-/custody-like services, namely: transaction logs and CPI inner instructions.
Without this parameter, TransactionStatus data should be significantly smaller for many transactions.
