### PR TITLE
nit: cleanup feature status display

### DIFF
--- a/ci/test-bench.sh
+++ b/ci/test-bench.sh
@@ -23,6 +23,10 @@ fi
 BENCH_FILE=bench_output.log
 BENCH_ARTIFACT=current_bench_results.log
 
+# solana-keygen required when building C programs
+_ "$cargo" build --manifest-path=keygen/Cargo.toml
+export PATH="$PWD/target/debug":$PATH
+
 # Clear the C dependency files, if dependeny moves these files are not regenerated
 test -d target/debug/bpf && find target/debug/bpf -name '*.d' -delete
 test -d target/release/bpf && find target/release/bpf -name '*.d' -delete

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -70,8 +70,8 @@ impl fmt::Display for CliFeatures {
                 f,
                 "{}",
                 style(format!(
-                    "{:<44} {:<40} {}",
-                    "Feature", "Description", "Status"
+                    "{:<44} {:<28} {}",
+                    "Feature", "Status", "Description"
                 ))
                 .bold()
             )?;
@@ -79,15 +79,15 @@ impl fmt::Display for CliFeatures {
         for feature in &self.features {
             writeln!(
                 f,
-                "{:<44} {:<40} {}",
+                "{:<44} {:<28} {}",
                 feature.id,
-                feature.description,
                 match feature.status {
                     CliFeatureStatus::Inactive => style("inactive".to_string()).red(),
                     CliFeatureStatus::Pending => style("activation pending".to_string()).yellow(),
                     CliFeatureStatus::Active(activation_slot) =>
                         style(format!("active since slot {}", activation_slot)).green(),
-                }
+                },
+                feature.description,
             )?;
         }
         if self.inactive && !self.feature_activation_allowed {


### PR DESCRIPTION
#### Problem

Feature descriptions have gotten long which bungles the cli display of feature status

#### Summary of Changes

Re-org so that columns stay in alignment

Fixes #
