### PR TITLE
explorer: reverse order on market and event queue pubkeys for Serum: Consume Events

### DIFF
--- a/explorer/src/components/instruction/serum/types.ts
+++ b/explorer/src/components/instruction/serum/types.ts
@@ -181,8 +181,8 @@ export function decodeConsumeEvents(ix: TransactionInstruction): ConsumeEvents {
 
   const consumeEvents: ConsumeEvents = {
     openOrdersAccounts: ix.keys.slice(0, -2).map((k) => k.pubkey),
-    market: ix.keys[ix.keys.length - 3].pubkey,
-    eventQueue: ix.keys[ix.keys.length - 2].pubkey,
+    market: ix.keys[ix.keys.length - 2].pubkey,
+    eventQueue: ix.keys[ix.keys.length - 3].pubkey,
     programId: ix.programId,
     limit: decoded.limit,
   };


### PR DESCRIPTION
#### Problem
The Serum: Consume Events instruction card displays the event queue and market backwards.

#### Summary of Changes
Swap the indices so the proper pubkeys are displayed.
