### PR TITLE
assert 2 items in stores don't have same slot and version with different values

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4097,6 +4097,13 @@ impl AccountsDB {
                         i = k;
                         look_for_first_key = false;
                         continue 'outer;
+                    } else {
+                        let prev = &slice[k - 1];
+                        assert!(
+                            !(prev.slot == now.slot
+                                && prev.version == now.version
+                                && (prev.hash != now.hash || prev.lamports != now.lamports))
+                        );
                     }
                 }
 
@@ -5938,7 +5945,13 @@ pub mod tests {
             .zip(keys.iter())
             .enumerate()
             .map(|(i, (hash, key))| {
-                CalculateHashIntermediate::new(VERSION, hash, (i + 1) as u64, Slot::default(), *key)
+                CalculateHashIntermediate::new(
+                    VERSION,
+                    hash,
+                    (i + 1) as u64,
+                    u64::MAX - i as u64,
+                    *key,
+                )
             })
             .collect();
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4102,7 +4102,8 @@ impl AccountsDB {
                         assert!(
                             !(prev.slot == now.slot
                                 && prev.version == now.version
-                                && (prev.hash != now.hash || prev.lamports != now.lamports))
+                                && (prev.hash != now.hash || prev.lamports != now.lamports)),
+                            "Conflicting store data. Pubkey: {}, Slot: {}, Version: {}, Hashes: {}, {}, Lamports: {}, {}", now.pubkey, now.slot, now.version, prev.hash, now.hash, prev.lamports, now.lamports
                         );
                     }
                 }


### PR DESCRIPTION
#### Problem
This is an assumption we're making in the code. There are hash mismatches we're tracking. This check has no measurable cost.

#### Summary of Changes
assert the assumption.

Fixes #
