### PR TITLE
Return blockstore error if previous_blockhash cannot be determined

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2183,7 +2183,7 @@ mod tests {
 
             transaction_status_service.join().unwrap();
 
-            let confirmed_block = blockstore.get_confirmed_block(bank.slot()).unwrap();
+            let confirmed_block = blockstore.get_confirmed_block(bank.slot(), false).unwrap();
             assert_eq!(confirmed_block.transactions.len(), 3);
 
             for TransactionWithStatusMeta { transaction, meta } in

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2761,7 +2761,7 @@ pub(crate) mod tests {
                 blockstore.clone(),
             );
 
-            let confirmed_block = blockstore.get_confirmed_block(slot).unwrap();
+            let confirmed_block = blockstore.get_confirmed_block(slot, false).unwrap();
             assert_eq!(confirmed_block.transactions.len(), 3);
 
             for TransactionWithStatusMeta { transaction, meta } in

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -737,7 +737,7 @@ impl JsonRpcRequestProcessor {
                     .unwrap()
                     .highest_confirmed_root()
         {
-            let result = self.blockstore.get_confirmed_block(slot);
+            let result = self.blockstore.get_confirmed_block(slot, true);
             self.check_blockstore_root(&result, slot)?;
             if result.is_err() {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -137,7 +137,7 @@ pub async fn upload_confirmed_blocks(
                         break;
                     }
 
-                    let _ = match blockstore.get_confirmed_block(*slot) {
+                    let _ = match blockstore.get_confirmed_block(*slot, true) {
                         Ok(confirmed_block) => sender.send((*slot, Some(confirmed_block))),
                         Err(err) => {
                             warn!(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1686,7 +1686,11 @@ impl Blockstore {
         Ok(root_iterator.next().unwrap_or_default())
     }
 
-    pub fn get_confirmed_block(&self, slot: Slot) -> Result<ConfirmedBlock> {
+    pub fn get_confirmed_block(
+        &self,
+        slot: Slot,
+        require_previous_blockhash: bool,
+    ) -> Result<ConfirmedBlock> {
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_confirmed_block".to_string(), String)
@@ -1727,10 +1731,14 @@ impl Blockstore {
                 let parent_slot_entries = self
                     .get_slot_entries(slot_meta.parent_slot, 0)
                     .unwrap_or_default();
-                if parent_slot_entries.is_empty() {
+                if parent_slot_entries.is_empty() && require_previous_blockhash {
                     return Err(BlockstoreError::ParentEntriesUnavailable);
                 }
-                let previous_blockhash = get_last_hash(parent_slot_entries.iter()).unwrap();
+                let previous_blockhash = if !parent_slot_entries.is_empty() {
+                    get_last_hash(parent_slot_entries.iter()).unwrap()
+                } else {
+                    Hash::default()
+                };
 
                 let blockhash = get_last_hash(slot_entries.iter())
                     .unwrap_or_else(|| panic!("Rooted slot {:?} must have blockhash", slot));
@@ -2072,12 +2080,13 @@ impl Blockstore {
                 match transaction_status {
                     None => return Ok(vec![]),
                     Some((slot, _)) => {
-                        let confirmed_block = self.get_confirmed_block(slot).map_err(|err| {
-                            BlockstoreError::IO(IOError::new(
-                                ErrorKind::Other,
-                                format!("Unable to get confirmed block: {}", err),
-                            ))
-                        })?;
+                        let confirmed_block =
+                            self.get_confirmed_block(slot, false).map_err(|err| {
+                                BlockstoreError::IO(IOError::new(
+                                    ErrorKind::Other,
+                                    format!("Unable to get confirmed block: {}", err),
+                                ))
+                            })?;
 
                         // Load all signatures for the block
                         let mut slot_signatures: Vec<_> = confirmed_block
@@ -2122,12 +2131,13 @@ impl Blockstore {
                 match transaction_status {
                     None => (0, HashSet::new()),
                     Some((slot, _)) => {
-                        let confirmed_block = self.get_confirmed_block(slot).map_err(|err| {
-                            BlockstoreError::IO(IOError::new(
-                                ErrorKind::Other,
-                                format!("Unable to get confirmed block: {}", err),
-                            ))
-                        })?;
+                        let confirmed_block =
+                            self.get_confirmed_block(slot, false).map_err(|err| {
+                                BlockstoreError::IO(IOError::new(
+                                    ErrorKind::Other,
+                                    format!("Unable to get confirmed block: {}", err),
+                                ))
+                            })?;
 
                         // Load all signatures for the block
                         let mut slot_signatures: Vec<_> = confirmed_block
@@ -5739,18 +5749,31 @@ pub mod tests {
             .collect();
 
         // Even if marked as root, a slot that is empty of entries should return an error
-        let confirmed_block_err = ledger.get_confirmed_block(slot - 1).unwrap_err();
+        let confirmed_block_err = ledger.get_confirmed_block(slot - 1, true).unwrap_err();
         assert_matches!(confirmed_block_err, BlockstoreError::SlotNotRooted);
 
-        // The previous_blockhash of `expected_block` is default because its parent slot is a
-        // root, but empty of entries (eg. snapshot root slots). This now returns an error.
-        let confirmed_block_err = ledger.get_confirmed_block(slot).unwrap_err();
+        // The previous_blockhash of `expected_block` is default because its parent slot is a root,
+        // but empty of entries (eg. snapshot root slots). This now returns an error.
+        let confirmed_block_err = ledger.get_confirmed_block(slot, true).unwrap_err();
         assert_matches!(
             confirmed_block_err,
             BlockstoreError::ParentEntriesUnavailable
         );
 
-        let confirmed_block = ledger.get_confirmed_block(slot + 1).unwrap();
+        // Test if require_previous_blockhash is false
+        let confirmed_block = ledger.get_confirmed_block(slot, false).unwrap();
+        assert_eq!(confirmed_block.transactions.len(), 100);
+        let expected_block = ConfirmedBlock {
+            transactions: expected_transactions.clone(),
+            parent_slot: slot - 1,
+            blockhash: blockhash.to_string(),
+            previous_blockhash: Hash::default().to_string(),
+            rewards: vec![],
+            block_time: None,
+        };
+        assert_eq!(confirmed_block, expected_block);
+
+        let confirmed_block = ledger.get_confirmed_block(slot + 1, true).unwrap();
         assert_eq!(confirmed_block.transactions.len(), 100);
 
         let mut expected_block = ConfirmedBlock {
@@ -5763,7 +5786,7 @@ pub mod tests {
         };
         assert_eq!(confirmed_block, expected_block);
 
-        let not_root = ledger.get_confirmed_block(slot + 2).unwrap_err();
+        let not_root = ledger.get_confirmed_block(slot + 2, true).unwrap_err();
         assert_matches!(not_root, BlockstoreError::SlotNotRooted);
 
         // Test block_time returns, if available
@@ -5771,7 +5794,7 @@ pub mod tests {
         ledger.blocktime_cf.put(slot + 1, &timestamp).unwrap();
         expected_block.block_time = Some(timestamp);
 
-        let confirmed_block = ledger.get_confirmed_block(slot + 1).unwrap();
+        let confirmed_block = ledger.get_confirmed_block(slot + 1, true).unwrap();
         assert_eq!(confirmed_block, expected_block);
 
         drop(ledger);

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -75,6 +75,7 @@ pub enum BlockstoreError {
     NoVoteTimestampsInRange,
     ProtobufEncodeError(#[from] prost::EncodeError),
     ProtobufDecodeError(#[from] prost::DecodeError),
+    ParentEntriesUnavailable,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 


### PR DESCRIPTION
#### Problem
If a ledger has been pruned, or if a node has started from a snapshot, the first available block does not have a previous_blockhash available. This is because the previous_blockhash is determined from the parent block's entries, which don't exist in these cases. Currently, we return `Hash::default()` as the previous_blockhash for these blocks when `Blockstore::get_confirmed_block()` is called. This is problematic because the successful return elides the fact that some data was not available and (a) prevents returning the complete block should a BigTable fallback be available, and (b) allows such a block to be happily uploaded to BigTable.

#### Summary of Changes
- Return a BlockstoreError when parent_slot_entries are empty.
- I added a `require_previous_blockhash` arg to `get_confirmed_block` for callers that want the block, even when previous_blockhash is unavailable. I considered passing this through for the rpc caller, but couldn't come up with a strong use-case suggesting that was worth the churn. `solana-ledger-tool` will still return all that same data.

Fixes #14623
