### PR TITLE
explorer: remove old hotfix for web3 inner instructions

### DIFF
--- a/explorer/src/components/transaction/InstructionsSection.tsx
+++ b/explorer/src/components/transaction/InstructionsSection.tsx
@@ -178,23 +178,6 @@ function renderInstructionCard({
     }
   }
 
-  // TODO: There is a bug in web3, where inner instructions
-  // aren't getting coerced. This is a temporary fix.
-
-  if (typeof ix.programId === "string") {
-    ix.programId = new PublicKey(ix.programId);
-  }
-
-  ix.accounts = ix.accounts.map((account) => {
-    if (typeof account === "string") {
-      return new PublicKey(account);
-    }
-
-    return account;
-  });
-
-  // TODO: End hotfix
-
   const transactionIx = intoTransactionInstruction(tx, ix);
 
   if (!transactionIx) {


### PR DESCRIPTION
#### Problem
There existed an old hotfix to account for web3's lack of inner instruction coercion. This has since been remedied and this chunk of code can go.

#### Summary of Changes
Remove hotfix.
