### PR TITLE
Implement OutputFormat for block in Cli and ledger-tool bigtable

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -294,6 +294,30 @@ pub fn println_transaction(
     }
 }
 
+pub fn writeln_transaction(
+    f: &mut dyn fmt::Write,
+    transaction: &Transaction,
+    transaction_status: &Option<UiTransactionStatusMeta>,
+    prefix: &str,
+    sigverify_status: Option<&[CliSignatureVerificationStatus]>,
+) -> fmt::Result {
+    let mut w = Vec::new();
+    if write_transaction(
+        &mut w,
+        transaction,
+        transaction_status,
+        prefix,
+        sigverify_status,
+    )
+    .is_ok()
+    {
+        if let Ok(s) = String::from_utf8(w) {
+            write!(f, "{}", s)?;
+        }
+    }
+    Ok(())
+}
+
 /// Creates a new process bar for processing that will take an unknown amount of time
 pub fn new_spinner_progress_bar() -> ProgressBar {
     let progress_bar = ProgressBar::new(42);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -843,6 +843,15 @@ fn main() {
                 .global(true)
                 .help("Use DIR for ledger location"),
         )
+        .arg(
+            Arg::with_name("output_format")
+                .long("output")
+                .value_name("FORMAT")
+                .global(true)
+                .takes_value(true)
+                .possible_values(&["json", "json-compact"])
+                .help("Return information in specified output format, currently only available for bigtable subcommands"),
+        )
         .bigtable_subcommand()
         .subcommand(
             SubCommand::with_name("print")


### PR DESCRIPTION
#### Problem
Not all cli commands have been updated to produce properly formatted output.
Also, consumers of `solana-ledger-tool bigtable block` would like to access the same json output as rpc/cli

#### Summary of Changes
- Implement OutputFormat for solana block
- Use in `solana-ledger-tool bigtable block`

Toward https://github.com/solana-labs/solana/issues/14509
