### PR TITLE
v1.5: solana-test-validator now uses the BPF JIT by default, `--no-bpf-jit` to disable

### DIFF
--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -49,6 +49,7 @@ pub struct TestValidatorGenesis {
     rpc_config: JsonRpcConfig,
     rpc_ports: Option<(u16, u16)>, // (JsonRpc, JsonRpcPubSub), None == random ports
     warp_slot: Option<Slot>,
+    no_bpf_jit: bool,
     accounts: HashMap<Pubkey, Account>,
     programs: Vec<ProgramInfo>,
 }
@@ -81,6 +82,11 @@ impl TestValidatorGenesis {
 
     pub fn warp_slot(&mut self, warp_slot: Slot) -> &mut Self {
         self.warp_slot = Some(warp_slot);
+        self
+    }
+
+    pub fn bpf_jit(&mut self, bpf_jit: bool) -> &mut Self {
+        self.no_bpf_jit = !bpf_jit;
         self
     }
 
@@ -394,6 +400,7 @@ impl TestValidator {
             }),
             enforce_ulimit_nofile: false,
             warp_slot: config.warp_slot,
+            bpf_jit: !config.no_bpf_jit,
             ..ValidatorConfig::default()
         };
 

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -158,6 +158,12 @@ fn main() {
                 ),
         )
         .arg(
+            Arg::with_name("no_bpf_jit")
+                .long("no-bpf-jit")
+                .takes_value(false)
+                .help("Disable the just-in-time compiler and instead use the interpreter for BPF"),
+        )
+        .arg(
             Arg::with_name("clone_account")
                 .long("clone")
                 .short("c")
@@ -220,6 +226,7 @@ fn main() {
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
         FAUCET_PORT,
     ));
+    let bpf_jit = !matches.is_present("no_bpf_jit");
 
     let mut programs = vec![];
     if let Some(values) = matches.values_of("bpf_program") {
@@ -380,6 +387,7 @@ fn main() {
                 faucet_addr,
                 ..JsonRpcConfig::default()
             })
+            .bpf_jit(bpf_jit)
             .rpc_port(rpc_port)
             .add_programs_with_path(&programs);
 


### PR DESCRIPTION
Backport of https://github.com/solana-labs/solana/pull/15216