### PR TITLE
Count if optimistically confirmed slot is already rooted

### DIFF
--- a/core/src/optimistically_confirmed_bank_tracker.rs
+++ b/core/src/optimistically_confirmed_bank_tracker.rs
@@ -127,6 +127,8 @@ impl OptimisticallyConfirmedBankTracker {
                     drop(w_optimistically_confirmed_bank);
                 } else if slot > bank_forks.read().unwrap().root_bank().slot() {
                     pending_optimistically_confirmed_banks.insert(slot);
+                } else {
+                    inc_new_counter_info!("dropped-already-rooted-optimistic-bank-notification", 1);
                 }
             }
             BankNotification::Frozen(bank) => {


### PR DESCRIPTION
#### Problem
The optimistically-confirmed-bank-tracker assumes that an slot for which it's receiving a `BankNotification::OptimisticallyConfirmed` is not yet rooted, but we aren't certain that's true.

#### Summary of Changes
Add a counter to track how frequently slots are rooted (and removed from BankForks) before `BankNotification::OptimisticallyConfirmed` is received.
