### PR TITLE
Rename IOError to BorshIoError

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -72,7 +72,7 @@ pub fn to_instruction_error(error: ProgramError) -> InstructionError {
         ProgramError::AccountBorrowFailed => InstructionError::AccountBorrowFailed,
         ProgramError::MaxSeedLengthExceeded => InstructionError::MaxSeedLengthExceeded,
         ProgramError::InvalidSeeds => InstructionError::InvalidSeeds,
-        ProgramError::IOError(err) => InstructionError::IOError(err),
+        ProgramError::BorshIoError(err) => InstructionError::BorshIoError(err),
         ProgramError::AccountNotRentExempt => InstructionError::AccountNotRentExempt,
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -109,7 +109,7 @@ impl ExecuteTimings {
 }
 
 type BankStatusCache = StatusCache<Result<()>>;
-#[frozen_abi(digest = "GESbL4xC5ndicqqZeCW4fEHtNR71NMESVWM3i2Ty2MY9")]
+#[frozen_abi(digest = "9wmxRM64shxBcCCjQtRMwCGkWun4VeUufNoHgLXwwFfz")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 type TransactionAccountRefCells = Vec<Rc<RefCell<Account>>>;
 type TransactionAccountDepRefCells = Vec<(Pubkey, RefCell<Account>)>;

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -189,7 +189,7 @@ pub enum InstructionError {
     IncorrectAuthority,
 
     #[error("Failed to serialize or deserialize account data: {0}")]
-    IOError(String),
+    BorshIoError(String),
 
     #[error("An account does not have enough lamports to be rent-exempt")]
     AccountNotRentExempt,

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -1,5 +1,5 @@
 use crate::{decode_error::DecodeError, instruction::InstructionError, msg, pubkey::PubkeyError};
-use borsh::maybestd::io::Error as IOError;
+use borsh::maybestd::io::Error as BorshIoError;
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -39,7 +39,7 @@ pub enum ProgramError {
     #[error("Provided seeds do not result in a valid address")]
     InvalidSeeds,
     #[error("IO Error: {0}")]
-    IOError(String),
+    BorshIoError(String),
     #[error("An account does not have enough lamports to be rent-exempt")]
     AccountNotRentExempt,
 }
@@ -76,7 +76,7 @@ impl PrintProgramError for ProgramError {
             Self::AccountBorrowFailed => msg!("Error: AccountBorrowFailed"),
             Self::MaxSeedLengthExceeded => msg!("Error: MaxSeedLengthExceeded"),
             Self::InvalidSeeds => msg!("Error: InvalidSeeds"),
-            Self::IOError(_) => msg!("Error: IOError"),
+            Self::BorshIoError(_) => msg!("Error: BorshIoError"),
             Self::AccountNotRentExempt => msg!("Error: AccountNotRentExempt"),
         }
     }
@@ -104,7 +104,7 @@ pub const NOT_ENOUGH_ACCOUNT_KEYS: u64 = to_builtin!(11);
 pub const ACCOUNT_BORROW_FAILED: u64 = to_builtin!(12);
 pub const MAX_SEED_LENGTH_EXCEEDED: u64 = to_builtin!(13);
 pub const INVALID_SEEDS: u64 = to_builtin!(14);
-pub const IO_ERROR: u64 = to_builtin!(15);
+pub const BORSH_IO_ERROR: u64 = to_builtin!(15);
 pub const ACCOUNT_NOT_RENT_EXEMPT: u64 = to_builtin!(16);
 
 impl From<ProgramError> for u64 {
@@ -123,7 +123,7 @@ impl From<ProgramError> for u64 {
             ProgramError::AccountBorrowFailed => ACCOUNT_BORROW_FAILED,
             ProgramError::MaxSeedLengthExceeded => MAX_SEED_LENGTH_EXCEEDED,
             ProgramError::InvalidSeeds => INVALID_SEEDS,
-            ProgramError::IOError(_) => IO_ERROR,
+            ProgramError::BorshIoError(_) => BORSH_IO_ERROR,
             ProgramError::AccountNotRentExempt => ACCOUNT_NOT_RENT_EXEMPT,
 
             ProgramError::Custom(error) => {
@@ -177,7 +177,7 @@ impl TryFrom<InstructionError> for ProgramError {
             Self::Error::NotEnoughAccountKeys => Ok(Self::NotEnoughAccountKeys),
             Self::Error::AccountBorrowFailed => Ok(Self::AccountBorrowFailed),
             Self::Error::MaxSeedLengthExceeded => Ok(Self::MaxSeedLengthExceeded),
-            Self::Error::IOError(err) => Ok(Self::IOError(err)),
+            Self::Error::BorshIoError(err) => Ok(Self::BorshIoError(err)),
             Self::Error::AccountNotRentExempt => Ok(Self::AccountNotRentExempt),
             _ => Err(error),
         }
@@ -226,8 +226,8 @@ impl From<PubkeyError> for ProgramError {
     }
 }
 
-impl From<IOError> for ProgramError {
-    fn from(error: IOError) -> Self {
-        ProgramError::IOError(format!("{}", error))
+impl From<BorshIoError> for ProgramError {
+    fn from(error: BorshIoError) -> Self {
+        ProgramError::BorshIoError(format!("{}", error))
     }
 }

--- a/storage-proto/proto/solana.storage.transaction_by_addr.rs
+++ b/storage-proto/proto/solana.storage.transaction_by_addr.rs
@@ -114,6 +114,6 @@ pub enum InstructionErrorType {
     ProgramFailedToCompile = 41,
     Immutable = 42,
     IncorrectAuthority = 43,
-    IOError = 44,
+    BorshIoError = 44,
     AccountNotRentExempt = 45,
 }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -700,8 +700,8 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                             InstructionError::IncorrectAuthority => {
                                 tx_by_addr::InstructionErrorType::IncorrectAuthority
                             }
-                            InstructionError::IOError(_) => {
-                                tx_by_addr::InstructionErrorType::IOError
+                            InstructionError::BorshIoError(_) => {
+                                tx_by_addr::InstructionErrorType::BorshIoError
                             }
                             InstructionError::AccountNotRentExempt => {
                                 tx_by_addr::InstructionErrorType::AccountNotRentExempt

--- a/storage-proto/src/transaction_by_addr.proto
+++ b/storage-proto/src/transaction_by_addr.proto
@@ -93,6 +93,8 @@ enum InstructionErrorType {
     PROGRAM_FAILED_TO_COMPILE = 41;
     IMMUTABLE = 42;
     INCORRECT_AUTHORITY = 43;
+    BORSH_IO_ERROR = 44;
+    ACCOUNT_NOT_RENT_EXEMPT = 45;
 }
 
 message UnixTimestamp {


### PR DESCRIPTION
Clippy bucks hard against `IOError`, it wants `IoError`.  But wait, this isn't really `IoError`.  It's a `BorshIoError`.  
It's ok to rename this SDK enum entry since it was just added days ago.

Prerequisite for https://github.com/solana-labs/solana/pull/15428