### PR TITLE
web3.js: update commitment variants

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -76,10 +76,7 @@ declare module '@solana/web3.js' {
     value: T;
   };
 
-  export type Commitment =
-    | 'processed'
-    | 'confirmed'
-    | 'finalized';
+  export type Commitment = 'processed' | 'confirmed' | 'finalized';
 
   export type LargestAccountsFilter = 'circulating' | 'nonCirculating';
 

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -77,11 +77,9 @@ declare module '@solana/web3.js' {
   };
 
   export type Commitment =
-    | 'max'
-    | 'recent'
-    | 'root'
-    | 'single'
-    | 'singleGossip';
+    | 'processed'
+    | 'confirmed'
+    | 'finalized';
 
   export type LargestAccountsFilter = 'circulating' | 'nonCirculating';
 

--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -76,7 +76,15 @@ declare module '@solana/web3.js' {
     value: T;
   };
 
-  export type Commitment = 'processed' | 'confirmed' | 'finalized';
+  export type Commitment =
+    | 'processed'
+    | 'confirmed'
+    | 'finalized'
+    | 'recent' // Deprecated as of v1.5.5
+    | 'single' // Deprecated as of v1.5.5
+    | 'singleGossip' // Deprecated as of v1.5.5
+    | 'root' // Deprecated as of v1.5.5
+    | 'max'; // Deprecated as of v1.5.5
 
   export type LargestAccountsFilter = 'circulating' | 'nonCirculating';
 

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -90,7 +90,15 @@ declare module '@solana/web3.js' {
     value: T,
   };
 
-  declare export type Commitment = 'processed' | 'confirmed' | 'finalized';
+  declare export type Commitment =
+    | 'processed'
+    | 'confirmed'
+    | 'finalized'
+    | 'recent' // Deprecated as of v1.5.5
+    | 'single' // Deprecated as of v1.5.5
+    | 'singleGossip' // Deprecated as of v1.5.5
+    | 'root' // Deprecated as of v1.5.5
+    | 'max'; // Deprecated as of v1.5.5
 
   declare export type LargestAccountsFilter = 'circulating' | 'nonCirculating';
 

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -91,11 +91,9 @@ declare module '@solana/web3.js' {
   };
 
   declare export type Commitment =
-    | 'max'
-    | 'recent'
-    | 'root'
-    | 'single'
-    | 'singleGossip';
+    | 'processed'
+    | 'confirmed'
+    | 'finalized';
 
   declare export type LargestAccountsFilter = 'circulating' | 'nonCirculating';
 

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -90,10 +90,7 @@ declare module '@solana/web3.js' {
     value: T,
   };
 
-  declare export type Commitment =
-    | 'processed'
-    | 'confirmed'
-    | 'finalized';
+  declare export type Commitment = 'processed' | 'confirmed' | 'finalized';
 
   declare export type LargestAccountsFilter = 'circulating' | 'nonCirculating';
 

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -152,7 +152,15 @@ function notificationResultAndContext(resultDescription: any) {
  *
  * @typedef {'processed' | 'confirmed' | 'finalized'} Commitment
  */
-export type Commitment = 'processed' | 'confirmed' | 'finalized';
+export type Commitment =
+  | 'processed'
+  | 'confirmed'
+  | 'finalized'
+  | 'recent' // Deprecated as of v1.5.5
+  | 'single' // Deprecated as of v1.5.5
+  | 'singleGossip' // Deprecated as of v1.5.5
+  | 'root' // Deprecated as of v1.5.5
+  | 'max'; // Deprecated as of v1.5.5
 
 /**
  * Filter for largest accounts query
@@ -2289,13 +2297,16 @@ export class Connection {
 
     let timeoutMs = 60 * 1000;
     switch (subscriptionCommitment) {
+      case 'processed':
       case 'recent':
       case 'single':
+      case 'confirmed':
       case 'singleGossip': {
         timeoutMs = 30 * 1000;
         break;
       }
       // exhaust enums to ensure full coverage
+      case 'finalized':
       case 'max':
       case 'root':
     }
@@ -2874,7 +2885,7 @@ export class Connection {
     try {
       const startTime = Date.now();
       for (let i = 0; i < 50; i++) {
-        const {blockhash} = await this.getRecentBlockhash('max');
+        const {blockhash} = await this.getRecentBlockhash('finalized');
 
         if (this._blockhashInfo.recentBlockhash != blockhash) {
           this._blockhashInfo = {

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -145,16 +145,14 @@ function notificationResultAndContext(resultDescription: any) {
 /**
  * The level of commitment desired when querying state
  * <pre>
- *   'max':    Query the most recent block which has been finalized by the cluster
- *   'recent': Query the most recent block which has reached 1 confirmation by the connected node
- *   'root':   Query the most recent block which has been rooted by the connected node
- *   'single': Query the most recent block which has reached 1 confirmation by the cluster
- *   'singleGossip': Query the most recent block which has reached 1 confirmation according to votes seen in gossip
+ *   'processed': Query the most recent block which has reached 1 confirmation by the connected node
+ *   'confirmed': Query the most recent block which has reached 1 confirmation by the cluster
+ *   'finalized': Query the most recent block which has been finalized by the cluster
  * </pre>
  *
- * @typedef {'max' | 'recent' | 'root' | 'single' | 'singleGossip'} Commitment
+ * @typedef {'processed' | 'confirmed' | 'finalized'} Commitment
  */
-export type Commitment = 'max' | 'recent' | 'root' | 'single' | 'singleGossip';
+export type Commitment = 'processed' | 'confirmed' | 'finalized';
 
 /**
  * Filter for largest accounts query

--- a/web3.js/src/loader.js
+++ b/web3.js/src/loader.js
@@ -68,7 +68,7 @@ export class Loader {
       // Fetch program account info to check if it has already been created
       const programInfo = await connection.getAccountInfo(
         program.publicKey,
-        'singleGossip',
+        'confirmed',
       );
 
       let transaction: Transaction | null = null;
@@ -128,7 +128,7 @@ export class Loader {
           transaction,
           [payer, program],
           {
-            commitment: 'singleGossip',
+            commitment: 'confirmed',
           },
         );
       }
@@ -169,7 +169,7 @@ export class Loader {
       });
       transactions.push(
         sendAndConfirmTransaction(connection, transaction, [payer, program], {
-          commitment: 'singleGossip',
+          commitment: 'confirmed',
         }),
       );
 
@@ -209,7 +209,7 @@ export class Loader {
         transaction,
         [payer, program],
         {
-          commitment: 'singleGossip',
+          commitment: 'confirmed',
         },
       );
     }

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -141,8 +141,8 @@ if (process.env.TEST_LIVE) {
           transaction,
           [payerAccount],
           {
-            commitment: 'max', // `getParsedConfirmedTransaction` requires max commitment
-            preflightCommitment: connection.commitment || 'max',
+            commitment: 'finalized', // `getParsedConfirmedTransaction` requires max commitment
+            preflightCommitment: connection.commitment || 'finalized',
           },
         );
 

--- a/web3.js/test/bpf-loader.test.js
+++ b/web3.js/test/bpf-loader.test.js
@@ -22,7 +22,7 @@ if (process.env.TEST_LIVE) {
     it('load BPF C program', async () => {
       const data = await fs.readFile('test/fixtures/noop-c/noop.so');
 
-      const connection = new Connection(url, 'singleGossip');
+      const connection = new Connection(url, 'confirmed');
       const {feeCalculator} = await connection.getRecentBlockhash();
       const fees =
         feeCalculator.lamportsPerSignature *
@@ -59,13 +59,13 @@ if (process.env.TEST_LIVE) {
         programId: program.publicKey,
       });
       await sendAndConfirmTransaction(connection, transaction, [from], {
-        commitment: 'singleGossip',
-        preflightCommitment: 'singleGossip',
+        commitment: 'confirmed',
+        preflightCommitment: 'confirmed',
       });
     }).timeout(5000);
 
     describe('load BPF Rust program', () => {
-      const connection = new Connection(url, 'singleGossip');
+      const connection = new Connection(url, 'confirmed');
 
       let program = new Account();
       let payerAccount = new Account();

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1483,8 +1483,8 @@ describe('Connection', () => {
       expect(activation.inactive).to.eq(80);
 
       await addStakeActivationMock('invalid');
-      await expect(connection.getStakeActivation(publicKey, 'confirmed')).to
-        .be.rejected;
+      await expect(connection.getStakeActivation(publicKey, 'confirmed')).to.be
+        .rejected;
     });
   }
 
@@ -1515,10 +1515,7 @@ describe('Connection', () => {
       withContext: true,
     });
 
-    const balance = await connection.getBalance(
-      account.publicKey,
-      'confirmed',
-    );
+    const balance = await connection.getBalance(account.publicKey, 'confirmed');
     expect(balance).to.eq(LAMPORTS_PER_SOL);
 
     await mockRpcResponse({

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1012,13 +1012,7 @@ describe('Connection', () => {
   });
 
   it('get recent blockhash', async () => {
-    for (const commitment of [
-      'max',
-      'confirmed',
-      'root',
-      'single',
-      'confirmed',
-    ]) {
+    for (const commitment of ['processed', 'confirmed', 'finalized']) {
       const {blockhash, feeCalculator} = await helpers.recentBlockhash({
         connection,
         commitment,
@@ -1205,7 +1199,7 @@ describe('Connection', () => {
           new u64(1),
         );
 
-        await connection.confirmTransaction(testSignature, 'max');
+        await connection.confirmTransaction(testSignature, 'finalized');
 
         testOwner = accountOwner;
         testToken = token;

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -125,7 +125,7 @@ describe('Connection', () => {
         connection,
         transaction,
         signers: [account0],
-        commitment: 'singleGossip',
+        commitment: 'confirmed',
       });
     }
 
@@ -147,7 +147,7 @@ describe('Connection', () => {
         connection,
         transaction,
         signers: [account1],
-        commitment: 'singleGossip',
+        commitment: 'confirmed',
       });
     }
 
@@ -159,7 +159,7 @@ describe('Connection', () => {
         method: 'getProgramAccounts',
         params: [
           programId.publicKey.toBase58(),
-          {commitment: 'singleGossip', encoding: 'base64'},
+          {commitment: 'confirmed', encoding: 'base64'},
         ],
         value: [
           {
@@ -188,7 +188,7 @@ describe('Connection', () => {
 
       const programAccounts = await connection.getProgramAccounts(
         programId.publicKey,
-        'singleGossip',
+        'confirmed',
       );
       expect(programAccounts).to.have.length(2);
       programAccounts.forEach(function (keyedAccount) {
@@ -210,7 +210,7 @@ describe('Connection', () => {
         method: 'getProgramAccounts',
         params: [
           programId.publicKey.toBase58(),
-          {commitment: 'singleGossip', encoding: 'jsonParsed'},
+          {commitment: 'confirmed', encoding: 'jsonParsed'},
         ],
         value: [
           {
@@ -239,7 +239,7 @@ describe('Connection', () => {
 
       const programAccounts = await connection.getParsedProgramAccounts(
         programId.publicKey,
-        'singleGossip',
+        'confirmed',
       );
       expect(programAccounts).to.have.length(2);
 
@@ -319,7 +319,7 @@ describe('Connection', () => {
   it('get epoch info', async () => {
     await mockRpcResponse({
       method: 'getEpochInfo',
-      params: [{commitment: 'singleGossip'}],
+      params: [{commitment: 'confirmed'}],
       value: {
         epoch: 0,
         slotIndex: 1,
@@ -329,7 +329,7 @@ describe('Connection', () => {
       },
     });
 
-    const epochInfo = await connection.getEpochInfo('singleGossip');
+    const epochInfo = await connection.getEpochInfo('confirmed');
 
     for (const key of [
       'epoch',
@@ -1014,10 +1014,10 @@ describe('Connection', () => {
   it('get recent blockhash', async () => {
     for (const commitment of [
       'max',
-      'singleGossip',
+      'confirmed',
       'root',
       'single',
-      'singleGossip',
+      'confirmed',
     ]) {
       const {blockhash, feeCalculator} = await helpers.recentBlockhash({
         connection,
@@ -1032,7 +1032,7 @@ describe('Connection', () => {
     const {blockhash} = await helpers.recentBlockhash({connection});
     await mockRpcResponse({
       method: 'getFeeCalculatorForBlockhash',
-      params: [blockhash, {commitment: 'singleGossip'}],
+      params: [blockhash, {commitment: 'confirmed'}],
       value: {
         feeCalculator: {
           lamportsPerSignature: 5000,
@@ -1042,7 +1042,7 @@ describe('Connection', () => {
     });
 
     const feeCalculator = (
-      await connection.getFeeCalculatorForBlockhash(blockhash, 'singleGossip')
+      await connection.getFeeCalculatorForBlockhash(blockhash, 'confirmed')
     ).value;
     if (feeCalculator === null) {
       expect(feeCalculator).not.to.be.null;
@@ -1149,7 +1149,7 @@ describe('Connection', () => {
 
   if (process.env.TEST_LIVE) {
     describe('token methods', () => {
-      const connection = new Connection(url, 'singleGossip');
+      const connection = new Connection(url, 'confirmed');
       const newAccount = new Account().publicKey;
 
       let testToken: Token;
@@ -1402,7 +1402,7 @@ describe('Connection', () => {
         authorized.publicKey,
         2 * LAMPORTS_PER_SOL,
       );
-      await connection.confirmTransaction(signature, 'singleGossip');
+      await connection.confirmTransaction(signature, 'confirmed');
 
       const minimumAmount = await connection.getMinimumBalanceForRentExemption(
         StakeProgram.space,
@@ -1422,8 +1422,8 @@ describe('Connection', () => {
         createAndInitialize,
         [authorized, newStakeAccount],
         {
-          preflightCommitment: 'singleGossip',
-          commitment: 'singleGossip',
+          preflightCommitment: 'confirmed',
+          commitment: 'confirmed',
         },
       );
       let delegation = StakeProgram.delegate({
@@ -1432,15 +1432,15 @@ describe('Connection', () => {
         votePubkey,
       });
       await sendAndConfirmTransaction(connection, delegation, [authorized], {
-        preflightCommitment: 'singleGossip',
-        commitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
+        commitment: 'confirmed',
       });
 
       const LARGE_EPOCH = 4000;
       await expect(
         connection.getStakeActivation(
           newStakeAccount.publicKey,
-          'singleGossip',
+          'confirmed',
           LARGE_EPOCH,
         ),
       ).to.be.rejectedWith(
@@ -1449,7 +1449,7 @@ describe('Connection', () => {
 
       const activationState = await connection.getStakeActivation(
         newStakeAccount.publicKey,
-        'singleGossip',
+        'confirmed',
       );
       expect(activationState.state).to.eq('activating');
       expect(activationState.inactive).to.eq(42);
@@ -1476,14 +1476,14 @@ describe('Connection', () => {
       await addStakeActivationMock('active');
       let activation = await connection.getStakeActivation(
         publicKey,
-        'singleGossip',
+        'confirmed',
       );
       expect(activation.state).to.eq('active');
       expect(activation.active).to.eq(0);
       expect(activation.inactive).to.eq(80);
 
       await addStakeActivationMock('invalid');
-      await expect(connection.getStakeActivation(publicKey, 'singleGossip')).to
+      await expect(connection.getStakeActivation(publicKey, 'confirmed')).to
         .be.rejected;
     });
   }
@@ -1510,14 +1510,14 @@ describe('Connection', () => {
 
     await mockRpcResponse({
       method: 'getBalance',
-      params: [account.publicKey.toBase58(), {commitment: 'singleGossip'}],
+      params: [account.publicKey.toBase58(), {commitment: 'confirmed'}],
       value: LAMPORTS_PER_SOL,
       withContext: true,
     });
 
     const balance = await connection.getBalance(
       account.publicKey,
-      'singleGossip',
+      'confirmed',
     );
     expect(balance).to.eq(LAMPORTS_PER_SOL);
 
@@ -1525,7 +1525,7 @@ describe('Connection', () => {
       method: 'getAccountInfo',
       params: [
         account.publicKey.toBase58(),
-        {commitment: 'singleGossip', encoding: 'base64'},
+        {commitment: 'confirmed', encoding: 'base64'},
       ],
       value: {
         owner: '11111111111111111111111111111111',
@@ -1538,7 +1538,7 @@ describe('Connection', () => {
 
     const accountInfo = await connection.getAccountInfo(
       account.publicKey,
-      'singleGossip',
+      'confirmed',
     );
     if (accountInfo === null) {
       expect(accountInfo).not.to.be.null;
@@ -1552,7 +1552,7 @@ describe('Connection', () => {
       method: 'getAccountInfo',
       params: [
         account.publicKey.toBase58(),
-        {commitment: 'singleGossip', encoding: 'jsonParsed'},
+        {commitment: 'confirmed', encoding: 'jsonParsed'},
       ],
       value: {
         owner: '11111111111111111111111111111111',
@@ -1564,7 +1564,7 @@ describe('Connection', () => {
     });
 
     const parsedAccountInfo = (
-      await connection.getParsedAccountInfo(account.publicKey, 'singleGossip')
+      await connection.getParsedAccountInfo(account.publicKey, 'confirmed')
     ).value;
     if (parsedAccountInfo === null) {
       expect(parsedAccountInfo).not.to.be.null;
@@ -1602,7 +1602,7 @@ describe('Connection', () => {
       connection,
       transaction,
       signers: [payer, newAccount],
-      commitment: 'singleGossip',
+      commitment: 'confirmed',
     });
 
     // This should fail because the account is already created
@@ -1612,7 +1612,7 @@ describe('Connection', () => {
         connection,
         transaction,
         signers: [payer, newAccount],
-        commitment: 'singleGossip',
+        commitment: 'confirmed',
         err: expectedErr,
       })
     ).value;
@@ -1639,7 +1639,7 @@ describe('Connection', () => {
 
   if (process.env.TEST_LIVE) {
     it('transaction', async () => {
-      connection._commitment = 'singleGossip';
+      connection._commitment = 'confirmed';
 
       const accountFrom = new Account();
       const accountTo = new Account();
@@ -1670,7 +1670,7 @@ describe('Connection', () => {
         connection,
         transaction,
         [accountFrom],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
 
       // Send again and ensure that new blockhash is used
@@ -1687,7 +1687,7 @@ describe('Connection', () => {
         connection,
         transaction2,
         [accountFrom],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
 
       expect(signature).not.to.eq(signature2);
@@ -1704,7 +1704,7 @@ describe('Connection', () => {
         }),
       );
       await sendAndConfirmTransaction(connection, transaction3, [accountFrom], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
       expect(transaction2.recentBlockhash).to.eq(transaction3.recentBlockhash);
 
@@ -1725,7 +1725,7 @@ describe('Connection', () => {
       );
 
       await sendAndConfirmTransaction(connection, transaction4, [accountFrom], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
 
       expect(transaction4.recentBlockhash).not.to.eq(
@@ -1742,7 +1742,7 @@ describe('Connection', () => {
     }).timeout(45 * 1000); // waits 30s for cache timeout
 
     it('multi-instruction transaction', async () => {
-      connection._commitment = 'singleGossip';
+      connection._commitment = 'confirmed';
 
       const accountFrom = new Account();
       const accountTo = new Account();
@@ -1821,7 +1821,7 @@ describe('Connection', () => {
     //     return;
     //   }
 
-    //   const connection = new Connection(url, 'singleGossip');
+    //   const connection = new Connection(url, 'confirmed');
     //   const owner = new Account();
     //   const programAccount = new Account();
 
@@ -1830,7 +1830,7 @@ describe('Connection', () => {
     //   const subscriptionId = connection.onAccountChange(
     //     programAccount.publicKey,
     //     mockCallback,
-    //     'singleGossip',
+    //     'confirmed',
     //   );
 
     //   const balanceNeeded = Math.max(
@@ -1852,7 +1852,7 @@ describe('Connection', () => {
     //       }),
     //     );
     //     await sendAndConfirmTransaction(connection, transaction, [owner], {
-    //       commitment: 'singleGossip',
+    //       commitment: 'confirmed',
     //     });
     //   } catch (err) {
     //     await connection.removeAccountChangeListener(subscriptionId);
@@ -1881,7 +1881,7 @@ describe('Connection', () => {
     // });
 
     it('program account change notification', async () => {
-      connection._commitment = 'singleGossip';
+      connection._commitment = 'confirmed';
 
       const owner = new Account();
       const programAccount = new Account();
@@ -1923,7 +1923,7 @@ describe('Connection', () => {
           }),
         );
         await sendAndConfirmTransaction(connection, transaction, [owner], {
-          commitment: 'singleGossip',
+          commitment: 'confirmed',
         });
       } catch (err) {
         await connection.removeProgramAccountChangeListener(subscriptionId);

--- a/web3.js/test/mocks/rpc-http.js
+++ b/web3.js/test/mocks/rpc-http.js
@@ -162,11 +162,11 @@ const airdrop = async ({
 
   await mockRpcMessage({
     method: 'signatureSubscribe',
-    params: [signature, {commitment: 'singleGossip'}],
+    params: [signature, {commitment: 'confirmed'}],
     result: {err: null},
   });
 
-  await connection.confirmTransaction(signature, 'singleGossip');
+  await connection.confirmTransaction(signature, 'confirmed');
   return signature;
 };
 

--- a/web3.js/test/nonce.test.js
+++ b/web3.js/test/nonce.test.js
@@ -78,14 +78,14 @@ describe('Nonce', () => {
       connection,
       transaction,
       signers: [from, nonceAccount],
-      commitment: 'singleGossip',
+      commitment: 'confirmed',
     });
 
     await mockRpcResponse({
       method: 'getAccountInfo',
       params: [
         nonceAccount.publicKey.toBase58(),
-        {encoding: 'base64', commitment: 'singleGossip'},
+        {encoding: 'base64', commitment: 'confirmed'},
       ],
       value: {
         owner: '11111111111111111111111111111111',
@@ -98,7 +98,7 @@ describe('Nonce', () => {
 
     const nonceAccountData = await connection.getNonce(
       nonceAccount.publicKey,
-      'singleGossip',
+      'confirmed',
     );
     if (nonceAccountData === null) {
       expect(nonceAccountData).not.to.be.null;
@@ -148,14 +148,14 @@ describe('Nonce', () => {
       connection,
       transaction,
       signers: [from],
-      commitment: 'singleGossip',
+      commitment: 'confirmed',
     });
 
     await mockRpcResponse({
       method: 'getAccountInfo',
       params: [
         noncePubkey.toBase58(),
-        {encoding: 'base64', commitment: 'singleGossip'},
+        {encoding: 'base64', commitment: 'confirmed'},
       ],
       value: {
         owner: '11111111111111111111111111111111',
@@ -168,7 +168,7 @@ describe('Nonce', () => {
 
     const nonceAccountData = await connection.getNonce(
       noncePubkey,
-      'singleGossip',
+      'confirmed',
     );
     if (nonceAccountData === null) {
       expect(nonceAccountData).not.to.be.null;

--- a/web3.js/test/secp256k1-program.test.js
+++ b/web3.js/test/secp256k1-program.test.js
@@ -33,12 +33,12 @@ if (process.env.TEST_LIVE) {
         keccak_256.update(toBuffer(message)).digest(),
       );
       const {signature, recid: recoveryId} = ecdsaSign(messageHash, privateKey);
-      const connection = new Connection(url, 'singleGossip');
+      const connection = new Connection(url, 'confirmed');
 
       const from = new Account();
       await connection.confirmTransaction(
         await connection.requestAirdrop(from.publicKey, 2 * LAMPORTS_PER_SOL),
-        'singleGossip',
+        'confirmed',
       );
 
       const transaction = new Transaction().add(
@@ -51,19 +51,19 @@ if (process.env.TEST_LIVE) {
       );
 
       await sendAndConfirmTransaction(connection, transaction, [from], {
-        commitment: 'singleGossip',
-        preflightCommitment: 'singleGossip',
+        commitment: 'confirmed',
+        preflightCommitment: 'confirmed',
       });
     });
 
     it('create secp256k1 instruction with private key', async () => {
       const privateKey = randomPrivateKey();
-      const connection = new Connection(url, 'singleGossip');
+      const connection = new Connection(url, 'confirmed');
 
       const from = new Account();
       await connection.confirmTransaction(
         await connection.requestAirdrop(from.publicKey, 2 * LAMPORTS_PER_SOL),
-        'singleGossip',
+        'confirmed',
       );
 
       const transaction = new Transaction().add(
@@ -74,8 +74,8 @@ if (process.env.TEST_LIVE) {
       );
 
       await sendAndConfirmTransaction(connection, transaction, [from], {
-        commitment: 'singleGossip',
-        preflightCommitment: 'singleGossip',
+        commitment: 'confirmed',
+        preflightCommitment: 'confirmed',
       });
     });
   });

--- a/web3.js/test/stake-program.test.js
+++ b/web3.js/test/stake-program.test.js
@@ -326,7 +326,7 @@ describe('StakeProgram', () => {
 
   if (process.env.TEST_LIVE) {
     it('live staking actions', async () => {
-      const connection = new Connection(url, 'singleGossip');
+      const connection = new Connection(url, 'confirmed');
 
       const voteAccounts = await connection.getVoteAccounts();
       const voteAccount = voteAccounts.current.concat(
@@ -377,7 +377,7 @@ describe('StakeProgram', () => {
           connection,
           createAndInitialize,
           [payer, newStakeAccount],
-          {preflightCommitment: 'singleGossip'},
+          {preflightCommitment: 'confirmed'},
         );
         expect(await connection.getBalance(newStakeAccount.publicKey)).to.eq(
           minimumAmount + 42,
@@ -389,7 +389,7 @@ describe('StakeProgram', () => {
           votePubkey,
         });
         await sendAndConfirmTransaction(connection, delegation, [authorized], {
-          commitment: 'singleGossip',
+          commitment: 'confirmed',
         });
       }
 
@@ -415,7 +415,7 @@ describe('StakeProgram', () => {
         connection,
         createAndInitializeWithSeed,
         [payer],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
       let originalStakeBalance = await connection.getBalance(newAccountPubkey);
       expect(originalStakeBalance).to.eq(3 * minimumAmount + 42);
@@ -426,7 +426,7 @@ describe('StakeProgram', () => {
         votePubkey,
       });
       await sendAndConfirmTransaction(connection, delegation, [authorized], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
 
       // Test that withdraw fails before deactivation
@@ -439,7 +439,7 @@ describe('StakeProgram', () => {
       });
       await expect(
         sendAndConfirmTransaction(connection, withdraw, [authorized], {
-          preflightCommitment: 'singleGossip',
+          preflightCommitment: 'confirmed',
         }),
       ).to.be.rejected;
 
@@ -449,7 +449,7 @@ describe('StakeProgram', () => {
         authorizedPubkey: authorized.publicKey,
       });
       await sendAndConfirmTransaction(connection, deactivate, [authorized], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
 
       let stakeActivationState;
@@ -468,7 +468,7 @@ describe('StakeProgram', () => {
       });
 
       await sendAndConfirmTransaction(connection, withdraw, [authorized], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
       const recipientBalance = await connection.getBalance(recipient.publicKey);
       expect(recipientBalance).to.eq(minimumAmount + 20);
@@ -486,7 +486,7 @@ describe('StakeProgram', () => {
         split,
         [authorized, newStake],
         {
-          preflightCommitment: 'singleGossip',
+          preflightCommitment: 'confirmed',
         },
       );
       const balance = await connection.getBalance(newAccountPubkey);
@@ -506,7 +506,7 @@ describe('StakeProgram', () => {
         stakeAuthorizationType: StakeAuthorizationLayout.Withdrawer,
       });
       await sendAndConfirmTransaction(connection, authorize, [authorized], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
       authorize = StakeProgram.authorize({
         stakePubkey: newAccountPubkey,
@@ -515,7 +515,7 @@ describe('StakeProgram', () => {
         stakeAuthorizationType: StakeAuthorizationLayout.Staker,
       });
       await sendAndConfirmTransaction(connection, authorize, [authorized], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
 
       // Test old authorized can't delegate
@@ -530,7 +530,7 @@ describe('StakeProgram', () => {
           delegateNotAuthorized,
           [authorized],
           {
-            preflightCommitment: 'singleGossip',
+            preflightCommitment: 'confirmed',
           },
         ),
       ).to.be.rejected;
@@ -543,7 +543,7 @@ describe('StakeProgram', () => {
         stakeAuthorizationType: StakeAuthorizationLayout.Withdrawer,
       });
       await sendAndConfirmTransaction(connection, authorize, [newAuthorized], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
 
       // Restore the previous authority using a derived address
@@ -556,7 +556,7 @@ describe('StakeProgram', () => {
         stakeAuthorizationType: StakeAuthorizationLayout.Withdrawer,
       });
       await sendAndConfirmTransaction(connection, authorize, [payer], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
     }).timeout(10 * 1000);
   }

--- a/web3.js/test/system-program.test.js
+++ b/web3.js/test/system-program.test.js
@@ -290,7 +290,7 @@ describe('SystemProgram', () => {
 
   if (process.env.TEST_LIVE) {
     it('live Nonce actions', async () => {
-      const connection = new Connection(url, 'singleGossip');
+      const connection = new Connection(url, 'confirmed');
       const nonceAccount = new Account();
       const from = new Account();
       await helpers.airdrop({
@@ -323,7 +323,7 @@ describe('SystemProgram', () => {
         connection,
         createNonceAccount,
         [from, nonceAccount],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
       const nonceBalance = await connection.getBalance(nonceAccount.publicKey);
       expect(nonceBalance).to.eq(minimumAmount);
@@ -352,7 +352,7 @@ describe('SystemProgram', () => {
         }),
       );
       await sendAndConfirmTransaction(connection, advanceNonce, [from], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
       const nonceQuery3 = await connection.getNonce(nonceAccount.publicKey);
       if (nonceQuery3 === null) {
@@ -373,7 +373,7 @@ describe('SystemProgram', () => {
         }),
       );
       await sendAndConfirmTransaction(connection, authorizeNonce, [from], {
-        preflightCommitment: 'singleGossip',
+        preflightCommitment: 'confirmed',
       });
 
       let transfer = new Transaction().add(
@@ -396,7 +396,7 @@ describe('SystemProgram', () => {
         transfer,
         [from, newAuthority],
         {
-          preflightCommitment: 'singleGossip',
+          preflightCommitment: 'confirmed',
         },
       );
       const toBalance = await connection.getBalance(to.publicKey);
@@ -419,7 +419,7 @@ describe('SystemProgram', () => {
         withdrawNonce,
         [newAuthority],
         {
-          preflightCommitment: 'singleGossip',
+          preflightCommitment: 'confirmed',
         },
       );
       expect(await connection.getBalance(nonceAccount.publicKey)).to.eq(0);
@@ -430,7 +430,7 @@ describe('SystemProgram', () => {
     }).timeout(10 * 1000);
 
     it('live withSeed actions', async () => {
-      const connection = new Connection(url, 'singleGossip');
+      const connection = new Connection(url, 'confirmed');
       const baseAccount = new Account();
       await helpers.airdrop({
         connection,
@@ -468,7 +468,7 @@ describe('SystemProgram', () => {
         connection,
         createAccountWithSeedTransaction,
         [baseAccount],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
       const createAccountWithSeedBalance = await connection.getBalance(
         createAccountWithSeedAddress,
@@ -492,7 +492,7 @@ describe('SystemProgram', () => {
           }),
         ),
         [baseAccount],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
       let transferWithSeedAddressBalance = await connection.getBalance(
         transferWithSeedAddress,
@@ -521,7 +521,7 @@ describe('SystemProgram', () => {
         connection,
         transferWithSeedTransaction,
         [baseAccount],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
       const toBalance = await connection.getBalance(toPubkey);
       expect(toBalance).to.eq(2 * minimumAmount);
@@ -545,7 +545,7 @@ describe('SystemProgram', () => {
         connection,
         allocateWithSeedTransaction,
         [baseAccount],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
       let account = await connection.getAccountInfo(toPubkey);
       if (account === null) {
@@ -568,7 +568,7 @@ describe('SystemProgram', () => {
         connection,
         assignWithSeedTransaction,
         [baseAccount],
-        {preflightCommitment: 'singleGossip'},
+        {preflightCommitment: 'confirmed'},
       );
       account = await connection.getAccountInfo(toPubkey);
       if (account === null) {

--- a/web3.js/test/transaction-payer.test.js
+++ b/web3.js/test/transaction-payer.test.js
@@ -75,7 +75,7 @@ describe('Transaction Payer', () => {
       connection,
       transaction,
       signers: [accountPayer, accountFrom],
-      commitment: 'singleGossip',
+      commitment: 'confirmed',
     });
 
     const signature = base58.encode(transaction.signature);
@@ -103,7 +103,7 @@ describe('Transaction Payer', () => {
 
     await mockRpcResponse({
       method: 'getBalance',
-      params: [accountPayer.publicKey.toBase58(), {commitment: 'singleGossip'}],
+      params: [accountPayer.publicKey.toBase58(), {commitment: 'confirmed'}],
       value: LAMPORTS_PER_SOL - 1,
       withContext: true,
     });
@@ -112,7 +112,7 @@ describe('Transaction Payer', () => {
     // (exact amount less depends on the current cluster fees)
     const balance = await connection.getBalance(
       accountPayer.publicKey,
-      'singleGossip',
+      'confirmed',
     );
     expect(balance).to.be.greaterThan(0);
     expect(balance).to.be.at.most(LAMPORTS_PER_SOL);
@@ -120,12 +120,12 @@ describe('Transaction Payer', () => {
     // accountFrom should have exactly 2, since it didn't pay for the transaction
     await mockRpcResponse({
       method: 'getBalance',
-      params: [accountFrom.publicKey.toBase58(), {commitment: 'singleGossip'}],
+      params: [accountFrom.publicKey.toBase58(), {commitment: 'confirmed'}],
       value: minimumAmount + 2,
       withContext: true,
     });
     expect(
-      await connection.getBalance(accountFrom.publicKey, 'singleGossip'),
+      await connection.getBalance(accountFrom.publicKey, 'confirmed'),
     ).to.eq(minimumAmount + 2);
   });
 });

--- a/web3.js/test/url.js
+++ b/web3.js/test/url.js
@@ -6,7 +6,7 @@
 
 export const MOCK_PORT = 9999;
 export const url = process.env.TEST_LIVE
-  ? 'http://localhost:8899/'
+  ? 'http://192.168.0.187:8899/'
   : 'http://localhost:9999/';
 
 //export const url = 'https://devnet.solana.com/';

--- a/web3.js/test/url.js
+++ b/web3.js/test/url.js
@@ -6,7 +6,7 @@
 
 export const MOCK_PORT = 9999;
 export const url = process.env.TEST_LIVE
-  ? 'http://192.168.0.187:8899/'
+  ? 'http://localhost:8899/'
   : 'http://localhost:9999/';
 
 //export const url = 'https://devnet.solana.com/';


### PR DESCRIPTION
#### Problem
web3 js sdk is using commitment variants that are deprecated as of #14797 

#### Summary of Changes
Update commitment variants.

Fixes https://github.com/solana-labs/solana/issues/14863
