### PR TITLE
blockstore: Revert hard nofile limit back to 500000

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3552,7 +3552,7 @@ fn adjust_ulimit_nofile(_enforce_ulimit_nofile: bool) -> Result<()> {
 fn adjust_ulimit_nofile(enforce_ulimit_nofile: bool) -> Result<()> {
     // Rocks DB likes to have many open files.  The default open file descriptor limit is
     // usually not enough
-    let desired_nofile = 700000;
+    let desired_nofile = 500000;
 
     fn get_nofile() -> libc::rlimit {
         let mut nofile = libc::rlimit {


### PR DESCRIPTION
894b412aef bumped the hard limit up to 700000.  This will cause every v1.5 validator that had previously followed our guidance to set nofile to 500000 to fail to start up.   Too harsh!