### PR TITLE
use thread pool for non-index hash calculations

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1050,6 +1050,7 @@ fn new_banks_from_ledger(
             None,
             &snapshot_config.snapshot_package_output_path,
             snapshot_config.archive_format,
+            &bank_forks.root_bank().get_thread_pool(),
         )
         .unwrap_or_else(|err| {
             error!("Unable to create snapshot: {}", err);

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -45,6 +45,7 @@ mod tests {
     };
     use solana_runtime::{
         accounts_background_service::{ABSRequestSender, SnapshotRequestHandler},
+        accounts_db,
         bank::{Bank, BankSlotDelta},
         bank_forks::{ArchiveFormat, BankForks, SnapshotConfig},
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
@@ -241,7 +242,10 @@ mod tests {
             None,
         )
         .unwrap();
-        let snapshot_package = snapshot_utils::process_accounts_package_pre(snapshot_package);
+        let snapshot_package = snapshot_utils::process_accounts_package_pre(
+            snapshot_package,
+            Some(&last_bank.get_thread_pool()),
+        );
         snapshot_utils::archive_snapshot_package(&snapshot_package).unwrap();
 
         // Restore bank from snapshot
@@ -419,6 +423,8 @@ mod tests {
             &cluster_info,
         );
 
+        let thread_pool = accounts_db::make_min_priority_thread_pool();
+
         let _package_receiver = std::thread::Builder::new()
             .name("package-receiver".to_string())
             .spawn(move || {
@@ -431,6 +437,7 @@ mod tests {
                     let snapshot_package =
                         solana_runtime::snapshot_utils::process_accounts_package_pre(
                             snapshot_package,
+                            Some(&thread_pool),
                         );
                     *pending_snapshot_package.lock().unwrap() = Some(snapshot_package);
                 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1933,6 +1933,7 @@ fn main() {
                         Some(snapshot_version),
                         output_directory,
                         ArchiveFormat::TarZstd,
+                        &bank.get_thread_pool(),
                     )
                     .unwrap_or_else(|err| {
                         eprintln!("Unable to create snapshot: {}", err);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -27,6 +27,7 @@ use crate::{
 use byteorder::{ByteOrder, LittleEndian};
 use itertools::Itertools;
 use log::*;
+use rayon::ThreadPool;
 use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, inc_new_counter_debug, inc_new_counter_info};
 use solana_sdk::{
@@ -4305,6 +4306,10 @@ impl Bank {
 
     pub fn get_accounts_hash(&self) -> Hash {
         self.rc.accounts.accounts_db.get_accounts_hash(self.slot)
+    }
+
+    pub fn get_thread_pool(&self) -> &ThreadPool {
+        &self.rc.accounts.accounts_db.thread_pool_clean
     }
 
     pub fn update_accounts_hash_with_index_option(


### PR DESCRIPTION
#### Problem
can't let hash calculations consume all threads

#### Summary of Changes
use a smaller thread pool

Fixes #
