### PR TITLE
coalesces vote packets into one Packets

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -397,7 +397,7 @@ impl ClusterInfoVoteListener {
                 if let Some(bank) = bank {
                     let last_version = bank.last_vote_sync.load(Ordering::Relaxed);
                     let (new_version, msgs) = verified_vote_packets.get_latest_votes(last_version);
-                    verified_packets_sender.send(msgs)?;
+                    verified_packets_sender.send(vec![msgs])?;
                     #[allow(deprecated)]
                     bank.last_vote_sync.compare_and_swap(
                         last_version,


### PR DESCRIPTION
#### Problem
banking-stage is iterating over individual vote packets:
https://github.com/solana-labs/solana/blob/d47f1fae4/core/src/banking_stage.rs#L1045-L1048
which breaks the windowing logic in vote-listener:
https://github.com/solana-labs/solana/blob/d47f1fae4/core/src/cluster_info_vote_listener.rs#L395-L409

#### Summary of Changes
coalesce vote packets into one Packets