### PR TITLE
fix: default preflightCommitment to Connection.commitment when sending tx

### DIFF
--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -3034,7 +3034,8 @@ export class Connection {
     const config: any = {encoding: 'base64'};
     const args = [encodedTransaction, config];
     const skipPreflight = options && options.skipPreflight;
-    const preflightCommitment = options && options.preflightCommitment;
+    const preflightCommitment =
+      (options && options.preflightCommitment) || this.commitment;
 
     if (skipPreflight) {
       config.skipPreflight = skipPreflight;

--- a/web3.js/test/connection.test.js
+++ b/web3.js/test/connection.test.js
@@ -1361,6 +1361,25 @@ describe('Connection', () => {
         ).to.be.rejected;
       });
     });
+
+    it('consistent preflightCommitment', async () => {
+      const connection = new Connection(url, 'singleGossip');
+      const sender = new Account();
+      const recipient = new Account();
+      let signature = await connection.requestAirdrop(
+        sender.publicKey,
+        2 * LAMPORTS_PER_SOL,
+      );
+      await connection.confirmTransaction(signature, 'singleGossip');
+      const transaction = new Transaction().add(
+        SystemProgram.transfer({
+          fromPubkey: sender.publicKey,
+          toPubkey: recipient.publicKey,
+          lamports: LAMPORTS_PER_SOL,
+        }),
+      );
+      await sendAndConfirmTransaction(connection, transaction, [sender]);
+    });
   }
 
   it('get largest accounts', async () => {


### PR DESCRIPTION
#### Problem
If a users instantiates a `Connection` object with a commitment, this commitment is used by default for all rpc queries and transaction confirmations. However, it is *not* used as the preflightCommitment for transaction sends, which defaults to `finalized` (max) on the rpc side. As such, if a client is using a commitment level less than `finalized`, they must specify preflightCommitment for all sends or preflight simulations may fail due to unfinalized state.

#### Summary of Changes
Default preflightCommitment to Connection.commitment if not specified
Test throws error without code change
