### PR TITLE
Refactoring: Move KeyedAccounts to InvokeContext

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -103,7 +103,7 @@ pub fn builtin_process_instruction(
 ) -> Result<(), InstructionError> {
     set_invoke_context(invoke_context);
 
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     // Copy all the accounts into a HashMap to ensure there are no duplicates
     let mut accounts: HashMap<Pubkey, Account> = keyed_accounts

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -105,6 +105,9 @@ pub fn builtin_process_instruction(
 ) -> Result<(), InstructionError> {
     set_invoke_context(invoke_context);
 
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
+
     // Copy all the accounts into a HashMap to ensure there are no duplicates
     let mut accounts: HashMap<Pubkey, Account> = keyed_accounts
         .iter()

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -25,7 +25,6 @@ use {
         hash::Hash,
         instruction::Instruction,
         instruction::InstructionError,
-        keyed_account::KeyedAccount,
         message::Message,
         native_token::sol_to_lamports,
         process_instruction::{
@@ -99,14 +98,12 @@ fn get_invoke_context<'a>() -> &'a mut dyn InvokeContext {
 pub fn builtin_process_instruction(
     process_instruction: solana_sdk::entrypoint::ProcessInstruction,
     program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
     input: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     set_invoke_context(invoke_context);
 
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
+    let keyed_accounts = invoke_context.get_keyed_accounts();
 
     // Copy all the accounts into a HashMap to ensure there are no duplicates
     let mut accounts: HashMap<Pubkey, Account> = keyed_accounts
@@ -175,13 +172,11 @@ macro_rules! processor {
     ($process_instruction:expr) => {
         Some(
             |program_id: &Pubkey,
-             keyed_accounts: &[solana_sdk::keyed_account::KeyedAccount],
              input: &[u8],
              invoke_context: &mut dyn solana_sdk::process_instruction::InvokeContext| {
                 $crate::builtin_process_instruction(
                     $process_instruction,
                     program_id,
-                    keyed_accounts,
                     input,
                     invoke_context,
                 )

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -91,7 +91,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
         .unwrap();
     inner_iter.write_u64::<LittleEndian>(0).unwrap();
     let loader_id = bpf_loader::id();
-    let mut invoke_context = MockInvokeContext::default();
+    let mut invoke_context = MockInvokeContext::new(&[]);
 
     let elf = load_elf("bench_alu").unwrap();
     let mut executable =
@@ -195,8 +195,6 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
 fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     const BUDGET: u64 = 200_000;
     let loader_id = bpf_loader::id();
-    let mut invoke_context = MockInvokeContext::default();
-    invoke_context.compute_meter.remaining = BUDGET;
 
     let accounts = [RefCell::new(AccountSharedData::new(
         1,
@@ -210,6 +208,9 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         .map(|(key, account)| solana_sdk::keyed_account::KeyedAccount::new(&key, false, &account))
         .collect();
     let instruction_data = vec![0u8];
+
+    let mut invoke_context = MockInvokeContext::new(&keyed_accounts);
+    invoke_context.compute_meter.remaining = BUDGET;
 
     // Serialize account data
     let mut serialized = serialize_parameters(

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -91,7 +91,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
         .unwrap();
     inner_iter.write_u64::<LittleEndian>(0).unwrap();
     let loader_id = bpf_loader::id();
-    let mut invoke_context = MockInvokeContext::new(&[]);
+    let mut invoke_context = MockInvokeContext::new(vec![]);
 
     let elf = load_elf("bench_alu").unwrap();
     let mut executable =
@@ -208,14 +208,15 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         .collect();
     let instruction_data = vec![0u8];
 
-    let mut invoke_context = MockInvokeContext::new(&keyed_accounts);
+    let mut invoke_context = MockInvokeContext::new(keyed_accounts);
     invoke_context.compute_meter.remaining = BUDGET;
 
     // Serialize account data
+    let keyed_accounts = invoke_context.get_keyed_accounts().unwrap();
     let mut serialized = serialize_parameters(
         &bpf_loader::id(),
         &solana_sdk::pubkey::new_rand(),
-        &keyed_accounts,
+        keyed_accounts,
         &instruction_data,
     )
     .unwrap();

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -105,7 +105,6 @@ fn bench_program_alu(bencher: &mut Bencher) {
         &loader_id,
         executable.as_ref(),
         &mut inner_iter,
-        &[],
         &mut invoke_context,
     )
     .unwrap();
@@ -232,7 +231,6 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
         &loader_id,
         executable.as_ref(),
         &mut serialized,
-        &[],
         &mut invoke_context,
     )
     .unwrap();

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -76,7 +76,7 @@ fn bench_program_create_executable(bencher: &mut Bencher) {
 
     bencher.iter(|| {
         let _ =
-            Executable::<BpfError, ThisInstructionMeter>::from_elf(&elf, None, Config::default())
+            <dyn Executable::<BpfError, ThisInstructionMeter>>::from_elf(&elf, None, Config::default())
                 .unwrap();
     });
 }
@@ -95,7 +95,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
 
     let elf = load_elf("bench_alu").unwrap();
     let mut executable =
-        Executable::<BpfError, ThisInstructionMeter>::from_elf(&elf, None, Config::default())
+        <dyn Executable::<BpfError, ThisInstructionMeter>>::from_elf(&elf, None, Config::default())
             .unwrap();
     executable.set_syscall_registry(register_syscalls(&mut invoke_context).unwrap());
     executable.jit_compile().unwrap();
@@ -223,7 +223,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
 
     let elf = load_elf("tuner").unwrap();
     let mut executable =
-        Executable::<BpfError, ThisInstructionMeter>::from_elf(&elf, None, Config::default())
+        <dyn Executable::<BpfError, ThisInstructionMeter>>::from_elf(&elf, None, Config::default())
             .unwrap();
     executable.set_syscall_registry(register_syscalls(&mut invoke_context).unwrap());
     let compute_meter = invoke_context.get_compute_meter();

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -188,7 +188,7 @@ fn run_program(
     let mut data = vec![];
     file.read_to_end(&mut data).unwrap();
     let loader_id = bpf_loader::id();
-    let mut invoke_context = MockInvokeContext::default();
+    let mut invoke_context = MockInvokeContext::new(parameter_accounts);
     let parameter_bytes = serialize_parameters(
         &bpf_loader::id(),
         program_id,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -179,7 +179,7 @@ fn upgrade_bpf_program(
 fn run_program(
     name: &str,
     program_id: &Pubkey,
-    parameter_accounts: &[KeyedAccount],
+    parameter_accounts: Vec<KeyedAccount>,
     instruction_data: &[u8],
 ) -> Result<u64, InstructionError> {
     let path = create_bpf_path(name);
@@ -188,14 +188,14 @@ fn run_program(
     let mut data = vec![];
     file.read_to_end(&mut data).unwrap();
     let loader_id = bpf_loader::id();
-    let mut invoke_context = MockInvokeContext::new(parameter_accounts);
     let parameter_bytes = serialize_parameters(
         &bpf_loader::id(),
         program_id,
-        parameter_accounts,
+        &parameter_accounts,
         &instruction_data,
     )
     .unwrap();
+    let mut invoke_context = MockInvokeContext::new(parameter_accounts);
     let compute_meter = invoke_context.get_compute_meter();
     let mut instruction_meter = ThisInstructionMeter { compute_meter };
 
@@ -213,19 +213,46 @@ fn run_program(
     let mut tracer = None;
     for i in 0..2 {
         let mut parameter_bytes = parameter_bytes.clone();
-        let mut vm = create_vm(
-            &loader_id,
-            executable.as_ref(),
-            &mut parameter_bytes,
-            &mut invoke_context,
-        )
-        .unwrap();
-        let result = if i == 0 {
-            vm.execute_program_interpreted(&mut instruction_meter)
-        } else {
-            vm.execute_program_jit(&mut instruction_meter)
-        };
-        assert_eq!(SUCCESS, result.unwrap());
+        {
+            let mut vm = create_vm(
+                &loader_id,
+                executable.as_ref(),
+                &mut parameter_bytes,
+                &mut invoke_context,
+            )
+            .unwrap();
+            let result = if i == 0 {
+                vm.execute_program_interpreted(&mut instruction_meter)
+            } else {
+                vm.execute_program_jit(&mut instruction_meter)
+            };
+            assert_eq!(SUCCESS, result.unwrap());
+            if i == 1 {
+                assert_eq!(instruction_count, vm.get_total_instruction_count());
+            }
+            instruction_count = vm.get_total_instruction_count();
+            if config.enable_instruction_tracing {
+                if i == 1 {
+                    if !Tracer::compare(tracer.as_ref().unwrap(), vm.get_tracer()) {
+                        let mut tracer_display = String::new();
+                        tracer
+                            .as_ref()
+                            .unwrap()
+                            .write(&mut tracer_display, vm.get_program())
+                            .unwrap();
+                        println!("TRACE (interpreted): {}", tracer_display);
+                        let mut tracer_display = String::new();
+                        vm.get_tracer()
+                            .write(&mut tracer_display, vm.get_program())
+                            .unwrap();
+                        println!("TRACE (jit): {}", tracer_display);
+                        assert!(false);
+                    }
+                }
+                tracer = Some(vm.get_tracer().clone());
+            }
+        }
+        let parameter_accounts = invoke_context.get_keyed_accounts().unwrap();
         deserialize_parameters(
             &bpf_loader::id(),
             parameter_accounts,
@@ -233,30 +260,6 @@ fn run_program(
             true,
         )
         .unwrap();
-        if i == 1 {
-            assert_eq!(instruction_count, vm.get_total_instruction_count());
-        }
-        instruction_count = vm.get_total_instruction_count();
-        if config.enable_instruction_tracing {
-            if i == 1 {
-                if !Tracer::compare(tracer.as_ref().unwrap(), vm.get_tracer()) {
-                    let mut tracer_display = String::new();
-                    tracer
-                        .as_ref()
-                        .unwrap()
-                        .write(&mut tracer_display, vm.get_program())
-                        .unwrap();
-                    println!("TRACE (interpreted): {}", tracer_display);
-                    let mut tracer_display = String::new();
-                    vm.get_tracer()
-                        .write(&mut tracer_display, vm.get_program())
-                        .unwrap();
-                    println!("TRACE (jit): {}", tracer_display);
-                    assert!(false);
-                }
-            }
-            tracer = Some(vm.get_tracer().clone());
-        }
     }
 
     Ok(instruction_count)
@@ -1262,7 +1265,7 @@ fn assert_instruction_count() {
         let key = solana_sdk::pubkey::new_rand();
         let mut account = RefCell::new(AccountSharedData::default());
         let parameter_accounts = vec![KeyedAccount::new(&key, false, &mut account)];
-        let count = run_program(program.0, &program_id, &parameter_accounts[..], &[]).unwrap();
+        let count = run_program(program.0, &program_id, parameter_accounts, &[]).unwrap();
         let diff: i64 = count as i64 - program.1 as i64;
         println!("  {:30} {:8} {:6} {:+4}", program.0, program.1, count, diff);
         if count > program.1 {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -217,7 +217,6 @@ fn run_program(
             &loader_id,
             executable.as_ref(),
             &mut parameter_bytes,
-            parameter_accounts,
             &mut invoke_context,
         )
         .unwrap();

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -346,7 +346,8 @@ fn process_loader_upgradeable_instruction(
             let buffer = keyed_account_at_index(keyed_accounts, 3)?;
             let rent = from_keyed_account::<Rent>(keyed_account_at_index(keyed_accounts, 4)?)?;
             let clock = from_keyed_account::<Clock>(keyed_account_at_index(keyed_accounts, 5)?)?;
-            let system = keyed_account_at_index(keyed_accounts, 6)?;
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            // let _system = keyed_account_at_index(keyed_accounts, 6)?;
             let authority = keyed_account_at_index(keyed_accounts, 7)?;
             let upgrade_authority_address = Some(*authority.unsigned_key());
             let upgrade_authority_signer = authority.signer_key().is_none();
@@ -420,7 +421,7 @@ fn process_loader_upgradeable_instruction(
                     programdata_len as u64,
                     program_id,
                 ),
-                &[payer, programdata, system],
+                &[0, 1, 6],
                 &[&[program.unsigned_key().as_ref(), &[bump_seed]]],
             )?;
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -198,7 +198,7 @@ fn process_instruction_common(
                     ic_logger_msg!(logger, "Wrong ProgramData account for this Program account");
                     return Err(InstructionError::InvalidArgument);
                 }
-                invoke_context.pop_first_keyed_account();
+                invoke_context.remove_first_keyed_account();
                 UpgradeableLoaderState::programdata_data_offset()?
             } else {
                 ic_logger_msg!(logger, "Invalid Program account");
@@ -747,7 +747,7 @@ impl Executor for BpfExecutor {
         let logger = invoke_context.get_logger();
         let invoke_depth = invoke_context.invoke_depth();
 
-        invoke_context.pop_first_keyed_account();
+        invoke_context.remove_first_keyed_account();
 
         let mut serialize_time = Measure::start("serialize");
         let keyed_accounts = invoke_context.get_keyed_accounts();

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -147,19 +147,12 @@ pub fn create_vm<'a>(
     loader_id: &'a Pubkey,
     program: &'a dyn Executable<BpfError, ThisInstructionMeter>,
     parameter_bytes: &mut [u8],
-    parameter_accounts: &'a [KeyedAccount<'a>],
     invoke_context: &'a mut dyn InvokeContext,
 ) -> Result<EbpfVm<'a, BpfError, ThisInstructionMeter>, EbpfError<BpfError>> {
     let heap = vec![0_u8; DEFAULT_HEAP_SIZE];
     let heap_region = MemoryRegion::new_from_slice(&heap, MM_HEAP_START, 0, true);
     let mut vm = EbpfVm::new(program, parameter_bytes, &[heap_region])?;
-    syscalls::bind_syscall_context_objects(
-        loader_id,
-        &mut vm,
-        parameter_accounts,
-        invoke_context,
-        heap,
-    )?;
+    syscalls::bind_syscall_context_objects(loader_id, &mut vm, invoke_context, heap)?;
     Ok(vm)
 }
 
@@ -797,7 +790,6 @@ impl Executor for BpfExecutor {
                 loader_id,
                 self.program.as_ref(),
                 &mut parameter_bytes,
-                &parameter_accounts,
                 invoke_context,
             ) {
                 Ok(info) => info,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1108,10 +1108,12 @@ mod tests {
         );
 
         // Case: limited budget
+        let keyed_accounts_range = 0..keyed_accounts.len();
         let mut invoke_context = MockInvokeContext {
             invoke_stack: vec![InvokeContextStackFrame {
                 key: Pubkey::default(),
                 keyed_accounts,
+                keyed_accounts_range,
             }],
             logger: MockLogger::default(),
             bpf_compute_budget: BpfComputeBudget::default(),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -747,8 +747,6 @@ impl Executor for BpfExecutor {
         let logger = invoke_context.get_logger();
         let invoke_depth = invoke_context.invoke_depth();
 
-        // TODO [KeyedAccounts to InvokeContext refactoring]
-        // invoke_context.set_keyed_accounts(&keyed_accounts[1..]);
         invoke_context.pop_first_keyed_account();
 
         let mut serialize_time = Measure::start("serialize");

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -219,6 +219,9 @@ fn process_instruction_common(
                         );
                         return Err(InstructionError::InvalidArgument);
                     }
+                    // TODO [KeyedAccounts to InvokeContext refactoring]
+                    // invoke_context.set_keyed_accounts(&keyed_accounts[1..]);
+                    invoke_context.pop_first_keyed_account();
                     (
                         programdata,
                         &keyed_accounts[1..],
@@ -778,6 +781,9 @@ impl Executor for BpfExecutor {
         let invoke_depth = invoke_context.invoke_depth();
 
         let mut serialize_time = Measure::start("serialize");
+        // TODO [KeyedAccounts to InvokeContext refactoring]
+        // invoke_context.set_keyed_accounts(&keyed_accounts[1..]);
+        invoke_context.pop_first_keyed_account();
         let parameter_accounts = &keyed_accounts[1..];
         let mut parameter_bytes =
             serialize_parameters(loader_id, program_id, parameter_accounts, &instruction_data)?;

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1093,14 +1093,12 @@ mod tests {
 
         // Case: limited budget
         let mut invoke_context = MockInvokeContext {
-            key: Pubkey::default(),
+            invoke_stack: vec![(Pubkey::default(), &keyed_accounts)],
             logger: MockLogger::default(),
             bpf_compute_budget: BpfComputeBudget::default(),
             compute_meter: MockComputeMeter::default(),
-            keyed_accounts: &keyed_accounts,
             programs: vec![],
             accounts: vec![],
-            invoke_depth: 0,
             sysvars: vec![],
         };
         assert_eq!(

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -197,6 +197,7 @@ fn process_instruction_common(
     use_jit: bool,
 ) -> Result<(), InstructionError> {
     let logger = invoke_context.get_logger();
+    debug_assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
 
     let first_account = keyed_account_at_index(keyed_accounts, 0)?;
     if first_account.executable()? {
@@ -779,6 +780,7 @@ impl Executor for BpfExecutor {
     ) -> Result<(), InstructionError> {
         let logger = invoke_context.get_logger();
         let invoke_depth = invoke_context.invoke_depth();
+        debug_assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
 
         let mut serialize_time = Measure::start("serialize");
         // TODO [KeyedAccounts to InvokeContext refactoring]

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -103,9 +103,7 @@ pub fn create_executor(
             return Err(InstructionError::ProgramFailedToCompile);
         }
     }
-    Ok(Arc::new(BpfExecutor {
-        program: executable,
-    }))
+    Ok(Arc::new(BpfExecutor { executable }))
 }
 
 fn write_program_data(
@@ -725,7 +723,7 @@ impl InstructionMeter for ThisInstructionMeter {
 
 /// BPF Loader's Executor implementation
 pub struct BpfExecutor {
-    program: Box<dyn Executable<BpfError, ThisInstructionMeter>>,
+    executable: Box<dyn Executable<BpfError, ThisInstructionMeter>>,
 }
 
 // Well, implement Debug for solana_rbpf::vm::Executable in solana-rbpf...
@@ -760,7 +758,7 @@ impl Executor for BpfExecutor {
             let compute_meter = invoke_context.get_compute_meter();
             let mut vm = match create_vm(
                 loader_id,
-                self.program.as_ref(),
+                self.executable.as_ref(),
                 &mut parameter_bytes,
                 invoke_context,
             ) {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -33,7 +33,7 @@ use solana_sdk::{
     feature_set::{skip_ro_deserialization, upgradeable_close_instruction},
     ic_logger_msg, ic_msg,
     instruction::InstructionError,
-    keyed_account::{from_keyed_account, keyed_account_at_index, KeyedAccount},
+    keyed_account::{from_keyed_account, keyed_account_at_index},
     loader_instruction::LoaderInstruction,
     loader_upgradeable_instruction::UpgradeableLoaderInstruction,
     process_instruction::{stable_log, ComputeMeter, Executor, InvokeContext},
@@ -158,7 +158,6 @@ pub fn create_vm<'a>(
 
 pub fn process_instruction(
     program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
@@ -167,7 +166,6 @@ pub fn process_instruction(
 
 pub fn process_instruction_jit(
     program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
@@ -860,6 +858,7 @@ mod tests {
         genesis_config::create_genesis_config,
         instruction::Instruction,
         instruction::{AccountMeta, InstructionError},
+        keyed_account::KeyedAccount,
         message::Message,
         process_instruction::{BpfComputeBudget, MockComputeMeter, MockInvokeContext, MockLogger},
         pubkey::Pubkey,
@@ -932,7 +931,6 @@ mod tests {
             Err(InstructionError::NotEnoughAccountKeys),
             process_instruction(
                 &bpf_loader::id(),
-                &[],
                 &instruction_data,
                 &mut MockInvokeContext::new(&[])
             )
@@ -943,7 +941,6 @@ mod tests {
             Err(InstructionError::MissingRequiredSignature),
             process_instruction(
                 &bpf_loader::id(),
-                &keyed_accounts,
                 &instruction_data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -957,7 +954,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader::id(),
-                &keyed_accounts,
                 &instruction_data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -975,7 +971,6 @@ mod tests {
             Err(InstructionError::AccountDataTooSmall),
             process_instruction(
                 &bpf_loader::id(),
-                &keyed_accounts,
                 &instruction_data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1001,7 +996,6 @@ mod tests {
             Err(InstructionError::NotEnoughAccountKeys),
             process_instruction(
                 &bpf_loader::id(),
-                &[],
                 &instruction_data,
                 &mut MockInvokeContext::new(&[])
             )
@@ -1012,7 +1006,6 @@ mod tests {
             Err(InstructionError::MissingRequiredSignature),
             process_instruction(
                 &bpf_loader::id(),
-                &keyed_accounts,
                 &instruction_data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1024,7 +1017,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader::id(),
-                &keyed_accounts,
                 &instruction_data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1040,7 +1032,6 @@ mod tests {
             Err(InstructionError::InvalidAccountData),
             process_instruction(
                 &bpf_loader::id(),
-                &keyed_accounts,
                 &instruction_data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1065,7 +1056,7 @@ mod tests {
         // Case: Empty keyed accounts
         assert_eq!(
             Err(InstructionError::NotEnoughAccountKeys),
-            process_instruction(&program_id, &[], &[], &mut MockInvokeContext::new(&[]))
+            process_instruction(&program_id, &[], &mut MockInvokeContext::new(&[]))
         );
 
         // Case: Only a program account
@@ -1073,7 +1064,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &program_key,
-                &keyed_accounts,
                 &[],
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1085,7 +1075,6 @@ mod tests {
             Err(InstructionError::InvalidInstructionData),
             process_instruction(
                 &program_id,
-                &keyed_accounts,
                 &[],
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1099,7 +1088,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &program_key,
-                &keyed_accounts,
                 &[],
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1119,7 +1107,7 @@ mod tests {
         };
         assert_eq!(
             Err(InstructionError::ProgramFailedToComplete),
-            process_instruction(&program_key, &keyed_accounts, &[], &mut invoke_context)
+            process_instruction(&program_key, &[], &mut invoke_context)
         );
 
         // Case: With duplicate accounts
@@ -1132,7 +1120,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &program_key,
-                &keyed_accounts,
                 &[],
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1160,7 +1147,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &program_key,
-                &keyed_accounts,
                 &[],
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1176,7 +1162,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &program_key,
-                &keyed_accounts,
                 &[],
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1204,7 +1189,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &program_key,
-                &keyed_accounts,
                 &[],
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1220,7 +1204,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &program_key,
-                &keyed_accounts,
                 &[],
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1253,7 +1236,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1275,7 +1257,6 @@ mod tests {
             Err(InstructionError::AccountAlreadyInitialized),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1312,7 +1293,6 @@ mod tests {
             Err(InstructionError::InvalidAccountData),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1338,7 +1318,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1381,7 +1360,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1419,7 +1397,6 @@ mod tests {
             Err(InstructionError::MissingRequiredSignature),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1445,7 +1422,6 @@ mod tests {
             Err(InstructionError::AccountDataTooSmall),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1471,7 +1447,6 @@ mod tests {
             Err(InstructionError::AccountDataTooSmall),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1498,7 +1473,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -1525,7 +1499,6 @@ mod tests {
             Err(InstructionError::Immutable),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2302,7 +2275,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2365,7 +2337,6 @@ mod tests {
             Err(InstructionError::Immutable),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2400,7 +2371,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2434,7 +2404,6 @@ mod tests {
             Err(InstructionError::MissingRequiredSignature),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2469,7 +2438,6 @@ mod tests {
             Err(InstructionError::AccountNotExecutable),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2504,7 +2472,6 @@ mod tests {
             Err(InstructionError::IncorrectProgramId),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2538,7 +2505,6 @@ mod tests {
             Err(InstructionError::InvalidArgument),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2576,7 +2542,6 @@ mod tests {
             Err(InstructionError::InvalidAccountData),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2611,7 +2576,6 @@ mod tests {
             Err(InstructionError::InvalidArgument),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2649,7 +2613,6 @@ mod tests {
             Err(InstructionError::InvalidArgument),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2694,7 +2657,6 @@ mod tests {
             Err(InstructionError::AccountDataTooSmall),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2735,7 +2697,6 @@ mod tests {
             Err(InstructionError::InvalidAccountData),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2769,7 +2730,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2809,7 +2769,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2856,7 +2815,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2905,7 +2863,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2939,7 +2896,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -2973,7 +2929,6 @@ mod tests {
             Err(InstructionError::MissingRequiredSignature),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3005,7 +2960,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3032,7 +2986,6 @@ mod tests {
             Err(InstructionError::Immutable),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3058,7 +3011,6 @@ mod tests {
             Err(InstructionError::InvalidArgument),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3095,7 +3047,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3123,7 +3074,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3152,7 +3102,6 @@ mod tests {
             Err(InstructionError::MissingRequiredSignature),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3175,7 +3124,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3198,7 +3146,6 @@ mod tests {
             Err(InstructionError::Immutable),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3220,7 +3167,6 @@ mod tests {
             Err(InstructionError::InvalidArgument),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3241,7 +3187,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts)
             )
@@ -3278,7 +3223,6 @@ mod tests {
             Ok(()),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts),
             )
@@ -3308,7 +3252,6 @@ mod tests {
             Err(InstructionError::IncorrectAuthority),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts),
             )
@@ -3330,7 +3273,6 @@ mod tests {
             Err(InstructionError::InvalidArgument),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
-                &keyed_accounts,
                 &instruction,
                 &mut MockInvokeContext::new(&keyed_accounts),
             )
@@ -3391,7 +3333,6 @@ mod tests {
 
                 let _result = process_instruction(
                     &bpf_loader::id(),
-                    &keyed_accounts,
                     &[],
                     &mut MockInvokeContext::new(&keyed_accounts),
                 );

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -169,7 +169,6 @@ macro_rules! bind_feature_gated_syscall_context_object {
 pub fn bind_syscall_context_objects<'a>(
     loader_id: &'a Pubkey,
     vm: &mut EbpfVm<'a, BpfError, crate::ThisInstructionMeter>,
-    callers_keyed_accounts: &'a [KeyedAccount<'a>],
     invoke_context: &'a mut dyn InvokeContext,
     heap: Vec<u8>,
 ) -> Result<(), EbpfError<BpfError>> {
@@ -299,7 +298,6 @@ pub fn bind_syscall_context_objects<'a>(
     // Cross-program invocation syscalls
     vm.bind_syscall_context_object(
         Box::new(SyscallInvokeSignedC {
-            callers_keyed_accounts,
             invoke_context: invoke_context.clone(),
             loader_id,
         }),
@@ -307,7 +305,6 @@ pub fn bind_syscall_context_objects<'a>(
     )?;
     vm.bind_syscall_context_object(
         Box::new(SyscallInvokeSignedRust {
-            callers_keyed_accounts,
             invoke_context: invoke_context.clone(),
             loader_id,
         }),
@@ -1029,7 +1026,6 @@ type TranslatedAccounts<'a> = (
 trait SyscallInvokeSigned<'a> {
     fn get_context_mut(&self) -> Result<RefMut<&'a mut dyn InvokeContext>, EbpfError<BpfError>>;
     fn get_context(&self) -> Result<Ref<&'a mut dyn InvokeContext>, EbpfError<BpfError>>;
-    fn get_callers_keyed_accounts(&self) -> &'a [KeyedAccount<'a>];
     fn translate_instruction(
         &self,
         addr: u64,
@@ -1055,7 +1051,6 @@ trait SyscallInvokeSigned<'a> {
 
 /// Cross-program invocation called from Rust
 pub struct SyscallInvokeSignedRust<'a> {
-    callers_keyed_accounts: &'a [KeyedAccount<'a>],
     invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
     loader_id: &'a Pubkey,
 }
@@ -1069,9 +1064,6 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
         self.invoke_context
             .try_borrow()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
-    }
-    fn get_callers_keyed_accounts(&self) -> &'a [KeyedAccount<'a>] {
-        self.callers_keyed_accounts
     }
     fn translate_instruction(
         &self,
@@ -1350,7 +1342,6 @@ struct SolSignerSeedsC {
 
 /// Cross-program invocation called from C
 pub struct SyscallInvokeSignedC<'a> {
-    callers_keyed_accounts: &'a [KeyedAccount<'a>],
     invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
     loader_id: &'a Pubkey,
 }
@@ -1364,10 +1355,6 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
         self.invoke_context
             .try_borrow()
             .map_err(|_| SyscallError::InvokeContextBorrowFailed.into())
-    }
-
-    fn get_callers_keyed_accounts(&self) -> &'a [KeyedAccount<'a>] {
-        self.callers_keyed_accounts
     }
 
     fn translate_instruction(
@@ -1777,8 +1764,8 @@ fn call<'a>(
             signers_seeds_len,
             memory_mapping,
         )?;
-        let keyed_account_refs = syscall
-            .get_callers_keyed_accounts()
+        let keyed_account_refs = invoke_context
+            .get_keyed_accounts()
             .iter()
             .collect::<Vec<&KeyedAccount>>();
         let (message, callee_program_id, callee_program_id_index) =

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2683,7 +2683,7 @@ mod tests {
                 leader_schedule_epoch: 4,
                 unix_timestamp: 5,
             };
-            let mut invoke_context = MockInvokeContext::default();
+            let mut invoke_context = MockInvokeContext::new(&[]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_clock).unwrap();
             invoke_context
@@ -2725,7 +2725,7 @@ mod tests {
                 first_normal_epoch: 3,
                 first_normal_slot: 4,
             };
-            let mut invoke_context = MockInvokeContext::default();
+            let mut invoke_context = MockInvokeContext::new(&[]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_epochschedule).unwrap();
             invoke_context
@@ -2773,7 +2773,7 @@ mod tests {
                     lamports_per_signature: 1,
                 },
             };
-            let mut invoke_context = MockInvokeContext::default();
+            let mut invoke_context = MockInvokeContext::new(&[]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_fees).unwrap();
             invoke_context
@@ -2813,7 +2813,7 @@ mod tests {
                 exemption_threshold: 2.0,
                 burn_percent: 3,
             };
-            let mut invoke_context = MockInvokeContext::default();
+            let mut invoke_context = MockInvokeContext::new(&[]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_rent).unwrap();
             invoke_context

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -2671,7 +2671,7 @@ mod tests {
                 leader_schedule_epoch: 4,
                 unix_timestamp: 5,
             };
-            let mut invoke_context = MockInvokeContext::new(&[]);
+            let mut invoke_context = MockInvokeContext::new(vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_clock).unwrap();
             invoke_context
@@ -2713,7 +2713,7 @@ mod tests {
                 first_normal_epoch: 3,
                 first_normal_slot: 4,
             };
-            let mut invoke_context = MockInvokeContext::new(&[]);
+            let mut invoke_context = MockInvokeContext::new(vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_epochschedule).unwrap();
             invoke_context
@@ -2761,7 +2761,7 @@ mod tests {
                     lamports_per_signature: 1,
                 },
             };
-            let mut invoke_context = MockInvokeContext::new(&[]);
+            let mut invoke_context = MockInvokeContext::new(vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_fees).unwrap();
             invoke_context
@@ -2801,7 +2801,7 @@ mod tests {
                 exemption_threshold: 2.0,
                 burn_percent: 3,
             };
-            let mut invoke_context = MockInvokeContext::new(&[]);
+            let mut invoke_context = MockInvokeContext::new(vec![]);
             let mut data = vec![];
             bincode::serialize_into(&mut data, &src_rent).unwrap();
             invoke_context

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1766,6 +1766,7 @@ fn call<'a>(
         )?;
         let keyed_account_refs = invoke_context
             .get_keyed_accounts()
+            .map_err(SyscallError::InstructionError)?
             .iter()
             .collect::<Vec<&KeyedAccount>>();
         let (message, callee_program_id, callee_program_id_index) =

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -118,8 +118,11 @@ pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     data: &[u8],
-    _invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+
     let instruction = limited_deserialize(data)?;
 
     trace!("process_instruction: {:?}", instruction);

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -116,12 +116,13 @@ fn apply_account_data(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    let keyed_accounts = invoke_context.get_keyed_accounts();
     // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+    assert_eq!(_keyed_accounts, keyed_accounts);
 
     let instruction = limited_deserialize(data)?;
 

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -116,13 +116,10 @@ fn apply_account_data(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts();
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(_keyed_accounts, keyed_accounts);
 
     let instruction = limited_deserialize(data)?;
 

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     account::{ReadableAccount, WritableAccount},
     hash::hash,
     instruction::InstructionError,
-    keyed_account::{next_keyed_account, KeyedAccount},
+    keyed_account::{keyed_account_at_index, KeyedAccount},
     process_instruction::InvokeContext,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
@@ -120,18 +120,17 @@ pub fn process_instruction(
     data: &[u8],
     _invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts_iter = &mut keyed_accounts.iter();
     let instruction = limited_deserialize(data)?;
 
     trace!("process_instruction: {:?}", instruction);
 
     match instruction {
         BudgetInstruction::InitializeAccount(expr) => {
-            let contract_keyed_account = next_keyed_account(keyed_accounts_iter)?;
+            let contract_keyed_account = keyed_account_at_index(keyed_accounts, 0)?;
 
             if let Some(payment) = expr.final_payment() {
                 let to_keyed_account = contract_keyed_account;
-                let contract_keyed_account = next_keyed_account(keyed_accounts_iter)?;
+                let contract_keyed_account = keyed_account_at_index(keyed_accounts, 1)?;
                 contract_keyed_account.try_account_ref_mut()?.lamports = 0;
                 to_keyed_account.try_account_ref_mut()?.lamports += payment.lamports;
                 return Ok(());
@@ -154,8 +153,8 @@ pub fn process_instruction(
             )
         }
         BudgetInstruction::ApplyTimestamp(dt) => {
-            let witness_keyed_account = next_keyed_account(keyed_accounts_iter)?;
-            let contract_keyed_account = next_keyed_account(keyed_accounts_iter)?;
+            let witness_keyed_account = keyed_account_at_index(keyed_accounts, 0)?;
+            let contract_keyed_account = keyed_account_at_index(keyed_accounts, 1)?;
             let mut budget_state =
                 BudgetState::deserialize(&contract_keyed_account.try_account_ref()?.data())?;
             if !budget_state.is_pending() {
@@ -173,7 +172,7 @@ pub fn process_instruction(
                 &mut budget_state,
                 witness_keyed_account,
                 contract_keyed_account,
-                next_keyed_account(keyed_accounts_iter),
+                keyed_account_at_index(keyed_accounts, 2),
                 dt,
             )?;
             trace!("apply timestamp committed");
@@ -184,8 +183,8 @@ pub fn process_instruction(
             )
         }
         BudgetInstruction::ApplySignature => {
-            let witness_keyed_account = next_keyed_account(keyed_accounts_iter)?;
-            let contract_keyed_account = next_keyed_account(keyed_accounts_iter)?;
+            let witness_keyed_account = keyed_account_at_index(keyed_accounts, 0)?;
+            let contract_keyed_account = keyed_account_at_index(keyed_accounts, 1)?;
             let mut budget_state =
                 BudgetState::deserialize(&contract_keyed_account.try_account_ref()?.data())?;
             if !budget_state.is_pending() {
@@ -203,7 +202,7 @@ pub fn process_instruction(
                 &mut budget_state,
                 witness_keyed_account,
                 contract_keyed_account,
-                next_keyed_account(keyed_accounts_iter),
+                keyed_account_at_index(keyed_accounts, 2),
             )?;
             trace!("apply signature committed");
             budget_state.serialize(
@@ -213,8 +212,8 @@ pub fn process_instruction(
             )
         }
         BudgetInstruction::ApplyAccountData => {
-            let witness_keyed_account = next_keyed_account(keyed_accounts_iter)?;
-            let contract_keyed_account = next_keyed_account(keyed_accounts_iter)?;
+            let witness_keyed_account = keyed_account_at_index(keyed_accounts, 0)?;
+            let contract_keyed_account = keyed_account_at_index(keyed_accounts, 1)?;
             let mut budget_state =
                 BudgetState::deserialize(&contract_keyed_account.try_account_ref()?.data())?;
             if !budget_state.is_pending() {
@@ -228,7 +227,7 @@ pub fn process_instruction(
                 &mut budget_state,
                 witness_keyed_account,
                 contract_keyed_account,
-                next_keyed_account(keyed_accounts_iter),
+                keyed_account_at_index(keyed_accounts, 2),
             )?;
             trace!("apply account data committed");
             budget_state.serialize(

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -119,7 +119,7 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     let instruction = limited_deserialize(data)?;
 

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -192,7 +192,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instructions[1].data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Ok(())
         );
@@ -227,7 +227,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Ok(())
         );
@@ -254,7 +254,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::InvalidInstructionData)
         );
@@ -277,7 +277,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -312,7 +312,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Ok(())
         );
@@ -346,7 +346,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::InvalidAccountData)
         );
@@ -377,7 +377,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -393,7 +393,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -430,7 +430,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Ok(())
         );
@@ -450,7 +450,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Ok(())
         );
@@ -476,7 +476,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -499,7 +499,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -537,7 +537,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Ok(())
         );
@@ -556,7 +556,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Ok(())
         );
@@ -578,7 +578,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -597,7 +597,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instructions[1].data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::NotEnoughAccountKeys)
         );
@@ -628,7 +628,7 @@ mod tests {
                 &id(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&keyed_accounts)
             ),
             Err(InstructionError::InvalidAccountOwner)
         );

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -14,12 +14,13 @@ use solana_sdk::{
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    let keyed_accounts = invoke_context.get_keyed_accounts();
     // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+    assert_eq!(_keyed_accounts, keyed_accounts);
 
     let key_list: ConfigKeys = limited_deserialize(data)?;
     let config_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -191,7 +191,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instructions[1].data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Ok(())
         );
@@ -225,7 +225,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Ok(())
         );
@@ -251,7 +251,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::InvalidInstructionData)
         );
@@ -273,7 +273,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -307,7 +307,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Ok(())
         );
@@ -340,7 +340,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::InvalidAccountData)
         );
@@ -370,7 +370,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -385,7 +385,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -421,7 +421,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Ok(())
         );
@@ -440,7 +440,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Ok(())
         );
@@ -465,7 +465,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -487,7 +487,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -524,7 +524,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Ok(())
         );
@@ -542,7 +542,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Ok(())
         );
@@ -563,7 +563,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -581,7 +581,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instructions[1].data,
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::NotEnoughAccountKeys)
         );
@@ -611,7 +611,7 @@ mod tests {
             process_instruction(
                 &id(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts),
+                &mut MockInvokeContext::new(keyed_accounts),
             ),
             Err(InstructionError::InvalidAccountOwner)
         );

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -17,7 +17,7 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     let key_list: ConfigKeys = limited_deserialize(data)?;
     let config_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -18,6 +18,9 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+
     let key_list: ConfigKeys = limited_deserialize(data)?;
     let config_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;
     let current_data: ConfigKeys = {

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -6,7 +6,7 @@ use solana_sdk::{
     account::{ReadableAccount, WritableAccount},
     feature_set, ic_msg,
     instruction::InstructionError,
-    keyed_account::{keyed_account_at_index, KeyedAccount},
+    keyed_account::keyed_account_at_index,
     process_instruction::InvokeContext,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
@@ -14,13 +14,10 @@ use solana_sdk::{
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts();
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(_keyed_accounts, keyed_accounts);
 
     let key_list: ConfigKeys = limited_deserialize(data)?;
     let config_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;
@@ -193,7 +190,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instructions[1].data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -228,7 +224,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -255,7 +250,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -278,7 +272,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -313,7 +306,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -347,7 +339,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -378,7 +369,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -394,7 +384,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -431,7 +420,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -451,7 +439,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -477,7 +464,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -500,7 +486,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -538,7 +523,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -557,7 +541,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -579,7 +562,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -598,7 +580,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instructions[1].data,
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -629,7 +610,6 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &id(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts),
             ),

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -132,7 +132,7 @@ mod tests {
     use serde_derive::{Deserialize, Serialize};
     use solana_sdk::{
         account::{Account, AccountSharedData},
-        keyed_account::create_keyed_is_signer_accounts,
+        keyed_account::create_keyed_accounts_unified,
         process_instruction::MockInvokeContext,
         signature::{Keypair, Signer},
         system_instruction::SystemInstruction,
@@ -185,8 +185,8 @@ mod tests {
             owner: id(),
             ..Account::default()
         }));
-        let accounts = vec![(&config_pubkey, true, &config_account)];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let accounts = vec![(true, false, &config_pubkey, &config_account)];
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -219,8 +219,8 @@ mod tests {
         let my_config = MyConfig::new(42);
 
         let instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
-        let accounts = vec![(&config_pubkey, true, &config_account)];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let accounts = vec![(true, false, &config_pubkey, &config_account)];
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -245,8 +245,8 @@ mod tests {
 
         let mut instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
         instruction.data = vec![0; 123]; // <-- Replace data with a vector that's too large
-        let accounts = vec![(&config_pubkey, true, &config_account)];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let accounts = vec![(true, false, &config_pubkey, &config_account)];
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -267,8 +267,8 @@ mod tests {
 
         let mut instruction = config_instruction::store(&config_pubkey, true, vec![], &my_config);
         instruction.accounts[0].is_signer = false; // <----- not a signer
-        let accounts = vec![(&config_pubkey, false, &config_account)];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let accounts = vec![(false, false, &config_pubkey, &config_account)];
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -298,11 +298,11 @@ mod tests {
         let signer0_account = RefCell::new(AccountSharedData::default());
         let signer1_account = RefCell::new(AccountSharedData::default());
         let accounts = vec![
-            (&config_pubkey, true, &config_account),
-            (&signer0_pubkey, true, &signer0_account),
-            (&signer1_pubkey, true, &signer1_account),
+            (true, false, &config_pubkey, &config_account),
+            (true, false, &signer0_pubkey, &signer0_account),
+            (true, false, &signer1_pubkey, &signer1_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -334,8 +334,8 @@ mod tests {
             owner: id(),
             ..Account::default()
         }));
-        let accounts = vec![(&signer0_pubkey, true, &signer0_account)];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let accounts = vec![(true, false, &signer0_pubkey, &signer0_account)];
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -362,10 +362,10 @@ mod tests {
 
         // Config-data pubkey doesn't match signer
         let accounts = vec![
-            (&config_pubkey, true, &config_account),
-            (&signer1_pubkey, true, &signer1_account),
+            (true, false, &config_pubkey, &config_account),
+            (true, false, &signer1_pubkey, &signer1_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -377,10 +377,10 @@ mod tests {
 
         // Config-data pubkey not a signer
         let accounts = vec![
-            (&config_pubkey, true, &config_account),
-            (&signer0_pubkey, false, &signer0_account),
+            (true, false, &config_pubkey, &config_account),
+            (false, false, &signer0_pubkey, &signer0_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -412,11 +412,11 @@ mod tests {
 
         let instruction = config_instruction::store(&config_pubkey, true, keys.clone(), &my_config);
         let accounts = vec![
-            (&config_pubkey, true, &config_account),
-            (&signer0_pubkey, true, &signer0_account),
-            (&signer1_pubkey, true, &signer1_account),
+            (true, false, &config_pubkey, &config_account),
+            (true, false, &signer0_pubkey, &signer0_account),
+            (true, false, &signer1_pubkey, &signer1_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -431,11 +431,11 @@ mod tests {
         let instruction =
             config_instruction::store(&config_pubkey, false, keys.clone(), &new_config);
         let accounts = vec![
-            (&config_pubkey, false, &config_account),
-            (&signer0_pubkey, true, &signer0_account),
-            (&signer1_pubkey, true, &signer1_account),
+            (false, false, &config_pubkey, &config_account),
+            (true, false, &signer0_pubkey, &signer0_account),
+            (true, false, &signer1_pubkey, &signer1_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -456,11 +456,11 @@ mod tests {
         let keys = vec![(pubkey, false), (signer0_pubkey, true)];
         let instruction = config_instruction::store(&config_pubkey, false, keys, &my_config);
         let accounts = vec![
-            (&config_pubkey, false, &config_account),
-            (&signer0_pubkey, true, &signer0_account),
-            (&signer1_pubkey, false, &signer1_account),
+            (false, false, &config_pubkey, &config_account),
+            (true, false, &signer0_pubkey, &signer0_account),
+            (false, false, &signer1_pubkey, &signer1_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -478,11 +478,11 @@ mod tests {
         ];
         let instruction = config_instruction::store(&config_pubkey, false, keys, &my_config);
         let accounts = vec![
-            (&config_pubkey, false, &config_account),
-            (&signer0_pubkey, true, &signer0_account),
-            (&signer2_pubkey, true, &signer2_account),
+            (false, false, &config_pubkey, &config_account),
+            (true, false, &signer0_pubkey, &signer0_account),
+            (true, false, &signer2_pubkey, &signer2_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -516,10 +516,10 @@ mod tests {
 
         let instruction = config_instruction::store(&config_pubkey, true, keys.clone(), &my_config);
         let accounts = vec![
-            (&config_pubkey, true, &config_account),
-            (&signer0_pubkey, true, &signer0_account),
+            (true, false, &config_pubkey, &config_account),
+            (true, false, &signer0_pubkey, &signer0_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -534,10 +534,10 @@ mod tests {
         let instruction =
             config_instruction::store(&config_pubkey, true, keys.clone(), &new_config);
         let accounts = vec![
-            (&config_pubkey, true, &config_account),
-            (&signer0_pubkey, true, &signer0_account),
+            (true, false, &config_pubkey, &config_account),
+            (true, false, &signer0_pubkey, &signer0_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -557,8 +557,8 @@ mod tests {
         // Attempt update with incomplete signatures
         let keys = vec![(pubkey, false), (config_keypair.pubkey(), true)];
         let instruction = config_instruction::store(&config_pubkey, true, keys, &my_config);
-        let accounts = vec![(&config_pubkey, true, &config_account)];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let accounts = vec![(true, false, &config_pubkey, &config_account)];
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -576,7 +576,7 @@ mod tests {
         let instructions =
             config_instruction::create_account::<MyConfig>(&from_pubkey, &config_pubkey, 1, vec![]);
         let accounts = vec![];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),
@@ -603,10 +603,10 @@ mod tests {
 
         let instruction = config_instruction::store(&config_pubkey, true, keys, &new_config);
         let accounts = vec![
-            (&config_pubkey, true, &config_account),
-            (&signer0_pubkey, true, &signer0_account),
+            (true, false, &config_pubkey, &config_account),
+            (true, false, &signer0_pubkey, &signer0_account),
         ];
-        let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
+        let keyed_accounts = create_keyed_accounts_unified(&accounts);
         assert_eq!(
             process_instruction(
                 &id(),

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -487,13 +487,10 @@ impl ExchangeProcessor {
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts();
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(_keyed_accounts, keyed_accounts);
 
     solana_logger::setup();
     match limited_deserialize::<ExchangeInstruction>(data)? {

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -487,15 +487,15 @@ impl ExchangeProcessor {
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    solana_logger::setup();
-
+    let keyed_accounts = invoke_context.get_keyed_accounts();
     // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+    assert_eq!(_keyed_accounts, keyed_accounts);
 
+    solana_logger::setup();
     match limited_deserialize::<ExchangeInstruction>(data)? {
         ExchangeInstruction::AccountRequest => {
             ExchangeProcessor::do_account_request(keyed_accounts)

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -489,9 +489,12 @@ pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     data: &[u8],
-    _invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
+
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
 
     match limited_deserialize::<ExchangeInstruction>(data)? {
         ExchangeInstruction::AccountRequest => {

--- a/programs/exchange/src/exchange_processor.rs
+++ b/programs/exchange/src/exchange_processor.rs
@@ -490,7 +490,7 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     solana_logger::setup();
     match limited_deserialize::<ExchangeInstruction>(data)? {

--- a/programs/failure/src/lib.rs
+++ b/programs/failure/src/lib.rs
@@ -1,6 +1,5 @@
 use solana_sdk::{
-    instruction::InstructionError, keyed_account::KeyedAccount, process_instruction::InvokeContext,
-    pubkey::Pubkey,
+    instruction::InstructionError, process_instruction::InvokeContext, pubkey::Pubkey,
 };
 
 solana_sdk::declare_program!(
@@ -11,7 +10,6 @@ solana_sdk::declare_program!(
 
 fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     _data: &[u8],
     _invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {

--- a/programs/noop/src/lib.rs
+++ b/programs/noop/src/lib.rs
@@ -1,7 +1,6 @@
 use log::*;
 use solana_sdk::{
-    instruction::InstructionError, keyed_account::KeyedAccount, process_instruction::InvokeContext,
-    pubkey::Pubkey,
+    instruction::InstructionError, process_instruction::InvokeContext, pubkey::Pubkey,
 };
 
 solana_sdk::declare_program!(
@@ -12,13 +11,11 @@ solana_sdk::declare_program!(
 
 pub fn process_instruction(
     program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     _invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
     trace!("noop: program_id: {:?}", program_id);
-    trace!("noop: keyed_accounts: {:#?}", _keyed_accounts);
     trace!("noop: data: {:?}", data);
     Ok(())
 }

--- a/programs/noop/src/lib.rs
+++ b/programs/noop/src/lib.rs
@@ -12,13 +12,13 @@ solana_sdk::declare_program!(
 
 pub fn process_instruction(
     program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     _invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     solana_logger::setup();
     trace!("noop: program_id: {:?}", program_id);
-    trace!("noop: keyed_accounts: {:#?}", keyed_accounts);
+    trace!("noop: keyed_accounts: {:#?}", _keyed_accounts);
     trace!("noop: data: {:?}", data);
     Ok(())
 }

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -32,8 +32,10 @@ pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     data: &[u8],
-    _invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
     let new_owner_pubkey: Pubkey = limited_deserialize(data)?;
     let account_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;
     let mut account_owner_pubkey: Pubkey =

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -33,7 +33,7 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     let new_owner_pubkey: Pubkey = limited_deserialize(data)?;
     let account_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -30,12 +30,14 @@ fn set_owner(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    let keyed_accounts = invoke_context.get_keyed_accounts();
     // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+    assert_eq!(_keyed_accounts, keyed_accounts);
+
     let new_owner_pubkey: Pubkey = limited_deserialize(data)?;
     let account_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;
     let mut account_owner_pubkey: Pubkey =

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -5,7 +5,7 @@ use bincode::serialize_into;
 use solana_sdk::{
     account::{ReadableAccount, WritableAccount},
     instruction::InstructionError,
-    keyed_account::{next_keyed_account, KeyedAccount},
+    keyed_account::{keyed_account_at_index, KeyedAccount},
     process_instruction::InvokeContext,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
@@ -35,15 +35,14 @@ pub fn process_instruction(
     _invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let new_owner_pubkey: Pubkey = limited_deserialize(data)?;
-    let keyed_accounts_iter = &mut keyed_accounts.iter();
-    let account_keyed_account = &mut next_keyed_account(keyed_accounts_iter)?;
+    let account_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;
     let mut account_owner_pubkey: Pubkey =
         limited_deserialize(&account_keyed_account.try_account_ref()?.data())?;
 
     if account_owner_pubkey == Pubkey::default() {
         account_owner_pubkey = new_owner_pubkey;
     } else {
-        let owner_keyed_account = &mut next_keyed_account(keyed_accounts_iter)?;
+        let owner_keyed_account = &mut keyed_account_at_index(keyed_accounts, 1)?;
         set_owner(
             &mut account_owner_pubkey,
             new_owner_pubkey,

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -30,13 +30,10 @@ fn set_owner(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts();
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(_keyed_accounts, keyed_accounts);
 
     let new_owner_pubkey: Pubkey = limited_deserialize(data)?;
     let account_keyed_account = &mut keyed_account_at_index(keyed_accounts, 0)?;

--- a/programs/secp256k1/src/lib.rs
+++ b/programs/secp256k1/src/lib.rs
@@ -1,11 +1,9 @@
 use solana_sdk::{
-    instruction::InstructionError, keyed_account::KeyedAccount, process_instruction::InvokeContext,
-    pubkey::Pubkey,
+    instruction::InstructionError, process_instruction::InvokeContext, pubkey::Pubkey,
 };
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     _data: &[u8],
     _invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     decode_error::DecodeError,
     feature_set,
     instruction::{AccountMeta, Instruction, InstructionError},
-    keyed_account::{from_keyed_account, get_signers, keyed_account_at_index, KeyedAccount},
+    keyed_account::{from_keyed_account, get_signers, keyed_account_at_index},
     process_instruction::InvokeContext,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
@@ -483,13 +483,10 @@ pub fn set_lockup(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts();
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(_keyed_accounts, keyed_accounts);
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
@@ -630,6 +627,7 @@ mod tests {
     use bincode::serialize;
     use solana_sdk::{
         account::{self, Account, AccountSharedData},
+        keyed_account::KeyedAccount,
         process_instruction::MockInvokeContext,
         rent::Rent,
         sysvar::stake_history::StakeHistory,
@@ -714,7 +712,6 @@ mod tests {
                 .collect();
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts),
             )
@@ -925,7 +922,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &[],
                 &serialize(&StakeInstruction::Initialize(
                     Authorized::default(),
                     Lockup::default()
@@ -943,7 +939,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::Initialize(
                     Authorized::default(),
                     Lockup::default()
@@ -966,7 +961,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::Initialize(
                     Authorized::default(),
                     Lockup::default()
@@ -991,7 +985,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::Initialize(
                     Authorized::default(),
                     Lockup::default()
@@ -1009,7 +1002,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -1023,7 +1015,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -1056,7 +1047,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -1085,7 +1075,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::Withdraw(42)).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -1099,7 +1088,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::Withdraw(42)).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -1120,7 +1108,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::Deactivate).unwrap(),
                 &mut MockInvokeContext::new(&keyed_accounts)
             ),
@@ -1131,7 +1118,6 @@ mod tests {
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &serialize(&StakeInstruction::Deactivate).unwrap(),
                 &mut MockInvokeContext::new(&[])
             ),

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -486,7 +486,7 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -483,12 +483,14 @@ pub fn set_lockup(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    let keyed_accounts = invoke_context.get_keyed_accounts();
     // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+    assert_eq!(_keyed_accounts, keyed_accounts);
+
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -713,7 +713,7 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts),
+                &mut MockInvokeContext::new(keyed_accounts),
             )
         }
     }
@@ -927,7 +927,7 @@ mod tests {
                     Lockup::default()
                 ))
                 .unwrap(),
-                &mut MockInvokeContext::new(&[])
+                &mut MockInvokeContext::new(vec![])
             ),
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -935,7 +935,7 @@ mod tests {
         // no account for rent
         let stake_address = Pubkey::default();
         let stake_account = create_default_stake_account();
-        let keyed_accounts = [KeyedAccount::new(&stake_address, false, &stake_account)];
+        let keyed_accounts = vec![KeyedAccount::new(&stake_address, false, &stake_account)];
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
@@ -944,7 +944,7 @@ mod tests {
                     Lockup::default()
                 ))
                 .unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -954,7 +954,7 @@ mod tests {
         let stake_account = create_default_stake_account();
         let rent_address = sysvar::rent::id();
         let rent_account = create_default_account();
-        let keyed_accounts = [
+        let keyed_accounts = vec![
             KeyedAccount::new(&stake_address, false, &stake_account),
             KeyedAccount::new(&rent_address, false, &rent_account),
         ];
@@ -966,7 +966,7 @@ mod tests {
                     Lockup::default()
                 ))
                 .unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::InvalidArgument),
         );
@@ -978,7 +978,7 @@ mod tests {
         let rent_account = RefCell::new(account::create_account_shared_data_for_test(
             &Rent::default(),
         ));
-        let keyed_accounts = [
+        let keyed_accounts = vec![
             KeyedAccount::new(&stake_address, false, &stake_account),
             KeyedAccount::new(&rent_address, false, &rent_account),
         ];
@@ -990,7 +990,7 @@ mod tests {
                     Lockup::default()
                 ))
                 .unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::InvalidAccountData),
         );
@@ -998,12 +998,12 @@ mod tests {
         // gets the first check in delegate, wrong number of accounts
         let stake_address = Pubkey::default();
         let stake_account = create_default_stake_account();
-        let keyed_accounts = [KeyedAccount::new(&stake_address, false, &stake_account)];
+        let keyed_accounts = vec![KeyedAccount::new(&stake_address, false, &stake_account)];
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -1011,12 +1011,12 @@ mod tests {
         // gets the sub-check for number of args
         let stake_address = Pubkey::default();
         let stake_account = create_default_stake_account();
-        let keyed_accounts = [KeyedAccount::new(&stake_address, false, &stake_account)];
+        let keyed_accounts = vec![KeyedAccount::new(&stake_address, false, &stake_account)];
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -1037,7 +1037,7 @@ mod tests {
         ));
         let config_address = config::id();
         let config_account = RefCell::new(config::create_account(0, &config::Config::default()));
-        let keyed_accounts = [
+        let keyed_accounts = vec![
             KeyedAccount::new(&stake_address, true, &stake_account),
             KeyedAccount::new(&vote_address, false, &bad_vote_account),
             KeyedAccount::new(&clock_address, false, &clock_account),
@@ -1048,7 +1048,7 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &serialize(&StakeInstruction::DelegateStake).unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::InvalidAccountData),
         );
@@ -1066,7 +1066,7 @@ mod tests {
         let stake_history_account = RefCell::new(account::create_account_shared_data_for_test(
             &StakeHistory::default(),
         ));
-        let keyed_accounts = [
+        let keyed_accounts = vec![
             KeyedAccount::new(&stake_address, false, &stake_account),
             KeyedAccount::new(&vote_address, false, &vote_account),
             KeyedAccount::new(&rewards_address, false, &rewards_account),
@@ -1076,7 +1076,7 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &serialize(&StakeInstruction::Withdraw(42)).unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::InvalidArgument),
         );
@@ -1084,12 +1084,12 @@ mod tests {
         // Tests correct number of accounts are provided in withdraw
         let stake_address = Pubkey::default();
         let stake_account = create_default_stake_account();
-        let keyed_accounts = [KeyedAccount::new(&stake_address, false, &stake_account)];
+        let keyed_accounts = vec![KeyedAccount::new(&stake_address, false, &stake_account)];
         assert_eq!(
             super::process_instruction(
                 &Pubkey::default(),
                 &serialize(&StakeInstruction::Withdraw(42)).unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -1101,7 +1101,7 @@ mod tests {
         let rewards_account = RefCell::new(account::create_account_shared_data_for_test(
             &sysvar::rewards::Rewards::new(0.0),
         ));
-        let keyed_accounts = [
+        let keyed_accounts = vec![
             KeyedAccount::new(&stake_address, false, &stake_account),
             KeyedAccount::new(&rewards_address, false, &rewards_account),
         ];
@@ -1109,7 +1109,7 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &serialize(&StakeInstruction::Deactivate).unwrap(),
-                &mut MockInvokeContext::new(&keyed_accounts)
+                &mut MockInvokeContext::new(keyed_accounts)
             ),
             Err(InstructionError::InvalidArgument),
         );
@@ -1119,7 +1119,7 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &serialize(&StakeInstruction::Deactivate).unwrap(),
-                &mut MockInvokeContext::new(&[])
+                &mut MockInvokeContext::new(vec![])
             ),
             Err(InstructionError::NotEnoughAccountKeys),
         );

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -487,6 +487,8 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -5103,9 +5103,9 @@ mod tests {
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let invoke_context = MockInvokeContext::default();
 
         let signers = vec![authorized_pubkey].into_iter().collect();
+        let invoke_context = MockInvokeContext::new(&[]);
 
         for state in &[
             StakeState::Initialized(Meta::auto(&authorized_pubkey)),
@@ -5213,7 +5213,7 @@ mod tests {
 
     #[test]
     fn test_merge_self_fails() {
-        let invoke_context = MockInvokeContext::default();
+        let invoke_context = MockInvokeContext::new(&[]);
         let stake_address = Pubkey::new_unique();
         let authority_pubkey = Pubkey::new_unique();
         let signers = HashSet::from_iter(vec![authority_pubkey]);
@@ -5257,7 +5257,6 @@ mod tests {
 
     #[test]
     fn test_merge_incorrect_authorized_staker() {
-        let invoke_context = MockInvokeContext::default();
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5266,6 +5265,7 @@ mod tests {
 
         let signers = vec![authorized_pubkey].into_iter().collect();
         let wrong_signers = vec![wrong_authorized_pubkey].into_iter().collect();
+        let invoke_context = MockInvokeContext::new(&[]);
 
         for state in &[
             StakeState::Initialized(Meta::auto(&authorized_pubkey)),
@@ -5327,12 +5327,12 @@ mod tests {
 
     #[test]
     fn test_merge_invalid_account_data() {
-        let invoke_context = MockInvokeContext::default();
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let signers = vec![authorized_pubkey].into_iter().collect();
+        let invoke_context = MockInvokeContext::new(&[]);
 
         for state in &[
             StakeState::Uninitialized,
@@ -5379,7 +5379,6 @@ mod tests {
 
     #[test]
     fn test_merge_fake_stake_source() {
-        let invoke_context = MockInvokeContext::default();
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let source_stake_pubkey = solana_sdk::pubkey::new_rand();
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
@@ -5411,6 +5410,7 @@ mod tests {
         .expect("source_stake_account");
         let source_stake_keyed_account =
             KeyedAccount::new(&source_stake_pubkey, true, &source_stake_account);
+        let invoke_context = MockInvokeContext::new(&[]);
 
         assert_eq!(
             stake_keyed_account.merge(
@@ -5426,7 +5426,6 @@ mod tests {
 
     #[test]
     fn test_merge_active_stake() {
-        let invoke_context = MockInvokeContext::default();
         let base_lamports = 4242424242;
         let stake_address = Pubkey::new_unique();
         let source_address = Pubkey::new_unique();
@@ -5480,6 +5479,7 @@ mod tests {
 
         let mut clock = Clock::default();
         let mut stake_history = StakeHistory::default();
+        let invoke_context = MockInvokeContext::new(&[]);
 
         clock.epoch = 0;
         let mut effective = base_lamports;
@@ -6144,7 +6144,6 @@ mod tests {
 
     #[test]
     fn test_things_can_merge() {
-        let invoke_context = MockInvokeContext::default();
         let good_stake = Stake {
             credits_observed: 4242,
             delegation: Delegation {
@@ -6154,6 +6153,7 @@ mod tests {
                 ..Delegation::default()
             },
         };
+        let invoke_context = MockInvokeContext::new(&[]);
 
         let identical = good_stake;
         assert!(
@@ -6314,7 +6314,6 @@ mod tests {
 
     #[test]
     fn test_merge_kind_get_if_mergeable() {
-        let invoke_context = MockInvokeContext::default();
         let authority_pubkey = Pubkey::new_unique();
         let initial_lamports = 4242424242;
         let rent = Rent::default();
@@ -6333,9 +6332,9 @@ mod tests {
         )
         .expect("stake_account");
         let stake_keyed_account = KeyedAccount::new(&authority_pubkey, true, &stake_account);
-
         let mut clock = Clock::default();
         let mut stake_history = StakeHistory::default();
+        let invoke_context = MockInvokeContext::new(&[]);
 
         // Uninitialized state fails
         assert_eq!(
@@ -6547,7 +6546,6 @@ mod tests {
 
     #[test]
     fn test_merge_kind_merge() {
-        let invoke_context = MockInvokeContext::default();
         let lamports = 424242;
         let meta = Meta {
             rent_exempt_reserve: 42,
@@ -6563,6 +6561,7 @@ mod tests {
         let inactive = MergeKind::Inactive(Meta::default(), lamports);
         let activation_epoch = MergeKind::ActivationEpoch(meta, stake);
         let fully_active = MergeKind::FullyActive(meta, stake);
+        let invoke_context = MockInvokeContext::new(&[]);
 
         assert_eq!(
             inactive

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -5105,7 +5105,7 @@ mod tests {
         let stake_lamports = 42;
 
         let signers = vec![authorized_pubkey].into_iter().collect();
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
 
         for state in &[
             StakeState::Initialized(Meta::auto(&authorized_pubkey)),
@@ -5213,7 +5213,7 @@ mod tests {
 
     #[test]
     fn test_merge_self_fails() {
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
         let stake_address = Pubkey::new_unique();
         let authority_pubkey = Pubkey::new_unique();
         let signers = HashSet::from_iter(vec![authority_pubkey]);
@@ -5265,7 +5265,7 @@ mod tests {
 
         let signers = vec![authorized_pubkey].into_iter().collect();
         let wrong_signers = vec![wrong_authorized_pubkey].into_iter().collect();
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
 
         for state in &[
             StakeState::Initialized(Meta::auto(&authorized_pubkey)),
@@ -5332,7 +5332,7 @@ mod tests {
         let authorized_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let signers = vec![authorized_pubkey].into_iter().collect();
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
 
         for state in &[
             StakeState::Uninitialized,
@@ -5410,7 +5410,7 @@ mod tests {
         .expect("source_stake_account");
         let source_stake_keyed_account =
             KeyedAccount::new(&source_stake_pubkey, true, &source_stake_account);
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
 
         assert_eq!(
             stake_keyed_account.merge(
@@ -5479,7 +5479,7 @@ mod tests {
 
         let mut clock = Clock::default();
         let mut stake_history = StakeHistory::default();
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
 
         clock.epoch = 0;
         let mut effective = base_lamports;
@@ -6153,7 +6153,7 @@ mod tests {
                 ..Delegation::default()
             },
         };
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
 
         let identical = good_stake;
         assert!(
@@ -6334,7 +6334,7 @@ mod tests {
         let stake_keyed_account = KeyedAccount::new(&authority_pubkey, true, &stake_account);
         let mut clock = Clock::default();
         let mut stake_history = StakeHistory::default();
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
 
         // Uninitialized state fails
         assert_eq!(
@@ -6561,7 +6561,7 @@ mod tests {
         let inactive = MergeKind::Inactive(Meta::default(), lamports);
         let activation_epoch = MergeKind::ActivationEpoch(meta, stake);
         let fully_active = MergeKind::FullyActive(meta, stake);
-        let invoke_context = MockInvokeContext::new(&[]);
+        let invoke_context = MockInvokeContext::new(vec![]);
 
         assert_eq!(
             inactive

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     account::{AccountSharedData, ReadableAccount, WritableAccount},
     feature_set,
     instruction::InstructionError,
-    keyed_account::{next_keyed_account, KeyedAccount},
+    keyed_account::{keyed_account_at_index, KeyedAccount},
     process_instruction::InvokeContext,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
@@ -63,8 +63,7 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts_iter = &mut keyed_accounts.iter();
-    let contract_account = &mut next_keyed_account(keyed_accounts_iter)?.try_account_ref_mut()?;
+    let contract_account = &mut keyed_account_at_index(keyed_accounts, 0)?.try_account_ref_mut()?;
     if invoke_context.is_feature_active(&feature_set::check_program_owner::id())
         && contract_account.owner != crate::id()
     {
@@ -97,25 +96,25 @@ pub fn process_instruction(
         VestInstruction::InitializeAccount { .. } => {}
         VestInstruction::SetTerminator(new_pubkey) => {
             verify_signed_account(
-                next_keyed_account(keyed_accounts_iter)?,
+                keyed_account_at_index(keyed_accounts, 1)?,
                 &vest_state.terminator_pubkey,
             )?;
             vest_state.terminator_pubkey = new_pubkey;
         }
         VestInstruction::SetPayee(new_pubkey) => {
             verify_signed_account(
-                next_keyed_account(keyed_accounts_iter)?,
+                keyed_account_at_index(keyed_accounts, 1)?,
                 &vest_state.payee_pubkey,
             )?;
             vest_state.payee_pubkey = new_pubkey;
         }
         VestInstruction::RedeemTokens => {
             let current_date = verify_date_account(
-                next_keyed_account(keyed_accounts_iter)?,
+                keyed_account_at_index(keyed_accounts, 1)?,
                 &vest_state.date_pubkey,
             )?;
             let mut payee_account = verify_account(
-                next_keyed_account(keyed_accounts_iter)?,
+                keyed_account_at_index(keyed_accounts, 2)?,
                 &vest_state.payee_pubkey,
             )?;
             vest_state.redeem_tokens(contract_account, current_date, &mut payee_account);
@@ -127,11 +126,11 @@ pub fn process_instruction(
                 contract_account.lamports
             };
             let terminator_account = verify_signed_account(
-                next_keyed_account(keyed_accounts_iter)?,
+                keyed_account_at_index(keyed_accounts, 1)?,
                 &vest_state.terminator_pubkey,
             )?;
-            let payee_keyed_account = keyed_accounts_iter.next();
-            let mut payee_account = if let Some(payee_keyed_account) = payee_keyed_account {
+            let payee_keyed_account = keyed_account_at_index(keyed_accounts, 2);
+            let mut payee_account = if let Ok(payee_keyed_account) = payee_keyed_account {
                 payee_keyed_account.try_account_ref_mut()?
             } else {
                 terminator_account
@@ -140,7 +139,7 @@ pub fn process_instruction(
         }
         VestInstruction::VestAll => {
             verify_signed_account(
-                next_keyed_account(keyed_accounts_iter)?,
+                keyed_account_at_index(keyed_accounts, 1)?,
                 &vest_state.terminator_pubkey,
             )?;
             vest_state.vest_all();

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -63,6 +63,9 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+
     let contract_account = &mut keyed_account_at_index(keyed_accounts, 0)?.try_account_ref_mut()?;
     if invoke_context.is_feature_active(&feature_set::check_program_owner::id())
         && contract_account.owner != crate::id()

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -62,7 +62,7 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     let contract_account = &mut keyed_account_at_index(keyed_accounts, 0)?.try_account_ref_mut()?;
     if invoke_context.is_feature_active(&feature_set::check_program_owner::id())

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -59,13 +59,10 @@ fn verify_signed_account<'a>(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts();
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(_keyed_accounts, keyed_accounts);
 
     let contract_account = &mut keyed_account_at_index(keyed_accounts, 0)?.try_account_ref_mut()?;
     if invoke_context.is_feature_active(&feature_set::check_program_owner::id())

--- a/programs/vest/src/vest_processor.rs
+++ b/programs/vest/src/vest_processor.rs
@@ -59,12 +59,13 @@ fn verify_signed_account<'a>(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    let keyed_accounts = invoke_context.get_keyed_accounts();
     // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+    assert_eq!(_keyed_accounts, keyed_accounts);
 
     let contract_account = &mut keyed_account_at_index(keyed_accounts, 0)?.try_account_ref_mut()?;
     if invoke_context.is_feature_active(&feature_set::check_program_owner::id())

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -281,6 +281,9 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
 

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -277,12 +277,13 @@ fn verify_rent_exemption(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
+    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    let keyed_accounts = invoke_context.get_keyed_accounts();
     // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+    assert_eq!(_keyed_accounts, keyed_accounts);
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -353,7 +353,11 @@ mod tests {
     #[test]
     fn test_vote_process_instruction_decode_bail() {
         assert_eq!(
-            super::process_instruction(&Pubkey::default(), &[], &mut MockInvokeContext::new(&[])),
+            super::process_instruction(
+                &Pubkey::default(),
+                &[],
+                &mut MockInvokeContext::new(vec![])
+            ),
             Err(InstructionError::NotEnoughAccountKeys),
         );
     }
@@ -397,7 +401,7 @@ mod tests {
             super::process_instruction(
                 &Pubkey::default(),
                 &instruction.data,
-                &mut MockInvokeContext::new(&keyed_accounts),
+                &mut MockInvokeContext::new(keyed_accounts),
             )
         }
     }

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -14,7 +14,7 @@ use solana_sdk::{
     feature_set,
     hash::Hash,
     instruction::{AccountMeta, Instruction, InstructionError},
-    keyed_account::{from_keyed_account, get_signers, next_keyed_account, KeyedAccount},
+    keyed_account::{from_keyed_account, get_signers, keyed_account_at_index, KeyedAccount},
     process_instruction::InvokeContext,
     program_utils::limited_deserialize,
     pubkey::Pubkey,
@@ -286,8 +286,7 @@ pub fn process_instruction(
 
     let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
 
-    let keyed_accounts = &mut keyed_accounts.iter();
-    let me = &mut next_keyed_account(keyed_accounts)?;
+    let me = &mut keyed_account_at_index(keyed_accounts, 0)?;
 
     if invoke_context.is_feature_active(&feature_set::check_program_owner::id())
         && me.owner()? != id()
@@ -297,12 +296,12 @@ pub fn process_instruction(
 
     match limited_deserialize(data)? {
         VoteInstruction::InitializeAccount(vote_init) => {
-            verify_rent_exemption(me, next_keyed_account(keyed_accounts)?)?;
+            verify_rent_exemption(me, keyed_account_at_index(keyed_accounts, 1)?)?;
             vote_state::initialize_account(
                 me,
                 &vote_init,
                 &signers,
-                &from_keyed_account::<Clock>(next_keyed_account(keyed_accounts)?)?,
+                &from_keyed_account::<Clock>(keyed_account_at_index(keyed_accounts, 2)?)?,
                 invoke_context.is_feature_active(&feature_set::check_init_vote_data::id()),
             )
         }
@@ -311,11 +310,11 @@ pub fn process_instruction(
             &voter_pubkey,
             vote_authorize,
             &signers,
-            &from_keyed_account::<Clock>(next_keyed_account(keyed_accounts)?)?,
+            &from_keyed_account::<Clock>(keyed_account_at_index(keyed_accounts, 1)?)?,
         ),
         VoteInstruction::UpdateValidatorIdentity => vote_state::update_validator_identity(
             me,
-            next_keyed_account(keyed_accounts)?.unsigned_key(),
+            keyed_account_at_index(keyed_accounts, 1)?.unsigned_key(),
             &signers,
         ),
         VoteInstruction::UpdateCommission(commission) => {
@@ -325,14 +324,14 @@ pub fn process_instruction(
             inc_new_counter_info!("vote-native", 1);
             vote_state::process_vote(
                 me,
-                &from_keyed_account::<SlotHashes>(next_keyed_account(keyed_accounts)?)?,
-                &from_keyed_account::<Clock>(next_keyed_account(keyed_accounts)?)?,
+                &from_keyed_account::<SlotHashes>(keyed_account_at_index(keyed_accounts, 1)?)?,
+                &from_keyed_account::<Clock>(keyed_account_at_index(keyed_accounts, 2)?)?,
                 &vote,
                 &signers,
             )
         }
         VoteInstruction::Withdraw(lamports) => {
-            let to = next_keyed_account(keyed_accounts)?;
+            let to = keyed_account_at_index(keyed_accounts, 1)?;
             vote_state::withdraw(me, lamports, to, &signers)
         }
     }

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -280,7 +280,7 @@ pub fn process_instruction(
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -357,7 +357,7 @@ mod tests {
                 &Pubkey::default(),
                 &[],
                 &[],
-                &mut MockInvokeContext::default()
+                &mut MockInvokeContext::new(&[])
             ),
             Err(InstructionError::NotEnoughAccountKeys),
         );
@@ -403,7 +403,7 @@ mod tests {
                 &Pubkey::default(),
                 &keyed_accounts,
                 &instruction.data,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&keyed_accounts),
             )
         }
     }

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -277,13 +277,10 @@ fn verify_rent_exemption(
 
 pub fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts();
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(_keyed_accounts, keyed_accounts);
 
     trace!("process_instruction: {:?}", data);
     trace!("keyed_accounts: {:?}", keyed_accounts);
@@ -356,12 +353,7 @@ mod tests {
     #[test]
     fn test_vote_process_instruction_decode_bail() {
         assert_eq!(
-            super::process_instruction(
-                &Pubkey::default(),
-                &[],
-                &[],
-                &mut MockInvokeContext::new(&[])
-            ),
+            super::process_instruction(&Pubkey::default(), &[], &mut MockInvokeContext::new(&[])),
             Err(InstructionError::NotEnoughAccountKeys),
         );
     }
@@ -404,7 +396,6 @@ mod tests {
                 .collect();
             super::process_instruction(
                 &Pubkey::default(),
-                &keyed_accounts,
                 &instruction.data,
                 &mut MockInvokeContext::new(&keyed_accounts),
             )

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -788,7 +788,7 @@ mod tests {
         account::AccountSharedData,
         account_utils::StateMut,
         hash::hash,
-        keyed_account::{get_signers, next_keyed_account},
+        keyed_account::{get_signers, keyed_account_at_index},
     };
     use std::cell::RefCell;
 
@@ -1715,9 +1715,8 @@ mod tests {
             KeyedAccount::new(&authorized_withdrawer_pubkey, true, &withdrawer_account),
         ];
         let signers: HashSet<Pubkey> = get_signers(keyed_accounts);
-        let keyed_accounts = &mut keyed_accounts.iter();
-        let vote_keyed_account = next_keyed_account(keyed_accounts).unwrap();
-        let withdrawer_keyed_account = next_keyed_account(keyed_accounts).unwrap();
+        let vote_keyed_account = keyed_account_at_index(keyed_accounts, 0).unwrap();
+        let withdrawer_keyed_account = keyed_account_at_index(keyed_accounts, 1).unwrap();
         let res = withdraw(
             vote_keyed_account,
             lamports,

--- a/runtime/benches/bank.rs
+++ b/runtime/benches/bank.rs
@@ -11,7 +11,6 @@ use solana_sdk::{
     clock::MAX_RECENT_BLOCKHASHES,
     genesis_config::create_genesis_config,
     instruction::InstructionError,
-    keyed_account::KeyedAccount,
     message::Message,
     process_instruction::InvokeContext,
     pubkey::Pubkey,
@@ -34,7 +33,6 @@ const NOOP_PROGRAM_ID: [u8; 32] = [
 #[allow(clippy::unnecessary_wraps)]
 fn process_instruction(
     _program_id: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     _data: &[u8],
     _invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5432,8 +5432,10 @@ pub(crate) mod tests {
         _program_id: &Pubkey,
         keyed_accounts: &[KeyedAccount],
         data: &[u8],
-        _invoke_context: &mut dyn InvokeContext,
+        invoke_context: &mut dyn InvokeContext,
     ) -> result::Result<(), InstructionError> {
+        // TODO [KeyedAccounts to InvokeContext refactoring]
+        assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
         if let Ok(instruction) = bincode::deserialize(data) {
             match instruction {
                 MockInstruction::Deduction => {
@@ -9007,10 +9009,12 @@ pub(crate) mod tests {
         }
         fn mock_vote_processor(
             program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
+            keyed_accounts: &[KeyedAccount],
             _instruction_data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
             if mock_vote_program_id() != *program_id {
                 return Err(InstructionError::IncorrectProgramId);
             }
@@ -9852,8 +9856,10 @@ pub(crate) mod tests {
             _program_id: &Pubkey,
             keyed_accounts: &[KeyedAccount],
             data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
             let lamports = data[0] as u64;
             {
                 let mut to_account = keyed_accounts[1].try_account_ref_mut()?;
@@ -9904,10 +9910,12 @@ pub(crate) mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
             _program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
+            keyed_accounts: &[KeyedAccount],
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
             Ok(())
         }
 
@@ -10344,8 +10352,10 @@ pub(crate) mod tests {
             _program_id: &Pubkey,
             keyed_accounts: &[KeyedAccount],
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
             assert_eq!(42, keyed_accounts[0].lamports().unwrap());
             let mut account = keyed_accounts[0].try_account_ref_mut()?;
             account.lamports += 1;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10962,7 +10962,6 @@ pub(crate) mod tests {
             &self,
             _loader_id: &Pubkey,
             _program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
             _instruction_data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
             _use_jit: bool,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -208,7 +208,7 @@ impl AbiExample for Builtin {
         Self {
             name: String::default(),
             id: Pubkey::default(),
-            process_instruction_with_context: |_, _, _, _| Ok(()),
+            process_instruction_with_context: |_, _, _| Ok(()),
         }
     }
 }
@@ -5071,7 +5071,6 @@ pub(crate) mod tests {
         feature::Feature,
         genesis_config::create_genesis_config,
         instruction::{AccountMeta, CompiledInstruction, Instruction, InstructionError},
-        keyed_account::KeyedAccount,
         message::{Message, MessageHeader},
         nonce,
         poh_config::PohConfig,
@@ -5430,13 +5429,10 @@ pub(crate) mod tests {
 
     fn mock_process_instruction(
         _program_id: &Pubkey,
-        _keyed_accounts: &[KeyedAccount],
         data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> result::Result<(), InstructionError> {
         let keyed_accounts = invoke_context.get_keyed_accounts();
-        // TODO [KeyedAccounts to InvokeContext refactoring]
-        assert_eq!(_keyed_accounts, keyed_accounts);
         if let Ok(instruction) = bincode::deserialize(data) {
             match instruction {
                 MockInstruction::Deduction => {
@@ -9010,13 +9006,9 @@ pub(crate) mod tests {
         }
         fn mock_vote_processor(
             program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
             _instruction_data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
-            let keyed_accounts = invoke_context.get_keyed_accounts();
-            // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(_keyed_accounts, keyed_accounts);
             if mock_vote_program_id() != *program_id {
                 return Err(InstructionError::IncorrectProgramId);
             }
@@ -9071,7 +9063,6 @@ pub(crate) mod tests {
 
         fn mock_vote_processor(
             _pubkey: &Pubkey,
-            _ka: &[KeyedAccount],
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
@@ -9122,7 +9113,6 @@ pub(crate) mod tests {
 
         fn mock_ix_processor(
             _pubkey: &Pubkey,
-            _ka: &[KeyedAccount],
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
@@ -9856,13 +9846,10 @@ pub(crate) mod tests {
 
         fn mock_process_instruction(
             _program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let keyed_accounts = invoke_context.get_keyed_accounts();
-            // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(_keyed_accounts, keyed_accounts);
             let lamports = data[0] as u64;
             {
                 let mut to_account = keyed_accounts[1].try_account_ref_mut()?;
@@ -9913,12 +9900,9 @@ pub(crate) mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
             _program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
             _data: &[u8],
-            invoke_context: &mut dyn InvokeContext,
+            _invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
-            // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(invoke_context.get_keyed_accounts(), _keyed_accounts);
             Ok(())
         }
 
@@ -10102,7 +10086,6 @@ pub(crate) mod tests {
     #[allow(clippy::unnecessary_wraps)]
     fn mock_ok_vote_processor(
         _pubkey: &Pubkey,
-        _ka: &[KeyedAccount],
         _data: &[u8],
         _invoke_context: &mut dyn InvokeContext,
     ) -> std::result::Result<(), InstructionError> {
@@ -10353,13 +10336,10 @@ pub(crate) mod tests {
     fn test_same_program_id_uses_unqiue_executable_accounts() {
         fn nested_processor(
             _program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
             _data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
             let keyed_accounts = invoke_context.get_keyed_accounts();
-            // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(_keyed_accounts, keyed_accounts);
             assert_eq!(42, keyed_accounts[0].lamports().unwrap());
             let mut account = keyed_accounts[0].try_account_ref_mut()?;
             account.lamports += 1;
@@ -10636,7 +10616,6 @@ pub(crate) mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_ix_processor(
             _pubkey: &Pubkey,
-            _ka: &[KeyedAccount],
             _data: &[u8],
             _invoke_context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
@@ -10682,7 +10661,6 @@ pub(crate) mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_ix_processor(
             _pubkey: &Pubkey,
-            _ka: &[KeyedAccount],
             _data: &[u8],
             _context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
@@ -12415,12 +12393,12 @@ pub(crate) mod tests {
 
         fn mock_ix_processor(
             _pubkey: &Pubkey,
-            ka: &[KeyedAccount],
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             use solana_sdk::account::WritableAccount;
-            let mut data = ka[1].try_account_ref_mut()?;
+            let keyed_accounts = invoke_context.get_keyed_accounts();
+            let mut data = keyed_accounts[1].try_account_ref_mut()?;
             data.data_as_mut_slice()[0] = 5;
             Ok(())
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5430,12 +5430,13 @@ pub(crate) mod tests {
 
     fn mock_process_instruction(
         _program_id: &Pubkey,
-        keyed_accounts: &[KeyedAccount],
+        _keyed_accounts: &[KeyedAccount],
         data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> result::Result<(), InstructionError> {
+        let keyed_accounts = invoke_context.get_keyed_accounts();
         // TODO [KeyedAccounts to InvokeContext refactoring]
-        assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
+        assert_eq!(_keyed_accounts, keyed_accounts);
         if let Ok(instruction) = bincode::deserialize(data) {
             match instruction {
                 MockInstruction::Deduction => {
@@ -9009,12 +9010,13 @@ pub(crate) mod tests {
         }
         fn mock_vote_processor(
             program_id: &Pubkey,
-            keyed_accounts: &[KeyedAccount],
+            _keyed_accounts: &[KeyedAccount],
             _instruction_data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
+            let keyed_accounts = invoke_context.get_keyed_accounts();
             // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
+            assert_eq!(_keyed_accounts, keyed_accounts);
             if mock_vote_program_id() != *program_id {
                 return Err(InstructionError::IncorrectProgramId);
             }
@@ -9854,12 +9856,13 @@ pub(crate) mod tests {
 
         fn mock_process_instruction(
             _program_id: &Pubkey,
-            keyed_accounts: &[KeyedAccount],
+            _keyed_accounts: &[KeyedAccount],
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
+            let keyed_accounts = invoke_context.get_keyed_accounts();
             // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
+            assert_eq!(_keyed_accounts, keyed_accounts);
             let lamports = data[0] as u64;
             {
                 let mut to_account = keyed_accounts[1].try_account_ref_mut()?;
@@ -9910,12 +9913,12 @@ pub(crate) mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
             _program_id: &Pubkey,
-            keyed_accounts: &[KeyedAccount],
+            _keyed_accounts: &[KeyedAccount],
             _data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
             // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
+            assert_eq!(invoke_context.get_keyed_accounts(), _keyed_accounts);
             Ok(())
         }
 
@@ -10350,12 +10353,13 @@ pub(crate) mod tests {
     fn test_same_program_id_uses_unqiue_executable_accounts() {
         fn nested_processor(
             _program_id: &Pubkey,
-            keyed_accounts: &[KeyedAccount],
+            _keyed_accounts: &[KeyedAccount],
             _data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
+            let keyed_accounts = invoke_context.get_keyed_accounts();
             // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(invoke_context.get_keyed_accounts(), keyed_accounts);
+            assert_eq!(_keyed_accounts, keyed_accounts);
             assert_eq!(42, keyed_accounts[0].lamports().unwrap());
             let mut account = keyed_accounts[0].try_account_ref_mut()?;
             account.lamports += 1;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5432,7 +5432,7 @@ pub(crate) mod tests {
         data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> result::Result<(), InstructionError> {
-        let keyed_accounts = invoke_context.get_keyed_accounts();
+        let keyed_accounts = invoke_context.get_keyed_accounts()?;
         if let Ok(instruction) = bincode::deserialize(data) {
             match instruction {
                 MockInstruction::Deduction => {
@@ -9849,7 +9849,7 @@ pub(crate) mod tests {
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
-            let keyed_accounts = invoke_context.get_keyed_accounts();
+            let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let lamports = data[0] as u64;
             {
                 let mut to_account = keyed_accounts[1].try_account_ref_mut()?;
@@ -10339,7 +10339,7 @@ pub(crate) mod tests {
             _data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> result::Result<(), InstructionError> {
-            let keyed_accounts = invoke_context.get_keyed_accounts();
+            let keyed_accounts = invoke_context.get_keyed_accounts()?;
             assert_eq!(42, keyed_accounts[0].lamports().unwrap());
             let mut account = keyed_accounts[0].try_account_ref_mut()?;
             account.lamports += 1;
@@ -12397,7 +12397,7 @@ pub(crate) mod tests {
             invoke_context: &mut dyn InvokeContext,
         ) -> std::result::Result<(), InstructionError> {
             use solana_sdk::account::WritableAccount;
-            let keyed_accounts = invoke_context.get_keyed_accounts();
+            let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let mut data = keyed_accounts[1].try_account_ref_mut()?;
             data.data_as_mut_slice()[0] = 5;
             Ok(())

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -18,6 +18,9 @@ fn process_instruction_with_program_logging(
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+
     let logger = invoke_context.get_logger();
     stable_log::program_invoke(&logger, program_id, invoke_context.invoke_depth());
 

--- a/runtime/src/builtins.rs
+++ b/runtime/src/builtins.rs
@@ -5,7 +5,6 @@ use crate::{
 use solana_sdk::{
     feature_set,
     instruction::InstructionError,
-    keyed_account::KeyedAccount,
     process_instruction::{stable_log, InvokeContext, ProcessInstructionWithContext},
     pubkey::Pubkey,
     system_program,
@@ -14,17 +13,13 @@ use solana_sdk::{
 fn process_instruction_with_program_logging(
     process_instruction: ProcessInstructionWithContext,
     program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
-
     let logger = invoke_context.get_logger();
     stable_log::program_invoke(&logger, program_id, invoke_context.invoke_depth());
 
-    let result = process_instruction(program_id, keyed_accounts, instruction_data, invoke_context);
+    let result = process_instruction(program_id, instruction_data, invoke_context);
 
     match &result {
         Ok(()) => stable_log::program_success(&logger, program_id),
@@ -35,14 +30,10 @@ fn process_instruction_with_program_logging(
 
 macro_rules! with_program_logging {
     ($process_instruction:expr) => {
-        |program_id: &Pubkey,
-         keyed_accounts: &[KeyedAccount],
-         instruction_data: &[u8],
-         invoke_context: &mut dyn InvokeContext| {
+        |program_id: &Pubkey, instruction_data: &[u8], invoke_context: &mut dyn InvokeContext| {
             process_instruction_with_program_logging(
                 $process_instruction,
                 program_id,
-                keyed_accounts,
                 instruction_data,
                 invoke_context,
             )

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -597,7 +597,8 @@ impl MessageProcessor {
         instruction_data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
-        debug_assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+        // TODO [KeyedAccounts to InvokeContext refactoring]
+        assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
         if let Some(root_account) = keyed_accounts.iter().next() {
             let root_id = root_account.unsigned_key();
             if native_loader::check_id(&root_account.owner()?) {
@@ -722,7 +723,7 @@ impl MessageProcessor {
         invoke_context: &mut dyn InvokeContext,
         instruction: Instruction,
         keyed_account_indices: &[usize],
-        signers_seeds: &[&[&[u8]]],
+        signers: &[Pubkey],
     ) -> Result<(), InstructionError> {
         let invoke_context = RefCell::new(invoke_context);
 
@@ -736,14 +737,7 @@ impl MessageProcessor {
         ) = {
             let invoke_context = invoke_context.borrow();
 
-            let caller_program_id = invoke_context.get_caller()?;
-
             // Translate and verify caller's data
-
-            let signers = signers_seeds
-                .iter()
-                .map(|seeds| Pubkey::create_program_address(&seeds, caller_program_id))
-                .collect::<Result<Vec<_>, solana_sdk::pubkey::PubkeyError>>()?;
             let keyed_accounts = invoke_context.get_keyed_accounts();
             let keyed_accounts = keyed_account_indices
                 .iter()

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -363,7 +363,7 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
             .last()
             .ok_or(InstructionError::GenericError)
     }
-    fn pop_first_keyed_account(&mut self) {
+    fn remove_first_keyed_account(&mut self) {
         self.keyed_accounts = &self.keyed_accounts[1..];
     }
     fn get_keyed_accounts(&self) -> &[KeyedAccount] {
@@ -603,7 +603,7 @@ impl MessageProcessor {
             if native_loader::check_id(&root_account.owner()?) {
                 for (id, process_instruction) in &self.programs {
                     if id == root_id {
-                        invoke_context.pop_first_keyed_account();
+                        invoke_context.remove_first_keyed_account();
                         // Call the builtin program
                         return process_instruction(&program_id, instruction_data, invoke_context);
                     }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -597,6 +597,7 @@ impl MessageProcessor {
         instruction_data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
+        debug_assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
         if let Some(root_account) = keyed_accounts.iter().next() {
             let root_id = root_account.unsigned_key();
             if native_loader::check_id(&root_account.owner()?) {

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1787,12 +1787,13 @@ mod tests {
 
         fn mock_system_process_instruction(
             _program_id: &Pubkey,
-            keyed_accounts: &[KeyedAccount],
+            _keyed_accounts: &[KeyedAccount],
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> Result<(), InstructionError> {
+            let keyed_accounts = invoke_context.get_keyed_accounts();
             // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+            assert_eq!(_keyed_accounts, keyed_accounts);
             if let Ok(instruction) = bincode::deserialize(data) {
                 match instruction {
                     MockSystemInstruction::Correct => Ok(()),
@@ -1942,12 +1943,13 @@ mod tests {
 
         fn mock_system_process_instruction(
             _program_id: &Pubkey,
-            keyed_accounts: &[KeyedAccount],
+            _keyed_accounts: &[KeyedAccount],
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> Result<(), InstructionError> {
+            let keyed_accounts = invoke_context.get_keyed_accounts();
             // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+            assert_eq!(_keyed_accounts, keyed_accounts);
             if let Ok(instruction) = bincode::deserialize(data) {
                 match instruction {
                     MockSystemInstruction::BorrowFail => {
@@ -2123,12 +2125,13 @@ mod tests {
 
         fn mock_process_instruction(
             program_id: &Pubkey,
-            keyed_accounts: &[KeyedAccount],
+            _keyed_accounts: &[KeyedAccount],
             data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> Result<(), InstructionError> {
+            let keyed_accounts = invoke_context.get_keyed_accounts();
             // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+            assert_eq!(_keyed_accounts, keyed_accounts);
             assert_eq!(*program_id, keyed_accounts[0].owner()?);
             assert_ne!(
                 keyed_accounts[1].owner()?,
@@ -2274,12 +2277,12 @@ mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
             _program_id: &Pubkey,
-            keyed_accounts: &[KeyedAccount],
+            _keyed_accounts: &[KeyedAccount],
             _data: &[u8],
             invoke_context: &mut dyn InvokeContext,
         ) -> Result<(), InstructionError> {
             // TODO [KeyedAccounts to InvokeContext refactoring]
-            assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+            assert_eq!(_keyed_accounts, invoke_context.get_keyed_accounts());
             Ok(())
         }
         #[allow(clippy::unnecessary_wraps)]

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -356,6 +356,13 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
             .last()
             .ok_or(InstructionError::GenericError)
     }
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    /*fn set_keyed_accounts(&mut self, keyed_accounts: &'a [KeyedAccount<'a>]) {
+        self.keyed_accounts = keyed_accounts;
+    }*/
+    fn pop_first_keyed_account(&mut self) {
+        self.keyed_accounts = &self.keyed_accounts[1..];
+    }
     fn get_keyed_accounts(&self) -> &[KeyedAccount] {
         self.keyed_accounts
     }
@@ -595,6 +602,9 @@ impl MessageProcessor {
             if native_loader::check_id(&root_account.owner()?) {
                 for (id, process_instruction) in &self.programs {
                     if id == root_id {
+                        // TODO [KeyedAccounts to InvokeContext refactoring]
+                        // invoke_context.set_keyed_accounts(&keyed_accounts[1..]);
+                        invoke_context.pop_first_keyed_account();
                         // Call the builtin program
                         return process_instruction(
                             &program_id,
@@ -886,6 +896,9 @@ impl MessageProcessor {
                 accounts,
                 demote_sysvar_write_locks,
             );
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            // let previous_keyed_accounts = invoke_context.get_keyed_accounts();
+            // invoke_context.set_keyed_accounts(&keyed_accounts);
 
             // Invoke callee
             invoke_context.push(program_id)?;
@@ -906,6 +919,8 @@ impl MessageProcessor {
                 result = invoke_context.verify_and_update(message, instruction, accounts, None);
             }
             invoke_context.pop();
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            // invoke_context.set_keyed_accounts(previous_keyed_accounts);
 
             result
         } else {

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1789,8 +1789,10 @@ mod tests {
             _program_id: &Pubkey,
             keyed_accounts: &[KeyedAccount],
             data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> Result<(), InstructionError> {
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
             if let Ok(instruction) = bincode::deserialize(data) {
                 match instruction {
                     MockSystemInstruction::Correct => Ok(()),
@@ -1942,8 +1944,10 @@ mod tests {
             _program_id: &Pubkey,
             keyed_accounts: &[KeyedAccount],
             data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> Result<(), InstructionError> {
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
             if let Ok(instruction) = bincode::deserialize(data) {
                 match instruction {
                     MockSystemInstruction::BorrowFail => {
@@ -2121,8 +2125,10 @@ mod tests {
             program_id: &Pubkey,
             keyed_accounts: &[KeyedAccount],
             data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> Result<(), InstructionError> {
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
             assert_eq!(*program_id, keyed_accounts[0].owner()?);
             assert_ne!(
                 keyed_accounts[1].owner()?,
@@ -2268,10 +2274,12 @@ mod tests {
         #[allow(clippy::unnecessary_wraps)]
         fn mock_process_instruction(
             _program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
+            keyed_accounts: &[KeyedAccount],
             _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
+            invoke_context: &mut dyn InvokeContext,
         ) -> Result<(), InstructionError> {
+            // TODO [KeyedAccounts to InvokeContext refactoring]
+            assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
             Ok(())
         }
         #[allow(clippy::unnecessary_wraps)]

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -255,6 +255,7 @@ pub struct ThisInvokeContext<'a> {
     pre_accounts: Vec<PreAccount>,
     executables: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
     account_deps: &'a [(Pubkey, Rc<RefCell<AccountSharedData>>)],
+    keyed_accounts: &'a [KeyedAccount<'a>],
     programs: &'a [(Pubkey, ProcessInstructionWithContext)],
     logger: Rc<RefCell<dyn Logger>>,
     bpf_compute_budget: BpfComputeBudget,
@@ -292,6 +293,7 @@ impl<'a> ThisInvokeContext<'a> {
             pre_accounts,
             executables,
             account_deps,
+            keyed_accounts: &[], // TODO [KeyedAccounts to InvokeContext refactoring]
             programs,
             logger: Rc::new(RefCell::new(ThisLogger { log_collector })),
             bpf_compute_budget,
@@ -352,6 +354,9 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
         self.program_ids
             .last()
             .ok_or(InstructionError::GenericError)
+    }
+    fn get_keyed_accounts(&self) -> &[KeyedAccount] {
+        self.keyed_accounts
     }
     fn get_programs(&self) -> &[(Pubkey, ProcessInstructionWithContext)] {
         self.programs

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -341,6 +341,9 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
         }
         // Alias the keys and account references in the provided keyed_accounts
         // with the ones already existing in self, so that the lifetime 'a matches.
+        fn transmute_lifetime<'a, 'b, T: Sized>(value: &'a T) -> &'b T {
+            unsafe { std::mem::transmute(value) }
+        }
         let keyed_accounts = keyed_accounts
             .iter()
             .map(|(is_signer, is_writable, search_key, account)| {
@@ -368,7 +371,7 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
                                 // before calling MessageProcessor::process_cross_program_instruction
                                 // Ideally we would recycle the existing accounts here like this:
                                 // &self.accounts[index] as &RefCell<AccountSharedData>,
-                                unsafe { std::mem::transmute(*account) },
+                                transmute_lifetime(*account),
                             )
                         }
                     })

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -139,7 +139,7 @@ impl NativeLoader {
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
         let (program_id, name_vec) = {
-            let keyed_accounts = invoke_context.get_keyed_accounts();
+            let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let program = keyed_account_at_index(keyed_accounts, 0)?;
             if native_loader::id() != *program_id {
                 error!("Program id mismatch");
@@ -170,7 +170,7 @@ impl NativeLoader {
             return Err(NativeLoaderError::InvalidAccountData.into());
         }
         trace!("Call native {:?}", name);
-        invoke_context.remove_first_keyed_account();
+        invoke_context.remove_first_keyed_account()?;
         if name.ends_with("loader_program") {
             let entrypoint =
                 Self::get_entrypoint::<LoaderEntrypoint>(name, &self.loader_symbol_cache)?;
@@ -181,7 +181,7 @@ impl NativeLoader {
             unsafe {
                 entrypoint(
                     &program_id,
-                    invoke_context.get_keyed_accounts(),
+                    invoke_context.get_keyed_accounts()?,
                     instruction_data,
                 )
             }

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -10,7 +10,7 @@ use solana_sdk::{
     decode_error::DecodeError,
     entrypoint_native::ProgramEntrypoint,
     instruction::InstructionError,
-    keyed_account::{next_keyed_account, KeyedAccount},
+    keyed_account::{keyed_account_at_index, KeyedAccount},
     native_loader,
     process_instruction::{InvokeContext, LoaderEntrypoint},
     pubkey::Pubkey,
@@ -139,8 +139,7 @@ impl NativeLoader {
         instruction_data: &[u8],
         invoke_context: &dyn InvokeContext,
     ) -> Result<(), InstructionError> {
-        let mut keyed_accounts_iter = keyed_accounts.iter();
-        let program = next_keyed_account(&mut keyed_accounts_iter)?;
+        let program = keyed_account_at_index(keyed_accounts, 0)?;
         if native_loader::id() != *program_id {
             error!("Program id mismatch");
             return Err(InstructionError::IncorrectProgramId);
@@ -150,8 +149,8 @@ impl NativeLoader {
             return Err(InstructionError::IncorrectProgramId);
         }
 
-        let params = keyed_accounts_iter.as_slice();
-        let account = program.try_account_ref()?;
+        let params = &keyed_accounts[1..];
+        let account = &program.try_account_ref()?;
         let name = match str::from_utf8(account.data()) {
             Ok(v) => v,
             Err(e) => {

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -139,6 +139,7 @@ impl NativeLoader {
         instruction_data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
+        debug_assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
         let program = keyed_account_at_index(keyed_accounts, 0)?;
         if native_loader::id() != *program_id {
             error!("Program id mismatch");

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -151,7 +151,7 @@ impl NativeLoader {
             }
             // TODO: Remove these two copies (* deref is also a copy)
             // Both could be avoided as we know that the first KeyedAccount
-            // still exists even after invoke_context.pop_first_keyed_account() is called
+            // still exists even after invoke_context.remove_first_keyed_account() is called
             (
                 *program.unsigned_key(),
                 &program.try_account_ref()?.data().clone(),
@@ -170,7 +170,7 @@ impl NativeLoader {
             return Err(NativeLoaderError::InvalidAccountData.into());
         }
         trace!("Call native {:?}", name);
-        invoke_context.pop_first_keyed_account();
+        invoke_context.remove_first_keyed_account();
         if name.ends_with("loader_program") {
             let entrypoint =
                 Self::get_entrypoint::<LoaderEntrypoint>(name, &self.loader_symbol_cache)?;

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -149,7 +149,9 @@ impl NativeLoader {
                 error!("Executable account now owned by loader");
                 return Err(InstructionError::IncorrectProgramId);
             }
-            // TODO [KeyedAccounts to InvokeContext refactoring]
+            // TODO: Remove these two copies (* deref is also a copy)
+            // Both could be avoided as we know that the first KeyedAccount
+            // still exists even after invoke_context.pop_first_keyed_account() is called
             (
                 *program.unsigned_key(),
                 &program.try_account_ref()?.data().clone(),

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -137,7 +137,7 @@ impl NativeLoader {
         program_id: &Pubkey,
         keyed_accounts: &[KeyedAccount],
         instruction_data: &[u8],
-        invoke_context: &dyn InvokeContext,
+        invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
         let program = keyed_account_at_index(keyed_accounts, 0)?;
         if native_loader::id() != *program_id {
@@ -149,6 +149,9 @@ impl NativeLoader {
             return Err(InstructionError::IncorrectProgramId);
         }
 
+        // TODO [KeyedAccounts to InvokeContext refactoring]
+        // invoke_context.set_keyed_accounts(&keyed_accounts[1..]);
+        invoke_context.pop_first_keyed_account();
         let params = &keyed_accounts[1..];
         let account = &program.try_account_ref()?;
         let name = match str::from_utf8(account.data()) {

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -139,7 +139,8 @@ impl NativeLoader {
         instruction_data: &[u8],
         invoke_context: &mut dyn InvokeContext,
     ) -> Result<(), InstructionError> {
-        debug_assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
+        // TODO [KeyedAccounts to InvokeContext refactoring]
+        assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
         let program = keyed_account_at_index(keyed_accounts, 0)?;
         if native_loader::id() != *program_id {
             error!("Program id mismatch");

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -255,13 +255,10 @@ fn transfer_with_seed(
 
 pub fn process_instruction(
     _owner: &Pubkey,
-    _keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let keyed_accounts = invoke_context.get_keyed_accounts();
-    // TODO [KeyedAccounts to InvokeContext refactoring]
-    assert_eq!(_keyed_accounts, keyed_accounts);
     let instruction = limited_deserialize(instruction_data)?;
 
     trace!("process_instruction: {:?}", instruction);
@@ -491,7 +488,6 @@ mod tests {
     ) -> Result<(), InstructionError> {
         super::process_instruction(
             owner,
-            keyed_accounts,
             instruction_data,
             &mut MockInvokeContext::new(keyed_accounts),
         )

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -482,7 +482,7 @@ mod tests {
             owner,
             keyed_accounts,
             instruction_data,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(keyed_accounts),
         )
     }
 
@@ -616,7 +616,7 @@ mod tests {
             Address::create(
                 &to,
                 Some((&from, seed, &owner)),
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             ),
             Err(SystemError::AddressWithSeedMismatch.into())
         );
@@ -634,7 +634,7 @@ mod tests {
         let to_address = Address::create(
             &to,
             Some((&from, seed, &new_owner)),
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         )
         .unwrap();
 
@@ -647,7 +647,7 @@ mod tests {
                 2,
                 &new_owner,
                 &HashSet::new(),
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -674,7 +674,7 @@ mod tests {
                 2,
                 &new_owner,
                 &[to].iter().cloned().collect::<HashSet<_>>(),
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             ),
             Ok(())
         );
@@ -706,7 +706,7 @@ mod tests {
             2,
             &new_owner,
             &[from, to].iter().cloned().collect::<HashSet<_>>(),
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
     }
@@ -730,7 +730,7 @@ mod tests {
             MAX_PERMITTED_DATA_LENGTH + 1,
             &system_program::id(),
             &signers,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert!(result.is_err());
         assert_eq!(
@@ -747,7 +747,7 @@ mod tests {
             MAX_PERMITTED_DATA_LENGTH,
             &system_program::id(),
             &signers,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert!(result.is_ok());
         assert_eq!(to_account.borrow().lamports, 50);
@@ -780,7 +780,7 @@ mod tests {
             2,
             &new_owner,
             &signers,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
 
@@ -799,7 +799,7 @@ mod tests {
             2,
             &new_owner,
             &signers,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
         let from_lamports = from_account.borrow().lamports;
@@ -817,7 +817,7 @@ mod tests {
             2,
             &new_owner,
             &signers,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
         assert_eq!(from_lamports, 100);
@@ -845,7 +845,7 @@ mod tests {
             2,
             &new_owner,
             &[owned_key].iter().cloned().collect::<HashSet<_>>(),
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
 
@@ -859,7 +859,7 @@ mod tests {
             2,
             &new_owner,
             &[from].iter().cloned().collect::<HashSet<_>>(),
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
 
@@ -873,7 +873,7 @@ mod tests {
             2,
             &new_owner,
             &[owned_key].iter().cloned().collect::<HashSet<_>>(),
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Ok(()));
     }
@@ -899,7 +899,7 @@ mod tests {
             2,
             &sysvar::id(),
             &signers,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
 
         assert_eq!(result, Err(SystemError::InvalidProgramId.into()));
@@ -933,7 +933,7 @@ mod tests {
             2,
             &new_owner,
             &signers,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
     }
@@ -967,7 +967,7 @@ mod tests {
                 0,
                 &solana_sdk::pubkey::new_rand(),
                 &signers,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             ),
             Err(InstructionError::InvalidArgument),
         );
@@ -986,7 +986,7 @@ mod tests {
                 &pubkey.into(),
                 &new_owner,
                 &HashSet::new(),
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -997,7 +997,7 @@ mod tests {
                 &pubkey.into(),
                 &system_program::id(),
                 &HashSet::new(),
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             ),
             Ok(())
         );
@@ -1026,7 +1026,7 @@ mod tests {
                 &from.into(),
                 &new_owner,
                 &[from].iter().cloned().collect::<HashSet<_>>(),
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             ),
             Err(SystemError::InvalidProgramId.into())
         );
@@ -1067,7 +1067,7 @@ mod tests {
             &from_keyed_account,
             &to_keyed_account,
             50,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         )
         .unwrap();
         let from_lamports = from_keyed_account.account.borrow().lamports;
@@ -1081,7 +1081,7 @@ mod tests {
             &from_keyed_account,
             &to_keyed_account,
             100,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
         assert_eq!(from_keyed_account.account.borrow().lamports, 50);
@@ -1094,7 +1094,7 @@ mod tests {
             &from_keyed_account,
             &to_keyed_account,
             0,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         )
         .is_ok(),);
         assert_eq!(from_keyed_account.account.borrow().lamports, 50);
@@ -1121,7 +1121,7 @@ mod tests {
             &from_owner,
             &to_keyed_account,
             50,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         )
         .unwrap();
         let from_lamports = from_keyed_account.account.borrow().lamports;
@@ -1138,7 +1138,7 @@ mod tests {
             &from_owner,
             &to_keyed_account,
             100,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
         assert_eq!(from_keyed_account.account.borrow().lamports, 50);
@@ -1153,7 +1153,7 @@ mod tests {
             &from_owner,
             &to_keyed_account,
             0,
-            &mut MockInvokeContext::default(),
+            &mut MockInvokeContext::new(&[]),
         )
         .is_ok(),);
         assert_eq!(from_keyed_account.account.borrow().lamports, 50);
@@ -1184,7 +1184,7 @@ mod tests {
                 &KeyedAccount::new(&from, true, &from_account),
                 &KeyedAccount::new(&to, false, &to_account),
                 50,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             ),
             Err(InstructionError::InvalidArgument),
         )

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -259,6 +259,8 @@ pub fn process_instruction(
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    assert_eq!(keyed_accounts, invoke_context.get_keyed_accounts());
     let instruction = limited_deserialize(instruction_data)?;
 
     trace!("process_instruction: {:?}", instruction);

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -483,7 +483,7 @@ mod tests {
 
     fn process_instruction(
         owner: &Pubkey,
-        keyed_accounts: &[KeyedAccount],
+        keyed_accounts: Vec<KeyedAccount>,
         instruction_data: &[u8],
     ) -> Result<(), InstructionError> {
         super::process_instruction(
@@ -522,7 +522,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(&from, true, &from_account),
                     KeyedAccount::new(&to, true, &to_account)
                 ],
@@ -554,7 +554,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(&from, true, &from_account),
                     KeyedAccount::new(&to, false, &to_account)
                 ],
@@ -590,7 +590,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(&from, true, &from_account),
                     KeyedAccount::new(&to, false, &to_account),
                     KeyedAccount::new(&base, true, &base_account)
@@ -623,7 +623,7 @@ mod tests {
             Address::create(
                 &to,
                 Some((&from, seed, &owner)),
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             ),
             Err(SystemError::AddressWithSeedMismatch.into())
         );
@@ -641,7 +641,7 @@ mod tests {
         let to_address = Address::create(
             &to,
             Some((&from, seed, &new_owner)),
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         )
         .unwrap();
 
@@ -654,7 +654,7 @@ mod tests {
                 2,
                 &new_owner,
                 &HashSet::new(),
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -681,7 +681,7 @@ mod tests {
                 2,
                 &new_owner,
                 &[to].iter().cloned().collect::<HashSet<_>>(),
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             ),
             Ok(())
         );
@@ -713,7 +713,7 @@ mod tests {
             2,
             &new_owner,
             &[from, to].iter().cloned().collect::<HashSet<_>>(),
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
     }
@@ -737,7 +737,7 @@ mod tests {
             MAX_PERMITTED_DATA_LENGTH + 1,
             &system_program::id(),
             &signers,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert!(result.is_err());
         assert_eq!(
@@ -754,7 +754,7 @@ mod tests {
             MAX_PERMITTED_DATA_LENGTH,
             &system_program::id(),
             &signers,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert!(result.is_ok());
         assert_eq!(to_account.borrow().lamports, 50);
@@ -787,7 +787,7 @@ mod tests {
             2,
             &new_owner,
             &signers,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
 
@@ -806,7 +806,7 @@ mod tests {
             2,
             &new_owner,
             &signers,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
         let from_lamports = from_account.borrow().lamports;
@@ -824,7 +824,7 @@ mod tests {
             2,
             &new_owner,
             &signers,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
         assert_eq!(from_lamports, 100);
@@ -852,7 +852,7 @@ mod tests {
             2,
             &new_owner,
             &[owned_key].iter().cloned().collect::<HashSet<_>>(),
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
 
@@ -866,7 +866,7 @@ mod tests {
             2,
             &new_owner,
             &[from].iter().cloned().collect::<HashSet<_>>(),
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
 
@@ -880,7 +880,7 @@ mod tests {
             2,
             &new_owner,
             &[owned_key].iter().cloned().collect::<HashSet<_>>(),
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Ok(()));
     }
@@ -906,7 +906,7 @@ mod tests {
             2,
             &sysvar::id(),
             &signers,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
 
         assert_eq!(result, Err(SystemError::InvalidProgramId.into()));
@@ -940,7 +940,7 @@ mod tests {
             2,
             &new_owner,
             &signers,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::AccountAlreadyInUse.into()));
     }
@@ -974,7 +974,7 @@ mod tests {
                 0,
                 &solana_sdk::pubkey::new_rand(),
                 &signers,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             ),
             Err(InstructionError::InvalidArgument),
         );
@@ -993,7 +993,7 @@ mod tests {
                 &pubkey.into(),
                 &new_owner,
                 &HashSet::new(),
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             ),
             Err(InstructionError::MissingRequiredSignature)
         );
@@ -1004,7 +1004,7 @@ mod tests {
                 &pubkey.into(),
                 &system_program::id(),
                 &HashSet::new(),
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             ),
             Ok(())
         );
@@ -1013,7 +1013,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[KeyedAccount::new(&pubkey, true, &account)],
+                vec![KeyedAccount::new(&pubkey, true, &account)],
                 &bincode::serialize(&SystemInstruction::Assign { owner: new_owner }).unwrap()
             ),
             Ok(())
@@ -1033,7 +1033,7 @@ mod tests {
                 &from.into(),
                 &new_owner,
                 &[from].iter().cloned().collect::<HashSet<_>>(),
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             ),
             Err(SystemError::InvalidProgramId.into())
         );
@@ -1046,7 +1046,7 @@ mod tests {
             owner: solana_sdk::pubkey::new_rand(),
         };
         let data = serialize(&instruction).unwrap();
-        let result = process_instruction(&system_program::id(), &[], &data);
+        let result = process_instruction(&system_program::id(), vec![], &data);
         assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
 
         let from = solana_sdk::pubkey::new_rand();
@@ -1056,7 +1056,7 @@ mod tests {
         let data = serialize(&instruction).unwrap();
         let result = process_instruction(
             &system_program::id(),
-            &[KeyedAccount::new(&from, true, &from_account)],
+            vec![KeyedAccount::new(&from, true, &from_account)],
             &data,
         );
         assert_eq!(result, Err(InstructionError::NotEnoughAccountKeys));
@@ -1074,7 +1074,7 @@ mod tests {
             &from_keyed_account,
             &to_keyed_account,
             50,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         )
         .unwrap();
         let from_lamports = from_keyed_account.account.borrow().lamports;
@@ -1088,7 +1088,7 @@ mod tests {
             &from_keyed_account,
             &to_keyed_account,
             100,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
         assert_eq!(from_keyed_account.account.borrow().lamports, 50);
@@ -1101,7 +1101,7 @@ mod tests {
             &from_keyed_account,
             &to_keyed_account,
             0,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         )
         .is_ok(),);
         assert_eq!(from_keyed_account.account.borrow().lamports, 50);
@@ -1128,7 +1128,7 @@ mod tests {
             &from_owner,
             &to_keyed_account,
             50,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         )
         .unwrap();
         let from_lamports = from_keyed_account.account.borrow().lamports;
@@ -1145,7 +1145,7 @@ mod tests {
             &from_owner,
             &to_keyed_account,
             100,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         );
         assert_eq!(result, Err(SystemError::ResultWithNegativeLamports.into()));
         assert_eq!(from_keyed_account.account.borrow().lamports, 50);
@@ -1160,7 +1160,7 @@ mod tests {
             &from_owner,
             &to_keyed_account,
             0,
-            &MockInvokeContext::new(&[]),
+            &MockInvokeContext::new(vec![]),
         )
         .is_ok(),);
         assert_eq!(from_keyed_account.account.borrow().lamports, 50);
@@ -1191,7 +1191,7 @@ mod tests {
                 &KeyedAccount::new(&from, true, &from_account),
                 &KeyedAccount::new(&to, false, &to_account),
                 50,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             ),
             Err(InstructionError::InvalidArgument),
         )
@@ -1398,7 +1398,7 @@ mod tests {
                 .zip(accounts.iter())
                 .map(|(meta, account)| KeyedAccount::new(&meta.pubkey, meta.is_signer, account))
                 .collect();
-            process_instruction(&Pubkey::default(), &keyed_accounts, &instruction.data)
+            process_instruction(&Pubkey::default(), keyed_accounts, &instruction.data)
         }
     }
 
@@ -1418,7 +1418,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[],
+                vec![],
                 &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap()
             ),
             Err(InstructionError::NotEnoughAccountKeys),
@@ -1430,11 +1430,11 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[KeyedAccount::new(
+                vec![KeyedAccount::new(
                     &Pubkey::default(),
                     true,
                     &create_default_account(),
-                ),],
+                )],
                 &serialize(&SystemInstruction::AdvanceNonceAccount).unwrap(),
             ),
             Err(InstructionError::NotEnoughAccountKeys),
@@ -1446,7 +1446,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(&Pubkey::default(), true, &create_default_account()),
                     KeyedAccount::new(
                         &sysvar::recent_blockhashes::id(),
@@ -1465,7 +1465,7 @@ mod tests {
         let nonce_acc = nonce_account::create_account(1_000_000);
         process_instruction(
             &Pubkey::default(),
-            &[
+            vec![
                 KeyedAccount::new(&Pubkey::default(), true, &nonce_acc),
                 KeyedAccount::new(
                     &sysvar::recent_blockhashes::id(),
@@ -1493,7 +1493,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(&Pubkey::default(), true, &nonce_acc,),
                     KeyedAccount::new(
                         &sysvar::recent_blockhashes::id(),
@@ -1525,7 +1525,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[],
+                vec![],
                 &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
             ),
             Err(InstructionError::NotEnoughAccountKeys),
@@ -1537,11 +1537,11 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[KeyedAccount::new(
+                vec![KeyedAccount::new(
                     &Pubkey::default(),
                     true,
                     &create_default_account()
-                ),],
+                )],
                 &serialize(&SystemInstruction::WithdrawNonceAccount(42)).unwrap(),
             ),
             Err(InstructionError::NotEnoughAccountKeys),
@@ -1553,7 +1553,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(&Pubkey::default(), true, &create_default_account()),
                     KeyedAccount::new(&Pubkey::default(), false, &create_default_account()),
                     KeyedAccount::new(
@@ -1573,7 +1573,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(
                         &Pubkey::default(),
                         true,
@@ -1598,7 +1598,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(
                         &Pubkey::default(),
                         true,
@@ -1623,7 +1623,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[],
+                vec![],
                 &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
             ),
             Err(InstructionError::NotEnoughAccountKeys),
@@ -1635,11 +1635,11 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[KeyedAccount::new(
+                vec![KeyedAccount::new(
                     &Pubkey::default(),
                     true,
                     &nonce_account::create_account(1_000_000),
-                ),],
+                )],
                 &serialize(&SystemInstruction::InitializeNonceAccount(Pubkey::default())).unwrap(),
             ),
             Err(InstructionError::NotEnoughAccountKeys),
@@ -1651,7 +1651,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(
                         &Pubkey::default(),
                         true,
@@ -1674,7 +1674,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(
                         &Pubkey::default(),
                         true,
@@ -1698,7 +1698,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[
+                vec![
                     KeyedAccount::new(
                         &Pubkey::default(),
                         true,
@@ -1722,7 +1722,7 @@ mod tests {
         let nonce_acc = nonce_account::create_account(1_000_000);
         process_instruction(
             &Pubkey::default(),
-            &[
+            vec![
                 KeyedAccount::new(&Pubkey::default(), true, &nonce_acc),
                 KeyedAccount::new(
                     &sysvar::recent_blockhashes::id(),
@@ -1737,7 +1737,7 @@ mod tests {
         assert_eq!(
             process_instruction(
                 &Pubkey::default(),
-                &[KeyedAccount::new(&Pubkey::default(), true, &nonce_acc,),],
+                vec![KeyedAccount::new(&Pubkey::default(), true, &nonce_acc,),],
                 &serialize(&SystemInstruction::AuthorizeNonceAccount(Pubkey::default(),)).unwrap(),
             ),
             Ok(()),

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -258,7 +258,7 @@ pub fn process_instruction(
     instruction_data: &[u8],
     invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
-    let keyed_accounts = invoke_context.get_keyed_accounts();
+    let keyed_accounts = invoke_context.get_keyed_accounts()?;
     let instruction = limited_deserialize(instruction_data)?;
 
     trace!("process_instruction: {:?}", instruction);

--- a/sdk/src/entrypoint_native.rs
+++ b/sdk/src/entrypoint_native.rs
@@ -89,14 +89,12 @@ macro_rules! declare_name {
 /// use solana_sdk::{
 ///     declare_program,
 ///     instruction::InstructionError,
-///     keyed_account::KeyedAccount,
 ///     process_instruction::InvokeContext,
 ///     pubkey::Pubkey,
 /// };
 ///
 /// fn my_process_instruction(
 ///     program_id: &Pubkey,
-///     keyed_accounts: &[KeyedAccount],
 ///     instruction_data: &[u8],
 ///     invoke_context: &mut dyn InvokeContext,
 /// ) -> Result<(), InstructionError> {
@@ -124,14 +122,12 @@ macro_rules! declare_name {
 /// use solana_sdk::{
 ///     declare_program,
 ///     instruction::InstructionError,
-///     keyed_account::KeyedAccount,
 ///     process_instruction::InvokeContext,
 ///     pubkey::Pubkey,
 /// };
 ///
 /// fn my_process_instruction(
 ///     program_id: &Pubkey,
-///     keyed_accounts: &[KeyedAccount],
 ///     instruction_data: &[u8],
 ///     invoke_context: &mut dyn InvokeContext,
 /// ) -> Result<(), InstructionError> {
@@ -158,11 +154,10 @@ macro_rules! declare_program(
         #[no_mangle]
         pub extern "C" fn $name(
             program_id: &$crate::pubkey::Pubkey,
-            keyed_accounts: &[$crate::keyed_account::KeyedAccount],
             instruction_data: &[u8],
             invoke_context: &mut dyn $crate::process_instruction::InvokeContext,
         ) -> Result<(), $crate::instruction::InstructionError> {
-            $entrypoint(program_id, keyed_accounts, instruction_data, invoke_context)
+            $entrypoint(program_id, instruction_data, invoke_context)
         }
     )
 );

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -186,11 +186,22 @@ where
         .collect::<A>()
 }
 
+#[deprecated(since = "1.7.0", note = "Please use keyed_account_at_index instead")]
 /// Return the next KeyedAccount or a NotEnoughAccountKeys error
 pub fn next_keyed_account<'a, 'b, I: Iterator<Item = &'a KeyedAccount<'b>>>(
     iter: &mut I,
 ) -> Result<I::Item, InstructionError> {
     iter.next().ok_or(InstructionError::NotEnoughAccountKeys)
+}
+
+/// Return the KeyedAccount at the specified index or a NotEnoughAccountKeys error
+pub fn keyed_account_at_index<'a>(
+    keyed_accounts: &'a [KeyedAccount],
+    index: usize,
+) -> Result<&'a KeyedAccount<'a>, InstructionError> {
+    keyed_accounts
+        .get(index)
+        .ok_or(InstructionError::NotEnoughAccountKeys)
 }
 
 /// Return true if the first keyed_account is executable, used to determine if

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KeyedAccount<'a> {
     is_signer: bool, // Transaction was signed by this account's key
     is_writable: bool,

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -146,6 +146,10 @@ pub fn create_keyed_accounts<'a>(
     accounts.iter().map(Into::into).collect()
 }
 
+#[deprecated(
+    since = "1.7.0",
+    note = "Please use create_keyed_accounts_unified instead"
+)]
 pub fn create_keyed_is_signer_accounts<'a>(
     accounts: &'a [(&'a Pubkey, bool, &'a RefCell<AccountSharedData>)],
 ) -> Vec<KeyedAccount<'a>> {
@@ -160,6 +164,10 @@ pub fn create_keyed_is_signer_accounts<'a>(
         .collect()
 }
 
+#[deprecated(
+    since = "1.7.0",
+    note = "Please use create_keyed_accounts_unified instead"
+)]
 pub fn create_keyed_readonly_accounts(
     accounts: &[(Pubkey, Rc<RefCell<AccountSharedData>>)],
 ) -> Vec<KeyedAccount> {
@@ -168,6 +176,20 @@ pub fn create_keyed_readonly_accounts(
         .map(|(key, account)| KeyedAccount {
             is_signer: false,
             is_writable: false,
+            key,
+            account,
+        })
+        .collect()
+}
+
+pub fn create_keyed_accounts_unified<'a>(
+    accounts: &[(bool, bool, &'a Pubkey, &'a RefCell<AccountSharedData>)],
+) -> Vec<KeyedAccount<'a>> {
+    accounts
+        .iter()
+        .map(|(is_signer, is_writable, key, account)| KeyedAccount {
+            is_signer: *is_signer,
+            is_writable: *is_writable,
             key,
             account,
         })

--- a/sdk/src/nonce_keyed_account.rs
+++ b/sdk/src/nonce_keyed_account.rs
@@ -300,7 +300,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             let state = AccountUtilsState::<Versions>::state(keyed_account)
@@ -315,7 +315,11 @@ mod test {
             assert_eq!(state, State::Initialized(data.clone()));
             let recent_blockhashes = create_test_recent_blockhashes(63);
             keyed_account
-                .advance_nonce_account(&recent_blockhashes, &signers, &MockInvokeContext::new(&[]))
+                .advance_nonce_account(
+                    &recent_blockhashes,
+                    &signers,
+                    &MockInvokeContext::new(vec![]),
+                )
                 .unwrap();
             let state = AccountUtilsState::<Versions>::state(keyed_account)
                 .unwrap()
@@ -329,7 +333,11 @@ mod test {
             assert_eq!(state, State::Initialized(data.clone()));
             let recent_blockhashes = create_test_recent_blockhashes(31);
             keyed_account
-                .advance_nonce_account(&recent_blockhashes, &signers, &MockInvokeContext::new(&[]))
+                .advance_nonce_account(
+                    &recent_blockhashes,
+                    &signers,
+                    &MockInvokeContext::new(vec![]),
+                )
                 .unwrap();
             let state = AccountUtilsState::<Versions>::state(keyed_account)
                 .unwrap()
@@ -354,7 +362,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &MockInvokeContext::new(&[]),
+                        &MockInvokeContext::new(vec![]),
                     )
                     .unwrap();
                 // Empties Account balance
@@ -388,7 +396,7 @@ mod test {
                     &authority,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             let pubkey = nonce_account.account.borrow().owner;
@@ -407,7 +415,7 @@ mod test {
             let result = nonce_account.advance_nonce_account(
                 &recent_blockhashes,
                 &signers,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
         })
@@ -430,14 +438,14 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             let recent_blockhashes = vec![].into_iter().collect();
             let result = keyed_account.advance_nonce_account(
                 &recent_blockhashes,
                 &signers,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
@@ -460,13 +468,13 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             let result = keyed_account.advance_nonce_account(
                 &recent_blockhashes,
                 &signers,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(NonceError::NotExpired.into()));
         })
@@ -486,7 +494,7 @@ mod test {
             let result = keyed_account.advance_nonce_account(
                 &recent_blockhashes,
                 &signers,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
@@ -510,7 +518,7 @@ mod test {
                         &authorized,
                         &recent_blockhashes,
                         &rent,
-                        &MockInvokeContext::new(&[]),
+                        &MockInvokeContext::new(vec![]),
                     )
                     .unwrap();
                 let mut signers = HashSet::new();
@@ -519,7 +527,7 @@ mod test {
                 let result = nonce_account.advance_nonce_account(
                     &recent_blockhashes,
                     &signers,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 );
                 assert_eq!(result, Ok(()));
             });
@@ -544,13 +552,13 @@ mod test {
                         &authorized,
                         &recent_blockhashes,
                         &rent,
-                        &MockInvokeContext::new(&[]),
+                        &MockInvokeContext::new(vec![]),
                     )
                     .unwrap();
                 let result = nonce_account.advance_nonce_account(
                     &recent_blockhashes,
                     &signers,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 );
                 assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
             });
@@ -584,7 +592,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &MockInvokeContext::new(&[]),
+                        &MockInvokeContext::new(vec![]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -623,7 +631,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 );
                 assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
             })
@@ -653,7 +661,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 );
                 assert_eq!(result, Err(InstructionError::InsufficientFunds));
             })
@@ -683,7 +691,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &MockInvokeContext::new(&[]),
+                        &MockInvokeContext::new(vec![]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -703,7 +711,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &MockInvokeContext::new(&[]),
+                        &MockInvokeContext::new(vec![]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -733,7 +741,7 @@ mod test {
                     &authority,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -757,7 +765,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &MockInvokeContext::new(&[]),
+                        &MockInvokeContext::new(vec![]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -783,7 +791,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &MockInvokeContext::new(&[]),
+                        &MockInvokeContext::new(vec![]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -811,7 +819,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             with_test_keyed_account(42, false, |to_keyed| {
@@ -824,7 +832,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 );
                 assert_eq!(result, Err(NonceError::NotExpired.into()));
             })
@@ -846,7 +854,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             with_test_keyed_account(42, false, |to_keyed| {
@@ -860,7 +868,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 );
                 assert_eq!(result, Err(InstructionError::InsufficientFunds));
             })
@@ -882,7 +890,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             with_test_keyed_account(42, false, |to_keyed| {
@@ -896,7 +904,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 );
                 assert_eq!(result, Err(InstructionError::InsufficientFunds));
             })
@@ -918,7 +926,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             with_test_keyed_account(55, false, |to_keyed| {
@@ -932,7 +940,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 );
                 assert_eq!(result, Err(InstructionError::InsufficientFunds));
             })
@@ -959,7 +967,7 @@ mod test {
                 &authority,
                 &recent_blockhashes,
                 &rent,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             let data = nonce::state::Data {
                 authority,
@@ -990,7 +998,7 @@ mod test {
                 &authorized,
                 &recent_blockhashes,
                 &rent,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
@@ -1011,7 +1019,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             let recent_blockhashes = create_test_recent_blockhashes(0);
@@ -1019,7 +1027,7 @@ mod test {
                 &authorized,
                 &recent_blockhashes,
                 &rent,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
@@ -1039,7 +1047,7 @@ mod test {
                 &authorized,
                 &recent_blockhashes,
                 &rent,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(InstructionError::InsufficientFunds));
         })
@@ -1062,7 +1070,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             let authority = Pubkey::default();
@@ -1074,7 +1082,7 @@ mod test {
             let result = nonce_account.authorize_nonce_account(
                 &Pubkey::default(),
                 &signers,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Ok(()));
             let state = AccountUtilsState::<Versions>::state(nonce_account)
@@ -1097,7 +1105,7 @@ mod test {
             let result = nonce_account.authorize_nonce_account(
                 &Pubkey::default(),
                 &signers,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
@@ -1120,13 +1128,13 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             let result = nonce_account.authorize_nonce_account(
                 &Pubkey::default(),
                 &signers,
-                &MockInvokeContext::new(&[]),
+                &MockInvokeContext::new(vec![]),
             );
             assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
         })
@@ -1147,7 +1155,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &Rent::free(),
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             assert!(verify_nonce_account(
@@ -1182,7 +1190,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &Rent::free(),
-                    &MockInvokeContext::new(&[]),
+                    &MockInvokeContext::new(vec![]),
                 )
                 .unwrap();
             assert!(!verify_nonce_account(

--- a/sdk/src/nonce_keyed_account.rs
+++ b/sdk/src/nonce_keyed_account.rs
@@ -300,7 +300,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let state = AccountUtilsState::<Versions>::state(keyed_account)
@@ -318,7 +318,7 @@ mod test {
                 .advance_nonce_account(
                     &recent_blockhashes,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let state = AccountUtilsState::<Versions>::state(keyed_account)
@@ -336,7 +336,7 @@ mod test {
                 .advance_nonce_account(
                     &recent_blockhashes,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let state = AccountUtilsState::<Versions>::state(keyed_account)
@@ -362,7 +362,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &mut MockInvokeContext::default(),
+                        &mut MockInvokeContext::new(&[]),
                     )
                     .unwrap();
                 // Empties Account balance
@@ -396,7 +396,7 @@ mod test {
                     &authority,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let pubkey = nonce_account.account.borrow().owner;
@@ -415,7 +415,7 @@ mod test {
             let result = nonce_account.advance_nonce_account(
                 &recent_blockhashes,
                 &signers,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
         })
@@ -438,14 +438,14 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let recent_blockhashes = vec![].into_iter().collect();
             let result = keyed_account.advance_nonce_account(
                 &recent_blockhashes,
                 &signers,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
@@ -468,13 +468,13 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let result = keyed_account.advance_nonce_account(
                 &recent_blockhashes,
                 &signers,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(NonceError::NotExpired.into()));
         })
@@ -494,7 +494,7 @@ mod test {
             let result = keyed_account.advance_nonce_account(
                 &recent_blockhashes,
                 &signers,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
@@ -518,7 +518,7 @@ mod test {
                         &authorized,
                         &recent_blockhashes,
                         &rent,
-                        &mut MockInvokeContext::default(),
+                        &mut MockInvokeContext::new(&[]),
                     )
                     .unwrap();
                 let mut signers = HashSet::new();
@@ -527,7 +527,7 @@ mod test {
                 let result = nonce_account.advance_nonce_account(
                     &recent_blockhashes,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 );
                 assert_eq!(result, Ok(()));
             });
@@ -552,13 +552,13 @@ mod test {
                         &authorized,
                         &recent_blockhashes,
                         &rent,
-                        &mut MockInvokeContext::default(),
+                        &mut MockInvokeContext::new(&[]),
                     )
                     .unwrap();
                 let result = nonce_account.advance_nonce_account(
                     &recent_blockhashes,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 );
                 assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
             });
@@ -592,7 +592,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &mut MockInvokeContext::default(),
+                        &mut MockInvokeContext::new(&[]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -631,7 +631,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 );
                 assert_eq!(result, Err(InstructionError::MissingRequiredSignature),);
             })
@@ -661,7 +661,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 );
                 assert_eq!(result, Err(InstructionError::InsufficientFunds));
             })
@@ -691,7 +691,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &mut MockInvokeContext::default(),
+                        &mut MockInvokeContext::new(&[]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -711,7 +711,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &mut MockInvokeContext::default(),
+                        &mut MockInvokeContext::new(&[]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -741,7 +741,7 @@ mod test {
                     &authority,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -765,7 +765,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &mut MockInvokeContext::default(),
+                        &mut MockInvokeContext::new(&[]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -791,7 +791,7 @@ mod test {
                         &recent_blockhashes,
                         &rent,
                         &signers,
-                        &mut MockInvokeContext::default(),
+                        &mut MockInvokeContext::new(&[]),
                     )
                     .unwrap();
                 let state = AccountUtilsState::<Versions>::state(nonce_keyed)
@@ -819,7 +819,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             with_test_keyed_account(42, false, |to_keyed| {
@@ -832,7 +832,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 );
                 assert_eq!(result, Err(NonceError::NotExpired.into()));
             })
@@ -854,7 +854,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             with_test_keyed_account(42, false, |to_keyed| {
@@ -868,7 +868,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 );
                 assert_eq!(result, Err(InstructionError::InsufficientFunds));
             })
@@ -890,7 +890,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             with_test_keyed_account(42, false, |to_keyed| {
@@ -904,7 +904,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 );
                 assert_eq!(result, Err(InstructionError::InsufficientFunds));
             })
@@ -926,7 +926,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             with_test_keyed_account(55, false, |to_keyed| {
@@ -940,7 +940,7 @@ mod test {
                     &recent_blockhashes,
                     &rent,
                     &signers,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 );
                 assert_eq!(result, Err(InstructionError::InsufficientFunds));
             })
@@ -967,7 +967,7 @@ mod test {
                 &authority,
                 &recent_blockhashes,
                 &rent,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             let data = nonce::state::Data {
                 authority,
@@ -998,7 +998,7 @@ mod test {
                 &authorized,
                 &recent_blockhashes,
                 &rent,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(NonceError::NoRecentBlockhashes.into()));
         })
@@ -1019,7 +1019,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let recent_blockhashes = create_test_recent_blockhashes(0);
@@ -1027,7 +1027,7 @@ mod test {
                 &authorized,
                 &recent_blockhashes,
                 &rent,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
@@ -1047,7 +1047,7 @@ mod test {
                 &authorized,
                 &recent_blockhashes,
                 &rent,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(InstructionError::InsufficientFunds));
         })
@@ -1070,7 +1070,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let authority = Pubkey::default();
@@ -1082,7 +1082,7 @@ mod test {
             let result = nonce_account.authorize_nonce_account(
                 &Pubkey::default(),
                 &signers,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Ok(()));
             let state = AccountUtilsState::<Versions>::state(nonce_account)
@@ -1105,7 +1105,7 @@ mod test {
             let result = nonce_account.authorize_nonce_account(
                 &Pubkey::default(),
                 &signers,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(NonceError::BadAccountState.into()));
         })
@@ -1128,13 +1128,13 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &rent,
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             let result = nonce_account.authorize_nonce_account(
                 &Pubkey::default(),
                 &signers,
-                &mut MockInvokeContext::default(),
+                &mut MockInvokeContext::new(&[]),
             );
             assert_eq!(result, Err(InstructionError::MissingRequiredSignature));
         })
@@ -1155,7 +1155,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &Rent::free(),
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             assert!(verify_nonce_account(
@@ -1190,7 +1190,7 @@ mod test {
                     &authorized,
                     &recent_blockhashes,
                     &Rent::free(),
-                    &mut MockInvokeContext::default(),
+                    &mut MockInvokeContext::new(&[]),
                 )
                 .unwrap();
             assert!(!verify_nonce_account(

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -244,7 +244,6 @@ pub trait Executor: Debug + Send + Sync {
         &self,
         loader_id: &Pubkey,
         program_id: &Pubkey,
-        keyed_accounts: &[KeyedAccount],
         instruction_data: &[u8],
         invoke_context: &mut dyn InvokeContext,
         use_jit: bool,

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -48,7 +48,7 @@ pub trait InvokeContext {
     /// Get the program ID of the currently executing program
     fn get_caller(&self) -> Result<&Pubkey, InstructionError>;
     /// Removes the first keyed account
-    fn pop_first_keyed_account(&mut self);
+    fn remove_first_keyed_account(&mut self);
     /// Get the list of keyed accounts
     fn get_keyed_accounts(&self) -> &[KeyedAccount];
     /// Get a list of built-in programs
@@ -343,7 +343,7 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
     fn get_caller(&self) -> Result<&Pubkey, InstructionError> {
         Ok(&self.key)
     }
-    fn pop_first_keyed_account(&mut self) {
+    fn remove_first_keyed_account(&mut self) {
         self.keyed_accounts = &self.keyed_accounts[1..];
     }
     fn get_keyed_accounts(&self) -> &[KeyedAccount] {

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -289,8 +289,8 @@ pub struct MockInvokeContext<'a> {
     pub invoke_depth: usize,
     pub sysvars: Vec<(Pubkey, Option<Rc<Vec<u8>>>)>,
 }
-impl<'a> Default for MockInvokeContext<'a> {
-    fn default() -> Self {
+impl<'a> MockInvokeContext<'a> {
+    pub fn new(keyed_accounts: &'a [KeyedAccount<'a>]) -> Self {
         MockInvokeContext {
             key: Pubkey::default(),
             logger: MockLogger::default(),
@@ -298,7 +298,7 @@ impl<'a> Default for MockInvokeContext<'a> {
             compute_meter: MockComputeMeter {
                 remaining: std::i64::MAX as u64,
             },
-            keyed_accounts: &[], // TODO [KeyedAccounts to InvokeContext refactoring]
+            keyed_accounts,
             programs: vec![],
             accounts: vec![],
             invoke_depth: 0,

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -41,6 +41,8 @@ pub trait InvokeContext {
     ) -> Result<(), InstructionError>;
     /// Get the program ID of the currently executing program
     fn get_caller(&self) -> Result<&Pubkey, InstructionError>;
+    /// Set the list of keyed accounts
+    fn set_keyed_accounts(&mut self, keyed_accounts: &[KeyedAccount]);
     /// Removes the first keyed account
     fn pop_first_keyed_account(&mut self);
     /// Get the list of keyed accounts
@@ -332,9 +334,9 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
         Ok(&self.key)
     }
     // TODO [KeyedAccounts to InvokeContext refactoring]
-    /*fn set_keyed_accounts(&mut self, keyed_accounts: &'a [KeyedAccount<'a>]) {
-        self.keyed_accounts = keyed_accounts;
-    }*/
+    fn set_keyed_accounts(&mut self, keyed_accounts: &[KeyedAccount]) {
+        self.keyed_accounts = unsafe { std::mem::transmute(keyed_accounts) };
+    }
     fn pop_first_keyed_account(&mut self) {
         self.keyed_accounts = &self.keyed_accounts[1..];
     }

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -57,16 +57,17 @@ impl<'a> InvokeContextStackFrame<'a> {
 
 /// Invocation context passed to loaders
 pub trait InvokeContext {
-    /// Push a program ID on to the invocation stack
+    /// Push a stack frame onto the invocation stack
     ///
-    /// It returns the keyed_accounts_to_restore
-    /// to be used in the matching pop call.
+    /// Used in MessageProcessor::process_cross_program_instruction
     fn push(
         &mut self,
         key: &Pubkey,
         keyed_accounts: &[(&Pubkey, bool, bool, &RefCell<AccountSharedData>)],
     ) -> Result<(), InstructionError>;
-    /// Pop a program ID off of the invocation stack
+    /// Pop a stack frame from the invocation stack
+    ///
+    /// Used in MessageProcessor::process_cross_program_instruction
     fn pop(&mut self);
     /// Current depth of the invocation stake
     fn invoke_depth(&self) -> usize;

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -41,6 +41,8 @@ pub trait InvokeContext {
     ) -> Result<(), InstructionError>;
     /// Get the program ID of the currently executing program
     fn get_caller(&self) -> Result<&Pubkey, InstructionError>;
+    /// Removes the first keyed account
+    fn pop_first_keyed_account(&mut self);
     /// Get the list of keyed accounts
     fn get_keyed_accounts(&self) -> &[KeyedAccount];
     /// Get a list of built-in programs
@@ -328,6 +330,13 @@ impl<'a> InvokeContext for MockInvokeContext<'a> {
     }
     fn get_caller(&self) -> Result<&Pubkey, InstructionError> {
         Ok(&self.key)
+    }
+    // TODO [KeyedAccounts to InvokeContext refactoring]
+    /*fn set_keyed_accounts(&mut self, keyed_accounts: &'a [KeyedAccount<'a>]) {
+        self.keyed_accounts = keyed_accounts;
+    }*/
+    fn pop_first_keyed_account(&mut self) {
+        self.keyed_accounts = &self.keyed_accounts[1..];
     }
     fn get_keyed_accounts(&self) -> &[KeyedAccount] {
         self.keyed_accounts

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -15,13 +15,12 @@ use std::{cell::RefCell, fmt::Debug, rc::Rc, sync::Arc};
 /// invoke_context: Invocation context
 pub type LoaderEntrypoint = unsafe extern "C" fn(
     program_id: &Pubkey,
-    keyed_accounts: &[KeyedAccount],
     instruction_data: &[u8],
     invoke_context: &dyn InvokeContext,
 ) -> Result<(), InstructionError>;
 
 pub type ProcessInstructionWithContext =
-    fn(&Pubkey, &[KeyedAccount], &[u8], &mut dyn InvokeContext) -> Result<(), InstructionError>;
+    fn(&Pubkey, &[u8], &mut dyn InvokeContext) -> Result<(), InstructionError>;
 
 /// Invocation context passed to loaders
 pub trait InvokeContext {


### PR DESCRIPTION
## Problem
`keyed_accounts` are currently passed as a parameter everywhere, but they need to be managed in one place so that their allocation scheme can be changed.

## Summary of Changes
Collects all parametric occurrences and the construction of `keyed_accounts` and puts them into `InvokeContext`.

## Progress and Open Issues

### `next_keyed_account()` vs. `keyed_account_at_index()`
The replacement of `next_keyed_account` by `keyed_account_at_index` is necessary in order to drop references of `keyed_accounts` and retrieve them after function calls which involve passing `invoke_context`. The reference inside the iterator of `keyed_accounts` would lead to a collision of borrows otherwise. Ideas of alternative approaches are welcome!

#### Pro
Indices are better because they:
- Can be explicated later (e.g. as enums or consts).
- Make it possible to move parts of the code around more freely as it would not depend on the order of `.next()`.
- Enable leaving gaps in case a specific slot is not needed any longer.

#### Contra
Quoting @garious:
> In early versions of this code, we indexed the accounts as you're proposing now. We generally viewed that code as unreadable (so directly opposed to your "indices are better because..." arguments). As I recall, the indexing also caused more fights with the borrow checker and so we'd end up passing the whole accounts list into low-level functions when they only required references to one or two accounts.
> The first step to improving readability was to replace all the hardcoded indexes with constants. After that, we did a big refactor to replace all the indexing with the parsing style you see today (next_keyed_account()), at which point we were finally able to pass individual accounts to lower-level functions.

#### Neutral
Quoting @jackcmay:
> @garious I could go either way on the iter vs index debate. Both have access functions that provide sufficient protection. Also, our instruction definitions specify the accounts numerically, so it kinda lends itself to index-based accessing as well. We might also want to provide some kind of (maybe generated) accessor functions along with the instruction definitions to index a specific account of an instruction. Doing this by index also eliminates the need to convert to an iter to grab some accounts, and then back to a slice to pass off to other instructions. One place where it isn't as nice is in instructions where there is a group of accounts that will be iterated through but the length may not be known, like list of multisig acounts.

### The tale of MessageProcessor::process_cross_program_instruction
The main problem is getting the `KeyedAccount`s into the `InvokeContext` through the [stack push](https://github.com/solana-labs/solana/blob/bb30c47a936d6f2f427a2588aa2a766f9e9527d6/runtime/src/message_processor.rs#L893). This is hard as there are two references inside the [`KeyedAccount` struct](https://github.com/solana-labs/solana/blob/6d5c6c17c57d1e0a5afd2cc010f575b2056a7b88/sdk/src/keyed_account.rs#L17):
* `key: &'a Pubkey`
* `account: &'a RefCell<AccountSharedData>`

Both give the `KeyedAccount` struct the lifetime `'a`. Now, in oder to push the new `KeyedAccount`s into the `InvokeContext` we need to prove to the borrow checker that the new `KeyedAccount`s will live as long as `InvokeContext` does. We can't just recycle the existing `KeyedAccount`s, as they also have two other fields `is_signer` and `is_writable` which can be different at every invocation level.

#### Lifetime of KeyedAccounts
Because the `InvokeContext` is a [trait](https://github.com/solana-labs/solana/blob/ad9901d7c67aa29a8569e6caf879c74409a0345c/sdk/src/process_instruction.rs#L27) we can not alias the lifetime of its [implementation](https://github.com/solana-labs/solana/blob/bb30c47a936d6f2f427a2588aa2a766f9e9527d6/runtime/src/message_processor.rs#L266) with the [`push` method](https://github.com/solana-labs/solana/blob/bb30c47a936d6f2f427a2588aa2a766f9e9527d6/runtime/src/message_processor.rs#L315) directly. Instead the constructor of the `KeyedAccount`s has to be called from inside the specific implementations of the trait so that the two lifetimes correctly alias.

#### Lifetime of Account keys
The `key`s can not be borrowed from [`Vec<PreAccount>`](https://github.com/solana-labs/solana/blob/bb30c47a936d6f2f427a2588aa2a766f9e9527d6/runtime/src/message_processor.rs#L254) as the `Vec` is owned by `self` inside of `ThisInvokeContext`. Instead they must be borrowed from `message.account_keys` like it is done in [create_keyed_accounts](https://github.com/solana-labs/solana/blob/bb30c47a936d6f2f427a2588aa2a766f9e9527d6/runtime/src/message_processor.rs#L581).

#### Lifetime of Account RefCells
While the `key`s of the `KeyedAccount`s can be borrowed from the existing ones, the `Account`s are created on the Rust stack at these three locations:
* [BPF syscall](https://github.com/solana-labs/solana/blob/ad7f8e7f238ca98557bc57321590f870d46de287/programs/bpf_loader/src/syscalls.rs#L1674)
* [message_processor](https://github.com/solana-labs/solana/blob/92f4018b07524ef6a0c44492309bde04205a4b5a/runtime/src/message_processor.rs#L790)
* [program-test](https://github.com/solana-labs/solana/blob/dee655df3586946f419a7bf396ac6bd6f68391df/program-test/src/lib.rs#L288)

So we have to [`unsafe { transmute }` the lifetime](https://github.com/solana-labs/solana/blob/788ff6f486082460723f471e592dfc1d37b7cd16/runtime/src/message_processor.rs#L344) to get them into the `InvokeContext`. This is possible as we know that the stack frame will be [popped](https://github.com/solana-labs/solana/blob/788ff6f486082460723f471e592dfc1d37b7cd16/runtime/src/message_processor.rs#L978) again before the [original reference](https://github.com/solana-labs/solana/blob/788ff6f486082460723f471e592dfc1d37b7cd16/runtime/src/message_processor.rs#L935) goes out of scope.

Otherwise, if we instead correctly bind the existing `Account`s to the new `KeyedAccount`s [verify_and_update](https://github.com/solana-labs/solana/blob/92f4018b07524ef6a0c44492309bde04205a4b5a/runtime/src/message_processor.rs#L874) will sound alarm as the inner instruction supposedly changed the `Account`s of the outer one.

## Future Work (for subsequent PRs)
* Map `Account`s into the BPF VM using [`MemoryRegion`s](https://github.com/solana-labs/rbpf/blob/14f27ad0dde469d2d8897c3d7b93d307c704b77c/src/memory_region.rs#L12)
* Apply the `KeyedAccount`s `is_writable` flag to make some readonly
* Remove the `PreAccount`s from the `InvokeContext` as the `Account`s are readonly anyways
* Remove the `unsafe { transmute }` which was introduced in this PR