### PR TITLE
Introduce minimalistic ttl eviction for Recycler/PinnedVec

### DIFF
--- a/perf/benches/recycler.rs
+++ b/perf/benches/recycler.rs
@@ -1,0 +1,23 @@
+#![feature(test)]
+
+extern crate test;
+
+use solana_perf::recycler::Recycler;
+use test::Bencher;
+
+#[bench]
+fn bench_recycler(bencher: &mut Bencher) {
+    solana_logger::setup();
+
+    let recycler = Recycler::default();
+
+    for _ in 0..1000 {
+        let mut p = solana_perf::packet::Packets::with_capacity(128);
+        p.packets.resize(128, solana_sdk::packet::Packet::default());
+        recycler.recycle_for_test(p.packets);
+    }
+
+    bencher.iter(move || {
+        recycler.recycle_for_test(recycler.allocate("me"));
+    });
+}

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -76,6 +76,9 @@ impl<T: Default + Clone + Sized> Reset for PinnedVec<T> {
     fn set_recycler(&mut self, recycler: Weak<RecyclerX<Self>>) {
         self.recycler = Some(recycler);
     }
+    fn unset_recycler(&mut self) {
+        self.recycler = None;
+    }
 }
 
 impl<T: Clone + Default + Sized> Default for PinnedVec<T> {


### PR DESCRIPTION
#### Problem

PinnedVec tends to leak indefinitely due to some past burst.

https://github.com/solana-labs/solana/issues/14366#issuecomment-761295421

> > @sakridge could this also be a legimate leak aside from the Vec HashMap capacity leak? I don't think we need 5GB / 3GB heap data at any given moment to run validator...
> 
> The recyclers just allocate to cover the transitional load and don't size down generally. Potentially we can size down with some heuristic if we can detect there is too much being held onto.

#### Summary of Changes

Amortized very-lightweight (1 vdso call for writes, 1 vdso + 2 `O(1)` VecDeque ops + 1 `T::drop()` for reads) eviction at each read from Recycler only when there has been enough capacity for the last hour.