### PR TITLE
Only report metrics every second

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -521,7 +521,7 @@ impl BankingStage {
                 Err(RecvTimeoutError::Disconnected) => break,
             }
 
-            banking_stage_stats.report(100);
+            banking_stage_stats.report(1000);
         }
     }
 


### PR DESCRIPTION
#### Problem
Banking stage metrics are noisy
#### Summary of Changes
Reduce frequency of banking stage metrics reporting
Fixes #
