### PR TITLE
Transition config program over to ic_msg() logging

### DIFF
--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -2,8 +2,8 @@
 
 use crate::ConfigKeys;
 use bincode::deserialize;
-use log::*;
 use solana_sdk::{
+    ic_msg,
     instruction::InstructionError,
     keyed_account::{next_keyed_account, KeyedAccount},
     process_instruction::InvokeContext,
@@ -15,7 +15,7 @@ pub fn process_instruction(
     _program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     data: &[u8],
-    _invoke_context: &mut dyn InvokeContext,
+    invoke_context: &mut dyn InvokeContext,
 ) -> Result<(), InstructionError> {
     let key_list: ConfigKeys = limited_deserialize(data)?;
     let keyed_accounts_iter = &mut keyed_accounts.iter();
@@ -23,10 +23,9 @@ pub fn process_instruction(
     let current_data: ConfigKeys = {
         let config_account = config_keyed_account.try_account_ref_mut()?;
         deserialize(&config_account.data).map_err(|err| {
-            error!(
-                "Unable to deserialize account[0]: {:?} (len={}): {:?}",
-                config_account.data,
-                config_account.data.len(),
+            ic_msg!(
+                invoke_context,
+                "Unable to deserialize config account: {}",
                 err
             );
             InstructionError::InvalidAccountData
@@ -43,7 +42,6 @@ pub fn process_instruction(
         // Config account keypair must be a signer on account initialization,
         // or when no signers specified in Config data
         if config_keyed_account.signer_key().is_none() {
-            error!("account[0].signer_key().is_none()");
             return Err(InstructionError::MissingRequiredSignature);
         }
     }
@@ -54,16 +52,25 @@ pub fn process_instruction(
         if signer != config_keyed_account.unsigned_key() {
             let signer_account = keyed_accounts_iter.next();
             if signer_account.is_none() {
-                error!("account {:?} is not in account list", signer);
+                ic_msg!(
+                    invoke_context,
+                    "account {:?} is not in account list",
+                    signer
+                );
                 return Err(InstructionError::MissingRequiredSignature);
             }
             let signer_key = signer_account.unwrap().signer_key();
             if signer_key.is_none() {
-                error!("account {:?} signer_key().is_none()", signer);
+                ic_msg!(
+                    invoke_context,
+                    "account {:?} signer_key().is_none()",
+                    signer
+                );
                 return Err(InstructionError::MissingRequiredSignature);
             }
             if signer_key.unwrap() != signer {
-                error!(
+                ic_msg!(
+                    invoke_context,
                     "account[{:?}].signer_key() does not match Config data)",
                     counter + 1
                 );
@@ -76,18 +83,23 @@ pub fn process_instruction(
                     .find(|&pubkey| pubkey == signer)
                     .is_none()
             {
-                error!("account {:?} is not in stored signer list", signer);
+                ic_msg!(
+                    invoke_context,
+                    "account {:?} is not in stored signer list",
+                    signer
+                );
                 return Err(InstructionError::MissingRequiredSignature);
             }
         } else if config_keyed_account.signer_key().is_none() {
-            error!("account[0].signer_key().is_none()");
+            ic_msg!(invoke_context, "account[0].signer_key().is_none()");
             return Err(InstructionError::MissingRequiredSignature);
         }
     }
 
     // Check for Config data signers not present in incoming account update
     if current_signer_keys.len() > counter {
-        error!(
+        ic_msg!(
+            invoke_context,
             "too few signers: {:?}; expected: {:?}",
             counter,
             current_signer_keys.len()
@@ -96,7 +108,7 @@ pub fn process_instruction(
     }
 
     if config_keyed_account.data_len()? < data.len() {
-        error!("instruction data too large");
+        ic_msg!(invoke_context, "instruction data too large");
         return Err(InstructionError::InvalidInstructionData);
     }
 


### PR DESCRIPTION
Config program uses `error!()` logging, which is:
1. Quite yelly
2. Something that node operators don't care about

Switch logging to `ic_msg()`, which associates the log messages with the transaction that contained the config instruction instead.