### PR TITLE
More configurable rocksdb compaction

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -80,6 +80,8 @@ pub struct TvuConfig {
     pub accounts_hash_fault_injection_slots: u64,
     pub accounts_db_caching_enabled: bool,
     pub test_hash_calculation: bool,
+    pub rocksdb_compaction_interval: Option<u64>,
+    pub rocksdb_max_compaction_jitter: Option<u64>,
 }
 
 impl Tvu {
@@ -151,6 +153,8 @@ impl Tvu {
 
         let cluster_slots = Arc::new(ClusterSlots::default());
         let (duplicate_slots_reset_sender, duplicate_slots_reset_receiver) = unbounded();
+        let compaction_interval = tvu_config.rocksdb_compaction_interval;
+        let max_compaction_jitter = tvu_config.rocksdb_max_compaction_jitter;
         let retransmit_stage = RetransmitStage::new(
             bank_forks.clone(),
             leader_schedule_cache,
@@ -267,6 +271,8 @@ impl Tvu {
                 blockstore.clone(),
                 max_ledger_shreds,
                 &exit,
+                compaction_interval,
+                max_compaction_jitter,
             )
         });
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -104,6 +104,8 @@ pub struct ValidatorConfig {
     pub accounts_hash_fault_injection_slots: u64, // 0 = no fault injection
     pub frozen_accounts: Vec<Pubkey>,
     pub no_rocksdb_compaction: bool,
+    pub rocksdb_compaction_interval: Option<u64>,
+    pub rocksdb_max_compaction_jitter: Option<u64>,
     pub accounts_hash_interval_slots: u64,
     pub max_genesis_archive_unpacked_size: u64,
     pub wal_recovery_mode: Option<BlockstoreRecoveryMode>,
@@ -152,6 +154,8 @@ impl Default for ValidatorConfig {
             accounts_hash_fault_injection_slots: 0,
             frozen_accounts: vec![],
             no_rocksdb_compaction: false,
+            rocksdb_compaction_interval: None,
+            rocksdb_max_compaction_jitter: None,
             accounts_hash_interval_slots: std::u64::MAX,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             wal_recovery_mode: None,
@@ -644,6 +648,8 @@ impl Validator {
                 accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
                 accounts_db_caching_enabled: config.accounts_db_caching_enabled,
                 test_hash_calculation: config.accounts_db_test_hash_calculation,
+                rocksdb_compaction_interval: config.rocksdb_compaction_interval,
+                rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
             },
         );
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1236,6 +1236,20 @@ pub fn main() {
                 .help("Disable manual compaction of the ledger database. May increase storage requirements.")
         )
         .arg(
+            Arg::with_name("rocksdb_compaction_interval")
+                .long("rocksdb-compaction-interval-slots")
+                .value_name("ROCKSDB_COMPACTION_INTERVAL_SLOTS")
+                .takes_value(true)
+                .help("Number of slots between compacting ledger"),
+        )
+        .arg(
+            Arg::with_name("rocksdb_max_compaction_jitter")
+                .long("rocksdb-max-compaction-jitter-slots")
+                .value_name("ROCKSDB_MAX_COMPACTION_JITTER_SLOTS")
+                .takes_value(true)
+                .help("Introduce jitter into the compaction to offset compaction operation"),
+        )
+        .arg(
             Arg::with_name("bind_address")
                 .long("bind-address")
                 .value_name("HOST")
@@ -1486,6 +1500,9 @@ pub fn main() {
     let private_rpc = matches.is_present("private_rpc");
     let no_port_check = matches.is_present("no_port_check");
     let no_rocksdb_compaction = matches.is_present("no_rocksdb_compaction");
+    let rocksdb_compaction_interval = value_t!(matches, "rocksdb_compaction_interval", u64).ok();
+    let rocksdb_max_compaction_jitter =
+        value_t!(matches, "rocksdb_max_compaction_jitter", u64).ok();
     let wal_recovery_mode = matches
         .value_of("wal_recovery_mode")
         .map(BlockstoreRecoveryMode::from);
@@ -1620,6 +1637,8 @@ pub fn main() {
         gossip_validators,
         frozen_accounts: values_t!(matches, "frozen_accounts", Pubkey).unwrap_or_default(),
         no_rocksdb_compaction,
+        rocksdb_compaction_interval,
+        rocksdb_max_compaction_jitter,
         wal_recovery_mode,
         poh_verify: !matches.is_present("skip_poh_verify"),
         debug_keys,


### PR DESCRIPTION
#### Problem

rocksdb compaction can cause long stalls

#### Summary of Changes

make it more configurable to try and reduce those stalls
and also to coordinate between multiple nodes to not induce
a stall at the same time.

cc #14586

Fixes #
