### PR TITLE
stake-o-matic: Add --minimum-release-version argument to allow for destaking of nodes that fail to keep with software updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5234,6 +5234,7 @@ version = "1.6.0"
 dependencies = [
  "clap",
  "log 0.4.11",
+ "semver 0.9.0",
  "serde_yaml",
  "solana-clap-utils",
  "solana-cli-config",

--- a/stake-o-matic/Cargo.toml
+++ b/stake-o-matic/Cargo.toml
@@ -11,6 +11,7 @@ version = "1.6.0"
 [dependencies]
 clap = "2.33.0"
 log = "0.4.11"
+semver = "0.9.0"
 serde_yaml = "0.8.13"
 solana-clap-utils = { path = "../clap-utils", version = "1.6.0" }
 solana-client = { path = "../client", version = "1.6.0" }


### PR DESCRIPTION
We'll need to manually bump `--minimum-release-version` in the automation periodically but I'm hoping this won't be needed after the first bump or two