### PR TITLE
pass expected capitalization to hash calculation to improve assert msg

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -113,6 +113,7 @@ fn main() {
                 solana_sdk::clock::Slot::default(),
                 &ancestors,
                 true,
+                None,
             );
             time_store.stop();
             if results != results_store {

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
             time.stop();
             let mut time_store = Measure::start("hash using store");
             let results_store = accounts.accounts_db.update_accounts_hash_with_index_option(
-                true,
+                false,
                 false,
                 solana_sdk::clock::Slot::default(),
                 &ancestors,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -123,7 +123,7 @@ impl SnapshotRequestHandler {
                 let mut hash_time = Measure::start("hash_time");
                 const USE_INDEX: bool = true;
                 snapshot_root_bank
-                    .update_accounts_hash_with_index_option(!USE_INDEX, test_hash_calculation);
+                    .update_accounts_hash_with_index_option(USE_INDEX, test_hash_calculation);
                 let hash_for_testing = if test_hash_calculation {
                     Some(snapshot_root_bank.get_accounts_hash())
                 } else {

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -121,13 +121,14 @@ impl SnapshotRequestHandler {
                 flush_accounts_cache_time.stop();
 
                 let mut hash_time = Measure::start("hash_time");
-                let mut hash_for_testing = None;
                 const USE_INDEX: bool = true;
                 snapshot_root_bank
                     .update_accounts_hash_with_index_option(!USE_INDEX, test_hash_calculation);
-                if test_hash_calculation {
-                    hash_for_testing = Some(snapshot_root_bank.get_accounts_hash());
-                }
+                let hash_for_testing = if test_hash_calculation {
+                    Some(snapshot_root_bank.get_accounts_hash())
+                } else {
+                    None
+                };
                 hash_time.stop();
 
                 let mut clean_time = Measure::start("clean_time");

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3868,12 +3868,12 @@ impl AccountsDB {
 
     fn calculate_accounts_hash_helper(
         &self,
-        do_not_use_index: bool,
+        use_index: bool,
         slot: Slot,
         ancestors: &Ancestors,
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
-        if do_not_use_index {
+        if !use_index {
             let combined_maps = self.get_snapshot_storages(slot);
 
             Self::calculate_accounts_hash_without_index(
@@ -3897,7 +3897,7 @@ impl AccountsDB {
         expected_capitalization: Option<u64>,
     ) -> (Hash, u64) {
         let (hash, total_lamports) = self.calculate_accounts_hash_helper(
-            !use_index,
+            use_index,
             slot,
             ancestors,
             simple_capitalization_enabled,
@@ -3905,7 +3905,7 @@ impl AccountsDB {
         if debug_verify {
             // calculate the other way (store or non-store) and verify results match.
             let (hash_other, total_lamports_other) = self.calculate_accounts_hash_helper(
-                use_index,
+                !use_index,
                 slot,
                 ancestors,
                 simple_capitalization_enabled,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3914,7 +3914,7 @@ impl AccountsDB {
             let succeed = hash == hash_other
                 && total_lamports == total_lamports_other
                 && total_lamports == expected_capitalization.unwrap_or(total_lamports);
-            assert!(succeed, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, use_index);
+            assert!(succeed, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}, slot: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, use_index, slot);
         }
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3911,10 +3911,10 @@ impl AccountsDB {
                 simple_capitalization_enabled,
             );
 
-            let succeed = hash == hash_other
+            let success = hash == hash_other
                 && total_lamports == total_lamports_other
                 && total_lamports == expected_capitalization.unwrap_or(total_lamports);
-            assert!(succeed, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}, slot: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, use_index, slot);
+            assert!(success, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}, slot: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, use_index, slot);
         }
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3629,6 +3629,7 @@ impl AccountsDB {
             slot,
             ancestors,
             simple_capitalization_enabled,
+            None,
         )
     }
 
@@ -3644,6 +3645,7 @@ impl AccountsDB {
             slot,
             ancestors,
             simple_capitalization_enabled,
+            None,
         )
     }
 
@@ -3892,6 +3894,7 @@ impl AccountsDB {
         slot: Slot,
         ancestors: &Ancestors,
         simple_capitalization_enabled: bool,
+        expected_capitalization: Option<u64>,
     ) -> (Hash, u64) {
         let (hash, total_lamports) = self.calculate_accounts_hash_helper(
             do_not_use_index,
@@ -3908,8 +3911,10 @@ impl AccountsDB {
                 simple_capitalization_enabled,
             );
 
-            assert_eq!(hash, hash_other);
-            assert_eq!(total_lamports, total_lamports_other);
+            let succeed = hash == hash_other
+                && total_lamports == total_lamports_other
+                && total_lamports == expected_capitalization.unwrap_or(total_lamports);
+            assert!(succeed, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, !do_not_use_index);
         }
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3624,7 +3624,7 @@ impl AccountsDB {
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
         self.update_accounts_hash_with_index_option(
-            false,
+            true,
             false,
             slot,
             ancestors,
@@ -3640,7 +3640,7 @@ impl AccountsDB {
         simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
         self.update_accounts_hash_with_index_option(
-            false,
+            true,
             true,
             slot,
             ancestors,
@@ -3889,7 +3889,7 @@ impl AccountsDB {
 
     pub fn update_accounts_hash_with_index_option(
         &self,
-        do_not_use_index: bool,
+        use_index: bool,
         debug_verify: bool,
         slot: Slot,
         ancestors: &Ancestors,
@@ -3897,7 +3897,7 @@ impl AccountsDB {
         expected_capitalization: Option<u64>,
     ) -> (Hash, u64) {
         let (hash, total_lamports) = self.calculate_accounts_hash_helper(
-            do_not_use_index,
+            !use_index,
             slot,
             ancestors,
             simple_capitalization_enabled,
@@ -3905,7 +3905,7 @@ impl AccountsDB {
         if debug_verify {
             // calculate the other way (store or non-store) and verify results match.
             let (hash_other, total_lamports_other) = self.calculate_accounts_hash_helper(
-                !do_not_use_index,
+                use_index,
                 slot,
                 ancestors,
                 simple_capitalization_enabled,
@@ -3914,7 +3914,7 @@ impl AccountsDB {
             let succeed = hash == hash_other
                 && total_lamports == total_lamports_other
                 && total_lamports == expected_capitalization.unwrap_or(total_lamports);
-            assert!(succeed, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, !do_not_use_index);
+            assert!(succeed, "update_accounts_hash_with_index_option mismatch. hashes: {}, {}; lamports: {}, {}; expected lamports: {:?}, using index: {}", hash, hash_other, total_lamports, total_lamports_other, expected_capitalization, use_index);
         }
         let mut bank_hashes = self.bank_hashes.write().unwrap();
         let mut bank_hash_info = bank_hashes.get_mut(&slot).unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4327,6 +4327,7 @@ impl Bank {
                 self.slot(),
                 &self.ancestors,
                 self.simple_capitalization_enabled(),
+                Some(self.capitalization()),
             );
         assert_eq!(total_lamports, self.capitalization());
         hash

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4322,7 +4322,7 @@ impl Bank {
             .accounts
             .accounts_db
             .update_accounts_hash_with_index_option(
-                !use_index,
+                use_index,
                 debug_verify,
                 self.slot(),
                 &self.ancestors,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4314,7 +4314,7 @@ impl Bank {
 
     pub fn update_accounts_hash_with_index_option(
         &self,
-        do_not_use_index: bool,
+        use_index: bool,
         debug_verify: bool,
     ) -> Hash {
         let (hash, total_lamports) = self
@@ -4322,7 +4322,7 @@ impl Bank {
             .accounts
             .accounts_db
             .update_accounts_hash_with_index_option(
-                do_not_use_index,
+                !use_index,
                 debug_verify,
                 self.slot(),
                 &self.ancestors,
@@ -4334,7 +4334,7 @@ impl Bank {
     }
 
     pub fn update_accounts_hash(&self) -> Hash {
-        self.update_accounts_hash_with_index_option(false, false)
+        self.update_accounts_hash_with_index_option(true, false)
     }
 
     /// A snapshot bank should be purged of 0 lamport accounts which are not part of the hash


### PR DESCRIPTION
Problem
With a debug flag to the validator (--accounts-db-test-hash-calculation), the validator can calculate hash and lamports 2 ways and compare. If the two ways conflict, we fail to report the comparison of lamports to the bank's expected capitalization.

Summary of Changes
Pass the bank's expected capitalization and compare it and print it on assertion.
Also, cleanup an if, and remove a double-negative from a parameter.

Fixes #