### PR TITLE
First step towards denying clippy::integer_arithmetic

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #[macro_use]
 extern crate log;
 use clap::{crate_description, crate_name, value_t, App, Arg};

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{crate_description, crate_name, value_t, App, Arg};
 use crossbeam_channel::unbounded;
 use log::*;

--- a/banks-server/src/lib.rs
+++ b/banks-server/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod banks_server;
 pub mod rpc_banks_service;
 pub mod send_transaction_service;

--- a/bench-exchange/src/bench.rs
+++ b/bench-exchange/src/bench.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::useless_attribute)]
+#![allow(clippy::integer_arithmetic)]
 
 use crate::order_book::*;
 use itertools::izip;

--- a/bench-exchange/src/main.rs
+++ b/bench-exchange/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod bench;
 mod cli;
 pub mod order_book;

--- a/bench-streamer/src/main.rs
+++ b/bench-streamer/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{crate_description, crate_name, App, Arg};
 use solana_streamer::packet::{Packet, Packets, PacketsRecycler, PACKET_DATA_SIZE};
 use solana_streamer::streamer::{receiver, PacketReceiver};

--- a/bench-tps/src/lib.rs
+++ b/bench-tps/src/lib.rs
@@ -1,2 +1,3 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod bench;
 pub mod cli;

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use log::*;
 use solana_bench_tps::bench::{do_bench_tps, generate_and_fund_keypairs, generate_keypairs};
 use solana_bench_tps::cli;

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use serial_test::serial;
 use solana_bench_tps::bench::{do_bench_tps, generate_and_fund_keypairs};
 use solana_bench_tps::cli::Config;

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -56,7 +56,7 @@ _ "$cargo" stable fmt --all -- --check
 
 # -Z... is needed because of clippy bug: https://github.com/rust-lang/rust-clippy/issues/4612
 # run nightly clippy for `sdk/` as there's a moderate amount of nightly-only code there
-_ "$cargo" nightly clippy -Zunstable-options --workspace --all-targets -- --deny=warnings
+_ "$cargo" nightly clippy -Zunstable-options --workspace --all-targets -- --deny=warnings --deny=clippy::integer_arithmetic
 
 cargo_audit_ignores=(
   # failure is officially deprecated/unmaintained

--- a/cli-config/src/lib.rs
+++ b/cli-config/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #[macro_use]
 extern crate lazy_static;
 

--- a/cli-output/src/lib.rs
+++ b/cli-output/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 mod cli_output;
 pub mod display;
 pub use cli_output::*;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 macro_rules! ACCOUNT_STRING {
     () => {
         r#", one of:

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #[macro_use]
 extern crate serde_derive;
 

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![feature(test)]
 
 extern crate test;

--- a/core/benches/blockstore.rs
+++ b/core/benches/blockstore.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![feature(test)]
 extern crate solana_ledger;
 extern crate test;

--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![feature(test)]
 
 extern crate test;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
+#![allow(clippy::integer_arithmetic)]
 //! The `solana` library implements the Solana high-performance blockchain architecture.
 //! It includes a full Rust implementation of the architecture (see
 //! [Validator](server/struct.Validator.html)) as well as hooks to GPU implementations of its most

--- a/core/tests/cluster_info.rs
+++ b/core/tests/cluster_info.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use rayon::iter::ParallelIterator;
 use rayon::prelude::*;
 use serial_test::serial;

--- a/core/tests/crds_gossip.rs
+++ b/core/tests/crds_gossip.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use bincode::serialized_size;
 use log::*;
 use rayon::prelude::*;

--- a/core/tests/fork-selection.rs
+++ b/core/tests/fork-selection.rs
@@ -71,6 +71,7 @@
 //! ```
 //! time: 4007, tip converged: 10, trunk id: 3830, trunk time: 3827, trunk converged 100, trunk height 348
 //! ```
+#![allow(clippy::integer_arithmetic)]
 
 extern crate rand;
 use rand::{thread_rng, Rng};

--- a/core/tests/gossip.rs
+++ b/core/tests/gossip.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #[macro_use]
 extern crate log;
 

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 // Long-running ledger_cleanup tests
 
 #[cfg(test)]

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -1,4 +1,5 @@
 // Long-running bank_forks tests
+#![allow(clippy::integer_arithmetic)]
 
 macro_rules! DEFINE_SNAPSHOT_VERSION_PARAMETERIZED_TEST_FUNCTIONS {
     ($x:ident, $y:ident, $z:ident) => {

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg};
 use log::*;
 use rand::{thread_rng, Rng};

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use console::Emoji;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::*;

--- a/frozen-abi/macro/src/lib.rs
+++ b/frozen-abi/macro/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 extern crate proc_macro;
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 #![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
+#![allow(clippy::integer_arithmetic)]
 
 // Allows macro expansion of `use ::solana_frozen_abi::*` to work within this crate
 extern crate self as solana_frozen_abi;

--- a/genesis/src/lib.rs
+++ b/genesis/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod address_generator;
 pub mod genesis_accounts;
 pub mod stakes;

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -1,4 +1,5 @@
 //! A command-line executable for generating the chain's genesis config.
+#![allow(clippy::integer_arithmetic)]
 
 #[macro_use]
 extern crate solana_budget_program;

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #[macro_use]
 extern crate lazy_static;
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use bip39::{Language, Mnemonic, MnemonicType, Seed};
 use clap::{
     crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App, AppSettings,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{
     crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App, Arg,
     ArgMatches, SubCommand,

--- a/ledger/benches/protobuf.rs
+++ b/ledger/benches/protobuf.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #![feature(test)]
 extern crate test;
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
+#![allow(clippy::integer_arithmetic)]
 #[macro_use]
 extern crate solana_bpf_loader_program;
 

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use solana_ledger::entry::Entry;
 use solana_ledger::shred::{
     max_entries_per_n_shred, verify_test_data_shred, Shred, Shredder,

--- a/local-cluster/src/lib.rs
+++ b/local-cluster/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod cluster;
 pub mod cluster_tests;
 pub mod local_cluster;

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use assert_matches::assert_matches;
 use crossbeam_channel::{unbounded, Receiver};
 use gag::BufferRedirect;

--- a/log-analyzer/src/main.rs
+++ b/log-analyzer/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 extern crate byte_unit;
 
 use byte_unit::Byte;

--- a/measure/src/lib.rs
+++ b/measure/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod measure;
 pub mod thread_mem_usage;
 

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -1,2 +1,3 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod merkle_tree;
 pub use merkle_tree::MerkleTree;

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod counter;
 pub mod datapoint;
 mod metrics;

--- a/net-shaper/src/main.rs
+++ b/net-shaper/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{
     crate_description, crate_name, crate_version, value_t, value_t_or_exit, App, Arg, ArgMatches,
     SubCommand,

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,4 +1,5 @@
 //! The `net_utils` module assists with networking
+#![allow(clippy::integer_arithmetic)]
 use {
     log::*,
     rand::{thread_rng, Rng},

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod cuda_runtime;
 pub mod packet;
 pub mod perf_libs;

--- a/poh-bench/src/main.rs
+++ b/poh-bench/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{crate_description, crate_name, value_t, App, Arg};
 use solana_ledger::entry::{self, create_ticks, init_poh, EntrySlice, VerifyRecyclers};
 use solana_measure::measure::Measure;

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1,4 +1,5 @@
 //! The solana-program-test provides a BanksClient-based test framework BPF programs
+#![allow(clippy::integer_arithmetic)]
 
 use {
     async_trait::async_trait,

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use {
     solana_program::{
         account_info::{next_account_info, AccountInfo},

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod alloc;
 pub mod allocator_bump;
 pub mod bpf_verifier;

--- a/programs/budget/src/lib.rs
+++ b/programs/budget/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod budget_expr;
 pub mod budget_instruction;
 pub mod budget_processor;

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod config_instruction;
 pub mod config_processor;
 pub mod date_instruction;

--- a/programs/exchange/src/lib.rs
+++ b/programs/exchange/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod exchange_instruction;
 pub mod exchange_processor;
 pub mod exchange_state;

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
+#![allow(clippy::integer_arithmetic)]
 use solana_sdk::genesis_config::GenesisConfig;
 
 pub mod config;

--- a/programs/vest/src/lib.rs
+++ b/programs/vest/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod vest_instruction;
 pub mod vest_processor;
 pub mod vest_schedule;

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
+#![allow(clippy::integer_arithmetic)]
 
 pub mod authorized_voters;
 pub mod vote_instruction;

--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -1,4 +1,5 @@
 //! Ramp up TPS for Tour de SOL until all validators drop out
+#![allow(clippy::integer_arithmetic)]
 
 mod results;
 mod stake;

--- a/remote-wallet/src/lib.rs
+++ b/remote-wallet/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod ledger;
 pub mod ledger_error;
 pub mod remote_keypair;

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(clippy::integer_arithmetic)]
 
 extern crate test;
 

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(clippy::integer_arithmetic)]
 
 extern crate test;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
+#![allow(clippy::integer_arithmetic)]
 pub mod accounts;
 pub mod accounts_background_service;
 pub mod accounts_cache;

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use solana_runtime::{
     bank::Bank,
     bank_client::BankClient,

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 #![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
+#![allow(clippy::integer_arithmetic)]
 
 // Allows macro expansion of `use ::solana_program::*` to work within this crate
 extern crate self as solana_program;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 #![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
+#![allow(clippy::integer_arithmetic)]
 
 // Allows macro expansion of `use ::solana_sdk::*` to work within this crate
 extern crate self as solana_sdk;

--- a/stake-accounts/src/main.rs
+++ b/stake-accounts/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 mod arg_parser;
 mod args;
 mod stake_accounts;

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use log::*;
 use serde::{Deserialize, Serialize};
 use solana_client::{client_error::Result as ClientResult, rpc_client::RpcClient};

--- a/stake-o-matic/src/main.rs
+++ b/stake-o-matic/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{crate_description, crate_name, crate_version, value_t, value_t_or_exit, App, Arg};
 use log::*;
 use solana_clap_utils::{

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use log::*;
 use serde::{Deserialize, Serialize};
 use solana_sdk::{

--- a/streamer/src/lib.rs
+++ b/streamer/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod packet;
 pub mod recvmmsg;
 pub mod sendmmsg;

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub mod arg_parser;
 pub mod args;
 pub mod commands;

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 pub use solana_core::test_validator;
 use {
     log::*,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::integer_arithmetic)]
 use clap::{
     crate_description, crate_name, value_t, value_t_or_exit, values_t, values_t_or_exit, App,
     AppSettings, Arg, ArgMatches, SubCommand,

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -1,4 +1,5 @@
 //! A command-line executable for monitoring the health of a cluster
+#![allow(clippy::integer_arithmetic)]
 
 use {
     clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg},


### PR DESCRIPTION
#### Problem

Overflowing integer math is bad.  Clippy can warn us, but we aren't letting it!

#### Summary of Changes

* Globally deny clippy::integer_arithmetic in CI
* Re-allow it at crate-level to ease adoption