### PR TITLE
cli: Don't over-allocate upgradeable program if --final specified

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -659,7 +659,7 @@ fn process_program_deploy(
         true
     };
 
-    let (program_data, buffer_data_len) = if buffer_provided {
+    let (program_data, program_len) = if buffer_provided {
         // Check supplied buffer account
         if let Some(account) = rpc_client
             .get_account_with_commitment(&buffer_pubkey, config.commitment)?
@@ -678,14 +678,20 @@ fn process_program_deploy(
         }
     } else if let Some(program_location) = program_location {
         let program_data = read_and_verify_elf(&program_location)?;
-        let buffer_data_len = if let Some(len) = max_len {
-            len
-        } else {
-            program_data.len() * 2
-        };
-        (program_data, buffer_data_len)
+        let program_len = program_data.len();
+        (program_data, program_len)
     } else {
         return Err("Program location required if buffer not supplied".into());
+    };
+    let buffer_data_len = if let Some(len) = max_len {
+        if program_len > len {
+            return Err("Max length specified not large enough".into());
+        }
+        len
+    } else if is_final {
+        program_len
+    } else {
+        program_len * 2
     };
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(
         UpgradeableLoaderState::programdata_len(buffer_data_len)?,


### PR DESCRIPTION
#### Problem

`solana program deploy` over-allocates by default if `--max-len` not specified even if `--final` is.  This requires deployments of programs that will not be upgraded to pay extra rent

#### Summary of Changes

If `--final` is specified don't overallocate

Fixes #14971
