### PR TITLE
cli: don't overallocate upgradeable buffer accounts

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -718,7 +718,8 @@ fn process_program_deploy(
     } else {
         return Err("Program location required if buffer not supplied".into());
     };
-    let buffer_data_len = if let Some(len) = max_len {
+    let buffer_data_len = program_len;
+    let programdata_len = if let Some(len) = max_len {
         if program_len > len {
             return Err("Max length specified not large enough".into());
         }
@@ -738,6 +739,7 @@ fn process_program_deploy(
             config,
             &program_data,
             buffer_data_len,
+            programdata_len,
             minimum_balance,
             &bpf_loader_upgradeable::id(),
             Some(&[program_signer.unwrap(), upgrade_authority_signer]),
@@ -825,7 +827,7 @@ fn process_write_buffer(
     let buffer_data_len = if let Some(len) = max_len {
         len
     } else {
-        program_data.len() * 2
+        program_data.len()
     };
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(
         UpgradeableLoaderState::programdata_len(buffer_data_len)?,
@@ -835,6 +837,7 @@ fn process_write_buffer(
         rpc_client,
         config,
         &program_data,
+        program_data.len(),
         program_data.len(),
         minimum_balance,
         &bpf_loader_upgradeable::id(),
@@ -1082,6 +1085,7 @@ pub fn process_deploy(
         config,
         &program_data,
         program_data.len(),
+        program_data.len(),
         minimum_balance,
         &loader_id,
         Some(&[buffer_signer]),
@@ -1102,6 +1106,7 @@ fn do_process_program_write_and_deploy(
     config: &CliConfig,
     program_data: &[u8],
     buffer_data_len: usize,
+    programdata_len: usize,
     minimum_balance: u64,
     loader_id: &Pubkey,
     program_signers: Option<&[&dyn Signer]>,
@@ -1217,7 +1222,7 @@ fn do_process_program_write_and_deploy(
                     rpc_client.get_minimum_balance_for_rent_exemption(
                         UpgradeableLoaderState::program_len()?,
                     )?,
-                    buffer_data_len,
+                    programdata_len,
                 )?,
                 Some(&config.signers[0].pubkey()),
             )

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -571,7 +571,7 @@ fn test_cli_program_write_buffer() {
         .unwrap();
     let minimum_balance_for_buffer_default = rpc_client
         .get_minimum_balance_for_rent_exemption(
-            UpgradeableLoaderState::programdata_len(max_len * 2).unwrap(),
+            UpgradeableLoaderState::programdata_len(max_len).unwrap(),
         )
         .unwrap();
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -456,15 +456,14 @@ fn process_loader_upgradeable_instruction(
             programdata.try_account_ref_mut()?.data
                 [programdata_data_offset..programdata_data_offset + buffer_data_len]
                 .copy_from_slice(&buffer.try_account_ref()?.data[buffer_data_offset..]);
-            // Update the Program account
 
+            // Update the Program account
             program.set_state(&UpgradeableLoaderState::Program {
                 programdata_address: *programdata.unsigned_key(),
             })?;
             program.try_account_ref_mut()?.executable = true;
 
             // Drain the Buffer account back to the payer
-
             payer.try_account_ref_mut()?.lamports += buffer.lamports()?;
             buffer.try_account_ref_mut()?.lamports = 0;
 


### PR DESCRIPTION
#### Problem

Buffer account is over-allocated to allow for upgrade but it does not need to be.  A side effect of this is if the buffer account is created and written outside of the `deploy` command with the `write-buffer` command and then passed to `deploy` the cli was double over-allocating the final program account.

#### Summary of Changes

Don't over-allocate the buffer account

Fixes #15431
