### PR TITLE
hotfix: explorer temporarily disable vote instruction card

### DIFF
--- a/explorer/src/components/instruction/vote/VoteDetailsCard.tsx
+++ b/explorer/src/components/instruction/vote/VoteDetailsCard.tsx
@@ -69,12 +69,14 @@ export function VoteDetailsCard(props: {
         </td>
       </tr>
 
-      <tr>
-        <td>Timestamp</td>
-        <td className="text-lg-right text-monospace">
-          {displayTimestamp(info.vote.timestamp * 1000)}
-        </td>
-      </tr>
+      {info.vote.timestamp && (
+        <tr>
+          <td>Timestamp</td>
+          <td className="text-lg-right text-monospace">
+            {displayTimestamp(info.vote.timestamp * 1000)}
+          </td>
+        </tr>
+      )}
 
       <tr>
         <td>Slots</td>

--- a/explorer/src/components/instruction/vote/types.ts
+++ b/explorer/src/components/instruction/vote/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 
-import { array, number, pick, string, StructType } from "superstruct";
+import { array, number, optional, pick, string, StructType } from "superstruct";
 import { Pubkey } from "validators/pubkey";
 
 export type VoteInfo = StructType<typeof VoteInfo>;
@@ -12,6 +12,6 @@ export const VoteInfo = pick({
   vote: pick({
     hash: string(),
     slots: array(number()),
-    timestamp: number(),
+    timestamp: optional(number()),
   }),
 });

--- a/explorer/src/components/transaction/InstructionsSection.tsx
+++ b/explorer/src/components/transaction/InstructionsSection.tsx
@@ -34,7 +34,7 @@ import {
   useTransactionStatus,
 } from "providers/transactions";
 import { Cluster, useCluster } from "providers/cluster";
-import { VoteDetailsCard } from "components/instruction/vote/VoteDetailsCard";
+// import { VoteDetailsCard } from "components/instruction/vote/VoteDetailsCard";
 import { UpgradeableBpfLoaderDetailsCard } from "components/instruction/upgradeable-bpf-loader/UpgradeableBpfLoaderDetailsCard";
 
 export function InstructionsSection({ signature }: SignatureProps) {
@@ -171,9 +171,8 @@ function renderInstructionCard({
         return <StakeDetailsCard {...props} />;
       case "spl-memo":
         return <MemoDetailsCard {...props} />;
-      case "vote":
-        console.log(props);
-        return <VoteDetailsCard {...props} />;
+      /*case "vote":
+        return <VoteDetailsCard {...props} />;*/
       default:
         return <UnknownDetailsCard {...props} />;
     }


### PR DESCRIPTION
#### Problem
Vote instruction card appears to be missing some instruction types. 

#### Summary of Changes
I'm disabling this card until the other instructions are in place. This is causing some validation issues.