### PR TITLE
Move timer

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -967,12 +967,12 @@ pub fn process_accounts_package_pre(accounts_package: AccountsPackagePre) -> Acc
             accounts_package.storages.clone(),
             accounts_package.simple_capitalization_testing,
         );
-        time.stop();
 
         assert_eq!(accounts_package.expected_capitalization, lamports);
 
         assert_eq!(expected_hash, hash);
     };
+    time.stop();
 
     datapoint_info!(
         "accounts_hash_verifier",


### PR DESCRIPTION
#### Problem
timer that is reported to metrics isn't stopped in normal operation (only with testing flag)

#### Summary of Changes
move the stop

Fixes #
