### PR TITLE
Add max retransmit and shred insert slot

### DIFF
--- a/core/benches/retransmit_stage.rs
+++ b/core/benches/retransmit_stage.rs
@@ -6,6 +6,7 @@ extern crate test;
 use log::*;
 use solana_core::cluster_info::{ClusterInfo, Node};
 use solana_core::contact_info::ContactInfo;
+use solana_core::max_slots::MaxSlots;
 use solana_core::retransmit_stage::retransmitter;
 use solana_ledger::entry::Entry;
 use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
@@ -92,6 +93,7 @@ fn bench_retransmitter(bencher: &mut Bencher) {
         &leader_schedule_cache,
         cluster_info,
         packet_receiver,
+        &Arc::new(MaxSlots::default()),
     );
 
     let mut index = 0;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cluster_info_vote_listener;
 pub mod commitment_service;
 pub mod completed_data_sets_service;
 mod deprecated;
+pub mod max_slots;
 pub mod sample_performance_service;
 pub mod shred_fetch_stage;
 #[macro_use]

--- a/core/src/max_slots.rs
+++ b/core/src/max_slots.rs
@@ -1,0 +1,7 @@
+use std::sync::atomic::AtomicU64;
+
+#[derive(Default)]
+pub struct MaxSlots {
+    pub retransmit: AtomicU64,
+    pub shred_insert: AtomicU64,
+}

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -3,6 +3,7 @@
 use crate::{
     cluster_info::ClusterInfo,
     contact_info::ContactInfo,
+    max_slots::MaxSlots,
     non_circulating_supply::calculate_non_circulating_supply,
     optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
     rpc_health::*,
@@ -138,6 +139,7 @@ pub struct JsonRpcRequestProcessor {
     bigtable_ledger_storage: Option<solana_storage_bigtable::LedgerStorage>,
     optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
     largest_accounts_cache: Arc<RwLock<LargestAccountsCache>>,
+    max_slots: Arc<MaxSlots>,
 }
 impl Metadata for JsonRpcRequestProcessor {}
 
@@ -221,6 +223,7 @@ impl JsonRpcRequestProcessor {
         bigtable_ledger_storage: Option<solana_storage_bigtable::LedgerStorage>,
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
         largest_accounts_cache: Arc<RwLock<LargestAccountsCache>>,
+        max_slots: Arc<MaxSlots>,
     ) -> (Self, Receiver<TransactionInfo>) {
         let (sender, receiver) = channel();
         (
@@ -239,6 +242,7 @@ impl JsonRpcRequestProcessor {
                 bigtable_ledger_storage,
                 optimistically_confirmed_bank,
                 largest_accounts_cache,
+                max_slots,
             },
             receiver,
         )
@@ -279,6 +283,7 @@ impl JsonRpcRequestProcessor {
                 bank: bank.clone(),
             })),
             largest_accounts_cache: Arc::new(RwLock::new(LargestAccountsCache::new(30))),
+            max_slots: Arc::new(MaxSlots::default()),
         }
     }
 
@@ -483,6 +488,14 @@ impl JsonRpcRequestProcessor {
 
     fn get_slot(&self, commitment: Option<CommitmentConfig>) -> Slot {
         self.bank(commitment).slot()
+    }
+
+    fn get_max_retransmit_slot(&self) -> Slot {
+        self.max_slots.retransmit.load(Ordering::Relaxed)
+    }
+
+    fn get_max_shred_insert_slot(&self) -> Slot {
+        self.max_slots.shred_insert.load(Ordering::Relaxed)
     }
 
     fn get_slot_leader(&self, commitment: Option<CommitmentConfig>) -> String {
@@ -1915,6 +1928,12 @@ pub trait RpcSol {
     #[rpc(meta, name = "getSlot")]
     fn get_slot(&self, meta: Self::Metadata, commitment: Option<CommitmentConfig>) -> Result<Slot>;
 
+    #[rpc(meta, name = "getMaxRetransmitSlot")]
+    fn get_max_retransmit_slot(&self, meta: Self::Metadata) -> Result<Slot>;
+
+    #[rpc(meta, name = "getMaxShredInsertSlot")]
+    fn get_max_shred_insert_slot(&self, meta: Self::Metadata) -> Result<Slot>;
+
     #[rpc(meta, name = "getTransactionCount")]
     fn get_transaction_count(
         &self,
@@ -2497,6 +2516,16 @@ impl RpcSol for RpcSolImpl {
     fn get_slot(&self, meta: Self::Metadata, commitment: Option<CommitmentConfig>) -> Result<Slot> {
         debug!("get_slot rpc request received");
         Ok(meta.get_slot(commitment))
+    }
+
+    fn get_max_retransmit_slot(&self, meta: Self::Metadata) -> Result<Slot> {
+        debug!("get_max_retransmit_slot rpc request received");
+        Ok(meta.get_max_retransmit_slot())
+    }
+
+    fn get_max_shred_insert_slot(&self, meta: Self::Metadata) -> Result<Slot> {
+        debug!("get_max_shred_insert_slot rpc request received");
+        Ok(meta.get_max_shred_insert_slot())
     }
 
     fn get_transaction_count(
@@ -3200,6 +3229,10 @@ pub mod tests {
             .write_perf_sample(0, &sample1)
             .expect("write to blockstore");
 
+        let max_slots = Arc::new(MaxSlots::default());
+        max_slots.retransmit.store(42, Ordering::Relaxed);
+        max_slots.shred_insert.store(43, Ordering::Relaxed);
+
         let (meta, receiver) = JsonRpcRequestProcessor::new(
             JsonRpcConfig {
                 enable_rpc_transaction_history: true,
@@ -3218,6 +3251,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
             Arc::new(RwLock::new(LargestAccountsCache::new(30))),
+            max_slots,
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
 
@@ -4628,6 +4662,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
             Arc::new(RwLock::new(LargestAccountsCache::new(30))),
+            Arc::new(MaxSlots::default()),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
 
@@ -4825,6 +4860,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
             Arc::new(RwLock::new(LargestAccountsCache::new(30))),
+            Arc::new(MaxSlots::default()),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
         assert_eq!(request_processor.validator_exit(), false);
@@ -4859,6 +4895,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
             Arc::new(RwLock::new(LargestAccountsCache::new(30))),
+            Arc::new(MaxSlots::default()),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
         assert_eq!(request_processor.validator_exit(), true);
@@ -4884,6 +4921,24 @@ pub mod tests {
         let result: Response = serde_json::from_str(&res.expect("actual response"))
             .expect("actual response deserialization");
         assert_eq!(expected, result);
+    }
+
+    fn test_basic_slot(method: &str, expected: Slot) {
+        let bob_pubkey = solana_sdk::pubkey::new_rand();
+        let RpcHandler { io, meta, .. } = start_rpc_handler_with_tx(&bob_pubkey);
+
+        let req = format!("{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"{}\"}}", method);
+        let res = io.handle_request_sync(&req, meta);
+
+        let json: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        let slot: Slot = serde_json::from_value(json["result"].clone()).unwrap();
+        assert_eq!(slot, expected);
+    }
+
+    #[test]
+    fn test_rpc_get_max_slots() {
+        test_basic_slot("getMaxRetransmitSlot", 42);
+        test_basic_slot("getMaxShredInsertSlot", 43);
     }
 
     #[test]
@@ -4952,6 +5007,7 @@ pub mod tests {
             None,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
             Arc::new(RwLock::new(LargestAccountsCache::new(30))),
+            Arc::new(MaxSlots::default()),
         );
         SendTransactionService::new(tpu_address, &bank_forks, None, receiver, 1000, 1);
         assert_eq!(
@@ -6182,6 +6238,7 @@ pub mod tests {
             None,
             optimistically_confirmed_bank.clone(),
             Arc::new(RwLock::new(LargestAccountsCache::new(30))),
+            Arc::new(MaxSlots::default()),
         );
 
         let mut io = MetaIoHandler::default();

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -3,6 +3,7 @@
 use crate::{
     bigtable_upload_service::BigTableUploadService,
     cluster_info::ClusterInfo,
+    max_slots::MaxSlots,
     optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
     poh_recorder::PohRecorder,
     rpc::*,
@@ -272,6 +273,7 @@ impl JsonRpcService {
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
         send_transaction_retry_ms: u64,
         send_transaction_leader_forward_count: u64,
+        max_slots: Arc<MaxSlots>,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -349,6 +351,7 @@ impl JsonRpcService {
             bigtable_ledger_storage,
             optimistically_confirmed_bank,
             largest_accounts_cache,
+            max_slots,
         );
 
         let leader_info =
@@ -510,6 +513,7 @@ mod tests {
             optimistically_confirmed_bank,
             1000,
             1,
+            Arc::new(MaxSlots::default()),
         );
         let thread = rpc_service.thread_hdl.thread();
         assert_eq!(thread.name().unwrap(), "solana-jsonrpc");

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -11,6 +11,7 @@ use crate::{
     completed_data_sets_service::CompletedDataSetsSender,
     consensus::Tower,
     ledger_cleanup_service::LedgerCleanupService,
+    max_slots::MaxSlots,
     optimistically_confirmed_bank_tracker::BankNotificationSender,
     poh_recorder::PohRecorder,
     replay_stage::{ReplayStage, ReplayStageConfig},
@@ -120,6 +121,7 @@ impl Tvu {
         completed_data_sets_sender: CompletedDataSetsSender,
         bank_notification_sender: Option<BankNotificationSender>,
         tvu_config: TvuConfig,
+        max_slots: &Arc<MaxSlots>,
     ) -> Self {
         let keypair: Arc<Keypair> = cluster_info.keypair.clone();
 
@@ -174,6 +176,7 @@ impl Tvu {
             verified_vote_receiver,
             tvu_config.repair_validators,
             completed_data_sets_sender,
+            max_slots,
         );
 
         let (ledger_cleanup_slot_sender, ledger_cleanup_slot_receiver) = channel();
@@ -407,6 +410,7 @@ pub mod tests {
             completed_data_sets_sender,
             None,
             TvuConfig::default(),
+            &Arc::new(MaxSlots::default()),
         );
         exit.store(true, Ordering::Relaxed);
         tvu.join().unwrap();

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -12,6 +12,7 @@ use crate::{
     consensus::{reconcile_blockstore_roots_with_tower, Tower},
     contact_info::ContactInfo,
     gossip_service::GossipService,
+    max_slots::MaxSlots,
     optimistically_confirmed_bank_tracker::{
         OptimisticallyConfirmedBank, OptimisticallyConfirmedBankTracker,
     },
@@ -414,6 +415,7 @@ impl Validator {
             config.pubsub_config.enable_vote_subscription,
         ));
 
+        let max_slots = Arc::new(MaxSlots::default());
         let (completed_data_sets_sender, completed_data_sets_receiver) =
             bounded(MAX_COMPLETED_DATA_SETS_IN_CHANNEL);
         let completed_data_sets_service = CompletedDataSetsService::new(
@@ -421,6 +423,7 @@ impl Validator {
             blockstore.clone(),
             subscriptions.clone(),
             &exit,
+            max_slots.clone(),
         );
 
         info!(
@@ -485,6 +488,7 @@ impl Validator {
                         optimistically_confirmed_bank.clone(),
                         config.send_transaction_retry_ms,
                         config.send_transaction_leader_forward_count,
+                        max_slots.clone(),
                     ),
                     pubsub_service: PubSubService::new(
                         config.pubsub_config.clone(),
@@ -654,6 +658,7 @@ impl Validator {
                 rocksdb_compaction_interval: config.rocksdb_compaction_interval,
                 rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
             },
+            &max_slots,
         );
 
         let tpu = Tpu::new(

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -42,6 +42,8 @@ gives a convenient interface for the RPC methods.
 - [getInflationRate](jsonrpc-api.md#getinflationrate)
 - [getLargestAccounts](jsonrpc-api.md#getlargestaccounts)
 - [getLeaderSchedule](jsonrpc-api.md#getleaderschedule)
+- [getMaxRetransmitSlot](jsonrpc-api.md#getmaxretransmitslot)
+- [getMaxShredInsertSlot](jsonrpc-api.md#getmaxshredinsertslot)
 - [getMinimumBalanceForRentExemption](jsonrpc-api.md#getminimumbalanceforrentexemption)
 - [getMultipleAccounts](jsonrpc-api.md#getmultipleaccounts)
 - [getProgramAccounts](jsonrpc-api.md#getprogramaccounts)
@@ -1610,6 +1612,50 @@ Result:
   },
   "id":1
 }
+```
+
+### getMaxRetransmitSlot
+
+Get the max slot seen from retransmit stage.
+
+#### Results:
+
+- `<u64>` - Slot
+
+#### Example:
+
+Request:
+```bash
+curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+  {"jsonrpc":"2.0","id":1, "method":"getMaxRetransmitSlot"}
+'
+```
+
+Result:
+```json
+{"jsonrpc":"2.0","result":1234,"id":1}
+```
+
+### getMaxShredInsertSlot
+
+Get the max slot seen from after shred insert.
+
+#### Results:
+
+- `<u64>` - Slot
+
+#### Example:
+
+Request:
+```bash
+curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+  {"jsonrpc":"2.0","id":1, "method":"getMaxShredInsertSlot"}
+'
+```
+
+Result:
+```json
+{"jsonrpc":"2.0","result":1234,"id":1}
 ```
 
 ### getMinimumBalanceForRentExemption


### PR DESCRIPTION
#### Problem

No easy way to tell over RPC how far behind a node might be in processing.

#### Summary of Changes

Add two points of max slots in retransmit and also after shred insert. A node could use this to tell how far behind the latest shreds in the network it is.

Fixes #
