### PR TITLE
Skip poh speed test for local demo

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -106,6 +106,7 @@ args+=(
   --identity "$identity"
   --vote-account "$vote_account"
   --rpc-faucet-address 127.0.0.1:9900
+  --no-poh-speed-test
 )
 default_arg --gossip-port 8001
 default_arg --log -

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -8,6 +8,7 @@ source "$here"/common.sh
 
 args=(
   --max-genesis-archive-unpacked-size 1073741824
+  --no-poh-speed-test
 )
 airdrops_enabled=1
 node_sol=500 # 500 SOL: number of SOL to airdrop the node for transaction fees and vote account rent exemption (ignored if airdrops_enabled=0)


### PR DESCRIPTION
#### Problem

Poh speed test fails sometimes on n1 nodes in automation or multinode tests.

#### Summary of Changes

Disable it.

Fixes #
