### PR TITLE
use copy_from_slice for [u8]

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -230,7 +230,7 @@ pub fn deserialize_parameters_aligned(
                 account.data.resize(post_len, 0);
                 data_end = start + post_len;
             }
-            account.data.clone_from_slice(&buffer[start..data_end]);
+            account.data.copy_from_slice(&buffer[start..data_end]);
             start += pre_len + MAX_PERMITTED_DATA_INCREASE; // data
             start += (start as *const u8).align_offset(align_of::<u128>());
             start += size_of::<u64>(); // rent_epoch


### PR DESCRIPTION
#### Problem
performance improvements

#### Summary of Changes
use copy_from_slice instead of clone_from_slice
[Rust docs say "If T implements Copy, it can be more performant to use copy_from_slice."](https://doc.rust-lang.org/std/primitive.slice.html#method.clone_from_slice)
T is a u8 in this case.
copy seems to be the better term and usage for what is happening here anyway.

Fixes #
