### PR TITLE
Warp timestamp and extend max-allowable-drift for accommodate slow blocks

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -387,11 +387,6 @@ intermittently adding a timestamp to a Vote for a particular block. A requested
 block's time is calculated from the stake-weighted mean of the Vote timestamps
 in a set of recent blocks recorded on the ledger.
 
-Nodes that are booting from snapshot or limiting ledger size (by purging old
-slots) will return null timestamps for blocks below their lowest root +
-`TIMESTAMP_SLOT_RANGE`. Users interested in having this historical data must
-query a node that is built from genesis and retains the entire ledger.
-
 #### Parameters:
 
 - `<u64>` - block, identified by Slot

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -24,20 +24,13 @@ use rocksdb::DBRawIterator;
 use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, datapoint_error};
 use solana_rayon_threadlimit::get_thread_count;
-use solana_runtime::{
-    hardened_unpack::{unpack_genesis_archive, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE},
-    vote_account::ArcVoteAccount,
-};
+use solana_runtime::hardened_unpack::{unpack_genesis_archive, MAX_GENESIS_ARCHIVE_UNPACKED_SIZE};
 use solana_sdk::{
     clock::{Slot, UnixTimestamp, DEFAULT_TICKS_PER_SECOND, MS_PER_TICK},
     genesis_config::GenesisConfig,
     hash::Hash,
-    program_utils::limited_deserialize,
     pubkey::Pubkey,
     signature::{Keypair, Signature, Signer},
-    stake_weighted_timestamp::{
-        calculate_stake_weighted_timestamp, EstimateType, TIMESTAMP_SLOT_RANGE,
-    },
     timing::timestamp,
     transaction::Transaction,
 };
@@ -46,7 +39,6 @@ use solana_transaction_status::{
     ConfirmedBlock, ConfirmedTransaction, ConfirmedTransactionStatusWithSignature, Rewards,
     TransactionStatusMeta, TransactionWithStatusMeta,
 };
-use solana_vote_program::vote_instruction::VoteInstruction;
 use std::{
     cell::RefCell,
     cmp,
@@ -59,7 +51,6 @@ use std::{
         mpsc::{sync_channel, Receiver, SyncSender, TrySendError},
         Arc, Mutex, RwLock,
     },
-    time::Duration,
 };
 use thiserror::Error;
 use trees::{Tree, TreeWalk};
@@ -1682,83 +1673,11 @@ impl Blockstore {
         self.blocktime_cf.get(slot)
     }
 
-    fn get_timestamp_slots(&self, slot: Slot, timestamp_sample_range: usize) -> Vec<Slot> {
-        let root_iterator = self
-            .db
-            .iter::<cf::Root>(IteratorMode::From(slot, IteratorDirection::Reverse));
-        if !self.is_root(slot) || root_iterator.is_err() {
-            return vec![];
-        }
-        let mut get_slots = Measure::start("get_slots");
-        let mut timestamp_slots: Vec<Slot> = root_iterator
-            .unwrap()
-            .map(|(iter_slot, _)| iter_slot)
-            .take(timestamp_sample_range)
-            .collect();
-        timestamp_slots.sort_unstable();
-        get_slots.stop();
-        datapoint_info!(
-            "blockstore-get-timestamp-slots",
-            ("slot", slot as i64, i64),
-            ("get_slots_us", get_slots.as_us() as i64, i64)
-        );
-        timestamp_slots
-    }
-
     pub fn cache_block_time(&self, slot: Slot, timestamp: UnixTimestamp) -> Result<()> {
         if !self.is_root(slot) {
             return Err(BlockstoreError::SlotNotRooted);
         }
         self.blocktime_cf.put(slot, &timestamp)
-    }
-
-    // DEPRECATED as of feature_set::timestamp_correction
-    pub fn cache_block_time_from_slot_entries(
-        &self,
-        slot: Slot,
-        slot_duration: Duration,
-        stakes: &HashMap<Pubkey, (u64, ArcVoteAccount)>,
-    ) -> Result<()> {
-        if !self.is_root(slot) {
-            return Err(BlockstoreError::SlotNotRooted);
-        }
-        let mut get_unique_timestamps = Measure::start("get_unique_timestamps");
-        let unique_timestamps: HashMap<Pubkey, (Slot, UnixTimestamp)> = self
-            .get_timestamp_slots(slot, TIMESTAMP_SLOT_RANGE)
-            .into_iter()
-            .flat_map(|query_slot| self.get_block_timestamps(query_slot).unwrap_or_default())
-            .collect();
-        get_unique_timestamps.stop();
-        if unique_timestamps.is_empty() {
-            return Err(BlockstoreError::NoVoteTimestampsInRange);
-        }
-
-        let mut calculate_timestamp = Measure::start("calculate_timestamp");
-        let stake_weighted_timestamp = calculate_stake_weighted_timestamp(
-            &unique_timestamps,
-            stakes,
-            slot,
-            slot_duration,
-            EstimateType::Unbounded,
-            None,
-        )
-        .ok_or(BlockstoreError::EmptyEpochStakes)?;
-        calculate_timestamp.stop();
-        datapoint_info!(
-            "blockstore-get-block-time",
-            ("slot", slot as i64, i64),
-            (
-                "get_unique_timestamps_us",
-                get_unique_timestamps.as_us() as i64,
-                i64
-            ),
-            (
-                "calculate_stake_weighted_timestamp_us",
-                calculate_timestamp.as_us() as i64,
-                i64
-            )
-        );
-        self.cache_block_time(slot, stake_weighted_timestamp)
     }
 
     pub fn get_first_available_block(&self) -> Result<Slot> {
@@ -2383,36 +2302,6 @@ impl Blockstore {
     pub fn write_rewards(&self, index: Slot, rewards: Rewards) -> Result<()> {
         let rewards = rewards.into();
         self.rewards_cf.put_protobuf(index, &rewards)
-    }
-
-    fn get_block_timestamps(&self, slot: Slot) -> Result<Vec<(Pubkey, (Slot, UnixTimestamp))>> {
-        let slot_entries = self.get_slot_entries(slot, 0)?;
-        Ok(slot_entries
-            .iter()
-            .cloned()
-            .flat_map(|entry| entry.transactions)
-            .flat_map(|transaction| {
-                let mut timestamps: Vec<(Pubkey, (Slot, UnixTimestamp))> = Vec::new();
-                for instruction in transaction.message.instructions {
-                    let program_id = instruction.program_id(&transaction.message.account_keys);
-                    if program_id == &solana_vote_program::id() {
-                        if let Ok(VoteInstruction::Vote(vote)) =
-                            limited_deserialize(&instruction.data)
-                        {
-                            if let Some(timestamp) = vote.timestamp {
-                                let timestamp_slot = vote.slots.iter().max();
-                                if let Some(timestamp_slot) = timestamp_slot {
-                                    let vote_pubkey = transaction.message.account_keys
-                                        [instruction.accounts[0] as usize];
-                                    timestamps.push((vote_pubkey, (*timestamp_slot, timestamp)));
-                                }
-                            }
-                        }
-                    }
-                }
-                timestamps
-            })
-            .collect())
     }
 
     pub fn get_recent_perf_samples(&self, num: usize) -> Result<Vec<(Slot, PerfSample)>> {
@@ -3595,7 +3484,6 @@ fn adjust_ulimit_nofile(enforce_ulimit_nofile: bool) -> Result<()> {
 pub mod tests {
     use super::*;
     use crate::{
-        blockstore_processor::fill_blockstore_slot_with_ticks,
         entry::{next_entry, next_entry_mut},
         genesis_utils::{create_genesis_config, GenesisConfigInfo},
         leader_schedule::{FixedSchedule, LeaderSchedule},
@@ -3609,7 +3497,6 @@ pub mod tests {
     use solana_sdk::{
         hash::{self, hash, Hash},
         instruction::CompiledInstruction,
-        message::Message,
         packet::PACKET_DATA_SIZE,
         pubkey::Pubkey,
         signature::Signature,
@@ -3617,7 +3504,6 @@ pub mod tests {
     };
     use solana_storage_proto::convert::generated;
     use solana_transaction_status::{InnerInstructions, Reward, Rewards};
-    use solana_vote_program::{vote_instruction, vote_state::Vote};
     use std::time::Duration;
 
     // used for tests only
@@ -5749,92 +5635,6 @@ pub mod tests {
     }
 
     #[test]
-    fn test_get_timestamp_slots() {
-        let timestamp_sample_range = 5;
-        let ticks_per_slot = 5;
-        /*
-            Build a blockstore with < TIMESTAMP_SLOT_RANGE roots
-        */
-        let blockstore_path = get_tmp_ledger_path!();
-        let blockstore = Blockstore::open(&blockstore_path).unwrap();
-        blockstore.set_roots(&[0]).unwrap();
-        let mut last_entry_hash = Hash::default();
-        for slot in 0..=3 {
-            let parent = {
-                if slot == 0 {
-                    0
-                } else {
-                    slot - 1
-                }
-            };
-            last_entry_hash = fill_blockstore_slot_with_ticks(
-                &blockstore,
-                ticks_per_slot,
-                slot,
-                parent,
-                last_entry_hash,
-            );
-        }
-        blockstore.set_roots(&[1, 2, 3]).unwrap();
-
-        assert_eq!(
-            blockstore.get_timestamp_slots(2, timestamp_sample_range),
-            vec![0, 1, 2]
-        );
-        assert_eq!(
-            blockstore.get_timestamp_slots(3, timestamp_sample_range),
-            vec![0, 1, 2, 3]
-        );
-
-        drop(blockstore);
-        Blockstore::destroy(&blockstore_path).expect("Expected successful database destruction");
-
-        /*
-            Build a blockstore in the ledger with gaps in rooted slot sequence
-
-        */
-        let blockstore_path = get_tmp_ledger_path!();
-        let blockstore = Blockstore::open(&blockstore_path).unwrap();
-        blockstore.set_roots(&[0]).unwrap();
-        let desired_roots = vec![1, 2, 3, 5, 6, 8, 11];
-        let mut last_entry_hash = Hash::default();
-        for (i, slot) in desired_roots.iter().enumerate() {
-            let parent = {
-                if i == 0 {
-                    0
-                } else {
-                    desired_roots[i - 1]
-                }
-            };
-            last_entry_hash = fill_blockstore_slot_with_ticks(
-                &blockstore,
-                ticks_per_slot,
-                *slot,
-                parent,
-                last_entry_hash,
-            );
-        }
-        blockstore.set_roots(&desired_roots).unwrap();
-
-        assert_eq!(
-            blockstore.get_timestamp_slots(2, timestamp_sample_range),
-            vec![0, 1, 2]
-        );
-        assert_eq!(
-            blockstore.get_timestamp_slots(6, timestamp_sample_range),
-            vec![1, 2, 3, 5, 6]
-        );
-        assert_eq!(
-            blockstore.get_timestamp_slots(8, timestamp_sample_range),
-            vec![2, 3, 5, 6, 8]
-        );
-        assert_eq!(
-            blockstore.get_timestamp_slots(11, timestamp_sample_range),
-            vec![3, 5, 6, 8, 11]
-        );
-    }
-
-    #[test]
     fn test_get_confirmed_block() {
         let slot = 10;
         let entries = make_slot_entries_with_transactions(100);
@@ -5961,130 +5761,6 @@ pub mod tests {
 
         drop(ledger);
         Blockstore::destroy(&ledger_path).expect("Expected successful database destruction");
-    }
-
-    #[test]
-    fn test_get_block_timestamps() {
-        let vote_keypairs: Vec<Keypair> = (0..6).map(|_| Keypair::new()).collect();
-        let base_timestamp = 1_576_183_541;
-        let mut expected_timestamps: Vec<(Pubkey, (Slot, UnixTimestamp))> = Vec::new();
-
-        // Populate slot 1 with vote transactions, some of which have timestamps
-        let mut vote_entries: Vec<Entry> = Vec::new();
-        for (i, keypair) in vote_keypairs.iter().enumerate() {
-            let timestamp = if i % 2 == 0 {
-                let unique_timestamp = base_timestamp + i as i64;
-                expected_timestamps.push((keypair.pubkey(), (1, unique_timestamp)));
-                Some(unique_timestamp)
-            } else {
-                None
-            };
-            let vote = Vote {
-                slots: vec![1],
-                hash: Hash::default(),
-                timestamp,
-            };
-            let vote_ix = vote_instruction::vote(&keypair.pubkey(), &keypair.pubkey(), vote);
-            let vote_msg = Message::new(&[vote_ix], Some(&keypair.pubkey()));
-            let vote_tx = Transaction::new(&[keypair], vote_msg, Hash::default());
-
-            vote_entries.push(next_entry_mut(&mut Hash::default(), 0, vec![vote_tx]));
-            let mut tick = create_ticks(1, 0, hash(&serialize(&i).unwrap()));
-            vote_entries.append(&mut tick);
-        }
-        let shreds = entries_to_test_shreds(vote_entries, 1, 0, true, 0);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Blockstore::open(&ledger_path).unwrap();
-        blockstore.insert_shreds(shreds, None, false).unwrap();
-        // Populate slot 2 with ticks only
-        fill_blockstore_slot_with_ticks(&blockstore, 6, 2, 1, Hash::default());
-        blockstore.set_roots(&[0, 1, 2]).unwrap();
-
-        assert_eq!(
-            blockstore.get_block_timestamps(1).unwrap(),
-            expected_timestamps
-        );
-        assert_eq!(blockstore.get_block_timestamps(2).unwrap(), vec![]);
-
-        blockstore.set_roots(&[3, 8]).unwrap();
-        let mut stakes = HashMap::new();
-        let slot_duration = Duration::from_millis(400);
-        for slot in &[1, 2, 3, 8] {
-            assert!(blockstore
-                .cache_block_time_from_slot_entries(*slot, slot_duration, &stakes)
-                .is_err());
-        }
-
-        // Build epoch vote_accounts HashMap to test stake-weighted block time
-        for (i, keypair) in vote_keypairs.iter().enumerate() {
-            stakes.insert(keypair.pubkey(), (1 + i as u64, ArcVoteAccount::default()));
-        }
-        for slot in &[1, 2, 3, 8] {
-            blockstore
-                .cache_block_time_from_slot_entries(*slot, slot_duration, &stakes)
-                .unwrap();
-        }
-        let block_time_slot_3 = blockstore.get_block_time(3);
-
-        let mut total_stake = 0;
-        let mut expected_time: u64 = (0..6)
-            .map(|x| {
-                if x % 2 == 0 {
-                    total_stake += 1 + x;
-                    (base_timestamp as u64 + x) * (1 + x)
-                } else {
-                    0
-                }
-            })
-            .sum();
-        expected_time /= total_stake;
-        assert_eq!(block_time_slot_3.unwrap().unwrap() as u64, expected_time);
-        assert_eq!(
-            blockstore.get_block_time(8).unwrap().unwrap() as u64,
-            expected_time + 2 // At 400ms block duration, 5 slots == 2sec
-        );
-    }
-
-    #[test]
-    fn test_get_block_time_no_timestamps() {
-        let vote_keypairs: Vec<Keypair> = (0..6).map(|_| Keypair::new()).collect();
-
-        // Populate slot 1 with vote transactions, none of which have timestamps
-        let mut vote_entries: Vec<Entry> = Vec::new();
-        for (i, keypair) in vote_keypairs.iter().enumerate() {
-            let vote = Vote {
-                slots: vec![1],
-                hash: Hash::default(),
-                timestamp: None,
-            };
-            let vote_ix = vote_instruction::vote(&keypair.pubkey(), &keypair.pubkey(), vote);
-            let vote_msg = Message::new(&[vote_ix], Some(&keypair.pubkey()));
-            let vote_tx = Transaction::new(&[keypair], vote_msg, Hash::default());
-
-            vote_entries.push(next_entry_mut(&mut Hash::default(), 0, vec![vote_tx]));
-            let mut tick = create_ticks(1, 0, hash(&serialize(&i).unwrap()));
-            vote_entries.append(&mut tick);
-        }
-        let shreds = entries_to_test_shreds(vote_entries, 1, 0, true, 0);
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Blockstore::open(&ledger_path).unwrap();
-        blockstore.insert_shreds(shreds, None, false).unwrap();
-        // Populate slot 2 with ticks only
-        fill_blockstore_slot_with_ticks(&blockstore, 6, 2, 1, Hash::default());
-        blockstore.set_roots(&[0, 1, 2]).unwrap();
-
-        // Build epoch vote_accounts HashMap to test stake-weighted block time
-        let mut stakes = HashMap::new();
-        for (i, keypair) in vote_keypairs.iter().enumerate() {
-            stakes.insert(keypair.pubkey(), (1 + i as u64, ArcVoteAccount::default()));
-        }
-        let slot_duration = Duration::from_millis(400);
-        for slot in &[1, 2, 3, 8] {
-            assert!(blockstore
-                .cache_block_time_from_slot_entries(*slot, slot_duration, &stakes)
-                .is_err());
-            assert_eq!(blockstore.get_block_time(*slot).unwrap(), None);
-        }
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10182,19 +10182,19 @@ pub(crate) mod tests {
             if bank.slot == 32 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "9FwpFSUvbCfzQMGXDSdvnNhNPpvHUsEJyNA9P3nqiLaJ"
+                    "4syPxVrVFUpksTre5BB5w7qd3BxSU4WzUT6R2fjFgMJ2"
                 );
             }
             if bank.slot == 64 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "7p6g7GmE9quceefLtPe97fr9YQeYWB562os2ttiG3Anq"
+                    "4GKgnCxQs6AJxcqYQkxa8oF8gEp13bfRNCm2uzCceA26"
                 );
             }
             if bank.slot == 128 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "DfeuEsVvVRUkce31sM1d4Vhhp6Si99JdVEtYddbBgLKV"
+                    "9YwXsk2qpM7bZLnWGdtqCmDEygiu1KpEcr4zWWBTUKw6"
                 );
                 break;
             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -61,8 +61,8 @@ use solana_sdk::{
     slot_hashes::SlotHashes,
     slot_history::SlotHistory,
     stake_weighted_timestamp::{
-        calculate_stake_weighted_timestamp, EstimateType,
-        DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE, MAX_ALLOWABLE_DRIFT_PERCENTAGE,
+        calculate_stake_weighted_timestamp, DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE,
+        MAX_ALLOWABLE_DRIFT_PERCENTAGE,
     },
     system_transaction,
     sysvar::{self},
@@ -1377,11 +1377,10 @@ impl Bank {
         } else {
             DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE
         };
-        let estimate_type = EstimateType::Bounded(max_allowable_drift);
 
         let ancestor_timestamp = self.clock().unix_timestamp;
         if let Some(timestamp_estimate) =
-            self.get_timestamp_estimate(estimate_type, epoch_start_timestamp)
+            self.get_timestamp_estimate(max_allowable_drift, epoch_start_timestamp)
         {
             unix_timestamp = timestamp_estimate;
             if timestamp_estimate < ancestor_timestamp {
@@ -1889,7 +1888,7 @@ impl Bank {
 
     fn get_timestamp_estimate(
         &self,
-        estimate_type: EstimateType,
+        max_allowable_drift: u32,
         epoch_start_timestamp: Option<(Slot, UnixTimestamp)>,
     ) -> Option<UnixTimestamp> {
         let mut get_timestamp_estimate_time = Measure::start("get_timestamp_estimate");
@@ -1921,8 +1920,8 @@ impl Bank {
             stakes,
             self.slot(),
             slot_duration,
-            estimate_type,
             epoch_start_timestamp,
+            max_allowable_drift,
         );
         get_timestamp_estimate_time.stop();
         datapoint_info!(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -61,8 +61,8 @@ use solana_sdk::{
     slot_hashes::SlotHashes,
     slot_history::SlotHistory,
     stake_weighted_timestamp::{
-        calculate_stake_weighted_timestamp, DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE,
-        MAX_ALLOWABLE_DRIFT_PERCENTAGE,
+        calculate_stake_weighted_timestamp, MaxAllowableDrift,
+        DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE, MAX_ALLOWABLE_DRIFT_PERCENTAGE,
     },
     system_transaction,
     sysvar::{self},
@@ -1373,9 +1373,15 @@ impl Bank {
             .feature_set
             .is_active(&feature_set::warp_timestamp::id())
         {
-            MAX_ALLOWABLE_DRIFT_PERCENTAGE
+            MaxAllowableDrift {
+                fast: MAX_ALLOWABLE_DRIFT_PERCENTAGE,
+                slow: MAX_ALLOWABLE_DRIFT_PERCENTAGE,
+            }
         } else {
-            DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE
+            MaxAllowableDrift {
+                fast: DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE,
+                slow: DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE,
+            }
         };
 
         let ancestor_timestamp = self.clock().unix_timestamp;
@@ -1888,7 +1894,7 @@ impl Bank {
 
     fn get_timestamp_estimate(
         &self,
-        max_allowable_drift: u32,
+        max_allowable_drift: MaxAllowableDrift,
         epoch_start_timestamp: Option<(Slot, UnixTimestamp)>,
     ) -> Option<UnixTimestamp> {
         let mut get_timestamp_estimate_time = Measure::start("get_timestamp_estimate");

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -327,7 +327,6 @@ mod tests {
         clock::UnixTimestamp,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
-        stake_weighted_timestamp::DEPRECATED_TIMESTAMP_SLOT_RANGE,
         sysvar::epoch_schedule::EpochSchedule,
     };
     use solana_vote_program::vote_state::BlockTimestamp;
@@ -436,8 +435,7 @@ mod tests {
 
         let additional_timestamp_secs = 2;
 
-        let num_slots = slots_in_epoch + 1 // Advance past first epoch boundary
-            + DEPRECATED_TIMESTAMP_SLOT_RANGE as u64 + 1; // ... and past deprecated slot range
+        let num_slots = slots_in_epoch + 1; // Advance past first epoch boundary
         for slot in 1..num_slots {
             // Just after the epoch boundary, timestamp a vote that will shift
             // Clock::unix_timestamp from Bank::unix_timestamp_from_genesis()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -230,10 +230,6 @@ pub mod try_find_program_address_syscall_enabled {
     solana_sdk::declare_id!("EMsMNadQNhCYDyGpYH5Tx6dGHxiUqKHk782PU5XaWfmi");
 }
 
-pub mod warp_timestamp {
-    solana_sdk::declare_id!("Bfqm7fGk5MBptqa2WHXWFLH7uJvq8hkJcAQPipy2bAMk");
-}
-
 pub mod stake_program_v3 {
     solana_sdk::declare_id!("Ego6nTu7WsBcZBvVqJQKp6Yku2N3mrfG8oYCfaLZkAeK");
 }
@@ -282,6 +278,10 @@ pub mod matching_buffer_upgrade_authorities {
     solana_sdk::declare_id!("B5PSjDEJvKJEUQSL7q94N7XCEoWJCYum8XfUg7yuugUU");
 }
 
+pub mod warp_timestamp_again {
+    solana_sdk::declare_id!("GvDsGDkH5gyzwpDhxNixx8vtx1kwYHH13RiNAPw27zXb");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -309,7 +309,6 @@ lazy_static! {
         (simple_capitalization::id(), "simple capitalization"),
         (bpf_loader_upgradeable_program::id(), "upgradeable bpf loader"),
         (try_find_program_address_syscall_enabled::id(), "add try_find_program_address syscall"),
-        (warp_timestamp::id(), "warp timestamp to current, adjust bounding to 50% #14210 & #14531"),
         (stake_program_v3::id(), "solana_stake_program v3"),
         (max_cpi_instruction_size_ipv6_mtu::id(), "max cross-program invocation size 1280"),
         (limit_cpi_loader_invoke::id(), "loader not authorized via CPI"),
@@ -348,6 +347,7 @@ lazy_static! {
         (full_inflation::stakeconomy::vote::id(), "Community vote allowing Stakeconomy.com to enable full inflation"),
         (full_inflation::w3m::vote::id(), "Community vote allowing w3m to enable full inflation"),
         (full_inflation::w3m::enable::id(), "Full inflation enabled by w3m"),
+        (warp_timestamp_again::id(), "warp timestamp again, adjust bounding to 25% fast 80% slow #TODO"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -190,10 +190,6 @@ pub mod max_program_call_depth_64 {
     solana_sdk::declare_id!("YCKSgA6XmjtkQrHBQjpyNrX6EMhJPcYcLWMVgWn36iv");
 }
 
-pub mod timestamp_correction {
-    solana_sdk::declare_id!("3zydSLUwuqqsV3wL5wBsaVgyvMox3XTHx7zLEuQf1U2Z");
-}
-
 pub mod cumulative_rent_related_fixes {
     solana_sdk::declare_id!("FtjnuAtJTWwX3Kx9m24LduNEhzaGuuPfDW6e14SX2Fy5");
 }
@@ -307,7 +303,6 @@ lazy_static! {
         (ristretto_mul_syscall_enabled::id(), "ristretto multiply syscall"),
         (max_invoke_depth_4::id(), "max invoke call depth 4"),
         (max_program_call_depth_64::id(), "max program call depth 64"),
-        (timestamp_correction::id(), "correct bank timestamps"),
         (cumulative_rent_related_fixes::id(), "rent fixes (#10206, #10468, #11342)"),
         (sol_log_compute_units_syscall::id(), "sol_log_compute_units syscall (#13243)"),
         (pubkey_log_syscall_enabled::id(), "pubkey log syscall"),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -206,10 +206,6 @@ pub mod pull_request_ping_pong_check {
     solana_sdk::declare_id!("5RzEHTnf6D7JPZCvwEzjM19kzBsyjSU3HoMfXaQmVgnZ");
 }
 
-pub mod timestamp_bounding {
-    solana_sdk::declare_id!("2cGj3HJYPhBrtQizd7YbBxEsifFs5qhzabyFjUAp6dBa");
-}
-
 pub mod stake_program_v2 {
     solana_sdk::declare_id!("Gvd9gGJZDHGMNf1b3jkxrfBQSR5etrfTQSBNKCvLSFJN");
 }
@@ -307,7 +303,6 @@ lazy_static! {
         (sol_log_compute_units_syscall::id(), "sol_log_compute_units syscall (#13243)"),
         (pubkey_log_syscall_enabled::id(), "pubkey log syscall"),
         (pull_request_ping_pong_check::id(), "ping-pong packet check #12794"),
-        (timestamp_bounding::id(), "add timestamp-correction bounding #13120"),
         (stake_program_v2::id(), "solana_stake_program v2"),
         (rewrite_stake::id(), "rewrite stake"),
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -347,7 +347,7 @@ lazy_static! {
         (full_inflation::stakeconomy::vote::id(), "Community vote allowing Stakeconomy.com to enable full inflation"),
         (full_inflation::w3m::vote::id(), "Community vote allowing w3m to enable full inflation"),
         (full_inflation::w3m::enable::id(), "Full inflation enabled by w3m"),
-        (warp_timestamp_again::id(), "warp timestamp again, adjust bounding to 25% fast 80% slow #TODO"),
+        (warp_timestamp_again::id(), "warp timestamp again, adjust bounding to 25% fast 80% slow #15204"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/stake_weighted_timestamp.rs
+++ b/sdk/src/stake_weighted_timestamp.rs
@@ -10,8 +10,6 @@ use std::{
     time::Duration,
 };
 
-pub const TIMESTAMP_SLOT_RANGE: usize = 32;
-pub const DEPRECATED_TIMESTAMP_SLOT_RANGE: usize = 16; // Deprecated.  Remove in the Solana v1.6.0 timeframe
 pub const DEPRECATED_MAX_ALLOWABLE_DRIFT_PERCENTAGE: u32 = 25;
 pub const MAX_ALLOWABLE_DRIFT_PERCENTAGE: u32 = 50;
 


### PR DESCRIPTION
#### Problem
Blocks have slowed, making current `MAX_ALLOWABLE_DRIFT_PERCENTAGE` again too restrictive and causing timestamp to drift away from (behind) real-world time.

#### Summary of Changes
- Remove old feature gating and deprecated code (`test_bank_hash_consistency` needs updating, since it runs without active features)
- Allow independent adjustment of max_allowable_drift values for blocks slower than PoH vs blocks faster than PoH
- Extend max_allowable_drift percentage to 80% for slow blocks: 720ms at current PoH target
- On activation, warp timestamp to current estimate with no bounding
- Also fix a i64 to u64 casting issue (unlikely to occur in the wild, since it is in the too-fast path, but feature-gated for safety first)
