### PR TITLE
configure rust-bpf toolchain for each tree

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -142,13 +142,6 @@ if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
            solana-bpf-tools-$machine.tar.bz2 \
            bpf-tools"
     get $version bpf-tools "$job"
-
-    set -ex
-    ./bpf-tools/rust/bin/rustc --print sysroot
-    set +e
-    rustup toolchain uninstall bpf
-    set -e
-    rustup toolchain link bpf bpf-tools/rust
   )
   exitcode=$?
   if [[ $exitcode -ne 0 ]]; then
@@ -156,6 +149,12 @@ if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   fi
   touch bpf-tools-$version.md
 fi
+set -ex
+./bpf-tools/rust/bin/rustc --print sysroot
+set +e
+rustup toolchain uninstall bpf
+set -e
+rustup toolchain link bpf bpf-tools/rust
 
 # Install Rust-BPF Sysroot sources
 version=v1.0


### PR DESCRIPTION
#### Problem

The Rust toolchain used by xargo is only specified when the toolchain is installed.  Switching between branches results in one branch using another branch's toolchain.  Since the Rust toolchain hasn't been updated for a bit this issue is mostly hidden but as we update the Rust toolchain more frequently this will result in failed builds with confusing error messages.

#### Summary of Changes

Configure the toolchain for the branch being built

Fixes #
