### PR TITLE
improve cli insufficient funds error messages

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -86,9 +86,13 @@ pub fn check_account_for_spend_multiple_fees_with_commitment(
             return Err(CliError::InsufficientFundsForSpendAndFee(
                 lamports_to_sol(balance),
                 lamports_to_sol(fee),
+                *account_pubkey,
             ));
         } else {
-            return Err(CliError::InsufficientFundsForFee(lamports_to_sol(fee)));
+            return Err(CliError::InsufficientFundsForFee(
+                lamports_to_sol(fee),
+                *account_pubkey,
+            ));
         }
     }
     Ok(())

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -369,25 +369,25 @@ pub struct CliCommandInfo {
 
 #[derive(Debug, Error)]
 pub enum CliError {
-    #[error("bad parameter: {0}")]
+    #[error("Bad parameter: {0}")]
     BadParameter(String),
     #[error(transparent)]
     ClientError(#[from] ClientError),
-    #[error("command not recognized: {0}")]
+    #[error("Command not recognized: {0}")]
     CommandNotRecognized(String),
-    #[error("insufficient funds for fee ({0} SOL)")]
-    InsufficientFundsForFee(f64),
-    #[error("insufficient funds for spend ({0} SOL)")]
-    InsufficientFundsForSpend(f64),
-    #[error("insufficient funds for spend ({0} SOL) and fee ({1} SOL)")]
-    InsufficientFundsForSpendAndFee(f64, f64),
+    #[error("Account {1} has insufficient funds for fee ({0} SOL)")]
+    InsufficientFundsForFee(f64, Pubkey),
+    #[error("Account {1} has insufficient funds for spend ({0} SOL)")]
+    InsufficientFundsForSpend(f64, Pubkey),
+    #[error("Account {2} has insufficient funds for spend ({0} SOL) + fee ({1} SOL)")]
+    InsufficientFundsForSpendAndFee(f64, f64, Pubkey),
     #[error(transparent)]
     InvalidNonce(nonce_utils::Error),
-    #[error("dynamic program error: {0}")]
+    #[error("Dynamic program error: {0}")]
     DynamicProgramError(String),
-    #[error("rpc request error: {0}")]
+    #[error("RPC request error: {0}")]
     RpcRequestError(String),
-    #[error("keypair file not found: {0}")]
+    #[error("Keypair file not found: {0}")]
     KeypairFileNotFound(String),
 }
 

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -107,15 +107,22 @@ where
                 return Err(CliError::InsufficientFundsForSpendAndFee(
                     lamports_to_sol(spend),
                     lamports_to_sol(fee),
+                    *from_pubkey,
                 ));
             }
         } else {
             if from_balance < spend {
-                return Err(CliError::InsufficientFundsForSpend(lamports_to_sol(spend)));
+                return Err(CliError::InsufficientFundsForSpend(
+                    lamports_to_sol(spend),
+                    *from_pubkey,
+                ));
             }
             if !check_account_for_balance_with_commitment(rpc_client, fee_pubkey, fee, commitment)?
             {
-                return Err(CliError::InsufficientFundsForFee(lamports_to_sol(fee)));
+                return Err(CliError::InsufficientFundsForFee(
+                    lamports_to_sol(fee),
+                    *fee_pubkey,
+                ));
             }
         }
         Ok((message, spend))


### PR DESCRIPTION
#### Problem

When an account has insufficient funds the error message is not as clear as it could be

#### Summary of Changes

Improve it, is now:

`Error: Account FwoGJNUaJN2zfVEex9BB11Dqb3NJKy3e9oY3KTh9XzCU has insufficient funds for spend (1.1308956 SOL) + fee (0.003565 SOL)`

Fixes #
