### PR TITLE
add api to load and retain in cache

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -381,7 +381,7 @@ impl Accounts {
                 {
                     if let Some(program) = self
                         .accounts_db
-                        .load(ancestors, &programdata_address)
+                        .load_and_keep_in_cache(ancestors, &programdata_address)
                         .map(|(account, _)| account)
                     {
                         accounts.insert(0, (programdata_address, program));


### PR DESCRIPTION
#### Problem
During replay, we load things like programs from accounts, sometimes many (375) times during 1 slot. If we don't load them from the cache, then we load them from a store on each load. Loading from a store always requires copying data from the store to new memory. An example data size on programs is 500k.

#### Summary of Changes
Add the ability for a caller to request that an account be loaded and kept in the cache for potential future loads.

Note that we need to work out details of this. When do we flush these accounts from the cache? Can we avoid writing them out again when we flush the cache? Should we architect this some other way? Should all account loads cause the loaded item to remain in the cache? If we move to an account being stored in the cache as an arc/cow then storing a loaded account in the cache isn't holding any additional resources as long as the account is kept in memory by the caller anyway. Clearly, it will be more memory than we use if we don't keep anything in the cache, but there are mitigating factors and tradeoffs to be made. I implemented this so far with the caller being explicit suggesting that there are likely to be more requests for this account in the future. We have to understand whether how reliable this information is.

Fixes #
