### PR TITLE
watchtower: Prevent u64 overflow when calculating current stake percentage

### DIFF
--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -241,9 +241,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     .sum();
 
                 let total_stake = total_current_stake + total_delinquent_stake;
-                let current_stake_percent = total_current_stake * 100 / total_stake;
+                let current_stake_percent = total_current_stake as f64 * 100. / total_stake as f64;
                 info!(
-                    "Current stake: {}% | Total stake: {}, current stake: {}, delinquent: {}",
+                    "Current stake: {:.2}% | Total stake: {}, current stake: {}, delinquent: {}",
                     current_stake_percent,
                     Sol(total_stake),
                     Sol(total_current_stake),
@@ -271,10 +271,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     ));
                 }
 
-                if config.monitor_active_stake && current_stake_percent < 80 {
+                if config.monitor_active_stake && current_stake_percent < 80. {
                     failures.push((
                         "current-stake",
-                        format!("Current stake is {}%", current_stake_percent),
+                        format!("Current stake is {:.2}%", current_stake_percent),
                     ));
                 }
 


### PR DESCRIPTION
#### Problem?
Too much delegated stake on mainnet-beta

#### Summary of Changes
Use f64 instead of a u64 to avoid an overflow

Fixes #15450