### PR TITLE
CLI: Add sigverify results to `solana decode-transaction` output

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1552,6 +1552,37 @@ pub fn parse_sign_only_reply_string(reply: &str) -> SignOnly {
     }
 }
 
+#[derive(Debug)]
+pub enum CliSignatureVerificationStatus {
+    None,
+    Pass,
+    Fail,
+}
+
+impl CliSignatureVerificationStatus {
+    pub fn get(tx: &Transaction) -> Vec<Self> {
+        tx.verify_with_results()
+            .iter()
+            .zip(&tx.signatures)
+            .map(|(stat, sig)| match stat {
+                true => CliSignatureVerificationStatus::Pass,
+                false if sig == &Signature::default() => CliSignatureVerificationStatus::None,
+                false => CliSignatureVerificationStatus::Fail,
+            })
+            .collect()
+    }
+}
+
+impl fmt::Display for CliSignatureVerificationStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Pass => write!(f, "pass"),
+            Self::Fail => write!(f, "fail"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1560,7 +1560,7 @@ pub enum CliSignatureVerificationStatus {
 }
 
 impl CliSignatureVerificationStatus {
-    pub fn get(tx: &Transaction) -> Vec<Self> {
+    pub fn verify_transaction(tx: &Transaction) -> Vec<Self> {
         tx.verify_with_results()
             .iter()
             .zip(&tx.signatures)

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -1,3 +1,4 @@
+use crate::cli_output::CliSignatureVerificationStatus;
 use console::style;
 use indicatif::{ProgressBar, ProgressStyle};
 use solana_sdk::{
@@ -85,6 +86,7 @@ pub fn write_transaction<W: io::Write>(
     transaction: &Transaction,
     transaction_status: &Option<UiTransactionStatusMeta>,
     prefix: &str,
+    sigverify_status: Option<&[CliSignatureVerificationStatus]>,
 ) -> io::Result<()> {
     let message = &transaction.message;
     writeln!(
@@ -92,11 +94,24 @@ pub fn write_transaction<W: io::Write>(
         "{}Recent Blockhash: {:?}",
         prefix, message.recent_blockhash
     )?;
-    for (signature_index, signature) in transaction.signatures.iter().enumerate() {
+    let sigverify_statuses = if let Some(sigverify_status) = sigverify_status {
+        sigverify_status
+            .iter()
+            .map(|s| format!(" ({})", s))
+            .collect()
+    } else {
+        vec!["".to_string(); transaction.signatures.len()]
+    };
+    for (signature_index, (signature, sigverify_status)) in transaction
+        .signatures
+        .iter()
+        .zip(&sigverify_statuses)
+        .enumerate()
+    {
         writeln!(
             w,
-            "{}Signature {}: {:?}",
-            prefix, signature_index, signature
+            "{}Signature {}: {:?}{}",
+            prefix, signature_index, signature, sigverify_status,
         )?;
     }
     writeln!(w, "{}{:?}", prefix, message.header)?;
@@ -217,9 +232,18 @@ pub fn println_transaction(
     transaction: &Transaction,
     transaction_status: &Option<UiTransactionStatusMeta>,
     prefix: &str,
+    sigverify_status: Option<&[CliSignatureVerificationStatus]>,
 ) {
     let mut w = Vec::new();
-    if write_transaction(&mut w, transaction, transaction_status, prefix).is_ok() {
+    if write_transaction(
+        &mut w,
+        transaction,
+        transaction_status,
+        prefix,
+        sigverify_status,
+    )
+    .is_ok()
+    {
         if let Ok(s) = String::from_utf8(w) {
             print!("{}", s);
         }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1934,7 +1934,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
         )
         .subcommand(
             SubCommand::with_name("decode-transaction")
-                .about("Decode a base-58 binary transaction")
+                .about("Decode a serialized transaction")
                 .arg(
                     Arg::with_name("transaction")
                         .index(1)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -18,7 +18,7 @@ use solana_clap_utils::{
 };
 use solana_cli_output::{
     display::{build_balance_message, println_name_value, println_transaction},
-    return_signers, CliAccount, CliSignature, OutputFormat,
+    return_signers, CliAccount, CliSignature, CliSignatureVerificationStatus, OutputFormat,
 };
 use solana_client::{
     blockhash_query::BlockhashQuery,
@@ -1044,7 +1044,8 @@ fn process_confirm(
 
 #[allow(clippy::unnecessary_wraps)]
 fn process_decode_transaction(transaction: &Transaction) -> ProcessResult {
-    println_transaction(transaction, &None, "", None);
+    let sig_stats = CliSignatureVerificationStatus::verify_transaction(&transaction);
+    println_transaction(transaction, &None, "", Some(&sig_stats));
     Ok("".to_string())
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1011,6 +1011,7 @@ fn process_confirm(
                                     .expect("Successful decode"),
                                 &confirmed_transaction.transaction.meta,
                                 "  ",
+                                None,
                             );
                         }
                         Err(err) => {
@@ -1043,7 +1044,7 @@ fn process_confirm(
 
 #[allow(clippy::unnecessary_wraps)]
 fn process_decode_transaction(transaction: &Transaction) -> ProcessResult {
-    println_transaction(transaction, &None, "");
+    println_transaction(transaction, &None, "", None);
     Ok("".to_string())
 }
 

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -967,6 +967,7 @@ pub fn process_get_block(
             &transaction_with_meta.transaction.decode().unwrap(),
             &transaction_with_meta.meta,
             "  ",
+            None,
         );
     }
     Ok("".to_string())
@@ -1838,6 +1839,7 @@ pub fn process_transaction_history(
                                 .expect("Successful decode"),
                             &confirmed_transaction.transaction.meta,
                             "  ",
+                            None,
                         );
                     }
                     Err(err) => println!("  Unable to get confirmed transaction details: {}", err),

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -69,6 +69,7 @@ async fn block(slot: Slot) -> Result<(), Box<dyn std::error::Error>> {
             &transaction_with_meta.transaction,
             &transaction_with_meta.meta.map(|meta| meta.into()),
             "  ",
+            None,
         );
     }
     Ok(())
@@ -104,6 +105,7 @@ async fn confirm(signature: &Signature, verbose: bool) -> Result<(), Box<dyn std
                     &confirmed_transaction.transaction.transaction,
                     &confirmed_transaction.transaction.meta.map(|m| m.into()),
                     "  ",
+                    None,
                 );
             }
             Ok(None) => println!("Finalized transaction details not available"),
@@ -183,6 +185,7 @@ pub async fn transaction_history(
                                         &transaction_with_meta.transaction,
                                         &transaction_with_meta.meta.clone().map(|m| m.into()),
                                         "  ",
+                                        None,
                                     );
                                 }
                             }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -122,6 +122,7 @@ fn output_entry(
                     &transaction,
                     &transaction_status,
                     "      ",
+                    None,
                 );
             }
         }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -387,7 +387,7 @@ fn print_confirmed_tx(name: &str, confirmed_tx: ConfirmedTransaction) {
     let tx = confirmed_tx.transaction.transaction.clone();
     let encoded = confirmed_tx.encode(UiTransactionEncoding::JsonParsed);
     println!("EXECUTE {} (slot {})", name, encoded.slot);
-    println_transaction(&tx, &encoded.transaction.meta, "  ");
+    println_transaction(&tx, &encoded.transaction.meta, "  ", None);
 }
 
 #[test]


### PR DESCRIPTION
#### Problem

No easy way to debug transaction missing/failed signature issues

#### Summary of Changes

Add sigverify results to `solana decode-transaction` output

```
$ solana decode-transaction ... base58
Recent Blockhash: 72p4Nbk8tqcUwn9od3EaENSB8wWjw9CRrter1csJj9YU
Signature 0: 5PBrpkUKt5codRBVgtWrPfD8Mv2NejPU28jsYnZE8TCwqAZtvPkLxeWvCRUrEoXUZUop593wCDcFhrd7SGDJi37t (pass)
Signature 1: 1111111111111111111111111111111111111111111111111111111111111111 (none)
MessageHeader { num_required_signatures: 2, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 2 }
```
```
$ solana decode-transaction ... base58
Recent Blockhash: BtZLathv3AuDcxZ6qoUJwjELStUHCQe6NdYm5EgAdEQj
Signature 0: 3VymSwBKKFW9vcYvQuCmkncawZsgwHCXMKQ41aVsEo1bChBP9kodoCKZffpxNJHGo1SR4uZ4MAqnvgfLzJ8XFQGt (fail)
MessageHeader { num_required_signatures: 1, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 1 }
```