### PR TITLE
Remove unused Accounts state

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -19,7 +19,7 @@ use solana_sdk::{
     account::Account,
     account_utils::StateMut,
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-    clock::{Epoch, Slot},
+    clock::Slot,
     feature_set::{self, FeatureSet},
     fee_calculator::{FeeCalculator, FeeConfig},
     genesis_config::ClusterType,
@@ -91,9 +91,6 @@ pub struct Accounts {
     /// my slot
     pub slot: Slot,
 
-    /// my epoch
-    pub epoch: Epoch,
-
     /// Single global AccountsDb
     pub accounts_db: Arc<AccountsDb>,
 
@@ -145,12 +142,11 @@ impl Accounts {
         }
     }
 
-    pub fn new_from_parent(parent: &Accounts, slot: Slot, parent_slot: Slot, epoch: Epoch) -> Self {
+    pub fn new_from_parent(parent: &Accounts, slot: Slot, parent_slot: Slot) -> Self {
         let accounts_db = parent.accounts_db.clone();
         accounts_db.set_hash(slot, parent_slot);
         Self {
             slot,
-            epoch,
             accounts_db,
             account_locks: Mutex::new(AccountLocks::default()),
         }

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -88,9 +88,6 @@ impl AccountLocks {
 /// This structure handles synchronization for db
 #[derive(Default, Debug, AbiExample)]
 pub struct Accounts {
-    /// my slot
-    pub slot: Slot,
-
     /// Single global AccountsDb
     pub accounts_db: Arc<AccountsDb>,
 
@@ -146,7 +143,6 @@ impl Accounts {
         let accounts_db = parent.accounts_db.clone();
         accounts_db.set_hash(slot, parent_slot);
         Self {
-            slot,
             accounts_db,
             account_locks: Mutex::new(AccountLocks::default()),
         }
@@ -465,10 +461,7 @@ impl Accounts {
 
     /// Slow because lock is held for 1 operation instead of many
     pub fn load_slow(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
-        let (account, slot) = self
-            .accounts_db
-            .load_slow(ancestors, pubkey)
-            .unwrap_or((Account::default(), self.slot));
+        let (account, slot) = self.accounts_db.load_slow(ancestors, pubkey)?;
 
         if account.lamports > 0 {
             Some((account, slot))

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -980,7 +980,6 @@ impl Bank {
                 &parent.rc.accounts,
                 slot,
                 parent.slot(),
-                epoch,
             )),
             parent: RwLock::new(Some(parent.clone())),
             slot,


### PR DESCRIPTION
#### Problem

`Accounts` holds references to the current slot and epoch, but doesn't use them.

#### Summary of Changes

Remove the `slot` and `epoch` state variables from `Accounts`.
