### PR TITLE
Update economics docs

### DIFF
--- a/docs/src/inflation/inflation_schedule.md
+++ b/docs/src/inflation/inflation_schedule.md
@@ -6,7 +6,7 @@ As mentioned above, the network's *Inflation Schedule* is uniquely described by 
 
 - A large portion of the SOL issued via inflation will be distributed to stake-holders in proportion to the SOL they have staked. We want to ensure that the *Inflation Schedule* design results in reasonable *Staking Yields* for token holders who delegate SOL and for validation service providers (via commissions taken from *Staking Yields*).
 - The primary driver of *Staked Yield* is the amount of SOL staked divided by the total amount of SOL (% of total SOL staked). Therefore the distribution and delegation of tokens across validators are important factors to understand when determining initial inflation parameters.
-- [Yield throttling](https://forums.solana.com/t/validator-yield-throttling-proposal-discussion/855/5) is a mechanism currently under consideration that would impact *staking-yields*. **This is not taken into consideration in the discussion here or the modeling below.**
+- [Yield throttling](https://forums.solana.com/t/validator-yield-throttling-proposal-discussion/855/5) is a current area or research that would impact *staking-yields*. This is not taken into consideration in the discussion here or the modeling below.
 - Overall token issuance - i.e. what do we expect the Current Total Supply to be in 10 years, or 20 years?
 - Long-term, steady-state inflation is an important consideration not only for sustainable support for the validator ecosystem and the Solana Foundation grant programs, but also should be tuned in consideration with expected token losses and burning over time.
 - The rate at which we expect network usage to grow, as a consideration to the dis-inflationary rate. Over time, we plan for inflation to drop and expect that usage will grow.
@@ -27,7 +27,7 @@ In the above graph we see the annual inflation rate [$\%$] over time, given the 
 
 Similarly, here we see the *Total Current Supply* of SOL [MM] over time, assuming an initial *Total Current Supply* of `488,587,349 SOL` (i.e. for this example, taking the *Total Current Supply* as of `2020-01-25` and simulating inflation starting from that day).
 
-The expected Staking Yield and Adjusted Staking Yield metrics are then primarily a function of the % of total SOL staked on the network. Therefore we can we can estimate the *Staking Yield*, if we introduce an additional parameter *% of Staked SOL*:
+Setting aside validator uptime and commissions, the expected Staking Yield and Adjusted Staking Yield metrics are then primarily a function of the % of total SOL staked on the network. Therefore we can we can model *Staking Yield*, if we introduce an additional parameter *% of Staked SOL*:
 
 $$
 \%~\text{SOL Staked} = \frac{\text{Total SOL Staked}}{\text{Total Current Supply}}

--- a/docs/src/inflation/terminology.md
+++ b/docs/src/inflation/terminology.md
@@ -34,11 +34,12 @@ The rate of return (aka *interest*) earned on SOL staked on the network. It is o
 - $100\%$ of inflationary issuances are to be distributed to staked token-holders in proportion to the SOL they have staked with validators.
     - There may be future consideration for an additional split of inflation issuance with the introduction of *Archivers* into the economy. *Archivers* are network participants who provide a decentralized storage service and should also be incentivized with token distribution from inflation issuances for this service.
 	- Similarly, early designs specified a fixed percentage of inflationary issuance to be delivered to the Foundation treasury for operational expenses and future grants. However, inflation will be launching without any portion allocated to the Foundation.
-- *Staking yield* can be calculated from the *Inflation Schedule* along with the fraction of the *Total Current Supply* that is staked at any given time. Since inflation interest is split between staked-token holders, the Foundation pool and, potentially, *Archivers* - only the portion delivered to validators should be considered in the calculation of *Staking Yield*. Currently, the only split discussed is the $5\%$ to the Foundation, which is likely to be directly staked upon receipt, so not impacting the yield calculation. Below, this is specified by setting the 'Fraction to Validators' to $100\%$. The explicit relationship is given by:
+- *Staking yield* can be calculated from the *Inflation Schedule* along with the fraction of the *Total Current Supply* that is staked at any given time. The explicit relationship is given by:
 
 $$
 \begin{aligned}
-\text{Staking Yield} &= \text{Inflation Rate}\times \text{Fraction to Validators}\times \left( \frac{1}{\%~\text{SOL Staked}} \right) \\
+\text{Staking Yield} =~&\text{Inflation Rate}\times\text{Validator Uptime}~\times \\
+&\left( 1 - \text{Validator Fee} \right) \times \left( \frac{1}{\%~\text{SOL Staked}} \right) \\
 \text{where:}\\
 \%~\text{SOL Staked} &= \frac{\text{Total SOL Staked}}{\text{Total Current Supply}}
 \end{aligned}

--- a/docs/src/inflation/terminology.md
+++ b/docs/src/inflation/terminology.md
@@ -31,7 +31,7 @@ The inflation rate actually observed on the Solana network after accounting for 
 ### Staking Yield [%]
 The rate of return (aka *interest*) earned on SOL staked on the network. It is often quoted as an annualized rate (e.g. "the network *staking yield* is currently $10\%$ per year").
 - *Staking yield* is of great interest to validators and token-holders holders who wish to delegate their tokens to avoid token dilution due to inflation (the extent of which is discussed below).
-- $100\%$ of inflationary issuances are to be distributed to staked token-holders in proportion to the SOL they have staked with validators.
+- $100\%$ of inflationary issuances are to be distributed to staked token-holders in proportion to their staked SOL and to validators who charge a commission on the rewards earned by their delegated SOL..
     - There may be future consideration for an additional split of inflation issuance with the introduction of *Archivers* into the economy. *Archivers* are network participants who provide a decentralized storage service and should also be incentivized with token distribution from inflation issuances for this service.
 	- Similarly, early designs specified a fixed percentage of inflationary issuance to be delivered to the Foundation treasury for operational expenses and future grants. However, inflation will be launching without any portion allocated to the Foundation.
 - *Staking yield* can be calculated from the *Inflation Schedule* along with the fraction of the *Total Current Supply* that is staked at any given time. The explicit relationship is given by:


### PR DESCRIPTION
#### Problem
Referenced old inflation design with split between Foundation, Archivers and Stakes/Validators.

#### Summary of Changes
Updated language to clarify that inflation issuances are initially only to be distributed across stakes and validators

Fixes #
