### PR TITLE
Buffer authority must match upgrade authority for deploys and upgrades

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -54,8 +54,7 @@ pub enum ProgramCliCommand {
         program_pubkey: Option<Pubkey>,
         buffer_signer_index: Option<SignerIndex>,
         buffer_pubkey: Option<Pubkey>,
-        upgrade_authority_signer_index: Option<SignerIndex>,
-        upgrade_authority_pubkey: Option<Pubkey>,
+        upgrade_authority_signer_index: SignerIndex,
         is_final: bool,
         max_len: Option<usize>,
         allow_excessive_balance: bool,
@@ -65,13 +64,12 @@ pub enum ProgramCliCommand {
         buffer_signer_index: Option<SignerIndex>,
         buffer_pubkey: Option<Pubkey>,
         buffer_authority_signer_index: Option<SignerIndex>,
-        is_final: bool,
         max_len: Option<usize>,
     },
     SetBufferAuthority {
         buffer_pubkey: Pubkey,
         buffer_authority_index: Option<SignerIndex>,
-        new_buffer_authority: Option<Pubkey>,
+        new_buffer_authority: Pubkey,
     },
     SetUpgradeAuthority {
         program_pubkey: Pubkey,
@@ -111,10 +109,12 @@ impl ProgramSubCommands for App<'_, '_> {
                                       [default: random address]")
                         )
                         .arg(
-                            pubkey!(Arg::with_name("upgrade_authority")
+                            Arg::with_name("upgrade_authority")
                                 .long("upgrade-authority")
-                                .value_name("UPGRADE_AUTHORITY"),
-                                "Upgrade authority [default: the default configured keypair]"),
+                                .value_name("UPGRADE_AUTHORITY_SIGNER")
+                                .takes_value(true)
+                                .validator(is_valid_signer)
+                                .help("Upgrade authority [default: the default configured keypair]")
                         )
                         .arg(
                             pubkey!(Arg::with_name("program_id")
@@ -172,11 +172,6 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .help("Buffer authority [default: the default configured keypair]")
                         )
                         .arg(
-                            Arg::with_name("final")
-                                .long("final")
-                                .help("The program will not be upgradeable")
-                        )
-                        .arg(
                             Arg::with_name("max_len")
                                 .long("max-len")
                                 .value_name("max_len")
@@ -209,14 +204,8 @@ impl ProgramSubCommands for App<'_, '_> {
                             pubkey!(Arg::with_name("new_buffer_authority")
                                 .long("new-buffer-authority")
                                 .value_name("NEW_BUFFER_AUTHORITY")
-                                .required_unless("final"),
+                                .required(true),
                                 "Address of the new buffer authority"),
-                        )
-                        .arg(
-                            Arg::with_name("final")
-                                .long("final")
-                                .conflicts_with("new_buffer_authority")
-                                .help("The buffer will be immutable")
                         )
                 )
                 .subcommand(
@@ -304,10 +293,6 @@ pub fn parse_program_subcommand(
                 {
                     bulk_signers.push(upgrade_authority_signer);
                     Some(upgrade_authority_pubkey)
-                } else if let Some(upgrade_authority_pubkey) =
-                    pubkey_of_signer(matches, "upgrade_authority", wallet_manager)?
-                {
-                    Some(upgrade_authority_pubkey)
                 } else {
                     Some(
                         default_signer
@@ -329,8 +314,8 @@ pub fn parse_program_subcommand(
                     buffer_signer_index: signer_info.index_of_or_none(buffer_pubkey),
                     buffer_pubkey,
                     upgrade_authority_signer_index: signer_info
-                        .index_of_or_none(upgrade_authority_pubkey),
-                    upgrade_authority_pubkey,
+                        .index_of(upgrade_authority_pubkey)
+                        .unwrap(),
                     is_final: matches.is_present("final"),
                     max_len,
                     allow_excessive_balance: matches.is_present("allow_excessive_balance"),
@@ -381,7 +366,6 @@ pub fn parse_program_subcommand(
                     buffer_pubkey,
                     buffer_authority_signer_index: signer_info
                         .index_of_or_none(buffer_authority_pubkey),
-                    is_final: matches.is_present("final"),
                     max_len,
                 }),
                 signers: signer_info.signers,
@@ -392,16 +376,14 @@ pub fn parse_program_subcommand(
 
             let (buffer_authority_signer, buffer_authority_pubkey) =
                 signer_of(matches, "buffer_authority", wallet_manager)?;
-            let new_buffer_authority = if matches.is_present("final") {
-                None
-            } else if let Some(new_buffer_authority) =
+            let new_buffer_authority = if let Some(new_buffer_authority) =
                 pubkey_of_signer(matches, "new_buffer_authority", wallet_manager)?
             {
-                Some(new_buffer_authority)
+                new_buffer_authority
             } else {
                 let (_, new_buffer_authority) =
                     signer_of(matches, "new_buffer_authority", wallet_manager)?;
-                new_buffer_authority
+                new_buffer_authority.unwrap()
             };
 
             let signer_info = default_signer.generate_unique_signers(
@@ -474,7 +456,6 @@ pub fn process_program_subcommand(
             buffer_signer_index,
             buffer_pubkey,
             upgrade_authority_signer_index,
-            upgrade_authority_pubkey,
             is_final,
             max_len,
             allow_excessive_balance,
@@ -487,7 +468,6 @@ pub fn process_program_subcommand(
             *buffer_signer_index,
             *buffer_pubkey,
             *upgrade_authority_signer_index,
-            *upgrade_authority_pubkey,
             *is_final,
             *max_len,
             *allow_excessive_balance,
@@ -497,7 +477,6 @@ pub fn process_program_subcommand(
             buffer_signer_index,
             buffer_pubkey,
             buffer_authority_signer_index,
-            is_final,
             max_len,
         } => process_write_buffer(
             &rpc_client,
@@ -506,7 +485,6 @@ pub fn process_program_subcommand(
             *buffer_signer_index,
             *buffer_pubkey,
             *buffer_authority_signer_index,
-            *is_final,
             *max_len,
         ),
         ProgramCliCommand::SetBufferAuthority {
@@ -519,7 +497,7 @@ pub fn process_program_subcommand(
             None,
             Some(*buffer_pubkey),
             *buffer_authority_index,
-            *new_buffer_authority,
+            Some(*new_buffer_authority),
         ),
         ProgramCliCommand::SetUpgradeAuthority {
             program_pubkey,
@@ -567,8 +545,7 @@ fn process_program_deploy(
     program_pubkey: Option<Pubkey>,
     buffer_signer_index: Option<SignerIndex>,
     buffer_pubkey: Option<Pubkey>,
-    upgrade_authority_signer_index: Option<SignerIndex>,
-    upgrade_authority_pubkey: Option<Pubkey>,
+    upgrade_authority_signer_index: SignerIndex,
     is_final: bool,
     max_len: Option<usize>,
     allow_excessive_balance: bool,
@@ -584,6 +561,7 @@ fn process_program_deploy(
             buffer_keypair.pubkey(),
         )
     };
+    let upgrade_authority_signer = config.signers[upgrade_authority_signer_index];
 
     let default_program_keypair = get_default_program_keypair(&program_location);
     let (program_signer, program_pubkey) = if let Some(i) = program_signer_index {
@@ -620,10 +598,11 @@ fn process_program_deploy(
                     if program_authority_pubkey.is_none() {
                         return Err("Program is no longer upgradeable".into());
                     }
-                    if program_authority_pubkey != upgrade_authority_pubkey {
+                    if program_authority_pubkey != Some(upgrade_authority_signer.pubkey()) {
                         return Err(format!(
                             "Program's authority {:?} does not match authority provided {:?}",
-                            program_authority_pubkey, upgrade_authority_pubkey,
+                            program_authority_pubkey,
+                            upgrade_authority_signer.pubkey(),
                         )
                         .into());
                     }
@@ -685,25 +664,22 @@ fn process_program_deploy(
             buffer_data_len,
             minimum_balance,
             &bpf_loader_upgradeable::id(),
-            Some(program_signer.unwrap()),
+            Some(&[program_signer.unwrap(), upgrade_authority_signer]),
             buffer_signer,
             &buffer_pubkey,
-            buffer_signer,
-            upgrade_authority_pubkey,
+            Some(upgrade_authority_signer),
             allow_excessive_balance,
         )
-    } else if let Some(upgrade_authority_index) = upgrade_authority_signer_index {
+    } else {
         do_process_program_upgrade(
             rpc_client,
             config,
             &program_data,
             &program_pubkey,
-            config.signers[upgrade_authority_index],
+            config.signers[upgrade_authority_signer_index],
             &buffer_pubkey,
             buffer_signer,
         )
-    } else {
-        return Err("Program upgrade requires an authority".into());
     };
     if result.is_ok() && is_final {
         process_set_authority(
@@ -711,7 +687,7 @@ fn process_program_deploy(
             config,
             Some(program_pubkey),
             None,
-            upgrade_authority_signer_index,
+            Some(upgrade_authority_signer_index),
             None,
         )?;
     }
@@ -728,7 +704,6 @@ fn process_write_buffer(
     buffer_signer_index: Option<SignerIndex>,
     buffer_pubkey: Option<Pubkey>,
     buffer_authority_signer_index: Option<SignerIndex>,
-    is_final: bool,
     max_len: Option<usize>,
 ) -> ProcessResult {
     // Create ephemeral keypair to use for Buffer account, if not provided
@@ -791,20 +766,8 @@ fn process_write_buffer(
         buffer_signer,
         &buffer_pubkey,
         Some(buffer_authority),
-        None,
         true,
     );
-
-    if result.is_ok() && is_final {
-        process_set_authority(
-            rpc_client,
-            config,
-            None,
-            Some(buffer_pubkey),
-            buffer_authority_signer_index,
-            None,
-        )?;
-    }
 
     if result.is_err() && buffer_signer_index.is_none() && buffer_signer.is_some() {
         report_ephemeral_mnemonic(words, mnemonic);
@@ -829,24 +792,28 @@ fn process_set_authority(
     trace!("Set a new authority");
     let (blockhash, _) = rpc_client.get_recent_blockhash()?;
 
-    let mut tx = if let Some(pubkey) = program_pubkey {
+    let mut tx = if let Some(ref pubkey) = program_pubkey {
         Transaction::new_unsigned(Message::new(
             &[bpf_loader_upgradeable::set_upgrade_authority(
-                &pubkey,
+                pubkey,
                 &authority_signer.pubkey(),
                 new_authority.as_ref(),
             )],
             Some(&config.signers[0].pubkey()),
         ))
     } else if let Some(pubkey) = buffer_pubkey {
-        Transaction::new_unsigned(Message::new(
-            &[bpf_loader_upgradeable::set_buffer_authority(
-                &pubkey,
-                &authority_signer.pubkey(),
-                new_authority.as_ref(),
-            )],
-            Some(&config.signers[0].pubkey()),
-        ))
+        if let Some(ref new_authority) = new_authority {
+            Transaction::new_unsigned(Message::new(
+                &[bpf_loader_upgradeable::set_buffer_authority(
+                    &pubkey,
+                    &authority_signer.pubkey(),
+                    new_authority,
+                )],
+                Some(&config.signers[0].pubkey()),
+            ))
+        } else {
+            return Err("Buffer authority cannot be None".into());
+        }
     } else {
         return Err("Program or Buffer not provided".into());
     };
@@ -908,11 +875,10 @@ pub fn process_deploy(
         program_data.len(),
         minimum_balance,
         &loader_id,
-        Some(buffer_signer),
+        Some(&[buffer_signer]),
         Some(buffer_signer),
         &buffer_signer.pubkey(),
         Some(buffer_signer),
-        None,
         allow_excessive_balance,
     );
     if result.is_err() && buffer_signer_index.is_none() {
@@ -929,11 +895,10 @@ fn do_process_program_write_and_deploy(
     buffer_data_len: usize,
     minimum_balance: u64,
     loader_id: &Pubkey,
-    program_signer: Option<&dyn Signer>,
+    program_signers: Option<&[&dyn Signer]>,
     buffer_signer: Option<&dyn Signer>,
     buffer_pubkey: &Pubkey,
     buffer_authority_signer: Option<&dyn Signer>,
-    upgrade_authority: Option<Pubkey>,
     allow_excessive_balance: bool,
 ) -> ProcessResult {
     // Build messages to calculate fees
@@ -964,7 +929,7 @@ fn do_process_program_write_and_deploy(
                     bpf_loader_upgradeable::create_buffer(
                         &config.signers[0].pubkey(),
                         buffer_pubkey,
-                        Some(&buffer_authority_signer.pubkey()),
+                        &buffer_authority_signer.pubkey(),
                         minimum_balance,
                         buffer_data_len,
                     )?,
@@ -998,7 +963,7 @@ fn do_process_program_write_and_deploy(
                 let instruction = if loader_id == &bpf_loader_upgradeable::id() {
                     bpf_loader_upgradeable::write(
                         buffer_pubkey,
-                        Some(&buffer_authority_signer.pubkey()),
+                        &buffer_authority_signer.pubkey(),
                         (i * DATA_CHUNK_SIZE) as u32,
                         chunk.to_vec(),
                     )
@@ -1032,14 +997,14 @@ fn do_process_program_write_and_deploy(
 
     // Create and add final message
 
-    let final_message = if let Some(program_signer) = program_signer {
+    let final_message = if let Some(program_signers) = program_signers {
         let message = if loader_id == &bpf_loader_upgradeable::id() {
             Message::new(
                 &bpf_loader_upgradeable::deploy_with_max_program_len(
                     &config.signers[0].pubkey(),
-                    &program_signer.pubkey(),
+                    &program_signers[0].pubkey(),
                     buffer_pubkey,
-                    upgrade_authority.as_ref(),
+                    &program_signers[1].pubkey(),
                     rpc_client.get_minimum_balance_for_rent_exemption(
                         UpgradeableLoaderState::program_len()?,
                     )?,
@@ -1071,12 +1036,12 @@ fn do_process_program_write_and_deploy(
         &final_message,
         buffer_signer,
         buffer_authority_signer,
-        program_signer,
+        program_signers,
     )?;
 
-    if let Some(program_signer) = program_signer {
+    if let Some(program_signers) = program_signers {
         Ok(json!({
-            "programId": format!("{}", program_signer.pubkey()),
+            "programId": format!("{}", program_signers[0].pubkey()),
         })
         .to_string())
     } else {
@@ -1126,7 +1091,7 @@ fn do_process_program_upgrade(
                     bpf_loader_upgradeable::create_buffer(
                         &config.signers[0].pubkey(),
                         buffer_pubkey,
-                        Some(&buffer_signer.pubkey()),
+                        &upgrade_authority.pubkey(),
                         minimum_balance,
                         data_len,
                     )?,
@@ -1148,7 +1113,7 @@ fn do_process_program_upgrade(
             for (chunk, i) in program_data.chunks(DATA_CHUNK_SIZE).zip(0..) {
                 let instruction = bpf_loader_upgradeable::write(
                     &buffer_signer.pubkey(),
-                    None,
+                    &upgrade_authority.pubkey(),
                     (i * DATA_CHUNK_SIZE) as u32,
                     chunk.to_vec(),
                 );
@@ -1192,8 +1157,8 @@ fn do_process_program_upgrade(
         &write_messages,
         &Some(final_message),
         buffer_signer,
-        buffer_signer,
         Some(upgrade_authority),
+        Some(&[upgrade_authority]),
     )?;
 
     Ok(json!({
@@ -1292,9 +1257,10 @@ fn send_deploy_messages(
     final_message: &Option<Message>,
     initial_signer: Option<&dyn Signer>,
     write_signer: Option<&dyn Signer>,
-    final_signer: Option<&dyn Signer>,
+    final_signers: Option<&[&dyn Signer]>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let payer_signer = config.signers[0];
+
     if let Some(message) = initial_message {
         if let Some(initial_signer) = initial_signer {
             trace!("Preparing the required accounts");
@@ -1343,12 +1309,14 @@ fn send_deploy_messages(
     }
 
     if let Some(message) = final_message {
-        if let Some(final_signer) = final_signer {
+        if let Some(final_signers) = final_signers {
             trace!("Deploying program");
             let (blockhash, _) = rpc_client.get_recent_blockhash()?;
 
             let mut final_tx = Transaction::new_unsigned(message.clone());
-            final_tx.try_sign(&[payer_signer, final_signer], blockhash)?;
+            let mut signers = final_signers.to_vec();
+            signers.push(payer_signer);
+            final_tx.try_sign(&signers, blockhash)?;
             rpc_client
                 .send_and_confirm_transaction_with_spinner_and_config(
                     &final_tx,
@@ -1573,8 +1541,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1600,8 +1567,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: Some(42),
                     allow_excessive_balance: false,
@@ -1629,8 +1595,7 @@ mod tests {
                     buffer_pubkey: Some(buffer_keypair.pubkey()),
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1660,8 +1625,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: Some(program_pubkey),
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1690,8 +1654,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: Some(1),
                     program_pubkey: Some(program_keypair.pubkey()),
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1700,34 +1663,6 @@ mod tests {
                     read_keypair_file(&keypair_file).unwrap().into(),
                     read_keypair_file(&program_keypair_file).unwrap().into(),
                 ],
-            }
-        );
-
-        let authority_pubkey = Pubkey::new_unique();
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "deploy",
-            "/Users/test/program.so",
-            "--upgrade-authority",
-            &authority_pubkey.to_string(),
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::Deploy {
-                    program_location: Some("/Users/test/program.so".to_string()),
-                    buffer_signer_index: None,
-                    buffer_pubkey: None,
-                    program_signer_index: None,
-                    program_pubkey: None,
-                    upgrade_authority_signer_index: None,
-                    upgrade_authority_pubkey: Some(authority_pubkey),
-                    is_final: false,
-                    max_len: None,
-                    allow_excessive_balance: false,
-                }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
             }
         );
 
@@ -1751,8 +1686,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(1),
-                    upgrade_authority_pubkey: Some(authority_keypair.pubkey()),
+                    upgrade_authority_signer_index: 1,
                     is_final: false,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1780,8 +1714,7 @@ mod tests {
                     buffer_pubkey: None,
                     program_signer_index: None,
                     program_pubkey: None,
-                    upgrade_authority_signer_index: Some(0),
-                    upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                    upgrade_authority_signer_index: 0,
                     is_final: true,
                     max_len: None,
                     allow_excessive_balance: false,
@@ -1819,7 +1752,6 @@ mod tests {
                     buffer_signer_index: None,
                     buffer_pubkey: None,
                     buffer_authority_signer_index: Some(0),
-                    is_final: false,
                     max_len: None,
                 }),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -1843,7 +1775,6 @@ mod tests {
                     buffer_signer_index: None,
                     buffer_pubkey: None,
                     buffer_authority_signer_index: Some(0),
-                    is_final: false,
                     max_len: Some(42),
                 }),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
@@ -1870,7 +1801,6 @@ mod tests {
                     buffer_signer_index: Some(1),
                     buffer_pubkey: Some(buffer_keypair.pubkey()),
                     buffer_authority_signer_index: Some(0),
-                    is_final: false,
                     max_len: None,
                 }),
                 signers: vec![
@@ -1900,7 +1830,6 @@ mod tests {
                     buffer_signer_index: None,
                     buffer_pubkey: None,
                     buffer_authority_signer_index: Some(1),
-                    is_final: false,
                     max_len: None,
                 }),
                 signers: vec![
@@ -1935,66 +1864,11 @@ mod tests {
                     buffer_signer_index: Some(1),
                     buffer_pubkey: Some(buffer_keypair.pubkey()),
                     buffer_authority_signer_index: Some(2),
-                    is_final: false,
                     max_len: None,
                 }),
                 signers: vec![
                     read_keypair_file(&keypair_file).unwrap().into(),
                     read_keypair_file(&buffer_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
-                ],
-            }
-        );
-
-        // specify authority
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "write-buffer",
-            "/Users/test/program.so",
-            "--final",
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::WriteBuffer {
-                    program_location: "/Users/test/program.so".to_string(),
-                    buffer_signer_index: None,
-                    buffer_pubkey: None,
-                    buffer_authority_signer_index: Some(0),
-                    is_final: true,
-                    max_len: None,
-                }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
-            }
-        );
-
-        // specify both buffer and authority and final
-        let authority_keypair = Keypair::new();
-        let authority_keypair_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&authority_keypair, &authority_keypair_file).unwrap();
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "write-buffer",
-            "/Users/test/program.so",
-            "--buffer-authority",
-            &authority_keypair_file,
-            "--final",
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::WriteBuffer {
-                    program_location: "/Users/test/program.so".to_string(),
-                    buffer_signer_index: None,
-                    buffer_pubkey: None,
-                    buffer_authority_signer_index: Some(1),
-                    is_final: true,
-                    max_len: None,
-                }),
-                signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
                     read_keypair_file(&authority_keypair_file).unwrap().into(),
                 ],
             }
@@ -2144,7 +2018,7 @@ mod tests {
                 command: CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
                     buffer_pubkey,
                     buffer_authority_index: Some(0),
-                    new_buffer_authority: Some(new_authority_pubkey),
+                    new_buffer_authority: new_authority_pubkey,
                 }),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
             }
@@ -2168,63 +2042,9 @@ mod tests {
                 command: CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
                     buffer_pubkey,
                     buffer_authority_index: Some(0),
-                    new_buffer_authority: Some(new_authority_pubkey.pubkey()),
+                    new_buffer_authority: new_authority_pubkey.pubkey(),
                 }),
                 signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
-            }
-        );
-
-        let buffer_pubkey = Pubkey::new_unique();
-        let new_authority_pubkey = Keypair::new();
-        let new_authority_pubkey_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&new_authority_pubkey, &new_authority_pubkey_file).unwrap();
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "set-buffer-authority",
-            &buffer_pubkey.to_string(),
-            "--final",
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
-                    buffer_pubkey,
-                    buffer_authority_index: Some(0),
-                    new_buffer_authority: None,
-                }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
-            }
-        );
-
-        let buffer_pubkey = Pubkey::new_unique();
-        let authority = Keypair::new();
-        let authority_keypair_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&authority, &authority_keypair_file).unwrap();
-        let new_authority_pubkey = Keypair::new();
-        let new_authority_pubkey_file = make_tmp_path("authority_keypair_file");
-        write_keypair_file(&new_authority_pubkey, &new_authority_pubkey_file).unwrap();
-        let test_deploy = test_commands.clone().get_matches_from(vec![
-            "test",
-            "program",
-            "set-buffer-authority",
-            &buffer_pubkey.to_string(),
-            "--buffer-authority",
-            &authority_keypair_file,
-            "--final",
-        ]);
-        assert_eq!(
-            parse_command(&test_deploy, &default_signer, &mut None).unwrap(),
-            CliCommandInfo {
-                command: CliCommand::Program(ProgramCliCommand::SetBufferAuthority {
-                    buffer_pubkey,
-                    buffer_authority_index: Some(1),
-                    new_buffer_authority: None,
-                }),
-                signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
-                ],
             }
         );
     }
@@ -2257,8 +2077,7 @@ mod tests {
                 buffer_pubkey: None,
                 program_signer_index: None,
                 program_pubkey: None,
-                upgrade_authority_signer_index: None,
-                upgrade_authority_pubkey: Some(default_keypair.pubkey()),
+                upgrade_authority_signer_index: 0,
                 is_final: false,
                 max_len: None,
                 allow_excessive_balance: false,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4583,8 +4583,8 @@ impl Bank {
             self.rent_collector.rent.burn_percent = 50; // 50% rent burn
         }
 
-        if new_feature_activations.contains(&feature_set::spl_token_v2_self_transfer_fix::id()) {
-            self.apply_spl_token_v2_self_transfer_fix();
+        if new_feature_activations.contains(&feature_set::spl_token_v2_multisig_fix::id()) {
+            self.apply_spl_token_v2_multisig_fix();
         }
         // Remove me after a while around v1.6
         if !self.no_stake_rewrite.load(Relaxed)
@@ -4676,7 +4676,7 @@ impl Bank {
         }
     }
 
-    fn apply_spl_token_v2_self_transfer_fix(&mut self) {
+    fn apply_spl_token_v2_multisig_fix(&mut self) {
         if let Some(mut account) = self.get_account(&inline_spl_token_v2_0::id()) {
             self.capitalization.fetch_sub(account.lamports, Relaxed);
             account.lamports = 0;
@@ -10840,7 +10840,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_spl_token_v2_self_transfer_fix() {
+    fn test_spl_token_v2_multisig_fix() {
         let (genesis_config, _mint_keypair) = create_genesis_config(0);
         let mut bank = Bank::new(&genesis_config);
 
@@ -10855,7 +10855,7 @@ pub(crate) mod tests {
         assert_eq!(bank.get_balance(&inline_spl_token_v2_0::id()), 100);
         let original_capitalization = bank.capitalization();
 
-        bank.apply_spl_token_v2_self_transfer_fix();
+        bank.apply_spl_token_v2_multisig_fix();
 
         // Account is now empty, and the account lamports were burnt
         assert_eq!(bank.get_balance(&inline_spl_token_v2_0::id()), 0);

--- a/sdk/program/src/loader_upgradeable_instruction.rs
+++ b/sdk/program/src/loader_upgradeable_instruction.rs
@@ -36,7 +36,7 @@ pub enum UpgradeableLoaderInstruction {
     /// Deploy an executable program.
     ///
     /// A program consists of a Program and ProgramData account pair.
-    ///   - The Program account's address will serve as the program id any
+    ///   - The Program account's address will serve as the program id for any
     ///     instructions that execute this program.
     ///   - The ProgramData account will remain mutable by the loader only and
     ///     holds the program data and authority information.  The ProgramData
@@ -54,21 +54,21 @@ pub enum UpgradeableLoaderInstruction {
     /// The `DeployWithMaxDataLen` instruction does not require the ProgramData
     /// account be a signer and therefore MUST be included within the same
     /// Transaction as the system program's `CreateAccount` instruction that
-    /// creates the Program account. Otherwise another party may initialize
-    /// the account.
+    /// creates the Program account. Otherwise another party may initialize the
+    /// account.
     ///
     /// # Account references
-    ///   0. [Signer] The payer account that will pay to create the ProgramData
+    ///   0. [signer] The payer account that will pay to create the ProgramData
     ///      account.
     ///   1. [writable] The uninitialized ProgramData account.
     ///   2. [writable] The uninitialized Program account.
     ///   3. [writable] The Buffer account where the program data has been
-    ///      written.
+    ///      written.  The buffer account's authority must match the program's
+    ///      authority
     ///   4. [] Rent sysvar.
     ///   5. [] Clock sysvar.
     ///   6. [] System program (`solana_sdk::system_program::id()`).
-    ///   7. [] The program's authority, optional, if omitted then the program
-    ///      will no longer upgradeable.
+    ///   7. [signer] The program's authority
     DeployWithMaxDataLen {
         /// Maximum length that the program can be upgraded to.
         max_data_len: usize,
@@ -81,14 +81,15 @@ pub enum UpgradeableLoaderInstruction {
     ///
     /// The Buffer account must contain sufficient lamports to fund the
     /// ProgramData account to be rent-exempt, any additional lamports left over
-    /// will be transferred to the spill, account leaving the Buffer account
+    /// will be transferred to the spill account, leaving the Buffer account
     /// balance at zero.
     ///
     /// # Account references
     ///   0. [writable] The ProgramData account.
     ///   1. [writable] The Program account.
     ///   2. [writable] The Buffer account where the program data has been
-    ///      written.
+    ///      written.  The buffer account's authority must match the program's
+    ///      authority
     ///   3. [writable] The spill account.
     ///   4. [] Rent sysvar.
     ///   5. [] Clock sysvar.

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -162,8 +162,8 @@ pub mod prevent_upgrade_and_invoke {
     solana_sdk::declare_id!("BiNjYd8jCYDgAwMqP91uwZs6skWpuHtKrZbckuKESs8N");
 }
 
-pub mod spl_token_v2_self_transfer_fix {
-    solana_sdk::declare_id!("BL99GYhdjjcv6ys22C9wPgn2aTVERDbPHHo4NbS3hgp7");
+pub mod matching_buffer_upgrade_authorities {
+    solana_sdk::declare_id!("B5PSjDEJvKJEUQSL7q94N7XCEoWJCYum8XfUg7yuugUU");
 }
 
 lazy_static! {
@@ -205,7 +205,7 @@ lazy_static! {
         (prevent_upgrade_and_invoke::id(), "Prevent upgrade and invoke in same tx batch"),
         (full_inflation::candidate_example::vote::id(), "Community vote allowing candidate_example to enable full inflation"),
         (full_inflation::candidate_example::enable::id(), "Full inflation enabled by candidate_example"),
-        (spl_token_v2_self_transfer_fix::id(), "spl-token self-transfer fix"),
+        (matching_buffer_upgrade_authorities::id(), "Upgradeable buffer and program authorities must match"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
This is a backport of #14923

#### Problem

Buffer account can be recreated after its authority is marked `None`

#### Summary of Changes

- Enforce that buffer authority matches upgrade authority during deploys / upgrades
- Deploys now require an upgrade authority to be specified as a signer
- Buffer state still has an optional authority but restrict everyone from setting it to `None`
- Remove the tooling around buffer write `--final`

The new CLI is also compatible with the existing upgradeable loader and the work flow is the same except:
- Cannot set the buffer's authority to `None` via --final (using either `write-buffer` or `set-buffer-authority`
- When deploying cannot specify the upgrade authority by public key, need to provide a keypair or use the default keypair

Fixes #