### PR TITLE
Cli: some moniker follow-up

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -471,11 +471,15 @@ impl CliConfig<'_> {
             (SettingType::Explicit, websocket_cfg_url.to_string()),
             (
                 SettingType::Computed,
-                solana_cli_config::Config::compute_websocket_url(json_rpc_cmd_url),
+                solana_cli_config::Config::compute_websocket_url(&normalize_to_url_if_moniker(
+                    json_rpc_cmd_url,
+                )),
             ),
             (
                 SettingType::Computed,
-                solana_cli_config::Config::compute_websocket_url(json_rpc_cfg_url),
+                solana_cli_config::Config::compute_websocket_url(&normalize_to_url_if_moniker(
+                    json_rpc_cfg_url,
+                )),
             ),
             (SettingType::SystemDefault, Self::default_websocket_url()),
         ])

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ use clap::{
 };
 use console::style;
 use solana_clap_utils::{
-    input_validators::{is_url, is_url_or_moniker},
+    input_validators::{is_url, is_url_or_moniker, normalize_to_url_if_moniker},
     keypair::{CliSigners, DefaultSigner, SKIP_SEED_PHRASE_VALIDATION_ARG},
     DisplayError,
 };
@@ -90,7 +90,7 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                 }
                 ("set", Some(subcommand_matches)) => {
                     if let Some(url) = subcommand_matches.value_of("json_rpc_url") {
-                        config.json_rpc_url = url.to_string();
+                        config.json_rpc_url = normalize_to_url_if_moniker(url);
                         // Revert to a computed `websocket_url` value when `json_rpc_url` is
                         // changed
                         config.websocket_url = "".to_string();


### PR DESCRIPTION
#### Problem
The cli url monikers are awesome! But if you try to run `solana config set -u d` or similar, you get scary panics next time you try to use the cli (`thread 'main' panicked at 'no nonempty setting', cli/src/cli.rs:450:14`)

Also, `solana logs -u d` doesn't work with a passed moniker. It actually attempts to connect to whatever you have set in your config, instead of `wss://devnet.solana.com`.

#### Summary of Changes
- Enable monikers in `solana config set`
- Fixup websocket compute to handle monikers properly
