### PR TITLE
fix: createAccountWithSeed account handling

### DIFF
--- a/web3.js/src/system-program.js
+++ b/web3.js/src/system-program.js
@@ -745,12 +745,16 @@ export class SystemProgram {
       space: params.space,
       programId: params.programId.toBuffer(),
     });
+    let keys = [
+      {pubkey: params.fromPubkey, isSigner: true, isWritable: true},
+      {pubkey: params.newAccountPubkey, isSigner: false, isWritable: true},
+    ];
+    if (params.basePubkey != params.fromPubkey) {
+      keys.push({pubkey: params.basePubkey, isSigner: true, isWritable: false});
+    }
 
     return new TransactionInstruction({
-      keys: [
-        {pubkey: params.fromPubkey, isSigner: true, isWritable: true},
-        {pubkey: params.newAccountPubkey, isSigner: false, isWritable: true},
-      ],
+      keys,
       programId: this.programId,
       data,
     });

--- a/web3.js/test/system-program.test.js
+++ b/web3.js/test/system-program.test.js
@@ -475,6 +475,42 @@ describe('SystemProgram', () => {
       );
       expect(createAccountWithSeedBalance).to.eq(minimumAmount);
 
+      // Test CreateAccountWithSeed where fromPubkey != basePubkey
+      const uniqueFromAccount = new Account();
+      const newBaseAccount = new Account();
+      const createAccountWithSeedAddress2 = await PublicKey.createWithSeed(
+        newBaseAccount.publicKey,
+        seed,
+        programId,
+      );
+      await helpers.airdrop({
+        connection,
+        address: uniqueFromAccount.publicKey,
+        amount: 2 * LAMPORTS_PER_SOL,
+      });
+      const createAccountWithSeedParams2 = {
+        fromPubkey: uniqueFromAccount.publicKey,
+        newAccountPubkey: createAccountWithSeedAddress2,
+        basePubkey: newBaseAccount.publicKey,
+        seed,
+        lamports: minimumAmount,
+        space,
+        programId,
+      };
+      const createAccountWithSeedTransaction2 = new Transaction().add(
+        SystemProgram.createAccountWithSeed(createAccountWithSeedParams2),
+      );
+      await sendAndConfirmTransaction(
+        connection,
+        createAccountWithSeedTransaction2,
+        [uniqueFromAccount, newBaseAccount],
+        {preflightCommitment: 'confirmed'},
+      );
+      const createAccountWithSeedBalance2 = await connection.getBalance(
+        createAccountWithSeedAddress2,
+      );
+      expect(createAccountWithSeedBalance2).to.eq(minimumAmount);
+
       // Transfer to a derived address to prep for TransferWithSeed
       const programId2 = new Account().publicKey;
       const transferWithSeedAddress = await PublicKey.createWithSeed(


### PR DESCRIPTION
#### Problem
The system-program `createAccountWithSeed` method passes 2 account addresses, regardless of whether the from and base pubkeys are equivalent. If they are not, transactions always fail:
`Error: failed to send transaction: Transaction simulation failed: Error processing Instruction 0: missing required signature for instruction`

#### Summary of Changes
Add optional third account when from and base pubkeys are different

Fixes #15477
