### PR TITLE
Clarify Instruction::new

### DIFF
--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -212,6 +212,14 @@ pub struct Instruction {
 
 impl Instruction {
     pub fn new<T: Serialize>(program_id: Pubkey, data: &T, accounts: Vec<AccountMeta>) -> Self {
+        Self::new_with_bincode(program_id, data, accounts)
+    }
+
+    pub fn new_with_bincode<T: Serialize>(
+        program_id: Pubkey,
+        data: &T,
+        accounts: Vec<AccountMeta>,
+    ) -> Self {
         let data = serialize(data).unwrap();
         Self {
             program_id,
@@ -229,6 +237,14 @@ impl Instruction {
         Self {
             program_id,
             data,
+            accounts,
+        }
+    }
+
+    pub fn new_with_bytes(program_id: Pubkey, data: &[u8], accounts: Vec<AccountMeta>) -> Self {
+        Self {
+            program_id,
+            data: data.to_vec(),
             accounts,
         }
     }


### PR DESCRIPTION
#### Problem

`Instruction::new` has a hidden dependency on bincode.  Now that we have `new_with_borsh` it makes sense to continue that pattern and make the data type/serialization explicit.

#### Summary of Changes

Added `new_with_bincode` and `new_with_bytes` (open to name suggestions on the latter :-) )

Fixes #5970
