### PR TITLE
CI: nits

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -43,6 +43,3 @@ cargo_audit_ignores=(
 
 )
 scripts/cargo-for-all-lock-files.sh +"$rust_stable" audit "${cargo_audit_ignores[@]}"
-
-cd "${src_root}/programs/bpf"
-"$cargo" stable audit

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+here="$(dirname "$0")"
+src_root="$(readlink -f "${here}/..")"
+
+cd "${src_root}"
+
+source ci/rust-version.sh stable
+
+cargo_audit_ignores=(
+  # failure is officially deprecated/unmaintained
+  #
+  # Blocked on multiple upstream crates removing their `failure` dependency.
+  --ignore RUSTSEC-2020-0036
+
+  # `net2` crate has been deprecated; use `socket2` instead
+  #
+  # Blocked on https://github.com/paritytech/jsonrpc/issues/575
+  --ignore RUSTSEC-2020-0016
+
+  # stdweb is unmaintained
+  #
+  # Blocked on multiple upstream crates removing their `stdweb` dependency.
+  --ignore RUSTSEC-2020-0056
+
+  # Potential segfault in the time crate
+  #
+  # Blocked on multiple crates updating `time` to >= 0.2.23
+  --ignore RUSTSEC-2020-0071
+
+  # difference is unmaintained
+  #
+  # Blocked on predicates v1.0.6 removing its dependency on `difference`
+  --ignore RUSTSEC-2020-0095
+
+  # generic-array: arr! macro erases lifetimes
+  #
+  # Blocked on libsecp256k1 releasing with upgraded dependencies
+  # https://github.com/paritytech/libsecp256k1/issues/66
+  --ignore RUSTSEC-2020-0146
+
+)
+scripts/cargo-for-all-lock-files.sh +"$rust_stable" audit "${cargo_audit_ignores[@]}"
+
+cd "${src_root}/programs/bpf"
+"$cargo" stable audit

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -59,44 +59,10 @@ _ "$cargo" nightly clippy -Zunstable-options --workspace --all-targets -- --deny
 
 _ "$cargo" stable fmt --all -- --check
 
-cargo_audit_ignores=(
-  # failure is officially deprecated/unmaintained
-  #
-  # Blocked on multiple upstream crates removing their `failure` dependency.
-  --ignore RUSTSEC-2020-0036
-
-  # `net2` crate has been deprecated; use `socket2` instead
-  #
-  # Blocked on https://github.com/paritytech/jsonrpc/issues/575
-  --ignore RUSTSEC-2020-0016
-
-  # stdweb is unmaintained
-  #
-  # Blocked on multiple upstream crates removing their `stdweb` dependency.
-  --ignore RUSTSEC-2020-0056
-
-  # Potential segfault in the time crate
-  #
-  # Blocked on multiple crates updating `time` to >= 0.2.23
-  --ignore RUSTSEC-2020-0071
-
-  # difference is unmaintained
-  #
-  # Blocked on predicates v1.0.6 removing its dependency on `difference`
-  --ignore RUSTSEC-2020-0095
-
-  # generic-array: arr! macro erases lifetimes
-  #
-  # Blocked on libsecp256k1 releasing with upgraded dependencies
-  # https://github.com/paritytech/libsecp256k1/issues/66
-  --ignore RUSTSEC-2020-0146
-
-)
-_ scripts/cargo-for-all-lock-files.sh +"$rust_stable" audit "${cargo_audit_ignores[@]}"
+_ ci/do-audit.sh
 
 {
   cd programs/bpf
-  _ "$cargo" stable audit "${cargo_audit_ignores[@]}"
   for project in rust/*/ ; do
     echo "+++ do_bpf_checks $project"
     (

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -12,6 +12,16 @@ cargo="$(readlink -f "./cargo")"
 
 scripts/increment-cargo-version.sh check
 
+# Disallow uncommitted Cargo.lock changes
+(
+  _ scripts/cargo-for-all-lock-files.sh tree
+  set +e
+  if ! _ git diff --exit-code; then
+    echo -e "\nError: Uncommitted Cargo.lock changes" 1>&2
+    exit 1
+  fi
+)
+
 echo --- build environment
 (
   set -x

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -52,11 +52,12 @@ else
 fi
 
 _ ci/order-crates-for-publishing.py
-_ "$cargo" stable fmt --all -- --check
 
 # -Z... is needed because of clippy bug: https://github.com/rust-lang/rust-clippy/issues/4612
 # run nightly clippy for `sdk/` as there's a moderate amount of nightly-only code there
 _ "$cargo" nightly clippy -Zunstable-options --workspace --all-targets -- --deny=warnings --deny=clippy::integer_arithmetic
+
+_ "$cargo" stable fmt --all -- --check
 
 cargo_audit_ignores=(
   # failure is officially deprecated/unmaintained
@@ -100,9 +101,9 @@ _ scripts/cargo-for-all-lock-files.sh +"$rust_stable" audit "${cargo_audit_ignor
     echo "+++ do_bpf_checks $project"
     (
       cd "$project"
+      _ "$cargo" nightly clippy -- --deny=warnings --allow=clippy::missing_safety_doc
       _ "$cargo" stable fmt -- --check
       _ "$cargo" nightly test
-      _ "$cargo" nightly clippy -- --deny=warnings --allow=clippy::missing_safety_doc
     )
   done
 }


### PR DESCRIPTION
#### Problem

1) `clippy` can make recommendations that re-break `fmt`, leading to ping-ponging
2) Can't run configured `audit` independently of the full test-checks suite
3) `Cargo.toml` changes can be committed without their corresponding `Cargo.lock` changes

#### Summary of Changes

1) Swap `fmt` and `clippy` run order
2) Factor out `audit` to its own script
3) Add check for uncommitted `Cargo.lock` changes (cc/ @leoluk)
