### PR TITLE
program-test: Add ability to warp to the future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4773,6 +4773,7 @@ dependencies = [
  "solana-program 1.6.0",
  "solana-runtime",
  "solana-sdk",
+ "thiserror",
  "tokio 0.3.5",
 ]
 

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -289,7 +289,10 @@ pub async fn start_tcp_client<T: ToSocketAddrs>(addr: T) -> io::Result<BanksClie
 mod tests {
     use super::*;
     use solana_banks_server::banks_server::start_local_server;
-    use solana_runtime::{bank::Bank, bank_forks::BankForks, genesis_utils::create_genesis_config};
+    use solana_runtime::{
+        bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache,
+        genesis_utils::create_genesis_config,
+    };
     use solana_sdk::{message::Message, signature::Signer, system_instruction};
     use std::sync::{Arc, RwLock};
     use tarpc::transport;
@@ -308,9 +311,12 @@ mod tests {
         // `runtime.block_on()` just once, to run all the async code.
 
         let genesis = create_genesis_config(10);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::new(
-            &genesis.genesis_config,
-        ))));
+        let bank = Bank::new(&genesis.genesis_config);
+        let slot = bank.slot();
+        let block_commitment_cache = Arc::new(RwLock::new(
+            BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
+        ));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let mint_pubkey = genesis.mint_keypair.pubkey();
@@ -318,7 +324,7 @@ mod tests {
         let message = Message::new(&[instruction], Some(&mint_pubkey));
 
         Runtime::new()?.block_on(async {
-            let client_transport = start_local_server(&bank_forks).await;
+            let client_transport = start_local_server(&bank_forks, &block_commitment_cache).await;
             let mut banks_client = start_client(client_transport).await?;
 
             let recent_blockhash = banks_client.get_recent_blockhash().await?;
@@ -336,9 +342,12 @@ mod tests {
         // server-side functionality is available to the client.
 
         let genesis = create_genesis_config(10);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::new(
-            &genesis.genesis_config,
-        ))));
+        let bank = Bank::new(&genesis.genesis_config);
+        let slot = bank.slot();
+        let block_commitment_cache = Arc::new(RwLock::new(
+            BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
+        ));
+        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
 
         let mint_pubkey = &genesis.mint_keypair.pubkey();
         let bob_pubkey = solana_sdk::pubkey::new_rand();
@@ -346,7 +355,7 @@ mod tests {
         let message = Message::new(&[instruction], Some(&mint_pubkey));
 
         Runtime::new()?.block_on(async {
-            let client_transport = start_local_server(&bank_forks).await;
+            let client_transport = start_local_server(&bank_forks, &block_commitment_cache).await;
             let mut banks_client = start_client(client_transport).await?;
             let (_, recent_blockhash, last_valid_slot) = banks_client.get_fees().await?;
             let transaction = Transaction::new(&[&genesis.mint_keypair], message, recent_blockhash);

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -324,7 +324,7 @@ mod tests {
         let message = Message::new(&[instruction], Some(&mint_pubkey));
 
         Runtime::new()?.block_on(async {
-            let client_transport = start_local_server(&bank_forks, &block_commitment_cache).await;
+            let client_transport = start_local_server(bank_forks, block_commitment_cache).await;
             let mut banks_client = start_client(client_transport).await?;
 
             let recent_blockhash = banks_client.get_recent_blockhash().await?;
@@ -355,7 +355,7 @@ mod tests {
         let message = Message::new(&[instruction], Some(&mint_pubkey));
 
         Runtime::new()?.block_on(async {
-            let client_transport = start_local_server(&bank_forks, &block_commitment_cache).await;
+            let client_transport = start_local_server(bank_forks, block_commitment_cache).await;
             let mut banks_client = start_client(client_transport).await?;
             let (_, recent_blockhash, last_valid_slot) = banks_client.get_fees().await?;
             let transaction = Transaction::new(&[&genesis.mint_keypair], message, recent_blockhash);

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -247,11 +247,10 @@ impl Banks for BanksServer {
 }
 
 pub async fn start_local_server(
-    bank_forks: &Arc<RwLock<BankForks>>,
-    block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
+    bank_forks: Arc<RwLock<BankForks>>,
+    block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
 ) -> UnboundedChannel<Response<BanksResponse>, ClientMessage<BanksRequest>> {
-    let banks_server =
-        BanksServer::new_loopback(bank_forks.clone(), block_commitment_cache.clone());
+    let banks_server = BanksServer::new_loopback(bank_forks, block_commitment_cache);
     let (client_transport, server_transport) = transport::channel::unbounded();
     let server = server::new(server::Config::default())
         .incoming(stream::once(future::ready(server_transport)))

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -62,7 +62,7 @@ impl BanksServer {
         }
     }
 
-    fn run(bank: &Bank, transaction_receiver: Receiver<TransactionInfo>) {
+    fn run(bank_forks: Arc<RwLock<BankForks>>, transaction_receiver: Receiver<TransactionInfo>) {
         while let Ok(info) = transaction_receiver.recv() {
             let mut transaction_infos = vec![info];
             while let Ok(info) = transaction_receiver.try_recv() {
@@ -72,21 +72,28 @@ impl BanksServer {
                 .into_iter()
                 .map(|info| deserialize(&info.wire_transaction).unwrap())
                 .collect();
+            let bank = bank_forks.read().unwrap().working_bank();
             let _ = bank.process_transactions(&transactions);
         }
     }
 
     /// Useful for unit-testing
-    fn new_loopback(bank_forks: Arc<RwLock<BankForks>>) -> Self {
+    fn new_loopback(
+        bank_forks: Arc<RwLock<BankForks>>,
+        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+    ) -> Self {
         let (transaction_sender, transaction_receiver) = channel();
         let bank = bank_forks.read().unwrap().working_bank();
         let slot = bank.slot();
-        let block_commitment_cache = Arc::new(RwLock::new(
-            BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
-        ));
+        {
+            // ensure that the commitment cache and bank are synced
+            let mut w_block_commitment_cache = block_commitment_cache.write().unwrap();
+            w_block_commitment_cache.set_all_slots(slot, slot);
+        }
+        let server_bank_forks = bank_forks.clone();
         Builder::new()
             .name("solana-bank-forks-client".to_string())
-            .spawn(move || Self::run(&bank, transaction_receiver))
+            .spawn(move || Self::run(server_bank_forks, transaction_receiver))
             .unwrap();
         Self::new(bank_forks, block_commitment_cache, transaction_sender)
     }
@@ -241,8 +248,10 @@ impl Banks for BanksServer {
 
 pub async fn start_local_server(
     bank_forks: &Arc<RwLock<BankForks>>,
+    block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
 ) -> UnboundedChannel<Response<BanksResponse>, ClientMessage<BanksRequest>> {
-    let banks_server = BanksServer::new_loopback(bank_forks.clone());
+    let banks_server =
+        BanksServer::new_loopback(bank_forks.clone(), block_commitment_cache.clone());
     let (client_transport, server_transport) = transport::channel::unbounded();
     let server = server::new(server::Config::default())
         .incoming(stream::once(future::ready(server_transport)))

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -21,4 +21,5 @@ solana-logger = { path = "../logger", version = "1.6.0" }
 solana-program = { path = "../sdk/program", version = "1.6.0" }
 solana-runtime = { path = "../runtime", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
+thiserror = "1.0"
 tokio = { version = "0.3.5", features = ["full"] }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -685,7 +685,8 @@ impl ProgramTest {
     pub async fn start(self) -> (BanksClient, Keypair, Hash) {
         let (bank_forks, block_commitment_cache, payer, last_blockhash, genesis_config) =
             self.setup_bank();
-        let transport = start_local_server(&bank_forks, &block_commitment_cache).await;
+        let transport =
+            start_local_server(bank_forks.clone(), block_commitment_cache.clone()).await;
         let banks_client = start_client(transport)
             .await
             .unwrap_or_else(|err| panic!("Failed to start banks client: {}", err));
@@ -714,7 +715,8 @@ impl ProgramTest {
     pub async fn start_with_context(self) -> ProgramTestContext {
         let (bank_forks, block_commitment_cache, payer, last_blockhash, genesis_config) =
             self.setup_bank();
-        let transport = start_local_server(&bank_forks, &block_commitment_cache).await;
+        let transport =
+            start_local_server(bank_forks.clone(), block_commitment_cache.clone()).await;
         let banks_client = start_client(transport)
             .await
             .unwrap_or_else(|err| panic!("Failed to start banks client: {}", err));

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -15,10 +15,12 @@ use {
     solana_runtime::{
         bank::{Bank, Builtin, ExecuteTimings},
         bank_forks::BankForks,
+        commitment::BlockCommitmentCache,
         genesis_utils::create_genesis_config_with_leader,
     },
     solana_sdk::{
         account::Account,
+        clock::Slot,
         genesis_config::GenesisConfig,
         keyed_account::KeyedAccount,
         process_instruction::{
@@ -41,6 +43,7 @@ use {
         },
         time::{Duration, Instant},
     },
+    thiserror::Error,
     tokio::task::JoinHandle,
 };
 
@@ -70,8 +73,16 @@ pub fn to_instruction_error(error: ProgramError) -> InstructionError {
     }
 }
 
+/// Errors from the program test environment
+#[derive(Error, Debug, PartialEq)]
+pub enum ProgramTestError {
+    /// The chosen warp slot is not in the future, so warp is not performed
+    #[error("Warp slot not in the future")]
+    InvalidWarpSlot,
+}
+
 thread_local! {
-    static INVOKE_CONTEXT:RefCell<Option<(usize, usize)>> = RefCell::new(None);
+    static INVOKE_CONTEXT: RefCell<Option<(usize, usize)>> = RefCell::new(None);
 }
 fn set_invoke_context(new: &mut dyn InvokeContext) {
     INVOKE_CONTEXT.with(|invoke_context| {
@@ -79,6 +90,9 @@ fn set_invoke_context(new: &mut dyn InvokeContext) {
             panic!("Overwiting invoke context!")
         }
     });
+}
+fn clear_invoke_context() {
+    INVOKE_CONTEXT.with(|invoke_context| invoke_context.replace(None));
 }
 fn get_invoke_context<'a>() -> &'a mut dyn InvokeContext {
     let fat = INVOKE_CONTEXT.with(|invoke_context| match *invoke_context.borrow() {
@@ -151,6 +165,8 @@ pub fn builtin_process_instruction(
             account.data = data.borrow().to_vec();
         }
     }
+
+    clear_invoke_context();
 
     result
 }
@@ -579,7 +595,15 @@ impl ProgramTest {
         }
     }
 
-    fn setup_bank(&self) -> (Arc<RwLock<BankForks>>, Keypair, Hash, GenesisConfig) {
+    fn setup_bank(
+        &self,
+    ) -> (
+        Arc<RwLock<BankForks>>,
+        Arc<RwLock<BlockCommitmentCache>>,
+        Keypair,
+        Hash,
+        GenesisConfig,
+    ) {
         {
             use std::sync::Once;
             static ONCE: Once = Once::new();
@@ -642,15 +666,26 @@ impl ProgramTest {
             }));
         }
         let bank = setup_fee_calculator(bank);
+        let slot = bank.slot();
         let last_blockhash = bank.last_blockhash();
         let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let block_commitment_cache = Arc::new(RwLock::new(
+            BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
+        ));
 
-        (bank_forks, payer, last_blockhash, genesis_config)
+        (
+            bank_forks,
+            block_commitment_cache,
+            payer,
+            last_blockhash,
+            genesis_config,
+        )
     }
 
     pub async fn start(self) -> (BanksClient, Keypair, Hash) {
-        let (bank_forks, payer, last_blockhash, genesis_config) = self.setup_bank();
-        let transport = start_local_server(&bank_forks).await;
+        let (bank_forks, block_commitment_cache, payer, last_blockhash, genesis_config) =
+            self.setup_bank();
+        let transport = start_local_server(&bank_forks, &block_commitment_cache).await;
         let banks_client = start_client(transport)
             .await
             .unwrap_or_else(|err| panic!("Failed to start banks client: {}", err));
@@ -677,14 +712,16 @@ impl ProgramTest {
     /// Returns a `BanksClient` interface into the test environment as well as a payer `Keypair`
     /// with SOL for sending transactions
     pub async fn start_with_context(self) -> ProgramTestContext {
-        let (bank_forks, payer, last_blockhash, genesis_config) = self.setup_bank();
-        let transport = start_local_server(&bank_forks).await;
+        let (bank_forks, block_commitment_cache, payer, last_blockhash, genesis_config) =
+            self.setup_bank();
+        let transport = start_local_server(&bank_forks, &block_commitment_cache).await;
         let banks_client = start_client(transport)
             .await
             .unwrap_or_else(|err| panic!("Failed to start banks client: {}", err));
 
         ProgramTestContext::new(
             bank_forks,
+            block_commitment_cache,
             banks_client,
             payer,
             last_blockhash,
@@ -742,12 +779,15 @@ pub struct ProgramTestContext {
     pub banks_client: BanksClient,
     pub payer: Keypair,
     pub last_blockhash: Hash,
+    bank_forks: Arc<RwLock<BankForks>>,
+    block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     _bank_task: DroppableTask<()>,
 }
 
 impl ProgramTestContext {
     fn new(
         bank_forks: Arc<RwLock<BankForks>>,
+        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         banks_client: BanksClient,
         payer: Keypair,
         last_blockhash: Hash,
@@ -756,6 +796,7 @@ impl ProgramTestContext {
         // Run a simulated PohService to provide the client with new blockhashes.  New blockhashes
         // are required when sending multiple otherwise identical transactions in series from a
         // test
+        let running_bank_forks = bank_forks.clone();
         let target_tick_duration = genesis_config.poh_config.target_tick_duration;
         let exit = Arc::new(AtomicBool::new(false));
         let bank_task = DroppableTask(
@@ -765,7 +806,7 @@ impl ProgramTestContext {
                     if exit.load(Ordering::Relaxed) {
                         break;
                     }
-                    bank_forks
+                    running_bank_forks
                         .read()
                         .unwrap()
                         .working_bank()
@@ -777,9 +818,58 @@ impl ProgramTestContext {
 
         Self {
             banks_client,
+            block_commitment_cache,
             payer,
             last_blockhash,
+            bank_forks,
             _bank_task: bank_task,
         }
+    }
+
+    /// Force the working bank ahead to a new slot
+    pub fn warp_to_slot(&mut self, warp_slot: Slot) -> Result<(), ProgramTestError> {
+        let mut bank_forks = self.bank_forks.write().unwrap();
+        let bank = bank_forks.working_bank();
+
+        // Force ticks until a new blockhash, otherwise retried transactions will have
+        // the same signature
+        let last_blockhash = bank.last_blockhash();
+        while last_blockhash == bank.last_blockhash() {
+            bank.register_tick(&Hash::new_unique());
+        }
+
+        // warp ahead to one slot *before* the desired slot because the warped
+        // bank is frozen
+        let working_slot = bank.slot();
+        if warp_slot <= working_slot {
+            return Err(ProgramTestError::InvalidWarpSlot);
+        }
+        let pre_warp_slot = warp_slot - 1;
+        let warp_bank = bank_forks.insert(Bank::warp_from_parent(
+            &bank,
+            &Pubkey::default(),
+            pre_warp_slot,
+        ));
+        bank_forks.set_root(
+            pre_warp_slot,
+            &solana_runtime::accounts_background_service::ABSRequestSender::default(),
+            Some(warp_slot),
+        );
+
+        // warp bank is frozen, so go forward one slot from it
+        bank_forks.insert(Bank::new_from_parent(
+            &warp_bank,
+            &Pubkey::default(),
+            warp_slot,
+        ));
+
+        // Update block commitment cache, otherwise banks server will poll at
+        // the wrong slot
+        let mut w_block_commitment_cache = self.block_commitment_cache.write().unwrap();
+        w_block_commitment_cache.set_all_slots(pre_warp_slot, warp_slot);
+
+        let bank = bank_forks.working_bank();
+        self.last_blockhash = bank.last_blockhash();
+        Ok(())
     }
 }

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -1,8 +1,8 @@
 use {
     solana_banks_client::BanksClient,
     solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, hash::Hash, pubkey::Pubkey,
-        rent::Rent,
+        account_info::AccountInfo, entrypoint::ProgramResult, hash::Hash, instruction::Instruction,
+        msg, pubkey::Pubkey, rent::Rent,
     },
     solana_program_test::{processor, ProgramTest},
     solana_sdk::{
@@ -17,6 +17,8 @@ fn process_instruction(
     _accounts: &[AccountInfo],
     _input: &[u8],
 ) -> ProgramResult {
+    // if we can call `msg!` successfully, then InvokeContext exists as required
+    msg!("Processing fuzz instruction, and ensure that InvokeContext exists");
     Ok(())
 }
 
@@ -94,6 +96,7 @@ async fn run_fuzz_instructions(
             program_id,
         );
         instructions.push(instruction);
+        instructions.push(Instruction::new(*program_id, &[0], vec![]));
         signer_keypairs.push(keypair);
     }
     // Process transaction on test network

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -1,0 +1,97 @@
+use {
+    solana_program::{
+        account_info::{next_account_info, AccountInfo},
+        clock::Clock,
+        entrypoint::ProgramResult,
+        instruction::{AccountMeta, Instruction, InstructionError},
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        sysvar::{clock, Sysvar},
+    },
+    solana_program_test::{processor, ProgramTest, ProgramTestError},
+    solana_sdk::{
+        signature::Signer,
+        transaction::{Transaction, TransactionError},
+    },
+    std::convert::TryInto,
+};
+
+// Use a big number to be sure that we get the right error
+const WRONG_SLOT_ERROR: u32 = 123456;
+
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    input: &[u8],
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+    let clock_info = next_account_info(account_info_iter)?;
+    let clock = &Clock::from_account_info(clock_info)?;
+    let expected_slot = u64::from_le_bytes(input.try_into().unwrap());
+    if clock.slot == expected_slot {
+        Ok(())
+    } else {
+        Err(ProgramError::Custom(WRONG_SLOT_ERROR))
+    }
+}
+
+#[tokio::test]
+async fn custom_warp() {
+    let program_id = Pubkey::new_unique();
+    // Initialize and start the test network
+    let program_test = ProgramTest::new(
+        "program-test-warp",
+        program_id,
+        processor!(process_instruction),
+    );
+
+    let mut context = program_test.start_with_context().await;
+    let expected_slot = 5_000_000;
+    let instruction = Instruction::new(
+        program_id,
+        &expected_slot,
+        vec![AccountMeta::new_readonly(clock::id(), false)],
+    );
+
+    // Fail transaction
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction.clone()],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    assert_eq!(
+        context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(0, InstructionError::Custom(WRONG_SLOT_ERROR))
+    );
+
+    // Warp to success!
+    context.warp_to_slot(expected_slot).unwrap();
+    let instruction = Instruction::new(
+        program_id,
+        &expected_slot,
+        vec![AccountMeta::new_readonly(clock::id(), false)],
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+
+    // Try warping again to the same slot
+    assert_eq!(
+        context.warp_to_slot(expected_slot).unwrap_err(),
+        ProgramTestError::InvalidWarpSlot,
+    );
+}

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -195,6 +195,13 @@ impl BlockCommitmentCache {
         self.commitment_slots.slot = slot;
         self.commitment_slots.root = slot;
     }
+
+    pub fn set_all_slots(&mut self, slot: Slot, root: Slot) {
+        self.commitment_slots.slot = slot;
+        self.commitment_slots.highest_confirmed_slot = slot;
+        self.commitment_slots.root = root;
+        self.commitment_slots.highest_confirmed_root = root;
+    }
 }
 
 #[derive(Default, Clone, Copy)]


### PR DESCRIPTION
#### Problem

Program-test is very useful for end-to-end testing many situations, but it doesn't have the ability to warp to a slot in the future to test clock-dependent programs.

#### Summary of Changes

Add it in!  There's a bit of extra plumbing required to sync up all parts of banks-server, namely giving ProgramTest access to BankForks and BlockCommitmentCache.

The main test added is just looking at the clock, but we can add more tests for things like stake rewards and rent collection.  I prefer to do it in a separate PR.

There's a change to clear the invoke context at the end of each instruction processing, and I'm not totally sure of the impact that might have elsewhere.  It might break someone adding two of their own programs to ProgramTest and CPI'ing from one to the other.  Note that it was required to get the warp test working.  The fuzz test also triggers the issue in a simpler context, which is why it's updated in the same PR.  Alternatively, I can change that logic to just always set the invoke context, and not panic if it's changed.

cc @mvines 
