### PR TITLE
removes pubkey references

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1,7 +1,4 @@
-use crate::{
-    progress_map::{LockoutIntervals, ProgressMap},
-    pubkey_references::PubkeyReferences,
-};
+use crate::progress_map::{LockoutIntervals, ProgressMap};
 use chrono::prelude::*;
 use solana_ledger::{ancestor_iterator::AncestorIterator, blockstore::Blockstore, blockstore_db};
 use solana_measure::measure::Measure;
@@ -214,7 +211,6 @@ impl Tower {
         bank_slot: Slot,
         vote_accounts: F,
         ancestors: &HashMap<Slot, HashSet<Slot>>,
-        all_pubkeys: &mut PubkeyReferences,
     ) -> ComputedBankState
     where
         F: IntoIterator<Item = (Pubkey, (u64, ArcVoteAccount))>,
@@ -247,7 +243,6 @@ impl Tower {
                 Ok(vote_state) => vote_state.clone(),
             };
             for vote in &vote_state.votes {
-                let key = all_pubkeys.get_or_insert(&key);
                 lockout_intervals
                     .entry(vote.expiration_slot())
                     .or_insert_with(Vec::new)
@@ -1270,7 +1265,6 @@ pub mod test {
         collections::HashMap,
         fs::{remove_file, OpenOptions},
         io::{Read, Seek, SeekFrom, Write},
-        rc::Rc,
         sync::RwLock,
     };
     use tempfile::TempDir;
@@ -1380,7 +1374,6 @@ pub mod test {
                 &VoteTracker::default(),
                 &ClusterSlots::default(),
                 &self.bank_forks,
-                &mut PubkeyReferences::default(),
                 &mut self.heaviest_subtree_fork_choice,
             );
 
@@ -1425,7 +1418,6 @@ pub mod test {
                 &self.bank_forks,
                 &mut self.progress,
                 &ABSRequestSender::default(),
-                &mut PubkeyReferences::default(),
                 None,
                 &mut self.heaviest_subtree_fork_choice,
             )
@@ -1467,7 +1459,7 @@ pub mod test {
                 .lockout_intervals
                 .entry(lockout_interval.1)
                 .or_default()
-                .push((lockout_interval.0, Rc::new(*vote_account_pubkey)));
+                .push((lockout_interval.0, *vote_account_pubkey));
         }
 
         fn can_progress_on_fork(
@@ -1993,13 +1985,7 @@ pub mod test {
             bank_weight,
             pubkey_votes,
             ..
-        } = Tower::collect_vote_lockouts(
-            &Pubkey::default(),
-            1,
-            accounts.into_iter(),
-            &ancestors,
-            &mut PubkeyReferences::default(),
-        );
+        } = Tower::collect_vote_lockouts(&Pubkey::default(), 1, accounts.into_iter(), &ancestors);
         assert_eq!(voted_stakes[&0], 2);
         assert_eq!(total_stake, 2);
         let mut pubkey_votes = Arc::try_unwrap(pubkey_votes).unwrap();
@@ -2051,7 +2037,6 @@ pub mod test {
             MAX_LOCKOUT_HISTORY as u64,
             accounts.into_iter(),
             &ancestors,
-            &mut PubkeyReferences::default(),
         );
         for i in 0..MAX_LOCKOUT_HISTORY {
             assert_eq!(voted_stakes[&(i as u64)], 2);
@@ -2358,7 +2343,6 @@ pub mod test {
             vote_to_evaluate,
             accounts.clone().into_iter(),
             &ancestors,
-            &mut PubkeyReferences::default(),
         );
         assert!(tower.check_vote_stake_threshold(vote_to_evaluate, &voted_stakes, total_stake,));
 
@@ -2375,7 +2359,6 @@ pub mod test {
             vote_to_evaluate,
             accounts.into_iter(),
             &ancestors,
-            &mut PubkeyReferences::default(),
         );
         assert!(!tower.check_vote_stake_threshold(vote_to_evaluate, &voted_stakes, total_stake,));
     }

--- a/core/src/pubkey_references.rs
+++ b/core/src/pubkey_references.rs
@@ -1,28 +1,8 @@
 use solana_sdk::pubkey::Pubkey;
 use std::{
     collections::HashSet,
-    rc::Rc,
     sync::{Arc, RwLock},
 };
-
-#[derive(Default)]
-pub struct PubkeyReferences(HashSet<Rc<Pubkey>>);
-
-impl PubkeyReferences {
-    pub fn get_or_insert(&mut self, pubkey: &Pubkey) -> Rc<Pubkey> {
-        let mut cached_pubkey: Option<Rc<Pubkey>> = self.0.get(pubkey).cloned();
-        if cached_pubkey.is_none() {
-            let new_pubkey = Rc::new(*pubkey);
-            self.0.insert(new_pubkey.clone());
-            cached_pubkey = Some(new_pubkey);
-        }
-        cached_pubkey.unwrap()
-    }
-
-    pub fn purge(&mut self) {
-        self.0.retain(|x| Rc::strong_count(x) > 1);
-    }
-}
 
 #[derive(Default)]
 pub struct LockedPubkeyReferences(pub RwLock<HashSet<Arc<Pubkey>>>);


### PR DESCRIPTION
#### Problem
The pubkeys are retained until the next epoch:
https://github.com/solana-labs/solana/blob/8376781ec/core/src/replay_stage.rs#L1867-L1869
plus the overhead of `Rc` itself.
So not clear these are saving any memory over the plain pubkeys.
And they are not necessary for the code logic either,
but they have a negative impact on the runtime.

#### Summary of Changes
Removed `PubkeyReferences`