### PR TITLE
Clarify that faucet_pubkey and bootstrap_validator arguments actually…

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -187,7 +187,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             Arg::with_name("faucet_pubkey")
                 .short("m")
                 .long("faucet-pubkey")
-                .value_name("PUBKEY")
+                .value_name("KEYPAIR_JSON_FILE")
                 .takes_value(true)
                 .validator(is_pubkey_or_keypair)
                 .requires("faucet_lamports")

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -158,13 +158,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             Arg::with_name("bootstrap_validator")
                 .short("b")
                 .long("bootstrap-validator")
-                .value_name("IDENTITY_PUBKEY VOTE_PUBKEY STAKE_PUBKEY")
+                .value_name("IDENTITY_KEYPAIR_JSON_FILE VOTE_KEYPAIR_JSON_FILE STAKE_KEYPAIR_JSON_FILE")
                 .takes_value(true)
                 .validator(is_pubkey_or_keypair)
                 .number_of_values(3)
                 .multiple(true)
                 .required(true)
-                .help("The bootstrap validator's identity, vote and stake pubkeys"),
+                .help("The files containing the bootstrap validator's identity, vote and stake ED25519 keypairs, serialized to JSON arrays (e.g. [12, 154, 94...])"),
         )
         .arg(
             Arg::with_name("ledger_path")
@@ -192,7 +192,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .validator(is_pubkey_or_keypair)
                 .requires("faucet_lamports")
                 .default_value(&default_faucet_pubkey)
-                .help("Path to file containing the faucet's pubkey"),
+                .help("Path to file containing the faucet's ED25519 keypair, serialized to a JSON array (e.g. [12, 154, 94...])"),
         )
         .arg(
             Arg::with_name("bootstrap_stake_authorized_pubkey")


### PR DESCRIPTION
… need keypairs, not just a pubkey

#### Problem
`bootstrap_validator` and `faucet_pubkey` arguments seem to indicate they want only a pubkey, but passing in just the pubkey without the privkey will throw:
```
error: Invalid value for '--faucet-pubkey <PUBKEY>': signature error
```
and
```
error: Invalid value for '--bootstrap-validator <IDENTITY_PUBKEY VOTE_PUBKEY STAKE_PUBKEY>...': signature error
```

#### Summary of Changes
Clarified that one must actually pass in files containing ED25519 keypairs, serialized to a JSON integer array

Ideally the `faucet_pubkey` argument would be renamed to be `faucet_keypair` to match, but that seemed like it could break a lot of stuff so I only touched the docs
