### PR TITLE
RPC: add caching to getLargestAccounts

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -8,6 +8,7 @@ pub mod mock_sender;
 pub mod nonce_utils;
 pub mod perf_utils;
 pub mod pubsub_client;
+pub mod rpc_cache;
 pub mod rpc_client;
 pub mod rpc_config;
 pub mod rpc_custom_error;

--- a/client/src/rpc_cache.rs
+++ b/client/src/rpc_cache.rs
@@ -1,0 +1,169 @@
+use crate::rpc_config::RpcLargestAccountsConfig;
+use crate::rpc_response::RpcAccountBalance;
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
+
+#[derive(Debug, Clone)]
+pub struct LargestAccountsCache {
+    size: usize,
+    duration: u64,
+    cache: HashMap<RpcLargestAccountsConfig, LargestAccountsCacheValue>,
+}
+
+#[derive(Debug, Clone)]
+struct LargestAccountsCacheValue {
+    accounts: Vec<RpcAccountBalance>,
+    cached_time: SystemTime,
+}
+
+impl LargestAccountsCache {
+    pub fn new(size: usize, duration: u64) -> Self {
+        Self {
+            size,
+            duration,
+            cache: HashMap::new(),
+        }
+    }
+
+    pub fn get_largest_accounts(
+        &self,
+        config: &RpcLargestAccountsConfig,
+    ) -> Option<Vec<RpcAccountBalance>> {
+        self.cache.get(&config).map(|value| {
+            value.cached_time.elapsed().ok().map(|elapsed| {
+                if elapsed < Duration::from_secs(self.duration) {
+                    Some(value.accounts.clone())
+                } else {
+                    None
+                }
+            })?
+        })?
+    }
+
+    pub fn set_largest_accounts(
+        &mut self,
+        config: &RpcLargestAccountsConfig,
+        accounts: &[RpcAccountBalance],
+    ) {
+        if self.cache.len() >= self.size {
+            self.evict();
+        }
+
+        if self.cache.len() < self.size {
+            self.cache.insert(
+                config.clone(),
+                LargestAccountsCacheValue {
+                    accounts: accounts.to_owned(),
+                    cached_time: SystemTime::now(),
+                },
+            );
+        }
+    }
+
+    fn evict(&mut self) {
+        let duration = Duration::from_secs(self.duration);
+        self.cache.retain(|_key, value| {
+            if let Ok(elapsed) = value.cached_time.elapsed() {
+                elapsed < duration
+            } else {
+                false
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use crate::rpc_cache::LargestAccountsCache;
+    use crate::rpc_config::{RpcLargestAccountsConfig, RpcLargestAccountsFilter};
+    use crate::rpc_response::RpcAccountBalance;
+    use std::time::Duration;
+
+    #[test]
+    fn test_cache_stays_within_size_limit() {
+        let mut cache = LargestAccountsCache::new(2, 30);
+
+        let config = RpcLargestAccountsConfig {
+            commitment: None,
+            filter: None,
+        };
+
+        let config2 = RpcLargestAccountsConfig {
+            commitment: None,
+            filter: Some(RpcLargestAccountsFilter::Circulating),
+        };
+
+        let config3 = RpcLargestAccountsConfig {
+            commitment: None,
+            filter: Some(RpcLargestAccountsFilter::NonCirculating),
+        };
+
+        let accounts: Vec<RpcAccountBalance> = Vec::new();
+
+        cache.set_largest_accounts(&config, &accounts);
+        cache.set_largest_accounts(&config2, &accounts);
+        cache.set_largest_accounts(&config3, &accounts);
+
+        assert_eq!(cache.cache.len(), 2);
+    }
+
+    #[test]
+    fn test_old_entries_expire() {
+        let mut cache = LargestAccountsCache::new(2, 1);
+
+        let config = RpcLargestAccountsConfig {
+            commitment: None,
+            filter: None,
+        };
+
+        let accounts: Vec<RpcAccountBalance> = Vec::new();
+
+        cache.set_largest_accounts(&config, &accounts);
+        std::thread::sleep(Duration::from_secs(1));
+        assert_eq!(cache.get_largest_accounts(&config), None);
+    }
+
+    #[test]
+    fn test_old_entries_get_evicted() {
+        let mut cache = LargestAccountsCache::new(2, 1);
+
+        let config = RpcLargestAccountsConfig {
+            commitment: None,
+            filter: None,
+        };
+
+        let config2 = RpcLargestAccountsConfig {
+            commitment: None,
+            filter: Some(RpcLargestAccountsFilter::Circulating),
+        };
+
+        let config3 = RpcLargestAccountsConfig {
+            commitment: None,
+            filter: Some(RpcLargestAccountsFilter::NonCirculating),
+        };
+
+        let accounts: Vec<RpcAccountBalance> = Vec::new();
+
+        cache.set_largest_accounts(&config, &accounts);
+        cache.set_largest_accounts(&config2, &accounts);
+        std::thread::sleep(Duration::from_secs(1));
+        cache.set_largest_accounts(&config3, &accounts);
+        assert_eq!(cache.cache.len(), 1);
+    }
+
+    #[test]
+    fn test_entries_hashed_the_same() {
+        let mut cache = LargestAccountsCache::new(2, 2);
+
+        let config = RpcLargestAccountsConfig {
+            commitment: None,
+            filter: None,
+        };
+
+        let accounts: Vec<RpcAccountBalance> = vec![];
+
+        cache.set_largest_accounts(&config, &accounts);
+        cache.set_largest_accounts(&config, &accounts);
+        assert_eq!(cache.cache.len(), 1);
+    }
+}

--- a/client/src/rpc_cache.rs
+++ b/client/src/rpc_cache.rs
@@ -29,15 +29,14 @@ impl LargestAccountsCache {
         &self,
         config: &RpcLargestAccountsConfig,
     ) -> Option<Vec<RpcAccountBalance>> {
-        self.cache.get(&config).map(|value| {
-            value.cached_time.elapsed().ok().map(|elapsed| {
+        self.cache.get(&config).and_then(|value| {
+            if let Ok(elapsed) = value.cached_time.elapsed() {
                 if elapsed < Duration::from_secs(self.duration) {
-                    Some(value.accounts.clone())
-                } else {
-                    None
+                    return Some(value.accounts.clone())
                 }
-            })?
-        })?
+            }
+            None
+        })
     }
 
     pub fn set_largest_accounts(

--- a/client/src/rpc_cache.rs
+++ b/client/src/rpc_cache.rs
@@ -1,7 +1,11 @@
-use crate::rpc_config::RpcLargestAccountsFilter;
-use crate::rpc_response::RpcAccountBalance;
-use std::collections::HashMap;
-use std::time::{Duration, SystemTime};
+use crate::{
+    rpc_config::RpcLargestAccountsFilter,
+    rpc_response::RpcAccountBalance,
+};
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
 
 #[derive(Debug, Clone)]
 pub struct LargestAccountsCache {
@@ -54,10 +58,7 @@ impl LargestAccountsCache {
 
 #[cfg(test)]
 pub mod test {
-    use crate::rpc_cache::LargestAccountsCache;
-    use crate::rpc_config::RpcLargestAccountsFilter;
-    use crate::rpc_response::RpcAccountBalance;
-    use std::time::Duration;
+    use super::*;
 
     #[test]
     fn test_old_entries_expire() {

--- a/client/src/rpc_cache.rs
+++ b/client/src/rpc_cache.rs
@@ -1,7 +1,4 @@
-use crate::{
-    rpc_config::RpcLargestAccountsFilter,
-    rpc_response::RpcAccountBalance,
-};
+use crate::{rpc_config::RpcLargestAccountsFilter, rpc_response::RpcAccountBalance};
 use std::{
     collections::HashMap,
     time::{Duration, SystemTime},
@@ -16,6 +13,7 @@ pub struct LargestAccountsCache {
 #[derive(Debug, Clone)]
 struct LargestAccountsCacheValue {
     accounts: Vec<RpcAccountBalance>,
+    slot: u64,
     cached_time: SystemTime,
 }
 
@@ -30,11 +28,11 @@ impl LargestAccountsCache {
     pub fn get_largest_accounts(
         &self,
         filter: &Option<RpcLargestAccountsFilter>,
-    ) -> Option<Vec<RpcAccountBalance>> {
+    ) -> Option<(u64, Vec<RpcAccountBalance>)> {
         self.cache.get(&filter).and_then(|value| {
             if let Ok(elapsed) = value.cached_time.elapsed() {
                 if elapsed < Duration::from_secs(self.duration) {
-                    return Some(value.accounts.clone());
+                    return Some((value.slot, value.accounts.clone()));
                 }
             }
             None
@@ -44,12 +42,14 @@ impl LargestAccountsCache {
     pub fn set_largest_accounts(
         &mut self,
         filter: &Option<RpcLargestAccountsFilter>,
+        slot: u64,
         accounts: &[RpcAccountBalance],
     ) {
         self.cache.insert(
             filter.clone(),
             LargestAccountsCacheValue {
                 accounts: accounts.to_owned(),
+                slot,
                 cached_time: SystemTime::now(),
             },
         );
@@ -68,7 +68,7 @@ pub mod test {
 
         let accounts: Vec<RpcAccountBalance> = Vec::new();
 
-        cache.set_largest_accounts(&filter, &accounts);
+        cache.set_largest_accounts(&filter, 1000, &accounts);
         std::thread::sleep(Duration::from_secs(1));
         assert_eq!(cache.get_largest_accounts(&filter), None);
     }

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -31,14 +31,14 @@ pub struct RpcSimulateTransactionConfig {
     pub encoding: Option<UiTransactionEncoding>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum RpcLargestAccountsFilter {
     Circulating,
     NonCirculating,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcLargestAccountsConfig {
     #[serde(flatten)]

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -38,7 +38,7 @@ pub enum RpcLargestAccountsFilter {
     NonCirculating,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcLargestAccountsConfig {
     #[serde(flatten)]

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -515,9 +515,7 @@ impl JsonRpcRequestProcessor {
         config: &RpcLargestAccountsConfig,
     ) -> Option<Vec<RpcAccountBalance>> {
         let largest_accounts_cache = self.largest_accounts_cache.read().unwrap();
-        let results = largest_accounts_cache.get_largest_accounts(config);
-        drop(largest_accounts_cache);
-        results
+        largest_accounts_cache.get_largest_accounts(config)
     }
 
     fn set_cached_largest_accounts(
@@ -526,8 +524,7 @@ impl JsonRpcRequestProcessor {
         accounts: &[RpcAccountBalance],
     ) {
         let mut largest_accounts_cache = self.largest_accounts_cache.write().unwrap();
-        largest_accounts_cache.set_largest_accounts(config, accounts);
-        drop(largest_accounts_cache);
+        largest_accounts_cache.set_largest_accounts(config, accounts)
     }
 
     fn get_largest_accounts(

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -16,6 +16,7 @@ use jsonrpc_http_server::{
     RequestMiddlewareAction, ServerBuilder,
 };
 use regex::Regex;
+use solana_client::rpc_cache::LargestAccountsCache;
 use solana_ledger::blockstore::Blockstore;
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::{
@@ -34,6 +35,9 @@ use std::{
 };
 use tokio::runtime;
 use tokio_util::codec::{BytesCodec, FramedRead};
+
+const LARGEST_ACCOUNTS_CACHE_SIZE: usize = 16;
+const LARGEST_ACCOUNTS_CACHE_DURATION: u64 = 60 * 60 * 2;
 
 pub struct JsonRpcService {
     thread_hdl: JoinHandle<()>,
@@ -262,6 +266,11 @@ impl JsonRpcService {
             override_health_check,
         ));
 
+        let largest_accounts_cache = Arc::new(RwLock::new(LargestAccountsCache::new(
+            LARGEST_ACCOUNTS_CACHE_SIZE,
+            LARGEST_ACCOUNTS_CACHE_DURATION,
+        )));
+
         let tpu_address = cluster_info.my_contact_info().tpu;
         let runtime = Arc::new(
             runtime::Builder::new_multi_thread()
@@ -322,6 +331,7 @@ impl JsonRpcService {
             runtime,
             bigtable_ledger_storage,
             optimistically_confirmed_bank,
+            largest_accounts_cache,
         );
 
         let leader_info =

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -36,7 +36,6 @@ use std::{
 use tokio::runtime;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
-const LARGEST_ACCOUNTS_CACHE_SIZE: usize = 16;
 const LARGEST_ACCOUNTS_CACHE_DURATION: u64 = 60 * 60 * 2;
 
 pub struct JsonRpcService {
@@ -267,7 +266,6 @@ impl JsonRpcService {
         ));
 
         let largest_accounts_cache = Arc::new(RwLock::new(LargestAccountsCache::new(
-            LARGEST_ACCOUNTS_CACHE_SIZE,
             LARGEST_ACCOUNTS_CACHE_DURATION,
         )));
 

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 use thiserror::Error;
 
-#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitmentConfig {
     pub commitment: CommitmentLevel,

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 use thiserror::Error;
 
-#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Default, Clone, Copy, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitmentConfig {
     pub commitment: CommitmentLevel,


### PR DESCRIPTION
#### Problem
The `getLargestAccounts` RPC call takes ~14 seconds (based on haproxy logs on the server).  We should cache this in the RPC subsystem in the validator and probably only refresh it once every couple hours. 

#### Summary of Changes
Implements a two hour cache on getLargestAccounts w/ its various config options.

Fixes https://github.com/solana-labs/solana/issues/14602
