### PR TITLE
remove new alloc on deserialization

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -251,7 +251,10 @@ pub fn deserialize_parameters_aligned(
                 + size_of::<u8>() // executable
                 + 4 // padding to 128-bit aligned
                 + size_of::<Pubkey>(); // key
-            account.owner = Pubkey::new(&buffer[start..start + size_of::<Pubkey>()]);
+            account
+                .owner
+                .as_mut()
+                .copy_from_slice(&buffer[start..start + size_of::<Pubkey>()]);
             start += size_of::<Pubkey>(); // owner
             account.lamports = LittleEndian::read_u64(&buffer[start..]);
             start += size_of::<u64>(); // lamports

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -325,6 +325,12 @@ impl AsRef<[u8]> for Pubkey {
     }
 }
 
+impl AsMut<[u8]> for Pubkey {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0[..]
+    }
+}
+
 impl fmt::Debug for Pubkey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", bs58::encode(self.0).into_string())


### PR DESCRIPTION
#### Problem
For every account in a transaction, we reallocate a new pubkey to replace the existing pubkey on deserialization. This seems like unnecessary exercising of the memory manager.

#### Summary of Changes
Overwrite the existing pubkey in place instead of allocating a new one. This should execute less code for the same result.

Fixes #
