### PR TITLE
fix: secp256k1 instruction should accept 64 byte public key

### DIFF
--- a/web3.js/test/secp256k1-program.test.js
+++ b/web3.js/test/secp256k1-program.test.js
@@ -27,7 +27,7 @@ if (process.env.TEST_LIVE) {
   describe('secp256k1', () => {
     it('create secp256k1 instruction with public key', async () => {
       const privateKey = randomPrivateKey();
-      const publicKey = publicKeyCreate(privateKey, false);
+      const publicKey = publicKeyCreate(privateKey, false).slice(1);
       const message = Buffer.from('This is a message');
       const messageHash = Buffer.from(
         keccak_256.update(toBuffer(message)).digest(),


### PR DESCRIPTION
#### Problem
web3 secp256k1 instruction api expects a 65 byte secp256k1 public key which is an implementation detail of how bitcoin keys are used (leading byte indicates compressed / uncompressed). Since our implementation is for verifying eth address signatures, we should use 64 byte public keys directly

#### Summary of Changes
- Use 64 byte public keys

Fixes https://github.com/solana-labs/solana-web3.js/issues/1012
