### PR TITLE
Rework spl_token_v2_self_transfer_fix to avoid any SPL Token downtime

### DIFF
--- a/runtime/src/inline_spl_token_v2_0.rs
+++ b/runtime/src/inline_spl_token_v2_0.rs
@@ -1,6 +1,10 @@
 // Partial SPL Token v2.0.x declarations inlined to avoid an external dependency on the spl-token crate
 solana_sdk::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
+pub(crate) mod new_token_program {
+    solana_sdk::declare_id!("t31zsgDmRntje65uXV3LrnWaJtJJpMd4LyJxq2R2VrU");
+}
+
 /*
     spl_token::state::Account {
         mint: Pubkey,


### PR DESCRIPTION
The original spl_token_v2_self_transfer_fix required a manual redeploy of the token program after feature is activated.  
Instead the new token program is deployed to a new address, and the feature activation is a move operation.

<s>Top commit in this PR is a hack to redirect account loads for the old token program to new.  This won't be merged but can be applied to a single validator to run mainnet-beta with the new token program for testing purposes prior to flipping on the feature</s>