### PR TITLE
docs: getLargestAccounts caching notice

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1464,7 +1464,7 @@ Result:
 
 ### getLargestAccounts
 
-Returns the 20 largest accounts, by lamport balance
+Returns the 20 largest accounts, by lamport balance (results may be cached up to two hours)
 
 #### Parameters:
 


### PR DESCRIPTION
#### Problem
Show that getLargestAccounts may be cached up to 2 hours. 