### PR TITLE
extract expected cluster type

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -146,7 +146,6 @@ impl Accounts {
         Self {
             accounts_db: Arc::new(accounts_db),
             account_locks: Mutex::new(AccountLocks::default()),
-            ..Self::default()
         }
     }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -130,7 +130,6 @@ impl Accounts {
                 caching_enabled,
             )),
             account_locks: Mutex::new(AccountLocks::default()),
-            ..Self::default()
         }
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1161,6 +1161,11 @@ impl AccountsDb {
         )
     }
 
+    pub fn expected_cluster_type(&self) -> ClusterType {
+        self.cluster_type
+            .expect("Cluster type must be set at initialization")
+    }
+
     // Reclaim older states of rooted accounts for AccountsDb bloat mitigation
     fn clean_old_rooted_accounts(
         &self,
@@ -3529,9 +3534,7 @@ impl AccountsDb {
                                                     let computed_hash = loaded_account
                                                         .compute_hash(
                                                             *slot,
-                                                            &self.cluster_type.expect(
-                                                                "Cluster type must be set at initialization",
-                                                            ),
+                                                            &self.expected_cluster_type(),
                                                             pubkey,
                                                         );
                                                     if computed_hash != *loaded_hash {
@@ -4172,13 +4175,7 @@ impl AccountsDb {
         }
         self.assert_frozen_accounts(accounts);
         let mut hash_time = Measure::start("hash_accounts");
-        let hashes = self.hash_accounts(
-            slot,
-            accounts,
-            &self
-                .cluster_type
-                .expect("Cluster type must be set at initialization"),
-        );
+        let hashes = self.hash_accounts(slot, accounts, &self.expected_cluster_type());
         hash_time.stop();
         self.stats
             .store_hash_accounts


### PR DESCRIPTION
#### Problem
Two places in the code do the same thing with a string constant. It is likely that more callers will use the asserted value.
#### Summary of Changes
Extract those 2 places into a function.
Fixes #
