### PR TITLE
Add ref count from storage to index debug

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4356,7 +4356,7 @@ impl AccountsDB {
         roots.sort();
         info!("{}: accounts_index roots: {:?}", label, roots,);
         for (pubkey, account_entry) in self.accounts_index.account_maps.read().unwrap().iter() {
-            info!("  key: {}", pubkey);
+            info!("  key: {} ref_count: {}", pubkey, account_entry.ref_count(),);
             info!(
                 "      slots: {:?}",
                 *account_entry.slot_list.read().unwrap()

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -78,6 +78,12 @@ pub struct AccountMapEntryInner<T> {
     pub slot_list: RwLock<SlotList<T>>,
 }
 
+impl<T> AccountMapEntryInner<T> {
+    pub fn ref_count(&self) -> u64 {
+        self.ref_count.load(Ordering::Relaxed)
+    }
+}
+
 #[self_referencing]
 pub struct ReadAccountMapEntry<T: 'static> {
     owned_entry: AccountMapEntry<T>,


### PR DESCRIPTION
#### Problem

Hard to debug when ref count not included in accounts debug

#### Summary of Changes

Print the storage ref count for each key.

Fixes #
