### PR TITLE
dump details of hash mismatches

### DIFF
--- a/runtime/src/accounts_hash.rs
+++ b/runtime/src/accounts_hash.rs
@@ -368,7 +368,7 @@ impl AccountsHash {
         hashes.par_sort_unstable_by(|a, b| a.0.cmp(&b.0));
     }
 
-    fn flatten_hash_intermediate<T>(
+    pub fn flatten_hash_intermediate<T>(
         data_sections_by_pubkey: Vec<Vec<Vec<T>>>,
         stats: &mut HashStats,
     ) -> Vec<Vec<T>>
@@ -423,7 +423,7 @@ impl AccountsHash {
         }
     }
 
-    fn sort_hash_intermediate(
+    pub fn sort_hash_intermediate(
         data_by_pubkey: Vec<Vec<CalculateHashIntermediate>>,
         stats: &mut HashStats,
     ) -> Vec<Vec<CalculateHashIntermediate>> {


### PR DESCRIPTION
#### Problem
There are intermittent inconsistencies when calculating hash and lamports from stores vs. using index. Turning on full checking is too expensive.

#### Summary of Changes
Turn on checking once we detect a cap mismatch. And, dump account differences between the two methods prior to panicing as before.

Fixes #
