### PR TITLE
CLI: Improve readability of `solana stake-history`

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1,5 +1,8 @@
 use crate::{
-    display::{build_balance_message, format_labeled_address, writeln_name_value},
+    display::{
+        build_balance_message, build_balance_message_with_config, format_labeled_address,
+        writeln_name_value, BuildBalanceMessageConfig,
+    },
     QuietDisplay, VerboseDisplay,
 };
 use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
@@ -902,14 +905,19 @@ impl fmt::Display for CliStakeHistory {
             ))
             .bold()
         )?;
+        let config = BuildBalanceMessageConfig {
+            use_lamports_unit: self.use_lamports_unit,
+            show_unit: false,
+            trim_trailing_zeros: false,
+        };
         for entry in &self.entries {
             writeln!(
                 f,
                 "  {:>5}  {:>20}  {:>20}  {:>20} {}",
                 entry.epoch,
-                build_balance_message(entry.effective_stake, self.use_lamports_unit, false),
-                build_balance_message(entry.activating_stake, self.use_lamports_unit, false),
-                build_balance_message(entry.deactivating_stake, self.use_lamports_unit, false),
+                build_balance_message_with_config(entry.effective_stake, &config),
+                build_balance_message_with_config(entry.activating_stake, &config),
+                build_balance_message_with_config(entry.deactivating_stake, &config),
                 if self.use_lamports_unit {
                     "lamports"
                 } else {


### PR DESCRIPTION
#### Problem

CLI's `stake-history` subcommand output trims trailing zeros, making it easy to misread

```
$ solana stake-history

  Epoch       Effective Stake      Activating Stake    Deactivating Stake

...

    136   146138438.460864574      4906654.91211578     8289086.277529985 SOL
    135   143831676.268124193     9103533.581938384     6796985.913750078 SOL
    134   144345849.266867161    11184119.569467206    11698500.167365184 SOL
    133   144665966.815965474     1244642.415586938     1564983.339111296 SOL
    132   147028060.159668416      2003864.10389568      4366177.19850176 SOL
    131   150090212.911809057       902361.30076673      3964514.05290737 SOL
    130   149969679.657577336          147332.58804        26799.33380828 SOL
    129   146913001.671272069    18485160.011824641    15428482.020953599 SOL
    128   151587368.041813165      1212534.27765856      5886900.63678525 SOL
    127   151804249.890516818        59518.73407232           664360.5404 SOL
    126   152418741.984559059      1266378.68546432      1880886.09254624 SOL
    125   156918489.728207082       2203044.9287296      6702807.98541728 SOL
    124   155340204.349735379      5385635.30948416      3807365.24405216 SOL

...
```

#### Summary of Changes
* Minor refactor of `cli_output::build_balance_message()`
* Don't trim trailing zeros in `solana stake-history` output

```
$ ./target/debug/solana stake-history

  Epoch       Effective Stake      Activating Stake    Deactivating Stake
    
...

    136   146138438.460864574     4906654.912115780     8289086.277529985 SOL
    135   143831676.268124193     9103533.581938384     6796985.913750078 SOL
    134   144345849.266867161    11184119.569467206    11698500.167365184 SOL
    133   144665966.815965474     1244642.415586938     1564983.339111296 SOL
    132   147028060.159668416     2003864.103895680     4366177.198501760 SOL
    131   150090212.911809057      902361.300766730     3964514.052907370 SOL
    130   149969679.657577336      147332.588040000       26799.333808280 SOL
    129   146913001.671272069    18485160.011824641    15428482.020953599 SOL
    128   151587368.041813165     1212534.277658560     5886900.636785250 SOL
    127   151804249.890516818       59518.734072320      664360.540400000 SOL
    126   152418741.984559059     1266378.685464320     1880886.092546240 SOL
    125   156918489.728207082     2203044.928729600     6702807.985417280 SOL
    124   155340204.349735379     5385635.309484160     3807365.244052160 SOL

...
```