### PR TITLE
Sortable feature status list

### DIFF
--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -70,7 +70,7 @@ impl fmt::Display for CliFeatures {
                 f,
                 "{}",
                 style(format!(
-                    "{:<44} {:<28} {}",
+                    "{:<44} | {:<27} | {}",
                     "Feature", "Status", "Description"
                 ))
                 .bold()
@@ -79,7 +79,7 @@ impl fmt::Display for CliFeatures {
         for feature in &self.features {
             writeln!(
                 f,
-                "{:<44} {:<28} {}",
+                "{:<44} | {:<27} | {}",
                 feature.id,
                 match feature.status {
                     CliFeatureStatus::Inactive => style("inactive".to_string()).red(),


### PR DESCRIPTION
#### Problem

CLI feature status list not sortable

#### Summary of Changes

Add ` | ` seperator

New output looks like:
```
Feature                                      | Status                      | Description
DummyEnab1eAddress1111111111111111111111111  | inactive                    | Full inflation enabled by candidate_example
DummyVoteAddress111111111111111111111111111  | inactive                    | Community vote allowing candidate_example to enable full inflation
MoqiU1vryuCGQSxFKA1SZ316JdLEFFhoAu6cKUNk7dN  | active since slot 45884260  | pubkey log syscall
NamwT9ejvrfcPXrCHEwp7BvUUFKPgVznu66HZUgFD9w  | inactive                    | Full inflation enabled by Nam
YCKSgA6XmjtkQrHBQjpyNrX6EMhJPcYcLWMVgWn36iv  | active since slot 41564260  | max program call depth 64
xGbcW7EEC7zMRJ6LaJCob65EJxKryWjwM4rv8f57SRM  | active since slot 57116256  | loader not authorized via CPI
26Bq2mgEJr93MtGTErrHNnhkDYWMoW7r7VB54r9erb5u | inactive                    | Full inflation enabled by rockx
2cGj3HJYPhBrtQizd7YbBxEsifFs5qhzabyFjUAp6dBa | active since slot 47612256  | add timestamp-correction bounding #13120
2wftmZhmArxv3eKjoRz4ffw385eZunydQU3Ruku1kvRX | inactive                    | Full inflation enabled by lowfeevalidation
```

Fixes #
