### PR TITLE
feat: standardize timestamps throughout explorer

### DIFF
--- a/explorer/src/components/account/SysvarAccountSection.tsx
+++ b/explorer/src/components/account/SysvarAccountSection.tsx
@@ -311,7 +311,7 @@ function SysvarAccountClockCard({
 
         <tr>
           <td>Timestamp</td>
-          <td className="text-lg-right">
+          <td className="text-lg-right text-monospace">
             {displayTimestamp(sysvarAccount.info.unixTimestamp * 1000)}
           </td>
         </tr>

--- a/explorer/src/components/account/VoteAccountSection.tsx
+++ b/explorer/src/components/account/VoteAccountSection.tsx
@@ -65,7 +65,7 @@ export function VoteAccountSection({
 
         <tr>
           <td>Last Timestamp</td>
-          <td className="text-lg-right">
+          <td className="text-lg-right text-monospace">
             {displayTimestamp(voteAccount.info.lastTimestamp.timestamp * 1000)}
           </td>
         </tr>

--- a/explorer/src/components/instruction/stake/InitializeDetailsCard.tsx
+++ b/explorer/src/components/instruction/stake/InitializeDetailsCard.tsx
@@ -8,6 +8,7 @@ import {
 import { InstructionCard } from "../InstructionCard";
 import { Address } from "components/common/Address";
 import { InitializeInfo } from "./types";
+import { displayTimestampUtc } from "utils/date";
 
 export function InitializeDetailsCard(props: {
   ix: ParsedInstruction;
@@ -66,8 +67,8 @@ export function InitializeDetailsCard(props: {
       {info.lockup.unixTimestamp > 0 && (
         <tr>
           <td>Lockup Expiry Timestamp</td>
-          <td className="text-lg-right">
-            {new Date(info.lockup.unixTimestamp * 1000).toUTCString()}
+          <td className="text-lg-right text-monospace">
+            {displayTimestampUtc(info.lockup.unixTimestamp * 1000)}
           </td>
         </tr>
       )}

--- a/explorer/src/components/instruction/vote/VoteDetailsCard.tsx
+++ b/explorer/src/components/instruction/vote/VoteDetailsCard.tsx
@@ -5,7 +5,7 @@ import { ParsedInfo } from "validators";
 import { VoteInfo } from "./types";
 import { InstructionCard } from "../InstructionCard";
 import { Address } from "components/common/Address";
-import { displayTimestampUtc } from "utils/date";
+import { displayTimestamp } from "utils/date";
 
 export function VoteDetailsCard(props: {
   ix: ParsedInstruction;
@@ -72,7 +72,7 @@ export function VoteDetailsCard(props: {
       <tr>
         <td>Timestamp</td>
         <td className="text-lg-right text-monospace">
-          {displayTimestampUtc(info.vote.timestamp * 1000)}
+          {displayTimestamp(info.vote.timestamp * 1000)}
         </td>
       </tr>
 

--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -237,7 +237,9 @@ function StatusCard({
           <td>Timestamp</td>
           <td className="text-lg-right">
             {info.timestamp !== "unavailable" ? (
-              displayTimestamp(info.timestamp * 1000)
+              <span className="text-monospace">
+                {displayTimestamp(info.timestamp * 1000)}
+              </span>
             ) : (
               <InfoTooltip
                 bottom


### PR DESCRIPTION
 s#### Problem
Most places in Explorer should display local timestamps, with a few exceptions (cluster stats, stake section). For consistency, we should also display timestamps monospaced.

#### Summary of Changes
- local timestamps
- monospaced 

