### PR TITLE
Lazy calculate hash for accounts stored in the cache

### DIFF
--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -87,7 +87,13 @@ impl Deref for SlotCacheInner {
 #[derive(Debug, Clone)]
 pub struct CachedAccount {
     pub account: Account,
-    pub hash: Hash,
+    hash: Hash,
+}
+
+impl CachedAccount {
+    pub fn hash(&self) -> &Hash {
+        &self.hash
+    }
 }
 
 #[derive(Debug, Default)]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -6947,7 +6947,7 @@ pub mod tests {
         db.add_root(some_slot);
 
         let bank_hashes = db.bank_hashes.read().unwrap();
-        let bank_hash = bank_hashes.get(&some_slot).unwrap();
+        let _bank_hash = bank_hashes.get(&some_slot).unwrap();
         /* TODO: temporarily disabled
         assert_eq!(bank_hash.stats.num_updated_accounts, 1);
         assert_eq!(bank_hash.stats.num_removed_accounts, 1);


### PR DESCRIPTION
#### Problem
While processing a slot, the same account can be written to many times.
Hashing accounts is not free and gets expensive with large data. Hashing an account that is not the final update does not appear to be necessary.

#### Summary of Changes
When an account is stored to the cache, don't hash the contents first - instead use the default hash. When behavior requires a hash, calculate it when necessary. Ideally, once we calculate it, it would be stored in the cache. I don't know enough yet about the race conditions possible in the cache to attempt to update the cached entry with a new hash. I can work on that if we decide this is optimization overall is useful.

Fixes #
