### PR TITLE
add validator flag no-accounts-db-index-hashing

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -80,6 +80,7 @@ pub struct TvuConfig {
     pub accounts_hash_fault_injection_slots: u64,
     pub accounts_db_caching_enabled: bool,
     pub test_hash_calculation: bool,
+    pub use_non_index_hash_calculation: bool,
     pub rocksdb_compaction_interval: Option<u64>,
     pub rocksdb_max_compaction_jitter: Option<u64>,
 }
@@ -282,6 +283,7 @@ impl Tvu {
             accounts_background_request_handler,
             tvu_config.accounts_db_caching_enabled,
             tvu_config.test_hash_calculation,
+            tvu_config.use_non_index_hash_calculation,
         );
 
         Tvu {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -80,7 +80,7 @@ pub struct TvuConfig {
     pub accounts_hash_fault_injection_slots: u64,
     pub accounts_db_caching_enabled: bool,
     pub test_hash_calculation: bool,
-    pub use_non_index_hash_calculation: bool,
+    pub use_index_hash_calculation: bool,
     pub rocksdb_compaction_interval: Option<u64>,
     pub rocksdb_max_compaction_jitter: Option<u64>,
 }
@@ -283,7 +283,7 @@ impl Tvu {
             accounts_background_request_handler,
             tvu_config.accounts_db_caching_enabled,
             tvu_config.test_hash_calculation,
-            tvu_config.use_non_index_hash_calculation,
+            tvu_config.use_index_hash_calculation,
         );
 
         Tvu {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -124,6 +124,7 @@ pub struct ValidatorConfig {
     pub accounts_db_caching_enabled: bool,
     pub warp_slot: Option<Slot>,
     pub accounts_db_test_hash_calculation: bool,
+    pub accounts_db_use_non_index_hash_calculation: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -174,6 +175,7 @@ impl Default for ValidatorConfig {
             accounts_db_caching_enabled: false,
             warp_slot: None,
             accounts_db_test_hash_calculation: false,
+            accounts_db_use_non_index_hash_calculation: false,
         }
     }
 }
@@ -648,6 +650,7 @@ impl Validator {
                 accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
                 accounts_db_caching_enabled: config.accounts_db_caching_enabled,
                 test_hash_calculation: config.accounts_db_test_hash_calculation,
+                use_non_index_hash_calculation: config.accounts_db_use_non_index_hash_calculation,
                 rocksdb_compaction_interval: config.rocksdb_compaction_interval,
                 rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
             },

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -124,7 +124,7 @@ pub struct ValidatorConfig {
     pub accounts_db_caching_enabled: bool,
     pub warp_slot: Option<Slot>,
     pub accounts_db_test_hash_calculation: bool,
-    pub accounts_db_use_non_index_hash_calculation: bool,
+    pub accounts_db_use_index_hash_calculation: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -175,7 +175,7 @@ impl Default for ValidatorConfig {
             accounts_db_caching_enabled: false,
             warp_slot: None,
             accounts_db_test_hash_calculation: false,
-            accounts_db_use_non_index_hash_calculation: false,
+            accounts_db_use_index_hash_calculation: true,
         }
     }
 }
@@ -650,7 +650,7 @@ impl Validator {
                 accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
                 accounts_db_caching_enabled: config.accounts_db_caching_enabled,
                 test_hash_calculation: config.accounts_db_test_hash_calculation,
-                use_non_index_hash_calculation: config.accounts_db_use_non_index_hash_calculation,
+                use_index_hash_calculation: config.accounts_db_use_index_hash_calculation,
                 rocksdb_compaction_interval: config.rocksdb_compaction_interval,
                 rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
             },

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -219,7 +219,7 @@ mod tests {
                 // set_root should send a snapshot request
                 bank_forks.set_root(bank.slot(), &request_sender, None);
                 bank.update_accounts_hash();
-                snapshot_request_handler.handle_snapshot_requests(false, false);
+                snapshot_request_handler.handle_snapshot_requests(false, false, false);
             }
         }
 

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -81,7 +81,7 @@ impl SnapshotRequestHandler {
         &self,
         accounts_db_caching_enabled: bool,
         test_hash_calculation: bool,
-        use_non_index_hash_calculation: bool,
+        use_index_hash_calculation: bool,
     ) -> Option<u64> {
         self.snapshot_request_receiver
             .try_iter()
@@ -131,7 +131,7 @@ impl SnapshotRequestHandler {
 
                 let mut hash_time = Measure::start("hash_time");
                 let this_hash = snapshot_root_bank.update_accounts_hash_with_index_option(
-                    !use_non_index_hash_calculation,
+                    use_index_hash_calculation,
                     test_hash_calculation,
                 );
                 let hash_for_testing = if test_hash_calculation {
@@ -243,7 +243,7 @@ impl ABSRequestHandler {
         &self,
         accounts_db_caching_enabled: bool,
         test_hash_calculation: bool,
-        use_non_index_hash_calculation: bool,
+        use_index_hash_calculation: bool,
     ) -> Option<u64> {
         self.snapshot_request_handler
             .as_ref()
@@ -251,7 +251,7 @@ impl ABSRequestHandler {
                 snapshot_request_handler.handle_snapshot_requests(
                     accounts_db_caching_enabled,
                     test_hash_calculation,
-                    use_non_index_hash_calculation,
+                    use_index_hash_calculation,
                 )
             })
     }
@@ -278,7 +278,7 @@ impl AccountsBackgroundService {
         request_handler: ABSRequestHandler,
         accounts_db_caching_enabled: bool,
         test_hash_calculation: bool,
-        use_non_index_hash_calculation: bool,
+        use_index_hash_calculation: bool,
     ) -> Self {
         info!("AccountsBackgroundService active");
         let exit = exit.clone();
@@ -324,7 +324,7 @@ impl AccountsBackgroundService {
                 let snapshot_block_height = request_handler.handle_snapshot_requests(
                     accounts_db_caching_enabled,
                     test_hash_calculation,
-                    use_non_index_hash_calculation,
+                    use_index_hash_calculation,
                 );
                 if accounts_db_caching_enabled {
                     // Note that the flush will do an internal clean of the

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -81,6 +81,7 @@ impl SnapshotRequestHandler {
         &self,
         accounts_db_caching_enabled: bool,
         test_hash_calculation: bool,
+        use_non_index_hash_calculation: bool,
     ) -> Option<u64> {
         self.snapshot_request_receiver
             .try_iter()
@@ -129,9 +130,10 @@ impl SnapshotRequestHandler {
                 flush_accounts_cache_time.stop();
 
                 let mut hash_time = Measure::start("hash_time");
-                const USE_INDEX: bool = true;
-                let this_hash = snapshot_root_bank
-                    .update_accounts_hash_with_index_option(USE_INDEX, test_hash_calculation);
+                let this_hash = snapshot_root_bank.update_accounts_hash_with_index_option(
+                    !use_non_index_hash_calculation,
+                    test_hash_calculation,
+                );
                 let hash_for_testing = if test_hash_calculation {
                     assert_eq!(previous_hash, this_hash);
                     Some(snapshot_root_bank.get_accounts_hash())
@@ -241,12 +243,16 @@ impl ABSRequestHandler {
         &self,
         accounts_db_caching_enabled: bool,
         test_hash_calculation: bool,
+        use_non_index_hash_calculation: bool,
     ) -> Option<u64> {
         self.snapshot_request_handler
             .as_ref()
             .and_then(|snapshot_request_handler| {
-                snapshot_request_handler
-                    .handle_snapshot_requests(accounts_db_caching_enabled, test_hash_calculation)
+                snapshot_request_handler.handle_snapshot_requests(
+                    accounts_db_caching_enabled,
+                    test_hash_calculation,
+                    use_non_index_hash_calculation,
+                )
             })
     }
 
@@ -272,6 +278,7 @@ impl AccountsBackgroundService {
         request_handler: ABSRequestHandler,
         accounts_db_caching_enabled: bool,
         test_hash_calculation: bool,
+        use_non_index_hash_calculation: bool,
     ) -> Self {
         info!("AccountsBackgroundService active");
         let exit = exit.clone();
@@ -314,8 +321,11 @@ impl AccountsBackgroundService {
                 // request for `N` to the snapshot request channel before setting a root `R > N`, and
                 // snapshot_request_handler.handle_requests() will always look for the latest
                 // available snapshot in the channel.
-                let snapshot_block_height = request_handler
-                    .handle_snapshot_requests(accounts_db_caching_enabled, test_hash_calculation);
+                let snapshot_block_height = request_handler.handle_snapshot_requests(
+                    accounts_db_caching_enabled,
+                    test_hash_calculation,
+                    use_non_index_hash_calculation,
+                );
                 if accounts_db_caching_enabled {
                     // Note that the flush will do an internal clean of the
                     // cache up to bank.slot(), so should be safe as long

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1441,6 +1441,11 @@ pub fn main() {
                 .help("Enables testing of hash calculation using stores in AccountsHashVerifier. This has a computational cost."),
         )
         .arg(
+            Arg::with_name("no_accounts_db_index_hashing")
+                .long("no-accounts-db-index-hashing")
+                .help("Disables the use of the index in hash calculation in AccountsHashVerifier/Accounts Background Service."),
+        )
+        .arg(
             // legacy nop argument
             Arg::with_name("accounts_db_caching_enabled")
                 .long("accounts-db-caching-enabled")
@@ -1656,6 +1661,8 @@ pub fn main() {
         account_indexes,
         accounts_db_caching_enabled: !matches.is_present("no_accounts_db_caching"),
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
+        accounts_db_use_non_index_hash_calculation: matches
+            .is_present("no_accounts_db_index_hashing"),
         ..ValidatorConfig::default()
     };
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1661,8 +1661,7 @@ pub fn main() {
         account_indexes,
         accounts_db_caching_enabled: !matches.is_present("no_accounts_db_caching"),
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
-        accounts_db_use_non_index_hash_calculation: matches
-            .is_present("no_accounts_db_index_hashing"),
+        accounts_db_use_index_hash_calculation: !matches.is_present("no_accounts_db_index_hashing"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem
We want to calculate hashes with or without using the index.
#### Summary of Changes
add
--no-accounts-db-index-hashing
to validator to disable using the index. The hash will be calculated based only on the stores.

Fixes #
