### PR TITLE
Buffer authority must match upgrade authority for deploys and upgrades

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -62,8 +62,7 @@ pub enum ProgramCliCommand {
         program_pubkey: Option<Pubkey>,
         buffer_signer_index: Option<SignerIndex>,
         buffer_pubkey: Option<Pubkey>,
-        upgrade_authority_signer_index: Option<SignerIndex>,
-        upgrade_authority_pubkey: Option<Pubkey>,
+        upgrade_authority_signer_index: SignerIndex,
         is_final: bool,
         max_len: Option<usize>,
         allow_excessive_balance: bool,
@@ -73,13 +72,12 @@ pub enum ProgramCliCommand {
         buffer_signer_index: Option<SignerIndex>,
         buffer_pubkey: Option<Pubkey>,
         buffer_authority_signer_index: Option<SignerIndex>,
-        is_final: bool,
         max_len: Option<usize>,
     },
     SetBufferAuthority {
         buffer_pubkey: Pubkey,
         buffer_authority_index: Option<SignerIndex>,
-        new_buffer_authority: Option<Pubkey>,
+        new_buffer_authority: Pubkey,
     },
     SetUpgradeAuthority {
         program_pubkey: Pubkey,
@@ -122,10 +120,12 @@ impl ProgramSubCommands for App<'_, '_> {
                                       [default: random address]")
                         )
                         .arg(
-                            pubkey!(Arg::with_name("upgrade_authority")
+                            Arg::with_name("upgrade_authority")
                                 .long("upgrade-authority")
-                                .value_name("UPGRADE_AUTHORITY"),
-                                "Upgrade authority [default: the default configured keypair]"),
+                                .value_name("UPGRADE_AUTHORITY_SIGNER")
+                                .takes_value(true)
+                                .validator(is_valid_signer)
+                                .help("Upgrade authority [default: the default configured keypair]")
                         )
                         .arg(
                             pubkey!(Arg::with_name("program_id")
@@ -183,11 +183,6 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .help("Buffer authority [default: the default configured keypair]")
                         )
                         .arg(
-                            Arg::with_name("final")
-                                .long("final")
-                                .help("The program will not be upgradeable")
-                        )
-                        .arg(
                             Arg::with_name("max_len")
                                 .long("max-len")
                                 .value_name("max_len")
@@ -220,14 +215,8 @@ impl ProgramSubCommands for App<'_, '_> {
                             pubkey!(Arg::with_name("new_buffer_authority")
                                 .long("new-buffer-authority")
                                 .value_name("NEW_BUFFER_AUTHORITY")
-                                .required_unless("final"),
+                                .required(true),
                                 "Address of the new buffer authority"),
-                        )
-                        .arg(
-                            Arg::with_name("final")
-                                .long("final")
-                                .conflicts_with("new_buffer_authority")
-                                .help("The buffer will be immutable")
                         )
                 )
                 .subcommand(
@@ -327,10 +316,6 @@ pub fn parse_program_subcommand(
                 {
                     bulk_signers.push(upgrade_authority_signer);
                     Some(upgrade_authority_pubkey)
-                } else if let Some(upgrade_authority_pubkey) =
-                    pubkey_of_signer(matches, "upgrade_authority", wallet_manager)?
-                {
-                    Some(upgrade_authority_pubkey)
                 } else {
                     Some(
                         default_signer
@@ -352,8 +337,8 @@ pub fn parse_program_subcommand(
                     buffer_signer_index: signer_info.index_of_or_none(buffer_pubkey),
                     buffer_pubkey,
                     upgrade_authority_signer_index: signer_info
-                        .index_of_or_none(upgrade_authority_pubkey),
-                    upgrade_authority_pubkey,
+                        .index_of(upgrade_authority_pubkey)
+                        .unwrap(),
                     is_final: matches.is_present("final"),
                     max_len,
                     allow_excessive_balance: matches.is_present("allow_excessive_balance"),
@@ -404,7 +389,6 @@ pub fn parse_program_subcommand(
                     buffer_pubkey,
                     buffer_authority_signer_index: signer_info
                         .index_of_or_none(buffer_authority_pubkey),
-                    is_final: matches.is_present("final"),
                     max_len,
                 }),
                 signers: signer_info.signers,
@@ -415,16 +399,14 @@ pub fn parse_program_subcommand(
 
             let (buffer_authority_signer, buffer_authority_pubkey) =
                 signer_of(matches, "buffer_authority", wallet_manager)?;
-            let new_buffer_authority = if matches.is_present("final") {
-                None
-            } else if let Some(new_buffer_authority) =
+            let new_buffer_authority = if let Some(new_buffer_authority) =
                 pubkey_of_signer(matches, "new_buffer_authority", wallet_manager)?
             {
-                Some(new_buffer_authority)
+                new_buffer_authority
             } else {
                 let (_, new_buffer_authority) =
                     signer_of(matches, "new_buffer_authority", wallet_manager)?;
-                new_buffer_authority
+                new_buffer_authority.unwrap()
             };
 
             let signer_info = default_signer.generate_unique_signers(
@@ -503,7 +485,6 @@ pub fn process_program_subcommand(
             buffer_signer_index,
             buffer_pubkey,
             upgrade_authority_signer_index,
-            upgrade_authority_pubkey,
             is_final,
             max_len,
             allow_excessive_balance,
@@ -516,7 +497,6 @@ pub fn process_program_subcommand(
             *buffer_signer_index,
             *buffer_pubkey,
             *upgrade_authority_signer_index,
-            *upgrade_authority_pubkey,
             *is_final,
             *max_len,
             *allow_excessive_balance,
@@ -526,7 +506,6 @@ pub fn process_program_subcommand(
             buffer_signer_index,
             buffer_pubkey,
             buffer_authority_signer_index,
-            is_final,
             max_len,
         } => process_write_buffer(
             &rpc_client,
@@ -535,7 +514,6 @@ pub fn process_program_subcommand(
             *buffer_signer_index,
             *buffer_pubkey,
             *buffer_authority_signer_index,
-            *is_final,
             *max_len,
         ),
         ProgramCliCommand::SetBufferAuthority {
@@ -548,7 +526,7 @@ pub fn process_program_subcommand(
             None,
             Some(*buffer_pubkey),
             *buffer_authority_index,
-            *new_buffer_authority,
+            Some(*new_buffer_authority),
         ),
         ProgramCliCommand::SetUpgradeAuthority {
             program_pubkey,
@@ -599,8 +577,7 @@ fn process_program_deploy(
     program_pubkey: Option<Pubkey>,
     buffer_signer_index: Option<SignerIndex>,
     buffer_pubkey: Option<Pubkey>,
-    upgrade_authority_signer_index: Option<SignerIndex>,
-    upgrade_authority_pubkey: Option<Pubkey>,
+    upgrade_authority_signer_index: SignerIndex,
     is_final: bool,
     max_len: Option<usize>,
     allow_excessive_balance: bool,
@@ -616,6 +593,7 @@ fn process_program_deploy(
             buffer_keypair.pubkey(),
         )
     };
+    let upgrade_authority_signer = config.signers[upgrade_authority_signer_index];
 
     let default_program_keypair = get_default_program_keypair(&program_location);
     let (program_signer, program_pubkey) = if let Some(i) = program_signer_index {
@@ -652,10 +630,11 @@ fn process_program_deploy(
                     if program_authority_pubkey.is_none() {
                         return Err("Program is no longer upgradeable".into());
                     }
-                    if program_authority_pubkey != upgrade_authority_pubkey {
+                    if program_authority_pubkey != Some(upgrade_authority_signer.pubkey()) {
                         return Err(format!(
                             "Program's authority {:?} does not match authority provided {:?}",
-                            program_authority_pubkey, upgrade_authority_pubkey,
+                            program_authority_pubkey,
+                            upgrade_authority_signer.pubkey(),
                         )
                         .into());
                     }
@@ -717,25 +696,22 @@ fn process_program_deploy(
             buffer_data_len,
             minimum_balance,
             &bpf_loader_upgradeable::id(),
-            Some(program_signer.unwrap()),
+            Some(&[program_signer.unwrap(), upgrade_authority_signer]),
             buffer_signer,
             &buffer_pubkey,
-            buffer_signer,
-            upgrade_authority_pubkey,
+            Some(upgrade_authority_signer),
             allow_excessive_balance,
         )
-    } else if let Some(upgrade_authority_index) = upgrade_authority_signer_index {
+    } else {
         do_process_program_upgrade(
             rpc_client,
             config,
             &program_data,
             &program_pubkey,
-            config.signers[upgrade_authority_index],
+            config.signers[upgrade_authority_signer_index],
             &buffer_pubkey,
             buffer_signer,
         )
-    } else {
-        return Err("Program upgrade requires an authority".into());
     };
     if result.is_ok() && is_final {
         process_set_authority(
@@ -743,7 +719,7 @@ fn process_program_deploy(
             config,
             Some(program_pubkey),
             None,
-            upgrade_authority_signer_index,
+            Some(upgrade_authority_signer_index),
             None,
         )?;
     }
@@ -760,7 +736,6 @@ fn process_write_buffer(
     buffer_signer_index: Option<SignerIndex>,
     buffer_pubkey: Option<Pubkey>,
     buffer_authority_signer_index: Option<SignerIndex>,
-    is_final: bool,
     max_len: Option<usize>,
 ) -> ProcessResult {
     // Create ephemeral keypair to use for Buffer account, if not provided
@@ -823,20 +798,8 @@ fn process_write_buffer(
         buffer_signer,
         &buffer_pubkey,
         Some(buffer_authority),
-        None,
         true,
     );
-
-    if result.is_ok() && is_final {
-        process_set_authority(
-            rpc_client,
-            config,
-            None,
-            Some(buffer_pubkey),
-            buffer_authority_signer_index,
-            None,
-        )?;
-    }
 
     if result.is_err() && buffer_signer_index.is_none() && buffer_signer.is_some() {
         report_ephemeral_mnemonic(words, mnemonic);
@@ -861,24 +824,28 @@ fn process_set_authority(
     trace!("Set a new authority");
     let (blockhash, _) = rpc_client.get_recent_blockhash()?;
 
-    let mut tx = if let Some(pubkey) = program_pubkey {
+    let mut tx = if let Some(ref pubkey) = program_pubkey {
         Transaction::new_unsigned(Message::new(
             &[bpf_loader_upgradeable::set_upgrade_authority(
-                &pubkey,
+                pubkey,
                 &authority_signer.pubkey(),
                 new_authority.as_ref(),
             )],
             Some(&config.signers[0].pubkey()),
         ))
     } else if let Some(pubkey) = buffer_pubkey {
-        Transaction::new_unsigned(Message::new(
-            &[bpf_loader_upgradeable::set_buffer_authority(
-                &pubkey,
-                &authority_signer.pubkey(),
-                new_authority.as_ref(),
-            )],
-            Some(&config.signers[0].pubkey()),
-        ))
+        if let Some(ref new_authority) = new_authority {
+            Transaction::new_unsigned(Message::new(
+                &[bpf_loader_upgradeable::set_buffer_authority(
+                    &pubkey,
+                    &authority_signer.pubkey(),
+                    new_authority,
+                )],
+                Some(&config.signers[0].pubkey()),
+            ))
+        } else {
+            return Err("Buffer authority cannot be None".into());
+        }
     } else {
         return Err("Program or Buffer not provided".into());
     };
@@ -984,11 +951,10 @@ pub fn process_deploy(
         program_data.len(),
         minimum_balance,
         &loader_id,
-        Some(buffer_signer),
+        Some(&[buffer_signer]),
         Some(buffer_signer),
         &buffer_signer.pubkey(),
         Some(buffer_signer),
-        None,
         allow_excessive_balance,
     );
     if result.is_err() && buffer_signer_index.is_none() {
@@ -1005,11 +971,10 @@ fn do_process_program_write_and_deploy(
     buffer_data_len: usize,
     minimum_balance: u64,
     loader_id: &Pubkey,
-    program_signer: Option<&dyn Signer>,
+    program_signers: Option<&[&dyn Signer]>,
     buffer_signer: Option<&dyn Signer>,
     buffer_pubkey: &Pubkey,
     buffer_authority_signer: Option<&dyn Signer>,
-    upgrade_authority: Option<Pubkey>,
     allow_excessive_balance: bool,
 ) -> ProcessResult {
     // Build messages to calculate fees
@@ -1040,7 +1005,7 @@ fn do_process_program_write_and_deploy(
                     bpf_loader_upgradeable::create_buffer(
                         &config.signers[0].pubkey(),
                         buffer_pubkey,
-                        Some(&buffer_authority_signer.pubkey()),
+                        &buffer_authority_signer.pubkey(),
                         minimum_balance,
                         buffer_data_len,
                     )?,
@@ -1074,7 +1039,7 @@ fn do_process_program_write_and_deploy(
                 let instruction = if loader_id == &bpf_loader_upgradeable::id() {
                     bpf_loader_upgradeable::write(
                         buffer_pubkey,
-                        Some(&buffer_authority_signer.pubkey()),
+                        &buffer_authority_signer.pubkey(),
                         (i * DATA_CHUNK_SIZE) as u32,
                         chunk.to_vec(),
                     )
@@ -1108,14 +1073,14 @@ fn do_process_program_write_and_deploy(
 
     // Create and add final message
 
-    let final_message = if let Some(program_signer) = program_signer {
+    let final_message = if let Some(program_signers) = program_signers {
         let message = if loader_id == &bpf_loader_upgradeable::id() {
             Message::new(
                 &bpf_loader_upgradeable::deploy_with_max_program_len(
                     &config.signers[0].pubkey(),
-                    &program_signer.pubkey(),
+                    &program_signers[0].pubkey(),
                     buffer_pubkey,
-                    upgrade_authority.as_ref(),
+                    &program_signers[1].pubkey(),
                     rpc_client.get_minimum_balance_for_rent_exemption(
                         UpgradeableLoaderState::program_len()?,
                     )?,
@@ -1147,12 +1112,12 @@ fn do_process_program_write_and_deploy(
         &final_message,
         buffer_signer,
         buffer_authority_signer,
-        program_signer,
+        program_signers,
     )?;
 
-    if let Some(program_signer) = program_signer {
+    if let Some(program_signers) = program_signers {
         Ok(json!({
-            "ProgramId": format!("{}", program_signer.pubkey()),
+            "ProgramId": format!("{}", program_signers[0].pubkey()),
         })
         .to_string())
     } else {
@@ -1202,7 +1167,7 @@ fn do_process_program_upgrade(
                     bpf_loader_upgradeable::create_buffer(
                         &config.signers[0].pubkey(),
                         buffer_pubkey,
-                        Some(&buffer_signer.pubkey()),
+                        &upgrade_authority.pubkey(),
                         minimum_balance,
                         data_len,
                     )?,
@@ -1224,7 +1189,7 @@ fn do_process_program_upgrade(
             for (chunk, i) in program_data.chunks(DATA_CHUNK_SIZE).zip(0..) {
                 let instruction = bpf_loader_upgradeable::write(
                     &buffer_signer.pubkey(),
-                    None,
+                    &upgrade_authority.pubkey(),
                     (i * DATA_CHUNK_SIZE) as u32,
                     chunk.to_vec(),
                 );
@@ -1268,8 +1233,8 @@ fn do_process_program_upgrade(
         &write_messages,
         &Some(final_message),
         buffer_signer,
-        buffer_signer,
         Some(upgrade_authority),
+        Some(&[upgrade_authority]),
     )?;
 
     Ok(json!({
@@ -1372,9 +1337,10 @@ fn send_deploy_messages(
     final_message: &Option<Message>,
     initial_signer: Option<&dyn Signer>,
     write_signer: Option<&dyn Signer>,
-    final_signer: Option<&dyn Signer>,
+    final_signers: Option<&[&dyn Signer]>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let payer_signer = config.signers[0];
+
     if let Some(message) = initial_message {
         if let Some(initial_signer) = initial_signer {
             trace!("Preparing the required accounts");
@@ -1423,12 +1389,14 @@ fn send_deploy_messages(
     }
 
     if let Some(message) = final_message {
-        if let Some(final_signer) = final_signer {
+        if let Some(final_signers) = final_signers {
             trace!("Deploying program");
             let (blockhash, _) = rpc_client.get_recent_blockhash()?;
 
             let mut final_tx = Transaction::new_unsigned(message.clone());
-            final_tx.try_sign(&[payer_signer, final_signer], blockhash)?;
+            let mut signers = final_signers.to_vec();
+            signers.push(payer_signer);
+            final_tx.try_sign(&signers, blockhash)?;
             rpc_client
                 .send_and_confirm_transaction_with_spinner_and_config(
                     &final_tx,
@@ -1700,8 +1668,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1727,8 +1694,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: Some(42),
                     allow_excessive_balance: false,
@@ -1756,8 +1722,7 @@ mod tests {
                     buffer_pubkey: Some(buffer_keypair.pubkey()),
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1787,8 +1752,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: Some(program_pubkey),
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1817,8 +1781,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: Some(1),
                     program_pubkey: Some(program_keypair.pubkey()),
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1827,34 +1790,6 @@ mod tests {
                     read_keypair_file(&keypair_file).unwrap().into(),
                     read_keypair_file(&program_keypair_file).unwrap().into(),
                 ],
-            }
-        );
-
-        let authority_pubkey = Pubkey::new_unique();
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "deploy",
-            "/Users/test/program.so",
-            "--upgrade-authority",
-            &authority_pubkey.to_string(),
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::Deploy {
-                    program_location: Some("/Users/test/program.so".to_string()),
-                    buffer_signer_index: None,
-                    buffer_pubkey: None,
-                    program_signer_index: None,
-                    program_pubkey: None,
-                    upgrade_authority_signer_index: None,
-                    upgrade_authority_pubkey: Some(authority_pubkey),
-                    is_final: false,
-                    max_len: None,
-                    allow_excessive_balance: false,
-                }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
             }
         );
 
@@ -1878,8 +1813,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(1),
-                    upgrade_authority_pubkey: Some(authority_keypair.pubkey()),
+                    upgrade_authority_signer_index: 1,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1907,8 +1841,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: true,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1946,7 +1879,6 @@ mod tests {
                     buffer_signer_index: None,
                     buffer_pubkey: None,
                     buffer_authority_signer_index: Some(0),
-                    is_final: false,
                     max_len: None,
                 }),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -1970,7 +1902,6 @@ mod tests {
                     buffer_signer_index: None,
                     buffer_pubkey: None,
                     buffer_authority_signer_index: Some(0),
-                    is_final: false,
                     max_len: Some(42),
                 }),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -1997,7 +1928,6 @@ mod tests {
                     buffer_signer_index: Some(1),
                     buffer_pubkey: Some(buffer_keypair.pubkey()),
                     buffer_authority_signer_index: Some(0),
-                    is_final: false,
                     max_len: None,
                 }),
                 signers: vec![
@@ -2027,7 +1957,6 @@ mod tests {
                     buffer_signer_index: None,
                     buffer_pubkey: None,
                     buffer_authority_signer_index: Some(1),
-                    is_final: false,
                     max_len: None,
                 }),
                 signers: vec![
@@ -2062,66 +1991,11 @@ mod tests {
                     buffer_signer_index: Some(1),
                     buffer_pubkey: Some(buffer_keypair.pubkey()),
                     buffer_authority_signer_index: Some(2),
-                    is_final: false,
                     max_len: None,
                 }),
                 signers: vec![
                     read_keypair_file(&keypair_file).unwrap().into(),
                     read_keypair_file(&buffer_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
-                ],
-            }
-        );
-
-        // specify authority
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "write-buffer",
-            "/Users/test/program.so",
-            "--final",
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::WriteBuffer {
-                    program_location: "/Users/test/program.so".to_string(),
-                    buffer_signer_index: None,
-                    buffer_pubkey: None,
-                    buffer_authority_signer_index: Some(0),
-                    is_final: true,
-                    max_len: None,
-                }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
-            }
-        );
-
-        // specify both buffer and authority and final
-        let authority_keypair = Keypair::new();
-        let authority_keypair_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&authority_keypair, &authority_keypair_file).unwrap();
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "write-buffer",
-            "/Users/test/program.so",
-            "--buffer-authority",
-            &authority_keypair_file,
-            "--final",
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::WriteBuffer {
-                    program_location: "/Users/test/program.so".to_string(),
-                    buffer_signer_index: None,
-                    buffer_pubkey: None,
-                    buffer_authority_signer_index: Some(1),
-                    is_final: true,
-                    max_len: None,
-                }),
-                signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
                     read_keypair_file(&authority_keypair_file).unwrap().into(),
                 ],
             }
@@ -2271,7 +2145,7 @@ mod tests {
                 command: CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
                     buffer_pubkey,
                     buffer_authority_index: Some(0),
-                    new_buffer_authority: Some(new_authority_pubkey),
+                    new_buffer_authority: new_authority_pubkey,
                 }),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
             }
@@ -2295,63 +2169,9 @@ mod tests {
                 command: CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
                     buffer_pubkey,
                     buffer_authority_index: Some(0),
-                    new_buffer_authority: Some(new_authority_pubkey.pubkey()),
+                    new_buffer_authority: new_authority_pubkey.pubkey(),
                 }),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
-            }
-        );
-
-        let buffer_pubkey = Pubkey::new_unique();
-        let new_authority_pubkey = Keypair::new();
-        let new_authority_pubkey_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&new_authority_pubkey, &new_authority_pubkey_file).unwrap();
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "set-buffer-authority",
-            &buffer_pubkey.to_string(),
-            "--final",
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
-                    buffer_pubkey,
-                    buffer_authority_index: Some(0),
-                    new_buffer_authority: None,
-                }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
-            }
-        );
-
-        let buffer_pubkey = Pubkey::new_unique();
-        let authority = Keypair::new();
-        let authority_keypair_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&authority, &authority_keypair_file).unwrap();
-        let new_authority_pubkey = Keypair::new();
-        let new_authority_pubkey_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&new_authority_pubkey, &new_authority_pubkey_file).unwrap();
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "set-buffer-authority",
-            &buffer_pubkey.to_string(),
-            "--buffer-authority",
-            &authority_keypair_file,
-            "--final",
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
-                    buffer_pubkey,
-                    buffer_authority_index: Some(1),
-                    new_buffer_authority: None,
-                }),
-                signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
-                ],
             }
         );
     }
@@ -2415,8 +2235,7 @@ mod tests {
                 buffer_pubkey: None,
                 program_signer_index: None,
                 program_pubkey: None,
-                upgrade_authority_signer_index: None,
-                upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                upgrade_authority_signer_index: 0,
                 is_final: false,
                 max_len: None,
                 allow_excessive_balance: false,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -177,8 +177,8 @@ fn test_cli_program_deploy_no_authority() {
     config.signers = vec![&keypair];
     process_command(&config).unwrap();
 
-    // Deploy a program with no authority
-    config.signers = vec![&keypair];
+    // Deploy a program
+    config.signers = vec![&keypair, &upgrade_authority];
     config.command = CliCommand::Program(ProgramCliCommand::Deploy {
         program_location: Some(pathbuf.to_str().unwrap().to_string()),
         program_signer_index: None,
@@ -186,9 +186,8 @@ fn test_cli_program_deploy_no_authority() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         allow_excessive_balance: false,
-        upgrade_authority_signer_index: None,
-        upgrade_authority_pubkey: None,
-        is_final: false,
+        upgrade_authority_signer_index: 1,
+        is_final: true,
         max_len: None,
     });
     let response = process_command(&config);
@@ -211,8 +210,7 @@ fn test_cli_program_deploy_no_authority() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         allow_excessive_balance: false,
-        upgrade_authority_signer_index: Some(1),
-        upgrade_authority_pubkey: Some(upgrade_authority.pubkey()),
+        upgrade_authority_signer_index: 1,
         is_final: false,
         max_len: None,
     });
@@ -272,8 +270,7 @@ fn test_cli_program_deploy_with_authority() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         allow_excessive_balance: false,
-        upgrade_authority_signer_index: Some(1),
-        upgrade_authority_pubkey: Some(upgrade_authority.pubkey()),
+        upgrade_authority_signer_index: 1,
         is_final: false,
         max_len: Some(max_len),
     });
@@ -319,8 +316,7 @@ fn test_cli_program_deploy_with_authority() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         allow_excessive_balance: false,
-        upgrade_authority_signer_index: Some(1),
-        upgrade_authority_pubkey: Some(upgrade_authority.pubkey()),
+        upgrade_authority_signer_index: 1,
         is_final: false,
         max_len: Some(max_len),
     });
@@ -361,8 +357,7 @@ fn test_cli_program_deploy_with_authority() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         allow_excessive_balance: false,
-        upgrade_authority_signer_index: Some(1),
-        upgrade_authority_pubkey: Some(upgrade_authority.pubkey()),
+        upgrade_authority_signer_index: 1,
         is_final: false,
         max_len: Some(max_len),
     });
@@ -416,8 +411,7 @@ fn test_cli_program_deploy_with_authority() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         allow_excessive_balance: false,
-        upgrade_authority_signer_index: Some(1),
-        upgrade_authority_pubkey: Some(new_upgrade_authority.pubkey()),
+        upgrade_authority_signer_index: 1,
         is_final: false,
         max_len: None,
     });
@@ -486,8 +480,7 @@ fn test_cli_program_deploy_with_authority() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         allow_excessive_balance: false,
-        upgrade_authority_signer_index: Some(1),
-        upgrade_authority_pubkey: Some(new_upgrade_authority.pubkey()),
+        upgrade_authority_signer_index: 1,
         is_final: false,
         max_len: None,
     });
@@ -502,8 +495,7 @@ fn test_cli_program_deploy_with_authority() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         allow_excessive_balance: false,
-        upgrade_authority_signer_index: Some(1),
-        upgrade_authority_pubkey: Some(new_upgrade_authority.pubkey()),
+        upgrade_authority_signer_index: 1,
         is_final: true,
         max_len: None,
     });
@@ -598,7 +590,6 @@ fn test_cli_program_write_buffer() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         buffer_authority_signer_index: None,
-        is_final: false,
         max_len: None,
     });
     let response = process_command(&config);
@@ -632,7 +623,6 @@ fn test_cli_program_write_buffer() {
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
         buffer_authority_signer_index: None,
-        is_final: false,
         max_len: Some(max_len),
     });
     let response = process_command(&config);
@@ -689,7 +679,6 @@ fn test_cli_program_write_buffer() {
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
         buffer_authority_signer_index: Some(2),
-        is_final: false,
         max_len: None,
     });
     let response = process_command(&config);
@@ -727,7 +716,6 @@ fn test_cli_program_write_buffer() {
         buffer_signer_index: None,
         buffer_pubkey: None,
         buffer_authority_signer_index: Some(2),
-        is_final: false,
         max_len: None,
     });
     let response = process_command(&config);
@@ -753,35 +741,6 @@ fn test_cli_program_write_buffer() {
         program_data[..]
     );
 
-    // Specify final
-    let buffer_keypair = Keypair::new();
-    let authority_keypair = Keypair::new();
-    config.signers = vec![&keypair, &buffer_keypair, &authority_keypair];
-    config.command = CliCommand::Program(ProgramCliCommand::WriteBuffer {
-        program_location: pathbuf.to_str().unwrap().to_string(),
-        buffer_signer_index: None,
-        buffer_pubkey: None,
-        buffer_authority_signer_index: Some(2),
-        is_final: true,
-        max_len: None,
-    });
-    let response = process_command(&config);
-    let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
-    let buffer_pubkey_str = json
-        .as_object()
-        .unwrap()
-        .get("Buffer")
-        .unwrap()
-        .as_str()
-        .unwrap();
-    let buffer_pubkey = Pubkey::from_str(&buffer_pubkey_str).unwrap();
-    let buffer_account = rpc_client.get_account(&buffer_pubkey).unwrap();
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
-        assert_eq!(authority_address, None);
-    } else {
-        panic!("not a buffer account");
-    }
-
     // Get buffer authority
     config.signers = vec![&keypair];
     config.command = CliCommand::Program(ProgramCliCommand::GetAuthority {
@@ -796,7 +755,10 @@ fn test_cli_program_write_buffer() {
         .unwrap()
         .as_str()
         .unwrap();
-    assert_eq!("None", authority_pubkey_str);
+    assert_eq!(
+        authority_keypair.pubkey(),
+        Pubkey::from_str(&authority_pubkey_str).unwrap()
+    );
 }
 
 #[test]
@@ -846,7 +808,6 @@ fn test_cli_program_set_buffer_authority() {
         buffer_signer_index: Some(1),
         buffer_pubkey: Some(buffer_keypair.pubkey()),
         buffer_authority_signer_index: None,
-        is_final: false,
         max_len: None,
     });
     process_command(&config).unwrap();
@@ -863,7 +824,7 @@ fn test_cli_program_set_buffer_authority() {
     config.command = CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
         buffer_pubkey: buffer_keypair.pubkey(),
         buffer_authority_index: Some(0),
-        new_buffer_authority: Some(new_buffer_authority.pubkey()),
+        new_buffer_authority: new_buffer_authority.pubkey(),
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -890,7 +851,7 @@ fn test_cli_program_set_buffer_authority() {
     config.command = CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
         buffer_pubkey: buffer_keypair.pubkey(),
         buffer_authority_index: Some(1),
-        new_buffer_authority: Some(buffer_keypair.pubkey()),
+        new_buffer_authority: buffer_keypair.pubkey(),
     });
     let response = process_command(&config);
     let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
@@ -911,28 +872,94 @@ fn test_cli_program_set_buffer_authority() {
     } else {
         panic!("not a buffer account");
     }
+}
 
-    // Set authority to None
-    config.signers = vec![&keypair, &buffer_keypair];
-    config.command = CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
-        buffer_pubkey: buffer_keypair.pubkey(),
-        buffer_authority_index: Some(1),
-        new_buffer_authority: None,
-    });
-    let response = process_command(&config);
-    let json: Value = serde_json::from_str(&response.unwrap()).unwrap();
-    let buffer_authority_str = json
-        .as_object()
-        .unwrap()
-        .get("Authority")
-        .unwrap()
-        .as_str()
+#[test]
+fn test_cli_program_mismatch_buffer_authority() {
+    solana_logger::setup();
+
+    let mut pathbuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    pathbuf.push("tests");
+    pathbuf.push("fixtures");
+    pathbuf.push("noop");
+    pathbuf.set_extension("so");
+
+    let mint_keypair = Keypair::new();
+    let test_validator = TestValidator::with_no_fees(mint_keypair.pubkey());
+    let faucet_addr = run_local_faucet(mint_keypair, None);
+
+    let rpc_client =
+        RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
+
+    let mut file = File::open(pathbuf.to_str().unwrap()).unwrap();
+    let mut program_data = Vec::new();
+    file.read_to_end(&mut program_data).unwrap();
+    let max_len = program_data.len();
+    let minimum_balance_for_buffer = rpc_client
+        .get_minimum_balance_for_rent_exemption(
+            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
+        )
         .unwrap();
-    assert_eq!(buffer_authority_str, "None");
+
+    let mut config = CliConfig::recent_for_tests();
+    let keypair = Keypair::new();
+    config.json_rpc_url = test_validator.rpc_url();
+    config.signers = vec![&keypair];
+    config.command = CliCommand::Airdrop {
+        faucet_host: None,
+        faucet_port: faucet_addr.port(),
+        pubkey: None,
+        lamports: 100 * minimum_balance_for_buffer,
+    };
+    process_command(&config).unwrap();
+
+    // Write a buffer
+    let buffer_authority = Keypair::new();
+    let buffer_keypair = Keypair::new();
+    config.signers = vec![&keypair, &buffer_keypair, &buffer_authority];
+    config.command = CliCommand::Program(ProgramCliCommand::WriteBuffer {
+        program_location: pathbuf.to_str().unwrap().to_string(),
+        buffer_signer_index: Some(1),
+        buffer_pubkey: Some(buffer_keypair.pubkey()),
+        buffer_authority_signer_index: Some(2),
+        max_len: None,
+    });
+    process_command(&config).unwrap();
     let buffer_account = rpc_client.get_account(&buffer_keypair.pubkey()).unwrap();
     if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
-        assert_eq!(authority_address, None);
+        assert_eq!(authority_address, Some(buffer_authority.pubkey()));
     } else {
         panic!("not a buffer account");
     }
+
+    // Attempt to deploy with mismatched authority
+    let upgrade_authority = Keypair::new();
+    config.signers = vec![&keypair, &upgrade_authority];
+    config.command = CliCommand::Program(ProgramCliCommand::Deploy {
+        program_location: Some(pathbuf.to_str().unwrap().to_string()),
+        program_signer_index: None,
+        program_pubkey: None,
+        buffer_signer_index: None,
+        buffer_pubkey: Some(buffer_keypair.pubkey()),
+        allow_excessive_balance: false,
+        upgrade_authority_signer_index: 1,
+        is_final: true,
+        max_len: None,
+    });
+    process_command(&config).unwrap_err();
+
+    // Attempt to deploy matched authority
+    config.signers = vec![&keypair, &buffer_authority];
+    config.command = CliCommand::Program(ProgramCliCommand::Deploy {
+        program_location: Some(pathbuf.to_str().unwrap().to_string()),
+        program_signer_index: None,
+        program_pubkey: None,
+        buffer_signer_index: None,
+        buffer_pubkey: Some(buffer_keypair.pubkey()),
+        allow_excessive_balance: false,
+        upgrade_authority_signer_index: 1,
+        is_final: true,
+        max_len: None,
+    });
+    process_command(&config).unwrap();
 }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -142,7 +142,13 @@ fn load_upgradeable_buffer(
     });
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    load_buffer_account(bank_client, payer_keypair, &buffer_keypair, buffer_authority_keypair, &elf);
+    load_buffer_account(
+        bank_client,
+        payer_keypair,
+        &buffer_keypair,
+        buffer_authority_keypair,
+        &elf,
+    );
 }
 
 fn upgrade_bpf_program(
@@ -153,7 +159,13 @@ fn upgrade_bpf_program(
     authority_keypair: &Keypair,
     name: &str,
 ) {
-    load_upgradeable_buffer(bank_client, payer_keypair, buffer_keypair, authority_keypair, name);
+    load_upgradeable_buffer(
+        bank_client,
+        payer_keypair,
+        buffer_keypair,
+        authority_keypair,
+        name,
+    );
     upgrade_program(
         bank_client,
         payer_keypair,
@@ -1663,7 +1675,13 @@ fn test_program_bpf_upgrade_and_invoke_in_same_tx() {
 
     // Prepare for upgrade
     let buffer_keypair = Keypair::new();
-    load_upgradeable_buffer(&bank_client, &mint_keypair, &buffer_keypair, &authority_keypair, "panic");
+    load_upgradeable_buffer(
+        &bank_client,
+        &mint_keypair,
+        &buffer_keypair,
+        &authority_keypair,
+        "panic",
+    );
 
     // Invoke, then upgrade the program, and then invoke again in same tx
     let message = Message::new(
@@ -1902,7 +1920,13 @@ fn test_program_bpf_upgrade_via_cpi() {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     let buffer_keypair = Keypair::new();
-    load_buffer_account(&bank_client, &mint_keypair, &buffer_keypair, &authority_keypair, &elf);
+    load_buffer_account(
+        &bank_client,
+        &mint_keypair,
+        &buffer_keypair,
+        &authority_keypair,
+        &elf,
+    );
 
     // Upgrade program via CPI
     let mut upgrade_instruction = bpf_loader_upgradeable::upgrade(
@@ -1981,7 +2005,13 @@ fn test_program_bpf_upgrade_self_via_cpi() {
 
     // Prepare for upgrade
     let buffer_keypair = Keypair::new();
-    load_upgradeable_buffer(&bank_client, &mint_keypair, &buffer_keypair, &authority_keypair, "panic");
+    load_upgradeable_buffer(
+        &bank_client,
+        &mint_keypair,
+        &buffer_keypair,
+        &authority_keypair,
+        "panic",
+    );
 
     // Invoke, then upgrade the program, and then invoke again in same tx
     let message = Message::new(
@@ -2046,7 +2076,13 @@ fn test_program_upgradeable_locks() {
         });
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
-        load_buffer_account(&bank_client, &mint_keypair, buffer_keypair, &payer_keypair, &elf);
+        load_buffer_account(
+            &bank_client,
+            &mint_keypair,
+            buffer_keypair,
+            &payer_keypair,
+            &elf,
+        );
 
         bank_client
             .send_and_confirm_instruction(

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -133,6 +133,7 @@ fn load_upgradeable_buffer(
     bank_client: &BankClient,
     payer_keypair: &Keypair,
     buffer_keypair: &Keypair,
+    buffer_authority_keypair: &Keypair,
     name: &str,
 ) {
     let path = create_bpf_path(name);
@@ -141,7 +142,7 @@ fn load_upgradeable_buffer(
     });
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
-    load_buffer_account(bank_client, payer_keypair, &buffer_keypair, &elf);
+    load_buffer_account(bank_client, payer_keypair, &buffer_keypair, buffer_authority_keypair, &elf);
 }
 
 fn upgrade_bpf_program(
@@ -152,7 +153,7 @@ fn upgrade_bpf_program(
     authority_keypair: &Keypair,
     name: &str,
 ) {
-    load_upgradeable_buffer(bank_client, payer_keypair, buffer_keypair, name);
+    load_upgradeable_buffer(bank_client, payer_keypair, buffer_keypair, authority_keypair, name);
     upgrade_program(
         bank_client,
         payer_keypair,
@@ -1662,7 +1663,7 @@ fn test_program_bpf_upgrade_and_invoke_in_same_tx() {
 
     // Prepare for upgrade
     let buffer_keypair = Keypair::new();
-    load_upgradeable_buffer(&bank_client, &mint_keypair, &buffer_keypair, "panic");
+    load_upgradeable_buffer(&bank_client, &mint_keypair, &buffer_keypair, &authority_keypair, "panic");
 
     // Invoke, then upgrade the program, and then invoke again in same tx
     let message = Message::new(
@@ -1901,7 +1902,7 @@ fn test_program_bpf_upgrade_via_cpi() {
     let mut elf = Vec::new();
     file.read_to_end(&mut elf).unwrap();
     let buffer_keypair = Keypair::new();
-    load_buffer_account(&bank_client, &mint_keypair, &buffer_keypair, &elf);
+    load_buffer_account(&bank_client, &mint_keypair, &buffer_keypair, &authority_keypair, &elf);
 
     // Upgrade program via CPI
     let mut upgrade_instruction = bpf_loader_upgradeable::upgrade(
@@ -1980,7 +1981,7 @@ fn test_program_bpf_upgrade_self_via_cpi() {
 
     // Prepare for upgrade
     let buffer_keypair = Keypair::new();
-    load_upgradeable_buffer(&bank_client, &mint_keypair, &buffer_keypair, "panic");
+    load_upgradeable_buffer(&bank_client, &mint_keypair, &buffer_keypair, &authority_keypair, "panic");
 
     // Invoke, then upgrade the program, and then invoke again in same tx
     let message = Message::new(
@@ -2045,7 +2046,7 @@ fn test_program_upgradeable_locks() {
         });
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
-        load_buffer_account(&bank_client, &mint_keypair, buffer_keypair, &elf);
+        load_buffer_account(&bank_client, &mint_keypair, buffer_keypair, &payer_keypair, &elf);
 
         bank_client
             .send_and_confirm_instruction(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -26,7 +26,10 @@ use solana_sdk::{
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     clock::Clock,
     entrypoint::SUCCESS,
-    feature_set::{bpf_compute_budget_balancing, prevent_upgrade_and_invoke},
+    feature_set::{
+        bpf_compute_budget_balancing, matching_buffer_upgrade_authorities,
+        prevent_upgrade_and_invoke,
+    },
     ic_logger_msg, ic_msg,
     instruction::InstructionError,
     keyed_account::{from_keyed_account, next_keyed_account, KeyedAccount},
@@ -296,16 +299,14 @@ fn process_loader_upgradeable_instruction(
     match limited_deserialize(instruction_data)? {
         UpgradeableLoaderInstruction::InitializeBuffer => {
             let buffer = next_keyed_account(account_iter)?;
-            let authority = next_keyed_account(account_iter)
-                .ok()
-                .map(|account| account.unsigned_key());
+            let authority = next_keyed_account(account_iter)?;
 
             if UpgradeableLoaderState::Uninitialized != buffer.state()? {
                 ic_logger_msg!(logger, "Buffer account already initialized");
                 return Err(InstructionError::AccountAlreadyInitialized);
             }
             buffer.set_state(&UpgradeableLoaderState::Buffer {
-                authority_address: authority.cloned(),
+                authority_address: Some(*authority.unsigned_key()),
             })?;
         }
         UpgradeableLoaderInstruction::Write { offset, bytes } => {
@@ -344,9 +345,7 @@ fn process_loader_upgradeable_instruction(
             let rent = from_keyed_account::<Rent>(next_keyed_account(account_iter)?)?;
             let clock = from_keyed_account::<Clock>(next_keyed_account(account_iter)?)?;
             let system = next_keyed_account(account_iter)?;
-            let authority = next_keyed_account(account_iter)
-                .ok()
-                .map(|account| account.unsigned_key());
+            let authority = next_keyed_account(account_iter)?;
 
             // Verify Program account
 
@@ -365,10 +364,15 @@ fn process_loader_upgradeable_instruction(
 
             // Verify Buffer account
 
-            if let UpgradeableLoaderState::Buffer {
-                authority_address: _,
-            } = buffer.state()?
-            {
+            if let UpgradeableLoaderState::Buffer { authority_address } = buffer.state()? {
+                if authority_address != Some(*authority.unsigned_key()) {
+                    ic_logger_msg!(logger, "Buffer and upgrade authority don't match");
+                    return Err(InstructionError::IncorrectAuthority);
+                }
+                if authority.signer_key().is_none() {
+                    ic_logger_msg!(logger, "Upgrade authority did not sign");
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
             } else {
                 ic_logger_msg!(logger, "Invalid Buffer account");
                 return Err(InstructionError::InvalidArgument);
@@ -427,7 +431,7 @@ fn process_loader_upgradeable_instruction(
 
             programdata.set_state(&UpgradeableLoaderState::ProgramData {
                 slot: clock.slot,
-                upgrade_authority_address: authority.cloned(),
+                upgrade_authority_address: Some(*authority.unsigned_key()),
             })?;
             programdata.try_account_ref_mut()?.data
                 [programdata_data_offset..programdata_data_offset + buffer_data_len]
@@ -472,6 +476,7 @@ fn process_loader_upgradeable_instruction(
                 ic_logger_msg!(logger, "Program account not owned by loader");
                 return Err(InstructionError::IncorrectProgramId);
             }
+
             if let UpgradeableLoaderState::Program {
                 programdata_address,
             } = program.state()?
@@ -487,10 +492,15 @@ fn process_loader_upgradeable_instruction(
 
             // Verify Buffer account
 
-            if let UpgradeableLoaderState::Buffer {
-                authority_address: _,
-            } = buffer.state()?
-            {
+            if let UpgradeableLoaderState::Buffer { authority_address } = buffer.state()? {
+                if authority_address != Some(*authority.unsigned_key()) {
+                    ic_logger_msg!(logger, "Buffer and upgrade authority don't match");
+                    return Err(InstructionError::IncorrectAuthority);
+                }
+                if authority.signer_key().is_none() {
+                    ic_logger_msg!(logger, "Upgrade authority did not sign");
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
             } else {
                 ic_logger_msg!(logger, "Invalid Buffer account");
                 return Err(InstructionError::InvalidArgument);
@@ -518,6 +528,7 @@ fn process_loader_upgradeable_instruction(
                 ic_logger_msg!(logger, "Buffer account balance too low to fund upgrade");
                 return Err(InstructionError::InsufficientFunds);
             }
+
             if let UpgradeableLoaderState::ProgramData {
                 slot: _,
                 upgrade_authority_address,
@@ -584,6 +595,12 @@ fn process_loader_upgradeable_instruction(
 
             match account.state()? {
                 UpgradeableLoaderState::Buffer { authority_address } => {
+                    if invoke_context.is_feature_active(&matching_buffer_upgrade_authorities::id())
+                        && new_authority == None
+                    {
+                        ic_logger_msg!(logger, "Buffer authority is not optional");
+                        return Err(InstructionError::IncorrectAuthority);
+                    }
                     if authority_address == None {
                         ic_logger_msg!(logger, "Buffer is immutable");
                         return Err(InstructionError::Immutable);
@@ -1195,57 +1212,37 @@ mod tests {
             UpgradeableLoaderState::buffer_len(9).unwrap(),
             &bpf_loader_upgradeable::id(),
         );
-
-        // Case: Success
-        assert_eq!(
-            Ok(()),
-            process_instruction(
-                &bpf_loader_upgradeable::id(),
-                &[KeyedAccount::new(&buffer_address, false, &buffer_account)],
-                &instruction,
-                &mut MockInvokeContext::default()
-            )
-        );
-        let state: UpgradeableLoaderState = buffer_account.borrow().state().unwrap();
-        assert_eq!(
-            state,
-            UpgradeableLoaderState::Buffer {
-                authority_address: None
-            }
-        );
-
-        // Case: Already initialized
-        assert_eq!(
-            Err(InstructionError::AccountAlreadyInitialized),
-            process_instruction(
-                &bpf_loader_upgradeable::id(),
-                &[KeyedAccount::new(&buffer_address, false, &buffer_account)],
-                &instruction,
-                &mut MockInvokeContext::default()
-            )
-        );
-        let state: UpgradeableLoaderState = buffer_account.borrow().state().unwrap();
-        assert_eq!(
-            state,
-            UpgradeableLoaderState::Buffer {
-                authority_address: None
-            }
-        );
-
-        // Case: With authority
-        let buffer_account = Account::new_ref(
-            1,
-            UpgradeableLoaderState::buffer_len(9).unwrap(),
-            &bpf_loader_upgradeable::id(),
-        );
         let authority_address = Pubkey::new_unique();
         let authority_account = Account::new_ref(
             1,
             UpgradeableLoaderState::buffer_len(9).unwrap(),
             &bpf_loader_upgradeable::id(),
         );
+
+        // Case: Success
         assert_eq!(
             Ok(()),
+            process_instruction(
+                &bpf_loader_upgradeable::id(),
+                &[
+                    KeyedAccount::new(&buffer_address, false, &buffer_account),
+                    KeyedAccount::new(&authority_address, false, &authority_account)
+                ],
+                &instruction,
+                &mut MockInvokeContext::default()
+            )
+        );
+        let state: UpgradeableLoaderState = buffer_account.borrow().state().unwrap();
+        assert_eq!(
+            state,
+            UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address)
+            }
+        );
+
+        // Case: Already initialized
+        assert_eq!(
+            Err(InstructionError::AccountAlreadyInitialized),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
                 &[
@@ -1490,7 +1487,7 @@ mod tests {
             &[program_keypair.pubkey().as_ref()],
             &bpf_loader_upgradeable::id(),
         );
-        let upgrade_authority_address = Pubkey::new_unique();
+        let upgrade_authority_keypair = Keypair::new();
         let mut file = File::open("test_elfs/noop_aligned.so").expect("file open failed");
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
@@ -1507,11 +1504,21 @@ mod tests {
         );
         buffer_account
             .set_state(&UpgradeableLoaderState::Buffer {
-                authority_address: Some(buffer_address),
+                authority_address: Some(upgrade_authority_keypair.pubkey()),
             })
             .unwrap();
         buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..]
             .copy_from_slice(&elf);
+        let program_account = Account::new(
+            min_programdata_balance,
+            UpgradeableLoaderState::program_len().unwrap(),
+            &bpf_loader_upgradeable::id(),
+        );
+        let programdata_account = Account::new(
+            1,
+            UpgradeableLoaderState::programdata_len(elf.len()).unwrap(),
+            &bpf_loader_upgradeable::id(),
+        );
 
         // Test successful deploy
         bank.clear_signatures();
@@ -1524,7 +1531,7 @@ mod tests {
                 &mint_keypair.pubkey(),
                 &program_keypair.pubkey(),
                 &buffer_address,
-                Some(&upgrade_authority_address),
+                &upgrade_authority_keypair.pubkey(),
                 min_program_balance,
                 elf.len(),
             )
@@ -1532,7 +1539,10 @@ mod tests {
             Some(&mint_keypair.pubkey()),
         );
         assert!(bank_client
-            .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+            .send_and_confirm_message(
+                &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                message
+            )
             .is_ok());
         assert_eq!(
             bank.get_balance(&mint_keypair.pubkey()),
@@ -1562,7 +1572,7 @@ mod tests {
             state,
             UpgradeableLoaderState::ProgramData {
                 slot: bank_client.get_slot().unwrap(),
-                upgrade_authority_address: Some(upgrade_authority_address)
+                upgrade_authority_address: Some(upgrade_authority_keypair.pubkey())
             }
         );
         for (i, byte) in post_programdata_account.data
@@ -1590,6 +1600,7 @@ mod tests {
                     AccountMeta::new_readonly(sysvar::rent::id(), false),
                     AccountMeta::new_readonly(sysvar::clock::id(), false),
                     AccountMeta::new_readonly(system_program::id(), false),
+                    AccountMeta::new_readonly(upgrade_authority_keypair.pubkey(), true),
                 ],
             )],
             Some(&mint_keypair.pubkey()),
@@ -1597,56 +1608,9 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(0, InstructionError::AccountAlreadyInitialized),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair], message)
+                .send_and_confirm_message(&[&mint_keypair, &upgrade_authority_keypair], message)
                 .unwrap_err()
                 .unwrap()
-        );
-
-        // Test successful deploy no authority
-        bank.clear_signatures();
-        bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
-        let message = Message::new(
-            &bpf_loader_upgradeable::deploy_with_max_program_len(
-                &mint_keypair.pubkey(),
-                &program_keypair.pubkey(),
-                &buffer_address,
-                None,
-                min_program_balance,
-                elf.len(),
-            )
-            .unwrap(),
-            Some(&mint_keypair.pubkey()),
-        );
-        assert!(bank_client
-            .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
-            .is_ok());
-        assert_eq!(None, bank.get_account(&buffer_address));
-        let post_program_account = bank.get_account(&program_keypair.pubkey()).unwrap();
-        assert_eq!(post_program_account.lamports, min_program_balance);
-        assert_eq!(post_program_account.owner, bpf_loader_upgradeable::id());
-        assert_eq!(
-            post_program_account.data.len(),
-            UpgradeableLoaderState::program_len().unwrap()
-        );
-        let state: UpgradeableLoaderState = post_program_account.state().unwrap();
-        assert_eq!(
-            state,
-            UpgradeableLoaderState::Program {
-                programdata_address
-            }
-        );
-        let post_programdata_account = bank.get_account(&programdata_address).unwrap();
-        assert_eq!(post_programdata_account.lamports, min_programdata_balance);
-        assert_eq!(post_programdata_account.owner, bpf_loader_upgradeable::id());
-        let state: UpgradeableLoaderState = post_programdata_account.state().unwrap();
-        assert_eq!(
-            state,
-            UpgradeableLoaderState::ProgramData {
-                slot: bank_client.get_slot().unwrap(),
-                upgrade_authority_address: None
-            }
         );
 
         // Test initialized ProgramData account
@@ -1658,7 +1622,7 @@ mod tests {
                 &mint_keypair.pubkey(),
                 &program_keypair.pubkey(),
                 &buffer_address,
-                None,
+                &upgrade_authority_keypair.pubkey(),
                 min_program_balance,
                 elf.len(),
             )
@@ -1668,7 +1632,73 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::Custom(0)),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
+                .unwrap_err()
+                .unwrap()
+        );
+
+        // Test deploy no authority
+        bank.clear_signatures();
+        bank.store_account(&buffer_address, &buffer_account);
+        bank.store_account(&program_keypair.pubkey(), &program_account);
+        bank.store_account(&programdata_address, &programdata_account);
+        let message = Message::new(
+            &[Instruction::new(
+                bpf_loader_upgradeable::id(),
+                &UpgradeableLoaderInstruction::DeployWithMaxDataLen {
+                    max_data_len: elf.len(),
+                },
+                vec![
+                    AccountMeta::new(mint_keypair.pubkey(), true),
+                    AccountMeta::new(programdata_address, false),
+                    AccountMeta::new(program_keypair.pubkey(), false),
+                    AccountMeta::new(buffer_address, false),
+                    AccountMeta::new_readonly(sysvar::rent::id(), false),
+                    AccountMeta::new_readonly(sysvar::clock::id(), false),
+                    AccountMeta::new_readonly(system_program::id(), false),
+                ],
+            )],
+            Some(&mint_keypair.pubkey()),
+        );
+        assert_eq!(
+            TransactionError::InstructionError(0, InstructionError::NotEnoughAccountKeys),
+            bank_client
+                .send_and_confirm_message(&[&mint_keypair], message)
+                .unwrap_err()
+                .unwrap()
+        );
+
+        // Test deploy authority not a signer
+        bank.clear_signatures();
+        bank.store_account(&buffer_address, &buffer_account);
+        bank.store_account(&program_keypair.pubkey(), &program_account);
+        bank.store_account(&programdata_address, &programdata_account);
+        let message = Message::new(
+            &[Instruction::new(
+                bpf_loader_upgradeable::id(),
+                &UpgradeableLoaderInstruction::DeployWithMaxDataLen {
+                    max_data_len: elf.len(),
+                },
+                vec![
+                    AccountMeta::new(mint_keypair.pubkey(), true),
+                    AccountMeta::new(programdata_address, false),
+                    AccountMeta::new(program_keypair.pubkey(), false),
+                    AccountMeta::new(buffer_address, false),
+                    AccountMeta::new_readonly(sysvar::rent::id(), false),
+                    AccountMeta::new_readonly(sysvar::clock::id(), false),
+                    AccountMeta::new_readonly(system_program::id(), false),
+                    AccountMeta::new_readonly(upgrade_authority_keypair.pubkey(), false),
+                ],
+            )],
+            Some(&mint_keypair.pubkey()),
+        );
+        assert_eq!(
+            TransactionError::InstructionError(0, InstructionError::MissingRequiredSignature),
+            bank_client
+                .send_and_confirm_message(&[&mint_keypair], message)
                 .unwrap_err()
                 .unwrap()
         );
@@ -1683,7 +1713,7 @@ mod tests {
                 &mint_keypair.pubkey(),
                 &program_keypair.pubkey(),
                 &buffer_address,
-                None,
+                &upgrade_authority_keypair.pubkey(),
                 min_program_balance,
                 elf.len(),
             )
@@ -1693,7 +1723,10 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::InvalidAccountData),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -1708,7 +1741,7 @@ mod tests {
                 &mint_keypair.pubkey(),
                 &program_keypair.pubkey(),
                 &buffer_address,
-                None,
+                &upgrade_authority_keypair.pubkey(),
                 min_program_balance - 1,
                 elf.len(),
             )
@@ -1718,7 +1751,10 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::ExecutableAccountNotRentExempt),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -1732,7 +1768,7 @@ mod tests {
             &mint_keypair.pubkey(),
             &program_keypair.pubkey(),
             &buffer_address,
-            None,
+            &upgrade_authority_keypair.pubkey(),
             min_program_balance,
             elf.len(),
         )
@@ -1748,7 +1784,10 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::ExecutableAccountNotRentExempt),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -1762,7 +1801,7 @@ mod tests {
             &mint_keypair.pubkey(),
             &program_keypair.pubkey(),
             &buffer_address,
-            None,
+            &upgrade_authority_keypair.pubkey(),
             min_program_balance,
             elf.len(),
         )
@@ -1778,7 +1817,10 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::AccountDataTooSmall),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -1797,7 +1839,7 @@ mod tests {
                 &mint_keypair.pubkey(),
                 &program_keypair.pubkey(),
                 &buffer_address,
-                None,
+                &upgrade_authority_keypair.pubkey(),
                 min_program_balance,
                 elf.len(),
             )
@@ -1807,7 +1849,10 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::Custom(1)),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -1826,7 +1871,7 @@ mod tests {
                 &mint_keypair.pubkey(),
                 &program_keypair.pubkey(),
                 &buffer_address,
-                None,
+                &upgrade_authority_keypair.pubkey(),
                 min_program_balance,
                 elf.len() - 1,
             )
@@ -1836,7 +1881,10 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::AccountDataTooSmall),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -1850,7 +1898,7 @@ mod tests {
             &mint_keypair.pubkey(),
             &program_keypair.pubkey(),
             &buffer_address,
-            None,
+            &upgrade_authority_keypair.pubkey(),
             min_program_balance,
             elf.len(),
         )
@@ -1860,7 +1908,10 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::MissingAccount),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -1879,7 +1930,7 @@ mod tests {
                 &mint_keypair.pubkey(),
                 &program_keypair.pubkey(),
                 &buffer_address,
-                None,
+                &upgrade_authority_keypair.pubkey(),
                 min_program_balance,
                 elf.len(),
             )
@@ -1889,7 +1940,10 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::InvalidAccountData),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -1903,7 +1957,7 @@ mod tests {
         );
         modified_buffer_account
             .set_state(&UpgradeableLoaderState::Buffer {
-                authority_address: None,
+                authority_address: Some(upgrade_authority_keypair.pubkey()),
             })
             .unwrap();
         modified_buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..]
@@ -1917,7 +1971,7 @@ mod tests {
                 &mint_keypair.pubkey(),
                 &program_keypair.pubkey(),
                 &buffer_address,
-                None,
+                &upgrade_authority_keypair.pubkey(),
                 min_program_balance,
                 elf.len(),
             )
@@ -1927,7 +1981,50 @@ mod tests {
         assert_eq!(
             TransactionError::InstructionError(1, InstructionError::InvalidAccountData),
             bank_client
-                .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
+                .unwrap_err()
+                .unwrap()
+        );
+
+        // Mismatched buffer and program authority
+        bank.clear_signatures();
+        let mut modified_buffer_account = Account::new(
+            min_programdata_balance,
+            UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
+            &bpf_loader_upgradeable::id(),
+        );
+        modified_buffer_account
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(buffer_address),
+            })
+            .unwrap();
+        modified_buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..]
+            .copy_from_slice(&elf);
+        bank.store_account(&buffer_address, &modified_buffer_account);
+        bank.store_account(&program_keypair.pubkey(), &Account::default());
+        bank.store_account(&programdata_address, &Account::default());
+        let message = Message::new(
+            &bpf_loader_upgradeable::deploy_with_max_program_len(
+                &mint_keypair.pubkey(),
+                &program_keypair.pubkey(),
+                &buffer_address,
+                &upgrade_authority_keypair.pubkey(),
+                min_program_balance,
+                elf.len(),
+            )
+            .unwrap(),
+            Some(&mint_keypair.pubkey()),
+        );
+        assert_eq!(
+            TransactionError::InstructionError(1, InstructionError::IncorrectAuthority),
+            bank_client
+                .send_and_confirm_message(
+                    &[&mint_keypair, &program_keypair, &upgrade_authority_keypair],
+                    message
+                )
                 .unwrap_err()
                 .unwrap()
         );
@@ -2032,7 +2129,7 @@ mod tests {
 
         // Case: Success
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2087,7 +2184,7 @@ mod tests {
 
         // Case: not upgradable
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2127,7 +2224,7 @@ mod tests {
 
         // Case: wrong authority
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2160,7 +2257,7 @@ mod tests {
 
         // Case: authority did not sign
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2193,7 +2290,7 @@ mod tests {
 
         // Case: Program account not executable
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2227,7 +2324,7 @@ mod tests {
 
         // Case: Program account now owned by loader
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2261,7 +2358,7 @@ mod tests {
 
         // Case: Program account not writable
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2294,7 +2391,7 @@ mod tests {
 
         // Case: Program account not initialized
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2331,7 +2428,7 @@ mod tests {
 
         // Case: ProgramData account not initialized
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2368,7 +2465,7 @@ mod tests {
 
         // Case: Program ProgramData account mismatch
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2401,7 +2498,7 @@ mod tests {
 
         // Case: Buffer account not initialized
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2438,7 +2535,7 @@ mod tests {
 
         // Case: Buffer account too big
         let (_, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2455,7 +2552,7 @@ mod tests {
         buffer_account
             .borrow_mut()
             .set_state(&UpgradeableLoaderState::Buffer {
-                authority_address: Some(buffer_address),
+                authority_address: Some(upgrade_authority_address),
             })
             .unwrap();
         assert_eq!(
@@ -2482,7 +2579,7 @@ mod tests {
 
         // Test small buffer account
         let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
-            &buffer_address,
+            &upgrade_authority_address,
             &programdata_address,
             &upgrade_authority_address,
             slot,
@@ -2494,12 +2591,45 @@ mod tests {
         buffer_account
             .borrow_mut()
             .set_state(&UpgradeableLoaderState::Buffer {
-                authority_address: None,
+                authority_address: Some(upgrade_authority_address),
             })
             .unwrap();
         buffer_account.borrow_mut().data.truncate(5);
         assert_eq!(
             Err(InstructionError::InvalidAccountData),
+            process_instruction(
+                &bpf_loader_upgradeable::id(),
+                &[
+                    KeyedAccount::new(&programdata_address, false, &programdata_account),
+                    KeyedAccount::new(&program_address, false, &program_account),
+                    KeyedAccount::new(&buffer_address, false, &buffer_account),
+                    KeyedAccount::new(&spill_address, false, &spill_account),
+                    KeyedAccount::new_readonly(&sysvar::rent::id(), false, &rent_account),
+                    KeyedAccount::new_readonly(&sysvar::clock::id(), false, &clock_account),
+                    KeyedAccount::new_readonly(
+                        &upgrade_authority_address,
+                        true,
+                        &upgrade_authority_account
+                    )
+                ],
+                &instruction,
+                &mut MockInvokeContext::default()
+            )
+        );
+
+        // Case: Mismatched buffer and program authority
+        let (buffer_account, program_account, programdata_account, spill_account) = get_accounts(
+            &buffer_address,
+            &programdata_address,
+            &upgrade_authority_address,
+            slot,
+            &elf_orig,
+            &elf_new,
+            min_program_balance,
+            min_programdata_balance,
+        );
+        assert_eq!(
+            Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
                 &[
@@ -2760,7 +2890,7 @@ mod tests {
             }
         );
 
-        // Case: Not upgradeable
+        // Case: New authority required
         buffer_account
             .borrow_mut()
             .set_state(&UpgradeableLoaderState::Buffer {
@@ -2768,7 +2898,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(
-            Ok(()),
+            Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
                 &[
@@ -2783,7 +2913,7 @@ mod tests {
         assert_eq!(
             state,
             UpgradeableLoaderState::Buffer {
-                authority_address: None,
+                authority_address: Some(authority_address),
             }
         );
 
@@ -2801,6 +2931,11 @@ mod tests {
                 &[
                     KeyedAccount::new(&buffer_address, false, &buffer_account),
                     KeyedAccount::new_readonly(&authority_address, false, &authority_account),
+                    KeyedAccount::new_readonly(
+                        &new_authority_address,
+                        false,
+                        &new_authority_account
+                    )
                 ],
                 &instruction,
                 &mut MockInvokeContext::default()
@@ -2846,6 +2981,11 @@ mod tests {
                 &[
                     KeyedAccount::new(&buffer_address, false, &buffer_account),
                     KeyedAccount::new_readonly(&Pubkey::new_unique(), true, &authority_account),
+                    KeyedAccount::new_readonly(
+                        &new_authority_address,
+                        false,
+                        &new_authority_account
+                    )
                 ],
                 &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
                 &mut MockInvokeContext::default()

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -87,14 +87,10 @@ impl UpgradeableLoaderState {
 pub fn create_buffer(
     payer_address: &Pubkey,
     buffer_address: &Pubkey,
-    authority_address: Option<&Pubkey>,
+    authority_address: &Pubkey,
     lamports: u64,
     program_len: usize,
 ) -> Result<Vec<Instruction>, InstructionError> {
-    let mut metas = vec![AccountMeta::new(*buffer_address, false)];
-    if let Some(authority_address) = authority_address {
-        metas.push(AccountMeta::new(*authority_address, false));
-    }
     Ok(vec![
         system_instruction::create_account(
             payer_address,
@@ -103,7 +99,14 @@ pub fn create_buffer(
             UpgradeableLoaderState::buffer_len(program_len)? as u64,
             &id(),
         ),
-        Instruction::new(id(), &UpgradeableLoaderInstruction::InitializeBuffer, metas),
+        Instruction::new(
+            id(),
+            &UpgradeableLoaderInstruction::InitializeBuffer,
+            vec![
+                AccountMeta::new(*buffer_address, false),
+                AccountMeta::new(*authority_address, false),
+            ],
+        ),
     ])
 }
 
@@ -111,21 +114,17 @@ pub fn create_buffer(
 /// buffer account.
 pub fn write(
     buffer_address: &Pubkey,
-    authority_address: Option<&Pubkey>,
+    authority_address: &Pubkey,
     offset: u32,
     bytes: Vec<u8>,
 ) -> Instruction {
-    let mut metas = vec![
-        AccountMeta::new(*buffer_address, false),
-        AccountMeta::new(*buffer_address, true),
-    ];
-    if let Some(authority_address) = authority_address {
-        metas[1] = AccountMeta::new(*authority_address, true);
-    }
     Instruction::new(
         id(),
         &UpgradeableLoaderInstruction::Write { offset, bytes },
-        metas,
+        vec![
+            AccountMeta::new(*buffer_address, false),
+            AccountMeta::new(*authority_address, true),
+        ],
     )
 }
 
@@ -136,23 +135,11 @@ pub fn deploy_with_max_program_len(
     payer_address: &Pubkey,
     program_address: &Pubkey,
     buffer_address: &Pubkey,
-    upgrade_authority_address: Option<&Pubkey>,
+    upgrade_authority_address: &Pubkey,
     program_lamports: u64,
     max_data_len: usize,
 ) -> Result<Vec<Instruction>, InstructionError> {
     let (programdata_address, _) = Pubkey::find_program_address(&[program_address.as_ref()], &id());
-    let mut metas = vec![
-        AccountMeta::new(*payer_address, true),
-        AccountMeta::new(programdata_address, false),
-        AccountMeta::new(*program_address, false),
-        AccountMeta::new(*buffer_address, false),
-        AccountMeta::new_readonly(sysvar::rent::id(), false),
-        AccountMeta::new_readonly(sysvar::clock::id(), false),
-        AccountMeta::new_readonly(crate::system_program::id(), false),
-    ];
-    if let Some(address) = upgrade_authority_address {
-        metas.push(AccountMeta::new_readonly(*address, false));
-    }
     Ok(vec![
         system_instruction::create_account(
             payer_address,
@@ -164,7 +151,16 @@ pub fn deploy_with_max_program_len(
         Instruction::new(
             id(),
             &UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len },
-            metas,
+            vec![
+                AccountMeta::new(*payer_address, true),
+                AccountMeta::new(programdata_address, false),
+                AccountMeta::new(*program_address, false),
+                AccountMeta::new(*buffer_address, false),
+                AccountMeta::new_readonly(sysvar::rent::id(), false),
+                AccountMeta::new_readonly(sysvar::clock::id(), false),
+                AccountMeta::new_readonly(crate::system_program::id(), false),
+                AccountMeta::new_readonly(*upgrade_authority_address, true),
+            ],
         ),
     ])
 }
@@ -200,16 +196,17 @@ pub fn is_upgrade_instruction(instruction_data: &[u8]) -> bool {
 pub fn set_buffer_authority(
     buffer_address: &Pubkey,
     current_authority_address: &Pubkey,
-    new_authority_address: Option<&Pubkey>,
+    new_authority_address: &Pubkey,
 ) -> Instruction {
-    let mut metas = vec![
-        AccountMeta::new(*buffer_address, false),
-        AccountMeta::new_readonly(*current_authority_address, true),
-    ];
-    if let Some(address) = new_authority_address {
-        metas.push(AccountMeta::new_readonly(*address, false));
-    }
-    Instruction::new(id(), &UpgradeableLoaderInstruction::SetAuthority, metas)
+    Instruction::new(
+        id(),
+        &UpgradeableLoaderInstruction::SetAuthority,
+        vec![
+            AccountMeta::new(*buffer_address, false),
+            AccountMeta::new_readonly(*current_authority_address, true),
+            AccountMeta::new_readonly(*new_authority_address, false),
+        ],
+    )
 }
 
 /// Returns the instructions required to set a program's authority.

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -104,7 +104,7 @@ pub fn create_buffer(
             &UpgradeableLoaderInstruction::InitializeBuffer,
             vec![
                 AccountMeta::new(*buffer_address, false),
-                AccountMeta::new(*authority_address, false),
+                AccountMeta::new_readonly(*authority_address, false),
             ],
         ),
     ])
@@ -123,7 +123,7 @@ pub fn write(
         &UpgradeableLoaderInstruction::Write { offset, bytes },
         vec![
             AccountMeta::new(*buffer_address, false),
-            AccountMeta::new(*authority_address, true),
+            AccountMeta::new_readonly(*authority_address, true),
         ],
     )
 }

--- a/sdk/program/src/loader_upgradeable_instruction.rs
+++ b/sdk/program/src/loader_upgradeable_instruction.rs
@@ -36,7 +36,7 @@ pub enum UpgradeableLoaderInstruction {
     /// Deploy an executable program.
     ///
     /// A program consists of a Program and ProgramData account pair.
-    ///   - The Program account's address will serve as the program id any
+    ///   - The Program account's address will serve as the program id for any
     ///     instructions that execute this program.
     ///   - The ProgramData account will remain mutable by the loader only and
     ///     holds the program data and authority information.  The ProgramData
@@ -54,21 +54,21 @@ pub enum UpgradeableLoaderInstruction {
     /// The `DeployWithMaxDataLen` instruction does not require the ProgramData
     /// account be a signer and therefore MUST be included within the same
     /// Transaction as the system program's `CreateAccount` instruction that
-    /// creates the Program account. Otherwise another party may initialize
-    /// the account.
+    /// creates the Program account. Otherwise another party may initialize the
+    /// account.
     ///
     /// # Account references
-    ///   0. [Signer] The payer account that will pay to create the ProgramData
+    ///   0. [signer] The payer account that will pay to create the ProgramData
     ///      account.
     ///   1. [writable] The uninitialized ProgramData account.
     ///   2. [writable] The uninitialized Program account.
     ///   3. [writable] The Buffer account where the program data has been
-    ///      written.
+    ///      written.  The buffer account's authority must match the program's
+    ///      authority
     ///   4. [] Rent sysvar.
     ///   5. [] Clock sysvar.
     ///   6. [] System program (`solana_sdk::system_program::id()`).
-    ///   7. [] The program's authority, optional, if omitted then the program
-    ///      will no longer upgradeable.
+    ///   7. [signer] The program's authority
     DeployWithMaxDataLen {
         /// Maximum length that the program can be upgraded to.
         max_data_len: usize,
@@ -81,14 +81,15 @@ pub enum UpgradeableLoaderInstruction {
     ///
     /// The Buffer account must contain sufficient lamports to fund the
     /// ProgramData account to be rent-exempt, any additional lamports left over
-    /// will be transferred to the spill, account leaving the Buffer account
+    /// will be transferred to the spill account, leaving the Buffer account
     /// balance at zero.
     ///
     /// # Account references
     ///   0. [writable] The ProgramData account.
     ///   1. [writable] The Program account.
     ///   2. [writable] The Buffer account where the program data has been
-    ///      written.
+    ///      written.  The buffer account's authority must match the program's
+    ///      authority
     ///   3. [writable] The spill account.
     ///   4. [] Rent sysvar.
     ///   5. [] Clock sysvar.

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -174,6 +174,10 @@ pub mod spl_token_v2_self_transfer_fix {
     solana_sdk::declare_id!("BL99GYhdjjcv6ys22C9wPgn2aTVERDbPHHo4NbS3hgp7");
 }
 
+pub mod matching_buffer_upgrade_authorities {
+    solana_sdk::declare_id!("B5PSjDEJvKJEUQSL7q94N7XCEoWJCYum8XfUg7yuugUU");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -216,6 +220,7 @@ lazy_static! {
         (full_inflation::candidate_example::enable::id(), "full inflation enabled by candidate_example"),
         (track_writable_deescalation::id(), "track account writable deescalation"),
         (spl_token_v2_self_transfer_fix::id(), "spl-token self-transfer fix"),
+        (matching_buffer_upgrade_authorities::id(), "Upgradeable buffer and program authorities must match"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Buffer account can be recreated after its authority is marked `None`

#### Summary of Changes

- Enforce that buffer authority matches upgrade authority during deploys / upgrades
- Deploys now require an upgrade authority to be specified as a signer
- Buffer state still has an optional authority but restrict everyone from setting it to `None`
- Remove the tooling around buffer write `--final`

The new CLI is also compatible with the existing upgradeable loader and the work flow is the same except:
- Cannot set the buffer's authority to `None` via --final (using either `write-buffer` or `set-buffer-authority`
- When deploying cannot specify the upgrade authority by public key, need to provide a keypair or use the default keypair

Fixes #
