### PR TITLE
explorer: expand vote details card to cover all instructions

### DIFF
--- a/explorer/src/components/instruction/vote/types.ts
+++ b/explorer/src/components/instruction/vote/types.ts
@@ -3,6 +3,26 @@
 import { array, number, optional, pick, string, StructType } from "superstruct";
 import { Pubkey } from "validators/pubkey";
 
+export type InitializeInfo = StructType<typeof InitializeInfo>;
+export const InitializeInfo = pick({
+  voteAccount: Pubkey,
+  rentSysvar: Pubkey,
+  clockSysvar: Pubkey,
+  node: Pubkey,
+  authorizedVoter: Pubkey,
+  authorizedWithdrawer: Pubkey,
+  commission: number(),
+});
+
+export type AuthorizeInfo = StructType<typeof AuthorizeInfo>;
+export const AuthorizeInfo = pick({
+  voteAccount: Pubkey,
+  clockSysvar: Pubkey,
+  authority: Pubkey,
+  newAuthority: Pubkey,
+  authorityType: number(),
+});
+
 export type VoteInfo = StructType<typeof VoteInfo>;
 export const VoteInfo = pick({
   clockSysvar: Pubkey,
@@ -14,4 +34,40 @@ export const VoteInfo = pick({
     slots: array(number()),
     timestamp: optional(number()),
   }),
+});
+
+export type WithdrawInfo = StructType<typeof WithdrawInfo>;
+export const WithdrawInfo = pick({
+  voteAccount: Pubkey,
+  destination: Pubkey,
+  withdrawAuthority: Pubkey,
+  lamports: number(),
+});
+
+export type UpdateValidatorInfo = StructType<typeof UpdateValidatorInfo>;
+export const UpdateValidatorInfo = pick({
+  voteAccount: Pubkey,
+  newValidatorIdentity: Pubkey,
+  withdrawAuthority: Pubkey,
+});
+
+export type UpdateCommissionInfo = StructType<typeof UpdateCommissionInfo>;
+export const UpdateCommissionInfo = pick({
+  voteAccount: Pubkey,
+  withdrawAuthority: Pubkey,
+  commission: number(),
+});
+
+export type VoteSwitchInfo = StructType<typeof VoteSwitchInfo>;
+export const VoteSwitchInfo = pick({
+  voteAccount: Pubkey,
+  slotHashesSysvar: Pubkey,
+  clockSysvar: Pubkey,
+  voteAuthority: Pubkey,
+  vote: pick({
+    hash: string(),
+    slots: array(number()),
+    timestamp: number(),
+  }),
+  hash: string(),
 });

--- a/explorer/src/components/transaction/InstructionsSection.tsx
+++ b/explorer/src/components/transaction/InstructionsSection.tsx
@@ -34,8 +34,17 @@ import {
   useTransactionStatus,
 } from "providers/transactions";
 import { Cluster, useCluster } from "providers/cluster";
-// import { VoteDetailsCard } from "components/instruction/vote/VoteDetailsCard";
 import { UpgradeableBpfLoaderDetailsCard } from "components/instruction/upgradeable-bpf-loader/UpgradeableBpfLoaderDetailsCard";
+import { VoteDetailsCard } from "components/instruction/vote/VoteDetailsCard";
+
+export type InstructionDetailsProps = {
+  tx: ParsedTransaction;
+  ix: ParsedInstruction;
+  index: number;
+  result: SignatureResult;
+  innerCards?: JSX.Element[];
+  childIndex?: number;
+};
 
 export function InstructionsSection({ signature }: SignatureProps) {
   const status = useTransactionStatus(signature);
@@ -171,8 +180,8 @@ function renderInstructionCard({
         return <StakeDetailsCard {...props} />;
       case "spl-memo":
         return <MemoDetailsCard {...props} />;
-      /*case "vote":
-        return <VoteDetailsCard {...props} />;*/
+      case "vote":
+        return <VoteDetailsCard {...props} />;
       default:
         return <UnknownDetailsCard {...props} />;
     }


### PR DESCRIPTION
#### Problem
Previous VoteDetailsCard was only handling a certain vote instruction, but it needed to support all available instructions.

#### Summary of Changes
Add structs for other vote instructions and generate details card dynamically.

Fixes https://github.com/solana-labs/solana/issues/15569
