### PR TITLE
docs: Remove references to "create_address_with_seed"

### DIFF
--- a/docs/src/developing/programming-model/calling-between-programs.md
+++ b/docs/src/developing/programming-model/calling-between-programs.md
@@ -182,12 +182,12 @@ off the curve.
 
 Deterministic program addresses for programs follow a similar derivation path as
 Accounts created with `SystemInstruction::CreateAccountWithSeed` which is
-implemented with `system_instruction::create_address_with_seed`.
+implemented with `Pubkey::create_with_seed`.
 
 For reference that implementation is as follows:
 
 ```rust,ignore
-pub fn create_address_with_seed(
+pub fn create_with_seed(
     base: &Pubkey,
     seed: &str,
     program_id: &Pubkey,

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -263,7 +263,7 @@ pub fn split_with_seed(
     stake_pubkey: &Pubkey,
     authorized_pubkey: &Pubkey,
     lamports: u64,
-    split_stake_pubkey: &Pubkey, // derived using create_address_with_seed()
+    split_stake_pubkey: &Pubkey, // derived using create_with_seed()
     base: &Pubkey,               // base
     seed: &str,                  // seed
 ) -> Vec<Instruction> {

--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -242,10 +242,10 @@ pub fn create_account(
 }
 
 // we accept `to` as a parameter so that callers do their own error handling when
-//   calling create_address_with_seed()
+//   calling create_with_seed()
 pub fn create_account_with_seed(
     from_pubkey: &Pubkey,
-    to_pubkey: &Pubkey, // must match create_address_with_seed(base, seed, owner)
+    to_pubkey: &Pubkey, // must match create_with_seed(base, seed, owner)
     base: &Pubkey,
     seed: &str,
     lamports: u64,
@@ -281,7 +281,7 @@ pub fn assign(pubkey: &Pubkey, owner: &Pubkey) -> Instruction {
 }
 
 pub fn assign_with_seed(
-    address: &Pubkey, // must match create_address_with_seed(base, seed, owner)
+    address: &Pubkey, // must match create_with_seed(base, seed, owner)
     base: &Pubkey,
     seed: &str,
     owner: &Pubkey,
@@ -314,7 +314,7 @@ pub fn transfer(from_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Inst
 }
 
 pub fn transfer_with_seed(
-    from_pubkey: &Pubkey, // must match create_address_with_seed(base, seed, owner)
+    from_pubkey: &Pubkey, // must match create_with_seed(base, seed, owner)
     from_base: &Pubkey,
     from_seed: String,
     from_owner: &Pubkey,
@@ -347,7 +347,7 @@ pub fn allocate(pubkey: &Pubkey, space: u64) -> Instruction {
 }
 
 pub fn allocate_with_seed(
-    address: &Pubkey, // must match create_address_with_seed(base, seed, owner)
+    address: &Pubkey, // must match create_with_seed(base, seed, owner)
     base: &Pubkey,
     seed: &str,
     space: u64,


### PR DESCRIPTION
#### Problem

Docs and comments mention `create_address_with_seed`, but it was replaced by `create_with_seed`.

#### Summary of Changes

Update 'em!

Fixes #
