### PR TITLE
Revert "v1.5: Make UiTokenAmount::ui_amount a String (#15447)"

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -24,7 +24,6 @@ use {
 };
 
 pub type StringAmount = String;
-pub type StringDecimals = String;
 
 /// A duplicate representation of an Account for pretty JSON serialization
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/account-decoder/src/parse_token.rs
+++ b/account-decoder/src/parse_token.rs
@@ -1,6 +1,6 @@
 use crate::{
     parse_account_data::{ParsableAccount, ParseAccountError},
-    StringAmount, StringDecimals,
+    StringAmount,
 };
 use solana_sdk::pubkey::Pubkey;
 use spl_token_v2_0::{
@@ -158,37 +158,44 @@ impl From<AccountState> for UiAccountState {
     }
 }
 
-pub fn real_number_string(amount: u64, decimals: u8) -> StringDecimals {
-    let decimals = decimals as usize;
-    if decimals > 0 {
-        // Left-pad zeros to decimals + 1, so we at least have an integer zero
-        let mut s = format!("{:01$}", amount, decimals + 1);
-        // Add the decimal point (Sorry, "," locales!)
-        s.insert(s.len() - decimals, '.');
-        s
-    } else {
-        amount.to_string()
-    }
-}
-
-pub fn real_number_string_trimmed(amount: u64, decimals: u8) -> StringDecimals {
-    let s = real_number_string(amount, decimals);
-    let zeros_trimmed = s.trim_end_matches('0');
-    let decimal_trimmed = zeros_trimmed.trim_end_matches('.');
-    decimal_trimmed.to_string()
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UiTokenAmount {
-    pub ui_amount: StringDecimals,
+    pub ui_amount: f64,
     pub decimals: u8,
     pub amount: StringAmount,
 }
 
+impl UiTokenAmount {
+    pub fn real_number_string(&self) -> String {
+        let decimals = self.decimals as usize;
+        if decimals > 0 {
+            let amount = u64::from_str(&self.amount).unwrap_or(0);
+
+            // Left-pad zeros to decimals + 1, so we at least have an integer zero
+            let mut s = format!("{:01$}", amount, decimals + 1);
+
+            // Add the decimal point (Sorry, "," locales!)
+            s.insert(s.len() - decimals, '.');
+            s
+        } else {
+            self.amount.clone()
+        }
+    }
+
+    pub fn real_number_string_trimmed(&self) -> String {
+        let s = self.real_number_string();
+        let zeros_trimmed = s.trim_end_matches('0');
+        let decimal_trimmed = zeros_trimmed.trim_end_matches('.');
+        decimal_trimmed.to_string()
+    }
+}
+
 pub fn token_amount_to_ui_amount(amount: u64, decimals: u8) -> UiTokenAmount {
+    // Use `amount_to_ui_amount()` once spl_token is bumped to a version that supports it: https://github.com/solana-labs/solana-program-library/pull/211
+    let amount_decimals = amount as f64 / 10_usize.pow(decimals as u32) as f64;
     UiTokenAmount {
-        ui_amount: real_number_string_trimmed(amount, decimals),
+        ui_amount: amount_decimals,
         decimals,
         amount: amount.to_string(),
     }
@@ -246,7 +253,7 @@ mod test {
                 mint: mint_pubkey.to_string(),
                 owner: owner_pubkey.to_string(),
                 token_amount: UiTokenAmount {
-                    ui_amount: "0.42".to_string(),
+                    ui_amount: 0.42,
                     decimals: 2,
                     amount: "42".to_string()
                 },
@@ -329,40 +336,17 @@ mod test {
 
     #[test]
     fn test_ui_token_amount_real_string() {
-        assert_eq!(&real_number_string(1, 0), "1");
-        assert_eq!(&real_number_string_trimmed(1, 0), "1");
         let token_amount = token_amount_to_ui_amount(1, 0);
-        assert_eq!(token_amount.ui_amount, real_number_string_trimmed(1, 0));
-        assert_eq!(&real_number_string(1, 9), "0.000000001");
-        assert_eq!(&real_number_string_trimmed(1, 9), "0.000000001");
+        assert_eq!(&token_amount.real_number_string(), "1");
+        assert_eq!(&token_amount.real_number_string_trimmed(), "1");
         let token_amount = token_amount_to_ui_amount(1, 9);
-        assert_eq!(token_amount.ui_amount, real_number_string_trimmed(1, 9));
-        assert_eq!(&real_number_string(1_000_000_000, 9), "1.000000000");
-        assert_eq!(&real_number_string_trimmed(1_000_000_000, 9), "1");
+        assert_eq!(&token_amount.real_number_string(), "0.000000001");
+        assert_eq!(&token_amount.real_number_string_trimmed(), "0.000000001");
         let token_amount = token_amount_to_ui_amount(1_000_000_000, 9);
-        assert_eq!(
-            token_amount.ui_amount,
-            real_number_string_trimmed(1_000_000_000, 9)
-        );
-        assert_eq!(&real_number_string(1_234_567_890, 3), "1234567.890");
-        assert_eq!(&real_number_string_trimmed(1_234_567_890, 3), "1234567.89");
+        assert_eq!(&token_amount.real_number_string(), "1.000000000");
+        assert_eq!(&token_amount.real_number_string_trimmed(), "1");
         let token_amount = token_amount_to_ui_amount(1_234_567_890, 3);
-        assert_eq!(
-            token_amount.ui_amount,
-            real_number_string_trimmed(1_234_567_890, 3)
-        );
-        assert_eq!(
-            &real_number_string(1_234_567_890, 25),
-            "0.0000000000000001234567890"
-        );
-        assert_eq!(
-            &real_number_string_trimmed(1_234_567_890, 25),
-            "0.000000000000000123456789"
-        );
-        let token_amount = token_amount_to_ui_amount(1_234_567_890, 20);
-        assert_eq!(
-            token_amount.ui_amount,
-            real_number_string_trimmed(1_234_567_890, 20)
-        );
+        assert_eq!(&token_amount.real_number_string(), "1234567.890");
+        assert_eq!(&token_amount.real_number_string_trimmed(), "1234567.89");
     }
 }

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1442,7 +1442,11 @@ impl fmt::Display for CliTokenAccount {
         writeln!(f)?;
         writeln_name_value(f, "Address:", &self.address)?;
         let account = &self.token_account;
-        writeln_name_value(f, "Balance:", &account.token_amount.ui_amount)?;
+        writeln_name_value(
+            f,
+            "Balance:",
+            &account.token_amount.real_number_string_trimmed(),
+        )?;
         let mint = format!(
             "{}{}",
             account.mint,
@@ -1455,7 +1459,7 @@ impl fmt::Display for CliTokenAccount {
             writeln!(f, "Delegation:")?;
             writeln_name_value(f, "  Delegate:", delegate)?;
             let allowance = account.delegated_amount.as_ref().unwrap();
-            writeln_name_value(f, "  Allowance:", &allowance.ui_amount)?;
+            writeln_name_value(f, "  Allowance:", &allowance.real_number_string_trimmed())?;
         }
         writeln_name_value(
             f,

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -5695,7 +5695,7 @@ pub mod tests {
         let balance: UiTokenAmount =
             serde_json::from_value(result["result"]["value"].clone()).unwrap();
         let error = f64::EPSILON;
-        assert!((f64::from_str(&balance.ui_amount).unwrap() - 4.2).abs() < error);
+        assert!((balance.ui_amount - 4.2).abs() < error);
         assert_eq!(balance.amount, 420.to_string());
         assert_eq!(balance.decimals, 2);
 
@@ -5720,7 +5720,7 @@ pub mod tests {
         let supply: UiTokenAmount =
             serde_json::from_value(result["result"]["value"].clone()).unwrap();
         let error = f64::EPSILON;
-        assert!((f64::from_str(&supply.ui_amount).unwrap() - 5.0).abs() < error);
+        assert!((supply.ui_amount - 5.0).abs() < error);
         assert_eq!(supply.amount, 500.to_string());
         assert_eq!(supply.decimals, 2);
 
@@ -6018,7 +6018,7 @@ pub mod tests {
                 RpcTokenAccountBalance {
                     address: token_with_different_mint_pubkey.to_string(),
                     amount: UiTokenAmount {
-                        ui_amount: "0.42".to_string(),
+                        ui_amount: 0.42,
                         decimals: 2,
                         amount: "42".to_string(),
                     }
@@ -6026,7 +6026,7 @@ pub mod tests {
                 RpcTokenAccountBalance {
                     address: token_with_smaller_balance.to_string(),
                     amount: UiTokenAmount {
-                        ui_amount: "0.1".to_string(),
+                        ui_amount: 0.1,
                         decimals: 2,
                         amount: "10".to_string(),
                     }
@@ -6100,7 +6100,7 @@ pub mod tests {
                         "mint": mint.to_string(),
                         "owner": owner.to_string(),
                         "tokenAmount": {
-                            "uiAmount": "4.2".to_string(),
+                            "uiAmount": 4.2,
                             "decimals": 2,
                             "amount": "420",
                         },
@@ -6108,12 +6108,12 @@ pub mod tests {
                         "state": "initialized",
                         "isNative": true,
                         "rentExemptReserve": {
-                            "uiAmount": "0.1".to_string(),
+                            "uiAmount": 0.1,
                             "decimals": 2,
                             "amount": "10",
                         },
                         "delegatedAmount": {
-                            "uiAmount": "0.3".to_string(),
+                            "uiAmount": 0.3,
                             "decimals": 2,
                             "amount": "30",
                         },

--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -105,5 +105,5 @@ EOF
 
 
 _ example_helloworld
-# _ spl
+_ spl
 _ serum_dex

--- a/storage-proto/proto/solana.storage.confirmed_block.rs
+++ b/storage-proto/proto/solana.storage.confirmed_block.rs
@@ -104,8 +104,6 @@ pub struct UiTokenAmount {
     pub decimals: u32,
     #[prost(string, tag = "3")]
     pub amount: std::string::String,
-    #[prost(string, tag = "4")]
-    pub ui_amount_string: std::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Reward {

--- a/storage-proto/src/confirmed_block.proto
+++ b/storage-proto/src/confirmed_block.proto
@@ -70,7 +70,6 @@ message UiTokenAmount {
     double ui_amount = 1;
     uint32 decimals = 2;
     string amount = 3;
-    string ui_amount_string = 4;
 }
 
 enum RewardType {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -1,5 +1,5 @@
 use crate::StoredExtendedRewards;
-use solana_account_decoder::parse_token::{real_number_string_trimmed, UiTokenAmount};
+use solana_account_decoder::parse_token::UiTokenAmount;
 use solana_sdk::{
     hash::Hash,
     instruction::CompiledInstruction,
@@ -14,10 +14,7 @@ use solana_transaction_status::{
     ConfirmedBlock, InnerInstructions, Reward, RewardType, TransactionByAddrInfo,
     TransactionStatusMeta, TransactionTokenBalance, TransactionWithStatusMeta,
 };
-use std::{
-    convert::{TryFrom, TryInto},
-    str::FromStr,
-};
+use std::convert::{TryFrom, TryInto};
 
 pub mod generated {
     include!(concat!(
@@ -386,10 +383,9 @@ impl From<TransactionTokenBalance> for generated::TokenBalance {
             account_index: value.account_index as u32,
             mint: value.mint,
             ui_token_amount: Some(generated::UiTokenAmount {
+                ui_amount: value.ui_token_amount.ui_amount,
                 decimals: value.ui_token_amount.decimals as u32,
                 amount: value.ui_token_amount.amount,
-                ui_amount_string: value.ui_token_amount.ui_amount,
-                ..generated::UiTokenAmount::default()
             }),
         }
     }
@@ -402,14 +398,7 @@ impl From<generated::TokenBalance> for TransactionTokenBalance {
             account_index: value.account_index as u8,
             mint: value.mint,
             ui_token_amount: UiTokenAmount {
-                ui_amount: if !ui_token_amount.ui_amount_string.is_empty() {
-                    ui_token_amount.ui_amount_string
-                } else {
-                    real_number_string_trimmed(
-                        u64::from_str(&ui_token_amount.amount).unwrap_or(0),
-                        ui_token_amount.decimals as u8,
-                    )
-                },
+                ui_amount: ui_token_amount.ui_amount,
                 decimals: ui_token_amount.decimals as u8,
                 amount: ui_token_amount.amount,
             },

--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -4,8 +4,7 @@ use crate::{
 };
 use console::style;
 use solana_account_decoder::parse_token::{
-    pubkey_from_spl_token_v2_0, real_number_string, spl_token_v2_0_pubkey,
-    token_amount_to_ui_amount,
+    pubkey_from_spl_token_v2_0, spl_token_v2_0_pubkey, token_amount_to_ui_amount,
 };
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{instruction::Instruction, native_token::lamports_to_sol};
@@ -110,7 +109,7 @@ pub fn check_spl_token_balances(
     if fee_payer_balance < fees + account_creation_amount {
         return Err(Error::InsufficientFunds(
             vec![FundingSource::FeePayer].into(),
-            lamports_to_sol(fees + account_creation_amount).to_string(),
+            lamports_to_sol(fees + account_creation_amount),
         ));
     }
     let source_token_account = client
@@ -143,12 +142,20 @@ pub fn print_token_balances(
     let (actual, difference) = if let Ok(recipient_token) =
         SplTokenAccount::unpack(&recipient_account.data)
     {
-        let actual_ui_amount = real_number_string(recipient_token.amount, spl_token_args.decimals);
-        let delta_string =
-            real_number_string(recipient_token.amount - expected, spl_token_args.decimals);
+        let actual_ui_amount =
+            token_amount_to_ui_amount(recipient_token.amount, spl_token_args.decimals).ui_amount;
+        let expected_ui_amount =
+            token_amount_to_ui_amount(expected, spl_token_args.decimals).ui_amount;
         (
-            style(format!("{:>24}", actual_ui_amount)),
-            format!("{:>24}", delta_string),
+            style(format!(
+                "{:>24.1$}",
+                actual_ui_amount, spl_token_args.decimals as usize
+            )),
+            format!(
+                "{:>24.1$}",
+                actual_ui_amount - expected_ui_amount,
+                spl_token_args.decimals as usize
+            ),
         )
     } else {
         (
@@ -157,11 +164,12 @@ pub fn print_token_balances(
         )
     };
     println!(
-        "{:<44}  {:>24}  {:>24}  {:>24}",
+        "{:<44}  {:>24.4$}  {:>24}  {:>24}",
         allocation.recipient,
-        real_number_string(expected, spl_token_args.decimals),
+        token_amount_to_ui_amount(expected, spl_token_args.decimals).ui_amount,
         actual,
         difference,
+        spl_token_args.decimals as usize
     );
     Ok(())
 }

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -888,7 +888,7 @@ mod test {
                    "mint": keys[3].to_string(),
                    "authority": keys[0].to_string(),
                    "tokenAmount": {
-                       "uiAmount": "0.42",
+                       "uiAmount": 0.42,
                        "decimals": 2,
                        "amount": "42"
                    }
@@ -920,7 +920,7 @@ mod test {
                    "multisigAuthority": keys[5].to_string(),
                    "signers": keys[0..2].iter().map(|key| key.to_string()).collect::<Vec<String>>(),
                    "tokenAmount": {
-                       "uiAmount": "0.42",
+                       "uiAmount": 0.42,
                        "decimals": 2,
                        "amount": "42"
                    }
@@ -952,7 +952,7 @@ mod test {
                    "delegate": keys[3].to_string(),
                    "owner": keys[0].to_string(),
                    "tokenAmount": {
-                       "uiAmount": "0.42",
+                       "uiAmount": 0.42,
                        "decimals": 2,
                        "amount": "42"
                    }
@@ -984,7 +984,7 @@ mod test {
                     "multisigOwner": keys[5].to_string(),
                     "signers": keys[0..2].iter().map(|key| key.to_string()).collect::<Vec<String>>(),
                     "tokenAmount": {
-                        "uiAmount": "0.42",
+                        "uiAmount": 0.42,
                         "decimals": 2,
                         "amount": "42"
                     }
@@ -1014,7 +1014,7 @@ mod test {
                    "account": keys[2].to_string(),
                    "mintAuthority": keys[0].to_string(),
                    "tokenAmount": {
-                       "uiAmount": "0.42",
+                       "uiAmount": 0.42,
                        "decimals": 2,
                        "amount": "42"
                    }
@@ -1044,7 +1044,7 @@ mod test {
                    "mint": keys[2].to_string(),
                    "authority": keys[0].to_string(),
                    "tokenAmount": {
-                       "uiAmount": "0.42",
+                       "uiAmount": 0.42,
                        "decimals": 2,
                        "amount": "42"
                    }


### PR DESCRIPTION
Reverts solana-labs/solana#15472

This is causing issues across the board.. Maybe, we can't change rpc field's type, expecting at-once micrale over-night transition.. `\(o_o)/`:

- explorer
- `solana`
- `spl-token`
- web3.js (I haven't checked; I'm pretty sure this is affected as well).

x

- mainnet-beta
- testnet
- devnet