### PR TITLE
Bump tonic, prost, tarpc, tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4370,7 +4370,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-version",
- "tokio 0.3.5",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -4749,7 +4749,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-logger 1.6.0",
  "solana-version",
- "tokio 0.3.5",
+ "tokio 1.1.1",
  "url 2.2.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,9 +2781,9 @@ checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -4188,7 +4188,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio 0.2.22",
- "tokio-util 0.2.0",
+ "tokio 0.3.5",
+ "tokio-util 0.3.1",
  "trees",
 ]
 
@@ -4493,7 +4494,7 @@ dependencies = [
  "solana-vote-program",
  "tempfile",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.3.5",
  "trees",
 ]
 
@@ -4529,7 +4530,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "tempfile",
- "tokio 0.2.22",
+ "tokio 0.3.5",
 ]
 
 [[package]]
@@ -5818,7 +5819,7 @@ dependencies = [
  "mio 0.7.6",
  "num_cpus",
  "parking_lot 0.11.0",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "signal-hook-registry",
  "slab",
  "tokio-macros 0.3.1",
@@ -5836,7 +5837,7 @@ dependencies = [
  "libc",
  "memchr 2.3.3",
  "mio 0.7.6",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "tokio-macros 1.0.0",
 ]
 
@@ -5989,7 +5990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "tokio 1.1.1",
 ]
 
@@ -6102,20 +6103,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
-dependencies = [
- "bytes 0.5.4",
- "futures-core",
- "futures-sink",
- "log 0.4.11",
- "pin-project-lite 0.1.5",
- "tokio 0.2.22",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
@@ -6152,7 +6139,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.11",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "tokio 1.1.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,6 +1045,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7260c7e6e656fc7702a1aa8d5b498a1a69aa84ac4ffcd5501b7d26939f368a93"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2 1.0.24",
+ "quote 1.0.6",
+ "syn 1.0.48",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1092,19 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
 dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.6",
+ "syn 1.0.48",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1676e1daadfd216bda88d3a6fedd1bf53b829a085f5cc4d81c6f3054f50ef983"
+dependencies = [
+ "num-bigint",
+ "num-traits",
  "proc-macro2 1.0.24",
  "quote 1.0.6",
  "syn 1.0.48",
@@ -2433,6 +2458,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
 dependencies = [
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3907,7 +3943,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "tarpc",
- "tokio 0.3.5",
+ "tokio 1.1.1",
  "tokio-serde",
 ]
 
@@ -3919,7 +3955,7 @@ dependencies = [
  "serde",
  "solana-sdk",
  "tarpc",
- "tokio 0.3.5",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -3935,8 +3971,9 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "tarpc",
- "tokio 0.3.5",
+ "tokio 1.1.1",
  "tokio-serde",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -4899,7 +4936,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "thiserror",
- "tokio 0.3.5",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -5656,9 +5693,9 @@ dependencies = [
 
 [[package]]
 name = "tarpc"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fc49715ecefc8e56b6d8bdc6fe4fd41664b437b2a285e0f36a28bc9252310f"
+checksum = "e325774dd5b35d979e9f4db2b0f0d7d85dc2ff2b676a3150af56c09eafc14b07"
 dependencies = [
  "anyhow",
  "fnv",
@@ -5670,16 +5707,16 @@ dependencies = [
  "serde",
  "static_assertions",
  "tarpc-plugins",
- "tokio 0.3.5",
+ "tokio 1.1.1",
  "tokio-serde",
- "tokio-util 0.4.0",
+ "tokio-util 0.6.3",
 ]
 
 [[package]]
 name = "tarpc-plugins"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbaf92ceea0a2ab555bea18a47a891e46ba2d6f930ec9506771662f4ab82bb7"
+checksum = "f3240378a22b1195734e085ba71d1d4188d50f034aea82635acc430b7005afb5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.6",
@@ -6099,16 +6136,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-serde"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdd897b01021779294eb09bb3b52b6e11b0747f9f7e333a84bef532b656de99"
+checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
 dependencies = [
  "bincode",
- "bytes 0.5.4",
- "derivative",
- "futures 0.3.8",
- "pin-project 0.4.23",
+ "bytes 1.0.1",
+ "educe",
+ "futures-core",
+ "futures-sink",
+ "pin-project 1.0.1",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6231,20 +6270,6 @@ dependencies = [
  "log 0.4.11",
  "pin-project-lite 0.1.5",
  "tokio 0.2.22",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24793699f4665ba0416ed287dc794fe6b11a4aa5e4e95b58624f45f6c46b97d4"
-dependencies = [
- "bytes 0.5.4",
- "futures-core",
- "futures-sink",
- "log 0.4.11",
- "pin-project-lite 0.1.5",
- "tokio 0.3.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 
 [[package]]
 name = "async-stream"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.6",
@@ -426,6 +426,12 @@ name = "bytes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "bytesize"
@@ -1465,6 +1471,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio 1.1.1",
+ "tokio-util 0.6.3",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "half"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,10 +1608,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+dependencies = [
+ "bytes 1.0.1",
+ "http",
+]
+
+[[package]]
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
@@ -1631,9 +1673,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.2.5",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "httparse",
  "itoa",
  "log 0.4.11",
@@ -1642,6 +1684,30 @@ dependencies = [
  "time 0.1.43",
  "tokio 0.2.22",
  "tower-service",
+ "want",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.0",
+ "http",
+ "http-body 0.4.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.1",
+ "socket2",
+ "tokio 1.1.1",
+ "tower-service",
+ "tracing",
  "want",
 ]
 
@@ -1655,9 +1721,9 @@ dependencies = [
  "futures-util",
  "hyper 0.13.5",
  "log 0.4.11",
- "rustls",
+ "rustls 0.18.0",
  "tokio 0.2.22",
- "tokio-rustls",
+ "tokio-rustls 0.14.0",
  "webpki",
 ]
 
@@ -1760,15 +1826,6 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2825,22 +2882,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 1.0.1",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools 0.8.2",
+ "itertools",
  "proc-macro2 1.0.24",
  "quote 1.0.6",
  "syn 1.0.48",
@@ -2848,11 +2905,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 1.0.1",
  "prost",
 ]
 
@@ -2927,6 +2984,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +3013,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2971,6 +3050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.0",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +3074,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -3169,7 +3266,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body",
+ "http-body 0.3.1",
  "hyper 0.13.5",
  "hyper-rustls",
  "hyper-tls",
@@ -3182,12 +3279,12 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.1.5",
- "rustls",
+ "rustls 0.18.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 0.2.22",
- "tokio-rustls",
+ "tokio-rustls 0.14.0",
  "tokio-tls 0.3.1",
  "url 2.1.1",
  "wasm-bindgen",
@@ -3272,6 +3369,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cac94b333ee2aac3284c5b8a1b7fb4dd11cba88c244e3fe33cdbd047af0eb693"
 dependencies = [
  "base64 0.12.3",
+ "log 0.4.11",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+dependencies = [
+ "base64 0.13.0",
  "log 0.4.11",
  "ring",
  "sct",
@@ -3754,7 +3864,7 @@ name = "solana-bench-exchange"
 version = "1.6.0"
 dependencies = [
  "clap",
- "itertools 0.9.0",
+ "itertools",
  "log 0.4.11",
  "num-derive",
  "num-traits",
@@ -4021,7 +4131,7 @@ dependencies = [
  "flate2",
  "fs_extra",
  "indexmap",
- "itertools 0.9.0",
+ "itertools",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-derive",
@@ -4348,7 +4458,7 @@ dependencies = [
  "fs_extra",
  "futures 0.3.8",
  "futures-util",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "libc",
  "log 0.4.11",
@@ -4399,7 +4509,7 @@ dependencies = [
  "futures 0.3.8",
  "futures-util",
  "histogram",
- "itertools 0.9.0",
+ "itertools",
  "log 0.4.11",
  "regex",
  "serde",
@@ -4430,7 +4540,7 @@ dependencies = [
  "crossbeam-channel 0.4.4",
  "fs_extra",
  "gag",
- "itertools 0.9.0",
+ "itertools",
  "log 0.4.11",
  "rand 0.7.3",
  "serial_test",
@@ -4641,7 +4751,7 @@ dependencies = [
  "bv",
  "curve25519-dalek 2.1.0",
  "hex",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "log 0.4.11",
  "num-derive",
@@ -4670,7 +4780,7 @@ dependencies = [
  "bv",
  "curve25519-dalek 2.1.0",
  "hex",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "log 0.4.11",
  "num-derive",
@@ -4775,7 +4885,7 @@ dependencies = [
  "flate2",
  "fnv",
  "fs_extra",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "libc",
  "libloading 0.6.2",
@@ -4834,7 +4944,7 @@ dependencies = [
  "generic-array 0.14.3",
  "hex",
  "hmac 0.10.1",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "libsecp256k1",
  "log 0.4.11",
@@ -5716,6 +5826,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
+dependencies = [
+ "autocfg 1.0.0",
+ "bytes 1.0.1",
+ "libc",
+ "memchr 2.3.3",
+ "mio 0.7.6",
+ "pin-project-lite 0.2.0",
+ "tokio-macros 1.0.0",
+]
+
+[[package]]
 name = "tokio-codec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5791,6 +5916,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.6",
+ "syn 1.0.48",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5816,8 +5952,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "228139ddd4fea3fa345a29233009635235833e52807af7ea6448ead03890d6a9"
 dependencies = [
  "futures-core",
- "rustls",
+ "rustls 0.18.0",
  "tokio 0.2.22",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls 0.19.0",
+ "tokio 1.1.1",
  "webpki",
 ]
 
@@ -5833,6 +5980,17 @@ dependencies = [
  "futures 0.3.8",
  "pin-project 0.4.23",
  "serde",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.0",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -5985,6 +6143,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.11",
+ "pin-project-lite 0.2.0",
+ "tokio 1.1.1",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5995,30 +6167,29 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b102a19758191af97cff34c6785dffd6610f68de5ab1c4bb8378638e4ef90"
+checksum = "3ba8f479158947373b6df40cf48f4779bb25c99ca3c661bd95e0ab1963ad8b0e"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.12.3",
- "bytes 0.5.4",
+ "base64 0.13.0",
+ "bytes 1.0.1",
  "futures-core",
  "futures-util",
+ "h2 0.3.0",
  "http",
- "http-body",
- "hyper 0.13.5",
+ "http-body 0.4.0",
+ "hyper 0.14.2",
  "percent-encoding 2.1.0",
- "pin-project 0.4.23",
+ "pin-project 1.0.1",
  "prost",
  "prost-derive",
- "tokio 0.2.22",
- "tokio-rustls",
- "tokio-util 0.3.1",
+ "tokio 1.1.1",
+ "tokio-rustls 0.22.0",
+ "tokio-stream",
+ "tokio-util 0.6.3",
  "tower",
- "tower-balance",
- "tower-load",
- "tower-make",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -6026,181 +6197,34 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.3.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3169017c090b7a28fce80abaad0ab4f5566423677c9331bb320af7e49cfe62"
-dependencies = [
- "futures-core",
- "tower-buffer",
- "tower-discover",
- "tower-layer",
- "tower-limit",
- "tower-load-shed",
- "tower-retry",
- "tower-service",
- "tower-timeout",
- "tower-util",
-]
-
-[[package]]
-name = "tower-balance"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a792277613b7052448851efcf98a2c433e6f1d01460832dc60bef676bc275d4c"
+checksum = "5fd7b451959622e21de79261673d658a0944b835012c58c51878ea55957fb51a"
 dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 0.4.23",
- "rand 0.7.3",
+ "pin-project 1.0.1",
+ "rand 0.8.3",
  "slab",
- "tokio 0.2.22",
- "tower-discover",
- "tower-layer",
- "tower-load",
- "tower-make",
- "tower-ready-cache",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-buffer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4887dc2a65d464c8b9b66e0e4d51c2fd6cf5b3373afc72805b0a60bce00446a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.23",
- "tokio 0.2.22",
+ "tokio 1.1.1",
+ "tokio-stream",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-discover"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6b5000c3c54d269cc695dff28136bb33d08cbf1df2c48129e143ab65bf3c2a"
-dependencies = [
- "futures-core",
- "pin-project 0.4.23",
- "tower-service",
 ]
 
 [[package]]
 name = "tower-layer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
-
-[[package]]
-name = "tower-limit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c3040c5dbed68abffaa0d4517ac1a454cd741044f33ab0eefab6b8d1361404"
-dependencies = [
- "futures-core",
- "pin-project 0.4.23",
- "tokio 0.2.22",
- "tower-layer",
- "tower-load",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc79fc3afd07492b7966d7efa7c6c50f8ed58d768a6075dd7ae6591c5d2017b"
-dependencies = [
- "futures-core",
- "log 0.4.11",
- "pin-project 0.4.23",
- "tokio 0.2.22",
- "tower-discover",
- "tower-service",
-]
-
-[[package]]
-name = "tower-load-shed"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f021e23900173dc315feb4b6922510dae3e79c689b74c089112066c11f0ae4e"
-dependencies = [
- "futures-core",
- "pin-project 0.4.23",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-make"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
-dependencies = [
- "tokio 0.2.22",
- "tower-service",
-]
-
-[[package]]
-name = "tower-ready-cache"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eabb6620e5481267e2ec832c780b31cad0c15dcb14ed825df5076b26b591e1f"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap",
- "log 0.4.11",
- "tokio 0.2.22",
- "tower-service",
-]
-
-[[package]]
-name = "tower-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6727956aaa2f8957d4d9232b308fe8e4e65d99db30f42b225646e86c9b6a952"
-dependencies = [
- "futures-core",
- "pin-project 0.4.23",
- "tokio 0.2.22",
- "tower-layer",
- "tower-service",
-]
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
-
-[[package]]
-name = "tower-timeout"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "127b8924b357be938823eaaec0608c482d40add25609481027b96198b2e4b31e"
-dependencies = [
- "pin-project 0.4.23",
- "tokio 0.2.22",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project 0.4.23",
- "tower-service",
-]
 
 [[package]]
 name = "tracing"
@@ -6772,6 +6796,6 @@ checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
 dependencies = [
  "cc",
  "glob",
- "itertools 0.9.0",
+ "itertools",
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,15 +62,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arc-swap"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+
+[[package]]
+name = "arc-swap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
 
 [[package]]
 name = "arrayref"
@@ -166,15 +172,16 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backoff"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721c249ab59cbc483ad4294c9ee2671835c1e43e9ffc277e6b4ecfef733cfdc5"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
 dependencies = [
  "futures-core",
+ "getrandom 0.2.0",
  "instant",
- "pin-project 0.4.23",
- "rand 0.7.3",
- "tokio 0.2.22",
+ "pin-project 1.0.1",
+ "rand 0.8.3",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -1204,6 +1211,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,21 +1440,21 @@ dependencies = [
 
 [[package]]
 name = "goauth"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c55b7ac37895bd6e4ca0b357c074248358c95e20cf1cf2b462603121f7b87"
+checksum = "d94101e84ede813c04773b0a43396c01b5a3a9376537dbce1125858ae090ae60"
 dependencies = [
- "arc-swap",
+ "arc-swap 1.2.0",
  "futures 0.3.8",
  "log 0.4.11",
- "reqwest",
+ "reqwest 0.11.0",
  "serde",
  "serde_derive",
  "serde_json",
  "simpl",
  "smpl_jwt",
- "time 0.2.16",
- "tokio 0.2.22",
+ "time 0.2.25",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -1563,6 +1580,16 @@ checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac 0.7.0",
  "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1729,15 +1756,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 0.5.4",
- "hyper 0.13.5",
+ "bytes 1.0.1",
+ "hyper 0.14.2",
  "native-tls",
- "tokio 0.2.22",
- "tokio-tls 0.3.1",
+ "tokio 1.1.1",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1885,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.40"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2484,11 +2511,11 @@ checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 dependencies = [
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
 ]
 
 [[package]]
@@ -2573,7 +2600,7 @@ dependencies = [
  "rand 0.7.3",
  "sha-1",
  "slab",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -2682,6 +2709,15 @@ checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "byteorder",
  "crypto-mac 0.7.0",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac 0.8.0",
 ]
 
 [[package]]
@@ -3269,28 +3305,60 @@ dependencies = [
  "http-body 0.3.1",
  "hyper 0.13.5",
  "hyper-rustls",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log 0.4.11",
  "mime 0.3.16",
  "mime_guess",
- "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite 0.1.5",
  "rustls 0.18.0",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_urlencoded 0.6.1",
  "tokio 0.2.22",
  "tokio-rustls 0.14.0",
- "tokio-tls 0.3.1",
- "url 2.1.1",
+ "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.4.0",
+ "hyper 0.14.2",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.11",
+ "mime 0.3.16",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded 0.7.0",
+ "tokio 1.1.1",
+ "tokio-native-tls",
+ "url 2.2.0",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "winreg",
 ]
 
@@ -3577,7 +3645,19 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde",
- "url 2.1.1",
+ "url 2.2.0",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3691,7 +3771,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
- "arc-swap",
+ "arc-swap 0.4.8",
  "libc",
 ]
 
@@ -3730,18 +3810,18 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smpl_jwt"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547e9c1059500ce0fe6cfa325f868b5621214957922be60a49d86e3e844ee9dc"
+checksum = "2fb8aea73548d19a00cbaed99a48dbdc61fed3469f39d035617eefd7a88fffd0"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "log 0.4.11",
  "openssl",
  "serde",
  "serde_derive",
  "serde_json",
  "simpl",
- "time 0.2.16",
+ "time 0.2.25",
 ]
 
 [[package]]
@@ -3985,8 +4065,8 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "thiserror",
- "tiny-bip39",
- "url 2.1.1",
+ "tiny-bip39 0.8.0",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4007,7 +4087,7 @@ dependencies = [
  "log 0.4.11",
  "num-traits",
  "pretty-hex",
- "reqwest",
+ "reqwest 0.10.8",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4031,8 +4111,8 @@ dependencies = [
  "solana_rbpf",
  "tempfile",
  "thiserror",
- "tiny-bip39",
- "url 2.1.1",
+ "tiny-bip39 0.7.3",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4044,7 +4124,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4083,7 +4163,7 @@ dependencies = [
  "log 0.4.11",
  "net2",
  "rayon",
- "reqwest",
+ "reqwest 0.10.8",
  "semver 0.11.0",
  "serde",
  "serde_derive",
@@ -4098,7 +4178,7 @@ dependencies = [
  "solana-vote-program",
  "thiserror",
  "tungstenite",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4150,7 +4230,7 @@ dependencies = [
  "raptorq",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.10.8",
  "rustc_version",
  "rustversion",
  "serde",
@@ -4188,7 +4268,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio 0.2.22",
- "tokio 0.3.5",
+ "tokio 1.1.1",
  "tokio-util 0.3.1",
  "trees",
 ]
@@ -4207,7 +4287,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.10.8",
  "serde",
  "syn 0.15.44",
  "syn 1.0.48",
@@ -4243,7 +4323,7 @@ dependencies = [
  "console",
  "indicatif",
  "log 0.4.11",
- "reqwest",
+ "reqwest 0.10.8",
  "solana-runtime",
  "solana-sdk",
  "tar",
@@ -4409,7 +4489,7 @@ dependencies = [
  "indicatif",
  "lazy_static",
  "nix 0.19.0",
- "reqwest",
+ "reqwest 0.10.8",
  "semver 0.9.0",
  "serde",
  "serde_derive",
@@ -4422,7 +4502,7 @@ dependencies = [
  "solana-version",
  "tar",
  "tempfile",
- "url 2.1.1",
+ "url 2.2.0",
  "winapi 0.3.8",
  "winreg",
 ]
@@ -4440,7 +4520,7 @@ dependencies = [
  "solana-remote-wallet",
  "solana-sdk",
  "solana-version",
- "tiny-bip39",
+ "tiny-bip39 0.7.3",
 ]
 
 [[package]]
@@ -4530,7 +4610,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "tempfile",
- "tokio 0.3.5",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -4637,7 +4717,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.11",
  "rand 0.7.3",
- "reqwest",
+ "reqwest 0.10.8",
  "serial_test",
  "solana-sdk",
 ]
@@ -4670,7 +4750,7 @@ dependencies = [
  "solana-logger 1.6.0",
  "solana-version",
  "tokio 0.3.5",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4687,7 +4767,7 @@ name = "solana-notifier"
 version = "1.6.0"
 dependencies = [
  "log 0.4.11",
- "reqwest",
+ "reqwest 0.10.8",
  "serde_json",
 ]
 
@@ -4829,7 +4909,7 @@ dependencies = [
  "bzip2",
  "clap",
  "log 0.4.11",
- "reqwest",
+ "reqwest 0.10.8",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4867,7 +4947,7 @@ dependencies = [
  "semver 0.9.0",
  "solana-sdk",
  "thiserror",
- "url 2.1.1",
+ "url 2.2.0",
 ]
 
 [[package]]
@@ -4970,7 +5050,7 @@ dependencies = [
  "solana-program 1.6.0",
  "solana-sdk-macro 1.6.0",
  "thiserror",
- "tiny-bip39",
+ "tiny-bip39 0.7.3",
 ]
 
 [[package]]
@@ -5092,7 +5172,7 @@ dependencies = [
 name = "solana-storage-bigtable"
 version = "1.6.0"
 dependencies = [
- "arc-swap",
+ "arc-swap 0.4.8",
  "backoff",
  "bincode",
  "bzip2",
@@ -5659,18 +5739,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.6",
@@ -5704,11 +5784,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.16"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
+checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
 dependencies = [
- "cfg-if 0.1.10",
+ "const_fn",
  "libc",
  "standback",
  "stdweb",
@@ -5757,6 +5837,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-bip39"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
+dependencies = [
+ "anyhow",
+ "hmac 0.8.1",
+ "once_cell",
+ "pbkdf2 0.4.0",
+ "rand 0.7.3",
+ "rustc-hash",
+ "sha2 0.9.2",
+ "thiserror",
+ "unicode-normalization",
+ "zeroize",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5800,7 +5913,7 @@ dependencies = [
  "pin-project-lite 0.1.5",
  "signal-hook-registry",
  "slab",
- "tokio-macros 0.2.5",
+ "tokio-macros 0.2.6",
  "winapi 0.3.8",
 ]
 
@@ -5837,8 +5950,13 @@ dependencies = [
  "libc",
  "memchr 2.3.3",
  "mio 0.7.6",
+ "num_cpus",
+ "once_cell",
+ "parking_lot 0.11.0",
  "pin-project-lite 0.2.4",
+ "signal-hook-registry",
  "tokio-macros 1.0.0",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -5896,9 +6014,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.6",
@@ -5925,6 +6043,16 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.6",
  "syn 1.0.48",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -6056,16 +6184,6 @@ dependencies = [
  "futures 0.1.29",
  "native-tls",
  "tokio-io",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio 0.2.22",
 ]
 
 [[package]]
@@ -6298,7 +6416,7 @@ dependencies = [
  "native-tls",
  "rand 0.7.3",
  "sha-1",
- "url 2.1.1",
+ "url 2.2.0",
  "utf-8",
 ]
 
@@ -6349,11 +6467,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.12"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
- "smallvec 1.6.1",
+ "tinyvec",
 ]
 
 [[package]]
@@ -6411,10 +6529,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -6510,11 +6629,11 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.63"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -6522,9 +6641,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.63"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -6537,11 +6656,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.13"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
+checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -6549,9 +6668,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.63"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
  "quote 1.0.6",
  "wasm-bindgen-macro-support",
@@ -6559,9 +6678,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.63"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.6",
@@ -6572,9 +6691,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.63"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "web-sys"
@@ -6620,7 +6739,7 @@ dependencies = [
  "tokio-io",
  "tokio-reactor",
  "tokio-tcp",
- "tokio-tls 0.2.1",
+ "tokio-tls",
  "unicase 1.4.2",
  "url 1.7.2",
  "websocket-base",
@@ -6643,7 +6762,7 @@ dependencies = [
  "tokio-codec",
  "tokio-io",
  "tokio-tcp",
- "tokio-tls 0.2.1",
+ "tokio-tls",
 ]
 
 [[package]]
@@ -6737,9 +6856,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 dependencies = [
  "zeroize_derive",
 ]

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -15,7 +15,7 @@ mio = "0.7.6"
 solana-banks-interface = { path = "../banks-interface", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 tarpc = { version = "0.23.0", features = ["full"] }
-tokio = { version = "0.3.5", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 tokio-serde = { version = "0.6", features = ["bincode"] }
 
 [dev-dependencies]

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -14,9 +14,9 @@ futures = "0.3"
 mio = "0.7.6"
 solana-banks-interface = { path = "../banks-interface", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
-tarpc = { version = "0.23.0", features = ["full"] }
-tokio = { version = "0.3", features = ["full"] }
-tokio-serde = { version = "0.6", features = ["bincode"] }
+tarpc = { version = "0.24.1", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
+tokio-serde = { version = "0.8", features = ["bincode"] }
 
 [dev-dependencies]
 solana-runtime = { path = "../runtime", version = "1.6.0" }

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -15,7 +15,7 @@ solana-sdk = { path = "../sdk", version = "1.6.0" }
 tarpc = { version = "0.23.0", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "0.3.5", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 
 [lib]
 crate-type = ["lib"]

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 mio = "0.7.6"
 serde = { version = "1.0.118", features = ["derive"] }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
-tarpc = { version = "0.23.0", features = ["full"] }
+tarpc = { version = "0.24.1", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
 
 [lib]
 crate-type = ["lib"]

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -17,9 +17,10 @@ solana-banks-interface = { path = "../banks-interface", version = "1.6.0" }
 solana-runtime = { path = "../runtime", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-metrics = { path = "../metrics", version = "1.6.0" }
-tarpc = { version = "0.23.0", features = ["full"] }
-tokio = { version = "0.3", features = ["full"] }
-tokio-serde = { version = "0.6", features = ["bincode"] }
+tarpc = { version = "0.24.1", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
+tokio-serde = { version = "0.8", features = ["bincode"] }
+tokio-stream = "0.1"
 
 [lib]
 crate-type = ["lib"]

--- a/banks-server/src/rpc_banks_service.rs
+++ b/banks-server/src/rpc_banks_service.rs
@@ -15,6 +15,7 @@ use tokio::{
     runtime::Runtime,
     time::{self, Duration},
 };
+use tokio_stream::wrappers::IntervalStream;
 
 pub struct RpcBanksService {
     thread_hdl: JoinHandle<()>,
@@ -35,7 +36,7 @@ async fn start_abortable_tcp_server(
         block_commitment_cache.clone(),
     )
     .fuse();
-    let interval = time::interval(Duration::from_millis(100)).fuse();
+    let interval = IntervalStream::new(time::interval(Duration::from_millis(100))).fuse();
     pin_mut!(server, interval);
     loop {
         select! {

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -14,7 +14,7 @@ rpassword = "4.0"
 solana-remote-wallet = { path = "../remote-wallet", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 thiserror = "1.0.21"
-tiny-bip39 = "0.7.0"
+tiny-bip39 = "0.8.0"
 url = "2.1.0"
 chrono = "0.4"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -76,8 +76,9 @@ solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
 spl-token-v2-0 = { package = "spl-token", version = "=3.0.1", features = ["no-entrypoint"] }
 tempfile = "3.1.0"
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["full"] }
-tokio-util = { version = "0.2", features = ["codec"] }
+tokio = { version = "0.3", features = ["full"] }
+tokio_02 = { version = "0.2", package = "tokio", features = ["full"] }
+tokio-util = { version = "0.3", features = ["codec"] }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "1.6.0" }
 trees = "0.2.1"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -76,7 +76,7 @@ solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
 spl-token-v2-0 = { package = "spl-token", version = "=3.0.1", features = ["no-entrypoint"] }
 tempfile = "3.1.0"
 thiserror = "1.0"
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
 tokio_02 = { version = "0.2", package = "tokio", features = ["full"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "1.6.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -78,7 +78,7 @@ tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "1.1", features = ["full"] }
 tokio_02 = { version = "0.2", package = "tokio", features = ["full"] }
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio-util = { version = "0.3", features = ["codec"] } # This crate needs to stay in sync with tokio_02, until that dependency can be removed
 solana-rayon-threadlimit = { path = "../rayon-threadlimit", version = "1.6.0" }
 trees = "0.2.1"
 

--- a/core/src/bigtable_upload_service.rs
+++ b/core/src/bigtable_upload_service.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, RwLock},
     thread::{self, Builder, JoinHandle},
 };
-use tokio::runtime;
+use tokio::runtime::Runtime;
 
 // Delay uploading the largest confirmed root for this many slots.  This is done in an attempt to
 // ensure that the `CacheBlockTimeService` has had enough time to add the block time for the root
@@ -21,7 +21,7 @@ pub struct BigTableUploadService {
 
 impl BigTableUploadService {
     pub fn new(
-        runtime_handle: runtime::Handle,
+        runtime: Arc<Runtime>,
         bigtable_ledger_storage: solana_storage_bigtable::LedgerStorage,
         blockstore: Arc<Blockstore>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
@@ -32,7 +32,7 @@ impl BigTableUploadService {
             .name("bigtable-upload".to_string())
             .spawn(move || {
                 Self::run(
-                    runtime_handle,
+                    runtime,
                     bigtable_ledger_storage,
                     blockstore,
                     block_commitment_cache,
@@ -45,7 +45,7 @@ impl BigTableUploadService {
     }
 
     fn run(
-        runtime: runtime::Handle,
+        runtime: Arc<Runtime>,
         bigtable_ledger_storage: solana_storage_bigtable::LedgerStorage,
         blockstore: Arc<Blockstore>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -1291,7 +1291,7 @@ pub(crate) mod tests {
     use std::{fmt::Debug, sync::mpsc::channel};
     use tokio::{
         runtime::Runtime,
-        time::{delay_for, timeout},
+        time::{sleep, timeout},
     };
 
     pub(crate) fn robust_poll_or_panic<T: Debug + Send + 'static>(
@@ -1317,7 +1317,7 @@ pub(crate) mod tests {
                 (None, _) => panic!("unexpected end of stream"),
             }
 
-            delay_for(Duration::from_millis(RECEIVE_DELAY_MILLIS * 2)).await;
+            sleep(Duration::from_millis(RECEIVE_DELAY_MILLIS * 2)).await;
         });
         inner_receiver.recv().expect("recv error")
     }

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -24,7 +24,7 @@ use std::{
     thread::sleep,
     time::{Duration, Instant},
 };
-use tokio::runtime::Runtime;
+use tokio_02::runtime::Runtime;
 
 macro_rules! json_req {
     ($method: expr, $params: expr) => {{
@@ -195,7 +195,7 @@ fn test_rpc_subscriptions() {
                 .signature_subscribe(sig.clone(), None)
                 .unwrap_or_else(|err| panic!("sig sub err: {:#?}", err));
 
-            tokio::spawn(async move {
+            tokio_02::spawn(async move {
                 let response = sig_sub.next().await.unwrap();
                 status_sender
                     .send((sig.clone(), response.unwrap()))
@@ -209,7 +209,7 @@ fn test_rpc_subscriptions() {
             let mut client_sub = client
                 .account_subscribe(pubkey, None)
                 .unwrap_or_else(|err| panic!("acct sub err: {:#?}", err));
-            tokio::spawn(async move {
+            tokio_02::spawn(async move {
                 let response = client_sub.next().await.unwrap();
                 account_sender.send(response.unwrap()).unwrap();
             });
@@ -219,7 +219,7 @@ fn test_rpc_subscriptions() {
         let mut slot_sub = client
             .slot_subscribe()
             .unwrap_or_else(|err| panic!("sig sub err: {:#?}", err));
-        tokio::spawn(async move {
+        tokio_02::spawn(async move {
             let _response = slot_sub.next().await.unwrap();
             ready_sender.send(()).unwrap();
         });

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -21,7 +21,7 @@ solana-logger = { path = "../logger", version = "1.6.0" }
 solana-metrics = { path = "../metrics", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
 
 [lib]
 crate-type = ["lib"]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -21,7 +21,7 @@ solana-logger = { path = "../logger", version = "1.6.0" }
 solana-metrics = { path = "../metrics", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }
-tokio = { version = "0.3.5", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 
 [lib]
 crate-type = ["lib"]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -35,7 +35,7 @@ solana-transaction-status = { path = "../transaction-status", version = "1.6.0" 
 solana-version = { path = "../version", version = "1.6.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
 tempfile = "3.1.0"
-tokio = { version = "0.2.22", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -35,7 +35,7 @@ solana-transaction-status = { path = "../transaction-status", version = "1.6.0" 
 solana-version = { path = "../version", version = "1.6.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
 tempfile = "3.1.0"
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -382,7 +382,7 @@ impl BigTableSubCommand for App<'_, '_> {
 }
 
 pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
-    let mut runtime = tokio::runtime::Runtime::new().unwrap();
+    let runtime = tokio::runtime::Runtime::new().unwrap();
 
     let future = match matches.subcommand() {
         ("upload", Some(arg_matches)) => {

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
 libc = "0.2.81"
 log = { version = "0.4.11" }
 num_cpus = "1.13.0"
-prost = "0.6.1"
+prost = "0.7.0"
 rand = "0.7.0"
 rand_chacha = "0.2.2"
 rayon = "1.5.0"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -51,7 +51,7 @@ solana-storage-proto = { path = "../storage-proto", version = "1.6.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
 tempfile = "3.1.0"
 thiserror = "1.0"
-tokio = { version = "0.2.22", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 trees = "0.2.1"
 
 [dependencies.rocksdb]

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -11,7 +11,6 @@ use std::{
     },
     time::Duration,
 };
-use tokio::time::delay_for;
 
 // Attempt to upload this many blocks in parallel
 const NUM_BLOCKS_TO_UPLOAD_IN_PARALLEL: usize = 32;
@@ -81,7 +80,7 @@ pub async fn upload_confirmed_blocks(
                     Err(err) => {
                         error!("get_confirmed_blocks for {} failed: {:?}", start_slot, err);
                         // Consider exponential backoff...
-                        delay_for(Duration::from_secs(2)).await;
+                        tokio::time::sleep(Duration::from_secs(2)).await;
                     }
                 }
             };

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -20,7 +20,7 @@ socket2 = "0.3.17"
 solana-clap-utils = { path = "../clap-utils", version = "1.6.0" }
 solana-logger = { path = "../logger", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
 url = "2.1.1"
 
 [lib]

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -20,7 +20,7 @@ socket2 = "0.3.17"
 solana-clap-utils = { path = "../clap-utils", version = "1.6.0" }
 solana-logger = { path = "../logger", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }
-tokio = { version = "0.3.5", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }
 url = "2.1.1"
 
 [lib]

--- a/net-utils/src/ip_echo_server.rs
+++ b/net-utils/src/ip_echo_server.rs
@@ -4,8 +4,8 @@ use {
     serde_derive::{Deserialize, Serialize},
     std::{io, net::SocketAddr, time::Duration},
     tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
         net::{TcpListener, TcpStream},
-        prelude::*,
         runtime::{self, Runtime},
         time::timeout,
     },
@@ -103,14 +103,14 @@ async fn process_connection(mut socket: TcpStream, peer_addr: SocketAddr) -> io:
         if *tcp_port != 0 {
             debug!("Connecting to tcp/{}", tcp_port);
 
-            let tcp_stream = timeout(
+            let mut tcp_stream = timeout(
                 IO_TIMEOUT,
                 TcpStream::connect(&SocketAddr::new(peer_addr.ip(), *tcp_port)),
             )
             .await??;
 
             debug!("Connection established to tcp/{}", *tcp_port);
-            let _ = tcp_stream.shutdown(std::net::Shutdown::Both);
+            let _ = tcp_stream.shutdown();
         }
     }
 

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -22,4 +22,4 @@ solana-program = { path = "../sdk/program", version = "1.6.0" }
 solana-runtime = { path = "../runtime", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 thiserror = "1.0"
-tokio = { version = "0.3.5", features = ["full"] }
+tokio = { version = "0.3", features = ["full"] }

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -22,4 +22,4 @@ solana-program = { path = "../sdk/program", version = "1.6.0" }
 solana-runtime = { path = "../runtime", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 thiserror = "1.0"
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -255,9 +255,9 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "bytes"
-version = "0.6.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "bzip2"
@@ -3038,7 +3038,7 @@ dependencies = [
  "solana-clap-utils",
  "solana-logger 1.6.0",
  "solana-version",
- "tokio 0.3.6",
+ "tokio 1.1.1",
  "url",
 ]
 
@@ -3629,13 +3629,12 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.3.6"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
+checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
 dependencies = [
  "autocfg",
- "bytes 0.6.0",
- "futures-core",
+ "bytes 1.0.1",
  "libc",
  "memchr",
  "mio 0.7.7",
@@ -3644,7 +3643,6 @@ dependencies = [
  "parking_lot 0.11.1",
  "pin-project-lite 0.2.4",
  "signal-hook-registry",
- "slab",
  "tokio-macros",
  "winapi 0.3.8",
 ]
@@ -3704,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.6",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -44,6 +44,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,28 +729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.6",
- "syn 1.0.48",
- "synstructure",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1045,16 @@ checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
  "crypto-mac 0.7.0",
  "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+dependencies = [
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1840,12 +1834,11 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
- "byteorder 1.3.4",
- "crypto-mac 0.7.0",
+ "crypto-mac 0.8.0",
 ]
 
 [[package]]
@@ -3561,19 +3554,36 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
+checksum = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
 dependencies = [
- "failure",
- "hmac 0.7.1",
+ "anyhow",
+ "hmac 0.8.1",
  "once_cell",
- "pbkdf2 0.3.0",
+ "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.8.2",
+ "sha2 0.9.2",
+ "thiserror",
  "unicode-normalization",
+ "zeroize",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -3928,11 +3938,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.12"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
- "smallvec 1.6.1",
+ "tinyvec",
 ]
 
 [[package]]
@@ -4212,9 +4222,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 dependencies = [
  "zeroize_derive",
 ]

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -10,24 +10,24 @@ edition = "2018"
 
 [dependencies]
 arc-swap = "0.4.8"
-backoff = {version="0.2.1", features = ["tokio"]}
+backoff = { version = "0.3.0", features = ["tokio"] }
 bincode = "1.2.1"
 bzip2 = "0.3.3"
 enum-iterator = "0.6.0"
 flate2 = "1.0.14"
-goauth = "0.8.1"
+goauth = "0.9.0"
 log = "0.4.11"
 prost = "0.7.0"
 prost-types = "0.7.0"
 serde = "1.0.118"
 serde_derive = "1.0.103"
-smpl_jwt = "0.5.0"
+smpl_jwt = "0.6.0"
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-storage-proto = { path = "../storage-proto", version = "1.6.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.6.0" }
 thiserror = "1.0"
 futures = "0.3.8"
-tonic = {version="0.4.0", features = ["tls", "transport"]}
+tonic = { version = "0.4.0", features = ["tls", "transport"] }
 zstd = "0.5.1"
 
 [lib]

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -17,8 +17,8 @@ enum-iterator = "0.6.0"
 flate2 = "1.0.14"
 goauth = "0.8.1"
 log = "0.4.11"
-prost = "0.6.1"
-prost-types = "0.6.1"
+prost = "0.7.0"
+prost-types = "0.7.0"
 serde = "1.0.118"
 serde_derive = "1.0.103"
 smpl_jwt = "0.5.0"
@@ -27,7 +27,7 @@ solana-storage-proto = { path = "../storage-proto", version = "1.6.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.6.0" }
 thiserror = "1.0"
 futures = "0.3.8"
-tonic = {version="0.3.0", features = ["tls", "transport"]}
+tonic = {version="0.4.0", features = ["tls", "transport"]}
 zstd = "0.5.1"
 
 [lib]

--- a/storage-bigtable/build-proto/Cargo.lock
+++ b/storage-bigtable/build-proto/Cargo.lock
@@ -14,9 +14,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cfg-if"
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
  "bytes",
  "heck",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes",
  "prost",
@@ -279,10 +279,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.2.0"
+name = "thiserror"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e8546fd40d56d28089835c0a81bb396848103b00f888aea42d46eb5974df07"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -310,11 +330,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
  "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -12,4 +12,4 @@ version = "1.6.0"
 [workspace]
 
 [dependencies]
-tonic-build = "0.2.0"
+tonic-build = "0.4.0"

--- a/storage-bigtable/proto/google.api.rs
+++ b/storage-bigtable/proto/google.api.rs
@@ -7,7 +7,7 @@ pub struct Http {
     ///
     /// **NOTE:** All service configuration rules follow "last one wins" order.
     #[prost(message, repeated, tag = "1")]
-    pub rules: ::std::vec::Vec<HttpRule>,
+    pub rules: ::prost::alloc::vec::Vec<HttpRule>,
     /// When set to true, URL path parameters will be fully URI-decoded except in
     /// cases of single segment matches in reserved expansion, where "%2F" will be
     /// left encoded.
@@ -292,7 +292,7 @@ pub struct HttpRule {
     ///
     /// Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
     #[prost(string, tag = "1")]
-    pub selector: std::string::String,
+    pub selector: ::prost::alloc::string::String,
     /// The name of the request field whose value is mapped to the HTTP request
     /// body, or `*` for mapping all request fields not captured by the path
     /// pattern to the HTTP body, or omitted for not having any HTTP request body.
@@ -300,7 +300,7 @@ pub struct HttpRule {
     /// NOTE: the referred field must be present at the top-level of the request
     /// message type.
     #[prost(string, tag = "7")]
-    pub body: std::string::String,
+    pub body: ::prost::alloc::string::String,
     /// Optional. The name of the response field whose value is mapped to the HTTP
     /// response body. When omitted, the entire response message will be used
     /// as the HTTP response body.
@@ -308,18 +308,19 @@ pub struct HttpRule {
     /// NOTE: The referred field must be present at the top-level of the response
     /// message type.
     #[prost(string, tag = "12")]
-    pub response_body: std::string::String,
+    pub response_body: ::prost::alloc::string::String,
     /// Additional HTTP bindings for the selector. Nested bindings must
     /// not contain an `additional_bindings` field themselves (that is,
     /// the nesting may only be one level deep).
     #[prost(message, repeated, tag = "11")]
-    pub additional_bindings: ::std::vec::Vec<HttpRule>,
+    pub additional_bindings: ::prost::alloc::vec::Vec<HttpRule>,
     /// Determines the URL pattern is matched by this rules. This pattern can be
     /// used with any of the {get|put|post|delete|patch} methods. A custom method
     /// can be defined using the 'custom' field.
     #[prost(oneof = "http_rule::Pattern", tags = "2, 3, 4, 5, 6, 8")]
-    pub pattern: ::std::option::Option<http_rule::Pattern>,
+    pub pattern: ::core::option::Option<http_rule::Pattern>,
 }
+/// Nested message and enum types in `HttpRule`.
 pub mod http_rule {
     /// Determines the URL pattern is matched by this rules. This pattern can be
     /// used with any of the {get|put|post|delete|patch} methods. A custom method
@@ -329,19 +330,19 @@ pub mod http_rule {
         /// Maps to HTTP GET. Used for listing and getting information about
         /// resources.
         #[prost(string, tag = "2")]
-        Get(std::string::String),
+        Get(::prost::alloc::string::String),
         /// Maps to HTTP PUT. Used for replacing a resource.
         #[prost(string, tag = "3")]
-        Put(std::string::String),
+        Put(::prost::alloc::string::String),
         /// Maps to HTTP POST. Used for creating a resource or performing an action.
         #[prost(string, tag = "4")]
-        Post(std::string::String),
+        Post(::prost::alloc::string::String),
         /// Maps to HTTP DELETE. Used for deleting a resource.
         #[prost(string, tag = "5")]
-        Delete(std::string::String),
+        Delete(::prost::alloc::string::String),
         /// Maps to HTTP PATCH. Used for updating a resource.
         #[prost(string, tag = "6")]
-        Patch(std::string::String),
+        Patch(::prost::alloc::string::String),
         /// The custom pattern is used for specifying an HTTP method that is not
         /// included in the `pattern` field, such as HEAD, or "*" to leave the
         /// HTTP method unspecified for this rule. The wild-card rule is useful
@@ -355,10 +356,10 @@ pub mod http_rule {
 pub struct CustomHttpPattern {
     /// The name of this custom HTTP verb.
     #[prost(string, tag = "1")]
-    pub kind: std::string::String,
+    pub kind: ::prost::alloc::string::String,
     /// The path matched by this custom verb.
     #[prost(string, tag = "2")]
-    pub path: std::string::String,
+    pub path: ::prost::alloc::string::String,
 }
 /// An indicator of the behavior of a given field (for example, that a field
 /// is required in requests, or given as output but ignored as input).
@@ -514,7 +515,7 @@ pub struct ResourceDescriptor {
     /// should use PascalCase (UpperCamelCase). The maximum number of
     /// characters allowed for the `resource_type_kind` is 100.
     #[prost(string, tag = "1")]
-    pub r#type: std::string::String,
+    pub r#type: ::prost::alloc::string::String,
     /// Optional. The relative resource name pattern associated with this resource
     /// type. The DNS prefix of the full resource name shouldn't be specified here.
     ///
@@ -535,11 +536,11 @@ pub struct ResourceDescriptor {
     /// the same component name (e.g. "project") refers to IDs of the same
     /// type of resource.
     #[prost(string, repeated, tag = "2")]
-    pub pattern: ::std::vec::Vec<std::string::String>,
+    pub pattern: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Optional. The field on the resource that designates the resource name
     /// field. If omitted, this is assumed to be "name".
     #[prost(string, tag = "3")]
-    pub name_field: std::string::String,
+    pub name_field: ::prost::alloc::string::String,
     /// Optional. The historical or future-looking state of the resource pattern.
     ///
     /// Example:
@@ -566,13 +567,19 @@ pub struct ResourceDescriptor {
     /// Note: The plural form is required even for singleton resources. See
     /// https://aip.dev/156
     #[prost(string, tag = "5")]
-    pub plural: std::string::String,
+    pub plural: ::prost::alloc::string::String,
     /// The same concept of the `singular` field in k8s CRD spec
     /// https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
     /// Such as "project" for the `resourcemanager.googleapis.com/Project` type.
     #[prost(string, tag = "6")]
-    pub singular: std::string::String,
+    pub singular: ::prost::alloc::string::String,
+    /// Style flag(s) for this resource.
+    /// These indicate that a resource is expected to conform to a given
+    /// style. See the specific style flags for additional information.
+    #[prost(enumeration = "resource_descriptor::Style", repeated, tag = "10")]
+    pub style: ::prost::alloc::vec::Vec<i32>,
 }
+/// Nested message and enum types in `ResourceDescriptor`.
 pub mod resource_descriptor {
     /// A description of the historical or future-looking state of the
     /// resource pattern.
@@ -588,6 +595,22 @@ pub mod resource_descriptor {
         /// later. (This is the inverse of ORIGINALLY_SINGLE_PATTERN, and prevents
         /// that from being necessary once there are multiple patterns.)
         FutureMultiPattern = 2,
+    }
+    /// A flag representing a specific style that a resource claims to conform to.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Style {
+        /// The unspecified value. Do not use.
+        Unspecified = 0,
+        /// This resource is intended to be "declarative-friendly".
+        ///
+        /// Declarative-friendly resources must be more strictly consistent, and
+        /// setting this to true communicates to tools that this resource should
+        /// adhere to declarative-friendly expectations.
+        ///
+        /// Note: This is used by the API linter (linter.aip.dev) to enable
+        /// additional checks.
+        DeclarativeFriendly = 1,
     }
 }
 /// Defines a proto annotation that describes a string field that refers to
@@ -615,7 +638,7 @@ pub struct ResourceReference {
     ///       }];
     ///     }
     #[prost(string, tag = "1")]
-    pub r#type: std::string::String,
+    pub r#type: ::prost::alloc::string::String,
     /// The resource type of a child collection that the annotated field
     /// references. This is useful for annotating the `parent` field that
     /// doesn't have a fixed resource type.
@@ -628,5 +651,5 @@ pub struct ResourceReference {
     ///       };
     ///     }
     #[prost(string, tag = "2")]
-    pub child_type: std::string::String,
+    pub child_type: ::prost::alloc::string::String,
 }

--- a/storage-bigtable/proto/google.bigtable.v2.rs
+++ b/storage-bigtable/proto/google.bigtable.v2.rs
@@ -263,7 +263,7 @@ pub mod row_filter {
         /// If multiple cells are produced with the same column and timestamp,
         /// they will all appear in the output row in an unspecified mutual order.
         /// Consider the following example, with three filters:
-        ///
+        ///```ignore
         ///                                  input row
         ///                                      |
         ///            -----------------------------------------------------
@@ -329,7 +329,7 @@ pub mod row_filter {
         /// Hook for introspection into the RowFilter. Outputs all cells directly to
         /// the output of the read rather than to any parent filter. Consider the
         /// following example:
-        ///
+        ///```ignore
         ///     Chain(
         ///       FamilyRegex("A"),
         ///       Interleave(

--- a/storage-bigtable/proto/google.bigtable.v2.rs
+++ b/storage-bigtable/proto/google.bigtable.v2.rs
@@ -5,12 +5,12 @@ pub struct Row {
     /// The unique key which identifies this row within its table. This is the same
     /// key that's used to identify the row in, for example, a MutateRowRequest.
     /// May contain any non-empty byte string up to 4KiB in length.
-    #[prost(bytes, tag = "1")]
-    pub key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
     /// May be empty, but only if the entire row is empty.
     /// The mutual ordering of column families is not specified.
     #[prost(message, repeated, tag = "2")]
-    pub families: ::std::vec::Vec<Family>,
+    pub families: ::prost::alloc::vec::Vec<Family>,
 }
 /// Specifies (some of) the contents of a single row/column family intersection
 /// of a table.
@@ -23,10 +23,10 @@ pub struct Family {
     /// produce cells in a sentinel family with an empty name.
     /// Must be no greater than 64 characters in length.
     #[prost(string, tag = "1")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     /// Must not be empty. Sorted in order of increasing "qualifier".
     #[prost(message, repeated, tag = "2")]
-    pub columns: ::std::vec::Vec<Column>,
+    pub columns: ::prost::alloc::vec::Vec<Column>,
 }
 /// Specifies (some of) the contents of a single row/column intersection of a
 /// table.
@@ -37,11 +37,11 @@ pub struct Column {
     /// which sets its `column_qualifier_regex_filter` field.
     /// May contain any byte string, including the empty string, up to 16kiB in
     /// length.
-    #[prost(bytes, tag = "1")]
-    pub qualifier: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub qualifier: ::prost::alloc::vec::Vec<u8>,
     /// Must not be empty. Sorted in order of decreasing "timestamp_micros".
     #[prost(message, repeated, tag = "2")]
-    pub cells: ::std::vec::Vec<Cell>,
+    pub cells: ::prost::alloc::vec::Vec<Cell>,
 }
 /// Specifies (some of) the contents of a single row/column/timestamp of a table.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -57,11 +57,11 @@ pub struct Cell {
     /// The value stored in the cell.
     /// May contain any byte string, including the empty string, up to 100MiB in
     /// length.
-    #[prost(bytes, tag = "2")]
-    pub value: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
     /// Labels applied to the cell by a [RowFilter][google.bigtable.v2.RowFilter].
     #[prost(string, repeated, tag = "3")]
-    pub labels: ::std::vec::Vec<std::string::String>,
+    pub labels: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Specifies a contiguous range of rows.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -69,12 +69,13 @@ pub struct RowRange {
     /// The row key at which to start the range.
     /// If neither field is set, interpreted as the empty string, inclusive.
     #[prost(oneof = "row_range::StartKey", tags = "1, 2")]
-    pub start_key: ::std::option::Option<row_range::StartKey>,
+    pub start_key: ::core::option::Option<row_range::StartKey>,
     /// The row key at which to end the range.
     /// If neither field is set, interpreted as the infinite row key, exclusive.
     #[prost(oneof = "row_range::EndKey", tags = "3, 4")]
-    pub end_key: ::std::option::Option<row_range::EndKey>,
+    pub end_key: ::core::option::Option<row_range::EndKey>,
 }
+/// Nested message and enum types in `RowRange`.
 pub mod row_range {
     /// The row key at which to start the range.
     /// If neither field is set, interpreted as the empty string, inclusive.
@@ -82,10 +83,10 @@ pub mod row_range {
     pub enum StartKey {
         /// Used when giving an inclusive lower bound for the range.
         #[prost(bytes, tag = "1")]
-        StartKeyClosed(std::vec::Vec<u8>),
+        StartKeyClosed(::prost::alloc::vec::Vec<u8>),
         /// Used when giving an exclusive lower bound for the range.
         #[prost(bytes, tag = "2")]
-        StartKeyOpen(std::vec::Vec<u8>),
+        StartKeyOpen(::prost::alloc::vec::Vec<u8>),
     }
     /// The row key at which to end the range.
     /// If neither field is set, interpreted as the infinite row key, exclusive.
@@ -93,21 +94,21 @@ pub mod row_range {
     pub enum EndKey {
         /// Used when giving an exclusive upper bound for the range.
         #[prost(bytes, tag = "3")]
-        EndKeyOpen(std::vec::Vec<u8>),
+        EndKeyOpen(::prost::alloc::vec::Vec<u8>),
         /// Used when giving an inclusive upper bound for the range.
         #[prost(bytes, tag = "4")]
-        EndKeyClosed(std::vec::Vec<u8>),
+        EndKeyClosed(::prost::alloc::vec::Vec<u8>),
     }
 }
 /// Specifies a non-contiguous set of rows.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RowSet {
     /// Single rows included in the set.
-    #[prost(bytes, repeated, tag = "1")]
-    pub row_keys: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub row_keys: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
     /// Contiguous row ranges included in the set.
     #[prost(message, repeated, tag = "2")]
-    pub row_ranges: ::std::vec::Vec<RowRange>,
+    pub row_ranges: ::prost::alloc::vec::Vec<RowRange>,
 }
 /// Specifies a contiguous range of columns within a single column family.
 /// The range spans from &lt;column_family&gt;:&lt;start_qualifier&gt; to
@@ -117,16 +118,17 @@ pub struct RowSet {
 pub struct ColumnRange {
     /// The name of the column family within which this range falls.
     #[prost(string, tag = "1")]
-    pub family_name: std::string::String,
+    pub family_name: ::prost::alloc::string::String,
     /// The column qualifier at which to start the range (within `column_family`).
     /// If neither field is set, interpreted as the empty string, inclusive.
     #[prost(oneof = "column_range::StartQualifier", tags = "2, 3")]
-    pub start_qualifier: ::std::option::Option<column_range::StartQualifier>,
+    pub start_qualifier: ::core::option::Option<column_range::StartQualifier>,
     /// The column qualifier at which to end the range (within `column_family`).
     /// If neither field is set, interpreted as the infinite string, exclusive.
     #[prost(oneof = "column_range::EndQualifier", tags = "4, 5")]
-    pub end_qualifier: ::std::option::Option<column_range::EndQualifier>,
+    pub end_qualifier: ::core::option::Option<column_range::EndQualifier>,
 }
+/// Nested message and enum types in `ColumnRange`.
 pub mod column_range {
     /// The column qualifier at which to start the range (within `column_family`).
     /// If neither field is set, interpreted as the empty string, inclusive.
@@ -134,10 +136,10 @@ pub mod column_range {
     pub enum StartQualifier {
         /// Used when giving an inclusive lower bound for the range.
         #[prost(bytes, tag = "2")]
-        StartQualifierClosed(std::vec::Vec<u8>),
+        StartQualifierClosed(::prost::alloc::vec::Vec<u8>),
         /// Used when giving an exclusive lower bound for the range.
         #[prost(bytes, tag = "3")]
-        StartQualifierOpen(std::vec::Vec<u8>),
+        StartQualifierOpen(::prost::alloc::vec::Vec<u8>),
     }
     /// The column qualifier at which to end the range (within `column_family`).
     /// If neither field is set, interpreted as the infinite string, exclusive.
@@ -145,10 +147,10 @@ pub mod column_range {
     pub enum EndQualifier {
         /// Used when giving an inclusive upper bound for the range.
         #[prost(bytes, tag = "4")]
-        EndQualifierClosed(std::vec::Vec<u8>),
+        EndQualifierClosed(::prost::alloc::vec::Vec<u8>),
         /// Used when giving an exclusive upper bound for the range.
         #[prost(bytes, tag = "5")]
-        EndQualifierOpen(std::vec::Vec<u8>),
+        EndQualifierOpen(::prost::alloc::vec::Vec<u8>),
     }
 }
 /// Specified a contiguous range of microsecond timestamps.
@@ -167,12 +169,13 @@ pub struct ValueRange {
     /// The value at which to start the range.
     /// If neither field is set, interpreted as the empty string, inclusive.
     #[prost(oneof = "value_range::StartValue", tags = "1, 2")]
-    pub start_value: ::std::option::Option<value_range::StartValue>,
+    pub start_value: ::core::option::Option<value_range::StartValue>,
     /// The value at which to end the range.
     /// If neither field is set, interpreted as the infinite string, exclusive.
     #[prost(oneof = "value_range::EndValue", tags = "3, 4")]
-    pub end_value: ::std::option::Option<value_range::EndValue>,
+    pub end_value: ::core::option::Option<value_range::EndValue>,
 }
+/// Nested message and enum types in `ValueRange`.
 pub mod value_range {
     /// The value at which to start the range.
     /// If neither field is set, interpreted as the empty string, inclusive.
@@ -180,10 +183,10 @@ pub mod value_range {
     pub enum StartValue {
         /// Used when giving an inclusive lower bound for the range.
         #[prost(bytes, tag = "1")]
-        StartValueClosed(std::vec::Vec<u8>),
+        StartValueClosed(::prost::alloc::vec::Vec<u8>),
         /// Used when giving an exclusive lower bound for the range.
         #[prost(bytes, tag = "2")]
-        StartValueOpen(std::vec::Vec<u8>),
+        StartValueOpen(::prost::alloc::vec::Vec<u8>),
     }
     /// The value at which to end the range.
     /// If neither field is set, interpreted as the infinite string, exclusive.
@@ -191,10 +194,10 @@ pub mod value_range {
     pub enum EndValue {
         /// Used when giving an inclusive upper bound for the range.
         #[prost(bytes, tag = "3")]
-        EndValueClosed(std::vec::Vec<u8>),
+        EndValueClosed(::prost::alloc::vec::Vec<u8>),
         /// Used when giving an exclusive upper bound for the range.
         #[prost(bytes, tag = "4")]
-        EndValueOpen(std::vec::Vec<u8>),
+        EndValueOpen(::prost::alloc::vec::Vec<u8>),
     }
 }
 /// Takes a row as input and produces an alternate view of the row based on
@@ -238,8 +241,9 @@ pub struct RowFilter {
         oneof = "row_filter::Filter",
         tags = "1, 2, 3, 16, 17, 18, 4, 14, 5, 6, 7, 8, 9, 15, 10, 11, 12, 13, 19"
     )]
-    pub filter: ::std::option::Option<row_filter::Filter>,
+    pub filter: ::core::option::Option<row_filter::Filter>,
 }
+/// Nested message and enum types in `RowFilter`.
 pub mod row_filter {
     /// A RowFilter which sends rows through several RowFilters in sequence.
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -248,7 +252,7 @@ pub mod row_filter {
         /// in row -> f(0) -> intermediate row -> f(1) -> ... -> f(N) -> out row
         /// The full chain is executed atomically.
         #[prost(message, repeated, tag = "1")]
-        pub filters: ::std::vec::Vec<super::RowFilter>,
+        pub filters: ::prost::alloc::vec::Vec<super::RowFilter>,
     }
     /// A RowFilter which sends each row to each of several component
     /// RowFilters and interleaves the results.
@@ -259,7 +263,7 @@ pub mod row_filter {
         /// If multiple cells are produced with the same column and timestamp,
         /// they will all appear in the output row in an unspecified mutual order.
         /// Consider the following example, with three filters:
-        ///```ignore
+        ///
         ///                                  input row
         ///                                      |
         ///            -----------------------------------------------------
@@ -280,7 +284,7 @@ pub mod row_filter {
         ///
         /// All interleaved filters are executed atomically.
         #[prost(message, repeated, tag = "1")]
-        pub filters: ::std::vec::Vec<super::RowFilter>,
+        pub filters: ::prost::alloc::vec::Vec<super::RowFilter>,
     }
     /// A RowFilter which evaluates one of two possible RowFilters, depending on
     /// whether or not a predicate RowFilter outputs any cells from the input row.
@@ -294,16 +298,16 @@ pub mod row_filter {
         /// If `predicate_filter` outputs any cells, then `true_filter` will be
         /// evaluated on the input row. Otherwise, `false_filter` will be evaluated.
         #[prost(message, optional, boxed, tag = "1")]
-        pub predicate_filter: ::std::option::Option<::std::boxed::Box<super::RowFilter>>,
+        pub predicate_filter: ::core::option::Option<::prost::alloc::boxed::Box<super::RowFilter>>,
         /// The filter to apply to the input row if `predicate_filter` returns any
         /// results. If not provided, no results will be returned in the true case.
         #[prost(message, optional, boxed, tag = "2")]
-        pub true_filter: ::std::option::Option<::std::boxed::Box<super::RowFilter>>,
+        pub true_filter: ::core::option::Option<::prost::alloc::boxed::Box<super::RowFilter>>,
         /// The filter to apply to the input row if `predicate_filter` does not
         /// return any results. If not provided, no results will be returned in the
         /// false case.
         #[prost(message, optional, boxed, tag = "3")]
-        pub false_filter: ::std::option::Option<::std::boxed::Box<super::RowFilter>>,
+        pub false_filter: ::core::option::Option<::prost::alloc::boxed::Box<super::RowFilter>>,
     }
     /// Which of the possible RowFilter types to apply. If none are set, this
     /// RowFilter returns all cells in the input row.
@@ -320,12 +324,12 @@ pub mod row_filter {
         /// Applies one of two possible RowFilters to the data based on the output of
         /// a predicate RowFilter.
         #[prost(message, tag = "3")]
-        Condition(Box<Condition>),
+        Condition(::prost::alloc::boxed::Box<Condition>),
         /// ADVANCED USE ONLY.
         /// Hook for introspection into the RowFilter. Outputs all cells directly to
         /// the output of the read rather than to any parent filter. Consider the
         /// following example:
-        ///```ignore
+        ///
         ///     Chain(
         ///       FamilyRegex("A"),
         ///       Interleave(
@@ -398,7 +402,7 @@ pub mod row_filter {
         /// will not match the new line character `\n`, which may be present in a
         /// binary key.
         #[prost(bytes, tag = "4")]
-        RowKeyRegexFilter(std::vec::Vec<u8>),
+        RowKeyRegexFilter(::prost::alloc::vec::Vec<u8>),
         /// Matches all cells from a row with probability p, and matches no cells
         /// from the row with probability 1-p.
         #[prost(double, tag = "14")]
@@ -410,7 +414,7 @@ pub mod row_filter {
         /// `\n`, it is sufficient to use `.` as a full wildcard when matching
         /// column family names.
         #[prost(string, tag = "5")]
-        FamilyNameRegexFilter(std::string::String),
+        FamilyNameRegexFilter(::prost::alloc::string::String),
         /// Matches only cells from columns whose qualifiers satisfy the given RE2
         /// regex.
         /// Note that, since column qualifiers can contain arbitrary bytes, the `\C`
@@ -418,7 +422,7 @@ pub mod row_filter {
         /// character will not match the new line character `\n`, which may be
         /// present in a binary qualifier.
         #[prost(bytes, tag = "6")]
-        ColumnQualifierRegexFilter(std::vec::Vec<u8>),
+        ColumnQualifierRegexFilter(::prost::alloc::vec::Vec<u8>),
         /// Matches only cells from columns within the given range.
         #[prost(message, tag = "7")]
         ColumnRangeFilter(super::ColumnRange),
@@ -431,7 +435,7 @@ pub mod row_filter {
         /// will not match the new line character `\n`, which may be present in a
         /// binary value.
         #[prost(bytes, tag = "9")]
-        ValueRegexFilter(std::vec::Vec<u8>),
+        ValueRegexFilter(::prost::alloc::vec::Vec<u8>),
         /// Matches only cells with values that fall within the given range.
         #[prost(message, tag = "15")]
         ValueRangeFilter(super::ValueRange),
@@ -470,7 +474,7 @@ pub mod row_filter {
         /// will be applied to separate copies of the input. This may be relaxed in
         /// the future.
         #[prost(string, tag = "19")]
-        ApplyLabelTransformer(std::string::String),
+        ApplyLabelTransformer(::prost::alloc::string::String),
     }
 }
 /// Specifies a particular change to be made to the contents of a row.
@@ -478,8 +482,9 @@ pub mod row_filter {
 pub struct Mutation {
     /// Which of the possible Mutation types to apply.
     #[prost(oneof = "mutation::Mutation", tags = "1, 2, 3, 4")]
-    pub mutation: ::std::option::Option<mutation::Mutation>,
+    pub mutation: ::core::option::Option<mutation::Mutation>,
 }
+/// Nested message and enum types in `Mutation`.
 pub mod mutation {
     /// A Mutation which sets the value of the specified cell.
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -487,11 +492,11 @@ pub mod mutation {
         /// The name of the family into which new data should be written.
         /// Must match `[-_.a-zA-Z0-9]+`
         #[prost(string, tag = "1")]
-        pub family_name: std::string::String,
+        pub family_name: ::prost::alloc::string::String,
         /// The qualifier of the column into which new data should be written.
         /// Can be any byte string, including the empty string.
-        #[prost(bytes, tag = "2")]
-        pub column_qualifier: std::vec::Vec<u8>,
+        #[prost(bytes = "vec", tag = "2")]
+        pub column_qualifier: ::prost::alloc::vec::Vec<u8>,
         /// The timestamp of the cell into which new data should be written.
         /// Use -1 for current Bigtable server time.
         /// Otherwise, the client should set this value itself, noting that the
@@ -500,8 +505,8 @@ pub mod mutation {
         #[prost(int64, tag = "3")]
         pub timestamp_micros: i64,
         /// The value to be written into the specified cell.
-        #[prost(bytes, tag = "4")]
-        pub value: std::vec::Vec<u8>,
+        #[prost(bytes = "vec", tag = "4")]
+        pub value: ::prost::alloc::vec::Vec<u8>,
     }
     /// A Mutation which deletes cells from the specified column, optionally
     /// restricting the deletions to a given timestamp range.
@@ -510,14 +515,14 @@ pub mod mutation {
         /// The name of the family from which cells should be deleted.
         /// Must match `[-_.a-zA-Z0-9]+`
         #[prost(string, tag = "1")]
-        pub family_name: std::string::String,
+        pub family_name: ::prost::alloc::string::String,
         /// The qualifier of the column from which cells should be deleted.
         /// Can be any byte string, including the empty string.
-        #[prost(bytes, tag = "2")]
-        pub column_qualifier: std::vec::Vec<u8>,
+        #[prost(bytes = "vec", tag = "2")]
+        pub column_qualifier: ::prost::alloc::vec::Vec<u8>,
         /// The range of timestamps within which cells should be deleted.
         #[prost(message, optional, tag = "3")]
-        pub time_range: ::std::option::Option<super::TimestampRange>,
+        pub time_range: ::core::option::Option<super::TimestampRange>,
     }
     /// A Mutation which deletes all cells from the specified column family.
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -525,7 +530,7 @@ pub mod mutation {
         /// The name of the family from which cells should be deleted.
         /// Must match `[-_.a-zA-Z0-9]+`
         #[prost(string, tag = "1")]
-        pub family_name: std::string::String,
+        pub family_name: ::prost::alloc::string::String,
     }
     /// A Mutation which deletes all cells from the containing row.
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -554,17 +559,18 @@ pub struct ReadModifyWriteRule {
     /// The name of the family to which the read/modify/write should be applied.
     /// Must match `[-_.a-zA-Z0-9]+`
     #[prost(string, tag = "1")]
-    pub family_name: std::string::String,
+    pub family_name: ::prost::alloc::string::String,
     /// The qualifier of the column to which the read/modify/write should be
     /// applied.
     /// Can be any byte string, including the empty string.
-    #[prost(bytes, tag = "2")]
-    pub column_qualifier: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub column_qualifier: ::prost::alloc::vec::Vec<u8>,
     /// The rule used to determine the column's new latest value from its current
     /// latest value.
     #[prost(oneof = "read_modify_write_rule::Rule", tags = "3, 4")]
-    pub rule: ::std::option::Option<read_modify_write_rule::Rule>,
+    pub rule: ::core::option::Option<read_modify_write_rule::Rule>,
 }
+/// Nested message and enum types in `ReadModifyWriteRule`.
 pub mod read_modify_write_rule {
     /// The rule used to determine the column's new latest value from its current
     /// latest value.
@@ -574,7 +580,7 @@ pub mod read_modify_write_rule {
         /// If the targeted cell is unset, it will be treated as containing the
         /// empty string.
         #[prost(bytes, tag = "3")]
-        AppendValue(std::vec::Vec<u8>),
+        AppendValue(::prost::alloc::vec::Vec<u8>),
         /// Rule specifying that `increment_amount` be added to the existing value.
         /// If the targeted cell is unset, it will be treated as containing a zero.
         /// Otherwise, the targeted cell must contain an 8-byte value (interpreted
@@ -590,18 +596,18 @@ pub struct ReadRowsRequest {
     /// Values are of the form
     /// `projects/<project>/instances/<instance>/tables/<table>`.
     #[prost(string, tag = "1")]
-    pub table_name: std::string::String,
+    pub table_name: ::prost::alloc::string::String,
     /// This value specifies routing for replication. If not specified, the
     /// "default" application profile will be used.
     #[prost(string, tag = "5")]
-    pub app_profile_id: std::string::String,
+    pub app_profile_id: ::prost::alloc::string::String,
     /// The row keys and/or ranges to read. If not specified, reads from all rows.
     #[prost(message, optional, tag = "2")]
-    pub rows: ::std::option::Option<RowSet>,
+    pub rows: ::core::option::Option<RowSet>,
     /// The filter to apply to the contents of the specified row(s). If unset,
     /// reads the entirety of each row.
     #[prost(message, optional, tag = "3")]
-    pub filter: ::std::option::Option<RowFilter>,
+    pub filter: ::core::option::Option<RowFilter>,
     /// The read will terminate after committing to N rows' worth of results. The
     /// default (zero) is to return all results.
     #[prost(int64, tag = "4")]
@@ -612,7 +618,7 @@ pub struct ReadRowsRequest {
 pub struct ReadRowsResponse {
     /// A collection of a row's contents as part of the read request.
     #[prost(message, repeated, tag = "1")]
-    pub chunks: ::std::vec::Vec<read_rows_response::CellChunk>,
+    pub chunks: ::prost::alloc::vec::Vec<read_rows_response::CellChunk>,
     /// Optionally the server might return the row key of the last row it
     /// has scanned.  The client can use this to construct a more
     /// efficient retry request if needed: any row keys or portions of
@@ -620,9 +626,10 @@ pub struct ReadRowsResponse {
     /// This is primarily useful for cases where the server has read a
     /// lot of data that was filtered out since the last committed row
     /// key, allowing the client to skip that work on a retry.
-    #[prost(bytes, tag = "2")]
-    pub last_scanned_row_key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub last_scanned_row_key: ::prost::alloc::vec::Vec<u8>,
 }
+/// Nested message and enum types in `ReadRowsResponse`.
 pub mod read_rows_response {
     /// Specifies a piece of a row's contents returned as part of the read
     /// response stream.
@@ -632,8 +639,8 @@ pub mod read_rows_response {
         /// this CellChunk is a continuation of the same row as the previous
         /// CellChunk in the response stream, even if that CellChunk was in a
         /// previous ReadRowsResponse message.
-        #[prost(bytes, tag = "1")]
-        pub row_key: std::vec::Vec<u8>,
+        #[prost(bytes = "vec", tag = "1")]
+        pub row_key: ::prost::alloc::vec::Vec<u8>,
         /// The column family name for this chunk of data.  If this message
         /// is not present this CellChunk is a continuation of the same column
         /// family as the previous CellChunk.  The empty string can occur as a
@@ -641,14 +648,14 @@ pub mod read_rows_response {
         /// explicitly for the presence of this message, not just for
         /// `family_name.value` being non-empty.
         #[prost(message, optional, tag = "2")]
-        pub family_name: ::std::option::Option<::std::string::String>,
+        pub family_name: ::core::option::Option<::prost::alloc::string::String>,
         /// The column qualifier for this chunk of data.  If this message
         /// is not present, this CellChunk is a continuation of the same column
         /// as the previous CellChunk.  Column qualifiers may be empty so
         /// clients must check for the presence of this message, not just
         /// for `qualifier.value` being non-empty.
         #[prost(message, optional, tag = "3")]
-        pub qualifier: ::std::option::Option<::std::vec::Vec<u8>>,
+        pub qualifier: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
         /// The cell's stored timestamp, which also uniquely identifies it
         /// within its column.  Values are always expressed in
         /// microseconds, but individual tables may set a coarser
@@ -663,14 +670,14 @@ pub mod read_rows_response {
         /// [RowFilter][google.bigtable.v2.RowFilter].  Labels are only set
         /// on the first CellChunk per cell.
         #[prost(string, repeated, tag = "5")]
-        pub labels: ::std::vec::Vec<std::string::String>,
+        pub labels: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
         /// The value stored in the cell.  Cell values can be split across
         /// multiple CellChunks.  In that case only the value field will be
         /// set in CellChunks after the first: the timestamp and labels
         /// will only be present in the first CellChunk, even if the first
         /// CellChunk came in a previous ReadRowsResponse.
-        #[prost(bytes, tag = "6")]
-        pub value: std::vec::Vec<u8>,
+        #[prost(bytes = "vec", tag = "6")]
+        pub value: ::prost::alloc::vec::Vec<u8>,
         /// If this CellChunk is part of a chunked cell value and this is
         /// not the final chunk of that cell, value_size will be set to the
         /// total length of the cell value.  The client can use this size
@@ -679,8 +686,9 @@ pub mod read_rows_response {
         pub value_size: i32,
         /// Signals to the client concerning previous CellChunks received.
         #[prost(oneof = "cell_chunk::RowStatus", tags = "8, 9")]
-        pub row_status: ::std::option::Option<cell_chunk::RowStatus>,
+        pub row_status: ::core::option::Option<cell_chunk::RowStatus>,
     }
+    /// Nested message and enum types in `CellChunk`.
     pub mod cell_chunk {
         /// Signals to the client concerning previous CellChunks received.
         #[derive(Clone, PartialEq, ::prost::Oneof)]
@@ -703,11 +711,11 @@ pub struct SampleRowKeysRequest {
     /// Values are of the form
     /// `projects/<project>/instances/<instance>/tables/<table>`.
     #[prost(string, tag = "1")]
-    pub table_name: std::string::String,
+    pub table_name: ::prost::alloc::string::String,
     /// This value specifies routing for replication. If not specified, the
     /// "default" application profile will be used.
     #[prost(string, tag = "2")]
-    pub app_profile_id: std::string::String,
+    pub app_profile_id: ::prost::alloc::string::String,
 }
 /// Response message for Bigtable.SampleRowKeys.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -719,8 +727,8 @@ pub struct SampleRowKeysResponse {
     /// Note that row keys in this list may not have ever been written to or read
     /// from, and users should therefore not make any assumptions about the row key
     /// structure that are specific to their use case.
-    #[prost(bytes, tag = "1")]
-    pub row_key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub row_key: ::prost::alloc::vec::Vec<u8>,
     /// Approximate total storage space used by all rows in the table which precede
     /// `row_key`. Buffering the contents of all rows between two subsequent
     /// samples would require space roughly equal to the difference in their
@@ -735,19 +743,19 @@ pub struct MutateRowRequest {
     /// Values are of the form
     /// `projects/<project>/instances/<instance>/tables/<table>`.
     #[prost(string, tag = "1")]
-    pub table_name: std::string::String,
+    pub table_name: ::prost::alloc::string::String,
     /// This value specifies routing for replication. If not specified, the
     /// "default" application profile will be used.
     #[prost(string, tag = "4")]
-    pub app_profile_id: std::string::String,
+    pub app_profile_id: ::prost::alloc::string::String,
     /// Required. The key of the row to which the mutation should be applied.
-    #[prost(bytes, tag = "2")]
-    pub row_key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub row_key: ::prost::alloc::vec::Vec<u8>,
     /// Required. Changes to be atomically applied to the specified row. Entries are applied
     /// in order, meaning that earlier mutations can be masked by later ones.
     /// Must contain at least one entry and at most 100000.
     #[prost(message, repeated, tag = "3")]
-    pub mutations: ::std::vec::Vec<Mutation>,
+    pub mutations: ::prost::alloc::vec::Vec<Mutation>,
 }
 /// Response message for Bigtable.MutateRow.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -757,32 +765,33 @@ pub struct MutateRowResponse {}
 pub struct MutateRowsRequest {
     /// Required. The unique name of the table to which the mutations should be applied.
     #[prost(string, tag = "1")]
-    pub table_name: std::string::String,
+    pub table_name: ::prost::alloc::string::String,
     /// This value specifies routing for replication. If not specified, the
     /// "default" application profile will be used.
     #[prost(string, tag = "3")]
-    pub app_profile_id: std::string::String,
+    pub app_profile_id: ::prost::alloc::string::String,
     /// Required. The row keys and corresponding mutations to be applied in bulk.
     /// Each entry is applied as an atomic mutation, but the entries may be
     /// applied in arbitrary order (even between entries for the same row).
     /// At least one entry must be specified, and in total the entries can
     /// contain at most 100000 mutations.
     #[prost(message, repeated, tag = "2")]
-    pub entries: ::std::vec::Vec<mutate_rows_request::Entry>,
+    pub entries: ::prost::alloc::vec::Vec<mutate_rows_request::Entry>,
 }
+/// Nested message and enum types in `MutateRowsRequest`.
 pub mod mutate_rows_request {
     /// A mutation for a given row.
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Entry {
         /// The key of the row to which the `mutations` should be applied.
-        #[prost(bytes, tag = "1")]
-        pub row_key: std::vec::Vec<u8>,
+        #[prost(bytes = "vec", tag = "1")]
+        pub row_key: ::prost::alloc::vec::Vec<u8>,
         /// Required. Changes to be atomically applied to the specified row. Mutations are
         /// applied in order, meaning that earlier mutations can be masked by
         /// later ones.
         /// You must specify at least one mutation.
         #[prost(message, repeated, tag = "2")]
-        pub mutations: ::std::vec::Vec<super::Mutation>,
+        pub mutations: ::prost::alloc::vec::Vec<super::Mutation>,
     }
 }
 /// Response message for BigtableService.MutateRows.
@@ -790,8 +799,9 @@ pub mod mutate_rows_request {
 pub struct MutateRowsResponse {
     /// One or more results for Entries from the batch request.
     #[prost(message, repeated, tag = "1")]
-    pub entries: ::std::vec::Vec<mutate_rows_response::Entry>,
+    pub entries: ::prost::alloc::vec::Vec<mutate_rows_response::Entry>,
 }
+/// Nested message and enum types in `MutateRowsResponse`.
 pub mod mutate_rows_response {
     /// The result of applying a passed mutation in the original request.
     #[derive(Clone, PartialEq, ::prost::Message)]
@@ -805,7 +815,7 @@ pub mod mutate_rows_response {
         /// for one Entry to fail due to an error with another Entry. In the event
         /// that this occurs, the same error will be reported for both entries.
         #[prost(message, optional, tag = "2")]
-        pub status: ::std::option::Option<super::super::super::rpc::Status>,
+        pub status: ::core::option::Option<super::super::super::rpc::Status>,
     }
 }
 /// Request message for Bigtable.CheckAndMutateRow.
@@ -816,34 +826,34 @@ pub struct CheckAndMutateRowRequest {
     /// Values are of the form
     /// `projects/<project>/instances/<instance>/tables/<table>`.
     #[prost(string, tag = "1")]
-    pub table_name: std::string::String,
+    pub table_name: ::prost::alloc::string::String,
     /// This value specifies routing for replication. If not specified, the
     /// "default" application profile will be used.
     #[prost(string, tag = "7")]
-    pub app_profile_id: std::string::String,
+    pub app_profile_id: ::prost::alloc::string::String,
     /// Required. The key of the row to which the conditional mutation should be applied.
-    #[prost(bytes, tag = "2")]
-    pub row_key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub row_key: ::prost::alloc::vec::Vec<u8>,
     /// The filter to be applied to the contents of the specified row. Depending
     /// on whether or not any results are yielded, either `true_mutations` or
     /// `false_mutations` will be executed. If unset, checks that the row contains
     /// any values at all.
     #[prost(message, optional, tag = "6")]
-    pub predicate_filter: ::std::option::Option<RowFilter>,
+    pub predicate_filter: ::core::option::Option<RowFilter>,
     /// Changes to be atomically applied to the specified row if `predicate_filter`
     /// yields at least one cell when applied to `row_key`. Entries are applied in
     /// order, meaning that earlier mutations can be masked by later ones.
     /// Must contain at least one entry if `false_mutations` is empty, and at most
     /// 100000.
     #[prost(message, repeated, tag = "4")]
-    pub true_mutations: ::std::vec::Vec<Mutation>,
+    pub true_mutations: ::prost::alloc::vec::Vec<Mutation>,
     /// Changes to be atomically applied to the specified row if `predicate_filter`
     /// does not yield any cells when applied to `row_key`. Entries are applied in
     /// order, meaning that earlier mutations can be masked by later ones.
     /// Must contain at least one entry if `true_mutations` is empty, and at most
     /// 100000.
     #[prost(message, repeated, tag = "5")]
-    pub false_mutations: ::std::vec::Vec<Mutation>,
+    pub false_mutations: ::prost::alloc::vec::Vec<Mutation>,
 }
 /// Response message for Bigtable.CheckAndMutateRow.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -861,26 +871,26 @@ pub struct ReadModifyWriteRowRequest {
     /// Values are of the form
     /// `projects/<project>/instances/<instance>/tables/<table>`.
     #[prost(string, tag = "1")]
-    pub table_name: std::string::String,
+    pub table_name: ::prost::alloc::string::String,
     /// This value specifies routing for replication. If not specified, the
     /// "default" application profile will be used.
     #[prost(string, tag = "4")]
-    pub app_profile_id: std::string::String,
+    pub app_profile_id: ::prost::alloc::string::String,
     /// Required. The key of the row to which the read/modify/write rules should be applied.
-    #[prost(bytes, tag = "2")]
-    pub row_key: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub row_key: ::prost::alloc::vec::Vec<u8>,
     /// Required. Rules specifying how the specified row's contents are to be transformed
     /// into writes. Entries are applied in order, meaning that earlier rules will
     /// affect the results of later ones.
     #[prost(message, repeated, tag = "3")]
-    pub rules: ::std::vec::Vec<ReadModifyWriteRule>,
+    pub rules: ::prost::alloc::vec::Vec<ReadModifyWriteRule>,
 }
 /// Response message for Bigtable.ReadModifyWriteRow.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ReadModifyWriteRowResponse {
     /// A Row containing the new contents of all cells modified by the request.
     #[prost(message, optional, tag = "1")]
-    pub row: ::std::option::Option<Row>,
+    pub row: ::core::option::Option<Row>,
 }
 #[doc = r" Generated client implementations."]
 pub mod bigtable_client {

--- a/storage-bigtable/proto/google.rpc.rs
+++ b/storage-bigtable/proto/google.rpc.rs
@@ -14,9 +14,9 @@ pub struct Status {
     /// user-facing error message should be localized and sent in the
     /// [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
     #[prost(string, tag = "2")]
-    pub message: std::string::String,
+    pub message: ::prost::alloc::string::String,
     /// A list of messages that carry the error details.  There is a common set of
     /// message types for APIs to use.
     #[prost(message, repeated, tag = "3")]
-    pub details: ::std::vec::Vec<::prost_types::Any>,
+    pub details: ::prost::alloc::vec::Vec<::prost_types::Any>,
 }

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -214,12 +214,11 @@ impl BigTableConnection {
     where
         T: serde::ser::Serialize,
     {
-        use backoff::{future::FutureOperation as _, ExponentialBackoff};
-        (|| async {
+        use backoff::{future::retry, ExponentialBackoff};
+        retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
             Ok(client.put_bincode_cells(table, cells).await?)
         })
-        .retry(ExponentialBackoff::default())
         .await
     }
 
@@ -231,12 +230,11 @@ impl BigTableConnection {
     where
         T: prost::Message,
     {
-        use backoff::{future::FutureOperation as _, ExponentialBackoff};
-        (|| async {
+        use backoff::{future::retry, ExponentialBackoff};
+        retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
             Ok(client.put_protobuf_cells(table, cells).await?)
         })
-        .retry(ExponentialBackoff::default())
         .await
     }
 }

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.2.1"
 bs58 = "0.3.1"
-prost = "0.6.1"
+prost = "0.7.0"
 serde = "1.0.118"
 serde_derive = "1.0.103"
 solana-account-decoder = { path = "../account-decoder", version = "1.6.0" }

--- a/storage-proto/build-proto/Cargo.lock
+++ b/storage-proto/build-proto/Cargo.lock
@@ -14,9 +14,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cfg-if"
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
  "bytes",
  "heck",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes",
  "prost",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.44"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03e57e4fcbfe7749842d53e24ccb9aa12b7252dbe5e91d2acad31834c8b8fdd"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -276,10 +276,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.2.0"
+name = "thiserror"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e8546fd40d56d28089835c0a81bb396848103b00f888aea42d46eb5974df07"
 dependencies = [
  "proc-macro2",
  "prost-build",
@@ -307,11 +327,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
  "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/storage-proto/build-proto/Cargo.toml
+++ b/storage-proto/build-proto/Cargo.toml
@@ -12,4 +12,4 @@ version = "1.6.0"
 [workspace]
 
 [dependencies]
-tonic-build = "0.2.0"
+tonic-build = "0.4.0"

--- a/storage-proto/proto/solana.storage.confirmed_block.rs
+++ b/storage-proto/proto/solana.storage.confirmed_block.rs
@@ -1,42 +1,42 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConfirmedBlock {
     #[prost(string, tag = "1")]
-    pub previous_blockhash: std::string::String,
+    pub previous_blockhash: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub blockhash: std::string::String,
+    pub blockhash: ::prost::alloc::string::String,
     #[prost(uint64, tag = "3")]
     pub parent_slot: u64,
     #[prost(message, repeated, tag = "4")]
-    pub transactions: ::std::vec::Vec<ConfirmedTransaction>,
+    pub transactions: ::prost::alloc::vec::Vec<ConfirmedTransaction>,
     #[prost(message, repeated, tag = "5")]
-    pub rewards: ::std::vec::Vec<Reward>,
+    pub rewards: ::prost::alloc::vec::Vec<Reward>,
     #[prost(message, optional, tag = "6")]
-    pub block_time: ::std::option::Option<UnixTimestamp>,
+    pub block_time: ::core::option::Option<UnixTimestamp>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConfirmedTransaction {
     #[prost(message, optional, tag = "1")]
-    pub transaction: ::std::option::Option<Transaction>,
+    pub transaction: ::core::option::Option<Transaction>,
     #[prost(message, optional, tag = "2")]
-    pub meta: ::std::option::Option<TransactionStatusMeta>,
+    pub meta: ::core::option::Option<TransactionStatusMeta>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Transaction {
-    #[prost(bytes, repeated, tag = "1")]
-    pub signatures: ::std::vec::Vec<std::vec::Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub signatures: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
     #[prost(message, optional, tag = "2")]
-    pub message: ::std::option::Option<Message>,
+    pub message: ::core::option::Option<Message>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
     #[prost(message, optional, tag = "1")]
-    pub header: ::std::option::Option<MessageHeader>,
-    #[prost(bytes, repeated, tag = "2")]
-    pub account_keys: ::std::vec::Vec<std::vec::Vec<u8>>,
-    #[prost(bytes, tag = "3")]
-    pub recent_blockhash: std::vec::Vec<u8>,
+    pub header: ::core::option::Option<MessageHeader>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub account_keys: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub recent_blockhash: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, repeated, tag = "4")]
-    pub instructions: ::std::vec::Vec<CompiledInstruction>,
+    pub instructions: ::prost::alloc::vec::Vec<CompiledInstruction>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MessageHeader {
@@ -50,51 +50,51 @@ pub struct MessageHeader {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionStatusMeta {
     #[prost(message, optional, tag = "1")]
-    pub err: ::std::option::Option<TransactionError>,
+    pub err: ::core::option::Option<TransactionError>,
     #[prost(uint64, tag = "2")]
     pub fee: u64,
     #[prost(uint64, repeated, tag = "3")]
-    pub pre_balances: ::std::vec::Vec<u64>,
+    pub pre_balances: ::prost::alloc::vec::Vec<u64>,
     #[prost(uint64, repeated, tag = "4")]
-    pub post_balances: ::std::vec::Vec<u64>,
+    pub post_balances: ::prost::alloc::vec::Vec<u64>,
     #[prost(message, repeated, tag = "5")]
-    pub inner_instructions: ::std::vec::Vec<InnerInstructions>,
+    pub inner_instructions: ::prost::alloc::vec::Vec<InnerInstructions>,
     #[prost(string, repeated, tag = "6")]
-    pub log_messages: ::std::vec::Vec<std::string::String>,
+    pub log_messages: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(message, repeated, tag = "7")]
-    pub pre_token_balances: ::std::vec::Vec<TokenBalance>,
+    pub pre_token_balances: ::prost::alloc::vec::Vec<TokenBalance>,
     #[prost(message, repeated, tag = "8")]
-    pub post_token_balances: ::std::vec::Vec<TokenBalance>,
+    pub post_token_balances: ::prost::alloc::vec::Vec<TokenBalance>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionError {
-    #[prost(bytes, tag = "1")]
-    pub err: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub err: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InnerInstructions {
     #[prost(uint32, tag = "1")]
     pub index: u32,
     #[prost(message, repeated, tag = "2")]
-    pub instructions: ::std::vec::Vec<CompiledInstruction>,
+    pub instructions: ::prost::alloc::vec::Vec<CompiledInstruction>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompiledInstruction {
     #[prost(uint32, tag = "1")]
     pub program_id_index: u32,
-    #[prost(bytes, tag = "2")]
-    pub accounts: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "3")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub accounts: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TokenBalance {
     #[prost(uint32, tag = "1")]
     pub account_index: u32,
     #[prost(string, tag = "2")]
-    pub mint: std::string::String,
+    pub mint: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "3")]
-    pub ui_token_amount: ::std::option::Option<UiTokenAmount>,
+    pub ui_token_amount: ::core::option::Option<UiTokenAmount>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UiTokenAmount {
@@ -103,12 +103,12 @@ pub struct UiTokenAmount {
     #[prost(uint32, tag = "2")]
     pub decimals: u32,
     #[prost(string, tag = "3")]
-    pub amount: std::string::String,
+    pub amount: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Reward {
     #[prost(string, tag = "1")]
-    pub pubkey: std::string::String,
+    pub pubkey: ::prost::alloc::string::String,
     #[prost(int64, tag = "2")]
     pub lamports: i64,
     #[prost(uint64, tag = "3")]
@@ -119,7 +119,7 @@ pub struct Reward {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Rewards {
     #[prost(message, repeated, tag = "1")]
-    pub rewards: ::std::vec::Vec<Reward>,
+    pub rewards: ::prost::alloc::vec::Vec<Reward>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnixTimestamp {

--- a/storage-proto/proto/solana.storage.transaction_by_addr.rs
+++ b/storage-proto/proto/solana.storage.transaction_by_addr.rs
@@ -1,32 +1,32 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionByAddr {
     #[prost(message, repeated, tag = "1")]
-    pub tx_by_addrs: ::std::vec::Vec<TransactionByAddrInfo>,
+    pub tx_by_addrs: ::prost::alloc::vec::Vec<TransactionByAddrInfo>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionByAddrInfo {
-    #[prost(bytes, tag = "1")]
-    pub signature: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub err: ::std::option::Option<TransactionError>,
+    pub err: ::core::option::Option<TransactionError>,
     #[prost(uint32, tag = "3")]
     pub index: u32,
     #[prost(message, optional, tag = "4")]
-    pub memo: ::std::option::Option<Memo>,
+    pub memo: ::core::option::Option<Memo>,
     #[prost(message, optional, tag = "5")]
-    pub block_time: ::std::option::Option<UnixTimestamp>,
+    pub block_time: ::core::option::Option<UnixTimestamp>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Memo {
     #[prost(string, tag = "1")]
-    pub memo: std::string::String,
+    pub memo: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionError {
     #[prost(enumeration = "TransactionErrorType", tag = "1")]
     pub transaction_error: i32,
     #[prost(message, optional, tag = "2")]
-    pub instruction_error: ::std::option::Option<InstructionError>,
+    pub instruction_error: ::core::option::Option<InstructionError>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InstructionError {
@@ -35,7 +35,7 @@ pub struct InstructionError {
     #[prost(enumeration = "InstructionErrorType", tag = "2")]
     pub error: i32,
     #[prost(message, optional, tag = "3")]
-    pub custom: ::std::option::Option<CustomError>,
+    pub custom: ::core::option::Option<CustomError>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UnixTimestamp {


### PR DESCRIPTION
#### Problem
Really old tokio is used throughout the code base, blocking upgrades of other dependencies.

#### Summary of Changes
- Update version of tonic and various related dependencies. Unfortunately, since there is no published version of `goauth` on tokio v0.3, tokio must be bumped to v1.0

Todo:
- [x] Rebase on #15018 and see what kind of tokio pinning is still necessary for jsonrpc
- [x] Update remaining tokio in code base to v1.0 - edit: only tarpc-related updates remaining

Fixes #10187
...as much as possible atm. We're dependent on the jsonrpc crates to eliminate tokio v0.2 entirely
