### PR TITLE
Improve vote-account for logical flow/reasoning

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -635,7 +635,7 @@ fn show_votes_and_credits(
     if let Some(newest) = newest_history_entry {
         writeln!(
             f,
-            "- ... (truncated older {} votes, which was rooted and became credits)",
+            "- ... (truncated {} rooted votes, which have been credited)",
             newest.credits
         )?;
     }
@@ -685,7 +685,7 @@ fn show_votes_and_credits(
 
             writeln!(
                 f,
-                "- ... (truncated older history covering {} credits/rooted votes)",
+                "- ... (omitting {} past rooted votes, which have already been credited)",
                 count
             )?;
         }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -610,10 +610,13 @@ fn show_votes_and_credits(
         return Ok(());
     }
 
+    // Existence of this should guarantee the occurrence of vote truncation
+    let newest_history_entry = epoch_voting_history.iter().rev().next();
+
     writeln!(
         f,
         "{} Votes (using {}/{} entries):",
-        (if votes.len() < MAX_LOCKOUT_HISTORY {
+        (if newest_history_entry.is_none() {
             "All"
         } else {
             "Recent"
@@ -623,9 +626,13 @@ fn show_votes_and_credits(
     )?;
 
     for vote in votes.iter().rev() {
-        writeln!(f, "- slot: {} (confirmation count: {})", vote.slot, vote.confirmation_count)?;
+        writeln!(
+            f,
+            "- slot: {} (confirmation count: {})",
+            vote.slot, vote.confirmation_count
+        )?;
     }
-    if let Some(newest) = epoch_voting_history.iter().rev().next() {
+    if let Some(newest) = newest_history_entry {
         writeln!(
             f,
             "- ... (truncated older {} votes, which was rooted and became credits)",

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -29,7 +29,7 @@ use {
     solana_stake_program::stake_state::{Authorized, Lockup},
     solana_vote_program::{
         authorized_voters::AuthorizedVoters,
-        vote_state::{BlockTimestamp, Lockout},
+        vote_state::{BlockTimestamp, Lockout, MAX_EPOCH_CREDITS_HISTORY, MAX_LOCKOUT_HISTORY},
     },
     std::{
         collections::{BTreeMap, HashMap},
@@ -610,17 +610,48 @@ fn show_votes_and_credits(
         return Ok(());
     }
 
-    writeln!(f, "Recent Votes:")?;
-    for vote in votes {
-        writeln!(f, "- slot: {}", vote.slot)?;
-        writeln!(f, "  confirmation count: {}", vote.confirmation_count)?;
-    }
-    writeln!(f, "Epoch Voting History:")?;
     writeln!(
         f,
-        "* missed credits include slots unavailable to vote on due to delinquent leaders",
+        "{} Votes (using {}/{} entries):",
+        (if votes.len() < MAX_LOCKOUT_HISTORY {
+            "All"
+        } else {
+            "Recent"
+        }),
+        votes.len(),
+        MAX_LOCKOUT_HISTORY
     )?;
-    for entry in epoch_voting_history {
+
+    for vote in votes.iter().rev() {
+        writeln!(f, "- slot: {} (confirmation count: {})", vote.slot, vote.confirmation_count)?;
+    }
+    if let Some(newest) = epoch_voting_history.iter().rev().next() {
+        writeln!(
+            f,
+            "- ... (truncated older {} votes, which was rooted and became credits)",
+            newest.credits
+        )?;
+    }
+
+    if !epoch_voting_history.is_empty() {
+        writeln!(
+            f,
+            "{} Epoch Voting History (using {}/{} entries):",
+            (if epoch_voting_history.len() < MAX_EPOCH_CREDITS_HISTORY {
+                "All"
+            } else {
+                "Recent"
+            }),
+            epoch_voting_history.len(),
+            MAX_EPOCH_CREDITS_HISTORY
+        )?;
+        writeln!(
+            f,
+            "* missed credits include slots unavailable to vote on due to delinquent leaders",
+        )?;
+    }
+
+    for entry in epoch_voting_history.iter().rev() {
         writeln!(
             f, // tame fmt so that this will be folded like following
             "- epoch: {}",
@@ -628,7 +659,7 @@ fn show_votes_and_credits(
         )?;
         writeln!(
             f,
-            "  credits range: [{}..{})",
+            "  credits range: ({}..{}]",
             entry.prev_credits, entry.credits
         )?;
         writeln!(
@@ -637,6 +668,22 @@ fn show_votes_and_credits(
             entry.credits_earned, entry.slots_in_epoch
         )?;
     }
+    if let Some(oldest) = epoch_voting_history.iter().next() {
+        if oldest.prev_credits > 0 {
+            // Oldest entry doesn't start with 0. so history must be truncated...
+
+            // count of this combined pseudo credits range: (0..=oldest.prev_credits] like the above
+            // (or this is just [1..=oldest.prev_credits] for human's simpler minds)
+            let count = oldest.prev_credits;
+
+            writeln!(
+                f,
+                "- ... (truncated older history covering {} credits/rooted votes)",
+                count
+            )?;
+        }
+    }
+
     Ok(())
 }
 

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -31,7 +31,7 @@ pub const MAX_LOCKOUT_HISTORY: usize = 31;
 pub const INITIAL_LOCKOUT: usize = 2;
 
 // Maximum number of credits history to keep around
-const MAX_EPOCH_CREDITS_HISTORY: usize = 64;
+pub const MAX_EPOCH_CREDITS_HISTORY: usize = 64;
 
 #[frozen_abi(digest = "Ch2vVEwos2EjAVqSHCyJjnN2MNX1yrpapZTGhMSCjWUH")]
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Eq, Clone, AbiExample)]


### PR DESCRIPTION
#### Problem

My last periodic inflation checkup was mislead to a false bug hunting due to my hurried look at `solana vote-account`.

I'd say this subcommand needs more love. ;)

#### Summary of Changes

- Consistent ordering in each sections (newest => oldest); I think _Recent_ warrants reverse-chronological order as this is done for rewards.
 - From top to the bottom of the output: newest votes => oldest votes => newest credits => oldest credits; so flow of information is ordered accordingly.
 - Also, I intended to make these vote/credit/rooting relations self-evident by `watch solana vote-account`-ing for awhile.
- Hint about maximum entry for each sections and possible truncation 
- Also, this breaks cli output compatibility, which I think is safe for only v1.6. (Ideally, I want this in v1.5 as well)

(Originally, I wanted to hide these additions under verbose, but I found that wiring takes some more work. I don't think this new by-default output impedes understanding for general consumption.)

BEFORE:

```
$ solana vote-account FKsC411dik9ktS6xPADxs4Fk2SCENvAiuccQHLAPndvk
Account Balance: 31.350967575 SOL
Validator Identity: DWvDTSh3qfn88UoQTEKRV2JnLt5jtJAVoiCo3ivtMwXP
Authorized Voters: {149: "BEYL4vi8LbqtE8LZnitTkyYzN5qwvbzPipPwXxpW4W8c"}
Authorized Withdrawer: 3bfD7Vt3552r2Kgzm7jQF6W3HToRBfGocerCsDokwVQ4
Credits: 52982912
Commission: 7%
Root Slot: 64759037
Recent Timestamp: 2021-02-10T13:14:39Z from slot 64759076
Recent Votes:
- slot: 64759038
  confirmation count: 31
- slot: 64759039
  confirmation count: 30
- slot: 64759040
  confirmation count: 29
- slot: 64759041
  confirmation count: 28
- slot: 64759042
  confirmation count: 27
- slot: 64759043
  confirmation count: 26
- slot: 64759045
  confirmation count: 25
- slot: 64759046
  confirmation count: 24
- slot: 64759047
  confirmation count: 23
- slot: 64759048
  confirmation count: 22
- slot: 64759049
  confirmation count: 21
- slot: 64759056
  confirmation count: 20
- slot: 64759057
  confirmation count: 19
- slot: 64759058
  confirmation count: 18
- slot: 64759059
  confirmation count: 17
- slot: 64759060
  confirmation count: 16
- slot: 64759061
  confirmation count: 15
- slot: 64759062
  confirmation count: 14
- slot: 64759063
  confirmation count: 13
- slot: 64759064
  confirmation count: 12
- slot: 64759065
  confirmation count: 11
- slot: 64759066
  confirmation count: 10
- slot: 64759067
  confirmation count: 9
- slot: 64759069
  confirmation count: 8
- slot: 64759070
  confirmation count: 7
- slot: 64759071
  confirmation count: 6
- slot: 64759072
  confirmation count: 5
- slot: 64759073
  confirmation count: 4
- slot: 64759074
  confirmation count: 3
- slot: 64759075
  confirmation count: 2
- slot: 64759076
  confirmation count: 1
Epoch Voting History:
* missed credits include slots unavailable to vote on due to delinquent leaders
- epoch: 86
  credits range: [31093438..31485431)
  credits/slots: 391993/432000
- epoch: 87
  credits range: [31485431..31872155)
  credits/slots: 386724/432000
- epoch: 88
  credits range: [31872155..32276705)
  credits/slots: 404550/432000
- epoch: 89
  credits range: [32276705..32675022)
  credits/slots: 398317/432000
- epoch: 90
  credits range: [32675022..33088998)
  credits/slots: 413976/432000
- epoch: 91
  credits range: [33088998..33492073)
  credits/slots: 403075/432000
- epoch: 92
  credits range: [33492073..33890924)
  credits/slots: 398851/432000
- epoch: 93
  credits range: [33890924..34292439)
  credits/slots: 401515/432000
- epoch: 94
  credits range: [34292439..34683616)
  credits/slots: 391177/432000
- epoch: 95
  credits range: [34683616..35047515)
  credits/slots: 363899/432000
- epoch: 96
  credits range: [35047515..35395144)
  credits/slots: 347629/432000
- epoch: 97
  credits range: [35395144..35804273)
  credits/slots: 409129/432000
- epoch: 98
  credits range: [35804273..36220258)
  credits/slots: 415985/432000
- epoch: 99
  credits range: [36220258..36627990)
  credits/slots: 407732/432000
- epoch: 100
  credits range: [36627990..37011736)
  credits/slots: 383746/432000
- epoch: 101
  credits range: [37011736..37410490)
  credits/slots: 398754/432000
- epoch: 102
  credits range: [37410490..37815801)
  credits/slots: 405311/432000
- epoch: 103
  credits range: [37815801..38208577)
  credits/slots: 392776/432000
- epoch: 104
  credits range: [38208577..38605894)
  credits/slots: 397317/432000
- epoch: 105
  credits range: [38605894..39008709)
  credits/slots: 402815/432000
- epoch: 106
  credits range: [39008709..39416873)
  credits/slots: 408164/432000
- epoch: 107
  credits range: [39416873..39824022)
  credits/slots: 407149/432000
- epoch: 108
  credits range: [39824022..40208585)
  credits/slots: 384563/432000
- epoch: 109
  credits range: [40208585..40578382)
  credits/slots: 369797/432000
- epoch: 110
  credits range: [40578382..40960490)
  credits/slots: 382108/432000
- epoch: 111
  credits range: [40960490..41347523)
  credits/slots: 387033/432000
- epoch: 112
  credits range: [41347523..41744495)
  credits/slots: 396972/432000
- epoch: 113
  credits range: [41744495..42130454)
  credits/slots: 385959/432000
- epoch: 114
  credits range: [42130454..42507929)
  credits/slots: 377475/432000
- epoch: 115
  credits range: [42507929..42888558)
  credits/slots: 380629/432000
- epoch: 116
  credits range: [42888558..43234394)
  credits/slots: 345836/432000
- epoch: 117
  credits range: [43234394..43561785)
  credits/slots: 327391/432000
- epoch: 118
  credits range: [43561785..43905947)
  credits/slots: 344162/432000
- epoch: 119
  credits range: [43905947..44234409)
  credits/slots: 328462/432000
- epoch: 120
  credits range: [44234409..44569202)
  credits/slots: 334793/432000
- epoch: 121
  credits range: [44569202..44855864)
  credits/slots: 286662/432000
- epoch: 122
  credits range: [44855864..45187857)
  credits/slots: 331993/432000
- epoch: 123
  credits range: [45187857..45546135)
  credits/slots: 358278/432000
- epoch: 124
  credits range: [45546135..45905338)
  credits/slots: 359203/432000
- epoch: 125
  credits range: [45905338..46117575)
  credits/slots: 212237/432000
- epoch: 126
  credits range: [46117575..46357064)
  credits/slots: 239489/432000
- epoch: 127
  credits range: [46357064..46623556)
  credits/slots: 266492/432000
- epoch: 128
  credits range: [46623556..46861905)
  credits/slots: 238349/432000
- epoch: 129
  credits range: [46861905..47069022)
  credits/slots: 207117/432000
- epoch: 130
  credits range: [47069022..47331463)
  credits/slots: 262441/432000
- epoch: 131
  credits range: [47331463..47523324)
  credits/slots: 191861/432000
- epoch: 132
  credits range: [47523324..47732454)
  credits/slots: 209130/432000
- epoch: 133
  credits range: [47732454..47929955)
  credits/slots: 197501/432000
- epoch: 134
  credits range: [47929955..48156316)
  credits/slots: 226361/432000
- epoch: 135
  credits range: [48156316..48383843)
  credits/slots: 227527/432000
- epoch: 136
  credits range: [48383843..48671276)
  credits/slots: 287433/432000
- epoch: 137
  credits range: [48671276..49005812)
  credits/slots: 334536/432000
- epoch: 138
  credits range: [49005812..49328994)
  credits/slots: 323182/432000
- epoch: 139
  credits range: [49328994..49646559)
  credits/slots: 317565/432000
- epoch: 140
  credits range: [49646559..49989489)
  credits/slots: 342930/432000
- epoch: 141
  credits range: [49989489..50306830)
  credits/slots: 317341/432000
- epoch: 142
  credits range: [50306830..50612612)
  credits/slots: 305782/432000
- epoch: 143
  credits range: [50612612..50956316)
  credits/slots: 343704/432000
- epoch: 144
  credits range: [50956316..51318093)
  credits/slots: 361777/432000
- epoch: 145
  credits range: [51318093..51677751)
  credits/slots: 359658/432000
- epoch: 146
  credits range: [51677751..52049937)
  credits/slots: 372186/432000
- epoch: 147
  credits range: [52049937..52386068)
  credits/slots: 336131/432000
- epoch: 148
  credits range: [52386068..52683859)
  credits/slots: 297791/432000
- epoch: 149
  credits range: [52683859..52982912)
  credits/slots: 299053/432000
Epoch Rewards:
  Epoch   Reward Slot  Amount            New Balance       Percent Change             APR
  148     64368000     ◎1.507476849       ◎31.350967575             5.05%         599.42%
  147     63936000     ◎1.647750662       ◎29.843490726             5.84%         720.44%
  146     63504000     ◎1.740032636       ◎28.195740064             6.58%         913.18%
  145     63072004     ◎1.532238646       ◎26.455707428             6.15%         816.94%
  144     62640000     ◎1.645030818       ◎24.923468782             7.07%         927.32%
  143     62208000     ◎2.014101233       ◎23.278437964             9.47%        1249.28%
  142     61776000     ◎2.685118569       ◎21.264336731            14.45%        1847.81%
  141     61344004     ◎2.471243465       ◎18.579218162            15.34%        1977.63%
  140     60912004     ◎1.913246446       ◎16.107974697            13.48%        1225.68%
  139     60480000     ◎1.725177229       ◎14.194728251            13.84%        1970.12%
  138     60048001     ◎1.966582520       ◎12.469551022            18.72%        2666.31%
  137     59616008     ◎1.802008387       ◎10.502968502            20.71%        2949.13%
  136     59184000     ◎1.740846306       ◎8.700960115             25.01%        3561.67%
  135     58752000     ◎1.737414700       ◎6.960113809             33.27%        4933.88%
  134     58320000     ◎1.730364010       ◎5.222699109             49.55%        7428.25%
  133     57888004     ◎1.743403550       ◎3.492335099             99.68%       14654.57%
  132     57456000     ◎1.722072909       ◎1.748931549           6411.62%      961067.52%
```


AFTER:

```
$ ./target/debug/solana vote-account FKsC411dik9ktS6xPADxs4Fk2SCENvAiuccQHLAPndvk
Account Balance: 1266.151350355 SOL
Validator Identity: DWvDTSh3qfn88UoQTEKRV2JnLt5jtJAVoiCo3ivtMwXP
Authorized Voters: {150: "BEYL4vi8LbqtE8LZnitTkyYzN5qwvbzPipPwXxpW4W8c"}
Authorized Withdrawer: 3bfD7Vt3552r2Kgzm7jQF6W3HToRBfGocerCsDokwVQ4
Credits: 53062534
Commission: 7%
Root Slot: 64878691
Recent Timestamp: 2021-02-11T10:35:15Z from slot 64878755
Recent Votes (using 31/31 entries):
- slot: 64878755 (confirmation count: 1)
- slot: 64878754 (confirmation count: 2)
- slot: 64878753 (confirmation count: 3)
- slot: 64878752 (confirmation count: 4)
- slot: 64878751 (confirmation count: 5)
- slot: 64878750 (confirmation count: 6)
- slot: 64878749 (confirmation count: 7)
- slot: 64878747 (confirmation count: 8)
- slot: 64878746 (confirmation count: 9)
- slot: 64878745 (confirmation count: 10)
- slot: 64878719 (confirmation count: 11)
- slot: 64878718 (confirmation count: 12)
- slot: 64878717 (confirmation count: 13)
- slot: 64878716 (confirmation count: 14)
- slot: 64878709 (confirmation count: 15)
- slot: 64878708 (confirmation count: 16)
- slot: 64878707 (confirmation count: 17)
- slot: 64878706 (confirmation count: 18)
- slot: 64878705 (confirmation count: 19)
- slot: 64878703 (confirmation count: 20)
- slot: 64878702 (confirmation count: 21)
- slot: 64878701 (confirmation count: 22)
- slot: 64878700 (confirmation count: 23)
- slot: 64878699 (confirmation count: 24)
- slot: 64878698 (confirmation count: 25)
- slot: 64878697 (confirmation count: 26)
- slot: 64878696 (confirmation count: 27)
- slot: 64878695 (confirmation count: 28)
- slot: 64878694 (confirmation count: 29)
- slot: 64878693 (confirmation count: 30)
- slot: 64878692 (confirmation count: 31)
- ... (truncated 53062534 rooted votes, which have been credited)
Recent Epoch Voting History (using 64/64 entries):
* missed credits include slots unavailable to vote on due to delinquent leaders
- epoch: 150
  credits range: (53007811..53062534]
  credits/slots: 54723/432000
- epoch: 149
  credits range: (52683859..53007811]
  credits/slots: 323952/432000
- epoch: 148
  credits range: (52386068..52683859]
  credits/slots: 297791/432000
- epoch: 147
  credits range: (52049937..52386068]
  credits/slots: 336131/432000
- epoch: 146
  credits range: (51677751..52049937]
  credits/slots: 372186/432000
- epoch: 145
  credits range: (51318093..51677751]
  credits/slots: 359658/432000
- epoch: 144
  credits range: (50956316..51318093]
  credits/slots: 361777/432000
- epoch: 143
  credits range: (50612612..50956316]
  credits/slots: 343704/432000
- epoch: 142
  credits range: (50306830..50612612]
  credits/slots: 305782/432000
- epoch: 141
  credits range: (49989489..50306830]
  credits/slots: 317341/432000
- epoch: 140
  credits range: (49646559..49989489]
  credits/slots: 342930/432000
- epoch: 139
  credits range: (49328994..49646559]
  credits/slots: 317565/432000
- epoch: 138
  credits range: (49005812..49328994]
  credits/slots: 323182/432000
- epoch: 137
  credits range: (48671276..49005812]
  credits/slots: 334536/432000
- epoch: 136
  credits range: (48383843..48671276]
  credits/slots: 287433/432000
- epoch: 135
  credits range: (48156316..48383843]
  credits/slots: 227527/432000
- epoch: 134
  credits range: (47929955..48156316]
  credits/slots: 226361/432000
- epoch: 133
  credits range: (47732454..47929955]
  credits/slots: 197501/432000
- epoch: 132
  credits range: (47523324..47732454]
  credits/slots: 209130/432000
- epoch: 131
  credits range: (47331463..47523324]
  credits/slots: 191861/432000
- epoch: 130
  credits range: (47069022..47331463]
  credits/slots: 262441/432000
- epoch: 129
  credits range: (46861905..47069022]
  credits/slots: 207117/432000
- epoch: 128
  credits range: (46623556..46861905]
  credits/slots: 238349/432000
- epoch: 127
  credits range: (46357064..46623556]
  credits/slots: 266492/432000
- epoch: 126
  credits range: (46117575..46357064]
  credits/slots: 239489/432000
- epoch: 125
  credits range: (45905338..46117575]
  credits/slots: 212237/432000
- epoch: 124
  credits range: (45546135..45905338]
  credits/slots: 359203/432000
- epoch: 123
  credits range: (45187857..45546135]
  credits/slots: 358278/432000
- epoch: 122
  credits range: (44855864..45187857]
  credits/slots: 331993/432000
- epoch: 121
  credits range: (44569202..44855864]
  credits/slots: 286662/432000
- epoch: 120
  credits range: (44234409..44569202]
  credits/slots: 334793/432000
- epoch: 119
  credits range: (43905947..44234409]
  credits/slots: 328462/432000
- epoch: 118
  credits range: (43561785..43905947]
  credits/slots: 344162/432000
- epoch: 117
  credits range: (43234394..43561785]
  credits/slots: 327391/432000
- epoch: 116
  credits range: (42888558..43234394]
  credits/slots: 345836/432000
- epoch: 115
  credits range: (42507929..42888558]
  credits/slots: 380629/432000
- epoch: 114
  credits range: (42130454..42507929]
  credits/slots: 377475/432000
- epoch: 113
  credits range: (41744495..42130454]
  credits/slots: 385959/432000
- epoch: 112
  credits range: (41347523..41744495]
  credits/slots: 396972/432000
- epoch: 111
  credits range: (40960490..41347523]
  credits/slots: 387033/432000
- epoch: 110
  credits range: (40578382..40960490]
  credits/slots: 382108/432000
- epoch: 109
  credits range: (40208585..40578382]
  credits/slots: 369797/432000
- epoch: 108
  credits range: (39824022..40208585]
  credits/slots: 384563/432000
- epoch: 107
  credits range: (39416873..39824022]
  credits/slots: 407149/432000
- epoch: 106
  credits range: (39008709..39416873]
  credits/slots: 408164/432000
- epoch: 105
  credits range: (38605894..39008709]
  credits/slots: 402815/432000
- epoch: 104
  credits range: (38208577..38605894]
  credits/slots: 397317/432000
- epoch: 103
  credits range: (37815801..38208577]
  credits/slots: 392776/432000
- epoch: 102
  credits range: (37410490..37815801]
  credits/slots: 405311/432000
- epoch: 101
  credits range: (37011736..37410490]
  credits/slots: 398754/432000
- epoch: 100
  credits range: (36627990..37011736]
  credits/slots: 383746/432000
- epoch: 99
  credits range: (36220258..36627990]
  credits/slots: 407732/432000
- epoch: 98
  credits range: (35804273..36220258]
  credits/slots: 415985/432000
- epoch: 97
  credits range: (35395144..35804273]
  credits/slots: 409129/432000
- epoch: 96
  credits range: (35047515..35395144]
  credits/slots: 347629/432000
- epoch: 95
  credits range: (34683616..35047515]
  credits/slots: 363899/432000
- epoch: 94
  credits range: (34292439..34683616]
  credits/slots: 391177/432000
- epoch: 93
  credits range: (33890924..34292439]
  credits/slots: 401515/432000
- epoch: 92
  credits range: (33492073..33890924]
  credits/slots: 398851/432000
- epoch: 91
  credits range: (33088998..33492073]
  credits/slots: 403075/432000
- epoch: 90
  credits range: (32675022..33088998]
  credits/slots: 413976/432000
- epoch: 89
  credits range: (32276705..32675022]
  credits/slots: 398317/432000
- epoch: 88
  credits range: (31872155..32276705]
  credits/slots: 404550/432000
- epoch: 87
  credits range: (31485431..31872155]
  credits/slots: 386724/432000
- ... (omitting 31485431 past rooted votes, which have already been credited)
Epoch Rewards:
  Epoch   Reward Slot  Amount            New Balance       Percent Change             APR
  149     64800004     ◎1234.800382780    ◎1266.151350355        3938.64%      467382.96%
  148     64368000     ◎1.507476849       ◎31.350967575             5.05%         599.42%
  147     63936000     ◎1.647750662       ◎29.843490726             5.84%         720.44%
  146     63504000     ◎1.740032636       ◎28.195740064             6.58%         913.18%
  145     63072004     ◎1.532238646       ◎26.455707428             6.15%         816.94%
  144     62640000     ◎1.645030818       ◎24.923468782             7.07%         927.32%
  143     62208000     ◎2.014101233       ◎23.278437964             9.47%        1249.28%
  142     61776000     ◎2.685118569       ◎21.264336731            14.45%        1847.81%
  141     61344004     ◎2.471243465       ◎18.579218162            15.34%        1977.63%
  140     60912004     ◎1.913246446       ◎16.107974697            13.48%        1225.68%
  139     60480000     ◎1.725177229       ◎14.194728251            13.84%        1970.12%
  138     60048001     ◎1.966582520       ◎12.469551022            18.72%        2666.31%
  137     59616008     ◎1.802008387       ◎10.502968502            20.71%        2949.13%
  136     59184000     ◎1.740846306       ◎8.700960115             25.01%        3561.67%
  135     58752000     ◎1.737414700       ◎6.960113809             33.27%        4933.88%
  134     58320000     ◎1.730364010       ◎5.222699109             49.55%        7428.25%
  133     57888004     ◎1.743403550       ◎3.492335099             99.68%       14654.57%
  132     57456000     ◎1.722072909       ◎1.748931549           6411.62%      961067.52%


```
