### PR TITLE
Skip leader slots until a vote lands

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1455,6 +1455,8 @@ pub mod test {
                 None,
                 &mut self.heaviest_subtree_fork_choice,
                 &mut BTreeMap::new(),
+                &mut true,
+                &mut Vec::new(),
             )
         }
 

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -422,6 +422,7 @@ impl TestValidator {
             warp_slot: config.warp_slot,
             bpf_jit: !config.no_bpf_jit,
             validator_exit: config.validator_exit.clone(),
+            no_wait_for_vote_to_start_leader: true,
             ..ValidatorConfig::default()
         };
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -86,6 +86,7 @@ pub struct TvuConfig {
     pub use_index_hash_calculation: bool,
     pub rocksdb_compaction_interval: Option<u64>,
     pub rocksdb_max_compaction_jitter: Option<u64>,
+    pub wait_for_vote_to_start_leader: bool,
 }
 
 impl Tvu {
@@ -259,6 +260,7 @@ impl Tvu {
             rewards_recorder_sender,
             cache_block_time_sender,
             bank_notification_sender,
+            wait_for_vote_to_start_leader: tvu_config.wait_for_vote_to_start_leader,
         };
 
         let replay_stage = ReplayStage::new(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -130,6 +130,7 @@ pub struct ValidatorConfig {
     pub accounts_db_use_index_hash_calculation: bool,
     pub tpu_coalesce_ms: u64,
     pub validator_exit: Arc<RwLock<ValidatorExit>>,
+    pub no_wait_for_vote_to_start_leader: bool,
 }
 
 impl Default for ValidatorConfig {
@@ -184,6 +185,7 @@ impl Default for ValidatorConfig {
             accounts_db_use_index_hash_calculation: true,
             tpu_coalesce_ms: DEFAULT_TPU_COALESCE_MS,
             validator_exit: Arc::new(RwLock::new(ValidatorExit::default())),
+            no_wait_for_vote_to_start_leader: true,
         }
     }
 }
@@ -629,15 +631,20 @@ impl Validator {
             check_poh_speed(&genesis_config, None);
         }
 
-        if wait_for_supermajority(
+        let waited_for_supermajority = if let Ok(waited) = wait_for_supermajority(
             config,
             &bank,
             &cluster_info,
             rpc_override_health_check,
             &start_progress,
         ) {
+            waited
+        } else {
             abort();
-        }
+        };
+
+        let wait_for_vote_to_start_leader =
+            !waited_for_supermajority && !config.no_wait_for_vote_to_start_leader;
 
         let poh_service = PohService::new(
             poh_recorder.clone(),
@@ -725,6 +732,7 @@ impl Validator {
                 use_index_hash_calculation: config.accounts_db_use_index_hash_calculation,
                 rocksdb_compaction_interval: config.rocksdb_compaction_interval,
                 rocksdb_max_compaction_jitter: config.rocksdb_compaction_interval,
+                wait_for_vote_to_start_leader,
             },
             &max_slots,
         );
@@ -1292,17 +1300,28 @@ fn initialize_rpc_transaction_history_services(
     }
 }
 
-// Return true on error, indicating the validator should exit.
+#[derive(Debug, PartialEq)]
+enum ValidatorError {
+    BadExpectedBankHash,
+    NotEnoughLedgerData,
+}
+
+// Return if the validator waited on other nodes to start. In this case
+// it should not wait for one of it's votes to land to produce blocks
+// because if the whole network is waiting, then it will stall.
+//
+// Error indicates that a bad hash was encountered or another condition
+// that is unrecoverable and the validator should exit.
 fn wait_for_supermajority(
     config: &ValidatorConfig,
     bank: &Bank,
     cluster_info: &ClusterInfo,
     rpc_override_health_check: Arc<AtomicBool>,
     start_progress: &Arc<RwLock<ValidatorStartProgress>>,
-) -> bool {
+) -> Result<bool, ValidatorError> {
     if let Some(wait_for_supermajority) = config.wait_for_supermajority {
         match wait_for_supermajority.cmp(&bank.slot()) {
-            std::cmp::Ordering::Less => return false,
+            std::cmp::Ordering::Less => return Ok(false),
             std::cmp::Ordering::Greater => {
                 error!(
                     "Ledger does not have enough data to wait for supermajority, \
@@ -1310,12 +1329,12 @@ fn wait_for_supermajority(
                     bank.slot(),
                     wait_for_supermajority
                 );
-                return true;
+                return Err(ValidatorError::NotEnoughLedgerData);
             }
             _ => {}
         }
     } else {
-        return false;
+        return Ok(false);
     }
 
     if let Some(expected_bank_hash) = config.expected_bank_hash {
@@ -1325,7 +1344,7 @@ fn wait_for_supermajority(
                 bank.hash(),
                 expected_bank_hash
             );
-            return true;
+            return Err(ValidatorError::BadExpectedBankHash);
         }
     }
 
@@ -1350,7 +1369,7 @@ fn wait_for_supermajority(
         sleep(Duration::new(1, 0));
     }
     rpc_override_health_check.store(false, Ordering::Relaxed);
-    false
+    Ok(true)
 }
 
 fn report_target_features() {
@@ -1641,17 +1660,21 @@ mod tests {
             &cluster_info,
             rpc_override_health_check.clone(),
             &start_progress,
-        ));
+        )
+        .unwrap());
 
         // bank=0, wait=1, should fail
         config.wait_for_supermajority = Some(1);
-        assert!(wait_for_supermajority(
-            &config,
-            &bank,
-            &cluster_info,
-            rpc_override_health_check.clone(),
-            &start_progress,
-        ));
+        assert_eq!(
+            wait_for_supermajority(
+                &config,
+                &bank,
+                &cluster_info,
+                rpc_override_health_check.clone(),
+                &start_progress,
+            ),
+            Err(ValidatorError::NotEnoughLedgerData)
+        );
 
         // bank=1, wait=0, should pass, bank is past the wait slot
         let bank = Bank::new_from_parent(&bank, &Pubkey::default(), 1);
@@ -1662,18 +1685,22 @@ mod tests {
             &cluster_info,
             rpc_override_health_check.clone(),
             &start_progress,
-        ));
+        )
+        .unwrap());
 
         // bank=1, wait=1, equal, but bad hash provided
         config.wait_for_supermajority = Some(1);
         config.expected_bank_hash = Some(hash(&[1]));
-        assert!(wait_for_supermajority(
-            &config,
-            &bank,
-            &cluster_info,
-            rpc_override_health_check,
-            &start_progress,
-        ));
+        assert_eq!(
+            wait_for_supermajority(
+                &config,
+                &bank,
+                &cluster_info,
+                rpc_override_health_check,
+                &start_progress,
+            ),
+            Err(ValidatorError::BadExpectedBankHash)
+        );
     }
 
     #[test]

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -53,6 +53,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         tpu_coalesce_ms: config.tpu_coalesce_ms,
         validator_exit: Arc::new(RwLock::new(ValidatorExit::default())),
         poh_hashes_per_batch: config.poh_hashes_per_batch,
+        no_wait_for_vote_to_start_leader: config.no_wait_for_vote_to_start_leader,
     }
 }
 

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -105,6 +105,7 @@ args+=(
   --vote-account "$vote_account"
   --rpc-faucet-address 127.0.0.1:9900
   --no-poh-speed-test
+  --no-wait-for-vote-to-start-leader
 )
 default_arg --gossip-port 8001
 default_arg --log -

--- a/run.sh
+++ b/run.sh
@@ -105,6 +105,7 @@ args=(
   --init-complete-file "$dataDir"/init-completed
   --snapshot-compression none
   --require-tower
+  --no-wait-for-vote-to-start-leader
 )
 # shellcheck disable=SC2086
 solana-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS &

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1369,6 +1369,14 @@ pub fn main() {
                        supermajority of stake is visible on gossip before starting PoH"),
         )
         .arg(
+            Arg::with_name("no_wait_for_vote_to_start_leader")
+                .hidden(true)
+                .long("no-wait-for-vote-to-start-leader")
+                .help("If the validator starts up with no ledger, it will wait to start block
+                      production until it sees a vote land in a rooted slot. This prevents
+                      double signing. Turn off to risk double signing a block."),
+        )
+        .arg(
             Arg::with_name("hard_forks")
                 .long("hard-fork")
                 .value_name("SLOT")
@@ -1997,6 +2005,7 @@ pub fn main() {
         accounts_db_test_hash_calculation: matches.is_present("accounts_db_test_hash_calculation"),
         accounts_db_use_index_hash_calculation: matches.is_present("accounts_db_index_hashing"),
         tpu_coalesce_ms,
+        no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
         ..ValidatorConfig::default()
     };
 


### PR DESCRIPTION
#### Problem

Nodes starting up after clearing their ledger can double sign for a slot when they start their leader slot again and are not aware they already produced a block for that slot.

#### Summary of Changes

Check to see if we have landed a vote since starting the node and wait to produce leader slots until then.

Fixes #
