### PR TITLE
explorer: add confirmation status to transaction details page

### DIFF
--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -270,6 +270,13 @@ function StatusCard({
         </tr>
 
         <tr>
+          <td>Confirmation Status</td>
+          <td className="text-lg-right text-uppercase">
+            {info.confirmationStatus || "Unknown"}
+          </td>
+        </tr>
+
+        <tr>
           <td>Confirmations</td>
           <td className="text-lg-right text-uppercase">{info.confirmations}</td>
         </tr>

--- a/explorer/src/providers/transactions/index.tsx
+++ b/explorer/src/providers/transactions/index.tsx
@@ -3,6 +3,7 @@ import {
   TransactionSignature,
   Connection,
   SignatureResult,
+  TransactionConfirmationStatus,
 } from "@solana/web3.js";
 import { useCluster, Cluster } from "../cluster";
 import { DetailsProvider } from "./details";
@@ -20,6 +21,7 @@ export interface TransactionStatusInfo {
   result: SignatureResult;
   timestamp: Timestamp;
   confirmations: Confirmations;
+  confirmationStatus: TransactionConfirmationStatus | null;
 }
 
 export interface TransactionStatus {
@@ -96,6 +98,7 @@ export async function fetchTransactionStatus(
         slot: value.slot,
         timestamp,
         confirmations,
+        confirmationStatus: value.confirmationStatus,
         result: { err: value.err },
       };
     }


### PR DESCRIPTION
#### Problem
It would be helpful to know if a transaction is optimistically confirmed before it's rooted.

#### Summary of Changes
Add confirmation status to the transaction details page.

Fixes https://github.com/solana-labs/solana/issues/14398