### PR TITLE
Only publish release-tag docs on beta channel

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -18,9 +18,15 @@ source ../ci/rust-version.sh
 npm run build
 echo $?
 
-# Publish only from merge commits and release tags
+eval "$(../ci/channel-info.sh)"
+
+# Publish only from merge commits and beta release tags
 if [[ -n $CI ]]; then
   if [[ -z $CI_PULL_REQUEST ]]; then
+    if [[ -n $CI_TAG ]] && [[ $CI_TAG != $BETA_CHANNEL* ]]; then
+      echo "not a beta tag"
+      exit 0
+    fi
     ./publish-docs.sh
   fi
 fi


### PR DESCRIPTION
#### Problem
Our intention is to maintain the `beta` channel docs on docs.solana.com. However, docs.solana.com gets overwritten on newer stable releases (and presumably would on any edge-channel tags as well).

#### Summary of Changes
Only publish docs on beta channel release tags
