### PR TITLE
cli: improve deploy resume interface

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -121,7 +121,6 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .conflicts_with("program_location")
                                 .help("Intermediate buffer account to write data to, which can be used to resume a failed deploy \
                                       [default: random address]")
                         )
@@ -694,7 +693,11 @@ fn process_program_deploy(
         true
     };
 
-    let (program_data, program_len) = if buffer_provided {
+    let (program_data, program_len) = if let Some(program_location) = program_location {
+        let program_data = read_and_verify_elf(&program_location)?;
+        let program_len = program_data.len();
+        (program_data, program_len)
+    } else if buffer_provided {
         // Check supplied buffer account
         if let Some(account) = rpc_client
             .get_account_with_commitment(&buffer_pubkey, config.commitment)?
@@ -711,10 +714,6 @@ fn process_program_deploy(
         } else {
             return Err("Buffer account not found, was it already consumed?".into());
         }
-    } else if let Some(program_location) = program_location {
-        let program_data = read_and_verify_elf(&program_location)?;
-        let program_len = program_data.len();
-        (program_data, program_len)
     } else {
         return Err("Program location required if buffer not supplied".into());
     };

--- a/docs/src/cli/deploy-a-program.md
+++ b/docs/src/cli/deploy-a-program.md
@@ -112,6 +112,40 @@ Note that program accounts are required to be
 `max-len` is fixed after initial deployment, so any SOL in the program accounts
 is locked up permanently.
 
+### Resuming a failed deploy
+
+If program deployment fails, there will be a hanging intermediate buffer account
+that contains a non-zero balance.  In order to recoup that balance you may
+resume a failed deployment by providing the same intermediate buffer to a new
+call to `deploy`.
+
+Deployment failures will print an error message specifying the seed phrase
+needed to recover the generated intermediate buffer's keypair:
+
+```bash
+=======================================================================
+To resume a failed deploy, recover the ephemeral keypair file with
+`solana-keygen recover` and the following 12-word seed phrase,
+then pass it as the [BUFFER_SIGNER] argument to `solana deploy` or `solana write-buffer`
+=======================================================================
+spy axis cream equip bonus daring muffin fish noise churn broken diesel
+=======================================================================
+```
+
+To recover the keypair:
+
+```bash
+$ solana-keypair recover -o <KEYPAIR_PATH>
+```
+
+When asked, enter the 12-word seed phrase.
+
+Then issue a new `deploy` command and specify the buffer:
+
+```bash
+$ solana program deploy --buffer <KEYPAIR_PATH> <PROGRAM_FILEPATH>
+```
+
 ### Set a program's upgrade authority
 
 The program's upgrade authority must to be present to deploy a program.  If no


### PR DESCRIPTION
#### Problem

If a deploy fails and buffer is partially written a message pops up telling the caller how to recreate the intermediate buffer's keypair in order to resume the deploy.  At the moment the caller then has to use `solana program write-buffer` to write the entire buffer, and then pass that buffer to `deploy`.  Doing so is non-intiutive.

#### Summary of Changes

Change the cli behavior to:
- (keeping) If only a location is supplied make up a new intermediate, write the program into it, and deploy
- (keeping) If only a buffer is supplied use the supplied buffer as the sole source of the program data
- (new behavior) if a buffer and program path are provided use the supplied buffer as the intermediate, write the program into it, and deploy

Fixes #
