### PR TITLE
Fix which shared object the test uses

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1655,7 +1655,7 @@ fn test_program_bpf_upgrade_and_invoke_in_same_tx() {
         &buffer_keypair,
         &program_keypair,
         &authority_keypair,
-        "noop",
+        "solana_bpf_rust_noop",
     );
 
     let invoke_instruction = Instruction::new(
@@ -1680,7 +1680,7 @@ fn test_program_bpf_upgrade_and_invoke_in_same_tx() {
         &mint_keypair,
         &buffer_keypair,
         &authority_keypair,
-        "panic",
+        "solana_bpf_rust_panic",
     );
 
     // Invoke, then upgrade the program, and then invoke again in same tx
@@ -1826,7 +1826,7 @@ fn test_program_bpf_disguised_as_bpf_loader() {
     }
     #[cfg(feature = "bpf_rust")]
     {
-        programs.extend_from_slice(&[("noop")]);
+        programs.extend_from_slice(&[("solana_bpf_rust_noop")]);
     }
 
     for program in programs.iter() {
@@ -1970,7 +1970,12 @@ fn test_program_bpf_upgrade_self_via_cpi() {
     bank.add_builtin(&name, id, entrypoint);
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
-    let noop_program_id = load_bpf_program(&bank_client, &bpf_loader::id(), &mint_keypair, "noop");
+    let noop_program_id = load_bpf_program(
+        &bank_client,
+        &bpf_loader::id(),
+        &mint_keypair,
+        "solana_bpf_rust_noop",
+    );
 
     // Deploy upgradeable program
     let buffer_keypair = Keypair::new();
@@ -2010,7 +2015,7 @@ fn test_program_bpf_upgrade_self_via_cpi() {
         &mint_keypair,
         &buffer_keypair,
         &authority_keypair,
-        "panic",
+        "solana_bpf_rust_panic",
     );
 
     // Invoke, then upgrade the program, and then invoke again in same tx


### PR DESCRIPTION
#### Problem

Using C objects for Rust tests is fine unless the C version isn't built due to features

#### Summary of Changes

Use the object that matches the feature

Fixes #
