### PR TITLE
Implement OutputFormat for confirm in Cli and ledger-tool bigtable

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1834,6 +1834,7 @@ impl fmt::Display for CliBlock {
                 &transaction_with_meta.meta,
                 "  ",
                 None,
+                None,
             )?;
         }
         Ok(())
@@ -1845,6 +1846,7 @@ impl fmt::Display for CliBlock {
 pub struct CliTransaction {
     pub transaction: EncodedTransaction,
     pub meta: Option<UiTransactionStatusMeta>,
+    pub block_time: Option<UnixTimestamp>,
     #[serde(skip_serializing)]
     pub decoded_transaction: Transaction,
     #[serde(skip_serializing)]
@@ -1868,6 +1870,7 @@ impl fmt::Display for CliTransaction {
             } else {
                 None
             },
+            self.block_time,
         )
     }
 }

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -1,6 +1,6 @@
 use {
     crate::cli_output::CliSignatureVerificationStatus,
-    chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc},
+    chrono::{DateTime, Local, NaiveDateTime, SecondsFormat, TimeZone, Utc},
     console::style,
     indicatif::{ProgressBar, ProgressStyle},
     solana_sdk::{
@@ -131,8 +131,17 @@ pub fn write_transaction<W: io::Write>(
     transaction_status: &Option<UiTransactionStatusMeta>,
     prefix: &str,
     sigverify_status: Option<&[CliSignatureVerificationStatus]>,
+    block_time: Option<UnixTimestamp>,
 ) -> io::Result<()> {
     let message = &transaction.message;
+    if let Some(block_time) = block_time {
+        writeln!(
+            w,
+            "{}Block Time: {:?}",
+            prefix,
+            Local.timestamp(block_time, 0)
+        )?;
+    }
     writeln!(
         w,
         "{}Recent Blockhash: {:?}",
@@ -277,6 +286,7 @@ pub fn println_transaction(
     transaction_status: &Option<UiTransactionStatusMeta>,
     prefix: &str,
     sigverify_status: Option<&[CliSignatureVerificationStatus]>,
+    block_time: Option<UnixTimestamp>,
 ) {
     let mut w = Vec::new();
     if write_transaction(
@@ -285,6 +295,7 @@ pub fn println_transaction(
         transaction_status,
         prefix,
         sigverify_status,
+        block_time,
     )
     .is_ok()
     {
@@ -300,6 +311,7 @@ pub fn writeln_transaction(
     transaction_status: &Option<UiTransactionStatusMeta>,
     prefix: &str,
     sigverify_status: Option<&[CliSignatureVerificationStatus]>,
+    block_time: Option<UnixTimestamp>,
 ) -> fmt::Result {
     let mut w = Vec::new();
     if write_transaction(
@@ -308,6 +320,7 @@ pub fn writeln_transaction(
         transaction_status,
         prefix,
         sigverify_status,
+        block_time,
     )
     .is_ok()
     {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1025,6 +1025,7 @@ fn process_confirm(
                                 &confirmed_transaction.transaction.meta,
                                 "  ",
                                 None,
+                                confirmed_transaction.block_time,
                             );
                         }
                         Err(err) => {
@@ -1062,6 +1063,7 @@ fn process_decode_transaction(config: &CliConfig, transaction: &Transaction) -> 
         decoded_transaction: transaction.clone(),
         transaction: EncodedTransaction::encode(transaction.clone(), UiTransactionEncoding::Json),
         meta: None,
+        block_time: None,
         prefix: "".to_string(),
         sigverify_status,
     };

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1785,6 +1785,7 @@ pub fn process_transaction_history(
                             &confirmed_transaction.transaction.meta,
                             "  ",
                             None,
+                            None,
                         );
                     }
                     Err(err) => println!("  Unable to get confirmed transaction details: {}", err),

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -4,10 +4,13 @@ use solana_clap_utils::{
     input_parsers::pubkey_of,
     input_validators::{is_slot, is_valid_pubkey},
 };
-use solana_cli_output::{display::println_transaction, CliBlock, OutputFormat};
+use solana_cli_output::{
+    display::println_transaction, CliBlock, CliTransaction, CliTransactionConfirmation,
+    OutputFormat,
+};
 use solana_ledger::{blockstore::Blockstore, blockstore_db::AccessType};
 use solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature};
-use solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding};
+use solana_transaction_status::{ConfirmedBlock, EncodedTransaction, UiTransactionEncoding};
 use std::{
     path::Path,
     process::exit,
@@ -75,38 +78,48 @@ async fn blocks(starting_slot: Slot, limit: usize) -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-async fn confirm(signature: &Signature, verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
+async fn confirm(
+    signature: &Signature,
+    verbose: bool,
+    output_format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
     let bigtable = solana_storage_bigtable::LedgerStorage::new(false, None)
         .await
         .map_err(|err| format!("Failed to connect to storage: {:?}", err))?;
 
     let transaction_status = bigtable.get_signature_status(signature).await?;
 
+    let mut transaction = None;
+    let mut get_transaction_error = None;
     if verbose {
         match bigtable.get_confirmed_transaction(signature).await {
             Ok(Some(confirmed_transaction)) => {
-                println!(
-                    "\nTransaction executed in slot {}:",
-                    confirmed_transaction.slot
-                );
-                println_transaction(
-                    &confirmed_transaction.transaction.transaction,
-                    &confirmed_transaction.transaction.meta.map(|m| m.into()),
-                    "  ",
-                    None,
-                    confirmed_transaction.block_time,
-                );
+                transaction = Some(CliTransaction {
+                    transaction: EncodedTransaction::encode(
+                        confirmed_transaction.transaction.transaction.clone(),
+                        UiTransactionEncoding::Json,
+                    ),
+                    meta: confirmed_transaction.transaction.meta.map(|m| m.into()),
+                    block_time: confirmed_transaction.block_time,
+                    slot: Some(confirmed_transaction.slot),
+                    decoded_transaction: confirmed_transaction.transaction.transaction,
+                    prefix: "  ".to_string(),
+                    sigverify_status: vec![],
+                });
             }
-            Ok(None) => println!("Finalized transaction details not available"),
-            Err(err) => println!("Unable to get finalized transaction details: {}", err),
+            Ok(None) => {}
+            Err(err) => {
+                get_transaction_error = Some(format!("{:?}", err));
+            }
         }
-        println!();
     }
-    if let Some(err) = &transaction_status.err {
-        println!("Transaction failed: {}", err);
-    } else {
-        println!("{:?}", transaction_status.confirmation_status());
-    }
+    let cli_transaction = CliTransactionConfirmation {
+        confirmation_status: Some(transaction_status.confirmation_status()),
+        transaction,
+        get_transaction_error,
+        err: transaction_status.err.clone(),
+    };
+    println!("{}", output_format.formatted_string(&cli_transaction));
     Ok(())
 }
 
@@ -303,13 +316,6 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .required(true)
                                 .index(1)
                                 .help("The transaction signature to confirm"),
-                        )
-                        .arg(
-                            Arg::with_name("verbose")
-                                .short("v")
-                                .long("verbose")
-                                .takes_value(false)
-                                .help("Show additional information"),
                         ),
                 )
                 .subcommand(
@@ -368,13 +374,6 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .long("show-transactions")
                                 .takes_value(false)
                                 .help("Display the full transactions"),
-                        )
-                        .arg(
-                            Arg::with_name("verbose")
-                                .short("v")
-                                .long("verbose")
-                                .takes_value(false)
-                                .help("Show additional information"),
                         ),
                 ),
         )
@@ -384,6 +383,7 @@ impl BigTableSubCommand for App<'_, '_> {
 pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
     let runtime = tokio::runtime::Runtime::new().unwrap();
 
+    let verbose = matches.is_present("verbose");
     let output_format = matches
         .value_of("output_format")
         .map(|value| match value {
@@ -391,7 +391,11 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             "json-compact" => OutputFormat::JsonCompact,
             _ => unreachable!(),
         })
-        .unwrap_or(OutputFormat::Display);
+        .unwrap_or(if verbose {
+            OutputFormat::DisplayVerbose
+        } else {
+            OutputFormat::Display
+        });
 
     let future = match matches.subcommand() {
         ("upload", Some(arg_matches)) => {
@@ -427,9 +431,8 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
                 .unwrap()
                 .parse()
                 .expect("Invalid signature");
-            let verbose = arg_matches.is_present("verbose");
 
-            runtime.block_on(confirm(&signature, verbose))
+            runtime.block_on(confirm(&signature, verbose, output_format))
         }
         ("transaction-history", Some(arg_matches)) => {
             let address = pubkey_of(arg_matches, "address").unwrap();
@@ -441,7 +444,6 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
             let until = arg_matches
                 .value_of("until")
                 .map(|signature| signature.parse().expect("Invalid signature"));
-            let verbose = arg_matches.is_present("verbose");
             let show_transactions = arg_matches.is_present("show_transactions");
 
             runtime.block_on(transaction_history(

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -94,6 +94,7 @@ async fn confirm(signature: &Signature, verbose: bool) -> Result<(), Box<dyn std
                     &confirmed_transaction.transaction.meta.map(|m| m.into()),
                     "  ",
                     None,
+                    confirmed_transaction.block_time,
                 );
             }
             Ok(None) => println!("Finalized transaction details not available"),
@@ -173,6 +174,7 @@ pub async fn transaction_history(
                                         &transaction_with_meta.transaction,
                                         &transaction_with_meta.meta.clone().map(|m| m.into()),
                                         "  ",
+                                        None,
                                         None,
                                     );
                                 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -853,6 +853,15 @@ fn main() {
                 .possible_values(&["json", "json-compact"])
                 .help("Return information in specified output format, currently only available for bigtable subcommands"),
         )
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .long("verbose")
+                .global(true)
+                .multiple(true)
+                .takes_value(false)
+                .help("Show additional information where supported"),
+        )
         .bigtable_subcommand()
         .subcommand(
             SubCommand::with_name("print")
@@ -873,14 +882,6 @@ fn main() {
                     .long("only-rooted")
                     .takes_value(false)
                     .help("Only print root slots"),
-            )
-            .arg(
-                Arg::with_name("verbose")
-                    .long("verbose")
-                    .short("v")
-                    .multiple(true)
-                    .takes_value(false)
-                    .help("How verbose to print the ledger contents."),
             )
         )
         .subcommand(
@@ -1350,7 +1351,7 @@ fn main() {
             let num_slots = value_t!(arg_matches, "num_slots", Slot).ok();
             let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
             let only_rooted = arg_matches.is_present("only_rooted");
-            let verbose = arg_matches.occurrences_of("verbose");
+            let verbose = matches.occurrences_of("verbose");
             output_ledger(
                 open_blockstore(
                     &ledger_path,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -123,6 +123,7 @@ fn output_entry(
                     &transaction_status,
                     "      ",
                     None,
+                    None,
                 );
             }
         }

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -387,7 +387,7 @@ fn print_confirmed_tx(name: &str, confirmed_tx: ConfirmedTransaction) {
     let tx = confirmed_tx.transaction.transaction.clone();
     let encoded = confirmed_tx.encode(UiTransactionEncoding::JsonParsed);
     println!("EXECUTE {} (slot {})", name, encoded.slot);
-    println_transaction(&tx, &encoded.transaction.meta, "  ", None);
+    println_transaction(&tx, &encoded.transaction.meta, "  ", None, confirmed_tx.block_time);
 }
 
 #[test]

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -384,10 +384,11 @@ fn execute_transactions(bank: &Bank, txs: &[Transaction]) -> Vec<ConfirmedTransa
 }
 
 fn print_confirmed_tx(name: &str, confirmed_tx: ConfirmedTransaction) {
+    let block_time = confirmed_tx.block_time;
     let tx = confirmed_tx.transaction.transaction.clone();
     let encoded = confirmed_tx.encode(UiTransactionEncoding::JsonParsed);
     println!("EXECUTE {} (slot {})", name, encoded.slot);
-    println_transaction(&tx, &encoded.transaction.meta, "  ", None, confirmed_tx.block_time);
+    println_transaction(&tx, &encoded.transaction.meta, "  ", None, block_time);
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
Not all cli commands have been updated to produce properly formatted output.
Also, consumers of solana-ledger-tool bigtable confirm should be consistent wrt json output

#### Summary of Changes
- Implement OutputFormat for solana confirm and solana decode-transaction
- Use in solana-ledger-tool bigtable confirm

`transaction-history` still needs handling for both cli and ledger-tool bigtable, but will save for a separate PR

Toward #14509
