### PR TITLE
explorer: Remove line breaks from wrapped raw data

### DIFF
--- a/explorer/src/components/instruction/RawDetails.tsx
+++ b/explorer/src/components/instruction/RawDetails.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { TransactionInstruction } from "@solana/web3.js";
 import { Address } from "components/common/Address";
-import { wrap } from "utils";
 
 export function RawDetails({ ix }: { ix: TransactionInstruction }) {
-  const data = wrap(ix.data.toString("hex"), 50);
+  const data = ix.data.toString("hex");
   return (
     <>
       {ix.keys.map(({ pubkey, isSigner, isWritable }, keyIndex) => (
@@ -27,7 +26,7 @@ export function RawDetails({ ix }: { ix: TransactionInstruction }) {
       <tr>
         <td>Instruction Data (Hex)</td>
         <td className="text-lg-right">
-          <pre className="d-inline-block text-left mb-0">{data}</pre>
+          <pre className="d-inline-block text-left mb-0 data-wrap">{data}</pre>
         </td>
       </tr>
     </>

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -331,3 +331,12 @@ div.inner-cards {
   background: red;
   border: 1px solid red;
 }
+
+pre.data-wrap {
+  max-width: 23rem;
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
#### Problem
The instruction data field contains newlines, which is annoying when you want to copy the data somewhere else.

#### Summary of Changes
Instead of relying on line breaks, use pre-wrap in CSS.

Fixes https://github.com/solana-labs/solana/issues/15296
