### PR TITLE
solana-install: garbage collect old releases

### DIFF
--- a/install/src/config.rs
+++ b/install/src/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     pub current_update_manifest: Option<UpdateManifest>,
     pub update_poll_secs: u64,
     pub explicit_release: Option<ExplicitRelease>,
-    releases_dir: PathBuf,
+    pub releases_dir: PathBuf,
     active_release_dir: PathBuf,
 }
 

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -209,6 +209,11 @@ pub fn main() -> Result<(), String> {
                 ),
         )
         .subcommand(
+            SubCommand::with_name("gc")
+                .about("Delete older releases from the install cache to reclaim disk space")
+                .setting(AppSettings::DisableVersion),
+        )
+        .subcommand(
             SubCommand::with_name("update")
                 .about("Checks for an update, and if available downloads and applies it")
                 .setting(AppSettings::DisableVersion),
@@ -255,6 +260,7 @@ pub fn main() -> Result<(), String> {
                 update_manifest_keypair_file,
             )
         }
+        ("gc", Some(_matches)) => command::gc(config_file),
         ("update", Some(_matches)) => command::update(config_file).map(|_| ()),
         ("run", Some(matches)) => {
             let program_name = matches.value_of("program_name").unwrap();

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -151,7 +151,7 @@ pub fn main() -> Result<(), String> {
         )
         .subcommand(
             SubCommand::with_name("info")
-                .about("displays information about the current installation")
+                .about("Displays information about the current installation")
                 .setting(AppSettings::DisableVersion)
                 .arg(
                     Arg::with_name("local_info_only")
@@ -169,7 +169,7 @@ pub fn main() -> Result<(), String> {
         )
         .subcommand(
             SubCommand::with_name("deploy")
-                .about("deploys a new update")
+                .about("Deploys a new update")
                 .setting(AppSettings::DisableVersion)
                 .arg({
                     let arg = Arg::with_name("from_keypair_file")
@@ -210,7 +210,7 @@ pub fn main() -> Result<(), String> {
         )
         .subcommand(
             SubCommand::with_name("update")
-                .about("checks for an update, and if available downloads and applies it")
+                .about("Checks for an update, and if available downloads and applies it")
                 .setting(AppSettings::DisableVersion),
         )
         .subcommand(
@@ -273,7 +273,7 @@ pub fn main_init() -> Result<(), String> {
     solana_logger::setup();
 
     let matches = App::new("solana-install-init")
-        .about("initializes a new installation")
+        .about("Initializes a new installation")
         .version(solana_version::version!())
         .arg({
             let arg = Arg::with_name("config_file")


### PR DESCRIPTION
`solana-install init` never cleans up after itself.  For example here's what the cache directory looks from one of the mainnet validators:
```
$ ls .local/share/solana/install/releases/ 
1.0.10  1.0.16  1.0.22  1.0.9   1.1.19  1.1.23  1.2.21  1.2.26  1.2.30  1.3.18  1.3.22  1.4.14  1.4.19  1.4.23
1.0.12  1.0.17  1.0.24  1.1.14  1.1.20  1.2.16  1.2.22  1.2.27  1.2.32  1.3.19  1.3.23  1.4.16  1.4.20  1.4.24
1.0.13  1.0.18  1.0.7   1.1.15  1.1.21  1.2.19  1.2.23  1.2.28  1.3.15  1.3.20  1.4.12  1.4.17  1.4.21  beta
1.0.14  1.0.19  1.0.8   1.1.17  1.1.22  1.2.20  1.2.24  1.2.29  1.3.17  1.3.21  1.4.13  1.4.18  1.4.22  stable
```

While it's actually kinda neat to see all this history it's now taking up 26GB of disk.  

Add the following:
1. A `solana-install gc` to explicitly remove old releases
2. `gc` is also run implicitly on an `init` and `update`

The 5 newest releases are kept around.  5 probably should be configurable eventually but for now it's hard coded 