### PR TITLE
Remove ValidatorConfig derive Clone, and fix local-cluster tests

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -561,7 +561,10 @@ fn main() {
 pub mod test {
     use super::*;
     use solana_core::validator::ValidatorConfig;
-    use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
+    use solana_local_cluster::{
+        local_cluster::{ClusterConfig, LocalCluster},
+        validator_configs::make_identical_validator_configs,
+    };
     use solana_sdk::poh_config::PohConfig;
 
     #[test]
@@ -573,7 +576,7 @@ pub mod test {
             cluster_lamports: 10_000_000,
             poh_config: PohConfig::new_sleep(Duration::from_millis(50)),
             node_stakes: vec![100; num_nodes],
-            validator_configs: vec![validator_config; num_nodes],
+            validator_configs: make_identical_validator_configs(&validator_config, num_nodes),
             ..ClusterConfig::default()
         };
 

--- a/bench-exchange/tests/bench_exchange.rs
+++ b/bench-exchange/tests/bench_exchange.rs
@@ -1,19 +1,23 @@
 use log::*;
 use solana_bench_exchange::bench::{airdrop_lamports, do_bench_exchange, Config};
-use solana_core::gossip_service::{discover_cluster, get_multi_client};
-use solana_core::validator::ValidatorConfig;
-use solana_exchange_program::exchange_processor::process_instruction;
-use solana_exchange_program::id;
-use solana_exchange_program::solana_exchange_program;
+use solana_core::{
+    gossip_service::{discover_cluster, get_multi_client},
+    validator::ValidatorConfig,
+};
+use solana_exchange_program::{
+    exchange_processor::process_instruction, id, solana_exchange_program,
+};
 use solana_faucet::faucet::run_local_faucet_with_port;
-use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
-use solana_runtime::bank::Bank;
-use solana_runtime::bank_client::BankClient;
-use solana_sdk::genesis_config::create_genesis_config;
-use solana_sdk::signature::{Keypair, Signer};
-use std::process::exit;
-use std::sync::mpsc::channel;
-use std::time::Duration;
+use solana_local_cluster::{
+    local_cluster::{ClusterConfig, LocalCluster},
+    validator_configs::make_identical_validator_configs,
+};
+use solana_runtime::{bank::Bank, bank_client::BankClient};
+use solana_sdk::{
+    genesis_config::create_genesis_config,
+    signature::{Keypair, Signer},
+};
+use std::{process::exit, sync::mpsc::channel, time::Duration};
 
 #[test]
 #[ignore]
@@ -44,7 +48,7 @@ fn test_exchange_local_cluster() {
     let cluster = LocalCluster::new(&mut ClusterConfig {
         node_stakes: vec![100_000; NUM_NODES],
         cluster_lamports: 100_000_000_000_000,
-        validator_configs: vec![ValidatorConfig::default(); NUM_NODES],
+        validator_configs: make_identical_validator_configs(&ValidatorConfig::default(), NUM_NODES),
         native_instruction_processors: [solana_exchange_program!()].to_vec(),
         ..ClusterConfig::default()
     });

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -1,15 +1,21 @@
 #![allow(clippy::integer_arithmetic)]
 use serial_test::serial;
-use solana_bench_tps::bench::{do_bench_tps, generate_and_fund_keypairs};
-use solana_bench_tps::cli::Config;
+use solana_bench_tps::{
+    bench::{do_bench_tps, generate_and_fund_keypairs},
+    cli::Config,
+};
 use solana_client::thin_client::create_client;
-use solana_core::cluster_info::VALIDATOR_PORT_RANGE;
-use solana_core::validator::ValidatorConfig;
+use solana_core::{cluster_info::VALIDATOR_PORT_RANGE, validator::ValidatorConfig};
 use solana_faucet::faucet::run_local_faucet_with_port;
-use solana_local_cluster::local_cluster::{ClusterConfig, LocalCluster};
+use solana_local_cluster::{
+    local_cluster::{ClusterConfig, LocalCluster},
+    validator_configs::make_identical_validator_configs,
+};
 use solana_sdk::signature::{Keypair, Signer};
-use std::sync::{mpsc::channel, Arc};
-use std::time::Duration;
+use std::{
+    sync::{mpsc::channel, Arc},
+    time::Duration,
+};
 
 fn test_bench_tps_local_cluster(config: Config) {
     let native_instruction_processors = vec![];
@@ -19,7 +25,7 @@ fn test_bench_tps_local_cluster(config: Config) {
     let cluster = LocalCluster::new(&mut ClusterConfig {
         node_stakes: vec![999_990; NUM_NODES],
         cluster_lamports: 200_000_000,
-        validator_configs: vec![ValidatorConfig::default(); NUM_NODES],
+        validator_configs: make_identical_validator_configs(&ValidatorConfig::default(), NUM_NODES),
         native_instruction_processors,
         ..ClusterConfig::default()
     });

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -79,7 +79,7 @@ use std::{
 
 const MAX_COMPLETED_DATA_SETS_IN_CHANNEL: usize = 100_000;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ValidatorConfig {
     pub dev_halt_at_slot: Option<Slot>,
     pub expected_genesis_hash: Option<Hash>,

--- a/local-cluster/src/lib.rs
+++ b/local-cluster/src/lib.rs
@@ -2,3 +2,4 @@
 pub mod cluster;
 pub mod cluster_tests;
 pub mod local_cluster;
+pub mod validator_configs;

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -1,0 +1,67 @@
+use solana_core::validator::{ValidatorConfig, ValidatorExit};
+use std::sync::{Arc, RwLock};
+
+pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
+    ValidatorConfig {
+        dev_halt_at_slot: config.dev_halt_at_slot,
+        expected_genesis_hash: config.expected_genesis_hash,
+        expected_bank_hash: config.expected_bank_hash,
+        expected_shred_version: config.expected_shred_version,
+        voting_disabled: config.voting_disabled,
+        account_paths: config.account_paths.clone(),
+        account_shrink_paths: config.account_shrink_paths.clone(),
+        rpc_config: config.rpc_config.clone(),
+        rpc_addrs: config.rpc_addrs,
+        pubsub_config: config.pubsub_config.clone(),
+        snapshot_config: config.snapshot_config.clone(),
+        max_ledger_shreds: config.max_ledger_shreds,
+        broadcast_stage_type: config.broadcast_stage_type.clone(),
+        enable_partition: config.enable_partition.clone(),
+        enforce_ulimit_nofile: config.enforce_ulimit_nofile,
+        fixed_leader_schedule: config.fixed_leader_schedule.clone(),
+        wait_for_supermajority: config.wait_for_supermajority,
+        new_hard_forks: config.new_hard_forks.clone(),
+        trusted_validators: config.trusted_validators.clone(),
+        repair_validators: config.repair_validators.clone(),
+        gossip_validators: config.gossip_validators.clone(),
+        halt_on_trusted_validators_accounts_hash_mismatch: config
+            .halt_on_trusted_validators_accounts_hash_mismatch,
+        accounts_hash_fault_injection_slots: config.accounts_hash_fault_injection_slots,
+        frozen_accounts: config.frozen_accounts.clone(),
+        no_rocksdb_compaction: config.no_rocksdb_compaction,
+        rocksdb_compaction_interval: config.rocksdb_compaction_interval,
+        rocksdb_max_compaction_jitter: config.rocksdb_max_compaction_jitter,
+        accounts_hash_interval_slots: config.accounts_hash_interval_slots,
+        max_genesis_archive_unpacked_size: config.max_genesis_archive_unpacked_size,
+        wal_recovery_mode: config.wal_recovery_mode.clone(),
+        poh_verify: config.poh_verify,
+        cuda: config.cuda,
+        require_tower: config.require_tower,
+        debug_keys: config.debug_keys.clone(),
+        contact_debug_interval: config.contact_debug_interval,
+        contact_save_interval: config.contact_save_interval,
+        bpf_jit: config.bpf_jit,
+        send_transaction_retry_ms: config.send_transaction_retry_ms,
+        send_transaction_leader_forward_count: config.send_transaction_leader_forward_count,
+        no_poh_speed_test: config.no_poh_speed_test,
+        poh_pinned_cpu_core: config.poh_pinned_cpu_core,
+        account_indexes: config.account_indexes.clone(),
+        accounts_db_caching_enabled: config.accounts_db_caching_enabled,
+        warp_slot: config.warp_slot,
+        accounts_db_test_hash_calculation: config.accounts_db_test_hash_calculation,
+        accounts_db_use_index_hash_calculation: config.accounts_db_use_index_hash_calculation,
+        tpu_coalesce_ms: config.tpu_coalesce_ms,
+        validator_exit: Arc::new(RwLock::new(ValidatorExit::default())),
+    }
+}
+
+pub fn make_identical_validator_configs(
+    config: &ValidatorConfig,
+    num: usize,
+) -> Vec<ValidatorConfig> {
+    let mut configs = vec![];
+    for _ in 0..num {
+        configs.push(safe_clone_config(config));
+    }
+    configs
+}


### PR DESCRIPTION
#### Problem
The local-cluster CI job is timing out on `test_no_optimistic_confirmation_violation_with_tower()`.
This is because https://github.com/solana-labs/solana/pull/15606 adds ValidatorExit to the ValidatorConfig struct, and the `vec![ValdiatorConfig; NUM` pattern used all over local-cluster implicitly clones the same ValidatorExit among all the validators.

#### Summary of Changes
Remove Clone footgun from ValidatorConfig
Add helper functions for local-cluster tests and benches that need a bunch of identical ValidatorConfigs
