### PR TITLE
Fix root scan in ledger tool

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1274,13 +1274,20 @@ fn main() {
         )
         .subcommand(
             SubCommand::with_name("list-roots")
-            .about("Output upto last <num-roots> root hashes and their heights starting at the given block height")
+            .about("Output up to last <num-roots> root hashes and their heights starting at the given block height")
             .arg(
                 Arg::with_name("max_height")
                     .long("max-height")
                     .value_name("NUM")
                     .takes_value(true)
                     .help("Maximum block height")
+            )
+            .arg(
+                Arg::with_name("start_root")
+                    .long("start-root")
+                    .value_name("NUM")
+                    .takes_value(true)
+                    .help("First root to start searching from")
             )
             .arg(
                 Arg::with_name("slot_list")
@@ -2687,6 +2694,11 @@ fn main() {
             } else {
                 usize::MAX
             };
+            let start_root = if let Some(height) = arg_matches.value_of("start_root") {
+                Slot::from_str(height).expect("Starting root must be a number")
+            } else {
+                0
+            };
             let num_roots = if let Some(roots) = arg_matches.value_of("num_roots") {
                 usize::from_str(roots).expect("Number of roots must be a number")
             } else {
@@ -2694,7 +2706,7 @@ fn main() {
             };
 
             let iter = blockstore
-                .rooted_slot_iterator(0)
+                .rooted_slot_iterator(start_root)
                 .expect("Failed to get rooted slot");
 
             let mut slot_hash = Vec::new();


### PR DESCRIPTION
#### Problem
Ledger tool root search starts at slot 0 which will panic for any ledgers that don't contain slot 0

#### Summary of Changes
Pass a starting slot
Fixes #
