### PR TITLE
Cli: send program deploy txs to up to 2 leaders

### DIFF
--- a/cli/src/send_tpu.rs
+++ b/cli/src/send_tpu.rs
@@ -1,21 +1,38 @@
 use log::*;
 use solana_client::rpc_response::{RpcContactInfo, RpcLeaderSchedule};
+use solana_sdk::clock::NUM_CONSECUTIVE_LEADER_SLOTS;
 use std::net::{SocketAddr, UdpSocket};
 
-pub fn get_leader_tpu(
+pub fn get_leader_tpus(
     slot_index: u64,
+    num_leaders: u64,
     leader_schedule: Option<&RpcLeaderSchedule>,
     cluster_nodes: Option<&Vec<RpcContactInfo>>,
-) -> Option<SocketAddr> {
-    leader_schedule?
-        .iter()
-        .find(|(_pubkey, slots)| slots.iter().any(|slot| *slot as u64 == slot_index))
-        .and_then(|(pubkey, _)| {
-            cluster_nodes?
+) -> Vec<SocketAddr> {
+    let leaders: Vec<_> = (0..num_leaders)
+        .filter_map(|i| {
+            leader_schedule?
                 .iter()
-                .find(|contact_info| contact_info.pubkey == *pubkey)
-                .and_then(|contact_info| contact_info.tpu)
+                .find(|(_pubkey, slots)| {
+                    slots.iter().any(|slot| {
+                        *slot as u64 == (slot_index + (i * NUM_CONSECUTIVE_LEADER_SLOTS))
+                    })
+                })
+                .and_then(|(pubkey, _)| {
+                    cluster_nodes?
+                        .iter()
+                        .find(|contact_info| contact_info.pubkey == *pubkey)
+                        .and_then(|contact_info| contact_info.tpu)
+                })
         })
+        .collect();
+    let mut unique_leaders = vec![];
+    for leader in leaders.into_iter() {
+        if !unique_leaders.contains(&leader) {
+            unique_leaders.push(leader);
+        }
+    }
+    unique_leaders
 }
 
 pub fn send_transaction_tpu(


### PR DESCRIPTION
#### Problem
Program deployments are sent to the cluster via a leader's TPU. But some transactions don't reach that leader in time to be included in the block and end up chasing the leader via banking-stage fwds. We can increase the chances to those transactions landing by sending to future leaders as well, as is done in the send-tx-service.

#### Summary of Changes
Send deploy transactions to up to 2 unique leaders' TPUs Right now the number of future leaders is hard-coded as a const in solana-cli, but we could make this configurable by command in the future.
