### PR TITLE
stake-o-matic: Sanity check that the RPC endpoint is healthy before performing too much work

### DIFF
--- a/stake-o-matic/src/main.rs
+++ b/stake-o-matic/src/main.rs
@@ -646,6 +646,12 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         process::exit(1);
     }
 
+    // Sanity check that the RPC endpoint is healthy before performing too much work
+    rpc_client.get_health().unwrap_or_else(|err| {
+        error!("RPC endpoint is unhealthy: {:?}", err);
+        process::exit(1);
+    });
+
     let source_stake_balance = validate_source_stake_account(&rpc_client, &config)?;
 
     let epoch_info = rpc_client.get_epoch_info()?;


### PR DESCRIPTION
It's pretty painful to spend 30 min slurping down blocks from BigTable only to find out that the RPC endpoint is unhealthy and won't accept transactions.  Check for health upfront