### PR TITLE
cli: `transaction-history -v` now shows the transaction timestamp if available

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1,41 +1,42 @@
-use crate::{
-    display::{
-        build_balance_message, build_balance_message_with_config, format_labeled_address,
-        writeln_name_value, BuildBalanceMessageConfig,
+use {
+    crate::{
+        display::{
+            build_balance_message, build_balance_message_with_config, format_labeled_address,
+            unix_timestamp_to_string, writeln_name_value, BuildBalanceMessageConfig,
+        },
+        QuietDisplay, VerboseDisplay,
     },
-    QuietDisplay, VerboseDisplay,
-};
-use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
-use console::{style, Emoji};
-use inflector::cases::titlecase::to_title_case;
-use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
-use solana_account_decoder::parse_token::UiTokenAccount;
-use solana_clap_utils::keypair::SignOnly;
-use solana_client::rpc_response::{
-    RpcAccountBalance, RpcInflationGovernor, RpcInflationRate, RpcKeyedAccount, RpcSupply,
-    RpcVoteAccountInfo,
-};
-use solana_sdk::{
-    clock::{self, Epoch, Slot, UnixTimestamp},
-    epoch_info::EpochInfo,
-    hash::Hash,
-    native_token::lamports_to_sol,
-    pubkey::Pubkey,
-    signature::Signature,
-    stake_history::StakeHistoryEntry,
-    transaction::Transaction,
-};
-use solana_stake_program::stake_state::{Authorized, Lockup};
-use solana_vote_program::{
-    authorized_voters::AuthorizedVoters,
-    vote_state::{BlockTimestamp, Lockout},
-};
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt,
-    str::FromStr,
-    time::Duration,
+    console::{style, Emoji},
+    inflector::cases::titlecase::to_title_case,
+    serde::{Deserialize, Serialize},
+    serde_json::{Map, Value},
+    solana_account_decoder::parse_token::UiTokenAccount,
+    solana_clap_utils::keypair::SignOnly,
+    solana_client::rpc_response::{
+        RpcAccountBalance, RpcInflationGovernor, RpcInflationRate, RpcKeyedAccount, RpcSupply,
+        RpcVoteAccountInfo,
+    },
+    solana_sdk::{
+        clock::{self, Epoch, Slot, UnixTimestamp},
+        epoch_info::EpochInfo,
+        hash::Hash,
+        native_token::lamports_to_sol,
+        pubkey::Pubkey,
+        signature::Signature,
+        stake_history::StakeHistoryEntry,
+        transaction::Transaction,
+    },
+    solana_stake_program::stake_state::{Authorized, Lockup},
+    solana_vote_program::{
+        authorized_voters::AuthorizedVoters,
+        vote_state::{BlockTimestamp, Lockout},
+    },
+    std::{
+        collections::{BTreeMap, HashMap},
+        fmt,
+        str::FromStr,
+        time::Duration,
+    },
 };
 
 static WARNING: Emoji = Emoji("⚠️", "!");
@@ -1152,18 +1153,6 @@ pub struct CliBlockTime {
 
 impl QuietDisplay for CliBlockTime {}
 impl VerboseDisplay for CliBlockTime {}
-
-fn unix_timestamp_to_string(unix_timestamp: UnixTimestamp) -> String {
-    format!(
-        "{} (UnixTimestamp: {})",
-        match NaiveDateTime::from_timestamp_opt(unix_timestamp, 0) {
-            Some(ndt) =>
-                DateTime::<Utc>::from_utc(ndt, Utc).to_rfc3339_opts(SecondsFormat::Secs, true),
-            None => "unknown".to_string(),
-        },
-        unix_timestamp,
-    )
-}
 
 impl fmt::Display for CliBlockTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -1,12 +1,15 @@
-use crate::cli_output::CliSignatureVerificationStatus;
-use console::style;
-use indicatif::{ProgressBar, ProgressStyle};
-use solana_sdk::{
-    hash::Hash, native_token::lamports_to_sol, program_utils::limited_deserialize,
-    transaction::Transaction,
+use {
+    crate::cli_output::CliSignatureVerificationStatus,
+    chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc},
+    console::style,
+    indicatif::{ProgressBar, ProgressStyle},
+    solana_sdk::{
+        clock::UnixTimestamp, hash::Hash, native_token::lamports_to_sol,
+        program_utils::limited_deserialize, transaction::Transaction,
+    },
+    solana_transaction_status::UiTransactionStatusMeta,
+    std::{collections::HashMap, fmt, io},
 };
-use solana_transaction_status::UiTransactionStatusMeta;
-use std::{collections::HashMap, fmt, io};
 
 #[derive(Clone, Debug)]
 pub struct BuildBalanceMessageConfig {
@@ -298,6 +301,13 @@ pub fn new_spinner_progress_bar() -> ProgressBar {
         .set_style(ProgressStyle::default_spinner().template("{spinner:.green} {wide_msg}"));
     progress_bar.enable_steady_tick(100);
     progress_bar
+}
+
+pub fn unix_timestamp_to_string(unix_timestamp: UnixTimestamp) -> String {
+    match NaiveDateTime::from_timestamp_opt(unix_timestamp, 0) {
+        Some(ndt) => DateTime::<Utc>::from_utc(ndt, Utc).to_rfc3339_opts(SecondsFormat::Secs, true),
+        None => format!("UnixTimestamp {}", unix_timestamp),
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -16,7 +16,7 @@ use solana_clap_utils::{
 use solana_cli_output::{
     display::{
         build_balance_message, format_labeled_address, new_spinner_progress_bar,
-        println_name_value, println_transaction, writeln_name_value,
+        println_name_value, println_transaction, unix_timestamp_to_string, writeln_name_value,
     },
     *,
 };
@@ -1812,9 +1812,14 @@ pub fn process_transaction_history(
     for result in results {
         if config.verbose {
             println!(
-                "{} [slot={} status={}] {}",
+                "{} [slot={} {}status={}] {}",
                 result.signature,
                 result.slot,
+                match result.block_time {
+                    None => "".to_string(),
+                    Some(block_time) =>
+                        format!("timestamp={} ", unix_timestamp_to_string(block_time)),
+                },
                 match result.err {
                     None => "Confirmed".to_string(),
                     Some(err) => format!("Failed: {:?}", err),


### PR DESCRIPTION
I'm jealous that the transaction history in the explorer now shows transaction timestamps but the cli doesn't.  Fix it