### PR TITLE
Stop removing bonus stake from neutral nodes

### DIFF
--- a/stake-o-matic/src/main.rs
+++ b/stake-o-matic/src/main.rs
@@ -1029,7 +1029,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         ),
                     ));
                     }
-                } else {
+                } else if poor_block_producers.contains(&node_pubkey) {
                     // Deactivate bonus stake
                     delegate_stake_transactions.push((
                     Transaction::new_unsigned(


### PR DESCRIPTION
#### Problem
Bonus stake being removed from neutral nodes.

#### Summary of Changes
Only remove bonus stake from real poor block producers.

Fixes #
Injustice in the world :)


My initial text:

This PR is a proposal to not remove stake from nodes that couldn't get any slot because their stake was too small.

This happened in testnet with at least 2 pubkeys:
ED3Y3cuH3wtHXT8TmbDE5toHU6kwQzevWtvkP6rGFNgc
5dB4Ygb8Sf3Sssdxxrpbb4NFX9bMrYnieiz11Vr5xJkJ

They were good producers in epoch 162 and in #tds-stake they were given 50k bonus stake.

But epoch 163 was a special one, nodes with a few stake (less than 1k) had a zero slot schedule, including good ones considered in epoch 162.

Check lines 479 to 485. If a node didn't get a slot, the node is not considered a quality neither a poor producer, which is correct.

But removing its bonus stake in the line 1032 to 1050 is not correct IMHO...

We should consider someone good until they prove they are bad right? And if you don't give a single slot (chance) for them to prove there's no reason to say they were bad....

Thanks and I'm happy to discuss this more...