### PR TITLE
Don't squash caught errors, please

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -487,8 +487,9 @@ impl Blockstore {
         Ok(meta_iter.map(|(slot, slot_meta_bytes)| {
             (
                 slot,
-                deserialize(&slot_meta_bytes)
-                    .unwrap_or_else(|e| panic!("Could not deserialize SlotMeta for slot {}: {:?}", slot, e)),
+                deserialize(&slot_meta_bytes).unwrap_or_else(|e| {
+                    panic!("Could not deserialize SlotMeta for slot {}: {:?}", slot, e)
+                }),
             )
         }))
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -488,7 +488,7 @@ impl Blockstore {
             (
                 slot,
                 deserialize(&slot_meta_bytes)
-                    .unwrap_or_else(|_| panic!("Could not deserialize SlotMeta for slot {}", slot)),
+                    .unwrap_or_else(|e| panic!("Could not deserialize SlotMeta for slot {}: {:?}", slot, e)),
             )
         }))
     }
@@ -2600,7 +2600,8 @@ impl Blockstore {
         debug!("{:?} shreds in last FEC set", data_shreds.len(),);
         bincode::deserialize::<Vec<Entry>>(&deshred_payload).map_err(|e| {
             BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
-                "could not reconstruct entries: {:?}", e
+                "could not reconstruct entries: {:?}",
+                e
             ))))
         })
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2598,10 +2598,10 @@ impl Blockstore {
         })?;
 
         debug!("{:?} shreds in last FEC set", data_shreds.len(),);
-        bincode::deserialize::<Vec<Entry>>(&deshred_payload).map_err(|_| {
-            BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
-                "could not reconstruct entries".to_string(),
-            )))
+        bincode::deserialize::<Vec<Entry>>(&deshred_payload).map_err(|e| {
+            BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
+                "could not reconstruct entries: {:?}", e
+            ))))
         })
     }
 


### PR DESCRIPTION
#### Problem

my poor testing tds validator got crippled due to this scary error:

Before

(error while running)

```
solana-validator-Cq8RWeXzbbd5mjMHjtowQG2nQZFwpRWwsrk4WwvfLkbf.log:[2021-01-29T21:05:01.484539684Z WARN  solana_core::replay_stage] Fatal replay error in slot: 60736948, err: FailedToLoadEntries(InvalidShredData(Custom("could not reconstruct entries")))

```

#### Summary of Changes

After

sample 1 (tried to show the detailed error with this patch)

```
$ /tmp/solana-ledger-tool --ledger target/tds31 slot 60736948 --allow-dead-slots 
[2021-02-03T13:41:20.851755489Z INFO  solana_ledger_tool] solana-ledger-tool 1.6.0 (src:d182038a; feat:2714168333)
[2021-02-03T13:41:20.851839852Z INFO  solana_ledger::blockstore] Maximum open file descriptors: 500000
[2021-02-03T13:41:20.851860652Z INFO  solana_ledger::blockstore] Opening database at "/home/ubuntu/target/tds31/rocksdb"
[2021-02-03T13:41:21.615848552Z INFO  solana_ledger::blockstore] "/home/ubuntu/target/tds31/rocksdb" open took 763ms
Slot 60736948
 Slot is dead
Failed to load entries for slot 60736948: InvalidShredData(Custom("could not reconstruct entries: Io(Kind(UnexpectedEof))"))

```


sample 2 (`run.sh` sample)

```
thread 'main' panicked at 'processing for bank 0 must succeed: FailedToLoadEntries(InvalidShredData(Custom("could not reconstruct entries: Io(Kind(UnexpectedEof))")))', ledger/src/blockstore_processor.rs:781:6
stack backtrace:
   0: rust_begin_unwind
             at /rustc/7efc097c4fe6e97f54a44cee91c56189e9ddb41c/library/std/src/panicking.rs:493:5
   1: core::panicking::panic_fmt
             at /rustc/7efc097c4fe6e97f54a44cee91c56189e9ddb41c/library/core/src/panicking.rs:92:14
   2: core::option::expect_none_failed
             at /rustc/7efc097c4fe6e97f54a44cee91c56189e9ddb41c/library/core/src/option.rs:1268:5
   3: core::result::Result<T,E>::expect
             at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:933:23
   4: solana_ledger::blockstore_processor::process_bank_0
             at ./ledger/src/blockstore_processor.rs:772:5
   5: solana_ledger::blockstore_processor::process_blockstore
             at ./ledger/src/blockstore_processor.rs:400:5
   6: solana_ledger::bank_forks_utils::load
             at ./ledger/src/bank_forks_utils.rs:111:9
   7: solana_core::validator::new_banks_from_ledger
             at ./core/src/validator.rs:992:70
   8: solana_core::validator::Validator::new
             at ./core/src/validator.rs:334:13
   9: solana_validator::create_validator
             at ./validator/src/main.rs:800:5
  10: solana_validator::main
             at ./validator/src/main.rs:1909:21
  11: core::ops::function::FnOnce::call_once
             at /home/ryoqun/.rustup/toolchains/nightly-2020-12-13-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```

Fixes #
