### PR TITLE
explorer: prevent large slot number input stemming from hex strings

### DIFF
--- a/explorer/src/pages/BlockDetailsPage.tsx
+++ b/explorer/src/pages/BlockDetailsPage.tsx
@@ -6,10 +6,11 @@ import { BlockOverviewCard } from "components/block/BlockOverviewCard";
 type Props = { slot: string };
 
 export function BlockDetailsPage({ slot }: Props) {
+  const slotNumber = Number(slot);
   let output = <ErrorCard text={`Block ${slot} is not valid`} />;
 
-  if (!isNaN(Number(slot))) {
-    output = <BlockOverviewCard slot={Number(slot)} />;
+  if (!isNaN(slotNumber) && slotNumber < Number.MAX_SAFE_INTEGER) {
+    output = <BlockOverviewCard slot={slotNumber} />;
   }
 
   return (

--- a/explorer/src/pages/BlockDetailsPage.tsx
+++ b/explorer/src/pages/BlockDetailsPage.tsx
@@ -3,13 +3,16 @@ import React from "react";
 import { ErrorCard } from "components/common/ErrorCard";
 import { BlockOverviewCard } from "components/block/BlockOverviewCard";
 
+// IE11 doesn't support Number.MAX_SAFE_INTEGER
+const MAX_SAFE_INTEGER = 9007199254740991;
+
 type Props = { slot: string };
 
 export function BlockDetailsPage({ slot }: Props) {
   const slotNumber = Number(slot);
   let output = <ErrorCard text={`Block ${slot} is not valid`} />;
 
-  if (!isNaN(slotNumber) && slotNumber < Number.MAX_SAFE_INTEGER) {
+  if (!isNaN(slotNumber) && slotNumber < MAX_SAFE_INTEGER) {
     output = <BlockOverviewCard slot={slotNumber} />;
   }
 


### PR DESCRIPTION
#### Problem
It appears large numbers as hex strings (such as ETH addresses) are being queried and passed along to the RPC.

#### Summary of Changes
Restrict slot size less than Number.MAX_SAFE_INTEGER, which will fit into a u64 (we can restrict this further if necessary).  

Fixes https://sentry.io/organizations/solana/issues/2112399279/?project=5390542&referrer=slack
