### PR TITLE
CLI: Surface account query errors

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1636,7 +1636,7 @@ pub fn process_show_stakes(
         CliError::RpcRequestError("Failed to deserialize stake history".to_string())
     })?;
     // At v1.6, this check can be removed and simply passed as `true`
-    let stake_program_v2_enabled = is_stake_program_v2_enabled(rpc_client);
+    let stake_program_v2_enabled = is_stake_program_v2_enabled(rpc_client)?;
 
     let mut stake_accounts: Vec<CliKeyedStakeState> = vec![];
     for (stake_pubkey, stake_account) in all_stake_accounts {

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -457,11 +457,11 @@ pub fn process_new_nonce(
         (&nonce_account, "nonce_account_pubkey".to_string()),
     )?;
 
-    let nonce_account_check = rpc_client.get_account(&nonce_account);
-    if nonce_account_check.is_err() {
-        return Err(CliError::BadParameter(
-            "Unable to create new nonce, no nonce account found".to_string(),
-        )
+    if let Err(err) = rpc_client.get_account(&nonce_account) {
+        return Err(CliError::BadParameter(format!(
+            "Unable to advance nonce account {}. error: {}",
+            nonce_account, err
+        ))
         .into());
     }
 


### PR DESCRIPTION
#### Problem

CLI eats account query errors in a few places, making it difficult to determine the root cause of failures

This most recently surfaced as someone was trying to delegate stake while our API infrastructure was struggling.  CLI was reporting that the specified vote account did not exist, when in fact the query was simply timing out

#### Summary of Changes

Surface them
