### PR TITLE
cli: Speed up program deploys

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1639,9 +1639,7 @@ fn send_and_confirm_transactions_with_spinner<T: Signers>(
             for pending_signatures_chunk in
                 pending_signatures.chunks(MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS)
             {
-                if let Ok(result) =
-                    rpc_client.get_signature_statuses_with_history(pending_signatures_chunk)
-                {
+                if let Ok(result) = rpc_client.get_signature_statuses(pending_signatures_chunk) {
                     let statuses = result.value;
                     for (signature, status) in
                         pending_signatures_chunk.iter().zip(statuses.into_iter())

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -1078,8 +1078,9 @@ fn test_cli_program_show() {
         max_len: Some(max_len),
     });
     config.output_format = OutputFormat::JsonCompact;
+    let min_slot = rpc_client.get_slot().unwrap();
     process_command(&config).unwrap();
-    let slot = rpc_client.get_slot().unwrap();
+    let max_slot = rpc_client.get_slot().unwrap();
 
     // Verify show
     config.signers = vec![&keypair];
@@ -1132,7 +1133,8 @@ fn test_cli_program_show() {
         .unwrap()
         .as_u64()
         .unwrap();
-    assert_eq!(slot, deployed_slot);
+    assert!(deployed_slot >= min_slot);
+    assert!(deployed_slot <= max_slot);
     let data_len = json
         .as_object()
         .unwrap()


### PR DESCRIPTION
#### Problem
The CLI fetches signature statuses with history instead of using the recent signature cache when confirming deploy transactions. Searching the history is a lot slower than checking the cache and often times out when checked a large batch of signatures.

#### Summary of Changes
- Search for deploy transactions in signature cache

Fixes #
