### PR TITLE
Update insn counts of BPF C tests for llvm 10.0 based toolchain

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1215,8 +1215,8 @@ fn assert_instruction_count() {
             ("multiple_static", 8),
             ("noop", 57),
             ("relative_call", 10),
-            ("sanity", 176),
-            ("sanity++", 176),
+            ("sanity", 175),
+            ("sanity++", 177),
             ("struct_pass", 8),
             ("struct_ret", 22),
         ]);


### PR DESCRIPTION
#### Problem

Instruction counts may change when a new toolchain is used.

#### Summary of Changes

Bring the instruction counts in sync with the code generated by llvm 10.0 toolchain.

Fixes #
