### PR TITLE
Bump SPL token version to v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4470,9 +4470,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.5.5"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0c1cf7dafbcf4e1e0a56b7b28848bdf41a5e3065e9763d3aae892027109956"
+checksum = "dc44c8096d5847d8cf7f3af3cce565de554cb56371decf93b060633ca8588913"
 dependencies = [
  "bs58",
  "bv",
@@ -4483,8 +4483,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.9.2",
- "solana-frozen-abi-macro 1.5.5",
- "solana-logger 1.5.5",
+ "solana-frozen-abi-macro 1.5.8",
+ "solana-logger 1.5.8",
  "thiserror",
 ]
 
@@ -4508,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.5.5"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb44325468e78e9e4535c90c656c36c953b42cd34ed4999d39f1d33b8780a545"
+checksum = "f905159beff1b53e4ba8b018a9d13d96ba164c3973bf3b9d587e730bcc14fc18"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.24",
@@ -4752,9 +4752,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.5.5"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a46715d2f6fda4697f640038fbd2a16645b10af81dbf2e5a19048c99b8a546"
+checksum = "d83a006d97da5514a4475141573383d3fcd71c729ff78494f96bb531cf734d21"
 dependencies = [
  "env_logger 0.8.2",
  "lazy_static",
@@ -4918,9 +4918,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.5.5"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb200f05cb93b01f6e9b2e0d94d240e7e5dfa0b14c4308713b236c01a525a0ef"
+checksum = "c2007bf285617f8a783e96b20ccd2f8d813549090a5b520f22e5f65b3cd9b157"
 dependencies = [
  "bincode",
  "bs58",
@@ -4939,10 +4939,10 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "sha2 0.9.2",
- "solana-frozen-abi 1.5.5",
- "solana-frozen-abi-macro 1.5.5",
- "solana-logger 1.5.5",
- "solana-sdk-macro 1.5.5",
+ "solana-frozen-abi 1.5.8",
+ "solana-frozen-abi-macro 1.5.8",
+ "solana-logger 1.5.8",
+ "solana-sdk-macro 1.5.8",
  "thiserror",
 ]
 
@@ -5155,9 +5155,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.5.5"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d463f2a24e75ca02f065ac2a9ac855f661c8d0f8917090514d65e4f82cdf05ab"
+checksum = "b8a6635f1798c8ff1b88bb0fad1d4693c011f36a73c9ae03f198203144edcabb"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.24",
@@ -5554,7 +5554,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4adc47eebe5d2b662cbaaba1843719c28a67e5ec5d0460bc3ca60900a51f74e2"
 dependencies = [
- "solana-program 1.5.5",
+ "solana-program 1.5.8",
  "spl-token",
 ]
 
@@ -5564,7 +5564,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2b771f6146dec14ef5fbf498f9374652c54badc3befc8c40c1d426dd45d720"
 dependencies = [
- "solana-program 1.5.5",
+ "solana-program 1.5.8",
 ]
 
 [[package]]
@@ -5573,20 +5573,20 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e76b60c6f58279b5469beb1705744e9778ee94d643c8e3e2ff91874c59bb3c63"
 dependencies = [
- "solana-program 1.5.5",
+ "solana-program 1.5.8",
 ]
 
 [[package]]
 name = "spl-token"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9774eebb62ff1ff2f5eca112413e476143925a2f5a43cee98fc5d3a6c0eec5c"
+checksum = "b795e50d15dfd35aa5460b80a16414503a322be115a417a43db987c5824c6798"
 dependencies = [
  "arrayref",
  "num-derive",
  "num-traits",
  "num_enum",
- "solana-program 1.5.5",
+ "solana-program 1.5.8",
  "thiserror",
 ]
 

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -22,7 +22,7 @@ solana-config-program = { path = "../programs/config", version = "1.6.0" }
 solana-sdk = { path = "../sdk", version = "1.6.0" }
 solana-stake-program = { path = "../programs/stake", version = "1.6.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
-spl-token-v2-0 = { package = "spl-token", version = "=3.0.1", features = ["no-entrypoint"] }
+spl-token-v2-0 = { package = "spl-token", version = "=3.1.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 zstd = "0.5.1"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -75,7 +75,7 @@ solana-sys-tuner = { path = "../sys-tuner", version = "1.6.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
-spl-token-v2-0 = { package = "spl-token", version = "=3.0.1", features = ["no-entrypoint"] }
+spl-token-v2-0 = { package = "spl-token", version = "=3.1.0", features = ["no-entrypoint"] }
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "1.1", features = ["full"] }

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2982,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.5.3"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac2e6c6c399b2db73f9aaf63b9a5d35fda67d792ced4ebfb06d538be32a9d24"
+checksum = "dc44c8096d5847d8cf7f3af3cce565de554cb56371decf93b060633ca8588913"
 dependencies = [
  "bs58",
  "bv",
@@ -2994,9 +2994,9 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
- "sha2 0.8.2",
- "solana-frozen-abi-macro 1.5.3",
- "solana-logger 1.5.3",
+ "sha2 0.9.2",
+ "solana-frozen-abi-macro 1.5.8",
+ "solana-logger 1.5.8",
  "thiserror",
 ]
 
@@ -3020,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.5.3"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8af04aaedb1de2d6fc6ec237291bfb9b648c38692bf3d53d844f3cc76aa152"
+checksum = "f905159beff1b53e4ba8b018a9d13d96ba164c3973bf3b9d587e730bcc14fc18"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.24",
@@ -3044,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.5.3"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3ce848f35b88e36ce5e13ed7a60102c3339acd5c4443fee55a7ff173a2d31d"
+checksum = "d83a006d97da5514a4475141573383d3fcd71c729ff78494f96bb531cf734d21"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -3106,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.5.3"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d7f0767921018572bbb33bbf1c912897c5712e50a839d09d7faacea547e89b5"
+checksum = "c2007bf285617f8a783e96b20ccd2f8d813549090a5b520f22e5f65b3cd9b157"
 dependencies = [
  "bincode",
  "bs58",
@@ -3126,11 +3126,11 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2 0.8.2",
- "solana-frozen-abi 1.5.3",
- "solana-frozen-abi-macro 1.5.3",
- "solana-logger 1.5.3",
- "solana-sdk-macro 1.5.3",
+ "sha2 0.9.2",
+ "solana-frozen-abi 1.5.8",
+ "solana-frozen-abi-macro 1.5.8",
+ "solana-logger 1.5.8",
+ "solana-sdk-macro 1.5.8",
  "thiserror",
 ]
 
@@ -3284,9 +3284,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.5.3"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13933248cf64f880813fc8606328400fa204a4bc1180f1567ffc019cdd8bae97"
+checksum = "b8a6635f1798c8ff1b88bb0fad1d4693c011f36a73c9ae03f198203144edcabb"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.24",
@@ -3425,7 +3425,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2b771f6146dec14ef5fbf498f9374652c54badc3befc8c40c1d426dd45d720"
 dependencies = [
- "solana-program 1.5.3",
+ "solana-program 1.5.8",
 ]
 
 [[package]]
@@ -3434,20 +3434,20 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e76b60c6f58279b5469beb1705744e9778ee94d643c8e3e2ff91874c59bb3c63"
 dependencies = [
- "solana-program 1.5.3",
+ "solana-program 1.5.8",
 ]
 
 [[package]]
 name = "spl-token"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9774eebb62ff1ff2f5eca112413e476143925a2f5a43cee98fc5d3a6c0eec5c"
+checksum = "b795e50d15dfd35aa5460b80a16414503a322be115a417a43db987c5824c6798"
 dependencies = [
  "arrayref",
  "num-derive 0.3.0",
  "num-traits",
  "num_enum",
- "solana-program 1.5.3",
+ "solana-program 1.5.8",
  "thiserror",
 ]
 

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -30,7 +30,7 @@ solana-stake-program = { path = "../programs/stake", version = "1.6.0" }
 solana-transaction-status = { path = "../transaction-status", version = "1.6.0" }
 solana-version = { path = "../version", version = "1.6.0" }
 spl-associated-token-account-v1-0 = { package = "spl-associated-token-account", version = "=1.0.2" }
-spl-token-v2-0 = { package = "spl-token", version = "=3.0.1", features = ["no-entrypoint"] }
+spl-token-v2-0 = { package = "spl-token", version = "=3.1.0", features = ["no-entrypoint"] }
 tempfile = "3.1.0"
 thiserror = "1.0"
 

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -24,7 +24,7 @@ solana-stake-program = { path = "../programs/stake", version = "1.6.0" }
 solana-vote-program = { path = "../programs/vote", version = "1.6.0" }
 spl-memo-v1-0 = { package = "spl-memo", version = "=2.0.1", features = ["no-entrypoint"] }
 spl-memo-v3-0 = { package = "spl-memo", version = "=3.0.0", features = ["no-entrypoint"] }
-spl-token-v2-0 = { package = "spl-token", version = "=3.0.1", features = ["no-entrypoint"] }
+spl-token-v2-0 = { package = "spl-token", version = "=3.1.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 
 [package.metadata.docs.rs]

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -64,6 +64,18 @@ pub fn parse_token(
                 }),
             })
         }
+        TokenInstruction::InitializeAccount2 { owner } => {
+            check_num_token_accounts(&instruction.accounts, 3)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "initializeAccount2".to_string(),
+                info: json!({
+                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "owner": owner.to_string(),
+                    "rentSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
+                }),
+            })
+        }
         TokenInstruction::InitializeMultisig { m } => {
             check_num_token_accounts(&instruction.accounts, 3)?;
             let mut signers: Vec<String> = vec![];


### PR DESCRIPTION
#### Problem
- Downstream projects cannot easily depend on spl-token v3.1.0 if they have a dependency on `solana-client` due to the hardcoded `spl-token` dependency
- No RPC support for parsing the new `initializeAccount2` instruction

#### Summary of Changes
- Bump from v3.0.1 to v3.1.0

Fixes #
