### PR TITLE
Fix pubkey refcount for shrink + clean

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8284,8 +8284,7 @@ pub mod tests {
         run_flush_rooted_accounts_cache(false);
     }
 
-    #[test]
-    fn test_shrink_unref() {
+    fn run_test_shrink_unref(do_intra_cache_clean: bool) {
         // Enable caching so that we use the straightforward implementation
         // of shrink that will shrink all candidate slots
         let caching_enabled = true;
@@ -8303,8 +8302,13 @@ pub mod tests {
         db.store_cached(0, &[(&account_key1, &account1)]);
         db.store_cached(0, &[(&account_key2, &account1)]);
         db.add_root(0);
-        // Flushes all roots
-        db.flush_accounts_cache(true, None);
+        if !do_intra_cache_clean {
+            // If we don't want the cache doing purges before flush,
+            // then we cannot flush multiple roots at once, otherwise the later
+            // roots will clean the earlier roots before they are stored.
+            // Thus flush the roots individually
+            db.flush_accounts_cache(true, None);
+        }
 
         // Make account_key1 in slot 0 outdated by updating in rooted slot 1
         db.store_cached(1, &[(&account_key1, &account1)]);
@@ -8349,6 +8353,16 @@ pub mod tests {
         // should be 1, since it was only stored in slot 0 and 1, and slot 0
         // is now dead
         assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
+    }
+
+    #[test]
+    fn test_shrink_unref() {
+        run_test_shrink_unref(false)
+    }
+
+    #[test]
+    fn test_shrink_unref_with_intra_slot_cleaning() {
+        run_test_shrink_unref(true)
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1640,10 +1640,17 @@ impl AccountsDB {
                     )| {
                         if let Some((locked_entry, _)) = self.accounts_index.get(pubkey, None, None)
                         {
-                            locked_entry
+                            let is_alive = locked_entry
                                 .slot_list()
                                 .iter()
-                                .any(|(_slot, i)| i.store_id == *store_id && i.offset == *offset)
+                                .any(|(_slot, i)| i.store_id == *store_id && i.offset == *offset);
+                            if !is_alive {
+                                // If the account index entry was removed, that means no other
+                                // AppendVec's for this slot contains this pubkey, so it's safe
+                                // to unref
+                                locked_entry.unref()
+                            }
+                            is_alive
                         } else {
                             false
                         }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -100,6 +100,10 @@ impl<T: Clone> ReadAccountMapEntry<T> {
     pub fn ref_count(&self) -> &AtomicU64 {
         &self.borrow_owned_entry_contents().ref_count
     }
+
+    pub fn unref(&self) {
+        self.ref_count().fetch_sub(1, Ordering::Relaxed);
+    }
 }
 
 #[self_referencing]
@@ -109,7 +113,7 @@ pub struct WriteAccountMapEntry<T: 'static> {
     slot_list_guard: RwLockWriteGuard<'this, SlotList<T>>,
 }
 
-impl<T: 'static + Clone> WriteAccountMapEntry<T> {
+impl<T: 'static + Clone + IsCached> WriteAccountMapEntry<T> {
     pub fn from_account_map_entry(account_map_entry: AccountMapEntry<T>) -> Self {
         WriteAccountMapEntryBuilder {
             owned_entry: account_map_entry,
@@ -146,12 +150,18 @@ impl<T: 'static + Clone> WriteAccountMapEntry<T> {
             .collect();
         assert!(same_slot_previous_updates.len() <= 1);
         if let Some((list_index, (s, previous_update_value))) = same_slot_previous_updates.pop() {
+            let is_flush_from_cache =
+                previous_update_value.is_cached() && !account_info.is_cached();
             reclaims.push((*s, previous_update_value.clone()));
             self.slot_list_mut(|list| list.remove(list_index));
-        } else {
-            // Only increment ref count if the account was not prevously updated in this slot
+            if is_flush_from_cache {
+                self.ref_count().fetch_add(1, Ordering::Relaxed);
+            }
+        } else if !account_info.is_cached() {
+            // If it's the first non-cache insert, also bump the stored ref count
             self.ref_count().fetch_add(1, Ordering::Relaxed);
         }
+
         self.slot_list_mut(|list| list.push((slot, account_info)));
     }
 }
@@ -856,7 +866,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
 
     pub fn unref_from_storage(&self, pubkey: &Pubkey) {
         if let Some(locked_entry) = self.get_account_read_entry(pubkey) {
-            locked_entry.ref_count().fetch_sub(1, Ordering::Relaxed);
+            locked_entry.unref();
         }
     }
 


### PR DESCRIPTION
#### Problem
Shrink doesn't unref accounts that it removes. For example:

1. Create two keys, `pubkey1`, `pubkey2` in slot 0
2. Updates `pubkey1` slot 1
3. Run clean + shrink on slot 0 so that it now only has 1 of those keys in the AppendVec
4. Updates the other key from slot 0 in slot 2
5. Run clean -> remove slot 0  via `process_dead_slots()`-> unref
6. Expect ref count to be 1 for `pubkey1`, but it's still 2.

#### Summary of Changes
Encode the above into a test.
@jeffwashington added a test here to illustrate setting up a clean + shrink. The bug is the ref count issue we discussed in the morning
Fixes #
