### PR TITLE
Tune RocksDB to avoid unbounded cache growth

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -226,6 +226,7 @@ impl Rocks {
         if let Some(recovery_mode) = recovery_mode {
             db_options.set_wal_recovery_mode(recovery_mode.into());
         }
+        db_options.set_max_open_files(512);
 
         // Column family names
         let meta_cf_descriptor =


### PR DESCRIPTION
#### Problem

Yet another slow mem leak is spotted; this time... by our usage of RocksDB (or lack of proper configuration...)

Unless we set `max_open_files` (`-1`; inifinite; is the default), rocksdb holds associated cache in memory. Putting aside just mere File descriptors, it burdens long-running validator operation. Note that, generally we continue to create SST files.

##### comparison of validators before/after running roughly equal time with same options against mainnet-beta under heaptrack

BEFORE

```
$ tail heaptrack.solana-validator2.190486-5.gz.report
total runtime: 133453.78s.

heaptrack.solana-validator2.190486-5.gz.report:1.01GB peak memory consumed over 1558 calls from
heaptrack.solana-validator2.190486-5.gz.report:570.43MB peak memory consumed over 5950 calls from

heaptrack.solana-validator2.190486-5.gz.report:1.07GB leaked over 1558 calls from
heaptrack.solana-validator2.190486-5.gz.report:570.43MB leaked over 5950 calls from

```

(Note: peak is same as leaked amount... so not freeing at all. lol)

AFTER

```
$ tail heaptrack.solana-validator3-all-v2.1-leak-fixes.813196-7.zst.report
total runtime: 133720.55s.

heaptrack.solana-validator3-all-v2.1-leak-fixes.813196-7.zst.report:570.43MB peak memory consumed over 9115 calls from
heaptrack.solana-validator3-all-v2.1-leak-fixes.813196-7.zst.report:327.85MB peak memory consumed over 2105 calls from

heaptrack.solana-validator3-all-v2.1-leak-fixes.813196-7.zst.report:469.76MB leaked over 9115 calls from
heaptrack.solana-validator3-all-v2.1-leak-fixes.813196-7.zst.report:333.79MB leaked over 2105 calls from

```

(Note: this report is taken when rocksdb dir contained more than 512 (new tuned value) files and lsof -p indicated actually less than 512 open file descriptor)

##### After very long run even after daily manually-triggered compaction was completed


```
$ tail heaptrack.solana-validator2.190486-9.gz.report
total runtime: 342044.07s.

heaptrack.solana-validator2.190486-9.gz.report:2.68GB peak memory consumed over 6003 calls from
heaptrack.solana-validator2.190486-9.gz.report:771.75MB peak memory consumed over 14875 calls from

heaptrack.solana-validator2.190486-9.gz.report:2.73GB leaked over 6003 calls from
heaptrack.solana-validator2.190486-9.gz.report:771.75MB leaked over 14875 calls from

```

(note: Dunno about small difference between peak vs leak)


resource: https://github.com/facebook/rocksdb/issues/4112 (sadly, very cluttered not-authoritative info...)

#### Summary of Changes

TODO:

- assess perf degradation (maybe, run on one of our validators?)
- assess risk of worsening known rocksdb troubles (stall by compaction, and still-unknown one #14586 ) 
- google around to see best practice by others (I have done lightly and have some links to grok)
  - goal is to then decide the correct tune value (static or dynamic? / different value depending `--rpc-port` or not).
  - alternatively, goal is to find more proper memory tuning option?


context #14366 
