### PR TITLE
validator: Add wait-for-restart-window subcommand

### DIFF
--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -1,7 +1,10 @@
 use {
-    crate::{get_validator_rpc_addr, get_validator_start_time},
+    crate::{
+        get_validator_rpc_addr, get_validator_start_time, new_spinner_progress_bar,
+        println_name_value,
+    },
     console::style,
-    indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle},
+    indicatif::ProgressBar,
     solana_client::{
         client_error, rpc_client::RpcClient, rpc_request, rpc_response::RpcContactInfo,
     },
@@ -18,21 +21,6 @@ use {
         time::Duration,
     },
 };
-
-/// Creates a new process bar for processing that will take an unknown amount of time
-fn new_spinner_progress_bar() -> ProgressBar {
-    let progress_bar = ProgressBar::new(42);
-    progress_bar.set_draw_target(ProgressDrawTarget::stdout());
-    progress_bar
-        .set_style(ProgressStyle::default_spinner().template("{spinner:.green} {wide_msg}"));
-    progress_bar.enable_steady_tick(100);
-    progress_bar
-}
-
-/// Pretty print a "name value"
-fn println_name_value(name: &str, value: &str) {
-    println!("{} {}", style(name).bold(), value);
-}
 
 pub struct Dashboard {
     progress_bar: ProgressBar,
@@ -56,7 +44,6 @@ impl Dashboard {
 
         Ok(Self {
             progress_bar,
-            //ledger_path: ledger_path.clone().to_path_buf(),
             ledger_path: ledger_path.to_path_buf(),
         })
     }

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::integer_arithmetic)]
 pub use solana_core::test_validator;
 use {
+    console::style,
+    indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle},
     log::*,
     serde_derive::{Deserialize, Serialize},
     std::{
@@ -133,4 +135,19 @@ pub fn get_validator_rpc_addr(ledger_path: &Path) -> Result<Option<SocketAddr>, 
 
 pub fn get_validator_start_time(ledger_path: &Path) -> Result<SystemTime, io::Error> {
     get_validator_process_info(ledger_path).map(|process_info| process_info.1)
+}
+
+/// Creates a new process bar for processing that will take an unknown amount of time
+pub fn new_spinner_progress_bar() -> ProgressBar {
+    let progress_bar = ProgressBar::new(42);
+    progress_bar.set_draw_target(ProgressDrawTarget::stdout());
+    progress_bar
+        .set_style(ProgressStyle::default_spinner().template("{spinner:.green} {wide_msg}"));
+    progress_bar.enable_steady_tick(100);
+    progress_bar
+}
+
+/// Pretty print a "name value"
+pub fn println_name_value(name: &str, value: &str) {
+    println!("{} {}", style(name).bold(), value);
 }


### PR DESCRIPTION
The `wait-for-restart-window` subcommand will connect locally to your validator over RPC, and when the node is
1. healthy,
2. in a time window when it won't be leader (default is 10 minutes, can be specified on the command-line),
3. produced a new snapshot, and 
4. there's no more than 5% cluster delinquency 
 
the command will exit with 0 and you can restart your validator using whatever method is preferred.

----
```
$ solana-validator wait-for-restart-window --help
solana-validator-wait-for-restart-window 
Monitor the validator for a good time to restart

USAGE:
    solana-validator --ledger <DIR> wait-for-restart-window [min_idle_time_in_minutes]

FLAGS:
    -h, --help    Prints help information

ARGS:
    <min_idle_time_in_minutes>    Minimum time that the validator should not be leader [default: 10]

Note: If this command exits with a non-zero status then this is not a good time for a restart