### PR TITLE
CLI: Support querying FeeCalculator for a specific blockhash

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1457,17 +1457,17 @@ impl fmt::Display for CliSupply {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CliFees {
+pub struct CliFeesInner {
     pub slot: Slot,
     pub blockhash: String,
     pub lamports_per_signature: u64,
-    pub last_valid_slot: Slot,
+    pub last_valid_slot: Option<Slot>,
 }
 
-impl QuietDisplay for CliFees {}
-impl VerboseDisplay for CliFees {}
+impl QuietDisplay for CliFeesInner {}
+impl VerboseDisplay for CliFeesInner {}
 
-impl fmt::Display for CliFees {
+impl fmt::Display for CliFeesInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln_name_value(f, "Blockhash:", &self.blockhash)?;
         writeln_name_value(
@@ -1477,6 +1477,46 @@ impl fmt::Display for CliFees {
         )?;
         writeln_name_value(f, "Last valid slot:", &self.last_valid_slot.to_string())?;
         Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliFees {
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub inner: Option<CliFeesInner>,
+}
+
+impl QuietDisplay for CliFees {}
+impl VerboseDisplay for CliFees {}
+
+impl fmt::Display for CliFees {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.inner.as_ref() {
+            Some(inner) => write!(f, "{}", inner),
+            None => write!(f, "Fees unavailable"),
+        }
+    }
+}
+
+impl CliFees {
+    pub fn some(
+        slot: Slot,
+        blockhash: Hash,
+        lamports_per_signature: u64,
+        last_valid_slot: Option<Slot>,
+    ) -> Self {
+        Self {
+            inner: Some(CliFeesInner {
+                slot,
+                blockhash: blockhash.to_string(),
+                lamports_per_signature,
+                last_valid_slot,
+            }),
+        }
+    }
+    pub fn none() -> Self {
+        Self { inner: None }
     }
 }
 

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1475,8 +1475,11 @@ impl fmt::Display for CliFeesInner {
             "Lamports per signature:",
             &self.lamports_per_signature.to_string(),
         )?;
-        writeln_name_value(f, "Last valid slot:", &self.last_valid_slot.to_string())?;
-        Ok(())
+        let last_valid_slot = self
+            .last_valid_slot
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        writeln_name_value(f, "Last valid slot:", &last_valid_slot)
     }
 }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -90,7 +90,9 @@ pub enum CliCommand {
     },
     Feature(FeatureCliCommand),
     Inflation(InflationCliCommand),
-    Fees,
+    Fees {
+        blockhash: Option<Hash>,
+    },
     FirstAvailableBlock,
     GetBlock {
         slot: Option<Slot>,
@@ -593,10 +595,13 @@ pub fn parse_command(
         ("feature", Some(matches)) => {
             parse_feature_subcommand(matches, default_signer, wallet_manager)
         }
-        ("fees", Some(_matches)) => Ok(CliCommandInfo {
-            command: CliCommand::Fees,
-            signers: vec![],
-        }),
+        ("fees", Some(matches)) => {
+            let blockhash = value_of::<Hash>(matches, "blockhash");
+            Ok(CliCommandInfo {
+                command: CliCommand::Fees { blockhash },
+                signers: vec![],
+            })
+        }
         ("first-available-block", Some(_matches)) => Ok(CliCommandInfo {
             command: CliCommand::FirstAvailableBlock,
             signers: vec![],
@@ -1263,7 +1268,7 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             seed,
             program_id,
         } => process_create_address_with_seed(config, from_pubkey.as_ref(), &seed, &program_id),
-        CliCommand::Fees => process_fees(&rpc_client, config),
+        CliCommand::Fees { ref blockhash } => process_fees(&rpc_client, config, blockhash.as_ref()),
         CliCommand::Feature(feature_subcommand) => {
             process_feature_subcommand(&rpc_client, config, feature_subcommand)
         }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -823,12 +823,12 @@ pub fn process_cluster_version(rpc_client: &RpcClient, config: &CliConfig) -> Pr
 pub fn process_fees(rpc_client: &RpcClient, config: &CliConfig) -> ProcessResult {
     let result = rpc_client.get_recent_blockhash_with_commitment(config.commitment)?;
     let (recent_blockhash, fee_calculator, last_valid_slot) = result.value;
-    let fees = CliFees {
-        slot: result.context.slot,
-        blockhash: recent_blockhash.to_string(),
-        lamports_per_signature: fee_calculator.lamports_per_signature,
+    let fees = CliFees::some(
+        result.context.slot,
+        recent_blockhash,
+        fee_calculator.lamports_per_signature,
         last_valid_slot,
-    };
+    );
     Ok(config.output_format.formatted_string(&fees))
 }
 


### PR DESCRIPTION
#### Problem

CLI has no means of querying the `FeeCalculator` for a specific blockhash.  While potentially not all that useful directly, this feature can be abused to test liveness of a target blockhash, which is helpful for implementing retry logic

#### Summary of Changes

Add `--blockhash BLOCKHASH` arg to `solana fees`

cc/ @ryoqun 

```
$ solana fees
Blockhash: A4UEr3EQDsQkboNe7LcaT3xPmKTgR9FcGcmyHc1nR5Fe
Lamports per signature: 5000
Last valid slot: 66866696
```
```
$ solana fees --output json
{
  "slot": 66866412,
  "blockhash": "8pWAAsovxkgQ6f5sNgaacwfTaCQxR5Jsaow1fwVLC5GS",
  "lamportsPerSignature": 5000,
  "lastValidSlot": 66866704
}
```
```
$ solana fees --output json --blockhash 8pWAAsovxkgQ6f5sNgaacwfTaCQxR5Jsaow1fwVLC5GS
{
  "slot": 66866424,
  "blockhash": "8pWAAsovxkgQ6f5sNgaacwfTaCQxR5Jsaow1fwVLC5GS",
  "lamportsPerSignature": 5000,
  "lastValidSlot": null
}
```
```
$ solana fees  --blockhash 8pWAAsovxkgQ6f5sNgaacwfTaCQxR5Jsaow1fwVLC5GS
Blockhash: 8pWAAsovxkgQ6f5sNgaacwfTaCQxR5Jsaow1fwVLC5GS
Lamports per signature: 5000
Last valid slot: (not set)
```
```
$ solana fees  --blockhash 8pWAAsovxkgQ6f5sNgaacwfTaCQxR5Jsaow1fwVLC5GS
Fees unavailable
```
```
$ solana fees --output json --blockhash 8pWAAsovxkgQ6f5sNgaacwfTaCQxR5Jsaow1fwVLC5GS
{}
```

context: #15123