### PR TITLE
explorer: block query should be strictly integers

### DIFF
--- a/explorer/src/pages/BlockDetailsPage.tsx
+++ b/explorer/src/pages/BlockDetailsPage.tsx
@@ -12,7 +12,11 @@ export function BlockDetailsPage({ slot }: Props) {
   const slotNumber = Number(slot);
   let output = <ErrorCard text={`Block ${slot} is not valid`} />;
 
-  if (!isNaN(slotNumber) && slotNumber < MAX_SAFE_INTEGER) {
+  if (
+    !isNaN(slotNumber) &&
+    slotNumber < MAX_SAFE_INTEGER &&
+    slotNumber % 1 === 0
+  ) {
     output = <BlockOverviewCard slot={slotNumber} />;
   }
 


### PR DESCRIPTION
#### Problem
I noticed the block query interface supported non-integer values. 

#### Summary of Changes
Ensure that integers are passed in.

