### PR TITLE
prevent data copies to verify instructions don't modify data

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -231,7 +231,7 @@ fn run_program(
             &bpf_loader::id(),
             parameter_accounts,
             &parameter_bytes,
-            &mut invoke_context,
+            &invoke_context,
         )
         .unwrap();
         if i == 1 {

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -227,7 +227,13 @@ fn run_program(
             vm.execute_program_jit(&mut instruction_meter)
         };
         assert_eq!(SUCCESS, result.unwrap());
-        deserialize_parameters(&bpf_loader::id(), parameter_accounts, &parameter_bytes).unwrap();
+        deserialize_parameters(
+            &bpf_loader::id(),
+            parameter_accounts,
+            &parameter_bytes,
+            &mut invoke_context,
+        )
+        .unwrap();
         if i == 1 {
             assert_eq!(instruction_count, vm.get_total_instruction_count());
         }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -834,7 +834,12 @@ impl Executor for BPFExecutor {
                 }
             }
         }
-        deserialize_parameters(loader_id, parameter_accounts, &parameter_bytes)?;
+        deserialize_parameters(
+            loader_id,
+            parameter_accounts,
+            &parameter_bytes,
+            invoke_context,
+        )?;
         stable_log::program_success(&logger, program_id);
         Ok(())
     }

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -35,7 +35,7 @@ pub fn deserialize_parameters(
     loader_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     buffer: &[u8],
-    invoke_context: &mut dyn InvokeContext,
+    invoke_context: &dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     if *loader_id == bpf_loader_deprecated::id() {
         deserialize_parameters_unaligned(keyed_accounts, buffer)
@@ -203,7 +203,7 @@ pub fn serialize_parameters_aligned(
 pub fn deserialize_parameters_aligned(
     keyed_accounts: &[KeyedAccount],
     buffer: &[u8],
-    context: &mut dyn InvokeContext,
+    context: &dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let mut start = size_of::<u64>(); // number of accounts
     for (i, keyed_account) in keyed_accounts.iter().enumerate() {

--- a/runtime/benches/message_processor.rs
+++ b/runtime/benches/message_processor.rs
@@ -5,6 +5,7 @@ extern crate test;
 use log::*;
 use solana_runtime::message_processor::PreAccount;
 use solana_sdk::{account::Account, pubkey, rent::Rent};
+use std::{cell::RefCell, rc::Rc};
 use test::Bencher;
 
 #[bench]
@@ -15,7 +16,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     let non_owner = pubkey::new_rand();
     let pre = PreAccount::new(
         &pubkey::new_rand(),
-        &Account::new(0, BUFSIZE, &owner),
+        &Rc::new(RefCell::new(Account::new(0, BUFSIZE, &owner))),
         false,
     );
     let post = Account::new(0, BUFSIZE, &owner);
@@ -40,7 +41,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
 
     let pre = PreAccount::new(
         &pubkey::new_rand(),
-        &Account::new(0, BUFSIZE, &owner),
+        &Rc::new(RefCell::new(Account::new(0, BUFSIZE, &owner))),
         false,
     );
     bencher.iter(|| {

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -64,6 +64,10 @@ pub trait InvokeContext {
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
     /// Get an account from a pre-account
     fn get_account(&self, pubkey: &Pubkey) -> Option<RefCell<Account>>;
+    /// Notify caller when account data field was modified
+    fn account_data_modified(&self, pubkey: &Pubkey);
+    /// Notify caller when account data field was modified
+    fn account_data_len_modified(&self, pubkey: &Pubkey);
 }
 
 /// Convenience macro to log a message with an `Rc<RefCell<dyn Logger>>`
@@ -371,4 +375,6 @@ impl InvokeContext for MockInvokeContext {
     fn get_account(&self, _pubkey: &Pubkey) -> Option<RefCell<Account>> {
         None
     }
+    fn account_data_modified(&self, _pubkey: &Pubkey) {}
+    fn account_data_len_modified(&self, _pubkey: &Pubkey) {}
 }


### PR DESCRIPTION
#### Problem
When executing instructions, we make a copy of data solely for the purpose of verifying that the data wasn't changed when it wasn't supposed to change. This is very expensive.

#### Summary of Changes
After executing an instruction, prior to deserializing, compare the data we would deserialize vs the data we passed into the function. If the size or content changed, then note that on the PreAccount.

Fixes #
