### PR TITLE
fix: explorer vote card has incorrect timestamp conversion

### DIFF
--- a/explorer/src/components/instruction/vote/VoteDetailsCard.tsx
+++ b/explorer/src/components/instruction/vote/VoteDetailsCard.tsx
@@ -72,7 +72,7 @@ export function VoteDetailsCard(props: {
       <tr>
         <td>Timestamp</td>
         <td className="text-lg-right text-monospace">
-          {displayTimestampUtc(info.vote.timestamp)}
+          {displayTimestampUtc(info.vote.timestamp * 1000)}
         </td>
       </tr>
 


### PR DESCRIPTION
#### Problem
Vote instruction card needs millisecond timestamp here.

#### Summary of Changes
Multiply by 1000. 

