### PR TITLE
Warn lastValidSlot with some terminology tweaks

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1220,7 +1220,7 @@ The result will be an RpcResponse JSON object with `value` set to a JSON object 
 
 - `blockhash: <string>` - a Hash as base-58 encoded string
 - `feeCalculator: <object>` - FeeCalculator object, the fee schedule for this block hash
-- `lastValidSlot: <u64>` - last slot in which a blockhash will be valid
+- `lastValidSlot: <u64>` - last slot in which a blockhash will be valid (NOTE: this can be inaccurate when there are [skipped slots](../../terminology.md#skipped-slot))
 
 #### Example:
 

--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -468,18 +468,11 @@ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "
 
 #### Blockhash Expiration
 
-When you request a recent blockhash for your withdrawal transaction using the
-[`getFees` endpoint](developing/clients/jsonrpc-api.md#getfees) or `solana fees`, the
-response will include the `lastValidSlot`, the last slot in which the blockhash
-will be valid. You can check the cluster slot with a
-[`getSlot` query](developing/clients/jsonrpc-api.md#getslot); once the cluster slot is
-greater than `lastValidSlot`, the withdrawal transaction using that blockhash
-should never succeed.
-
-You can also doublecheck whether a particular blockhash is still valid by sending a
+You can check whether a particular blockhash is still valid by sending a
 [`getFeeCalculatorForBlockhash`](developing/clients/jsonrpc-api.md#getfeecalculatorforblockhash)
-request with the blockhash as a parameter. If the response value is null, the
-blockhash is expired, and the withdrawal transaction should never succeed.
+request with the blockhash as a parameter. If the response value is `null`, the
+blockhash is expired, and the withdrawal transaction using that blockhash should
+never succeed.
 
 ### Validating User-supplied Account Addresses for Withdrawals
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -219,9 +219,9 @@ Thus, the first signature in transaction can be treated as [transacton id](termi
 
 ## skipped slot
 
-A past [slot](terminology.md#slot) where its scheduled leader didn't produce a [block](terminology.md#block) due to off-line or the [fork](terminology.md#fork) containing the slot was abandoned over a better alternative at the time by the cluster consensus. Being _skipped_ means that blocks at subsequent slots omits to include the skipped slots as ancestors, possibly creating an after-the-fact short cluster stall of transaction processing, oldest `recent_blockhash` expiration, [block height](terminology#block-height) increment, etc.
+A past [slot](terminology.md#slot) that did not produce a [block](terminology.md#block), because the leader was offline or the [fork](terminology.md#fork) containing the slot was abandoned for a better alternative by cluster consensus. A skipped slot will not appear as an ancestor for blocks at subsequent slots, increment the [block height](terminology#block-height), nor expire the oldest `recent_blockhash`.
 
-By definition, being skipped can be determined only after being older than the latest [rooted](terminology.md#root) (thus not-skipped) slot.
+Whether a slot has been skipped can only be determined when it becomes older than the latest [rooted](terminology.md#root) (thus not-skipped) slot.
 
 ## slot
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -136,7 +136,7 @@ The role of a [validator](terminology.md#validator) when it is appending [entrie
 
 ## leader schedule
 
-A sequence of [validator](terminology.md#validator) [public keys](terminology.md#public-key) ordered by [slots](terminology.md#slot). The cluster uses the leader schedule to determine which validator is the [leader](terminology.md#leader) at any moment in time.
+A sequence of [validator](terminology.md#validator) [public keys](terminology.md#public-key) mapped to [slots](terminology.md#slot). The cluster uses the leader schedule to determine which validator is the [leader](terminology.md#leader) at any moment in time.
 
 ## ledger
 
@@ -219,15 +219,15 @@ Thus, the first signature in transaction can be treated as [transacton id](termi
 
 ## skipped slot
 
-A past [slot](terminology.md#slot) that did not produce a [block](terminology.md#block), because the leader was offline or the [fork](terminology.md#fork) containing the slot was abandoned for a better alternative by cluster consensus. A skipped slot will not appear as an ancestor for blocks at subsequent slots, increment the [block height](terminology#block-height), nor expire the oldest `recent_blockhash`.
+A past [slot](terminology.md#slot) that did not produce a [block](terminology.md#block), because the leader was offline or the [fork](terminology.md#fork) containing the slot was abandoned for a better alternative by cluster consensus. A skipped slot will not appear as an ancestor for blocks at subsequent slots, nor increment the [block height](terminology#block-height), nor expire the oldest `recent_blockhash`.
 
 Whether a slot has been skipped can only be determined when it becomes older than the latest [rooted](terminology.md#root) (thus not-skipped) slot.
 
 ## slot
 
-The period of time for which each [leader](terminology.md#leader) ingests transactions and produces a [block](terminology.md#block) by rotation, abiding by [leader schedule](terminology.md#leader-schedule).
+The period of time for which each [leader](terminology.md#leader) ingests transactions and produces a [block](terminology.md#block).
 
-Collectively, slots create a logical clock as non-overlapping slices of the time. And they're ordered sequentially and numbered accordingly with roughly equal passage of real wall-clock utilizing [PoH](terminology.md#proof-of-history).
+Collectively, slots create a logical clock. Slots are ordered sequentially and non-overlapping, comprising roughly equal real-world time as per [PoH](terminology.md#proof-of-history).
 
 ## smart contract
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -136,7 +136,7 @@ The role of a [validator](terminology.md#validator) when it is appending [entrie
 
 ## leader schedule
 
-A sequence of [validator](terminology.md#validator) [public keys](terminology.md#public-key). The cluster uses the leader schedule to determine which validator is the [leader](terminology.md#leader) at any moment in time.
+A sequence of [validator](terminology.md#validator) [public keys](terminology.md#public-key) ordered by [slots](terminology.md#slot). The cluster uses the leader schedule to determine which validator is the [leader](terminology.md#leader) at any moment in time.
 
 ## ledger
 
@@ -217,9 +217,16 @@ A 64-byte ed25519 signature of R (32-bytes) and S (32-bytes). With the requireme
 This requirement ensures no signature malleability. Each transaction must have at least one signature for [fee account](terminology#fee-account).
 Thus, the first signature in transaction can be treated as [transacton id](terminology.md#transaction-id)
 
+## skipped slot
+
+A past [slot](terminology.md#slot) where its scheduled leader didn't produce a [block](terminology.md#block) due to off-line or the [fork](terminology.md#fork) containing the slot was abandoned over a better alternative at the time by the cluster consensus. Being _skipped_ means that blocks at subsequent slots omits to include the skipped slots as ancestors, possibly creating an after-the-fact short cluster stall of transaction processing, oldest `recent_blockhash` expiration, [block height](terminology#block-height) increment, etc.
+
+By definition, being skipped can be determined only after being older than the latest [rooted](terminology.md#root) (thus not-skipped) slot.
+
 ## slot
 
-The period of time for which a [leader](terminology.md#leader) ingests transactions and produces a [block](terminology.md#block).
+A numbered non-overlapping slice of logical time, ordered sequentially with roughly equal passage of real wall-clock utilizing [PoH](terminology.md#proof-of-history).
+Abiding by [leader schedule](terminology.md#leader-schedule), the [leader](terminology.md#leader) of newest slot can ingest transactions and produce a [block](terminology.md#block).
 
 ## smart contract
 

--- a/docs/src/terminology.md
+++ b/docs/src/terminology.md
@@ -225,8 +225,9 @@ Whether a slot has been skipped can only be determined when it becomes older tha
 
 ## slot
 
-A numbered non-overlapping slice of logical time, ordered sequentially with roughly equal passage of real wall-clock utilizing [PoH](terminology.md#proof-of-history).
-Abiding by [leader schedule](terminology.md#leader-schedule), the [leader](terminology.md#leader) of newest slot can ingest transactions and produce a [block](terminology.md#block).
+The period of time for which each [leader](terminology.md#leader) ingests transactions and produces a [block](terminology.md#block) by rotation, abiding by [leader schedule](terminology.md#leader-schedule).
+
+Collectively, slots create a logical clock as non-overlapping slices of the time. And they're ordered sequentially and numbered accordingly with roughly equal passage of real wall-clock utilizing [PoH](terminology.md#proof-of-history).
 
 ## smart contract
 


### PR DESCRIPTION
#### Problem

The advised `lastValidSlot` usage for tx expiration check isn't correct, possibly leading to false-positives for tx's expired status.

#### Summary of Changes

- Discourage usage of it by not-documenting from the exchanges integrtion page for now. (Ideally, we could provide `lastValidBlockHeight` or fix so that `lastValidSlot` can work even under the existence of skipped slots. But, there is alternative method for tx expiration check...)
- Add proper NOTE to the rpc reference
- Add some missing terminology definitions/clarifications as a bonus.

context: #13443 
