### PR TITLE
program-test: Add warp tests for rent and stake rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4935,6 +4935,8 @@ dependencies = [
  "solana-program 1.6.0",
  "solana-runtime",
  "solana-sdk",
+ "solana-stake-program",
+ "solana-vote-program",
  "thiserror",
  "tokio 1.1.1",
 ]

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -21,5 +21,9 @@ solana-logger = { path = "../logger", version = "1.6.0" }
 solana-program = { path = "../sdk/program", version = "1.6.0" }
 solana-runtime = { path = "../runtime", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
+solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
 thiserror = "1.0"
 tokio = { version = "1.1", features = ["full"] }
+
+[dev-dependencies]
+solana-stake-program = { path = "../programs/stake", version = "1.6.0" }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -817,6 +817,10 @@ impl ProgramTestContext {
         }
     }
 
+    pub fn genesis_config(&self) -> &GenesisConfig {
+        &self.genesis_config
+    }
+
     /// Manually increment vote credits for the current epoch in the specified vote account to simulate validator voting activity
     pub fn increment_vote_account_credits(
         &mut self,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -818,7 +818,11 @@ impl ProgramTestContext {
     }
 
     /// Manually increment vote credits for the current epoch in the specified vote account to simulate validator voting activity
-    pub fn increment_vote_account_credits(&mut self, vote_account_address: &Pubkey, number_of_credits: u64) {
+    pub fn increment_vote_account_credits(
+        &mut self,
+        vote_account_address: &Pubkey,
+        number_of_credits: u64,
+    ) {
         let bank_forks = self.bank_forks.read().unwrap();
         let bank = bank_forks.working_bank();
 

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -766,7 +766,7 @@ pub struct ProgramTestContext {
     pub banks_client: BanksClient,
     pub last_blockhash: Hash,
     pub payer: Keypair,
-    pub genesis_config: GenesisConfig,
+    genesis_config: GenesisConfig,
     bank_forks: Arc<RwLock<BankForks>>,
     block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     _bank_task: DroppableTask<()>,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -817,8 +817,8 @@ impl ProgramTestContext {
         }
     }
 
-    /// Fake vote activity to accrue vote credits, and eventually stake rewards
-    pub fn simulate_vote_activity(&mut self, voter: &Pubkey, number_of_slots: u64) {
+    /// Manually increment vote credits for the current epoch in the specified vote account to simulate validator voting activity
+    pub fn increment_vote_account_credits(&mut self, vote_account_address: &Pubkey, number_of_credits: u64) {
         let bank_forks = self.bank_forks.read().unwrap();
         let bank = bank_forks.working_bank();
         let working_slot = bank.slot();

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -2,12 +2,10 @@ use {
     solana_banks_client::BanksClient,
     solana_program::{
         account_info::AccountInfo, entrypoint::ProgramResult, hash::Hash, instruction::Instruction,
-        msg, pubkey::Pubkey, rent::Rent,
+        msg, pubkey::Pubkey, rent::Rent, system_instruction,
     },
     solana_program_test::{processor, ProgramTest},
-    solana_sdk::{
-        signature::Keypair, signature::Signer, system_instruction, transaction::Transaction,
-    },
+    solana_sdk::{signature::Keypair, signature::Signer, transaction::Transaction},
 };
 
 #[allow(clippy::unnecessary_wraps)]

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -1,17 +1,23 @@
 use {
     solana_program::{
         account_info::{next_account_info, AccountInfo},
-        clock::Clock,
+        clock::{Clock, DEFAULT_DEV_SLOTS_PER_EPOCH},
         entrypoint::ProgramResult,
         instruction::{AccountMeta, Instruction, InstructionError},
         program_error::ProgramError,
         pubkey::Pubkey,
+        rent::Rent,
+        system_instruction,
         sysvar::{clock, Sysvar},
     },
     solana_program_test::{processor, ProgramTest, ProgramTestError},
     solana_sdk::{
-        signature::Signer,
+        signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
+    },
+    solana_stake_program::{
+        stake_instruction,
+        stake_state::{Authorized, Lockup},
     },
     std::convert::TryInto,
 };
@@ -36,7 +42,7 @@ fn process_instruction(
 }
 
 #[tokio::test]
-async fn custom_warp() {
+async fn clock_sysvar_updated_from_warp() {
     let program_id = Pubkey::new_unique();
     // Initialize and start the test network
     let program_test = ProgramTest::new(
@@ -94,4 +100,120 @@ async fn custom_warp() {
         context.warp_to_slot(expected_slot).unwrap_err(),
         ProgramTestError::InvalidWarpSlot,
     );
+}
+
+#[tokio::test]
+async fn rent_collected_from_warp() {
+    let program_id = Pubkey::new_unique();
+    // Initialize and start the test network
+    let program_test = ProgramTest::default();
+
+    let mut context = program_test.start_with_context().await;
+    let account_size = 100;
+    let keypair = Keypair::new();
+    let account_lamports = Rent::default().minimum_balance(account_size) - 100; // not rent exempt
+    let instruction = system_instruction::create_account(
+        &context.payer.pubkey(),
+        &keypair.pubkey(),
+        account_lamports,
+        account_size as u64,
+        &program_id,
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+    let account = context
+        .banks_client
+        .get_account(keypair.pubkey())
+        .await
+        .expect("account exists")
+        .unwrap();
+    assert_eq!(account.lamports, account_lamports);
+
+    // this test is a bit flaky because of the bank freezing non-deterministically,
+    // so we do a few warps and hope that one of them gets it
+
+    // go forward and see that rent has been collected
+    context.warp_to_slot(DEFAULT_DEV_SLOTS_PER_EPOCH).unwrap();
+
+    // go forward and see that rent has been collected
+    context
+        .warp_to_slot(DEFAULT_DEV_SLOTS_PER_EPOCH * 2)
+        .unwrap();
+
+    let account = context
+        .banks_client
+        .get_account(keypair.pubkey())
+        .await
+        .expect("account exists")
+        .unwrap();
+    assert!(account.lamports < account_lamports);
+}
+
+#[tokio::test]
+async fn stake_rewards_from_warp() {
+    // Initialize and start the test network
+    let program_test = ProgramTest::default();
+
+    let mut context = program_test.start_with_context().await;
+    let staker_keypair = Keypair::new();
+    let stake_keypair = Keypair::new();
+    let stake_lamports = 1_000_000_000_000;
+    let instructions = stake_instruction::create_account_and_delegate_stake(
+        &context.payer.pubkey(),
+        &stake_keypair.pubkey(),
+        &context.voter.pubkey(),
+        &Authorized::auto(&staker_keypair.pubkey()),
+        &Lockup::default(),
+        stake_lamports,
+    );
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer, &stake_keypair, &staker_keypair],
+        context.last_blockhash,
+    );
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+    let account = context
+        .banks_client
+        .get_account(stake_keypair.pubkey())
+        .await
+        .expect("account exists")
+        .unwrap();
+    assert_eq!(account.lamports, stake_lamports);
+
+    // warp a few slots, no rewards collected
+    context.warp_to_slot(10).unwrap();
+    let account = context
+        .banks_client
+        .get_account(stake_keypair.pubkey())
+        .await
+        .expect("account exists")
+        .unwrap();
+    assert_eq!(account.lamports, stake_lamports);
+
+    // go forward and see that rewards have been distributed
+    context
+        .warp_to_slot(DEFAULT_DEV_SLOTS_PER_EPOCH * 2)
+        .unwrap();
+
+    let account = context
+        .banks_client
+        .get_account(stake_keypair.pubkey())
+        .await
+        .expect("account exists")
+        .unwrap();
+    assert!(account.lamports > stake_lamports);
 }

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -142,13 +142,9 @@ async fn rent_collected_from_warp() {
         .unwrap();
     assert_eq!(account.lamports, account_lamports);
 
-    // this test is a bit flaky because of the bank freezing non-deterministically,
-    // so we do a few warps and hope that one of them gets it
-
-    // go forward and see that rent has been collected
+    // Warp forward and see that rent has been collected
+    // This test was a bit flaky with one warp, but two warps always works
     context.warp_to_slot(DEFAULT_DEV_SLOTS_PER_EPOCH).unwrap();
-
-    // go forward and see that rent has been collected
     context
         .warp_to_slot(DEFAULT_DEV_SLOTS_PER_EPOCH * 2)
         .unwrap();

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -12,6 +12,7 @@ use {
     },
     solana_program_test::{processor, ProgramTest, ProgramTestError},
     solana_sdk::{
+        epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
         signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
     },
@@ -222,8 +223,8 @@ async fn stake_rewards_from_warp() {
         .unwrap();
     assert_eq!(account.lamports, stake_lamports);
 
-    // warp a few slots, no rewards collected
-    context.warp_to_slot(10).unwrap();
+    // warp one epoch forward for normal inflation, no rewards collected
+    context.warp_to_slot(MINIMUM_SLOTS_PER_EPOCH).unwrap();
     let account = context
         .banks_client
         .get_account(stake_keypair.pubkey())
@@ -232,7 +233,7 @@ async fn stake_rewards_from_warp() {
         .unwrap();
     assert_eq!(account.lamports, stake_lamports);
 
-    context.simulate_vote_activity(&vote_keypair.pubkey(), 100);
+    context.increment_vote_account_credits(&vote_keypair.pubkey(), 100);
 
     // go forward and see that rewards have been distributed
     context


### PR DESCRIPTION
#### Problem

Warping the bank forward in program-test worked for updating the sysvar clock, which is helpful for some testing usecases.  For stake pools, they will need to simulate stake rewards being distributed to various stake accounts.

#### Summary of Changes

Add the ability to simulate votes for staking rewards and a test.  I tried using the vote program directly, but without a history of hashes, I was unable to get any votes to succeed.

This also adds a rent collection test.

Fixes #
