### PR TITLE
Fix blockstore processor error severity

### DIFF
--- a/ledger/src/block_error.rs
+++ b/ledger/src/block_error.rs
@@ -2,7 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum BlockError {
-    /// Block did not have enough ticks or was not marked full
+    /// Block did not have enough ticks was not marked full
+    /// and no shred with is_last was seen.
     #[error("incomplete block")]
     Incomplete,
 
@@ -14,9 +15,16 @@ pub enum BlockError {
     #[error("invalid last tick")]
     InvalidLastTick,
 
-    /// Blocks can not have extra ticks or missing ticks
-    #[error("invalid tick count")]
-    InvalidTickCount,
+    /// Blocks can not have missing ticks
+    /// Usually indicates that the node was interruppted with a more valuable block during
+    /// production and abandoned it for that more-favorable block. Leader sent data to indicate
+    /// the end of the block.
+    #[error("too few ticks")]
+    TooFewTicks,
+
+    /// Blocks can not have extra ticks
+    #[error("too many ticks")]
+    TooManyTicks,
 
     /// All ticks must contain the same number of hashes within a block
     #[error("invalid tick hash count")]

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -543,12 +543,12 @@ pub fn verify_ticks(
 
     if next_bank_tick_height > max_bank_tick_height {
         warn!("Too many entry ticks found in slot: {}", bank.slot());
-        return Err(BlockError::InvalidTickCount);
+        return Err(BlockError::TooManyTicks);
     }
 
     if next_bank_tick_height < max_bank_tick_height && slot_full {
-        warn!("Too few entry ticks found in slot: {}", bank.slot());
-        return Err(BlockError::InvalidTickCount);
+        info!("Too few entry ticks found in slot: {}", bank.slot());
+        return Err(BlockError::TooFewTicks);
     }
 
     if next_bank_tick_height == max_bank_tick_height {


### PR DESCRIPTION
#### Problem

Blockstore processor error reporting logic in replay stage is inverted. Reporting InvalidTickCount as bad and others as not, when the reverse should be the case.

#### Summary of Changes

Fix the logic and split InvalidTickCount into two cases, too many ticks which is unexpected and too few ticks which is relatively expected.

Fixes #
