### PR TITLE
Fix cli usage build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-/docs/html/
-/docs/src/tests.ok
-/docs/src/cli/usage.md
-/docs/src/.gitbook/assets/*.svg
 /farf/
 /solana-release/
 /solana-release.tar.bz2

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -22,3 +22,9 @@ vercel.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Documentation build artifacts
+/html/
+/src/tests.ok
+/src/cli/usage.md
+/src/.gitbook/assets/*.svg

--- a/docs/build-cli-usage.sh
+++ b/docs/build-cli-usage.sh
@@ -2,7 +2,7 @@
 set -e
 
 cd "$(dirname "$0")"
-cargo="$(readlink -f "./cargo")"
+cargo=../cargo
 
 # shellcheck source=ci/rust-version.sh
 source ../ci/rust-version.sh stable


### PR DESCRIPTION
https://edge.docs.solana.com/cli/usage#usage is broken due to not being able to find `cargo`. 