### PR TITLE
Account -> AccountSharedData

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -129,7 +129,7 @@ impl BanksClient {
         self.get_account(sysvar::rent::id()).map(|result| {
             let rent_sysvar = result?
                 .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Rent sysvar not present"))?;
-            from_account::<Rent>(&rent_sysvar).ok_or_else(|| {
+            from_account::<Rent, _>(&rent_sysvar).ok_or_else(|| {
                 io::Error::new(io::ErrorKind::Other, "Failed to deserialize Rent sysvar")
             })
         })

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -242,7 +242,7 @@ impl Banks for BanksServer {
         commitment: CommitmentLevel,
     ) -> Option<Account> {
         let bank = self.bank(commitment);
-        bank.get_account(&address)
+        bank.get_account(&address).map(Account::from)
     }
 }
 

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1747,9 +1747,10 @@ pub fn process_show_stake_history(
     use_lamports_unit: bool,
 ) -> ProcessResult {
     let stake_history_account = rpc_client.get_account(&stake_history::id())?;
-    let stake_history = from_account::<StakeHistory>(&stake_history_account).ok_or_else(|| {
-        CliError::RpcRequestError("Failed to deserialize stake history".to_string())
-    })?;
+    let stake_history =
+        from_account::<StakeHistory, _>(&stake_history_account).ok_or_else(|| {
+            CliError::RpcRequestError("Failed to deserialize stake history".to_string())
+        })?;
 
     let mut entries: Vec<CliStakeHistoryEntry> = vec![];
     for entry in stake_history.deref() {

--- a/client/src/nonce_utils.rs
+++ b/client/src/nonce_utils.rs
@@ -1,6 +1,6 @@
 use crate::rpc_client::RpcClient;
 use solana_sdk::{
-    account::Account,
+    account::{Account, ReadableAccount},
     account_utils::StateMut,
     commitment_config::CommitmentConfig,
     nonce::{
@@ -52,24 +52,28 @@ pub fn get_account_with_commitment(
         })
 }
 
-pub fn account_identity_ok(account: &Account) -> Result<(), Error> {
-    if account.owner != system_program::id() {
+pub fn account_identity_ok<T: ReadableAccount>(account: &T) -> Result<(), Error> {
+    if account.owner() != &system_program::id() {
         Err(Error::InvalidAccountOwner)
-    } else if account.data.is_empty() {
+    } else if account.data().is_empty() {
         Err(Error::UnexpectedDataSize)
     } else {
         Ok(())
     }
 }
 
-pub fn state_from_account(account: &Account) -> Result<State, Error> {
+pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
+    account: &T,
+) -> Result<State, Error> {
     account_identity_ok(account)?;
     StateMut::<Versions>::state(account)
         .map_err(|_| Error::InvalidAccountData)
         .map(|v| v.convert_to_current())
 }
 
-pub fn data_from_account(account: &Account) -> Result<Data, Error> {
+pub fn data_from_account<T: ReadableAccount + StateMut<Versions>>(
+    account: &T,
+) -> Result<Data, Error> {
     account_identity_ok(account)?;
     state_from_account(account).and_then(|ref s| data_from_state(s).map(|d| d.clone()))
 }

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -253,7 +253,7 @@ mod tests {
         bank_forks::BankForks,
         genesis_utils::{create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs},
     };
-    use solana_sdk::{pubkey::Pubkey, signature::Signer};
+    use solana_sdk::{account::Account, pubkey::Pubkey, signature::Signer};
     use solana_stake_program::stake_state;
     use solana_vote_program::{
         vote_state::{self, VoteStateVersions},
@@ -411,16 +411,20 @@ mod tests {
             rooted_stake_amount,
         );
 
-        genesis_config.accounts.extend(vec![
-            (pk1, vote_account1.clone()),
-            (sk1, stake_account1),
-            (pk2, vote_account2.clone()),
-            (sk2, stake_account2),
-            (pk3, vote_account3.clone()),
-            (sk3, stake_account3),
-            (pk4, vote_account4.clone()),
-            (sk4, stake_account4),
-        ]);
+        genesis_config.accounts.extend(
+            vec![
+                (pk1, vote_account1.clone()),
+                (sk1, stake_account1),
+                (pk2, vote_account2.clone()),
+                (sk2, stake_account2),
+                (pk3, vote_account3.clone()),
+                (sk3, stake_account3),
+                (pk4, vote_account4.clone()),
+                (sk4, stake_account4),
+            ]
+            .into_iter()
+            .map(|(key, account)| (key, Account::from(account))),
+        );
 
         // Create bank
         let bank = Arc::new(Bank::new(&genesis_config));

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1253,7 +1253,7 @@ pub mod test {
         },
     };
     use solana_sdk::{
-        account::Account, clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signer,
+        account::AccountSharedData, clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signer,
         slot_history::SlotHistory,
     };
     use solana_vote_program::{
@@ -1571,10 +1571,10 @@ pub mod test {
     fn gen_stakes(stake_votes: &[(u64, &[u64])]) -> Vec<(Pubkey, (u64, ArcVoteAccount))> {
         let mut stakes = vec![];
         for (lamports, votes) in stake_votes {
-            let mut account = Account {
+            let mut account = AccountSharedData {
                 data: vec![0; VoteState::size_of()],
                 lamports: *lamports,
-                ..Account::default()
+                ..AccountSharedData::default()
             };
             let mut vote_state = VoteState::default();
             for slot in *votes {
@@ -2251,9 +2251,9 @@ pub mod test {
     #[test]
     fn test_stake_is_updated_for_entire_branch() {
         let mut voted_stakes = HashMap::new();
-        let account = Account {
+        let account = AccountSharedData {
             lamports: 1,
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         let set: HashSet<u64> = vec![0u64, 1u64].into_iter().collect();
         let ancestors: HashMap<u64, HashSet<u64>> = [(2u64, set)].iter().cloned().collect();

--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -40,7 +40,7 @@ pub fn calculate_non_circulating_supply(bank: &Arc<Bank>) -> NonCirculatingSuppl
         bank.get_program_accounts(&solana_stake_program::id())
     };
     for (pubkey, account) in stake_accounts.iter() {
-        let stake_account = StakeState::from(&account).unwrap_or_default();
+        let stake_account = StakeState::from(account).unwrap_or_default();
         match stake_account {
             StakeState::Initialized(meta) => {
                 if meta.lockup.is_in_force(&clock, None)
@@ -138,6 +138,7 @@ mod tests {
     use super::*;
     use solana_sdk::{
         account::Account,
+        account::AccountSharedData,
         epoch_schedule::EpochSchedule,
         genesis_config::{ClusterType, GenesisConfig},
     };
@@ -212,7 +213,10 @@ mod tests {
         bank = Arc::new(new_from_parent(&bank));
         let new_balance = 11;
         for key in non_circulating_accounts {
-            bank.store_account(&key, &Account::new(new_balance, 0, &Pubkey::default()));
+            bank.store_account(
+                &key,
+                &AccountSharedData::new(new_balance, 0, &Pubkey::default()),
+            );
         }
         let non_circulating_supply = calculate_non_circulating_supply(&bank);
         assert_eq!(

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -49,7 +49,7 @@ use solana_runtime::{
     snapshot_utils::get_highest_snapshot_archive_path,
 };
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     account_utils::StateMut,
     clock::{Slot, UnixTimestamp, MAX_RECENT_BLOCKHASHES},
     commitment_config::{CommitmentConfig, CommitmentLevel},
@@ -1157,7 +1157,7 @@ impl JsonRpcRequestProcessor {
             .get_account(&stake_history::id())
             .ok_or_else(Error::internal_error)?;
         let stake_history =
-            solana_sdk::account::from_account::<StakeHistory>(&stake_history_account)
+            solana_sdk::account::from_account::<StakeHistory, _>(&stake_history_account)
                 .ok_or_else(Error::internal_error)?;
 
         let (active, activating, deactivating) = delegation.stake_activating_and_deactivating(
@@ -1381,8 +1381,8 @@ impl JsonRpcRequestProcessor {
         bank: &Arc<Bank>,
         program_id: &Pubkey,
         filters: Vec<RpcFilterType>,
-    ) -> Vec<(Pubkey, Account)> {
-        let filter_closure = |account: &Account| {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
+        let filter_closure = |account: &AccountSharedData| {
             filters.iter().all(|filter_type| match filter_type {
                 RpcFilterType::DataSize(size) => account.data.len() as u64 == *size,
                 RpcFilterType::Memcmp(compare) => compare.bytes_match(&account.data),
@@ -1396,7 +1396,7 @@ impl JsonRpcRequestProcessor {
             bank.get_filtered_indexed_accounts(&IndexKey::ProgramId(*program_id), |account| {
                 // The program-id account index checks for Account owner on inclusion. However, due
                 // to the current AccountsDb implementation, an account may remain in storage as a
-                // zero-lamport Account::Default() after being wiped and reinitialized in later
+                // zero-lamport AccountSharedData::Default() after being wiped and reinitialized in later
                 // updates. We include the redundant filters here to avoid returning these
                 // accounts.
                 account.owner == *program_id && filter_closure(account)
@@ -1412,10 +1412,10 @@ impl JsonRpcRequestProcessor {
         bank: &Arc<Bank>,
         owner_key: &Pubkey,
         mut filters: Vec<RpcFilterType>,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         // The by-owner accounts index checks for Token Account state and Owner address on
         // inclusion. However, due to the current AccountsDb implementation, an account may remain
-        // in storage as a zero-lamport Account::Default() after being wiped and reinitialized in
+        // in storage as a zero-lamport AccountSharedData::Default() after being wiped and reinitialized in
         // later updates. We include the redundant filters here to avoid returning these accounts.
         //
         // Filter on Token Account state
@@ -1452,10 +1452,10 @@ impl JsonRpcRequestProcessor {
         bank: &Arc<Bank>,
         mint_key: &Pubkey,
         mut filters: Vec<RpcFilterType>,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         // The by-mint accounts index checks for Token Account state and Mint address on inclusion.
         // However, due to the current AccountsDb implementation, an account may remain in storage
-        // as be zero-lamport Account::Default() after being wiped and reinitialized in later
+        // as be zero-lamport AccountSharedData::Default() after being wiped and reinitialized in later
         // updates. We include the redundant filters here to avoid returning these accounts.
         //
         // Filter on Token Account state
@@ -1641,7 +1641,7 @@ fn get_spl_token_mint_filter(program_id: &Pubkey, filters: &[RpcFilterType]) -> 
 pub(crate) fn get_parsed_token_account(
     bank: Arc<Bank>,
     pubkey: &Pubkey,
-    account: Account,
+    account: AccountSharedData,
 ) -> UiAccount {
     let additional_data = get_token_account_mint(&account.data)
         .and_then(|mint_pubkey| get_mint_owner_and_decimals(&bank, &mint_pubkey).ok())
@@ -1663,7 +1663,7 @@ pub(crate) fn get_parsed_token_accounts<I>(
     keyed_accounts: I,
 ) -> impl Iterator<Item = RpcKeyedAccount>
 where
-    I: Iterator<Item = (Pubkey, Account)>,
+    I: Iterator<Item = (Pubkey, AccountSharedData)>,
 {
     let mut mint_decimals: HashMap<Pubkey, u8> = HashMap::new();
     keyed_accounts.filter_map(move |(pubkey, account)| {
@@ -3216,7 +3216,10 @@ pub mod tests {
                     .unwrap()
                     .set_root(*root, &AbsRequestSender::default(), Some(0));
                 let mut stakes = HashMap::new();
-                stakes.insert(leader_vote_keypair.pubkey(), (1, Account::default()));
+                stakes.insert(
+                    leader_vote_keypair.pubkey(),
+                    (1, AccountSharedData::default()),
+                );
                 let block_time = bank_forks
                     .read()
                     .unwrap()
@@ -3822,7 +3825,7 @@ pub mod tests {
 
         let address = solana_sdk::pubkey::new_rand();
         let data = vec![1, 2, 3, 4, 5];
-        let mut account = Account::new(42, 5, &Pubkey::default());
+        let mut account = AccountSharedData::new(42, 5, &Pubkey::default());
         account.data = data.clone();
         bank.store_account(&address, &account);
 
@@ -3879,7 +3882,7 @@ pub mod tests {
 
         let address = Pubkey::new(&[9; 32]);
         let data = vec![1, 2, 3, 4, 5];
-        let mut account = Account::new(42, 5, &Pubkey::default());
+        let mut account = AccountSharedData::new(42, 5, &Pubkey::default());
         account.data = data.clone();
         bank.store_account(&address, &account);
 
@@ -5611,11 +5614,11 @@ pub mod tests {
             close_authority: COption::Some(owner),
         };
         TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = Account {
+        let token_account = AccountSharedData {
             lamports: 111,
             data: account_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         let token_account_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_account_pubkey, &token_account);
@@ -5630,11 +5633,11 @@ pub mod tests {
             freeze_authority: COption::Some(owner),
         };
         Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = Account {
+        let mint_account = AccountSharedData {
             lamports: 111,
             data: mint_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
 
@@ -5707,11 +5710,11 @@ pub mod tests {
             close_authority: COption::Some(owner),
         };
         TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = Account {
+        let token_account = AccountSharedData {
             lamports: 111,
             data: account_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         let token_with_different_mint_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_with_different_mint_pubkey, &token_account);
@@ -5926,11 +5929,11 @@ pub mod tests {
             freeze_authority: COption::Some(owner),
         };
         Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = Account {
+        let mint_account = AccountSharedData {
             lamports: 111,
             data: mint_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         bank.store_account(
             &Pubkey::from_str(&new_mint.to_string()).unwrap(),
@@ -5948,11 +5951,11 @@ pub mod tests {
             close_authority: COption::Some(owner),
         };
         TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = Account {
+        let token_account = AccountSharedData {
             lamports: 111,
             data: account_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         let token_with_smaller_balance = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_with_smaller_balance, &token_account);
@@ -6012,11 +6015,11 @@ pub mod tests {
             close_authority: COption::Some(owner),
         };
         TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = Account {
+        let token_account = AccountSharedData {
             lamports: 111,
             data: account_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         let token_account_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_account_pubkey, &token_account);
@@ -6031,11 +6034,11 @@ pub mod tests {
             freeze_authority: COption::Some(owner),
         };
         Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = Account {
+        let mint_account = AccountSharedData {
             lamports: 111,
             data: mint_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
 

--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -28,7 +28,7 @@ use solana_runtime::{
     commitment::{BlockCommitmentCache, CommitmentSlots},
 };
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     clock::{Slot, UnixTimestamp},
     commitment_config::CommitmentConfig,
     pubkey::Pubkey,
@@ -276,7 +276,7 @@ impl RpcNotifier {
 }
 
 fn filter_account_result(
-    result: Option<(Account, Slot)>,
+    result: Option<(AccountSharedData, Slot)>,
     pubkey: &Pubkey,
     last_notified_slot: Slot,
     encoding: Option<UiAccountEncoding>,
@@ -320,7 +320,7 @@ fn filter_signature_result(
 }
 
 fn filter_program_results(
-    accounts: Vec<(Pubkey, Account)>,
+    accounts: Vec<(Pubkey, AccountSharedData)>,
     program_id: &Pubkey,
     last_notified_slot: Slot,
     config: Option<ProgramConfig>,

--- a/core/src/send_transaction_service.rs
+++ b/core/src/send_transaction_service.rs
@@ -321,7 +321,7 @@ mod test {
         create_genesis_config_with_vote_accounts, GenesisConfigInfo, ValidatorVoteKeypairs,
     };
     use solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         fee_calculator::FeeCalculator,
         genesis_config::create_genesis_config,
         nonce,
@@ -529,7 +529,8 @@ mod test {
                 blockhash: durable_nonce,
                 fee_calculator: FeeCalculator::new(42),
             }));
-        let nonce_account = Account::new_data(43, &nonce_state, &system_program::id()).unwrap();
+        let nonce_account =
+            AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
         root_bank.store_account(&nonce_address, &nonce_account);
 
         let working_bank = Arc::new(Bank::new_from_parent(&root_bank, &Pubkey::default(), 2));
@@ -753,7 +754,8 @@ mod test {
                 blockhash: new_durable_nonce,
                 fee_calculator: FeeCalculator::new(42),
             }));
-        let nonce_account = Account::new_data(43, &new_nonce_state, &system_program::id()).unwrap();
+        let nonce_account =
+            AccountSharedData::new_data(43, &new_nonce_state, &system_program::id()).unwrap();
         working_bank.store_account(&nonce_address, &nonce_account);
         let result = SendTransactionService::process_transactions(
             &working_bank,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -868,7 +868,7 @@ impl Validator {
 
 fn active_vote_account_exists_in_bank(bank: &Arc<Bank>, vote_account: &Pubkey) -> bool {
     if let Some(account) = &bank.get_account(vote_account) {
-        if let Some(vote_state) = VoteState::from(&account) {
+        if let Some(vote_state) = VoteState::from(account) {
             return !vote_state.votes.is_empty();
         }
     }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -19,7 +19,7 @@ use solana_ledger::{
 };
 use solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE;
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     clock,
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeRateGovernor,
@@ -82,7 +82,7 @@ pub fn load_genesis_accounts(file: &str, genesis_config: &mut GenesisConfig) -> 
             )
         })?;
 
-        let mut account = Account::new(account_details.balance, 0, &owner_program_id);
+        let mut account = AccountSharedData::new(account_details.balance, 0, &owner_program_id);
         if account_details.data != "~" {
             account.data = base64::decode(account_details.data.as_str()).map_err(|err| {
                 io::Error::new(
@@ -534,7 +534,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
         genesis_config.add_account(
             *identity_pubkey,
-            Account::new(bootstrap_validator_lamports, 0, &system_program::id()),
+            AccountSharedData::new(bootstrap_validator_lamports, 0, &system_program::id()),
         );
 
         let vote_account = vote_state::create_account_with_authorized(
@@ -568,7 +568,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     if let Some(faucet_pubkey) = faucet_pubkey {
         genesis_config.add_account(
             faucet_pubkey,
-            Account::new(faucet_lamports, 0, &system_program::id()),
+            AccountSharedData::new(faucet_lamports, 0, &system_program::id()),
         );
     }
 
@@ -618,7 +618,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         });
                     genesis_config.add_account(
                         address,
-                        Account {
+                        AccountSharedData {
                             lamports: genesis_config.rent.minimum_balance(program_data.len()),
                             data: program_data,
                             executable: true,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -31,7 +31,7 @@ use solana_runtime::{
     snapshot_utils::SnapshotVersion,
 };
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     clock::{Epoch, Slot},
     feature::{self, Feature},
     feature_set,
@@ -1876,7 +1876,7 @@ fn main() {
                     if let Some(faucet_pubkey) = faucet_pubkey {
                         bank.store_account(
                             &faucet_pubkey,
-                            &Account::new(faucet_lamports, 0, &system_program::id()),
+                            &AccountSharedData::new(faucet_lamports, 0, &system_program::id()),
                         );
                     }
 
@@ -1936,7 +1936,7 @@ fn main() {
 
                             bank.store_account(
                                 identity_pubkey,
-                                &Account::new(
+                                &AccountSharedData::new(
                                     bootstrap_validator_lamports,
                                     0,
                                     &system_program::id(),
@@ -2253,7 +2253,7 @@ fn main() {
                                     // capitalizaion, which doesn't affect inflation behavior!
                                     base_bank.store_account(
                                         &feature_set::secp256k1_program_enabled::id(),
-                                        &Account::default(),
+                                        &AccountSharedData::default(),
                                     );
                                     force_enabled_count -= 1;
                                 } else {
@@ -2270,7 +2270,7 @@ fn main() {
                                     // capitalizaion, which doesn't affect inflation behavior!
                                     base_bank.store_account(
                                         &feature_set::instructions_sysvar_enabled::id(),
-                                        &Account::default(),
+                                        &AccountSharedData::default(),
                                     );
                                     force_enabled_count -= 1;
                                 } else {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1209,7 +1209,7 @@ pub mod tests {
         self, create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
     };
     use solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         epoch_schedule::EpochSchedule,
         hash::Hash,
         pubkey::Pubkey,
@@ -2458,7 +2458,7 @@ pub mod tests {
         let mut hash = bank.last_blockhash();
 
         let present_account_key = Keypair::new();
-        let present_account = Account::new(1, 10, &Pubkey::default());
+        let present_account = AccountSharedData::new(1, 10, &Pubkey::default());
         bank.store_account(&present_account_key.pubkey(), &present_account);
 
         let entries: Vec<_> = (0..NUM_TRANSFERS)
@@ -2840,7 +2840,7 @@ pub mod tests {
         }
 
         let present_account_key = Keypair::new();
-        let present_account = Account::new(1, 10, &Pubkey::default());
+        let present_account = AccountSharedData::new(1, 10, &Pubkey::default());
         bank.store_account(&present_account_key.pubkey(), &present_account);
 
         let mut i = 0;
@@ -3013,7 +3013,7 @@ pub mod tests {
         let bank = Arc::new(Bank::new(&genesis_config));
 
         let present_account_key = Keypair::new();
-        let present_account = Account::new(1, 10, &Pubkey::default());
+        let present_account = AccountSharedData::new(1, 10, &Pubkey::default());
         bank.store_account(&present_account_key.pubkey(), &present_account);
 
         let keypair = Keypair::new();
@@ -3347,8 +3347,11 @@ pub mod tests {
                     .map(|(root, stake)| {
                         let mut vote_state = VoteState::default();
                         vote_state.root_slot = Some(root);
-                        let mut vote_account =
-                            Account::new(1, VoteState::size_of(), &solana_vote_program::id());
+                        let mut vote_account = AccountSharedData::new(
+                            1,
+                            VoteState::size_of(),
+                            &solana_vote_program::id(),
+                        );
                         let versioned = VoteStateVersions::new_current(vote_state);
                         VoteState::serialize(&versioned, &mut vote_account.data).unwrap();
                         (

--- a/ledger/src/staking_utils.rs
+++ b/ledger/src/staking_utils.rs
@@ -68,7 +68,7 @@ pub(crate) mod tests {
     use rand::Rng;
     use solana_runtime::vote_account::{ArcVoteAccount, VoteAccounts};
     use solana_sdk::{
-        account::{from_account, Account},
+        account::{from_account, AccountSharedData},
         clock::Clock,
         instruction::Instruction,
         pubkey::Pubkey,
@@ -212,7 +212,8 @@ pub(crate) mod tests {
         let mut result: Vec<_> = epoch_stakes_and_lockouts(&bank, next_leader_schedule_epoch);
         result.sort();
         let stake_history =
-            from_account::<StakeHistory>(&bank.get_account(&stake_history::id()).unwrap()).unwrap();
+            from_account::<StakeHistory, _>(&bank.get_account(&stake_history::id()).unwrap())
+                .unwrap();
         let mut expected = vec![
             (
                 leader_stake.stake(bank.epoch(), Some(&stake_history), true),
@@ -309,7 +310,7 @@ pub(crate) mod tests {
         ));
         let mut rng = rand::thread_rng();
         let vote_accounts = stakes.into_iter().map(|(stake, vote_state)| {
-            let account = Account::new_data(
+            let account = AccountSharedData::new_data(
                 rng.gen(), // lamports
                 &VoteStateVersions::new_current(vote_state),
                 &Pubkey::new_unique(), // owner

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -19,6 +19,7 @@ use solana_runtime::genesis_utils::{
 };
 use solana_sdk::{
     account::Account,
+    account::AccountSharedData,
     client::SyncClient,
     clock::{DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
     commitment_config::CommitmentConfig,
@@ -69,7 +70,7 @@ pub struct ClusterConfig {
     pub native_instruction_processors: Vec<(String, Pubkey)>,
     pub cluster_type: ClusterType,
     pub poh_config: PohConfig,
-    pub additional_accounts: Vec<(Pubkey, Account)>,
+    pub additional_accounts: Vec<(Pubkey, AccountSharedData)>,
 }
 
 impl Default for ClusterConfig {
@@ -169,9 +170,12 @@ impl LocalCluster {
             stakes_in_genesis,
             config.cluster_type,
         );
-        genesis_config
-            .accounts
-            .extend(config.additional_accounts.drain(..));
+        genesis_config.accounts.extend(
+            config
+                .additional_accounts
+                .drain(..)
+                .map(|(key, account)| (key, Account::from(account))),
+        );
         genesis_config.ticks_per_slot = config.ticks_per_slot;
         genesis_config.epoch_schedule = EpochSchedule::custom(
             config.slots_per_epoch,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -38,7 +38,7 @@ use solana_runtime::{
     snapshot_utils,
 };
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     client::{AsyncClient, SyncClient},
     clock::{self, Slot},
     commitment_config::CommitmentConfig,
@@ -286,7 +286,7 @@ fn run_cluster_partition<E, F>(
     leader_schedule: Option<(LeaderSchedule, Vec<Arc<Keypair>>)>,
     on_partition_start: E,
     on_partition_resolved: F,
-    additional_accounts: Vec<(Pubkey, Account)>,
+    additional_accounts: Vec<(Pubkey, AccountSharedData)>,
 ) where
     E: FnOnce(&mut LocalCluster),
     F: FnOnce(&mut LocalCluster),
@@ -2240,7 +2240,11 @@ fn setup_transfer_scan_threads(
     scan_commitment: CommitmentConfig,
     update_client_receiver: Receiver<ThinClient>,
     scan_client_receiver: Receiver<ThinClient>,
-) -> (JoinHandle<()>, JoinHandle<()>, Vec<(Pubkey, Account)>) {
+) -> (
+    JoinHandle<()>,
+    JoinHandle<()>,
+    Vec<(Pubkey, AccountSharedData)>,
+) {
     let exit_ = exit.clone();
     let starting_keypairs: Arc<Vec<Keypair>> = Arc::new(
         iter::repeat_with(Keypair::new)
@@ -2252,9 +2256,14 @@ fn setup_transfer_scan_threads(
             .take(num_starting_accounts)
             .collect(),
     );
-    let starting_accounts: Vec<(Pubkey, Account)> = starting_keypairs
+    let starting_accounts: Vec<(Pubkey, AccountSharedData)> = starting_keypairs
         .iter()
-        .map(|k| (k.pubkey(), Account::new(1, 0, &system_program::id())))
+        .map(|k| {
+            (
+                k.pubkey(),
+                AccountSharedData::new(1, 0, &system_program::id()),
+            )
+        })
         .collect();
 
     let starting_keypairs_ = starting_keypairs.clone();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -20,7 +20,7 @@ use {
         genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
     },
     solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         clock::Slot,
         genesis_config::GenesisConfig,
         keyed_account::KeyedAccount,
@@ -111,7 +111,7 @@ pub fn builtin_process_instruction(
     set_invoke_context(invoke_context);
 
     // Copy all the accounts into a HashMap to ensure there are no duplicates
-    let mut accounts: HashMap<Pubkey, Account> = keyed_accounts
+    let mut accounts: HashMap<Pubkey, AccountSharedData> = keyed_accounts
         .iter()
         .map(|ka| (*ka.unsigned_key(), ka.account.borrow().clone()))
         .collect();
@@ -238,8 +238,8 @@ impl program_stubs::SyscallStubs for SyscallStubs {
 
         stable_log::program_invoke(&logger, &program_id, invoke_context.invoke_depth());
 
-        fn ai_to_a(ai: &AccountInfo) -> Account {
-            Account {
+        fn ai_to_a(ai: &AccountInfo) -> AccountSharedData {
+            AccountSharedData {
                 lamports: ai.lamports(),
                 data: ai.try_borrow_data().unwrap().to_vec(),
                 owner: *ai.owner,
@@ -409,7 +409,7 @@ fn setup_fee_calculator(bank: Bank) -> Bank {
 }
 
 pub struct ProgramTest {
-    accounts: Vec<(Pubkey, Account)>,
+    accounts: Vec<(Pubkey, AccountSharedData)>,
     builtins: Vec<Builtin>,
     bpf_compute_max_units: Option<u64>,
     prefer_bpf: bool,
@@ -468,7 +468,7 @@ impl ProgramTest {
     }
 
     /// Add an account to the test environment
-    pub fn add_account(&mut self, address: Pubkey, account: Account) {
+    pub fn add_account(&mut self, address: Pubkey, account: AccountSharedData) {
         self.accounts.push((address, account));
     }
 
@@ -482,7 +482,7 @@ impl ProgramTest {
     ) {
         self.add_account(
             address,
-            Account {
+            AccountSharedData {
                 lamports,
                 data: read_file(find_file(filename).unwrap_or_else(|| {
                     panic!("Unable to locate {}", filename);
@@ -505,7 +505,7 @@ impl ProgramTest {
     ) {
         self.add_account(
             address,
-            Account {
+            AccountSharedData {
                 lamports,
                 data: base64::decode(data_base64)
                     .unwrap_or_else(|err| panic!("Failed to base64 decode: {}", err)),
@@ -568,7 +568,7 @@ impl ProgramTest {
 
             self.add_account(
                 program_id,
-                Account {
+                AccountSharedData {
                     lamports: Rent::default().minimum_balance(data.len()).min(1),
                     data,
                     owner: loader,

--- a/program-test/src/programs.rs
+++ b/program-test/src/programs.rs
@@ -1,4 +1,4 @@
-use solana_sdk::{account::Account, pubkey::Pubkey, rent::Rent};
+use solana_sdk::{account::AccountSharedData, pubkey::Pubkey, rent::Rent};
 
 mod spl_token {
     solana_sdk::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
@@ -29,13 +29,13 @@ static SPL_PROGRAMS: &[(Pubkey, &[u8])] = &[
     ),
 ];
 
-pub fn spl_programs(rent: &Rent) -> Vec<(Pubkey, Account)> {
+pub fn spl_programs(rent: &Rent) -> Vec<(Pubkey, AccountSharedData)> {
     SPL_PROGRAMS
         .iter()
         .map(|(program_id, elf)| {
             (
                 *program_id,
-                Account {
+                AccountSharedData {
                     lamports: rent.minimum_balance(elf.len()).min(1),
                     data: elf.to_vec(),
                     owner: solana_program::bpf_loader::id(),

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -19,7 +19,7 @@ use solana_runtime::{
     loader_utils::load_program,
 };
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     bpf_loader,
     client::SyncClient,
     entrypoint::SUCCESS,
@@ -198,7 +198,7 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
     let mut invoke_context = MockInvokeContext::default();
     invoke_context.compute_meter.remaining = BUDGET;
 
-    let accounts = [RefCell::new(Account::new(
+    let accounts = [RefCell::new(AccountSharedData::new(
         1,
         10000001,
         &solana_sdk::pubkey::new_rand(),

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -22,7 +22,7 @@ use solana_runtime::{
     },
 };
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
     client::SyncClient,
     clock::{DEFAULT_SLOTS_PER_EPOCH, MAX_PROCESSING_AGE},
@@ -544,10 +544,10 @@ fn test_program_bpf_duplicate_accounts() {
         let bank = Arc::new(bank);
         let bank_client = BankClient::new_shared(&bank);
         let program_id = load_bpf_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
-        let payee_account = Account::new(10, 1, &program_id);
+        let payee_account = AccountSharedData::new(10, 1, &program_id);
         let payee_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&payee_pubkey, &payee_account);
-        let account = Account::new(10, 1, &program_id);
+        let account = AccountSharedData::new(10, 1, &program_id);
 
         let pubkey = solana_sdk::pubkey::new_rand();
         let account_metas = vec![
@@ -780,15 +780,15 @@ fn test_program_bpf_invoke_sanity() {
             load_bpf_program(&bank_client, &bpf_loader::id(), &mint_keypair, program.3);
 
         let argument_keypair = Keypair::new();
-        let account = Account::new(42, 100, &invoke_program_id);
+        let account = AccountSharedData::new(42, 100, &invoke_program_id);
         bank.store_account(&argument_keypair.pubkey(), &account);
 
         let invoked_argument_keypair = Keypair::new();
-        let account = Account::new(10, 10, &invoked_program_id);
+        let account = AccountSharedData::new(10, 10, &invoked_program_id);
         bank.store_account(&invoked_argument_keypair.pubkey(), &account);
 
         let from_keypair = Keypair::new();
-        let account = Account::new(84, 0, &solana_sdk::system_program::id());
+        let account = AccountSharedData::new(84, 0, &solana_sdk::system_program::id());
         bank.store_account(&from_keypair.pubkey(), &account);
 
         let (derived_key1, bump_seed1) =
@@ -996,9 +996,9 @@ fn test_program_bpf_invoke_sanity() {
         }
 
         // Attempt to realloc into unauthorized address space
-        let account = Account::new(84, 0, &solana_sdk::system_program::id());
+        let account = AccountSharedData::new(84, 0, &solana_sdk::system_program::id());
         bank.store_account(&from_keypair.pubkey(), &account);
-        bank.store_account(&derived_key1, &Account::default());
+        bank.store_account(&derived_key1, &AccountSharedData::default());
         let instruction = Instruction::new_with_bytes(
             invoke_program_id,
             &[
@@ -1061,11 +1061,11 @@ fn test_program_bpf_program_id_spoofing() {
     );
 
     let from_pubkey = Pubkey::new_unique();
-    let account = Account::new(10, 0, &solana_sdk::system_program::id());
+    let account = AccountSharedData::new(10, 0, &solana_sdk::system_program::id());
     bank.store_account(&from_pubkey, &account);
 
     let to_pubkey = Pubkey::new_unique();
-    let account = Account::new(0, 0, &solana_sdk::system_program::id());
+    let account = AccountSharedData::new(0, 0, &solana_sdk::system_program::id());
     bank.store_account(&to_pubkey, &account);
 
     let account_metas = vec![
@@ -1148,7 +1148,7 @@ fn test_program_bpf_ro_modify() {
     );
 
     let test_keypair = Keypair::new();
-    let account = Account::new(10, 0, &solana_sdk::system_program::id());
+    let account = AccountSharedData::new(10, 0, &solana_sdk::system_program::id());
     bank.store_account(&test_keypair.pubkey(), &account);
 
     let account_metas = vec![
@@ -1261,7 +1261,7 @@ fn assert_instruction_count() {
         println!("Test program: {:?}", program.0);
         let program_id = solana_sdk::pubkey::new_rand();
         let key = solana_sdk::pubkey::new_rand();
-        let mut account = RefCell::new(Account::default());
+        let mut account = RefCell::new(AccountSharedData::default());
         let parameter_accounts = vec![KeyedAccount::new(&key, false, &mut account)];
         let count = run_program(program.0, &program_id, &parameter_accounts[..], &[]).unwrap();
         println!("  {} : {:?} ({:?})", program.0, count, program.1,);

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -866,7 +866,7 @@ mod tests {
         message_processor::{Executors, ThisInvokeContext},
     };
     use solana_sdk::{
-        account::{create_account, Account},
+        account::{create_account_shared_data as create_account, AccountSharedData},
         account_utils::StateMut,
         client::SyncClient,
         clock::Clock,
@@ -933,7 +933,7 @@ mod tests {
     fn test_bpf_loader_write() {
         let program_id = bpf_loader::id();
         let program_key = solana_sdk::pubkey::new_rand();
-        let program_account = Account::new_ref(1, 0, &program_id);
+        let program_account = AccountSharedData::new_ref(1, 0, &program_id);
         let keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         let instruction_data = bincode::serialize(&LoaderInstruction::Write {
             offset: 3,
@@ -1004,7 +1004,8 @@ mod tests {
         let mut elf = Vec::new();
         let rent = Rent::default();
         file.read_to_end(&mut elf).unwrap();
-        let program_account = Account::new_ref(rent.minimum_balance(elf.len()), 0, &program_id);
+        let program_account =
+            AccountSharedData::new_ref(rent.minimum_balance(elf.len()), 0, &program_id);
         program_account.borrow_mut().data = elf;
         let keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         let instruction_data = bincode::serialize(&LoaderInstruction::Finalize).unwrap();
@@ -1069,7 +1070,7 @@ mod tests {
         let mut file = File::open("test_elfs/noop_aligned.so").expect("file open failed");
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
-        let program_account = Account::new_ref(1, 0, &program_id);
+        let program_account = AccountSharedData::new_ref(1, 0, &program_id);
         program_account.borrow_mut().data = elf;
         program_account.borrow_mut().executable = true;
 
@@ -1098,7 +1099,7 @@ mod tests {
         keyed_accounts[0].account.borrow_mut().executable = true;
 
         // Case: With program and parameter account
-        let parameter_account = Account::new_ref(1, 0, &program_id);
+        let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
         keyed_accounts.push(KeyedAccount::new(&program_key, false, &parameter_account));
         assert_eq!(
             Ok(()),
@@ -1139,7 +1140,7 @@ mod tests {
 
         // Case: With duplicate accounts
         let duplicate_key = solana_sdk::pubkey::new_rand();
-        let parameter_account = Account::new_ref(1, 0, &program_id);
+        let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
@@ -1163,13 +1164,13 @@ mod tests {
         let mut file = File::open("test_elfs/noop_unaligned.so").expect("file open failed");
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
-        let program_account = Account::new_ref(1, 0, &program_id);
+        let program_account = AccountSharedData::new_ref(1, 0, &program_id);
         program_account.borrow_mut().data = elf;
         program_account.borrow_mut().executable = true;
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
 
         // Case: With program and parameter account
-        let parameter_account = Account::new_ref(1, 0, &program_id);
+        let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
         keyed_accounts.push(KeyedAccount::new(&program_key, false, &parameter_account));
         assert_eq!(
             Ok(()),
@@ -1183,7 +1184,7 @@ mod tests {
 
         // Case: With duplicate accounts
         let duplicate_key = solana_sdk::pubkey::new_rand();
-        let parameter_account = Account::new_ref(1, 0, &program_id);
+        let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
@@ -1207,13 +1208,13 @@ mod tests {
         let mut file = File::open("test_elfs/noop_aligned.so").expect("file open failed");
         let mut elf = Vec::new();
         file.read_to_end(&mut elf).unwrap();
-        let program_account = Account::new_ref(1, 0, &program_id);
+        let program_account = AccountSharedData::new_ref(1, 0, &program_id);
         program_account.borrow_mut().data = elf;
         program_account.borrow_mut().executable = true;
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
 
         // Case: With program and parameter account
-        let parameter_account = Account::new_ref(1, 0, &program_id);
+        let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
         keyed_accounts.push(KeyedAccount::new(&program_key, false, &parameter_account));
         assert_eq!(
             Ok(()),
@@ -1227,7 +1228,7 @@ mod tests {
 
         // Case: With duplicate accounts
         let duplicate_key = solana_sdk::pubkey::new_rand();
-        let parameter_account = Account::new_ref(1, 0, &program_id);
+        let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
         keyed_accounts.push(KeyedAccount::new(&duplicate_key, false, &parameter_account));
@@ -1247,13 +1248,13 @@ mod tests {
         let instruction =
             bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap();
         let buffer_address = Pubkey::new_unique();
-        let buffer_account = Account::new_ref(
+        let buffer_account = AccountSharedData::new_ref(
             1,
             UpgradeableLoaderState::buffer_len(9).unwrap(),
             &bpf_loader_upgradeable::id(),
         );
         let authority_address = Pubkey::new_unique();
-        let authority_account = Account::new_ref(
+        let authority_account = AccountSharedData::new_ref(
             1,
             UpgradeableLoaderState::buffer_len(9).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -1305,7 +1306,7 @@ mod tests {
     #[test]
     fn test_bpf_loader_upgradeable_write() {
         let buffer_address = Pubkey::new_unique();
-        let buffer_account = Account::new_ref(
+        let buffer_account = AccountSharedData::new_ref(
             1,
             UpgradeableLoaderState::buffer_len(9).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -1372,7 +1373,7 @@ mod tests {
             bytes: vec![42; 6],
         })
         .unwrap();
-        let buffer_account = Account::new_ref(
+        let buffer_account = AccountSharedData::new_ref(
             1,
             UpgradeableLoaderState::buffer_len(9).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -1564,7 +1565,7 @@ mod tests {
             UpgradeableLoaderState::programdata_len(elf.len()).unwrap(),
         );
         let buffer_address = Pubkey::new_unique();
-        let mut buffer_account = Account::new(
+        let mut buffer_account = AccountSharedData::new(
             min_programdata_balance,
             UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -1576,12 +1577,12 @@ mod tests {
             .unwrap();
         buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..]
             .copy_from_slice(&elf);
-        let program_account = Account::new(
+        let program_account = AccountSharedData::new(
             min_programdata_balance,
             UpgradeableLoaderState::program_len().unwrap(),
             &bpf_loader_upgradeable::id(),
         );
-        let programdata_account = Account::new(
+        let programdata_account = AccountSharedData::new(
             1,
             UpgradeableLoaderState::programdata_len(elf.len()).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -1590,8 +1591,8 @@ mod tests {
         // Test successful deploy
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let before = bank.get_balance(&mint_keypair.pubkey());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
@@ -1683,7 +1684,7 @@ mod tests {
         // Test initialized ProgramData account
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -1772,9 +1773,9 @@ mod tests {
 
         // Test invalid Buffer account state
         bank.clear_signatures();
-        bank.store_account(&buffer_address, &Account::default());
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&buffer_address, &AccountSharedData::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -1801,8 +1802,8 @@ mod tests {
         // Test program account not rent exempt
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -1829,8 +1830,8 @@ mod tests {
         // Test program account not rent exempt because data is larger than needed
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let mut instructions = bpf_loader_upgradeable::deploy_with_max_program_len(
             &mint_keypair.pubkey(),
             &program_keypair.pubkey(),
@@ -1862,8 +1863,8 @@ mod tests {
         // Test program account too small
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let mut instructions = bpf_loader_upgradeable::deploy_with_max_program_len(
             &mint_keypair.pubkey(),
             &program_keypair.pubkey(),
@@ -1896,11 +1897,11 @@ mod tests {
         bank.clear_signatures();
         bank.store_account(
             &mint_keypair.pubkey(),
-            &Account::new(min_program_balance, 0, &system_program::id()),
+            &AccountSharedData::new(min_program_balance, 0, &system_program::id()),
         );
         bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -1925,14 +1926,14 @@ mod tests {
         );
         bank.store_account(
             &mint_keypair.pubkey(),
-            &Account::new(1_000_000_000, 0, &system_program::id()),
+            &AccountSharedData::new(1_000_000_000, 0, &system_program::id()),
         );
 
         // Test max_data_len
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -1960,13 +1961,13 @@ mod tests {
         bank.clear_signatures();
         bank.store_account(
             &mint_keypair.pubkey(),
-            &Account::new(u64::MAX / 2, 0, &system_program::id()),
+            &AccountSharedData::new(u64::MAX / 2, 0, &system_program::id()),
         );
         let mut modified_buffer_account = buffer_account.clone();
         modified_buffer_account.lamports = u64::MAX / 2;
         bank.store_account(&buffer_address, &modified_buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -1993,8 +1994,8 @@ mod tests {
         // Test not the system account
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let mut instructions = bpf_loader_upgradeable::deploy_with_max_program_len(
             &mint_keypair.pubkey(),
             &program_keypair.pubkey(),
@@ -2024,8 +2025,8 @@ mod tests {
             .data
             .truncate(UpgradeableLoaderState::buffer_len(1).unwrap());
         bank.store_account(&buffer_address, &modified_buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -2051,7 +2052,7 @@ mod tests {
 
         // Test small buffer account
         bank.clear_signatures();
-        let mut modified_buffer_account = Account::new(
+        let mut modified_buffer_account = AccountSharedData::new(
             min_programdata_balance,
             UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -2065,8 +2066,8 @@ mod tests {
             .copy_from_slice(&elf);
         modified_buffer_account.data.truncate(5);
         bank.store_account(&buffer_address, &modified_buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -2092,7 +2093,7 @@ mod tests {
 
         // Mismatched buffer and program authority
         bank.clear_signatures();
-        let mut modified_buffer_account = Account::new(
+        let mut modified_buffer_account = AccountSharedData::new(
             min_programdata_balance,
             UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -2105,8 +2106,8 @@ mod tests {
         modified_buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..]
             .copy_from_slice(&elf);
         bank.store_account(&buffer_address, &modified_buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -2132,7 +2133,7 @@ mod tests {
 
         // Deploy buffer with mismatched None authority
         bank.clear_signatures();
-        let mut modified_buffer_account = Account::new(
+        let mut modified_buffer_account = AccountSharedData::new(
             min_programdata_balance,
             UpgradeableLoaderState::buffer_len(elf.len()).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -2145,8 +2146,8 @@ mod tests {
         modified_buffer_account.data[UpgradeableLoaderState::buffer_data_offset().unwrap()..]
             .copy_from_slice(&elf);
         bank.store_account(&buffer_address, &modified_buffer_account);
-        bank.store_account(&program_keypair.pubkey(), &Account::default());
-        bank.store_account(&programdata_address, &Account::default());
+        bank.store_account(&program_keypair.pubkey(), &AccountSharedData::default());
+        bank.store_account(&programdata_address, &AccountSharedData::default());
         let message = Message::new(
             &bpf_loader_upgradeable::deploy_with_max_program_len(
                 &mint_keypair.pubkey(),
@@ -2202,7 +2203,7 @@ mod tests {
         let (programdata_address, _) =
             Pubkey::find_program_address(&[program_address.as_ref()], &id());
         let spill_address = Pubkey::new_unique();
-        let upgrade_authority_account = Account::new_ref(1, 0, &Pubkey::new_unique());
+        let upgrade_authority_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
 
         #[allow(clippy::type_complexity)]
         fn get_accounts(
@@ -2215,12 +2216,12 @@ mod tests {
             min_program_balance: u64,
             min_programdata_balance: u64,
         ) -> (
-            Rc<RefCell<Account>>,
-            Rc<RefCell<Account>>,
-            Rc<RefCell<Account>>,
-            Rc<RefCell<Account>>,
+            Rc<RefCell<AccountSharedData>>,
+            Rc<RefCell<AccountSharedData>>,
+            Rc<RefCell<AccountSharedData>>,
+            Rc<RefCell<AccountSharedData>>,
         ) {
-            let buffer_account = Account::new_ref(
+            let buffer_account = AccountSharedData::new_ref(
                 1,
                 UpgradeableLoaderState::buffer_len(elf_new.len()).unwrap(),
                 &bpf_loader_upgradeable::id(),
@@ -2234,7 +2235,7 @@ mod tests {
             buffer_account.borrow_mut().data
                 [UpgradeableLoaderState::buffer_data_offset().unwrap()..]
                 .copy_from_slice(&elf_new);
-            let programdata_account = Account::new_ref(
+            let programdata_account = AccountSharedData::new_ref(
                 min_programdata_balance,
                 UpgradeableLoaderState::programdata_len(elf_orig.len().max(elf_new.len())).unwrap(),
                 &bpf_loader_upgradeable::id(),
@@ -2246,7 +2247,7 @@ mod tests {
                     upgrade_authority_address: Some(*upgrade_authority_address),
                 })
                 .unwrap();
-            let program_account = Account::new_ref(
+            let program_account = AccountSharedData::new_ref(
                 min_program_balance,
                 UpgradeableLoaderState::program_len().unwrap(),
                 &bpf_loader_upgradeable::id(),
@@ -2258,7 +2259,7 @@ mod tests {
                     programdata_address: *programdata_address,
                 })
                 .unwrap();
-            let spill_account = Account::new_ref(0, 0, &Pubkey::new_unique());
+            let spill_account = AccountSharedData::new_ref(0, 0, &Pubkey::new_unique());
 
             (
                 buffer_account,
@@ -2648,7 +2649,7 @@ mod tests {
             min_program_balance,
             min_programdata_balance,
         );
-        let buffer_account = Account::new_ref(
+        let buffer_account = AccountSharedData::new_ref(
             1,
             UpgradeableLoaderState::buffer_len(elf_orig.len().max(elf_new.len()) + 1).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -2845,13 +2846,13 @@ mod tests {
         let instruction = bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap();
         let slot = 0;
         let upgrade_authority_address = Pubkey::new_unique();
-        let upgrade_authority_account = Account::new_ref(1, 0, &Pubkey::new_unique());
+        let upgrade_authority_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
         let new_upgrade_authority_address = Pubkey::new_unique();
-        let new_upgrade_authority_account = Account::new_ref(1, 0, &Pubkey::new_unique());
+        let new_upgrade_authority_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
         let program_address = Pubkey::new_unique();
         let (programdata_address, _) =
             Pubkey::find_program_address(&[program_address.as_ref()], &id());
-        let programdata_account = Account::new_ref(
+        let programdata_account = AccountSharedData::new_ref(
             1,
             UpgradeableLoaderState::programdata_len(0).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -3037,11 +3038,11 @@ mod tests {
     fn test_bpf_loader_upgradeable_set_buffer_authority() {
         let instruction = bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap();
         let authority_address = Pubkey::new_unique();
-        let authority_account = Account::new_ref(1, 0, &Pubkey::new_unique());
+        let authority_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
         let new_authority_address = Pubkey::new_unique();
-        let new_authority_account = Account::new_ref(1, 0, &Pubkey::new_unique());
+        let new_authority_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
         let buffer_address = Pubkey::new_unique();
-        let buffer_account = Account::new_ref(
+        let buffer_account = AccountSharedData::new_ref(
             1,
             UpgradeableLoaderState::buffer_len(0).unwrap(),
             &bpf_loader_upgradeable::id(),
@@ -3264,11 +3265,11 @@ mod tests {
             0..elf.len(),
             0..255,
             |bytes: &mut [u8]| {
-                let program_account = Account::new_ref(1, 0, &program_id);
+                let program_account = AccountSharedData::new_ref(1, 0, &program_id);
                 program_account.borrow_mut().data = bytes.to_vec();
                 program_account.borrow_mut().executable = true;
 
-                let parameter_account = Account::new_ref(1, 0, &program_id);
+                let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
                 let keyed_accounts = vec![
                     KeyedAccount::new(&program_key, false, &program_account),
                     KeyedAccount::new(&program_key, false, &parameter_account),

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -243,7 +243,7 @@ pub fn deserialize_parameters_aligned(
 mod tests {
     use super::*;
     use solana_sdk::{
-        account::Account, account_info::AccountInfo, bpf_loader, entrypoint::deserialize,
+        account::AccountSharedData, account_info::AccountInfo, bpf_loader, entrypoint::deserialize,
     };
     use std::{
         cell::RefCell,
@@ -263,7 +263,7 @@ mod tests {
             solana_sdk::pubkey::new_rand(),
         ];
         let accounts = [
-            RefCell::new(Account {
+            RefCell::new(AccountSharedData {
                 lamports: 1,
                 data: vec![1u8, 2, 3, 4, 5],
                 owner: bpf_loader::id(),
@@ -271,21 +271,21 @@ mod tests {
                 rent_epoch: 100,
             }),
             // dup of first
-            RefCell::new(Account {
+            RefCell::new(AccountSharedData {
                 lamports: 1,
                 data: vec![1u8, 2, 3, 4, 5],
                 owner: bpf_loader::id(),
                 executable: false,
                 rent_epoch: 100,
             }),
-            RefCell::new(Account {
+            RefCell::new(AccountSharedData {
                 lamports: 2,
                 data: vec![11u8, 12, 13, 14, 15, 16, 17, 18, 19],
                 owner: bpf_loader::id(),
                 executable: true,
                 rent_epoch: 200,
             }),
-            RefCell::new(Account {
+            RefCell::new(AccountSharedData {
                 lamports: 3,
                 data: vec![],
                 owner: bpf_loader::id(),

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -10,7 +10,7 @@ use solana_rbpf::{
 };
 use solana_runtime::message_processor::MessageProcessor;
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     account_info::AccountInfo,
     account_utils::StateMut,
     bpf_loader, bpf_loader_deprecated,
@@ -851,9 +851,12 @@ struct AccountReferences<'a> {
     ref_to_len_in_vm: &'a mut u64,
     serialized_len_ptr: &'a mut u64,
 }
-type TranslatedAccount<'a> = (Rc<RefCell<Account>>, Option<AccountReferences<'a>>);
+type TranslatedAccount<'a> = (
+    Rc<RefCell<AccountSharedData>>,
+    Option<AccountReferences<'a>>,
+);
 type TranslatedAccounts<'a> = (
-    Vec<Rc<RefCell<Account>>>,
+    Vec<Rc<RefCell<AccountSharedData>>>,
     Vec<Option<AccountReferences<'a>>>,
 );
 
@@ -1018,7 +1021,7 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
             };
 
             Ok((
-                Rc::new(RefCell::new(Account {
+                Rc::new(RefCell::new(AccountSharedData {
                     lamports: *lamports,
                     data: data.to_vec(),
                     executable: account_info.executable,
@@ -1301,7 +1304,7 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
             )?;
 
             Ok((
-                Rc::new(RefCell::new(Account {
+                Rc::new(RefCell::new(AccountSharedData {
                     lamports: *lamports,
                     data: data.to_vec(),
                     executable: account_info.executable,
@@ -1512,9 +1515,9 @@ fn check_authorized_program(
 
 fn get_upgradeable_executable(
     callee_program_id: &Pubkey,
-    program_account: &RefCell<Account>,
+    program_account: &RefCell<AccountSharedData>,
     invoke_context: &Ref<&mut dyn InvokeContext>,
-) -> Result<Option<(Pubkey, RefCell<Account>)>, EbpfError<BpfError>> {
+) -> Result<Option<(Pubkey, RefCell<AccountSharedData>)>, EbpfError<BpfError>> {
     if program_account.borrow().owner == bpf_loader_upgradeable::id() {
         match program_account.borrow().state() {
             Ok(UpgradeableLoaderState::Program {

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -229,7 +229,7 @@ mod tests {
     use crate::id;
     use solana_runtime::bank::Bank;
     use solana_runtime::bank_client::BankClient;
-    use solana_sdk::account::Account;
+    use solana_sdk::account::AccountSharedData;
     use solana_sdk::client::SyncClient;
     use solana_sdk::genesis_config::create_genesis_config;
     use solana_sdk::hash::hash;
@@ -522,10 +522,10 @@ mod tests {
     fn test_pay_when_account_data() {
         let (bank, alice_keypair) = create_bank(42);
         let game_pubkey = solana_sdk::pubkey::new_rand();
-        let game_account = Account {
+        let game_account = AccountSharedData {
             lamports: 1,
             data: vec![1, 2, 3],
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         bank.store_account(&game_pubkey, &game_account);
         assert_eq!(bank.get_account(&game_pubkey).unwrap().data, vec![1, 2, 3]);

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -130,7 +130,7 @@ mod tests {
     use bincode::serialized_size;
     use serde_derive::{Deserialize, Serialize};
     use solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         keyed_account::create_keyed_is_signer_accounts,
         process_instruction::MockInvokeContext,
         signature::{Keypair, Signer},
@@ -162,7 +162,7 @@ mod tests {
         }
     }
 
-    fn create_config_account(keys: Vec<(Pubkey, bool)>) -> (Keypair, RefCell<Account>) {
+    fn create_config_account(keys: Vec<(Pubkey, bool)>) -> (Keypair, RefCell<AccountSharedData>) {
         let from_pubkey = solana_sdk::pubkey::new_rand();
         let config_keypair = Keypair::new();
         let config_pubkey = config_keypair.pubkey();
@@ -179,10 +179,10 @@ mod tests {
             } => space,
             _ => panic!("Not a CreateAccount system instruction"),
         };
-        let config_account = RefCell::new(Account {
+        let config_account = RefCell::new(AccountSharedData {
             data: vec![0; space as usize],
             owner: id(),
-            ..Account::default()
+            ..AccountSharedData::default()
         });
         let accounts = vec![(&config_pubkey, true, &config_account)];
         let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
@@ -298,8 +298,8 @@ mod tests {
         let my_config = MyConfig::new(42);
 
         let instruction = config_instruction::store(&config_pubkey, true, keys.clone(), &my_config);
-        let signer0_account = RefCell::new(Account::default());
-        let signer1_account = RefCell::new(Account::default());
+        let signer0_account = RefCell::new(AccountSharedData::default());
+        let signer1_account = RefCell::new(AccountSharedData::default());
         let accounts = vec![
             (&config_pubkey, true, &config_account),
             (&signer0_pubkey, true, &signer0_account),
@@ -334,9 +334,9 @@ mod tests {
         let my_config = MyConfig::new(42);
 
         let instruction = config_instruction::store(&config_pubkey, false, keys, &my_config);
-        let signer0_account = RefCell::new(Account {
+        let signer0_account = RefCell::new(AccountSharedData {
             owner: id(),
-            ..Account::default()
+            ..AccountSharedData::default()
         });
         let accounts = vec![(&signer0_pubkey, true, &signer0_account)];
         let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
@@ -356,8 +356,8 @@ mod tests {
         solana_logger::setup();
         let signer0_pubkey = solana_sdk::pubkey::new_rand();
         let signer1_pubkey = solana_sdk::pubkey::new_rand();
-        let signer0_account = RefCell::new(Account::default());
-        let signer1_account = RefCell::new(Account::default());
+        let signer0_account = RefCell::new(AccountSharedData::default());
+        let signer1_account = RefCell::new(AccountSharedData::default());
         let keys = vec![(signer0_pubkey, true)];
         let (config_keypair, config_account) = create_config_account(keys.clone());
         let config_pubkey = config_keypair.pubkey();
@@ -405,9 +405,9 @@ mod tests {
         let signer0_pubkey = solana_sdk::pubkey::new_rand();
         let signer1_pubkey = solana_sdk::pubkey::new_rand();
         let signer2_pubkey = solana_sdk::pubkey::new_rand();
-        let signer0_account = RefCell::new(Account::default());
-        let signer1_account = RefCell::new(Account::default());
-        let signer2_account = RefCell::new(Account::default());
+        let signer0_account = RefCell::new(AccountSharedData::default());
+        let signer1_account = RefCell::new(AccountSharedData::default());
+        let signer2_account = RefCell::new(AccountSharedData::default());
         let keys = vec![
             (pubkey, false),
             (signer0_pubkey, true),
@@ -508,7 +508,7 @@ mod tests {
         solana_logger::setup();
         let pubkey = solana_sdk::pubkey::new_rand();
         let signer0_pubkey = solana_sdk::pubkey::new_rand();
-        let signer0_account = RefCell::new(Account::default());
+        let signer0_account = RefCell::new(AccountSharedData::default());
         let keys = vec![
             (pubkey, false),
             (signer0_pubkey, true),
@@ -606,8 +606,8 @@ mod tests {
         let config_pubkey = solana_sdk::pubkey::new_rand();
         let new_config = MyConfig::new(84);
         let signer0_pubkey = solana_sdk::pubkey::new_rand();
-        let signer0_account = RefCell::new(Account::default());
-        let config_account = RefCell::new(Account::default());
+        let signer0_account = RefCell::new(AccountSharedData::default());
+        let config_account = RefCell::new(AccountSharedData::default());
         let keys = vec![
             (from_pubkey, false),
             (signer0_pubkey, true),

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -5,7 +5,7 @@ pub mod date_instruction;
 
 use bincode::{deserialize, serialize, serialized_size};
 use serde_derive::{Deserialize, Serialize};
-use solana_sdk::{account::Account, pubkey::Pubkey, short_vec};
+use solana_sdk::{account::AccountSharedData, pubkey::Pubkey, short_vec};
 
 solana_sdk::declare_id!("Config1111111111111111111111111111111111111");
 
@@ -40,13 +40,13 @@ pub fn create_config_account<T: ConfigState>(
     keys: Vec<(Pubkey, bool)>,
     config_data: &T,
     lamports: u64,
-) -> Account {
+) -> AccountSharedData {
     let mut data = serialize(&ConfigKeys { keys }).unwrap();
     data.extend_from_slice(&serialize(config_data).unwrap());
-    Account {
+    AccountSharedData {
         lamports,
         data,
         owner: id(),
-        ..Account::default()
+        ..AccountSharedData::default()
     }
 }

--- a/programs/ownable/src/ownable_processor.rs
+++ b/programs/ownable/src/ownable_processor.rs
@@ -61,7 +61,7 @@ mod tests {
     use crate::ownable_instruction;
     use solana_runtime::{bank::Bank, bank_client::BankClient};
     use solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         client::SyncClient,
         genesis_config::create_genesis_config,
         message::Message,
@@ -156,7 +156,7 @@ mod tests {
         let mut account_owner_pubkey = solana_sdk::pubkey::new_rand();
         let owner_pubkey = account_owner_pubkey;
         let new_owner_pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new_ref(1, 0, &system_program::id());
+        let account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let owner_keyed_account = KeyedAccount::new(&owner_pubkey, false, &account); // <-- Attack! Setting owner without the original owner's signature.
         let err = set_owner(
             &mut account_owner_pubkey,
@@ -171,7 +171,7 @@ mod tests {
     fn test_ownable_incorrect_owner() {
         let mut account_owner_pubkey = solana_sdk::pubkey::new_rand();
         let new_owner_pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new_ref(1, 0, &system_program::id());
+        let account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let mallory_pubkey = solana_sdk::pubkey::new_rand(); // <-- Attack! Signing with wrong pubkey
         let owner_keyed_account = KeyedAccount::new(&mallory_pubkey, true, &account);
         let err = set_owner(

--- a/programs/stake/src/config.rs
+++ b/programs/stake/src/config.rs
@@ -4,7 +4,9 @@ use bincode::{deserialize, serialized_size};
 use serde_derive::{Deserialize, Serialize};
 use solana_config_program::{create_config_account, get_config_data, ConfigState};
 use solana_sdk::{
-    account::Account, genesis_config::GenesisConfig, instruction::InstructionError,
+    account::{AccountSharedData, ReadableAccount},
+    genesis_config::GenesisConfig,
+    instruction::InstructionError,
     keyed_account::KeyedAccount,
 };
 
@@ -25,8 +27,8 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn from(account: &Account) -> Option<Self> {
-        get_config_data(&account.data)
+    pub fn from<T: ReadableAccount>(account: &T) -> Option<Self> {
+        get_config_data(&account.data())
             .ok()
             .and_then(|data| deserialize(data).ok())
     }
@@ -58,7 +60,7 @@ pub fn add_genesis_account(genesis_config: &mut GenesisConfig) -> u64 {
     lamports
 }
 
-pub fn create_account(lamports: u64, config: &Config) -> Account {
+pub fn create_account(lamports: u64, config: &Config) -> AccountSharedData {
     create_config_account(vec![], config, lamports)
 }
 

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -622,7 +622,7 @@ mod tests {
     use super::*;
     use bincode::serialize;
     use solana_sdk::{
-        account::{self, Account},
+        account::{self, AccountSharedData},
         process_instruction::MockInvokeContext,
         rent::Rent,
         sysvar::stake_history::StakeHistory,
@@ -630,14 +630,14 @@ mod tests {
     use std::cell::RefCell;
     use std::str::FromStr;
 
-    fn create_default_account() -> RefCell<Account> {
-        RefCell::new(Account::default())
+    fn create_default_account() -> RefCell<AccountSharedData> {
+        RefCell::new(AccountSharedData::default())
     }
 
-    fn create_default_stake_account() -> RefCell<Account> {
-        RefCell::new(Account {
+    fn create_default_stake_account() -> RefCell<AccountSharedData> {
+        RefCell::new(AccountSharedData {
             owner: id(),
-            ..Account::default()
+            ..AccountSharedData::default()
         })
     }
 
@@ -663,34 +663,34 @@ mod tests {
             .iter()
             .map(|meta| {
                 RefCell::new(if sysvar::clock::check_id(&meta.pubkey) {
-                    account::create_account(&sysvar::clock::Clock::default(), 1)
+                    account::create_account_shared_data(&sysvar::clock::Clock::default(), 1)
                 } else if sysvar::rewards::check_id(&meta.pubkey) {
-                    account::create_account(&sysvar::rewards::Rewards::new(0.0), 1)
+                    account::create_account_shared_data(&sysvar::rewards::Rewards::new(0.0), 1)
                 } else if sysvar::stake_history::check_id(&meta.pubkey) {
-                    account::create_account(&StakeHistory::default(), 1)
+                    account::create_account_shared_data(&StakeHistory::default(), 1)
                 } else if config::check_id(&meta.pubkey) {
                     config::create_account(0, &config::Config::default())
                 } else if sysvar::rent::check_id(&meta.pubkey) {
-                    account::create_account(&Rent::default(), 1)
+                    account::create_account_shared_data(&Rent::default(), 1)
                 } else if meta.pubkey == invalid_stake_state_pubkey() {
-                    Account {
+                    AccountSharedData {
                         owner: id(),
-                        ..Account::default()
+                        ..AccountSharedData::default()
                     }
                 } else if meta.pubkey == invalid_vote_state_pubkey() {
-                    Account {
+                    AccountSharedData {
                         owner: solana_vote_program::id(),
-                        ..Account::default()
+                        ..AccountSharedData::default()
                     }
                 } else if meta.pubkey == spoofed_stake_state_pubkey() {
-                    Account {
+                    AccountSharedData {
                         owner: spoofed_stake_program_id(),
-                        ..Account::default()
+                        ..AccountSharedData::default()
                     }
                 } else {
-                    Account {
+                    AccountSharedData {
                         owner: id(),
-                        ..Account::default()
+                        ..AccountSharedData::default()
                     }
                 })
             })
@@ -973,7 +973,7 @@ mod tests {
                     KeyedAccount::new(
                         &sysvar::rent::id(),
                         false,
-                        &RefCell::new(account::create_account(&Rent::default(), 0))
+                        &RefCell::new(account::create_account_shared_data(&Rent::default(), 0))
                     )
                 ],
                 &serialize(&StakeInstruction::Initialize(
@@ -1028,12 +1028,15 @@ mod tests {
                     KeyedAccount::new(
                         &sysvar::clock::id(),
                         false,
-                        &RefCell::new(account::create_account(&sysvar::clock::Clock::default(), 1))
+                        &RefCell::new(account::create_account_shared_data(
+                            &sysvar::clock::Clock::default(),
+                            1
+                        ))
                     ),
                     KeyedAccount::new(
                         &sysvar::stake_history::id(),
                         false,
-                        &RefCell::new(account::create_account(
+                        &RefCell::new(account::create_account_shared_data(
                             &sysvar::stake_history::StakeHistory::default(),
                             1
                         ))
@@ -1060,7 +1063,7 @@ mod tests {
                     KeyedAccount::new(
                         &sysvar::rewards::id(),
                         false,
-                        &RefCell::new(account::create_account(
+                        &RefCell::new(account::create_account_shared_data(
                             &sysvar::rewards::Rewards::new(0.0),
                             1
                         ))
@@ -1068,7 +1071,10 @@ mod tests {
                     KeyedAccount::new(
                         &sysvar::stake_history::id(),
                         false,
-                        &RefCell::new(account::create_account(&StakeHistory::default(), 1,))
+                        &RefCell::new(account::create_account_shared_data(
+                            &StakeHistory::default(),
+                            1,
+                        ))
                     ),
                 ],
                 &serialize(&StakeInstruction::Withdraw(42)).unwrap(),
@@ -1101,7 +1107,7 @@ mod tests {
                     KeyedAccount::new(
                         &sysvar::rewards::id(),
                         false,
-                        &RefCell::new(account::create_account(
+                        &RefCell::new(account::create_account_shared_data(
                             &sysvar::rewards::Rewards::new(0.0),
                             1
                         ))

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -10,7 +10,8 @@ use crate::{
 };
 use serde_derive::{Deserialize, Serialize};
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
+    account::ReadableAccount,
     account_utils::{State, StateMut},
     clock::{Clock, Epoch, UnixTimestamp},
     ic_msg,
@@ -76,11 +77,11 @@ impl StakeState {
     }
 
     // utility function, used by Stakes, tests
-    pub fn from(account: &Account) -> Option<StakeState> {
+    pub fn from<T: ReadableAccount + StateMut<StakeState>>(account: &T) -> Option<StakeState> {
         account.state().ok()
     }
 
-    pub fn stake_from(account: &Account) -> Option<Stake> {
+    pub fn stake_from<T: ReadableAccount + StateMut<StakeState>>(account: &T) -> Option<Stake> {
         Self::from(account).and_then(|state: Self| state.stake())
     }
     pub fn stake(&self) -> Option<Stake> {
@@ -90,7 +91,7 @@ impl StakeState {
         }
     }
 
-    pub fn delegation_from(account: &Account) -> Option<Delegation> {
+    pub fn delegation_from(account: &AccountSharedData) -> Option<Delegation> {
         Self::from(account).and_then(|state: Self| state.delegation())
     }
     pub fn delegation(&self) -> Option<Delegation> {
@@ -100,7 +101,7 @@ impl StakeState {
         }
     }
 
-    pub fn authorized_from(account: &Account) -> Option<Authorized> {
+    pub fn authorized_from(account: &AccountSharedData) -> Option<Authorized> {
         Self::from(account).and_then(|state: Self| state.authorized())
     }
 
@@ -112,7 +113,7 @@ impl StakeState {
         }
     }
 
-    pub fn lockup_from(account: &Account) -> Option<Lockup> {
+    pub fn lockup_from<T: ReadableAccount + StateMut<StakeState>>(account: &T) -> Option<Lockup> {
         Self::from(account).and_then(|state: Self| state.lockup())
     }
 
@@ -120,7 +121,7 @@ impl StakeState {
         self.meta().map(|meta| meta.lockup)
     }
 
-    pub fn meta_from(account: &Account) -> Option<Meta> {
+    pub fn meta_from(account: &AccountSharedData) -> Option<Meta> {
         Self::from(account).and_then(|state: Self| state.meta())
     }
 
@@ -1453,8 +1454,8 @@ impl MergeKind {
 // returns a tuple of (stakers_reward,voters_reward)
 pub fn redeem_rewards(
     rewarded_epoch: Epoch,
-    stake_account: &mut Account,
-    vote_account: &mut Account,
+    stake_account: &mut AccountSharedData,
+    vote_account: &mut AccountSharedData,
     point_value: &PointValue,
     stake_history: Option<&StakeHistory>,
     inflation_point_calc_tracer: &mut Option<impl FnMut(&InflationPointCalculationEvent)>,
@@ -1502,8 +1503,8 @@ pub fn redeem_rewards(
 
 // utility function, used by runtime
 pub fn calculate_points(
-    stake_account: &Account,
-    vote_account: &Account,
+    stake_account: &AccountSharedData,
+    vote_account: &AccountSharedData,
     stake_history: Option<&StakeHistory>,
     fix_stake_deactivate: bool,
 ) -> Result<u128, InstructionError> {
@@ -1538,7 +1539,7 @@ fn calculate_split_rent_exempt_reserve(
 pub type RewriteStakeStatus = (&'static str, (u64, u64), (u64, u64));
 
 pub fn rewrite_stakes(
-    stake_account: &mut Account,
+    stake_account: &mut AccountSharedData,
     rent: &Rent,
 ) -> Result<RewriteStakeStatus, InstructionError> {
     match stake_account.state()? {
@@ -1608,8 +1609,9 @@ pub fn create_lockup_stake_account(
     lockup: &Lockup,
     rent: &Rent,
     lamports: u64,
-) -> Account {
-    let mut stake_account = Account::new(lamports, std::mem::size_of::<StakeState>(), &id());
+) -> AccountSharedData {
+    let mut stake_account =
+        AccountSharedData::new(lamports, std::mem::size_of::<StakeState>(), &id());
 
     let rent_exempt_reserve = rent.minimum_balance(stake_account.data.len());
     assert!(
@@ -1634,10 +1636,10 @@ pub fn create_lockup_stake_account(
 pub fn create_account(
     authorized: &Pubkey,
     voter_pubkey: &Pubkey,
-    vote_account: &Account,
+    vote_account: &AccountSharedData,
     rent: &Rent,
     lamports: u64,
-) -> Account {
+) -> AccountSharedData {
     do_create_account(
         authorized,
         voter_pubkey,
@@ -1652,11 +1654,11 @@ pub fn create_account(
 pub fn create_account_with_activation_epoch(
     authorized: &Pubkey,
     voter_pubkey: &Pubkey,
-    vote_account: &Account,
+    vote_account: &AccountSharedData,
     rent: &Rent,
     lamports: u64,
     activation_epoch: Epoch,
-) -> Account {
+) -> AccountSharedData {
     do_create_account(
         authorized,
         voter_pubkey,
@@ -1670,12 +1672,13 @@ pub fn create_account_with_activation_epoch(
 fn do_create_account(
     authorized: &Pubkey,
     voter_pubkey: &Pubkey,
-    vote_account: &Account,
+    vote_account: &AccountSharedData,
     rent: &Rent,
     lamports: u64,
     activation_epoch: Epoch,
-) -> Account {
-    let mut stake_account = Account::new(lamports, std::mem::size_of::<StakeState>(), &id());
+) -> AccountSharedData {
+    let mut stake_account =
+        AccountSharedData::new(lamports, std::mem::size_of::<StakeState>(), &id());
 
     let vote_state = VoteState::from(vote_account).expect("vote_state");
 
@@ -1706,8 +1709,8 @@ mod tests {
     use super::*;
     use crate::id;
     use solana_sdk::{
-        account::Account, native_token, process_instruction::MockInvokeContext, pubkey::Pubkey,
-        system_program,
+        account::AccountSharedData, native_token, process_instruction::MockInvokeContext,
+        pubkey::Pubkey, system_program,
     };
     use solana_vote_program::vote_state;
     use std::{cell::RefCell, iter::FromIterator};
@@ -1861,7 +1864,7 @@ mod tests {
 
     #[test]
     fn test_stake_state_stake_from_fail() {
-        let mut stake_account = Account::new(0, std::mem::size_of::<StakeState>(), &id());
+        let mut stake_account = AccountSharedData::new(0, std::mem::size_of::<StakeState>(), &id());
 
         stake_account
             .set_state(&StakeState::default())
@@ -1917,7 +1920,7 @@ mod tests {
 
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta {
                 authorized: Authorized {
@@ -2679,7 +2682,7 @@ mod tests {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
         let stake_account =
-            Account::new_ref(stake_lamports, std::mem::size_of::<StakeState>(), &id());
+            AccountSharedData::new_ref(stake_lamports, std::mem::size_of::<StakeState>(), &id());
 
         // unsigned keyed account
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
@@ -2742,8 +2745,11 @@ mod tests {
     fn test_initialize_incorrect_account_sizes() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account =
-            Account::new_ref(stake_lamports, std::mem::size_of::<StakeState>() + 1, &id());
+        let stake_account = AccountSharedData::new_ref(
+            stake_lamports,
+            std::mem::size_of::<StakeState>() + 1,
+            &id(),
+        );
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
 
         assert_eq!(
@@ -2758,8 +2764,11 @@ mod tests {
             Err(InstructionError::InvalidAccountData)
         );
 
-        let stake_account =
-            Account::new_ref(stake_lamports, std::mem::size_of::<StakeState>() - 1, &id());
+        let stake_account = AccountSharedData::new_ref(
+            stake_lamports,
+            std::mem::size_of::<StakeState>() - 1,
+            &id(),
+        );
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, false, &stake_account);
 
         assert_eq!(
@@ -2779,7 +2788,7 @@ mod tests {
     fn test_deactivate() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&stake_pubkey)),
             std::mem::size_of::<StakeState>(),
@@ -2845,7 +2854,7 @@ mod tests {
     fn test_set_lockup() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
             std::mem::size_of::<StakeState>(),
@@ -2942,7 +2951,7 @@ mod tests {
     fn test_optional_lockup() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
             std::mem::size_of::<StakeState>(),
@@ -3056,7 +3065,7 @@ mod tests {
     fn test_withdraw_stake() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
             std::mem::size_of::<StakeState>(),
@@ -3067,7 +3076,7 @@ mod tests {
         let mut clock = Clock::default();
 
         let to = solana_sdk::pubkey::new_rand();
-        let to_account = Account::new_ref(1, 0, &system_program::id());
+        let to_account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
         // no signers, should fail
@@ -3232,7 +3241,7 @@ mod tests {
         let rent_exempt_reserve = rent.minimum_balance(std::mem::size_of::<StakeState>());
         let authority_pubkey = Pubkey::new_unique();
         let stake_pubkey = Pubkey::new_unique();
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             1_000_000_000,
             &StakeState::Initialized(Meta {
                 rent_exempt_reserve,
@@ -3248,7 +3257,7 @@ mod tests {
         .expect("stake_account");
 
         let stake2_pubkey = Pubkey::new_unique();
-        let stake2_account = Account::new_ref_data_with_space(
+        let stake2_account = AccountSharedData::new_ref_data_with_space(
             1_000_000_000,
             &StakeState::Initialized(Meta {
                 rent_exempt_reserve,
@@ -3265,7 +3274,7 @@ mod tests {
 
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
         let stake2_keyed_account = KeyedAccount::new(&stake2_pubkey, false, &stake2_account);
-        let authority_account = Account::new_ref(42, 0, &system_program::id());
+        let authority_account = AccountSharedData::new_ref(42, 0, &system_program::id());
         let authority_keyed_account =
             KeyedAccount::new(&authority_pubkey, true, &authority_account);
 
@@ -3287,7 +3296,7 @@ mod tests {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let total_lamports = 100;
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             total_lamports,
             &StakeState::Initialized(Meta::auto(&stake_pubkey)),
             std::mem::size_of::<StakeState>(),
@@ -3300,7 +3309,7 @@ mod tests {
         future.epoch += 16;
 
         let to = solana_sdk::pubkey::new_rand();
-        let to_account = Account::new_ref(1, 0, &system_program::id());
+        let to_account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
@@ -3357,7 +3366,7 @@ mod tests {
     fn test_withdraw_stake_invalid_state() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let total_lamports = 100;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             total_lamports,
             &StakeState::RewardsPool,
             std::mem::size_of::<StakeState>(),
@@ -3366,7 +3375,7 @@ mod tests {
         .expect("stake_account");
 
         let to = solana_sdk::pubkey::new_rand();
-        let to_account = Account::new_ref(1, 0, &system_program::id());
+        let to_account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
         assert_eq!(
@@ -3387,7 +3396,7 @@ mod tests {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let custodian = solana_sdk::pubkey::new_rand();
         let total_lamports = 100;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             total_lamports,
             &StakeState::Initialized(Meta {
                 lockup: Lockup {
@@ -3403,7 +3412,7 @@ mod tests {
         .expect("stake_account");
 
         let to = solana_sdk::pubkey::new_rand();
-        let to_account = Account::new_ref(1, 0, &system_program::id());
+        let to_account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
@@ -3424,7 +3433,7 @@ mod tests {
         );
 
         {
-            let custodian_account = Account::new_ref(1, 0, &system_program::id());
+            let custodian_account = AccountSharedData::new_ref(1, 0, &system_program::id());
             let custodian_keyed_account = KeyedAccount::new(&custodian, true, &custodian_account);
             assert_eq!(
                 stake_keyed_account.withdraw(
@@ -3463,7 +3472,7 @@ mod tests {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let custodian = stake_pubkey;
         let total_lamports = 100;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             total_lamports,
             &StakeState::Initialized(Meta {
                 lockup: Lockup {
@@ -3479,7 +3488,7 @@ mod tests {
         .expect("stake_account");
 
         let to = solana_sdk::pubkey::new_rand();
-        let to_account = Account::new_ref(1, 0, &system_program::id());
+        let to_account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
@@ -3816,7 +3825,7 @@ mod tests {
     fn test_authorize_uninit() {
         let new_authority = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::default(),
             std::mem::size_of::<StakeState>(),
@@ -3843,7 +3852,7 @@ mod tests {
     fn test_authorize_lockup() {
         let stake_authority = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&stake_authority)),
             std::mem::size_of::<StakeState>(),
@@ -3852,7 +3861,7 @@ mod tests {
         .expect("stake_account");
 
         let to = solana_sdk::pubkey::new_rand();
-        let to_account = Account::new_ref(1, 0, &system_program::id());
+        let to_account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
 
         let clock = Clock::default();
@@ -3980,7 +3989,7 @@ mod tests {
         let seed = "42";
         let withdrawer_pubkey = Pubkey::create_with_seed(&base_pubkey, &seed, &id()).unwrap();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&withdrawer_pubkey)),
             std::mem::size_of::<StakeState>(),
@@ -3988,7 +3997,7 @@ mod tests {
         )
         .expect("stake_account");
 
-        let base_account = Account::new_ref(1, 0, &id());
+        let base_account = AccountSharedData::new_ref(1, 0, &id());
         let base_keyed_account = KeyedAccount::new(&base_pubkey, true, &base_account);
 
         let stake_keyed_account = KeyedAccount::new(&withdrawer_pubkey, true, &stake_account);
@@ -4075,7 +4084,7 @@ mod tests {
     fn test_authorize_override() {
         let withdrawer_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&withdrawer_pubkey)),
             std::mem::size_of::<StakeState>(),
@@ -4162,7 +4171,7 @@ mod tests {
     fn test_split_source_uninitialized() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
             std::mem::size_of::<StakeState>(),
@@ -4171,7 +4180,7 @@ mod tests {
         .expect("stake_account");
 
         let split_stake_pubkey = solana_sdk::pubkey::new_rand();
-        let split_stake_account = Account::new_ref_data_with_space(
+        let split_stake_account = AccountSharedData::new_ref_data_with_space(
             0,
             &StakeState::Uninitialized,
             std::mem::size_of::<StakeState>(),
@@ -4209,7 +4218,7 @@ mod tests {
     fn test_split_split_not_uninitialized() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Stake(Meta::auto(&stake_pubkey), Stake::just_stake(stake_lamports)),
             std::mem::size_of::<StakeState>(),
@@ -4218,7 +4227,7 @@ mod tests {
         .expect("stake_account");
 
         let split_stake_pubkey = solana_sdk::pubkey::new_rand();
-        let split_stake_account = Account::new_ref_data_with_space(
+        let split_stake_account = AccountSharedData::new_ref_data_with_space(
             0,
             &StakeState::Initialized(Meta::auto(&stake_pubkey)),
             std::mem::size_of::<StakeState>(),
@@ -4251,7 +4260,7 @@ mod tests {
     fn test_split_more_than_staked() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Stake(
                 Meta::auto(&stake_pubkey),
@@ -4263,7 +4272,7 @@ mod tests {
         .expect("stake_account");
 
         let split_stake_pubkey = solana_sdk::pubkey::new_rand();
-        let split_stake_account = Account::new_ref_data_with_space(
+        let split_stake_account = AccountSharedData::new_ref_data_with_space(
             0,
             &StakeState::Uninitialized,
             std::mem::size_of::<StakeState>(),
@@ -4303,7 +4312,7 @@ mod tests {
                 Stake::just_stake(stake_lamports - rent_exempt_reserve),
             ),
         ] {
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 state,
                 std::mem::size_of::<StakeState>(),
@@ -4313,7 +4322,7 @@ mod tests {
 
             let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
 
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 0,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>(),
@@ -4395,7 +4404,7 @@ mod tests {
             StakeState::Initialized(Meta::auto(&stake_pubkey)),
             StakeState::Stake(Meta::auto(&stake_pubkey), Stake::just_stake(stake_lamports)),
         ] {
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 0,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>(),
@@ -4406,7 +4415,7 @@ mod tests {
             let split_stake_keyed_account =
                 KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 state,
                 std::mem::size_of::<StakeState>(),
@@ -4482,7 +4491,7 @@ mod tests {
         let split_stake_pubkey = solana_sdk::pubkey::new_rand();
         let signers = vec![stake_pubkey].into_iter().collect();
 
-        let split_stake_account = Account::new_ref_data_with_space(
+        let split_stake_account = AccountSharedData::new_ref_data_with_space(
             0,
             &StakeState::Uninitialized,
             std::mem::size_of::<StakeState>(),
@@ -4493,7 +4502,7 @@ mod tests {
         let split_stake_keyed_account =
             KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Stake(Meta::auto(&stake_pubkey), Stake::just_stake(stake_lamports)),
             std::mem::size_of::<StakeState>(),
@@ -4533,7 +4542,7 @@ mod tests {
         // test_split, since that test uses a Meta with rent_exempt_reserve = 0
         let split_lamport_balances = vec![0, 1, rent_exempt_reserve, rent_exempt_reserve + 1];
         for initial_balance in split_lamport_balances {
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 initial_balance,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>(),
@@ -4544,7 +4553,7 @@ mod tests {
             let split_stake_keyed_account =
                 KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 &state,
                 std::mem::size_of::<StakeState>(),
@@ -4648,7 +4657,7 @@ mod tests {
             expected_rent_exempt_reserve + 1,
         ];
         for initial_balance in split_lamport_balances {
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 initial_balance,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>(),
@@ -4659,7 +4668,7 @@ mod tests {
             let split_stake_keyed_account =
                 KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 &state,
                 std::mem::size_of::<StakeState>() + 100,
@@ -4766,7 +4775,7 @@ mod tests {
             expected_rent_exempt_reserve + 1,
         ];
         for initial_balance in split_lamport_balances {
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 initial_balance,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>() + 100,
@@ -4777,7 +4786,7 @@ mod tests {
             let split_stake_keyed_account =
                 KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 &state,
                 std::mem::size_of::<StakeState>(),
@@ -4822,7 +4831,7 @@ mod tests {
                 Stake::just_stake(stake_lamports - rent_exempt_reserve),
             ),
         ] {
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 0,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>(),
@@ -4833,7 +4842,7 @@ mod tests {
             let split_stake_keyed_account =
                 KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 state,
                 std::mem::size_of::<StakeState>(),
@@ -4909,7 +4918,7 @@ mod tests {
         // covered in test_split_100_percent_of_source, but included here as well for readability
         let split_lamport_balances = vec![0, 1, rent_exempt_reserve, rent_exempt_reserve + 1];
         for initial_balance in split_lamport_balances {
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 initial_balance,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>(),
@@ -4920,7 +4929,7 @@ mod tests {
             let split_stake_keyed_account =
                 KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 &state,
                 std::mem::size_of::<StakeState>(),
@@ -4985,7 +4994,7 @@ mod tests {
             ),
         ] {
             // Test that splitting to a larger account fails
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 0,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>() + 10000,
@@ -4995,7 +5004,7 @@ mod tests {
             let split_stake_keyed_account =
                 KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 &state,
                 std::mem::size_of::<StakeState>(),
@@ -5011,7 +5020,7 @@ mod tests {
 
             // Test that splitting from a larger account to a smaller one works.
             // Split amount should not matter, assuming other fund criteria are met
-            let split_stake_account = Account::new_ref_data_with_space(
+            let split_stake_account = AccountSharedData::new_ref_data_with_space(
                 0,
                 &StakeState::Uninitialized,
                 std::mem::size_of::<StakeState>(),
@@ -5021,7 +5030,7 @@ mod tests {
             let split_stake_keyed_account =
                 KeyedAccount::new(&split_stake_pubkey, true, &split_stake_account);
 
-            let stake_account = Account::new_ref_data_with_space(
+            let stake_account = AccountSharedData::new_ref_data_with_space(
                 stake_lamports,
                 &state,
                 std::mem::size_of::<StakeState>() + 100,
@@ -5114,7 +5123,7 @@ mod tests {
                     Stake::just_stake(stake_lamports),
                 ),
             ] {
-                let stake_account = Account::new_ref_data_with_space(
+                let stake_account = AccountSharedData::new_ref_data_with_space(
                     stake_lamports,
                     state,
                     std::mem::size_of::<StakeState>(),
@@ -5123,7 +5132,7 @@ mod tests {
                 .expect("stake_account");
                 let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
 
-                let source_stake_account = Account::new_ref_data_with_space(
+                let source_stake_account = AccountSharedData::new_ref_data_with_space(
                     stake_lamports,
                     source_state,
                     std::mem::size_of::<StakeState>(),
@@ -5227,7 +5236,7 @@ mod tests {
             },
             ..Stake::default()
         };
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Stake(meta, stake),
             std::mem::size_of::<StakeState>(),
@@ -5274,7 +5283,7 @@ mod tests {
                     Stake::just_stake(stake_lamports),
                 ),
             ] {
-                let stake_account = Account::new_ref_data_with_space(
+                let stake_account = AccountSharedData::new_ref_data_with_space(
                     stake_lamports,
                     state,
                     std::mem::size_of::<StakeState>(),
@@ -5283,7 +5292,7 @@ mod tests {
                 .expect("stake_account");
                 let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
 
-                let source_stake_account = Account::new_ref_data_with_space(
+                let source_stake_account = AccountSharedData::new_ref_data_with_space(
                     stake_lamports,
                     source_state,
                     std::mem::size_of::<StakeState>(),
@@ -5337,7 +5346,7 @@ mod tests {
             ),
         ] {
             for source_state in &[StakeState::Uninitialized, StakeState::RewardsPool] {
-                let stake_account = Account::new_ref_data_with_space(
+                let stake_account = AccountSharedData::new_ref_data_with_space(
                     stake_lamports,
                     state,
                     std::mem::size_of::<StakeState>(),
@@ -5346,7 +5355,7 @@ mod tests {
                 .expect("stake_account");
                 let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
 
-                let source_stake_account = Account::new_ref_data_with_space(
+                let source_stake_account = AccountSharedData::new_ref_data_with_space(
                     stake_lamports,
                     source_state,
                     std::mem::size_of::<StakeState>(),
@@ -5380,7 +5389,7 @@ mod tests {
 
         let signers = vec![authorized_pubkey].into_iter().collect();
 
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Stake(
                 Meta::auto(&authorized_pubkey),
@@ -5392,7 +5401,7 @@ mod tests {
         .expect("stake_account");
         let stake_keyed_account = KeyedAccount::new(&stake_pubkey, true, &stake_account);
 
-        let source_stake_account = Account::new_ref_data_with_space(
+        let source_stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Stake(
                 Meta::auto(&authorized_pubkey),
@@ -5444,7 +5453,7 @@ mod tests {
             },
             ..Stake::default()
         };
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Stake(meta, stake),
             std::mem::size_of::<StakeState>(),
@@ -5462,7 +5471,7 @@ mod tests {
             },
             ..stake
         };
-        let source_account = Account::new_ref_data_with_space(
+        let source_account = AccountSharedData::new_ref_data_with_space(
             source_lamports,
             &StakeState::Stake(meta, source_stake),
             std::mem::size_of::<StakeState>(),
@@ -5768,7 +5777,7 @@ mod tests {
     fn test_authorize_delegated_stake() {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         let stake_lamports = 42;
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Initialized(Meta::auto(&stake_pubkey)),
             std::mem::size_of::<StakeState>(),
@@ -5879,7 +5888,7 @@ mod tests {
             rent_exempt_reserve,
             ..Meta::auto(&withdrawer_pubkey)
         };
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Initialized(meta),
             std::mem::size_of::<StakeState>(),
@@ -5916,7 +5925,7 @@ mod tests {
 
         clock.epoch += 1;
         let to = Pubkey::new_unique();
-        let to_account = Account::new_ref(1, 0, &system_program::id());
+        let to_account = AccountSharedData::new_ref(1, 0, &system_program::id());
         let to_keyed_account = KeyedAccount::new(&to, false, &to_account);
         let withdraw_lamports = initial_lamports / 2;
         stake_keyed_account
@@ -6052,7 +6061,7 @@ mod tests {
                 rent_exempt_reserve: rent_exempt_reserve + offset,
                 ..Meta::default()
             };
-            let mut account = Account::new(account_balance, right_data_len, &id());
+            let mut account = AccountSharedData::new(account_balance, right_data_len, &id());
             account.set_state(&StakeState::Initialized(meta)).unwrap();
             let result = rewrite_stakes(&mut account, &rent);
             match expected_rewrite {
@@ -6088,7 +6097,7 @@ mod tests {
                 }),
                 ..Stake::default()
             };
-            let mut account = Account::new(account_balance, right_data_len, &id());
+            let mut account = AccountSharedData::new(account_balance, right_data_len, &id());
             account.set_state(&StakeState::Stake(meta, stake)).unwrap();
             let result = rewrite_stakes(&mut account, &rent);
             match expected_rewrite {
@@ -6318,7 +6327,7 @@ mod tests {
             rent_exempt_reserve,
             ..Meta::auto(&authority_pubkey)
         };
-        let stake_account = Account::new_ref_data_with_space(
+        let stake_account = AccountSharedData::new_ref_data_with_space(
             stake_lamports,
             &StakeState::Uninitialized,
             std::mem::size_of::<StakeState>(),

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -342,7 +342,7 @@ pub fn process_instruction(
 mod tests {
     use super::*;
     use solana_sdk::{
-        account::{self, Account},
+        account::{self, AccountSharedData},
         process_instruction::MockInvokeContext,
         rent::Rent,
     };
@@ -370,27 +370,27 @@ mod tests {
             .iter()
             .map(|meta| {
                 RefCell::new(if sysvar::clock::check_id(&meta.pubkey) {
-                    account::create_account(&Clock::default(), 1)
+                    account::create_account_shared_data(&Clock::default(), 1)
                 } else if sysvar::slot_hashes::check_id(&meta.pubkey) {
-                    account::create_account(&SlotHashes::default(), 1)
+                    account::create_account_shared_data(&SlotHashes::default(), 1)
                 } else if sysvar::rent::check_id(&meta.pubkey) {
-                    account::create_account(&Rent::free(), 1)
+                    account::create_account_shared_data(&Rent::free(), 1)
                 } else if meta.pubkey == invalid_vote_state_pubkey() {
-                    Account {
+                    AccountSharedData {
                         owner: invalid_vote_state_pubkey(),
-                        ..Account::default()
+                        ..AccountSharedData::default()
                     }
                 } else {
-                    Account {
+                    AccountSharedData {
                         owner: id(),
-                        ..Account::default()
+                        ..AccountSharedData::default()
                     }
                 })
             })
             .collect();
 
         for _ in 0..instruction.accounts.len() {
-            accounts.push(RefCell::new(Account::default()));
+            accounts.push(RefCell::new(AccountSharedData::default()));
         }
         {
             let keyed_accounts: Vec<_> = instruction

--- a/ramp-tps/src/stake.rs
+++ b/ramp-tps/src/stake.rs
@@ -52,7 +52,7 @@ fn calculate_stake_warmup(mut stake_entry: StakeHistoryEntry, stake_config: &Sta
 
 fn stake_history_entry(epoch: Epoch, rpc_client: &RpcClient) -> Option<StakeHistoryEntry> {
     let stake_history_account = rpc_client.get_account(&stake_history::id()).ok()?;
-    let stake_history = from_account::<StakeHistory>(&stake_history_account)?;
+    let stake_history = from_account::<StakeHistory, _>(&stake_history_account)?;
     stake_history.get(&epoch).cloned()
 }
 

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -11,7 +11,7 @@ use solana_runtime::{
     bank::*,
 };
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     genesis_config::{create_genesis_config, ClusterType},
     hash::Hash,
     pubkey::Pubkey,
@@ -27,7 +27,8 @@ use test::Bencher;
 fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) {
     for t in 0..num {
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
+        let account =
+            AccountSharedData::new((t + 1) as u64, 0, &AccountSharedData::default().owner);
         pubkeys.push(pubkey);
         assert!(bank.get_account(&pubkey).is_none());
         bank.deposit(&pubkey, (t + 1) as u64);
@@ -157,10 +158,11 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
         false,
     );
     let mut old_pubkey = Pubkey::default();
-    let zero_account = Account::new(0, 0, &Account::default().owner);
+    let zero_account = AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
     for i in 0..1000 {
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new((i + 1) as u64, 0, &Account::default().owner);
+        let account =
+            AccountSharedData::new((i + 1) as u64, 0, &AccountSharedData::default().owner);
         accounts.store_slow_uncached(i, &pubkey, &account);
         accounts.store_slow_uncached(i, &old_pubkey, &zero_account);
         old_pubkey = pubkey;
@@ -195,7 +197,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
         (0..num_keys)
             .map(|_| {
                 let pubkey = solana_sdk::pubkey::new_rand();
-                let account = Account::new(1, 0, &Account::default().owner);
+                let account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
                 accounts.store_slow_uncached(slot, &pubkey, &account);
                 pubkey
             })
@@ -215,7 +217,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
 
     let num_new_keys = 1000;
     let new_accounts: Vec<_> = (0..num_new_keys)
-        .map(|_| Account::new(1, 0, &Account::default().owner))
+        .map(|_| AccountSharedData::new(1, 0, &AccountSharedData::default().owner))
         .collect();
     bencher.iter(|| {
         for account in &new_accounts {
@@ -247,7 +249,9 @@ fn bench_concurrent_read_write(bencher: &mut Bencher) {
 #[ignore]
 fn bench_concurrent_scan_write(bencher: &mut Bencher) {
     store_accounts_with_possible_contention("concurrent_scan_write", bencher, |accounts, _| loop {
-        test::black_box(accounts.load_by_program(&HashMap::new(), &Account::default().owner));
+        test::black_box(
+            accounts.load_by_program(&HashMap::new(), &AccountSharedData::default().owner),
+        );
     })
 }
 
@@ -301,7 +305,7 @@ fn bench_rwlock_hashmap_single_reader_with_n_writers(bencher: &mut Bencher) {
     })
 }
 
-fn setup_bench_dashmap_iter() -> (Arc<Accounts>, DashMap<Pubkey, (Account, Hash)>) {
+fn setup_bench_dashmap_iter() -> (Arc<Accounts>, DashMap<Pubkey, (AccountSharedData, Hash)>) {
     let accounts = Arc::new(Accounts::new_with_config(
         vec![
             PathBuf::from(std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string()))
@@ -320,7 +324,7 @@ fn setup_bench_dashmap_iter() -> (Arc<Accounts>, DashMap<Pubkey, (Account, Hash)
         dashmap.insert(
             Pubkey::new_unique(),
             (
-                Account::new(1, 0, &Account::default().owner),
+                AccountSharedData::new(1, 0, &AccountSharedData::default().owner),
                 Hash::new_unique(),
             ),
         );

--- a/runtime/benches/message_processor.rs
+++ b/runtime/benches/message_processor.rs
@@ -4,7 +4,7 @@ extern crate test;
 
 use log::*;
 use solana_runtime::message_processor::{ExecuteDetailsTimings, PreAccount};
-use solana_sdk::{account::Account, pubkey, rent::Rent};
+use solana_sdk::{account::AccountSharedData, pubkey, rent::Rent};
 use test::Bencher;
 
 #[bench]
@@ -15,10 +15,10 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     let non_owner = pubkey::new_rand();
     let pre = PreAccount::new(
         &pubkey::new_rand(),
-        &Account::new(0, BUFSIZE, &owner),
+        &AccountSharedData::new(0, BUFSIZE, &owner),
         false,
     );
-    let post = Account::new(0, BUFSIZE, &owner);
+    let post = AccountSharedData::new(0, BUFSIZE, &owner);
     assert_eq!(
         pre.verify(
             &owner,
@@ -52,7 +52,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
 
     let pre = PreAccount::new(
         &pubkey::new_rand(),
-        &Account::new(0, BUFSIZE, &owner),
+        &AccountSharedData::new(0, BUFSIZE, &owner),
         false,
     );
     bencher.iter(|| {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -16,7 +16,7 @@ use dashmap::{
 use log::*;
 use rand::{thread_rng, Rng};
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     account_utils::StateMut,
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     clock::Slot,
@@ -92,10 +92,10 @@ pub struct Accounts {
 }
 
 // for the load instructions
-pub type TransactionAccounts = Vec<Account>;
-pub type TransactionAccountDeps = Vec<(Pubkey, Account)>;
+pub type TransactionAccounts = Vec<AccountSharedData>;
+pub type TransactionAccountDeps = Vec<(Pubkey, AccountSharedData)>;
 pub type TransactionRent = u64;
-pub type TransactionLoaders = Vec<Vec<(Pubkey, Account)>>;
+pub type TransactionLoaders = Vec<Vec<(Pubkey, AccountSharedData)>>;
 #[derive(PartialEq, Debug, Clone)]
 pub struct LoadedTransaction {
     pub accounts: TransactionAccounts,
@@ -162,13 +162,13 @@ impl Accounts {
         false
     }
 
-    fn construct_instructions_account(message: &Message) -> Account {
+    fn construct_instructions_account(message: &Message) -> AccountSharedData {
         let mut data = message.serialize_instructions();
         // add room for current instruction index.
         data.resize(data.len() + 2, 0);
-        Account {
+        AccountSharedData {
             data,
-            ..Account::default()
+            ..AccountSharedData::default()
         }
     }
 
@@ -248,7 +248,7 @@ impl Accounts {
                     }
                 } else {
                     // Fill in an empty account for the program slots.
-                    Account::default()
+                    AccountSharedData::default()
                 };
                 accounts.push(account);
             }
@@ -318,7 +318,7 @@ impl Accounts {
         ancestors: &Ancestors,
         program_id: &Pubkey,
         error_counters: &mut ErrorCounters,
-    ) -> Result<Vec<(Pubkey, Account)>> {
+    ) -> Result<Vec<(Pubkey, AccountSharedData)>> {
         let mut accounts = Vec::new();
         let mut depth = 0;
         let mut program_id = *program_id;
@@ -448,7 +448,11 @@ impl Accounts {
     }
 
     /// Slow because lock is held for 1 operation instead of many
-    pub fn load_slow(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
+    pub fn load_slow(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
         let (account, slot) = self.accounts_db.load_slow(ancestors, pubkey)?;
 
         if account.lamports > 0 {
@@ -512,7 +516,7 @@ impl Accounts {
         &self,
         slot: Slot,
         program_id: Option<&Pubkey>,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         self.scan_slot(slot, |stored_account| {
             let hit = match program_id {
                 None => true,
@@ -611,9 +615,9 @@ impl Accounts {
         lamports > 0
     }
 
-    fn load_while_filtering<F: Fn(&Account) -> bool>(
-        collector: &mut Vec<(Pubkey, Account)>,
-        some_account_tuple: Option<(&Pubkey, Account, Slot)>,
+    fn load_while_filtering<F: Fn(&AccountSharedData) -> bool>(
+        collector: &mut Vec<(Pubkey, AccountSharedData)>,
+        some_account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>,
         filter: F,
     ) {
         if let Some(mapped_account_tuple) = some_account_tuple
@@ -628,10 +632,10 @@ impl Accounts {
         &self,
         ancestors: &Ancestors,
         program_id: &Pubkey,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         self.accounts_db.scan_accounts(
             ancestors,
-            |collector: &mut Vec<(Pubkey, Account)>, some_account_tuple| {
+            |collector: &mut Vec<(Pubkey, AccountSharedData)>, some_account_tuple| {
                 Self::load_while_filtering(collector, some_account_tuple, |account| {
                     account.owner == *program_id
                 })
@@ -639,15 +643,15 @@ impl Accounts {
         )
     }
 
-    pub fn load_by_program_with_filter<F: Fn(&Account) -> bool>(
+    pub fn load_by_program_with_filter<F: Fn(&AccountSharedData) -> bool>(
         &self,
         ancestors: &Ancestors,
         program_id: &Pubkey,
         filter: F,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         self.accounts_db.scan_accounts(
             ancestors,
-            |collector: &mut Vec<(Pubkey, Account)>, some_account_tuple| {
+            |collector: &mut Vec<(Pubkey, AccountSharedData)>, some_account_tuple| {
                 Self::load_while_filtering(collector, some_account_tuple, |account| {
                     account.owner == *program_id && filter(account)
                 })
@@ -655,25 +659,25 @@ impl Accounts {
         )
     }
 
-    pub fn load_by_index_key_with_filter<F: Fn(&Account) -> bool>(
+    pub fn load_by_index_key_with_filter<F: Fn(&AccountSharedData) -> bool>(
         &self,
         ancestors: &Ancestors,
         index_key: &IndexKey,
         filter: F,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         self.accounts_db.index_scan_accounts(
             ancestors,
             *index_key,
-            |collector: &mut Vec<(Pubkey, Account)>, some_account_tuple| {
+            |collector: &mut Vec<(Pubkey, AccountSharedData)>, some_account_tuple| {
                 Self::load_while_filtering(collector, some_account_tuple, |account| filter(account))
             },
         )
     }
 
-    pub fn load_all(&self, ancestors: &Ancestors) -> Vec<(Pubkey, Account, Slot)> {
+    pub fn load_all(&self, ancestors: &Ancestors) -> Vec<(Pubkey, AccountSharedData, Slot)> {
         self.accounts_db.scan_accounts(
             ancestors,
-            |collector: &mut Vec<(Pubkey, Account, Slot)>, some_account_tuple| {
+            |collector: &mut Vec<(Pubkey, AccountSharedData, Slot)>, some_account_tuple| {
                 if let Some((pubkey, account, slot)) =
                     some_account_tuple.filter(|(_, account, _)| Self::is_loadable(account.lamports))
                 {
@@ -687,12 +691,12 @@ impl Accounts {
         &self,
         ancestors: &Ancestors,
         range: R,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         self.accounts_db.range_scan_accounts(
             "load_to_collect_rent_eagerly_scan_elapsed",
             ancestors,
             range,
-            |collector: &mut Vec<(Pubkey, Account)>, option| {
+            |collector: &mut Vec<(Pubkey, AccountSharedData)>, option| {
                 Self::load_while_filtering(collector, option, |_| true)
             },
         )
@@ -701,11 +705,11 @@ impl Accounts {
     /// Slow because lock is held for 1 operation instead of many.
     /// WARNING: This noncached version is only to be used for tests/benchmarking
     /// as bypassing the cache in general is not supported
-    pub fn store_slow_uncached(&self, slot: Slot, pubkey: &Pubkey, account: &Account) {
+    pub fn store_slow_uncached(&self, slot: Slot, pubkey: &Pubkey, account: &AccountSharedData) {
         self.accounts_db.store_uncached(slot, &[(pubkey, account)]);
     }
 
-    pub fn store_slow_cached(&self, slot: Slot, pubkey: &Pubkey, account: &Account) {
+    pub fn store_slow_cached(&self, slot: Slot, pubkey: &Pubkey, account: &AccountSharedData) {
         self.accounts_db.store_cached(slot, &[(pubkey, account)]);
     }
 
@@ -865,7 +869,7 @@ impl Accounts {
         rent_collector: &RentCollector,
         last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
         fix_recent_blockhashes_sysvar_delay: bool,
-    ) -> Vec<(&'a Pubkey, &'a Account)> {
+    ) -> Vec<(&'a Pubkey, &'a AccountSharedData)> {
         let mut accounts = Vec::with_capacity(loaded.len());
         for (i, ((raccs, _nonce_rollback), (_, tx))) in loaded
             .iter_mut()
@@ -945,10 +949,10 @@ impl Accounts {
 }
 
 pub fn prepare_if_nonce_account(
-    account: &mut Account,
+    account: &mut AccountSharedData,
     account_pubkey: &Pubkey,
     tx_result: &Result<()>,
-    maybe_nonce_rollback: Option<(&Pubkey, &Account, Option<&Account>)>,
+    maybe_nonce_rollback: Option<(&Pubkey, &AccountSharedData, Option<&AccountSharedData>)>,
     last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
     fix_recent_blockhashes_sysvar_delay: bool,
 ) -> bool {
@@ -994,7 +998,8 @@ pub fn create_test_accounts(
 ) {
     for t in 0..num {
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new((t + 1) as u64, 0, &Account::default().owner);
+        let account =
+            AccountSharedData::new((t + 1) as u64, 0, &AccountSharedData::default().owner);
         accounts.store_slow_uncached(slot, &pubkey, &account);
         pubkeys.push(pubkey);
     }
@@ -1005,7 +1010,7 @@ pub fn create_test_accounts(
 pub fn update_accounts_bench(accounts: &Accounts, pubkeys: &[Pubkey], slot: u64) {
     for pubkey in pubkeys {
         let amount = thread_rng().gen_range(0, 10);
-        let account = Account::new(amount, 0, &Account::default().owner);
+        let account = AccountSharedData::new(amount, 0, &AccountSharedData::default().owner);
         accounts.store_slow_uncached(slot, &pubkey, &account);
     }
 }
@@ -1015,7 +1020,7 @@ mod tests {
     use super::*;
     use crate::rent_collector::RentCollector;
     use solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         epoch_schedule::EpochSchedule,
         fee_calculator::FeeCalculator,
         genesis_config::ClusterType,
@@ -1034,7 +1039,7 @@ mod tests {
 
     fn load_accounts_with_fee_and_rent(
         tx: Transaction,
-        ka: &[(Pubkey, Account)],
+        ka: &[(Pubkey, AccountSharedData)],
         fee_calculator: &FeeCalculator,
         rent_collector: &RentCollector,
         error_counters: &mut ErrorCounters,
@@ -1062,7 +1067,7 @@ mod tests {
 
     fn load_accounts_with_fee(
         tx: Transaction,
-        ka: &[(Pubkey, Account)],
+        ka: &[(Pubkey, AccountSharedData)],
         fee_calculator: &FeeCalculator,
         error_counters: &mut ErrorCounters,
     ) -> Vec<TransactionLoadResult> {
@@ -1072,7 +1077,7 @@ mod tests {
 
     fn load_accounts(
         tx: Transaction,
-        ka: &[(Pubkey, Account)],
+        ka: &[(Pubkey, AccountSharedData)],
         error_counters: &mut ErrorCounters,
     ) -> Vec<TransactionLoadResult> {
         let fee_calculator = FeeCalculator::default();
@@ -1081,7 +1086,7 @@ mod tests {
 
     #[test]
     fn test_load_accounts_no_key() {
-        let accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
@@ -1105,7 +1110,7 @@ mod tests {
 
     #[test]
     fn test_load_accounts_no_account_0_exists() {
-        let accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
@@ -1131,17 +1136,17 @@ mod tests {
 
     #[test]
     fn test_load_accounts_unknown_program_id() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 0, &Pubkey::default());
+        let account = AccountSharedData::new(1, 0, &Pubkey::default());
         accounts.push((key0, account));
 
-        let account = Account::new(2, 1, &Pubkey::default());
+        let account = AccountSharedData::new(2, 1, &Pubkey::default());
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -1165,13 +1170,13 @@ mod tests {
 
     #[test]
     fn test_load_accounts_insufficient_funds() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
 
-        let account = Account::new(1, 0, &Pubkey::default());
+        let account = AccountSharedData::new(1, 0, &Pubkey::default());
         accounts.push((key0, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -1199,13 +1204,13 @@ mod tests {
 
     #[test]
     fn test_load_accounts_invalid_account_for_fee() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
 
-        let account = Account::new(1, 1, &solana_sdk::pubkey::new_rand()); // <-- owner is not the system program
+        let account = AccountSharedData::new(1, 1, &solana_sdk::pubkey::new_rand()); // <-- owner is not the system program
         accounts.push((key0, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -1244,7 +1249,7 @@ mod tests {
         let nonce = Keypair::new();
         let mut accounts = vec![(
             nonce.pubkey(),
-            Account::new_data(
+            AccountSharedData::new_data(
                 min_balance * 2,
                 &nonce::state::Versions::new_current(nonce::State::Initialized(
                     nonce::state::Data::default(),
@@ -1304,18 +1309,18 @@ mod tests {
 
     #[test]
     fn test_load_accounts_no_loaders() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let mut account = Account::new(1, 0, &Pubkey::default());
+        let mut account = AccountSharedData::new(1, 0, &Pubkey::default());
         account.rent_epoch = 1;
         accounts.push((key0, account));
 
-        let mut account = Account::new(2, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(2, 1, &Pubkey::default());
         account.rent_epoch = 1;
         accounts.push((key1, account));
 
@@ -1345,7 +1350,7 @@ mod tests {
 
     #[test]
     fn test_load_accounts_max_call_depth() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
@@ -1357,35 +1362,35 @@ mod tests {
         let key5 = Pubkey::new(&[9u8; 32]);
         let key6 = Pubkey::new(&[10u8; 32]);
 
-        let account = Account::new(1, 0, &Pubkey::default());
+        let account = AccountSharedData::new(1, 0, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(40, 1, &Pubkey::default());
         account.executable = true;
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
-        let mut account = Account::new(41, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(41, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key1;
         accounts.push((key2, account));
 
-        let mut account = Account::new(42, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(42, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key2;
         accounts.push((key3, account));
 
-        let mut account = Account::new(43, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(43, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key3;
         accounts.push((key4, account));
 
-        let mut account = Account::new(44, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(44, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key4;
         accounts.push((key5, account));
 
-        let mut account = Account::new(45, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(45, 1, &Pubkey::default());
         account.executable = true;
         account.owner = key5;
         accounts.push((key6, account));
@@ -1411,17 +1416,17 @@ mod tests {
 
     #[test]
     fn test_load_accounts_bad_program_id() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 0, &Pubkey::default());
+        let account = AccountSharedData::new(1, 0, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, &native_loader::id());
+        let mut account = AccountSharedData::new(40, 1, &native_loader::id());
         account.executable = true;
         accounts.push((key1, account));
 
@@ -1446,17 +1451,17 @@ mod tests {
 
     #[test]
     fn test_load_accounts_bad_owner() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 0, &Pubkey::default());
+        let account = AccountSharedData::new(1, 0, &Pubkey::default());
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(40, 1, &Pubkey::default());
         account.executable = true;
         accounts.push((key1, account));
 
@@ -1481,17 +1486,17 @@ mod tests {
 
     #[test]
     fn test_load_accounts_not_executable() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
         let key0 = keypair.pubkey();
         let key1 = Pubkey::new(&[5u8; 32]);
 
-        let account = Account::new(1, 0, &Pubkey::default());
+        let account = AccountSharedData::new(1, 0, &Pubkey::default());
         accounts.push((key0, account));
 
-        let account = Account::new(40, 1, &native_loader::id());
+        let account = AccountSharedData::new(40, 1, &native_loader::id());
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -1515,7 +1520,7 @@ mod tests {
 
     #[test]
     fn test_load_accounts_multiple_loaders() {
-        let mut accounts: Vec<(Pubkey, Account)> = Vec::new();
+        let mut accounts: Vec<(Pubkey, AccountSharedData)> = Vec::new();
         let mut error_counters = ErrorCounters::default();
 
         let keypair = Keypair::new();
@@ -1523,17 +1528,17 @@ mod tests {
         let key1 = Pubkey::new(&[5u8; 32]);
         let key2 = Pubkey::new(&[6u8; 32]);
 
-        let mut account = Account::new(1, 0, &Pubkey::default());
+        let mut account = AccountSharedData::new(1, 0, &Pubkey::default());
         account.rent_epoch = 1;
         accounts.push((key0, account));
 
-        let mut account = Account::new(40, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(40, 1, &Pubkey::default());
         account.executable = true;
         account.rent_epoch = 1;
         account.owner = native_loader::id();
         accounts.push((key1, account));
 
-        let mut account = Account::new(41, 1, &Pubkey::default());
+        let mut account = AccountSharedData::new(41, 1, &Pubkey::default());
         account.executable = true;
         account.rent_epoch = 1;
         account.owner = key1;
@@ -1580,13 +1585,13 @@ mod tests {
 
         // Load accounts owned by various programs into AccountsDb
         let pubkey0 = solana_sdk::pubkey::new_rand();
-        let account0 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
+        let account0 = AccountSharedData::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts.store_slow_uncached(0, &pubkey0, &account0);
         let pubkey1 = solana_sdk::pubkey::new_rand();
-        let account1 = Account::new(1, 0, &Pubkey::new(&[2; 32]));
+        let account1 = AccountSharedData::new(1, 0, &Pubkey::new(&[2; 32]));
         accounts.store_slow_uncached(0, &pubkey1, &account1);
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        let account2 = Account::new(1, 0, &Pubkey::new(&[3; 32]));
+        let account2 = AccountSharedData::new(1, 0, &Pubkey::new(&[3; 32]));
         accounts.store_slow_uncached(0, &pubkey2, &account2);
 
         let loaded = accounts.load_by_program_slot(0, Some(&Pubkey::new(&[2; 32])));
@@ -1630,10 +1635,10 @@ mod tests {
         let keypair2 = Keypair::new();
         let keypair3 = Keypair::new();
 
-        let account0 = Account::new(1, 0, &Pubkey::default());
-        let account1 = Account::new(2, 0, &Pubkey::default());
-        let account2 = Account::new(3, 0, &Pubkey::default());
-        let account3 = Account::new(4, 0, &Pubkey::default());
+        let account0 = AccountSharedData::new(1, 0, &Pubkey::default());
+        let account1 = AccountSharedData::new(2, 0, &Pubkey::default());
+        let account2 = AccountSharedData::new(3, 0, &Pubkey::default());
+        let account3 = AccountSharedData::new(4, 0, &Pubkey::default());
 
         let accounts =
             Accounts::new_with_config(Vec::new(), &ClusterType::Development, HashSet::new(), false);
@@ -1738,9 +1743,9 @@ mod tests {
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
 
-        let account0 = Account::new(1, 0, &Pubkey::default());
-        let account1 = Account::new(2, 0, &Pubkey::default());
-        let account2 = Account::new(3, 0, &Pubkey::default());
+        let account0 = AccountSharedData::new(1, 0, &Pubkey::default());
+        let account1 = AccountSharedData::new(2, 0, &Pubkey::default());
+        let account2 = AccountSharedData::new(3, 0, &Pubkey::default());
 
         let accounts =
             Accounts::new_with_config(Vec::new(), &ClusterType::Development, HashSet::new(), false);
@@ -1840,9 +1845,9 @@ mod tests {
 
         let loaders = vec![(Ok(()), None), (Ok(()), None)];
 
-        let account0 = Account::new(1, 0, &Pubkey::default());
-        let account1 = Account::new(2, 0, &Pubkey::default());
-        let account2 = Account::new(3, 0, &Pubkey::default());
+        let account0 = AccountSharedData::new(1, 0, &Pubkey::default());
+        let account1 = AccountSharedData::new(2, 0, &Pubkey::default());
+        let account2 = AccountSharedData::new(3, 0, &Pubkey::default());
 
         let transaction_accounts0 = vec![account0, account2.clone()];
         let transaction_loaders0 = vec![];
@@ -1923,11 +1928,12 @@ mod tests {
         let accounts =
             Accounts::new_with_config(Vec::new(), &ClusterType::Development, HashSet::new(), false);
         let mut old_pubkey = Pubkey::default();
-        let zero_account = Account::new(0, 0, &Account::default().owner);
+        let zero_account = AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
         info!("storing..");
         for i in 0..2_000 {
             let pubkey = solana_sdk::pubkey::new_rand();
-            let account = Account::new((i + 1) as u64, 0, &Account::default().owner);
+            let account =
+                AccountSharedData::new((i + 1) as u64, 0, &AccountSharedData::default().owner);
             accounts.store_slow_uncached(i, &pubkey, &account);
             accounts.store_slow_uncached(i, &old_pubkey, &zero_account);
             old_pubkey = pubkey;
@@ -1984,17 +1990,17 @@ mod tests {
 
     fn create_accounts_prepare_if_nonce_account() -> (
         Pubkey,
-        Account,
-        Account,
+        AccountSharedData,
+        AccountSharedData,
         Hash,
         FeeCalculator,
-        Option<Account>,
+        Option<AccountSharedData>,
     ) {
         let data = nonce::state::Versions::new_current(nonce::State::Initialized(
             nonce::state::Data::default(),
         ));
-        let account = Account::new_data(42, &data, &system_program::id()).unwrap();
-        let pre_account = Account {
+        let account = AccountSharedData::new_data(42, &data, &system_program::id()).unwrap();
+        let pre_account = AccountSharedData {
             lamports: 43,
             ..account.clone()
         };
@@ -2011,12 +2017,12 @@ mod tests {
     }
 
     fn run_prepare_if_nonce_account_test(
-        account: &mut Account,
+        account: &mut AccountSharedData,
         account_pubkey: &Pubkey,
         tx_result: &Result<()>,
-        maybe_nonce_rollback: Option<(&Pubkey, &Account, Option<&Account>)>,
+        maybe_nonce_rollback: Option<(&Pubkey, &AccountSharedData, Option<&AccountSharedData>)>,
         last_blockhash_with_fee_calculator: &(Hash, FeeCalculator),
-        expect_account: &Account,
+        expect_account: &AccountSharedData,
     ) -> bool {
         // Verify expect_account's relationship
         match maybe_nonce_rollback {
@@ -2088,7 +2094,7 @@ mod tests {
         ) = create_accounts_prepare_if_nonce_account();
         let post_account_pubkey = pre_account_pubkey;
 
-        let mut post_account = Account::default();
+        let mut post_account = AccountSharedData::default();
         let expect_account = post_account.clone();
         assert!(run_prepare_if_nonce_account_test(
             &mut post_account,
@@ -2192,8 +2198,9 @@ mod tests {
                 blockhash,
                 fee_calculator: FeeCalculator::default(),
             }));
-        let nonce_account_pre = Account::new_data(42, &nonce_state, &system_program::id()).unwrap();
-        let from_account_pre = Account::new(4242, 0, &Pubkey::default());
+        let nonce_account_pre =
+            AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
+        let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
 
         let nonce_rollback = Some(NonceRollbackFull::new(
             nonce_address,
@@ -2215,12 +2222,12 @@ mod tests {
                 fee_calculator: FeeCalculator::default(),
             }));
         let nonce_account_post =
-            Account::new_data(43, &nonce_state, &system_program::id()).unwrap();
+            AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
 
-        let from_account_post = Account::new(4199, 0, &Pubkey::default());
-        let to_account = Account::new(2, 0, &Pubkey::default());
-        let nonce_authority_account = Account::new(3, 0, &Pubkey::default());
-        let recent_blockhashes_sysvar_account = Account::new(4, 0, &Pubkey::default());
+        let from_account_post = AccountSharedData::new(4199, 0, &Pubkey::default());
+        let to_account = AccountSharedData::new(2, 0, &Pubkey::default());
+        let nonce_authority_account = AccountSharedData::new(3, 0, &Pubkey::default());
+        let recent_blockhashes_sysvar_account = AccountSharedData::new(4, 0, &Pubkey::default());
 
         let transaction_accounts = vec![
             from_account_post,
@@ -2303,7 +2310,8 @@ mod tests {
                 blockhash,
                 fee_calculator: FeeCalculator::default(),
             }));
-        let nonce_account_pre = Account::new_data(42, &nonce_state, &system_program::id()).unwrap();
+        let nonce_account_pre =
+            AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
 
         let nonce_rollback = Some(NonceRollbackFull::new(
             nonce_address,
@@ -2325,12 +2333,12 @@ mod tests {
                 fee_calculator: FeeCalculator::default(),
             }));
         let nonce_account_post =
-            Account::new_data(43, &nonce_state, &system_program::id()).unwrap();
+            AccountSharedData::new_data(43, &nonce_state, &system_program::id()).unwrap();
 
-        let from_account_post = Account::new(4200, 0, &Pubkey::default());
-        let to_account = Account::new(2, 0, &Pubkey::default());
-        let nonce_authority_account = Account::new(3, 0, &Pubkey::default());
-        let recent_blockhashes_sysvar_account = Account::new(4, 0, &Pubkey::default());
+        let from_account_post = AccountSharedData::new(4200, 0, &Pubkey::default());
+        let to_account = AccountSharedData::new(2, 0, &Pubkey::default());
+        let nonce_authority_account = AccountSharedData::new(3, 0, &Pubkey::default());
+        let recent_blockhashes_sysvar_account = AccountSharedData::new(4, 0, &Pubkey::default());
 
         let transaction_accounts = vec![
             from_account_post,

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -424,7 +424,7 @@ mod test {
     use super::*;
     use crate::genesis_utils::create_genesis_config;
     use crossbeam_channel::unbounded;
-    use solana_sdk::{account::Account, pubkey::Pubkey};
+    use solana_sdk::{account::AccountSharedData, pubkey::Pubkey};
 
     #[test]
     fn test_accounts_background_service_remove_dead_slots() {
@@ -438,7 +438,10 @@ mod test {
 
         // Store an account in slot 0
         let account_key = Pubkey::new_unique();
-        bank0.store_account(&account_key, &Account::new(264, 0, &Pubkey::default()));
+        bank0.store_account(
+            &account_key,
+            &AccountSharedData::new(264, 0, &Pubkey::default()),
+        );
         assert!(bank0.get_account(&account_key).is_some());
         pruned_banks_sender.send(0).unwrap();
         AccountsBackgroundService::remove_dead_slots(&bank0, &request_handler, &mut 0, &mut 0);

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -1,5 +1,5 @@
 use dashmap::DashMap;
-use solana_sdk::{account::Account, clock::Slot, hash::Hash, pubkey::Pubkey};
+use solana_sdk::{account::AccountSharedData, clock::Slot, hash::Hash, pubkey::Pubkey};
 use std::{
     collections::BTreeSet,
     ops::Deref,
@@ -42,7 +42,7 @@ impl SlotCacheInner {
         );
     }
 
-    pub fn insert(&self, pubkey: &Pubkey, account: Account, hash: Hash) {
+    pub fn insert(&self, pubkey: &Pubkey, account: AccountSharedData, hash: Hash) {
         if self.cache.contains_key(pubkey) {
             self.same_account_writes.fetch_add(1, Ordering::Relaxed);
             self.same_account_writes_size
@@ -86,7 +86,7 @@ impl Deref for SlotCacheInner {
 
 #[derive(Debug, Clone)]
 pub struct CachedAccount {
-    pub account: Account,
+    pub account: AccountSharedData,
     pub hash: Hash,
 }
 
@@ -123,7 +123,7 @@ impl AccountsCache {
         );
     }
 
-    pub fn store(&self, slot: Slot, pubkey: &Pubkey, account: Account, hash: Hash) {
+    pub fn store(&self, slot: Slot, pubkey: &Pubkey, account: AccountSharedData, hash: Hash) {
         let slot_cache = self.slot_cache(slot).unwrap_or_else(||
             // DashMap entry.or_insert() returns a RefMut, essentially a write lock,
             // which is dropped after this block ends, minimizing time held by the lock.
@@ -235,7 +235,7 @@ pub mod tests {
         cache.store(
             inserted_slot,
             &Pubkey::new_unique(),
-            Account::new(1, 0, &Pubkey::default()),
+            AccountSharedData::new(1, 0, &Pubkey::default()),
             Hash::default(),
         );
         // If the cache is told the size limit is 0, it should return the one slot
@@ -253,7 +253,7 @@ pub mod tests {
         cache.store(
             inserted_slot,
             &Pubkey::new_unique(),
-            Account::new(1, 0, &Pubkey::default()),
+            AccountSharedData::new(1, 0, &Pubkey::default()),
             Hash::default(),
         );
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 use solana_measure::measure::Measure;
 use solana_rayon_threadlimit::get_thread_count;
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     clock::{Epoch, Slot},
     genesis_config::ClusterType,
     hash::{Hash, Hasher},
@@ -276,7 +276,7 @@ impl<'a> LoadedAccount<'a> {
         }
     }
 
-    pub fn account(self) -> Account {
+    pub fn account(self) -> AccountSharedData {
         match self {
             LoadedAccount::Stored(stored_account_meta) => stored_account_meta.clone_account(),
             LoadedAccount::Cached((_, cached_account)) => match cached_account {
@@ -569,7 +569,7 @@ pub struct BankHashStats {
 }
 
 impl BankHashStats {
-    pub fn update(&mut self, account: &Account) {
+    pub fn update(&mut self, account: &AccountSharedData) {
         if account.lamports == 0 {
             self.num_removed_accounts += 1;
         } else {
@@ -1052,7 +1052,7 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
         let key = Pubkey::default();
         let some_data_len = 5;
         let some_slot: Slot = 0;
-        let account = Account::new(1, some_data_len, &key);
+        let account = AccountSharedData::new(1, some_data_len, &key);
         accounts_db.store_uncached(some_slot, &[(&key, &account)]);
         accounts_db.add_root(0);
 
@@ -1726,7 +1726,7 @@ impl AccountsDb {
         I: Iterator<Item = &'a Arc<AccountStorageEntry>>,
     {
         struct FoundStoredAccount {
-            account: Account,
+            account: AccountSharedData,
             account_hash: Hash,
             account_size: usize,
             store_id: AppendVecId,
@@ -2018,7 +2018,7 @@ impl AccountsDb {
 
     pub fn scan_accounts<F, A>(&self, ancestors: &Ancestors, scan_func: F) -> A
     where
-        F: Fn(&mut A, Option<(&Pubkey, Account, Slot)>),
+        F: Fn(&mut A, Option<(&Pubkey, AccountSharedData, Slot)>),
         A: Default,
     {
         let mut collector = A::default();
@@ -2077,7 +2077,7 @@ impl AccountsDb {
         scan_func: F,
     ) -> A
     where
-        F: Fn(&mut A, Option<(&Pubkey, Account, Slot)>),
+        F: Fn(&mut A, Option<(&Pubkey, AccountSharedData, Slot)>),
         A: Default,
         R: RangeBounds<Pubkey>,
     {
@@ -2109,7 +2109,7 @@ impl AccountsDb {
         scan_func: F,
     ) -> A
     where
-        F: Fn(&mut A, Option<(&Pubkey, Account, Slot)>),
+        F: Fn(&mut A, Option<(&Pubkey, AccountSharedData, Slot)>),
         A: Default,
     {
         let mut collector = A::default();
@@ -2209,7 +2209,11 @@ impl AccountsDb {
         bank_hashes.insert(slot, new_hash_info);
     }
 
-    pub fn load(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
+    pub fn load(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
         self.do_load(ancestors, pubkey, None)
     }
 
@@ -2218,7 +2222,7 @@ impl AccountsDb {
         ancestors: &Ancestors,
         pubkey: &Pubkey,
         max_root: Option<Slot>,
-    ) -> Option<(Account, Slot)> {
+    ) -> Option<(AccountSharedData, Slot)> {
         let (slot, store_id, offset) = {
             let (lock, index) = self.accounts_index.get(pubkey, Some(ancestors), max_root)?;
             let slot_list = lock.slot_list();
@@ -2261,7 +2265,11 @@ impl AccountsDb {
             .unwrap()
     }
 
-    pub fn load_slow(&self, ancestors: &Ancestors, pubkey: &Pubkey) -> Option<(Account, Slot)> {
+    pub fn load_slow(
+        &self,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
         self.load(ancestors, pubkey)
     }
 
@@ -2819,7 +2827,7 @@ impl AccountsDb {
 
     pub fn hash_account(
         slot: Slot,
-        account: &Account,
+        account: &AccountSharedData,
         pubkey: &Pubkey,
         cluster_type: &ClusterType,
     ) -> Hash {
@@ -2850,7 +2858,7 @@ impl AccountsDb {
         }
     }
 
-    fn hash_frozen_account_data(account: &Account) -> Hash {
+    fn hash_frozen_account_data(account: &AccountSharedData) -> Hash {
         let mut hasher = Hasher::default();
 
         hasher.hash(&account.data);
@@ -2963,7 +2971,7 @@ impl AccountsDb {
         slot: Slot,
         hashes: &[Hash],
         mut storage_finder: F,
-        accounts_and_meta_to_store: &[(StoredMeta, &Account)],
+        accounts_and_meta_to_store: &[(StoredMeta, &AccountSharedData)],
     ) -> Vec<AccountInfo> {
         assert_eq!(hashes.len(), accounts_and_meta_to_store.len());
         let mut infos: Vec<AccountInfo> = Vec::with_capacity(accounts_and_meta_to_store.len());
@@ -3188,7 +3196,7 @@ impl AccountsDb {
         // If `should_clean` is None, then`should_flush_f` is also None, which will cause
         // `flush_slot_cache` to flush all accounts to storage without cleaning any accounts.
         let mut should_flush_f = should_clean.map(|(account_bytes_saved, num_accounts_saved)| {
-            move |&pubkey: &Pubkey, account: &Account| {
+            move |&pubkey: &Pubkey, account: &AccountSharedData| {
                 use std::collections::hash_map::Entry::{Occupied, Vacant};
                 let should_flush = match written_accounts.entry(pubkey) {
                     Vacant(vacant_entry) => {
@@ -3255,7 +3263,7 @@ impl AccountsDb {
     fn flush_slot_cache(
         &self,
         slot: Slot,
-        mut should_flush_f: Option<&mut impl FnMut(&Pubkey, &Account) -> bool>,
+        mut should_flush_f: Option<&mut impl FnMut(&Pubkey, &AccountSharedData) -> bool>,
     ) -> FlushStats {
         let mut num_purged = 0;
         let mut total_size = 0;
@@ -3264,7 +3272,7 @@ impl AccountsDb {
             let iter_items: Vec<_> = slot_cache.iter().collect();
             let mut purged_slot_pubkeys: HashSet<(Slot, Pubkey)> = HashSet::new();
             let mut pubkey_to_slot_set: Vec<(Pubkey, Slot)> = vec![];
-            let (accounts, hashes): (Vec<(&Pubkey, &Account)>, Vec<Hash>) = iter_items
+            let (accounts, hashes): (Vec<(&Pubkey, &AccountSharedData)>, Vec<Hash>) = iter_items
                 .iter()
                 .filter_map(|iter_item| {
                     let key = iter_item.key();
@@ -3346,7 +3354,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         hashes: &[Hash],
-        accounts_and_meta_to_store: &[(StoredMeta, &Account)],
+        accounts_and_meta_to_store: &[(StoredMeta, &AccountSharedData)],
     ) -> Vec<AccountInfo> {
         assert_eq!(hashes.len(), accounts_and_meta_to_store.len());
         accounts_and_meta_to_store
@@ -3371,14 +3379,14 @@ impl AccountsDb {
     >(
         &self,
         slot: Slot,
-        accounts: &[(&Pubkey, &Account)],
+        accounts: &[(&Pubkey, &AccountSharedData)],
         hashes: &[Hash],
         storage_finder: F,
         mut write_version_producer: P,
         is_cached_store: bool,
     ) -> Vec<AccountInfo> {
-        let default_account = Account::default();
-        let accounts_and_meta_to_store: Vec<(StoredMeta, &Account)> = accounts
+        let default_account = AccountSharedData::default();
+        let accounts_and_meta_to_store: Vec<(StoredMeta, &AccountSharedData)> = accounts
             .iter()
             .map(|(pubkey, account)| {
                 let account = if account.lamports == 0 {
@@ -3931,7 +3939,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         infos: Vec<AccountInfo>,
-        accounts: &[(&Pubkey, &Account)],
+        accounts: &[(&Pubkey, &AccountSharedData)],
     ) -> SlotList<AccountInfo> {
         let mut reclaims = SlotList::<AccountInfo>::with_capacity(infos.len() * 2);
         for (info, pubkey_account) in infos.into_iter().zip(accounts.iter()) {
@@ -4113,7 +4121,7 @@ impl AccountsDb {
     fn hash_accounts(
         &self,
         slot: Slot,
-        accounts: &[(&Pubkey, &Account)],
+        accounts: &[(&Pubkey, &AccountSharedData)],
         cluster_type: &ClusterType,
     ) -> Vec<Hash> {
         let mut stats = BankHashStats::default();
@@ -4163,7 +4171,7 @@ impl AccountsDb {
     }
 
     /// Cause a panic if frozen accounts would be affected by data in `accounts`
-    fn assert_frozen_accounts(&self, accounts: &[(&Pubkey, &Account)]) {
+    fn assert_frozen_accounts(&self, accounts: &[(&Pubkey, &AccountSharedData)]) {
         if self.frozen_accounts.is_empty() {
             return;
         }
@@ -4189,16 +4197,16 @@ impl AccountsDb {
         }
     }
 
-    pub fn store_cached(&self, slot: Slot, accounts: &[(&Pubkey, &Account)]) {
+    pub fn store_cached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
         self.store(slot, accounts, self.caching_enabled);
     }
 
     /// Store the account update.
-    pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &Account)]) {
+    pub fn store_uncached(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)]) {
         self.store(slot, accounts, false);
     }
 
-    fn store(&self, slot: Slot, accounts: &[(&Pubkey, &Account)], is_cached_store: bool) {
+    fn store(&self, slot: Slot, accounts: &[(&Pubkey, &AccountSharedData)], is_cached_store: bool) {
         // If all transactions in a batch are errored,
         // it's possible to get a store with no accounts.
         if accounts.is_empty() {
@@ -4316,7 +4324,7 @@ impl AccountsDb {
     fn store_accounts_unfrozen(
         &self,
         slot: Slot,
-        accounts: &[(&Pubkey, &Account)],
+        accounts: &[(&Pubkey, &AccountSharedData)],
         hashes: &[Hash],
         is_cached_store: bool,
     ) {
@@ -4342,7 +4350,7 @@ impl AccountsDb {
     fn store_accounts_frozen<'a>(
         &'a self,
         slot: Slot,
-        accounts: &[(&Pubkey, &Account)],
+        accounts: &[(&Pubkey, &AccountSharedData)],
         hashes: &[Hash],
         storage_finder: Option<StorageFinder<'a>>,
         write_version_producer: Option<Box<dyn Iterator<Item = u64>>>,
@@ -4366,7 +4374,7 @@ impl AccountsDb {
     fn store_accounts_custom<'a>(
         &'a self,
         slot: Slot,
-        accounts: &[(&Pubkey, &Account)],
+        accounts: &[(&Pubkey, &AccountSharedData)],
         hashes: &[Hash],
         storage_finder: Option<StorageFinder<'a>>,
         write_version_producer: Option<Box<dyn Iterator<Item = u64>>>,
@@ -4682,7 +4690,7 @@ impl AccountsDb {
     // store ref count could become incorrect.
     fn do_shrink_slot_v1(&self, slot: Slot, forced: bool) -> usize {
         struct FoundStoredAccount {
-            account: Account,
+            account: AccountSharedData,
             account_hash: Hash,
             account_size: usize,
             store_id: AppendVecId,
@@ -5041,7 +5049,7 @@ pub mod tests {
     };
     use assert_matches::assert_matches;
     use rand::{thread_rng, Rng};
-    use solana_sdk::{account::Account, hash::HASH_BYTES, pubkey::PUBKEY_BYTES};
+    use solana_sdk::{account::AccountSharedData, hash::HASH_BYTES, pubkey::PUBKEY_BYTES};
     use std::{
         iter::FromIterator,
         str::FromStr,
@@ -5114,20 +5122,33 @@ pub mod tests {
             SLOT,
             &[(
                 &pubkey0,
-                &Account::new(raw_expected[0].lamports, 1, &Account::default().owner),
+                &AccountSharedData::new(
+                    raw_expected[0].lamports,
+                    1,
+                    &AccountSharedData::default().owner,
+                ),
             )],
         );
         accounts.store_uncached(
             SLOT,
-            &[(&pubkey127, &Account::new(128, 1, &Account::default().owner))],
+            &[(
+                &pubkey127,
+                &AccountSharedData::new(128, 1, &AccountSharedData::default().owner),
+            )],
         );
         accounts.store_uncached(
             SLOT,
-            &[(&pubkey128, &Account::new(129, 1, &Account::default().owner))],
+            &[(
+                &pubkey128,
+                &AccountSharedData::new(129, 1, &AccountSharedData::default().owner),
+            )],
         );
         accounts.store_uncached(
             SLOT,
-            &[(&pubkey255, &Account::new(256, 1, &Account::default().owner))],
+            &[(
+                &pubkey255,
+                &AccountSharedData::new(256, 1, &AccountSharedData::default().owner),
+            )],
         );
         accounts.add_root(SLOT);
 
@@ -5245,7 +5266,7 @@ pub mod tests {
         let arc = Arc::new(data);
         let storages = vec![vec![arc]];
         let pubkey = solana_sdk::pubkey::new_rand();
-        let acc = Account::new(1, 48, &Account::default().owner);
+        let acc = AccountSharedData::new(1, 48, &AccountSharedData::default().owner);
         let sm = StoredMeta {
             data_len: 1,
             pubkey,
@@ -5275,7 +5296,7 @@ pub mod tests {
         solana_logger::setup();
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
 
         db.store_uncached(0, &[(&key, &account0)]);
         db.add_root(0);
@@ -5288,11 +5309,11 @@ pub mod tests {
         solana_logger::setup();
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
 
         db.store_uncached(0, &[(&key, &account0)]);
 
-        let account1 = Account::new(0, 0, &key);
+        let account1 = AccountSharedData::new(0, 0, &key);
         db.store_uncached(1, &[(&key, &account1)]);
 
         let ancestors = vec![(1, 1)].into_iter().collect();
@@ -5301,10 +5322,13 @@ pub mod tests {
         let ancestors = vec![(1, 1), (0, 0)].into_iter().collect();
         assert_eq!(&db.load_slow(&ancestors, &key).unwrap().0, &account1);
 
-        let accounts: Vec<Account> =
-            db.unchecked_scan_accounts("", &ancestors, |accounts: &mut Vec<Account>, option| {
+        let accounts: Vec<AccountSharedData> = db.unchecked_scan_accounts(
+            "",
+            &ancestors,
+            |accounts: &mut Vec<AccountSharedData>, option| {
                 accounts.push(option.1.account());
-            });
+            },
+        );
         assert_eq!(accounts, vec![account1]);
     }
 
@@ -5313,11 +5337,11 @@ pub mod tests {
         solana_logger::setup();
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
 
         db.store_uncached(0, &[(&key, &account0)]);
 
-        let account1 = Account::new(0, 0, &key);
+        let account1 = AccountSharedData::new(0, 0, &key);
         db.store_uncached(1, &[(&key, &account1)]);
         db.add_root(0);
 
@@ -5334,7 +5358,7 @@ pub mod tests {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
 
         // store value 1 in the "root", i.e. db zero
         db.store_uncached(0, &[(&key, &account0)]);
@@ -5349,7 +5373,7 @@ pub mod tests {
         //                                       (via root0)
 
         // store value 0 in one child
-        let account1 = Account::new(0, 0, &key);
+        let account1 = AccountSharedData::new(0, 0, &key);
         db.store_uncached(1, &[(&key, &account1)]);
 
         // masking accounts is done at the Accounts level, at accountsDB we see
@@ -5380,9 +5404,9 @@ pub mod tests {
             let idx = thread_rng().gen_range(0, 99);
             let ancestors = vec![(0, 0)].into_iter().collect();
             let account = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
-            let default_account = Account {
+            let default_account = AccountSharedData {
                 lamports: (idx + 1) as u64,
-                ..Account::default()
+                ..AccountSharedData::default()
             };
             assert_eq!((default_account, 0), account);
         }
@@ -5396,9 +5420,9 @@ pub mod tests {
             let account0 = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
             let ancestors = vec![(1, 1)].into_iter().collect();
             let account1 = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
-            let default_account = Account {
+            let default_account = AccountSharedData {
                 lamports: (idx + 1) as u64,
-                ..Account::default()
+                ..AccountSharedData::default()
             };
             assert_eq!(&default_account, &account0.0);
             assert_eq!(&default_account, &account1.0);
@@ -5415,7 +5439,7 @@ pub mod tests {
         assert!(check_storage(&db, 0, 2));
 
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new(1, DEFAULT_FILE_SIZE as usize / 3, &pubkey);
+        let account = AccountSharedData::new(1, DEFAULT_FILE_SIZE as usize / 3, &pubkey);
         db.store_uncached(1, &[(&pubkey, &account)]);
         db.store_uncached(1, &[(&pubkeys[0], &account)]);
         {
@@ -5471,11 +5495,11 @@ pub mod tests {
 
         // 1 token in the "root", i.e. db zero
         let db0 = AccountsDb::new(Vec::new(), &ClusterType::Development);
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
         db0.store_uncached(0, &[(&key, &account0)]);
 
         // 0 lamports in the child
-        let account1 = Account::new(0, 0, &key);
+        let account1 = AccountSharedData::new(0, 0, &key);
         db0.store_uncached(1, &[(&key, &account1)]);
 
         // masking accounts is done at the Accounts level, at accountsDB we see
@@ -5492,7 +5516,7 @@ pub mod tests {
         let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         db.caching_enabled = true;
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
         let ancestors: HashMap<_, _> = vec![(unrooted_slot, 1)].into_iter().collect();
         db.store_cached(unrooted_slot, &[(&key, &account0)]);
         db.bank_hashes
@@ -5521,7 +5545,7 @@ pub mod tests {
             .is_none());
 
         // Test we can store for the same slot again and get the right information
-        let account0 = Account::new(2, 0, &key);
+        let account0 = AccountSharedData::new(2, 0, &key);
         db.store_uncached(unrooted_slot, &[(&key, &account0)]);
         assert_load_account(&db, unrooted_slot, key, 2);
     }
@@ -5532,7 +5556,7 @@ pub mod tests {
         let unrooted_slot = 9;
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let key = solana_sdk::pubkey::new_rand();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
         db.store_uncached(unrooted_slot, &[(&key, &account0)]);
 
         // Purge the slot
@@ -5566,14 +5590,16 @@ pub mod tests {
         let ancestors = vec![(slot, 0)].into_iter().collect();
         for t in 0..num {
             let pubkey = solana_sdk::pubkey::new_rand();
-            let account = Account::new((t + 1) as u64, space, &Account::default().owner);
+            let account =
+                AccountSharedData::new((t + 1) as u64, space, &AccountSharedData::default().owner);
             pubkeys.push(pubkey);
             assert!(accounts.load_slow(&ancestors, &pubkey).is_none());
             accounts.store_uncached(slot, &[(&pubkey, &account)]);
         }
         for t in 0..num_vote {
             let pubkey = solana_sdk::pubkey::new_rand();
-            let account = Account::new((num + t + 1) as u64, space, &solana_vote_program::id());
+            let account =
+                AccountSharedData::new((num + t + 1) as u64, space, &solana_vote_program::id());
             pubkeys.push(pubkey);
             let ancestors = vec![(slot, 0)].into_iter().collect();
             assert!(accounts.load_slow(&ancestors, &pubkey).is_none());
@@ -5592,9 +5618,9 @@ pub mod tests {
                     let ancestors = vec![(slot, 0)].into_iter().collect();
                     assert!(accounts.load_slow(&ancestors, &pubkeys[idx]).is_none());
                 } else {
-                    let default_account = Account {
+                    let default_account = AccountSharedData {
                         lamports: account.lamports,
-                        ..Account::default()
+                        ..AccountSharedData::default()
                     };
                     assert_eq!(default_account, account);
                 }
@@ -5647,7 +5673,11 @@ pub mod tests {
             let idx = thread_rng().gen_range(0, num);
             let account = accounts.load_slow(&ancestors, &pubkeys[idx]);
             let account1 = Some((
-                Account::new((idx + count) as u64, 0, &Account::default().owner),
+                AccountSharedData::new(
+                    (idx + count) as u64,
+                    0,
+                    &AccountSharedData::default().owner,
+                ),
                 slot,
             ));
             assert_eq!(account, account1);
@@ -5663,7 +5693,11 @@ pub mod tests {
         count: usize,
     ) {
         for idx in 0..num {
-            let account = Account::new((idx + count) as u64, 0, &Account::default().owner);
+            let account = AccountSharedData::new(
+                (idx + count) as u64,
+                0,
+                &AccountSharedData::default().owner,
+            );
             accounts.store_uncached(slot, &[(&pubkeys[idx], &account)]);
         }
     }
@@ -5676,9 +5710,9 @@ pub mod tests {
         create_account(&db, &mut pubkeys, 0, 1, 0, 0);
         let ancestors = vec![(0, 0)].into_iter().collect();
         let account = db.load_slow(&ancestors, &pubkeys[0]).unwrap();
-        let default_account = Account {
+        let default_account = AccountSharedData {
             lamports: 1,
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         assert_eq!((default_account, 0), account);
     }
@@ -5709,7 +5743,7 @@ pub mod tests {
         let mut keys = vec![];
         for i in 0..9 {
             let key = solana_sdk::pubkey::new_rand();
-            let account = Account::new(i + 1, size as usize / 4, &key);
+            let account = AccountSharedData::new(i + 1, size as usize / 4, &key);
             accounts.store_uncached(0, &[(&key, &account)]);
             keys.push(key);
         }
@@ -5740,7 +5774,7 @@ pub mod tests {
 
         let status = [AccountStorageStatus::Available, AccountStorageStatus::Full];
         let pubkey1 = solana_sdk::pubkey::new_rand();
-        let account1 = Account::new(1, DEFAULT_FILE_SIZE as usize / 2, &pubkey1);
+        let account1 = AccountSharedData::new(1, DEFAULT_FILE_SIZE as usize / 2, &pubkey1);
         accounts.store_uncached(0, &[(&pubkey1, &account1)]);
         {
             let stores = &accounts.storage.get_slot_stores(0).unwrap();
@@ -5751,7 +5785,7 @@ pub mod tests {
         }
 
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        let account2 = Account::new(1, DEFAULT_FILE_SIZE as usize / 2, &pubkey2);
+        let account2 = AccountSharedData::new(1, DEFAULT_FILE_SIZE as usize / 2, &pubkey2);
         accounts.store_uncached(0, &[(&pubkey2, &account2)]);
         {
             assert_eq!(accounts.storage.0.len(), 1);
@@ -5803,7 +5837,7 @@ pub mod tests {
         //not root, it means we are retaining dead banks.
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new(1, 0, &Account::default().owner);
+        let account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
         //store an account
         accounts.store_uncached(0, &[(&pubkey, &account)]);
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -5875,8 +5909,9 @@ pub mod tests {
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        let account = Account::new(1, 1, &Account::default().owner);
-        let zero_lamport_account = Account::new(0, 0, &Account::default().owner);
+        let account = AccountSharedData::new(1, 1, &AccountSharedData::default().owner);
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
 
         // Store two accounts
         accounts.store_uncached(0, &[(&pubkey1, &account)]);
@@ -5930,8 +5965,9 @@ pub mod tests {
 
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new(1, 0, &Account::default().owner);
-        let zero_lamport_account = Account::new(0, 0, &Account::default().owner);
+        let account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
 
         // Store a zero-lamport account
         accounts.store_uncached(0, &[(&pubkey, &account)]);
@@ -5969,7 +6005,7 @@ pub mod tests {
 
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new(1, 0, &Account::default().owner);
+        let account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
         //store an account
         accounts.store_uncached(0, &[(&pubkey, &account)]);
         accounts.store_uncached(1, &[(&pubkey, &account)]);
@@ -5998,8 +6034,8 @@ pub mod tests {
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        let normal_account = Account::new(1, 0, &Account::default().owner);
-        let zero_account = Account::new(0, 0, &Account::default().owner);
+        let normal_account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
+        let zero_account = AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
         //store an account
         accounts.store_uncached(0, &[(&pubkey1, &normal_account)]);
         accounts.store_uncached(1, &[(&pubkey1, &zero_account)]);
@@ -6044,10 +6080,10 @@ pub mod tests {
             vec![0; inline_spl_token_v2_0::state::Account::get_packed_len()];
         account_data_with_mint[..PUBKEY_BYTES].clone_from_slice(&(mint_key.clone().to_bytes()));
 
-        let mut normal_account = Account::new(1, 0, &Account::default().owner);
+        let mut normal_account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
         normal_account.owner = inline_spl_token_v2_0::id();
         normal_account.data = account_data_with_mint.clone();
-        let mut zero_account = Account::new(0, 0, &Account::default().owner);
+        let mut zero_account = AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
         zero_account.owner = inline_spl_token_v2_0::id();
         zero_account.data = account_data_with_mint;
 
@@ -6114,8 +6150,8 @@ pub mod tests {
 
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new(1, 0, &Account::default().owner);
-        let zero_account = Account::new(0, 0, &Account::default().owner);
+        let account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
+        let zero_account = AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
 
         // store an account, make it a zero lamport account
         // in slot 1
@@ -6151,7 +6187,7 @@ pub mod tests {
 
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new(1, 0, &Account::default().owner);
+        let account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
         //store an account
         accounts.store_uncached(0, &[(&pubkey, &account)]);
         assert_eq!(accounts.accounts_index.uncleaned_roots_len(), 0);
@@ -6209,7 +6245,7 @@ pub mod tests {
         modify_accounts(&accounts, &pubkeys, latest_slot, 10, 3);
         // Overwrite account 30 from slot 0 with lamports=0 into slot 1.
         // Slot 1 should now have 10 + 1 = 11 accounts
-        let account = Account::new(0, 0, &Account::default().owner);
+        let account = AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
         accounts.store_uncached(latest_slot, &[(&pubkeys[30], &account)]);
 
         // Create 10 new accounts in slot 1, should now have 11 + 10 = 21
@@ -6229,7 +6265,7 @@ pub mod tests {
         accounts.clean_accounts(None);
         // Overwrite account 31 from slot 0 with lamports=0 into slot 2.
         // Slot 2 should now have 20 + 1 = 21 accounts
-        let account = Account::new(0, 0, &Account::default().owner);
+        let account = AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
         accounts.store_uncached(latest_slot, &[(&pubkeys[31], &account)]);
 
         // Create 10 new accounts in slot 2. Slot 2 should now have
@@ -6325,15 +6361,15 @@ pub mod tests {
         let some_lamport = 223;
         let zero_lamport = 0;
         let no_data = 0;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(some_lamport, no_data, &owner);
+        let account = AccountSharedData::new(some_lamport, no_data, &owner);
         let pubkey = solana_sdk::pubkey::new_rand();
 
-        let account2 = Account::new(some_lamport, no_data, &owner);
+        let account2 = AccountSharedData::new(some_lamport, no_data, &owner);
         let pubkey2 = solana_sdk::pubkey::new_rand();
 
-        let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
+        let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
         let accounts = AccountsDb::new_single();
         accounts.add_root(0);
@@ -6404,12 +6440,12 @@ pub mod tests {
         let some_lamport = 223;
         let zero_lamport = 0;
         let no_data = 0;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(some_lamport, no_data, &owner);
+        let account = AccountSharedData::new(some_lamport, no_data, &owner);
         let pubkey = solana_sdk::pubkey::new_rand();
 
-        let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
+        let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
         let accounts = AccountsDb::new_single();
         accounts.add_root(0);
@@ -6464,16 +6500,16 @@ pub mod tests {
         let some_lamport = 223;
         let zero_lamport = 0;
         let no_data = 0;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(some_lamport, no_data, &owner);
+        let account = AccountSharedData::new(some_lamport, no_data, &owner);
         let pubkey = solana_sdk::pubkey::new_rand();
-        let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
+        let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
-        let account2 = Account::new(some_lamport + 1, no_data, &owner);
+        let account2 = AccountSharedData::new(some_lamport + 1, no_data, &owner);
         let pubkey2 = solana_sdk::pubkey::new_rand();
 
-        let filler_account = Account::new(some_lamport, no_data, &owner);
+        let filler_account = AccountSharedData::new(some_lamport, no_data, &owner);
         let filler_account_pubkey = solana_sdk::pubkey::new_rand();
 
         let accounts = AccountsDb::new_single();
@@ -6522,18 +6558,18 @@ pub mod tests {
         let zero_lamport = 0;
         let dummy_lamport = 999;
         let no_data = 0;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(some_lamport, no_data, &owner);
-        let account2 = Account::new(some_lamport + 100_001, no_data, &owner);
-        let account3 = Account::new(some_lamport + 100_002, no_data, &owner);
-        let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
+        let account = AccountSharedData::new(some_lamport, no_data, &owner);
+        let account2 = AccountSharedData::new(some_lamport + 100_001, no_data, &owner);
+        let account3 = AccountSharedData::new(some_lamport + 100_002, no_data, &owner);
+        let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
         let pubkey = solana_sdk::pubkey::new_rand();
         let purged_pubkey1 = solana_sdk::pubkey::new_rand();
         let purged_pubkey2 = solana_sdk::pubkey::new_rand();
 
-        let dummy_account = Account::new(dummy_lamport, no_data, &owner);
+        let dummy_account = AccountSharedData::new(dummy_lamport, no_data, &owner);
         let dummy_pubkey = Pubkey::default();
 
         let accounts = AccountsDb::new_single();
@@ -6612,7 +6648,7 @@ pub mod tests {
                     .name("account-writers".to_string())
                     .spawn(move || {
                         let pubkey = solana_sdk::pubkey::new_rand();
-                        let mut account = Account::new(1, 0, &pubkey);
+                        let mut account = AccountSharedData::new(1, 0, &pubkey);
                         let mut i = 0;
                         loop {
                             let account_bal = thread_rng().gen_range(1, 99);
@@ -6643,26 +6679,32 @@ pub mod tests {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let key = Pubkey::default();
         let key0 = solana_sdk::pubkey::new_rand();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
 
         db.store_uncached(0, &[(&key0, &account0)]);
 
         let key1 = solana_sdk::pubkey::new_rand();
-        let account1 = Account::new(2, 0, &key);
+        let account1 = AccountSharedData::new(2, 0, &key);
         db.store_uncached(1, &[(&key1, &account1)]);
 
         let ancestors = vec![(0, 0)].into_iter().collect();
-        let accounts: Vec<Account> =
-            db.unchecked_scan_accounts("", &ancestors, |accounts: &mut Vec<Account>, option| {
+        let accounts: Vec<AccountSharedData> = db.unchecked_scan_accounts(
+            "",
+            &ancestors,
+            |accounts: &mut Vec<AccountSharedData>, option| {
                 accounts.push(option.1.account());
-            });
+            },
+        );
         assert_eq!(accounts, vec![account0]);
 
         let ancestors = vec![(1, 1), (0, 0)].into_iter().collect();
-        let accounts: Vec<Account> =
-            db.unchecked_scan_accounts("", &ancestors, |accounts: &mut Vec<Account>, option| {
+        let accounts: Vec<AccountSharedData> = db.unchecked_scan_accounts(
+            "",
+            &ancestors,
+            |accounts: &mut Vec<AccountSharedData>, option| {
                 accounts.push(option.1.account());
-            });
+            },
+        );
         assert_eq!(accounts.len(), 2);
     }
 
@@ -6673,12 +6715,12 @@ pub mod tests {
 
         let key = Pubkey::default();
         let key0 = solana_sdk::pubkey::new_rand();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
 
         db.store_uncached(0, &[(&key0, &account0)]);
 
         let key1 = solana_sdk::pubkey::new_rand();
-        let account1 = Account::new(2, 0, &key);
+        let account1 = AccountSharedData::new(2, 0, &key);
         db.store_uncached(1, &[(&key1, &account1)]);
 
         db.print_accounts_stats("pre");
@@ -6687,7 +6729,7 @@ pub mod tests {
         let purge_keys = vec![(key1, slots)];
         db.purge_keys_exact(&purge_keys);
 
-        let account2 = Account::new(3, 0, &key);
+        let account2 = AccountSharedData::new(3, 0, &key);
         db.store_uncached(2, &[(&key1, &account2)]);
 
         db.print_accounts_stats("post");
@@ -6702,7 +6744,7 @@ pub mod tests {
 
         let key = Pubkey::default();
         let data_len = DEFAULT_FILE_SIZE as usize + 7;
-        let account = Account::new(1, data_len, &key);
+        let account = AccountSharedData::new(1, data_len, &key);
 
         db.store_uncached(0, &[(&key, &account)]);
 
@@ -6713,7 +6755,7 @@ pub mod tests {
 
     #[test]
     fn test_hash_frozen_account_data() {
-        let account = Account::new(1, 42, &Pubkey::default());
+        let account = AccountSharedData::new(1, 42, &Pubkey::default());
 
         let hash = AccountsDb::hash_frozen_account_data(&account);
         assert_ne!(hash, Hash::default()); // Better not be the default Hash
@@ -6766,7 +6808,7 @@ pub mod tests {
             Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
         let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
-        let mut account = Account::new(1, 42, &frozen_pubkey);
+        let mut account = AccountSharedData::new(1, 42, &frozen_pubkey);
         db.store_uncached(0, &[(&frozen_pubkey, &account)]);
 
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -6801,7 +6843,7 @@ pub mod tests {
             Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
         let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
-        let mut account = Account::new(1, 42, &frozen_pubkey);
+        let mut account = AccountSharedData::new(1, 42, &frozen_pubkey);
         db.store_uncached(0, &[(&frozen_pubkey, &account)]);
 
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -6834,7 +6876,7 @@ pub mod tests {
             Pubkey::from_str("My11111111111111111111111111111111111111111").unwrap();
         let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
-        let mut account = Account::new(1, 42, &frozen_pubkey);
+        let mut account = AccountSharedData::new(1, 42, &frozen_pubkey);
         db.store_uncached(0, &[(&frozen_pubkey, &account)]);
 
         let ancestors = vec![(0, 0)].into_iter().collect();
@@ -6910,7 +6952,7 @@ pub mod tests {
         let key = Pubkey::default();
         let some_data_len = 5;
         let some_slot: Slot = 0;
-        let account = Account::new(1, some_data_len, &key);
+        let account = AccountSharedData::new(1, some_data_len, &key);
         let ancestors = vec![(some_slot, 0)].into_iter().collect();
 
         db.store_uncached(some_slot, &[(&key, &account)]);
@@ -6938,7 +6980,7 @@ pub mod tests {
         let key = solana_sdk::pubkey::new_rand();
         let some_data_len = 0;
         let some_slot: Slot = 0;
-        let account = Account::new(1, some_data_len, &key);
+        let account = AccountSharedData::new(1, some_data_len, &key);
         let ancestors = vec![(some_slot, 0)].into_iter().collect();
 
         db.store_uncached(some_slot, &[(&key, &account)]);
@@ -6980,7 +7022,7 @@ pub mod tests {
         let key = solana_sdk::pubkey::new_rand();
         let some_data_len = 0;
         let some_slot: Slot = 0;
-        let account = Account::new(1, some_data_len, &key);
+        let account = AccountSharedData::new(1, some_data_len, &key);
         let ancestors = vec![(some_slot, 0)].into_iter().collect();
 
         db.store_uncached(some_slot, &[(&key, &account)]);
@@ -7044,7 +7086,7 @@ pub mod tests {
         let key = Pubkey::default();
         let some_data_len = 0;
         let some_slot: Slot = 0;
-        let account = Account::new(1, some_data_len, &key);
+        let account = AccountSharedData::new(1, some_data_len, &key);
         let ancestors = vec![(some_slot, 0)].into_iter().collect();
 
         let accounts = &[(&key, &account)];
@@ -7067,7 +7109,7 @@ pub mod tests {
         let key = solana_sdk::pubkey::new_rand();
         let lamports = 100;
         let data_len = 8190;
-        let account = Account::new(lamports, data_len, &solana_sdk::pubkey::new_rand());
+        let account = AccountSharedData::new(lamports, data_len, &solana_sdk::pubkey::new_rand());
         // pre-populate with a smaller empty store
         db.create_and_insert_store(1, 8192, "test_storage_finder");
         db.store_uncached(1, &[(&key, &account)]);
@@ -7084,7 +7126,7 @@ pub mod tests {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
         let key = Pubkey::default();
-        let account = Account::new(1, 0, &key);
+        let account = AccountSharedData::new(1, 0, &key);
         let before_slot = 0;
         let base_slot = before_slot + 1;
         let after_slot = base_slot + 1;
@@ -7102,7 +7144,7 @@ pub mod tests {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
         let key = Pubkey::default();
-        let account = Account::new(1, 0, &key);
+        let account = AccountSharedData::new(1, 0, &key);
         let base_slot = 0;
         let after_slot = base_slot + 1;
 
@@ -7125,7 +7167,7 @@ pub mod tests {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
         let key = Pubkey::default();
-        let account = Account::new(1, 0, &key);
+        let account = AccountSharedData::new(1, 0, &key);
         let base_slot = 0;
         let after_slot = base_slot + 1;
 
@@ -7141,7 +7183,7 @@ pub mod tests {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
 
         let key = Pubkey::default();
-        let account = Account::new(1, 0, &key);
+        let account = AccountSharedData::new(1, 0, &key);
         let base_slot = 0;
         let after_slot = base_slot + 1;
 
@@ -7166,7 +7208,7 @@ pub mod tests {
     fn test_storage_remove_account_double_remove() {
         let accounts = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let pubkey = solana_sdk::pubkey::new_rand();
-        let account = Account::new(1, 0, &Account::default().owner);
+        let account = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
         accounts.store_uncached(0, &[(&pubkey, &account)]);
         let storage_entry = accounts
             .storage
@@ -7188,13 +7230,13 @@ pub mod tests {
         let old_lamport = 223;
         let zero_lamport = 0;
         let no_data = 0;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(old_lamport, no_data, &owner);
-        let account2 = Account::new(old_lamport + 100_001, no_data, &owner);
-        let account3 = Account::new(old_lamport + 100_002, no_data, &owner);
-        let dummy_account = Account::new(99_999_999, no_data, &owner);
-        let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
+        let account = AccountSharedData::new(old_lamport, no_data, &owner);
+        let account2 = AccountSharedData::new(old_lamport + 100_001, no_data, &owner);
+        let account3 = AccountSharedData::new(old_lamport + 100_002, no_data, &owner);
+        let dummy_account = AccountSharedData::new(99_999_999, no_data, &owner);
+        let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
         let pubkey = solana_sdk::pubkey::new_rand();
         let dummy_pubkey = solana_sdk::pubkey::new_rand();
@@ -7255,13 +7297,13 @@ pub mod tests {
         // size data so only 1 fits in a 4k store
         let data_size = 2200;
 
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(old_lamport, data_size, &owner);
-        let account2 = Account::new(old_lamport + 100_001, data_size, &owner);
-        let account3 = Account::new(old_lamport + 100_002, data_size, &owner);
-        let account4 = Account::new(dummy_lamport, data_size, &owner);
-        let zero_lamport_account = Account::new(zero_lamport, data_size, &owner);
+        let account = AccountSharedData::new(old_lamport, data_size, &owner);
+        let account2 = AccountSharedData::new(old_lamport + 100_001, data_size, &owner);
+        let account3 = AccountSharedData::new(old_lamport + 100_002, data_size, &owner);
+        let account4 = AccountSharedData::new(dummy_lamport, data_size, &owner);
+        let zero_lamport_account = AccountSharedData::new(zero_lamport, data_size, &owner);
 
         let mut current_slot = 0;
         let accounts = AccountsDb::new_sized_no_extra_stores(Vec::new(), store_size);
@@ -7379,13 +7421,13 @@ pub mod tests {
         let zero_lamport = 0;
         let no_data = 0;
         let dummy_lamport = 999_999;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(old_lamport, no_data, &owner);
-        let account2 = Account::new(old_lamport + 100_001, no_data, &owner);
-        let account3 = Account::new(old_lamport + 100_002, no_data, &owner);
-        let dummy_account = Account::new(dummy_lamport, no_data, &owner);
-        let zero_lamport_account = Account::new(zero_lamport, no_data, &owner);
+        let account = AccountSharedData::new(old_lamport, no_data, &owner);
+        let account2 = AccountSharedData::new(old_lamport + 100_001, no_data, &owner);
+        let account3 = AccountSharedData::new(old_lamport + 100_002, no_data, &owner);
+        let dummy_account = AccountSharedData::new(dummy_lamport, no_data, &owner);
+        let zero_lamport_account = AccountSharedData::new(zero_lamport, no_data, &owner);
 
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let pubkey2 = solana_sdk::pubkey::new_rand();
@@ -7582,9 +7624,9 @@ pub mod tests {
 
         let some_lamport = 223;
         let no_data = 0;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(some_lamport, no_data, &owner);
+        let account = AccountSharedData::new(some_lamport, no_data, &owner);
 
         let mut current_slot = 0;
 
@@ -7650,9 +7692,9 @@ pub mod tests {
 
         let some_lamport = 223;
         let no_data = 0;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(some_lamport, no_data, &owner);
+        let account = AccountSharedData::new(some_lamport, no_data, &owner);
 
         let mut current_slot = 0;
 
@@ -7710,9 +7752,9 @@ pub mod tests {
 
         let some_lamport = 223;
         let no_data = 0;
-        let owner = Account::default().owner;
+        let owner = AccountSharedData::default().owner;
 
-        let account = Account::new(some_lamport, no_data, &owner);
+        let account = AccountSharedData::new(some_lamport, no_data, &owner);
 
         let mut current_slot = 0;
 
@@ -8018,7 +8060,7 @@ pub mod tests {
     fn test_store_overhead() {
         solana_logger::setup();
         let accounts = AccountsDb::new_single();
-        let account = Account::default();
+        let account = AccountSharedData::default();
         let pubkey = solana_sdk::pubkey::new_rand();
         accounts.store_uncached(0, &[(&pubkey, &account)]);
         let slot_stores = accounts.storage.get_slot_stores(0).unwrap();
@@ -8039,7 +8081,7 @@ pub mod tests {
         let num_accounts: usize = 100;
         let mut keys = Vec::new();
         for i in 0..num_accounts {
-            let account = Account::new((i + 1) as u64, size, &Pubkey::default());
+            let account = AccountSharedData::new((i + 1) as u64, size, &Pubkey::default());
             let pubkey = solana_sdk::pubkey::new_rand();
             accounts.store_uncached(0, &[(&pubkey, &account)]);
             keys.push(pubkey);
@@ -8047,7 +8089,8 @@ pub mod tests {
         accounts.add_root(0);
 
         for (i, key) in keys[1..].iter().enumerate() {
-            let account = Account::new((1 + i + num_accounts) as u64, size, &Pubkey::default());
+            let account =
+                AccountSharedData::new((1 + i + num_accounts) as u64, size, &Pubkey::default());
             accounts.store_uncached(1, &[(key, &account)]);
         }
         accounts.add_root(1);
@@ -8060,7 +8103,7 @@ pub mod tests {
         let mut account_refs = Vec::new();
         let num_to_store = 20;
         for (i, key) in keys[..num_to_store].iter().enumerate() {
-            let account = Account::new(
+            let account = AccountSharedData::new(
                 (1 + i + 2 * num_accounts) as u64,
                 i + 20,
                 &Pubkey::default(),
@@ -8084,7 +8127,8 @@ pub mod tests {
     fn test_zero_lamport_new_root_not_cleaned() {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let account_key = Pubkey::new_unique();
-        let zero_lamport_account = Account::new(0, 0, &Account::default().owner);
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
 
         // Store zero lamport account into slots 0 and 1, root both slots
         db.store_uncached(0, &[(&account_key, &zero_lamport_account)]);
@@ -8109,7 +8153,7 @@ pub mod tests {
         let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         db.caching_enabled = true;
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
         let slot = 0;
         db.store_cached(slot, &[(&key, &account0)]);
 
@@ -8137,7 +8181,7 @@ pub mod tests {
         let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         db.caching_enabled = true;
         let key = Pubkey::default();
-        let account0 = Account::new(1, 0, &key);
+        let account0 = AccountSharedData::new(1, 0, &key);
         let slot = 0;
         db.store_cached(slot, &[(&key, &account0)]);
         db.mark_slot_frozen(slot);
@@ -8161,7 +8205,7 @@ pub mod tests {
     fn test_flush_accounts_cache() {
         let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         db.caching_enabled = true;
-        let account0 = Account::new(1, 0, &Pubkey::default());
+        let account0 = AccountSharedData::new(1, 0, &Pubkey::default());
 
         let unrooted_slot = 4;
         let root5 = 5;
@@ -8220,7 +8264,7 @@ pub mod tests {
     fn run_test_flush_accounts_cache_if_needed(num_roots: usize, num_unrooted: usize) {
         let mut db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         db.caching_enabled = true;
-        let account0 = Account::new(1, 0, &Pubkey::default());
+        let account0 = AccountSharedData::new(1, 0, &Pubkey::default());
         let mut keys = vec![];
         let num_slots = 2 * MAX_CACHE_SLOTS;
         for i in 0..num_roots + num_unrooted {
@@ -8284,8 +8328,9 @@ pub mod tests {
         ));
 
         let account_key = Pubkey::new_unique();
-        let zero_lamport_account = Account::new(0, 0, &Account::default().owner);
-        let slot1_account = Account::new(1, 1, &Account::default().owner);
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
+        let slot1_account = AccountSharedData::new(1, 1, &AccountSharedData::default().owner);
         db.store_cached(0, &[(&account_key, &zero_lamport_account)]);
         db.store_cached(1, &[(&account_key, &slot1_account)]);
 
@@ -8322,8 +8367,10 @@ pub mod tests {
         let other_account_key = Pubkey::new_unique();
 
         let original_lamports = 1;
-        let slot0_account = Account::new(original_lamports, 1, &Account::default().owner);
-        let zero_lamport_account = Account::new(0, 0, &Account::default().owner);
+        let slot0_account =
+            AccountSharedData::new(original_lamports, 1, &AccountSharedData::default().owner);
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
 
         // Store into slot 0, and then flush the slot to storage
         db.store_cached(0, &[(&zero_lamport_account_key, &slot0_account)]);
@@ -8403,7 +8450,7 @@ pub mod tests {
             .spawn(move || {
                 db.scan_accounts(
                     &scan_ancestors,
-                    |_collector: &mut Vec<(Pubkey, Account)>, maybe_account| {
+                    |_collector: &mut Vec<(Pubkey, AccountSharedData)>, maybe_account| {
                         ready_.store(true, Ordering::Relaxed);
                         if let Some((pubkey, _, _)) = maybe_account {
                             if *pubkey == stall_key {
@@ -8440,9 +8487,10 @@ pub mod tests {
         ));
         let account_key = Pubkey::new_unique();
         let account_key2 = Pubkey::new_unique();
-        let zero_lamport_account = Account::new(0, 0, &Account::default().owner);
-        let slot1_account = Account::new(1, 1, &Account::default().owner);
-        let slot2_account = Account::new(2, 1, &Account::default().owner);
+        let zero_lamport_account =
+            AccountSharedData::new(0, 0, &AccountSharedData::default().owner);
+        let slot1_account = AccountSharedData::new(1, 1, &AccountSharedData::default().owner);
+        let slot2_account = AccountSharedData::new(2, 1, &AccountSharedData::default().owner);
 
         /*
             Store zero lamport account into slots 0, 1, 2 where
@@ -8525,7 +8573,7 @@ pub mod tests {
         let num_keys = 10;
 
         for data_size in 0..num_keys {
-            let account = Account::new(1, data_size, &Pubkey::default());
+            let account = AccountSharedData::new(1, data_size, &Pubkey::default());
             accounts_db.store_cached(slot, &[(&Pubkey::new_unique(), &account)]);
         }
 
@@ -8585,7 +8633,10 @@ pub mod tests {
             accounts_db.store_cached(
                 // Store it in a slot that isn't returned in `slots`
                 stall_slot,
-                &[(&scan_stall_key, &Account::new(1, 0, &Pubkey::default()))],
+                &[(
+                    &scan_stall_key,
+                    &AccountSharedData::new(1, 0, &Pubkey::default()),
+                )],
             );
         }
 
@@ -8593,7 +8644,10 @@ pub mod tests {
         let mut scan_tracker = None;
         for slot in &slots {
             for key in &keys[*slot as usize..] {
-                accounts_db.store_cached(*slot, &[(key, &Account::new(1, 0, &Pubkey::default()))]);
+                accounts_db.store_cached(
+                    *slot,
+                    &[(key, &AccountSharedData::new(1, 0, &Pubkey::default()))],
+                );
             }
             accounts_db.add_root(*slot as Slot);
             if Some(*slot) == scan_slot {
@@ -8629,7 +8683,7 @@ pub mod tests {
             // Store a slot that overwrites all previous keys, rendering all previous keys dead
             accounts_db.store_cached(
                 alive_slot,
-                &[(key, &Account::new(1, 0, &Pubkey::default()))],
+                &[(key, &AccountSharedData::new(1, 0, &Pubkey::default()))],
             );
             accounts_db.add_root(alive_slot);
         }
@@ -8959,7 +9013,7 @@ pub mod tests {
         );
         let account_key1 = Pubkey::new_unique();
         let account_key2 = Pubkey::new_unique();
-        let account1 = Account::new(1, 0, &Account::default().owner);
+        let account1 = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
 
         // Store into slot 0
         db.store_cached(0, &[(&account_key1, &account1)]);
@@ -9037,10 +9091,10 @@ pub mod tests {
         let db = AccountsDb::new(Vec::new(), &ClusterType::Development);
         let account_key1 = Pubkey::new_unique();
         let account_key2 = Pubkey::new_unique();
-        let account1 = Account::new(1, 0, &Account::default().owner);
-        let account2 = Account::new(2, 0, &Account::default().owner);
-        let account3 = Account::new(3, 0, &Account::default().owner);
-        let account4 = Account::new(4, 0, &Account::default().owner);
+        let account1 = AccountSharedData::new(1, 0, &AccountSharedData::default().owner);
+        let account2 = AccountSharedData::new(2, 0, &AccountSharedData::default().owner);
+        let account3 = AccountSharedData::new(3, 0, &AccountSharedData::default().owner);
+        let account4 = AccountSharedData::new(4, 0, &AccountSharedData::default().owner);
 
         // Store accounts into slots 0 and 1
         db.store_uncached(0, &[(&account_key1, &account1)]);

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -828,7 +828,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
             self.program_id_index.insert(account_owner, pubkey, slot);
         }
         // Note because of the below check below on the account data length, when an
-        // account hits zero lamports and is reset to Account::Default, then we skip
+        // account hits zero lamports and is reset to AccountSharedData::Default, then we skip
         // the below updates to the secondary indexes.
         //
         // Skipping means not updating secondary index to mark the account as missing.
@@ -837,7 +837,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         // removed from the secondary index, the scan function will:
         // 1) consult the primary index via `get(&pubkey, Some(ancestors), max_root)`
         // and find the zero-lamport version
-        // 2) When the fetch from storage occurs, it will return Account::Default
+        // 2) When the fetch from storage occurs, it will return AccountSharedData::Default
         // (as persisted tombstone for snapshots). This will then ultimately be
         // filtered out by post-scan filters, like in `get_filtered_spl_token_accounts_by_owner()`.
         if *account_owner == inline_spl_token_v2_0::id()

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -31,7 +31,7 @@ use rayon::ThreadPool;
 use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, inc_new_counter_debug, inc_new_counter_info};
 use solana_sdk::{
-    account::{create_account, from_account, Account},
+    account::{create_account_shared_data as create_account, from_account, AccountSharedData},
     clock::{
         Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, DEFAULT_TICKS_PER_SECOND,
         MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES, MAX_TRANSACTION_FORWARDING_DELAY,
@@ -113,9 +113,9 @@ impl ExecuteTimings {
 type BankStatusCache = StatusCache<Result<()>>;
 #[frozen_abi(digest = "3ZaEt781qwhfQSE4DZPBHhng2S6MuimchRjkR9ZWzDFs")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
-type TransactionAccountRefCells = Vec<Rc<RefCell<Account>>>;
-type TransactionAccountDepRefCells = Vec<(Pubkey, RefCell<Account>)>;
-type TransactionLoaderRefCells = Vec<Vec<(Pubkey, RefCell<Account>)>>;
+type TransactionAccountRefCells = Vec<Rc<RefCell<AccountSharedData>>>;
+type TransactionAccountDepRefCells = Vec<(Pubkey, RefCell<AccountSharedData>)>;
+type TransactionLoaderRefCells = Vec<Vec<(Pubkey, RefCell<AccountSharedData>)>>;
 
 // Eager rent collection repeats in cyclic manner.
 // Each cycle is composed of <partition_count> number of tiny pubkey subranges
@@ -444,19 +444,19 @@ pub struct TransactionLogCollector {
 
 pub trait NonceRollbackInfo {
     fn nonce_address(&self) -> &Pubkey;
-    fn nonce_account(&self) -> &Account;
+    fn nonce_account(&self) -> &AccountSharedData;
     fn fee_calculator(&self) -> Option<FeeCalculator>;
-    fn fee_account(&self) -> Option<&Account>;
+    fn fee_account(&self) -> Option<&AccountSharedData>;
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct NonceRollbackPartial {
     nonce_address: Pubkey,
-    nonce_account: Account,
+    nonce_account: AccountSharedData,
 }
 
 impl NonceRollbackPartial {
-    pub fn new(nonce_address: Pubkey, nonce_account: Account) -> Self {
+    pub fn new(nonce_address: Pubkey, nonce_account: AccountSharedData) -> Self {
         Self {
             nonce_address,
             nonce_account,
@@ -468,13 +468,13 @@ impl NonceRollbackInfo for NonceRollbackPartial {
     fn nonce_address(&self) -> &Pubkey {
         &self.nonce_address
     }
-    fn nonce_account(&self) -> &Account {
+    fn nonce_account(&self) -> &AccountSharedData {
         &self.nonce_account
     }
     fn fee_calculator(&self) -> Option<FeeCalculator> {
         nonce_account::fee_calculator_of(&self.nonce_account)
     }
-    fn fee_account(&self) -> Option<&Account> {
+    fn fee_account(&self) -> Option<&AccountSharedData> {
         None
     }
 }
@@ -482,16 +482,16 @@ impl NonceRollbackInfo for NonceRollbackPartial {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct NonceRollbackFull {
     nonce_address: Pubkey,
-    nonce_account: Account,
-    fee_account: Option<Account>,
+    nonce_account: AccountSharedData,
+    fee_account: Option<AccountSharedData>,
 }
 
 impl NonceRollbackFull {
     #[cfg(test)]
     pub fn new(
         nonce_address: Pubkey,
-        nonce_account: Account,
-        fee_account: Option<Account>,
+        nonce_account: AccountSharedData,
+        fee_account: Option<AccountSharedData>,
     ) -> Self {
         Self {
             nonce_address,
@@ -502,7 +502,7 @@ impl NonceRollbackFull {
     pub fn from_partial(
         partial: NonceRollbackPartial,
         message: &Message,
-        accounts: &[Account],
+        accounts: &[AccountSharedData],
     ) -> Result<Self> {
         let NonceRollbackPartial {
             nonce_address,
@@ -538,13 +538,13 @@ impl NonceRollbackInfo for NonceRollbackFull {
     fn nonce_address(&self) -> &Pubkey {
         &self.nonce_address
     }
-    fn nonce_account(&self) -> &Account {
+    fn nonce_account(&self) -> &AccountSharedData {
         &self.nonce_account
     }
     fn fee_calculator(&self) -> Option<FeeCalculator> {
         nonce_account::fee_calculator_of(&self.nonce_account)
     }
-    fn fee_account(&self) -> Option<&Account> {
+    fn fee_account(&self) -> Option<&AccountSharedData> {
         self.fee_account.as_ref()
     }
 }
@@ -1328,7 +1328,7 @@ impl Bank {
 
     fn update_sysvar_account<F>(&self, pubkey: &Pubkey, updater: F)
     where
-        F: Fn(&Option<Account>) -> Account,
+        F: Fn(&Option<AccountSharedData>) -> AccountSharedData,
     {
         let old_account = self.get_sysvar_account(pubkey);
         let new_account = updater(&old_account);
@@ -1340,7 +1340,10 @@ impl Bank {
         }
     }
 
-    fn inherit_specially_retained_account_balance(&self, old_account: &Option<Account>) -> u64 {
+    fn inherit_specially_retained_account_balance(
+        &self,
+        old_account: &Option<AccountSharedData>,
+    ) -> u64 {
         old_account.as_ref().map(|a| a.lamports).unwrap_or(1)
     }
 
@@ -1431,7 +1434,7 @@ impl Bank {
         self.update_sysvar_account(&sysvar::slot_history::id(), |account| {
             let mut slot_history = account
                 .as_ref()
-                .map(|account| from_account::<SlotHistory>(&account).unwrap())
+                .map(|account| from_account::<SlotHistory, _>(account).unwrap())
                 .unwrap_or_default();
             slot_history.add(self.slot());
             create_account(
@@ -1445,7 +1448,7 @@ impl Bank {
         self.update_sysvar_account(&sysvar::slot_hashes::id(), |account| {
             let mut slot_hashes = account
                 .as_ref()
-                .map(|account| from_account::<SlotHashes>(&account).unwrap())
+                .map(|account| from_account::<SlotHashes, _>(account).unwrap())
                 .unwrap_or_default();
             slot_hashes.add(self.parent_slot, self.parent_hash);
             create_account(
@@ -1720,7 +1723,7 @@ impl Bank {
     fn stake_delegation_accounts(
         &self,
         reward_calc_tracer: &mut Option<impl FnMut(&RewardCalculationEvent)>,
-    ) -> HashMap<Pubkey, (Vec<(Pubkey, Account)>, Account)> {
+    ) -> HashMap<Pubkey, (Vec<(Pubkey, AccountSharedData)>, AccountSharedData)> {
         let mut accounts = HashMap::new();
 
         self.stakes
@@ -2101,7 +2104,7 @@ impl Bank {
             if self.get_account(&pubkey).is_some() {
                 panic!("{} repeated in genesis config", pubkey);
             }
-            self.store_account(pubkey, account);
+            self.store_account(pubkey, &AccountSharedData::from(account.clone()));
             self.capitalization.fetch_add(account.lamports, Relaxed);
         }
         // updating sysvars (the fees sysvar in this case) now depends on feature activations in
@@ -2112,7 +2115,7 @@ impl Bank {
             if self.get_account(&pubkey).is_some() {
                 panic!("{} repeated in genesis config", pubkey);
             }
-            self.store_account(pubkey, account);
+            self.store_account(pubkey, &AccountSharedData::from(account.clone()));
         }
 
         // highest staked node is the first collector
@@ -2560,7 +2563,7 @@ impl Bank {
             .check_hash_age(hash, max_age)
     }
 
-    pub fn check_tx_durable_nonce(&self, tx: &Transaction) -> Option<(Pubkey, Account)> {
+    pub fn check_tx_durable_nonce(&self, tx: &Transaction) -> Option<(Pubkey, AccountSharedData)> {
         transaction::uses_durable_nonce(&tx)
             .and_then(|nonce_ix| transaction::get_nonce_pubkey_from_instruction(&nonce_ix, &tx))
             .and_then(|nonce_pubkey| {
@@ -2704,7 +2707,7 @@ impl Bank {
         }
     }
 
-    /// Converts Accounts into RefCell<Account>, this involves moving
+    /// Converts Accounts into RefCell<AccountSharedData>, this involves moving
     /// ownership by draining the source
     fn accounts_to_refcells(
         accounts: &mut TransactionAccounts,
@@ -2734,7 +2737,7 @@ impl Bank {
         (account_refcells, account_dep_refcells, loader_refcells)
     }
 
-    /// Converts back from RefCell<Account> to Account, this involves moving
+    /// Converts back from RefCell<AccountSharedData> to AccountSharedData, this involves moving
     /// ownership by draining the sources
     fn refcells_to_accounts(
         accounts: &mut TransactionAccounts,
@@ -2771,7 +2774,7 @@ impl Bank {
     fn get_executors(
         &self,
         message: &Message,
-        loaders: &[Vec<(Pubkey, Account)>],
+        loaders: &[Vec<(Pubkey, AccountSharedData)>],
     ) -> Rc<RefCell<Executors>> {
         let mut num_executors = message.account_keys.len();
         for instruction_loaders in loaders.iter() {
@@ -3352,7 +3355,7 @@ impl Bank {
     fn run_incinerator(&self) {
         if let Some((account, _)) = self.get_account_modified_since_parent(&incinerator::id()) {
             self.capitalization.fetch_sub(account.lamports, Relaxed);
-            self.store_account(&incinerator::id(), &Account::default());
+            self.store_account(&incinerator::id(), &AccountSharedData::default());
         }
     }
 
@@ -3809,7 +3812,7 @@ impl Bank {
         self.process_transaction(&tx).map(|_| signature)
     }
 
-    pub fn read_balance(account: &Account) -> u64 {
+    pub fn read_balance(account: &AccountSharedData) -> u64 {
         account.lamports
     }
     /// Each program would need to be able to introspect its own state
@@ -3838,7 +3841,7 @@ impl Bank {
         parents
     }
 
-    pub fn store_account(&self, pubkey: &Pubkey, account: &Account) {
+    pub fn store_account(&self, pubkey: &Pubkey, account: &AccountSharedData) {
         assert!(!self.freeze_started());
         self.rc
             .accounts
@@ -3872,7 +3875,11 @@ impl Bank {
         self.rc.accounts.accounts_db.expire_old_recycle_stores()
     }
 
-    fn store_account_and_update_capitalization(&self, pubkey: &Pubkey, new_account: &Account) {
+    fn store_account_and_update_capitalization(
+        &self,
+        pubkey: &Pubkey,
+        new_account: &AccountSharedData,
+    ) {
         if let Some(old_account) = self.get_account(&pubkey) {
             match new_account.lamports.cmp(&old_account.lamports) {
                 std::cmp::Ordering::Greater => {
@@ -3969,12 +3976,12 @@ impl Bank {
         self.hard_forks.clone()
     }
 
-    pub fn get_account(&self, pubkey: &Pubkey) -> Option<Account> {
+    pub fn get_account(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         self.get_account_modified_slot(pubkey)
             .map(|(acc, _slot)| acc)
     }
 
-    pub fn get_account_modified_slot(&self, pubkey: &Pubkey) -> Option<(Account, Slot)> {
+    pub fn get_account_modified_slot(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
         self.rc.accounts.load_slow(&self.ancestors, pubkey)
     }
 
@@ -3985,7 +3992,7 @@ impl Bank {
     // multiple times with the same parent_slot in the case of forking.
     //
     // Generally, all of sysvar update granularity should be slot boundaries.
-    fn get_sysvar_account(&self, pubkey: &Pubkey) -> Option<Account> {
+    fn get_sysvar_account(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
         let mut ancestors = self.ancestors.clone();
         ancestors.remove(&self.slot());
         self.rc
@@ -3994,40 +4001,40 @@ impl Bank {
             .map(|(acc, _slot)| acc)
     }
 
-    pub fn get_program_accounts(&self, program_id: &Pubkey) -> Vec<(Pubkey, Account)> {
+    pub fn get_program_accounts(&self, program_id: &Pubkey) -> Vec<(Pubkey, AccountSharedData)> {
         self.rc
             .accounts
             .load_by_program(&self.ancestors, program_id)
     }
 
-    pub fn get_filtered_program_accounts<F: Fn(&Account) -> bool>(
+    pub fn get_filtered_program_accounts<F: Fn(&AccountSharedData) -> bool>(
         &self,
         program_id: &Pubkey,
         filter: F,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         self.rc
             .accounts
             .load_by_program_with_filter(&self.ancestors, program_id, filter)
     }
 
-    pub fn get_filtered_indexed_accounts<F: Fn(&Account) -> bool>(
+    pub fn get_filtered_indexed_accounts<F: Fn(&AccountSharedData) -> bool>(
         &self,
         index_key: &IndexKey,
         filter: F,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         self.rc
             .accounts
             .load_by_index_key_with_filter(&self.ancestors, index_key, filter)
     }
 
-    pub fn get_all_accounts_with_modified_slots(&self) -> Vec<(Pubkey, Account, Slot)> {
+    pub fn get_all_accounts_with_modified_slots(&self) -> Vec<(Pubkey, AccountSharedData, Slot)> {
         self.rc.accounts.load_all(&self.ancestors)
     }
 
     pub fn get_program_accounts_modified_since_parent(
         &self,
         program_id: &Pubkey,
-    ) -> Vec<(Pubkey, Account)> {
+    ) -> Vec<(Pubkey, AccountSharedData)> {
         self.rc
             .accounts
             .load_by_program_slot(self.slot(), Some(program_id))
@@ -4053,11 +4060,14 @@ impl Bank {
         }
     }
 
-    pub fn get_all_accounts_modified_since_parent(&self) -> Vec<(Pubkey, Account)> {
+    pub fn get_all_accounts_modified_since_parent(&self) -> Vec<(Pubkey, AccountSharedData)> {
         self.rc.accounts.load_by_program_slot(self.slot(), None)
     }
 
-    pub fn get_account_modified_since_parent(&self, pubkey: &Pubkey) -> Option<(Account, Slot)> {
+    pub fn get_account_modified_since_parent(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
         let just_self: Ancestors = vec![(self.slot(), 0)].into_iter().collect();
         if let Some((account, slot)) = self.rc.accounts.load_slow(&just_self, pubkey) {
             if slot == self.slot() {
@@ -4765,7 +4775,7 @@ impl Bank {
                 // Clear new token account
                 self.store_account(
                     &inline_spl_token_v2_0::new_token_program::id(),
-                    &Account::default(),
+                    &AccountSharedData::default(),
                 );
 
                 self.remove_executor(&inline_spl_token_v2_0::id());
@@ -4815,7 +4825,7 @@ impl Bank {
         };
 
         if reconfigure_token2_native_mint {
-            let mut native_mint_account = solana_sdk::account::Account {
+            let mut native_mint_account = solana_sdk::account::AccountSharedData {
                 owner: inline_spl_token_v2_0::id(),
                 data: inline_spl_token_v2_0::native_mint::ACCOUNT_DATA.to_vec(),
                 lamports: sol_to_lamports(1.),
@@ -4952,6 +4962,7 @@ pub(crate) mod tests {
     };
     use crossbeam_channel::bounded;
     use solana_sdk::{
+        account::Account,
         account_utils::StateMut,
         clock::{DEFAULT_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT},
         epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
@@ -4993,7 +5004,7 @@ pub(crate) mod tests {
                 blockhash: Hash::new_unique(),
                 fee_calculator: fee_calculator.clone(),
             }));
-        let nonce_account = Account::new_data(43, &state, &system_program::id()).unwrap();
+        let nonce_account = AccountSharedData::new_data(43, &state, &system_program::id()).unwrap();
 
         // NonceRollbackPartial create + NonceRollbackInfo impl
         let partial = NonceRollbackPartial::new(nonce_address, nonce_account.clone());
@@ -5011,9 +5022,9 @@ pub(crate) mod tests {
         ];
         let message = Message::new(&instructions, Some(&from_address));
 
-        let from_account = Account::new(44, 0, &Pubkey::default());
-        let to_account = Account::new(45, 0, &Pubkey::default());
-        let recent_blockhashes_sysvar_account = Account::new(4, 0, &Pubkey::default());
+        let from_account = AccountSharedData::new(44, 0, &Pubkey::default());
+        let to_account = AccountSharedData::new(45, 0, &Pubkey::default());
+        let recent_blockhashes_sysvar_account = AccountSharedData::new(4, 0, &Pubkey::default());
         let accounts = [
             from_account.clone(),
             nonce_account.clone(),
@@ -5098,7 +5109,7 @@ pub(crate) mod tests {
         );
 
         let rent_account = bank.get_account(&sysvar::rent::id()).unwrap();
-        let rent = from_account::<sysvar::rent::Rent>(&rent_account).unwrap();
+        let rent = from_account::<sysvar::rent::Rent, _>(&rent_account).unwrap();
 
         assert_eq!(rent.burn_percent, 5);
         assert_eq!(rent.exemption_threshold, 1.2);
@@ -5240,12 +5251,12 @@ pub(crate) mod tests {
         assert_eq!(bank.last_blockhash(), genesis_config.hash());
 
         // Initialize credit-debit and credit only accounts
-        let account1 = Account::new(264, 0, &Pubkey::default());
-        let account2 = Account::new(264, 1, &Pubkey::default());
-        let account3 = Account::new(264, 0, &Pubkey::default());
-        let account4 = Account::new(264, 1, &Pubkey::default());
-        let account5 = Account::new(10, 0, &Pubkey::default());
-        let account6 = Account::new(10, 1, &Pubkey::default());
+        let account1 = AccountSharedData::new(264, 0, &Pubkey::default());
+        let account2 = AccountSharedData::new(264, 1, &Pubkey::default());
+        let account3 = AccountSharedData::new(264, 0, &Pubkey::default());
+        let account4 = AccountSharedData::new(264, 1, &Pubkey::default());
+        let account5 = AccountSharedData::new(10, 0, &Pubkey::default());
+        let account6 = AccountSharedData::new(10, 1, &Pubkey::default());
 
         bank.store_account(&keypair1.pubkey(), &account1);
         bank.store_account(&keypair2.pubkey(), &account2);
@@ -5359,10 +5370,11 @@ pub(crate) mod tests {
         mock_program_id: Pubkey,
         generic_rent_due_for_system_account: u64,
     ) {
-        let mut account_pairs: Vec<(Pubkey, Account)> = Vec::with_capacity(keypairs.len() - 1);
+        let mut account_pairs: Vec<(Pubkey, AccountSharedData)> =
+            Vec::with_capacity(keypairs.len() - 1);
         account_pairs.push((
             keypairs[0].pubkey(),
-            Account::new(
+            AccountSharedData::new(
                 generic_rent_due_for_system_account + 2,
                 0,
                 &Pubkey::default(),
@@ -5370,7 +5382,7 @@ pub(crate) mod tests {
         ));
         account_pairs.push((
             keypairs[1].pubkey(),
-            Account::new(
+            AccountSharedData::new(
                 generic_rent_due_for_system_account + 2,
                 0,
                 &Pubkey::default(),
@@ -5378,7 +5390,7 @@ pub(crate) mod tests {
         ));
         account_pairs.push((
             keypairs[2].pubkey(),
-            Account::new(
+            AccountSharedData::new(
                 generic_rent_due_for_system_account + 2,
                 0,
                 &Pubkey::default(),
@@ -5386,7 +5398,7 @@ pub(crate) mod tests {
         ));
         account_pairs.push((
             keypairs[3].pubkey(),
-            Account::new(
+            AccountSharedData::new(
                 generic_rent_due_for_system_account + 2,
                 0,
                 &Pubkey::default(),
@@ -5394,15 +5406,15 @@ pub(crate) mod tests {
         ));
         account_pairs.push((
             keypairs[4].pubkey(),
-            Account::new(10, 0, &Pubkey::default()),
+            AccountSharedData::new(10, 0, &Pubkey::default()),
         ));
         account_pairs.push((
             keypairs[5].pubkey(),
-            Account::new(10, 0, &Pubkey::default()),
+            AccountSharedData::new(10, 0, &Pubkey::default()),
         ));
         account_pairs.push((
             keypairs[6].pubkey(),
-            Account::new(
+            AccountSharedData::new(
                 (2 * generic_rent_due_for_system_account) + 24,
                 0,
                 &Pubkey::default(),
@@ -5411,7 +5423,7 @@ pub(crate) mod tests {
 
         account_pairs.push((
             keypairs[8].pubkey(),
-            Account::new(
+            AccountSharedData::new(
                 generic_rent_due_for_system_account + 2 + 929,
                 0,
                 &Pubkey::default(),
@@ -5419,13 +5431,13 @@ pub(crate) mod tests {
         ));
         account_pairs.push((
             keypairs[9].pubkey(),
-            Account::new(10, 0, &Pubkey::default()),
+            AccountSharedData::new(10, 0, &Pubkey::default()),
         ));
 
         // Feeding to MockProgram to test read only rent behaviour
         account_pairs.push((
             keypairs[10].pubkey(),
-            Account::new(
+            AccountSharedData::new(
                 generic_rent_due_for_system_account + 3,
                 0,
                 &Pubkey::default(),
@@ -5433,15 +5445,15 @@ pub(crate) mod tests {
         ));
         account_pairs.push((
             keypairs[11].pubkey(),
-            Account::new(generic_rent_due_for_system_account + 3, 0, &mock_program_id),
+            AccountSharedData::new(generic_rent_due_for_system_account + 3, 0, &mock_program_id),
         ));
         account_pairs.push((
             keypairs[12].pubkey(),
-            Account::new(generic_rent_due_for_system_account + 3, 0, &mock_program_id),
+            AccountSharedData::new(generic_rent_due_for_system_account + 3, 0, &mock_program_id),
         ));
         account_pairs.push((
             keypairs[13].pubkey(),
-            Account::new(14, 22, &mock_program_id),
+            AccountSharedData::new(14, 22, &mock_program_id),
         ));
 
         for account_pair in account_pairs.iter() {
@@ -5497,7 +5509,7 @@ pub(crate) mod tests {
         let pubkey = solana_sdk::pubkey::new_rand();
 
         let some_lamports = 400;
-        let account = Account::new(some_lamports, 0, &system_program::id());
+        let account = AccountSharedData::new(some_lamports, 0, &system_program::id());
 
         assert_capitalization_diff(
             &bank,
@@ -5515,7 +5527,7 @@ pub(crate) mod tests {
         let pubkey = mint_keypair.pubkey();
 
         let new_lamports = 500;
-        let account = Account::new(new_lamports, 0, &system_program::id());
+        let account = AccountSharedData::new(new_lamports, 0, &system_program::id());
 
         assert_capitalization_diff(
             &bank,
@@ -5533,7 +5545,7 @@ pub(crate) mod tests {
         let pubkey = mint_keypair.pubkey();
 
         let new_lamports = 100;
-        let account = Account::new(new_lamports, 0, &system_program::id());
+        let account = AccountSharedData::new(new_lamports, 0, &system_program::id());
 
         assert_capitalization_diff(
             &bank,
@@ -5550,7 +5562,7 @@ pub(crate) mod tests {
         let bank = Bank::new(&genesis_config);
         let pubkey = mint_keypair.pubkey();
 
-        let account = Account::new(lamports, 1, &system_program::id());
+        let account = AccountSharedData::new(lamports, 1, &system_program::id());
 
         assert_capitalization_diff(
             &bank,
@@ -5613,11 +5625,11 @@ pub(crate) mod tests {
         );
         genesis_config.accounts.insert(
             validator_1_staking_keypair.pubkey(),
-            validator_1_stake_account,
+            Account::from(validator_1_stake_account),
         );
         genesis_config.accounts.insert(
             validator_1_voting_keypair.pubkey(),
-            validator_1_vote_account,
+            Account::from(validator_1_vote_account),
         );
 
         let validator_2_pubkey = solana_sdk::pubkey::new_rand();
@@ -5646,11 +5658,11 @@ pub(crate) mod tests {
         );
         genesis_config.accounts.insert(
             validator_2_staking_keypair.pubkey(),
-            validator_2_stake_account,
+            Account::from(validator_2_stake_account),
         );
         genesis_config.accounts.insert(
             validator_2_voting_keypair.pubkey(),
-            validator_2_vote_account,
+            Account::from(validator_2_vote_account),
         );
 
         let validator_3_pubkey = solana_sdk::pubkey::new_rand();
@@ -5679,11 +5691,11 @@ pub(crate) mod tests {
         );
         genesis_config.accounts.insert(
             validator_3_staking_keypair.pubkey(),
-            validator_3_stake_account,
+            Account::from(validator_3_stake_account),
         );
         genesis_config.accounts.insert(
             validator_3_voting_keypair.pubkey(),
-            validator_3_vote_account,
+            Account::from(validator_3_vote_account),
         );
 
         genesis_config.rent = Rent {
@@ -5699,11 +5711,11 @@ pub(crate) mod tests {
         bank.rent_collector.slots_per_year = 192.0;
 
         let payer = Keypair::new();
-        let payer_account = Account::new(400, 0, &system_program::id());
+        let payer_account = AccountSharedData::new(400, 0, &system_program::id());
         bank.store_account_and_update_capitalization(&payer.pubkey(), &payer_account);
 
         let payee = Keypair::new();
-        let payee_account = Account::new(70, 1, &system_program::id());
+        let payee_account = AccountSharedData::new(70, 1, &system_program::id());
         bank.store_account_and_update_capitalization(&payee.pubkey(), &payee_account);
 
         let bootstrap_validator_initial_balance = bank.get_balance(&bootstrap_validator_pubkey);
@@ -5866,7 +5878,8 @@ pub(crate) mod tests {
 
         let account_pubkey = solana_sdk::pubkey::new_rand();
         let account_balance = 1;
-        let mut account = Account::new(account_balance, 0, &solana_sdk::pubkey::new_rand());
+        let mut account =
+            AccountSharedData::new(account_balance, 0, &solana_sdk::pubkey::new_rand());
         account.executable = true;
         bank.store_account(&account_pubkey, &account);
 
@@ -6710,15 +6723,15 @@ pub(crate) mod tests {
 
         bank.store_account(
             &zero_lamport_pubkey,
-            &Account::new(zero_lamports, 0, &Pubkey::default()),
+            &AccountSharedData::new(zero_lamports, 0, &Pubkey::default()),
         );
         bank.store_account(
             &rent_due_pubkey,
-            &Account::new(little_lamports, 0, &Pubkey::default()),
+            &AccountSharedData::new(little_lamports, 0, &Pubkey::default()),
         );
         bank.store_account(
             &rent_exempt_pubkey,
-            &Account::new(large_lamports, 0, &Pubkey::default()),
+            &AccountSharedData::new(large_lamports, 0, &Pubkey::default()),
         );
 
         let genesis_slot = 0;
@@ -6788,7 +6801,7 @@ pub(crate) mod tests {
         let bank1_without_zero = Arc::new(new_from_parent(&genesis_bank2));
         let zero_lamports = 0;
 
-        let account = Account::new(zero_lamports, 0, &Pubkey::default());
+        let account = AccountSharedData::new(zero_lamports, 0, &Pubkey::default());
         bank1_with_zero.store_account(&zero_lamport_pubkey, &account);
         bank1_without_zero.store_account(&zero_lamport_pubkey, &account);
 
@@ -6921,7 +6934,7 @@ pub(crate) mod tests {
 
         let rewards = bank1
             .get_account(&sysvar::rewards::id())
-            .map(|account| from_account::<Rewards>(&account).unwrap())
+            .map(|account| from_account::<Rewards, _>(&account).unwrap())
             .unwrap();
 
         // verify the stake and vote accounts are the right size
@@ -7351,7 +7364,7 @@ pub(crate) mod tests {
 
         let min_balance = bank.get_minimum_balance_for_rent_exemption(nonce::State::size());
         let nonce = Keypair::new();
-        let nonce_account = Account::new_data(
+        let nonce_account = AccountSharedData::new_data(
             min_balance + 42,
             &nonce::state::Versions::new_current(nonce::State::Initialized(
                 nonce::state::Data::default(),
@@ -8235,7 +8248,7 @@ pub(crate) mod tests {
                 let current_account = bank1.get_account(&dummy_clock_id).unwrap();
                 assert_eq!(
                     expected_previous_slot,
-                    from_account::<Clock>(&current_account).unwrap().slot
+                    from_account::<Clock, _>(&current_account).unwrap().slot
                 );
             },
             |old, new| {
@@ -8275,7 +8288,7 @@ pub(crate) mod tests {
             &bank2,
             || {
                 bank2.update_sysvar_account(&dummy_clock_id, |optional_account| {
-                    let slot = from_account::<Clock>(optional_account.as_ref().unwrap())
+                    let slot = from_account::<Clock, _>(optional_account.as_ref().unwrap())
                         .unwrap()
                         .slot
                         + 1;
@@ -8291,7 +8304,7 @@ pub(crate) mod tests {
                 let current_account = bank2.get_account(&dummy_clock_id).unwrap();
                 assert_eq!(
                     expected_next_slot,
-                    from_account::<Clock>(&current_account).unwrap().slot
+                    from_account::<Clock, _>(&current_account).unwrap().slot
                 );
             },
             |old, new| {
@@ -8306,7 +8319,7 @@ pub(crate) mod tests {
             &bank2,
             || {
                 bank2.update_sysvar_account(&dummy_clock_id, |optional_account| {
-                    let slot = from_account::<Clock>(optional_account.as_ref().unwrap())
+                    let slot = from_account::<Clock, _>(optional_account.as_ref().unwrap())
                         .unwrap()
                         .slot
                         + 1;
@@ -8322,7 +8335,7 @@ pub(crate) mod tests {
                 let current_account = bank2.get_account(&dummy_clock_id).unwrap();
                 assert_eq!(
                     expected_next_slot,
-                    from_account::<Clock>(&current_account).unwrap().slot
+                    from_account::<Clock, _>(&current_account).unwrap().slot
                 );
             },
             |old, new| {
@@ -8685,7 +8698,7 @@ pub(crate) mod tests {
         let bank = Arc::new(Bank::new(&genesis_config));
 
         let fees_account = bank.get_account(&sysvar::fees::id()).unwrap();
-        let fees = from_account::<Fees>(&fees_account).unwrap();
+        let fees = from_account::<Fees, _>(&fees_account).unwrap();
         assert_eq!(
             bank.fee_calculator.lamports_per_signature,
             fees.fee_calculator.lamports_per_signature
@@ -8751,7 +8764,7 @@ pub(crate) mod tests {
         let bank0 = Arc::new(new_from_parent(&parent));
         let pubkey0 = solana_sdk::pubkey::new_rand();
         let program_id = Pubkey::new(&[2; 32]);
-        let account0 = Account::new(1, 0, &program_id);
+        let account0 = AccountSharedData::new(1, 0, &program_id);
         bank0.store_account(&pubkey0, &account0);
 
         assert_eq!(
@@ -8776,11 +8789,11 @@ pub(crate) mod tests {
 
         let bank2 = Arc::new(new_from_parent(&bank1));
         let pubkey1 = solana_sdk::pubkey::new_rand();
-        let account1 = Account::new(3, 0, &program_id);
+        let account1 = AccountSharedData::new(3, 0, &program_id);
         bank2.store_account(&pubkey1, &account1);
         // Accounts with 0 lamports should be filtered out by Accounts::load_by_program()
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        let account2 = Account::new(0, 0, &program_id);
+        let account2 = AccountSharedData::new(0, 0, &program_id);
         bank2.store_account(&pubkey2, &account2);
 
         let bank3 = Arc::new(new_from_parent(&bank2));
@@ -8802,7 +8815,7 @@ pub(crate) mod tests {
 
         let address = Pubkey::new_unique();
         let program_id = Pubkey::new_unique();
-        let account = Account::new(1, 0, &program_id);
+        let account = AccountSharedData::new(1, 0, &program_id);
         bank.store_account(&address, &account);
 
         let indexed_accounts =
@@ -8814,7 +8827,7 @@ pub(crate) mod tests {
         // it is still present in the index under the original program id as well. This
         // demonstrates the need for a redundant post-processing filter.
         let another_program_id = Pubkey::new_unique();
-        let new_account = Account::new(1, 0, &another_program_id);
+        let new_account = AccountSharedData::new(1, 0, &another_program_id);
         let bank = Arc::new(new_from_parent(&bank));
         bank.store_account(&address, &new_account);
         let indexed_accounts =
@@ -9042,7 +9055,7 @@ pub(crate) mod tests {
         for i in 1..5 {
             let bhq_account = bank.get_account(&sysvar::recent_blockhashes::id()).unwrap();
             let recent_blockhashes =
-                from_account::<sysvar::recent_blockhashes::RecentBlockhashes>(&bhq_account)
+                from_account::<sysvar::recent_blockhashes::RecentBlockhashes, _>(&bhq_account)
                     .unwrap();
             // Check length
             assert_eq!(recent_blockhashes.len(), i);
@@ -9062,7 +9075,7 @@ pub(crate) mod tests {
 
         let bhq_account = bank.get_account(&sysvar::recent_blockhashes::id()).unwrap();
         let recent_blockhashes =
-            from_account::<sysvar::recent_blockhashes::RecentBlockhashes>(&bhq_account).unwrap();
+            from_account::<sysvar::recent_blockhashes::RecentBlockhashes, _>(&bhq_account).unwrap();
 
         let sysvar_recent_blockhash = recent_blockhashes[0].blockhash;
         let bank_last_blockhash = bank.last_blockhash();
@@ -9353,7 +9366,7 @@ pub(crate) mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000_000);
         let bank = Arc::new(Bank::new(&genesis_config));
         let nonce = Keypair::new();
-        let nonce_account = Account::new_data(
+        let nonce_account = AccountSharedData::new_data(
             42_424_242,
             &nonce::state::Versions::new_current(nonce::State::Initialized(
                 nonce::state::Data::default(),
@@ -9606,9 +9619,9 @@ pub(crate) mod tests {
         let pubkey0 = solana_sdk::pubkey::new_rand();
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let program_id = Pubkey::new(&[2; 32]);
-        let keypair_account = Account::new(8, 0, &program_id);
-        let account0 = Account::new(11, 0, &program_id);
-        let program_account = Account::new(1, 10, &Pubkey::default());
+        let keypair_account = AccountSharedData::new(8, 0, &program_id);
+        let account0 = AccountSharedData::new(11, 0, &program_id);
+        let program_account = AccountSharedData::new(1, 10, &Pubkey::default());
         bank0.store_account(&keypair.pubkey(), &keypair_account);
         bank0.store_account(&pubkey0, &account0);
         bank0.store_account(&program_id, &program_account);
@@ -9658,9 +9671,9 @@ pub(crate) mod tests {
         let pubkey0 = solana_sdk::pubkey::new_rand();
         let pubkey1 = solana_sdk::pubkey::new_rand();
         let pubkey2 = solana_sdk::pubkey::new_rand();
-        let keypair0_account = Account::new(8, 0, &Pubkey::default());
-        let keypair1_account = Account::new(9, 0, &Pubkey::default());
-        let account0 = Account::new(11, 0, &&Pubkey::default());
+        let keypair0_account = AccountSharedData::new(8, 0, &Pubkey::default());
+        let keypair1_account = AccountSharedData::new(9, 0, &Pubkey::default());
+        let account0 = AccountSharedData::new(11, 0, &&Pubkey::default());
         bank0.store_account(&keypair0.pubkey(), &keypair0_account);
         bank0.store_account(&keypair1.pubkey(), &keypair1_account);
         bank0.store_account(&pubkey0, &account0);
@@ -9735,8 +9748,8 @@ pub(crate) mod tests {
         let from_pubkey = solana_sdk::pubkey::new_rand();
         let to_pubkey = solana_sdk::pubkey::new_rand();
         let dup_pubkey = from_pubkey;
-        let from_account = Account::new(100, 1, &mock_program_id);
-        let to_account = Account::new(0, 1, &mock_program_id);
+        let from_account = AccountSharedData::new(100, 1, &mock_program_id);
+        let to_account = AccountSharedData::new(0, 1, &mock_program_id);
         bank.store_account(&from_pubkey, &from_account);
         bank.store_account(&to_pubkey, &to_account);
 
@@ -9780,8 +9793,8 @@ pub(crate) mod tests {
         let from_pubkey = solana_sdk::pubkey::new_rand();
         let to_pubkey = solana_sdk::pubkey::new_rand();
         let dup_pubkey = from_pubkey;
-        let from_account = Account::new(100, 1, &mock_program_id);
-        let to_account = Account::new(0, 1, &mock_program_id);
+        let from_account = AccountSharedData::new(100, 1, &mock_program_id);
+        let to_account = AccountSharedData::new(0, 1, &mock_program_id);
         bank.store_account(&from_pubkey, &from_account);
         bank.store_account(&to_pubkey, &to_account);
 
@@ -10028,7 +10041,7 @@ pub(crate) mod tests {
                     };
                     let space = thread_rng().gen_range(0, 10);
                     let owner = Pubkey::default();
-                    let account = Account::new(lamports, space, &owner);
+                    let account = AccountSharedData::new(lamports, space, &owner);
                     bank.store_account(&key, &account);
                     lamports
                 } else {
@@ -10160,7 +10173,7 @@ pub(crate) mod tests {
         let mut genesis_config = GenesisConfig::new(
             &[(
                 Pubkey::new(&[42; 32]),
-                Account::new(1_000_000_000_000, 0, &system_program::id()),
+                AccountSharedData::new(1_000_000_000_000, 0, &system_program::id()),
             )],
             &[],
         );
@@ -10224,7 +10237,7 @@ pub(crate) mod tests {
 
         // Add a new program owned by the first
         let program2_pubkey = solana_sdk::pubkey::new_rand();
-        let mut program2_account = Account::new(42, 1, &program1_pubkey);
+        let mut program2_account = AccountSharedData::new(42, 1, &program1_pubkey);
         program2_account.executable = true;
         bank.store_account(&program2_pubkey, &program2_account);
 
@@ -10283,7 +10296,7 @@ pub(crate) mod tests {
 
         let pubkey0_size = get_shrink_account_size();
 
-        let account0 = Account::new(1000, pubkey0_size as usize, &Pubkey::new_unique());
+        let account0 = AccountSharedData::new(1000, pubkey0_size as usize, &Pubkey::new_unique());
         bank0.store_account(&pubkey0, &account0);
 
         goto_end_of_slot(Arc::<Bank>::get_mut(&mut bank0).unwrap());
@@ -10909,8 +10922,11 @@ pub(crate) mod tests {
         };
 
         let loaders = &[
-            vec![(key3, Account::default()), (key4, Account::default())],
-            vec![(key1, Account::default())],
+            vec![
+                (key3, AccountSharedData::default()),
+                (key4, AccountSharedData::default()),
+            ],
+            vec![(key1, AccountSharedData::default())],
         ];
 
         // don't do any work if not dirty
@@ -10972,7 +10988,10 @@ pub(crate) mod tests {
         let key2 = solana_sdk::pubkey::new_rand();
         let executor: Arc<dyn Executor> = Arc::new(TestExecutor {});
 
-        let loaders = &[vec![(key1, Account::default()), (key2, Account::default())]];
+        let loaders = &[vec![
+            (key1, AccountSharedData::default()),
+            (key2, AccountSharedData::default()),
+        ]];
 
         // add one to root bank
         let mut executors = Executors::default();
@@ -11071,19 +11090,19 @@ pub(crate) mod tests {
         // Setup original token account
         bank.store_account_and_update_capitalization(
             &inline_spl_token_v2_0::id(),
-            &Account {
+            &AccountSharedData {
                 lamports: 100,
-                ..Account::default()
+                ..AccountSharedData::default()
             },
         );
         assert_eq!(bank.get_balance(&inline_spl_token_v2_0::id()), 100);
 
         // Setup new token account
-        let new_token_account = Account {
+        let new_token_account = AccountSharedData {
             lamports: 123,
             data: vec![1, 2, 3],
             executable: true,
-            ..Account::default()
+            ..AccountSharedData::default()
         };
         bank.store_account_and_update_capitalization(
             &inline_spl_token_v2_0::new_token_program::id(),
@@ -11138,12 +11157,12 @@ pub(crate) mod tests {
         // inhibit deprecated rewards sysvar creation altogether
         genesis_config.accounts.insert(
             feature_set::deprecate_rewards_sysvar::id(),
-            feature::create_account(
+            Account::from(feature::create_account(
                 &Feature {
                     activated_at: Some(0),
                 },
                 feature_balance,
-            ),
+            )),
         );
 
         let bank0 = Bank::new(&genesis_config);
@@ -11591,7 +11610,7 @@ pub(crate) mod tests {
             .collect();
         let program_id = system_program::id();
         let starting_lamports = 1;
-        let starting_account = Account::new(starting_lamports, 0, &program_id);
+        let starting_account = AccountSharedData::new(starting_lamports, 0, &program_id);
 
         // Write accounts to the store
         for key in &all_pubkeys {
@@ -11696,7 +11715,7 @@ pub(crate) mod tests {
                                 &solana_sdk::pubkey::new_rand(),
                                 current_minor_fork_bank.slot() + 2,
                             ));
-                            let account = Account::new(lamports, 0, &program_id);
+                            let account = AccountSharedData::new(lamports, 0, &program_id);
                             // Write partial updates to each of the banks in the minor fork so if any of them
                             // get cleaned up, there will be keys with the wrong account value/missing.
                             for key in pubkeys_to_modify {
@@ -11722,7 +11741,7 @@ pub(crate) mod tests {
                             current_minor_fork_bank.slot() - 1,
                         ));
                         let lamports = current_major_fork_bank.slot() + starting_lamports + 1;
-                        let account = Account::new(lamports, 0, &program_id);
+                        let account = AccountSharedData::new(lamports, 0, &program_id);
                         for key in pubkeys_to_modify.iter() {
                             // Store rooted updates to these pubkeys such that the minor
                             // fork updates to the same keys will be deleted by clean
@@ -11768,7 +11787,7 @@ pub(crate) mod tests {
                     let mut prev_bank = bank0;
                     loop {
                         let lamports_this_round = current_bank.slot() + starting_lamports + 1;
-                        let account = Account::new(lamports_this_round, 0, &program_id);
+                        let account = AccountSharedData::new(lamports_this_round, 0, &program_id);
                         for key in pubkeys_to_modify.iter() {
                             current_bank.store_account(key, &account);
                         }

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -117,7 +117,7 @@ impl SyncClient for BankClient {
     }
 
     fn get_account(&self, pubkey: &Pubkey) -> Result<Option<Account>> {
-        Ok(self.bank.get_account(pubkey))
+        Ok(self.bank.get_account(pubkey).map(Account::from))
     }
 
     fn get_account_with_commitment(
@@ -125,7 +125,7 @@ impl SyncClient for BankClient {
         pubkey: &Pubkey,
         _commitment_config: CommitmentConfig,
     ) -> Result<Option<Account>> {
-        Ok(self.bank.get_account(pubkey))
+        Ok(self.bank.get_account(pubkey).map(Account::from))
     }
 
     fn get_balance(&self, pubkey: &Pubkey) -> Result<u64> {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -116,13 +116,13 @@ impl EpochStakes {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use solana_sdk::account::Account;
+    use solana_sdk::account::AccountSharedData;
     use solana_vote_program::vote_state::create_account_with_authorized;
     use std::iter;
 
     struct VoteAccountInfo {
         vote_account: Pubkey,
-        account: Account,
+        account: AccountSharedData,
         authorized_voter: Pubkey,
     }
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -1,5 +1,6 @@
 use solana_sdk::{
     account::Account,
+    account::AccountSharedData,
     feature::{self, Feature},
     feature_set::FeatureSet,
     fee_calculator::FeeRateGovernor,
@@ -110,13 +111,15 @@ pub fn create_genesis_config_with_vote_accounts_and_cluster_type(
         // Create accounts
         let node_account = Account::new(VALIDATOR_LAMPORTS, 0, &system_program::id());
         let vote_account = vote_state::create_account(&vote_pubkey, &node_pubkey, 0, *stake);
-        let stake_account = stake_state::create_account(
+        let stake_account = Account::from(stake_state::create_account(
             &stake_pubkey,
             &vote_pubkey,
             &vote_account,
             &genesis_config_info.genesis_config.rent,
             *stake,
-        );
+        ));
+
+        let vote_account = Account::from(vote_account);
 
         // Put newly created accounts into genesis
         genesis_config_info.genesis_config.accounts.extend(vec![
@@ -163,12 +166,12 @@ pub fn activate_all_features(genesis_config: &mut GenesisConfig) {
     for feature_id in FeatureSet::default().inactive {
         genesis_config.accounts.insert(
             feature_id,
-            feature::create_account(
+            Account::from(feature::create_account(
                 &Feature {
                     activated_at: Some(0),
                 },
                 std::cmp::max(genesis_config.rent.minimum_balance(Feature::size_of()), 1),
-            ),
+            )),
         );
     }
 }
@@ -185,7 +188,7 @@ pub fn create_genesis_config_with_leader_ex(
     fee_rate_governor: FeeRateGovernor,
     rent: Rent,
     cluster_type: ClusterType,
-    mut initial_accounts: Vec<(Pubkey, Account)>,
+    mut initial_accounts: Vec<(Pubkey, AccountSharedData)>,
 ) -> GenesisConfig {
     let validator_vote_account = vote_state::create_account(
         &validator_vote_account_pubkey,
@@ -204,17 +207,21 @@ pub fn create_genesis_config_with_leader_ex(
 
     initial_accounts.push((
         *mint_pubkey,
-        Account::new(mint_lamports, 0, &system_program::id()),
+        AccountSharedData::new(mint_lamports, 0, &system_program::id()),
     ));
     initial_accounts.push((
         *validator_pubkey,
-        Account::new(validator_lamports, 0, &system_program::id()),
+        AccountSharedData::new(validator_lamports, 0, &system_program::id()),
     ));
     initial_accounts.push((*validator_vote_account_pubkey, validator_vote_account));
     initial_accounts.push((*validator_stake_account_pubkey, validator_stake_account));
 
     let mut genesis_config = GenesisConfig {
-        accounts: initial_accounts.iter().cloned().collect(),
+        accounts: initial_accounts
+            .iter()
+            .cloned()
+            .map(|(key, account)| (key, Account::from(account)))
+            .collect(),
         fee_rate_governor,
         rent,
         cluster_type,

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -1,7 +1,7 @@
 //! calculate and collect rent from Accounts
 use solana_sdk::{
-    account::Account, clock::Epoch, epoch_schedule::EpochSchedule, genesis_config::GenesisConfig,
-    incinerator, pubkey::Pubkey, rent::Rent, sysvar,
+    account::AccountSharedData, clock::Epoch, epoch_schedule::EpochSchedule,
+    genesis_config::GenesisConfig, incinerator, pubkey::Pubkey, rent::Rent, sysvar,
 };
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug, AbiExample)]
@@ -50,7 +50,11 @@ impl RentCollector {
     //  the account rent collected, if any
     //
     #[must_use = "add to Bank::collected_rent"]
-    pub fn collect_from_existing_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
+    pub fn collect_from_existing_account(
+        &self,
+        address: &Pubkey,
+        account: &mut AccountSharedData,
+    ) -> u64 {
         if account.executable
             || account.rent_epoch > self.epoch
             || sysvar::check_id(&account.owner)
@@ -88,7 +92,7 @@ impl RentCollector {
                     rent_due
                 } else {
                     let rent_charged = account.lamports;
-                    *account = Account::default();
+                    *account = AccountSharedData::default();
                     rent_charged
                 }
             } else {
@@ -99,7 +103,11 @@ impl RentCollector {
     }
 
     #[must_use = "add to Bank::collected_rent"]
-    pub fn collect_from_created_account(&self, address: &Pubkey, account: &mut Account) -> u64 {
+    pub fn collect_from_created_account(
+        &self,
+        address: &Pubkey,
+        account: &mut AccountSharedData,
+    ) -> u64 {
         // initialize rent_epoch as created at this epoch
         account.rent_epoch = self.epoch;
         self.collect_from_existing_account(address, account)
@@ -117,10 +125,10 @@ mod tests {
         let new_epoch = 3;
 
         let (mut created_account, mut existing_account) = {
-            let account = Account {
+            let account = AccountSharedData {
                 lamports: old_lamports,
                 rent_epoch: old_epoch,
-                ..Account::default()
+                ..AccountSharedData::default()
             };
 
             (account.clone(), account)
@@ -149,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_rent_exempt_temporal_escape() {
-        let mut account = Account::default();
+        let mut account = AccountSharedData::default();
         let epoch = 3;
         let huge_lamports = 123_456_789_012;
         let tiny_lamports = 789_012;

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -9,7 +9,7 @@ use {
     bincode::serialize_into,
     rand::{thread_rng, Rng},
     solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         clock::Slot,
         genesis_config::{create_genesis_config, ClusterType},
         pubkey::Pubkey,
@@ -45,7 +45,7 @@ fn check_accounts(accounts: &Accounts, pubkeys: &[Pubkey], num: usize) {
         let ancestors = vec![(0, 0)].into_iter().collect();
         let account = accounts.load_slow(&ancestors, &pubkeys[idx]);
         let account1 = Some((
-            Account::new((idx + 1) as u64, 0, &Account::default().owner),
+            AccountSharedData::new((idx + 1) as u64, 0, &AccountSharedData::default().owner),
             0,
         ));
         assert_eq!(account, account1);

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -2,7 +2,7 @@
 //! node stakes
 use crate::vote_account::{ArcVoteAccount, VoteAccounts};
 use solana_sdk::{
-    account::Account, clock::Epoch, pubkey::Pubkey, sysvar::stake_history::StakeHistory,
+    account::AccountSharedData, clock::Epoch, pubkey::Pubkey, sysvar::stake_history::StakeHistory,
 };
 use solana_stake_program::stake_state::{new_stake_history_entry, Delegation, StakeState};
 use solana_vote_program::vote_state::VoteState;
@@ -106,7 +106,7 @@ impl Stakes {
                 .sum::<u64>()
     }
 
-    pub fn is_stake(account: &Account) -> bool {
+    pub fn is_stake(account: &AccountSharedData) -> bool {
         solana_vote_program::check_id(&account.owner)
             || solana_stake_program::check_id(&account.owner)
                 && account.data.len() >= std::mem::size_of::<StakeState>()
@@ -115,7 +115,7 @@ impl Stakes {
     pub fn store(
         &mut self,
         pubkey: &Pubkey,
-        account: &Account,
+        account: &AccountSharedData,
         fix_stake_deactivate: bool,
         check_vote_init: bool,
     ) -> Option<ArcVoteAccount> {
@@ -232,7 +232,9 @@ pub mod tests {
     use solana_vote_program::vote_state::{self, VoteState, VoteStateVersions};
 
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
-    pub fn create_staked_node_accounts(stake: u64) -> ((Pubkey, Account), (Pubkey, Account)) {
+    pub fn create_staked_node_accounts(
+        stake: u64,
+    ) -> ((Pubkey, AccountSharedData), (Pubkey, AccountSharedData)) {
         let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account =
             vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
@@ -243,7 +245,7 @@ pub mod tests {
     }
 
     //   add stake to a vote_pubkey                               (   stake    )
-    pub fn create_stake_account(stake: u64, vote_pubkey: &Pubkey) -> (Pubkey, Account) {
+    pub fn create_stake_account(stake: u64, vote_pubkey: &Pubkey) -> (Pubkey, AccountSharedData) {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         (
             stake_pubkey,
@@ -260,7 +262,7 @@ pub mod tests {
     pub fn create_warming_staked_node_accounts(
         stake: u64,
         epoch: Epoch,
-    ) -> ((Pubkey, Account), (Pubkey, Account)) {
+    ) -> ((Pubkey, AccountSharedData), (Pubkey, AccountSharedData)) {
         let vote_pubkey = solana_sdk::pubkey::new_rand();
         let vote_account =
             vote_state::create_account(&vote_pubkey, &solana_sdk::pubkey::new_rand(), 0, 1);
@@ -275,7 +277,7 @@ pub mod tests {
         stake: u64,
         epoch: Epoch,
         vote_pubkey: &Pubkey,
-    ) -> (Pubkey, Account) {
+    ) -> (Pubkey, AccountSharedData) {
         let stake_pubkey = solana_sdk::pubkey::new_rand();
         (
             stake_pubkey,
@@ -557,7 +559,7 @@ pub mod tests {
         // not a stake account, and whacks above entry
         stakes.store(
             &stake_pubkey,
-            &Account::new(1, 0, &solana_stake_program::id()),
+            &AccountSharedData::new(1, 0, &solana_stake_program::id()),
             true,
             true,
         );

--- a/runtime/src/vote_account.rs
+++ b/runtime/src/vote_account.rs
@@ -1,6 +1,8 @@
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
-use solana_sdk::{account::Account, instruction::InstructionError, pubkey::Pubkey};
+use solana_sdk::{
+    account::Account, account::AccountSharedData, instruction::InstructionError, pubkey::Pubkey,
+};
 use solana_vote_program::vote_state::VoteState;
 use std::{
     borrow::Borrow,
@@ -172,9 +174,24 @@ impl<'de> Deserialize<'de> for ArcVoteAccount {
     }
 }
 
+impl From<AccountSharedData> for ArcVoteAccount {
+    fn from(account: AccountSharedData) -> Self {
+        Self(Arc::new(VoteAccount::from(account)))
+    }
+}
 impl From<Account> for ArcVoteAccount {
     fn from(account: Account) -> Self {
         Self(Arc::new(VoteAccount::from(account)))
+    }
+}
+
+impl From<AccountSharedData> for VoteAccount {
+    fn from(account: AccountSharedData) -> Self {
+        Self {
+            account: Account::from(account),
+            vote_state: RwLock::new(INVALID_VOTE_STATE),
+            vote_state_once: Once::new(),
+        }
     }
 }
 
@@ -299,7 +316,7 @@ mod tests {
     fn new_rand_vote_account<R: Rng>(
         rng: &mut R,
         node_pubkey: Option<Pubkey>,
-    ) -> (Account, VoteState) {
+    ) -> (AccountSharedData, VoteState) {
         let vote_init = VoteInit {
             node_pubkey: node_pubkey.unwrap_or_else(Pubkey::new_unique),
             authorized_voter: Pubkey::new_unique(),
@@ -314,7 +331,7 @@ mod tests {
             unix_timestamp: rng.gen(),
         };
         let vote_state = VoteState::new(&vote_init, &clock);
-        let account = Account::new_data(
+        let account = AccountSharedData::new_data(
             rng.gen(), // lamports
             &VoteStateVersions::new_current(vote_state.clone()),
             &Pubkey::new_unique(), // owner

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -3,7 +3,7 @@ use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use solana_runtime::{accounts_db::AccountsDb, accounts_index::Ancestors};
 use solana_sdk::genesis_config::ClusterType;
-use solana_sdk::{account::Account, clock::Slot, pubkey::Pubkey};
+use solana_sdk::{account::AccountSharedData, clock::Slot, pubkey::Pubkey};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -37,7 +37,7 @@ fn test_shrink_and_clean() {
             while alive_accounts.len() <= 10 {
                 alive_accounts.push((
                     solana_sdk::pubkey::new_rand(),
-                    Account::new(thread_rng().gen_range(0, 50), 0, &owner),
+                    AccountSharedData::new(thread_rng().gen_range(0, 50), 0, &owner),
                 ));
             }
 
@@ -78,7 +78,7 @@ fn test_bad_bank_hash() {
             let key = Keypair::new().pubkey();
             let lamports = thread_rng().gen_range(0, 100);
             let some_data_len = thread_rng().gen_range(0, 1000);
-            let account = Account::new(lamports, some_data_len, &key);
+            let account = AccountSharedData::new(lamports, some_data_len, &key);
             (key, account)
         })
         .collect();

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -77,7 +77,7 @@ fn warmed_up(bank: &Bank, stake_pubkey: &Pubkey) -> bool {
         == stake.stake(
             bank.epoch(),
             Some(
-                &from_account::<StakeHistory>(
+                &from_account::<StakeHistory, _>(
                     &bank.get_account(&sysvar::stake_history::id()).unwrap(),
                 )
                 .unwrap(),
@@ -92,7 +92,7 @@ fn get_staked(bank: &Bank, stake_pubkey: &Pubkey) -> u64 {
         .stake(
             bank.epoch(),
             Some(
-                &from_account::<StakeHistory>(
+                &from_account::<StakeHistory, _>(
                     &bank.get_account(&sysvar::stake_history::id()).unwrap(),
                 )
                 .unwrap(),

--- a/sdk/benches/slot_hashes.rs
+++ b/sdk/benches/slot_hashes.rs
@@ -16,6 +16,6 @@ fn bench_to_from_account(b: &mut Bencher) {
     }
     b.iter(|| {
         let account = create_account(&slot_hashes, 0);
-        slot_hashes = from_account::<SlotHashes>(&account).unwrap();
+        slot_hashes = from_account::<SlotHashes, _>(&account).unwrap();
     });
 }

--- a/sdk/benches/slot_history.rs
+++ b/sdk/benches/slot_history.rs
@@ -13,7 +13,7 @@ fn bench_to_from_account(b: &mut Bencher) {
 
     b.iter(|| {
         let account = create_account(&slot_history, 0);
-        slot_history = from_account::<SlotHistory>(&account).unwrap();
+        slot_history = from_account::<SlotHistory, _>(&account).unwrap();
     });
 }
 

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -1,6 +1,6 @@
 use crate::{clock::Epoch, pubkey::Pubkey};
 use solana_program::{account_info::AccountInfo, sysvar::Sysvar};
-use std::{cell::RefCell, cmp, fmt, rc::Rc};
+use std::{cell::Ref, cell::RefCell, cmp, fmt, rc::Rc};
 
 /// An Account with data that is stored on chain
 #[repr(C)]
@@ -21,72 +21,361 @@ pub struct Account {
     pub rent_epoch: Epoch,
 }
 
+/// An Account with data that is stored on chain
+/// This will become a new in-memory representation of the 'Account' struct data.
+/// The existing 'Account' structure cannot easily change due to downstream projects.
+/// This struct will shortly rely on something like the ReadableAccount trait for access to the fields.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Default, AbiExample)]
+pub struct AccountSharedData {
+    /// lamports in the account
+    pub lamports: u64,
+    /// data held in this account
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>, // will be: Arc<Vec<u8>>,
+    /// the program that owns this account. If executable, the program that loads this account.
+    pub owner: Pubkey,
+    /// this account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+    /// the epoch at which this account will next owe rent
+    pub rent_epoch: Epoch,
+}
+
+/// Compares two ReadableAccounts
+///
+/// Returns true if accounts are essentially equivalent as in all fields are equivalent.
+pub fn accounts_equal<T: ReadableAccount, U: ReadableAccount>(me: &T, other: &U) -> bool {
+    me.lamports() == other.lamports()
+        && me.data() == other.data()
+        && me.owner() == other.owner()
+        && me.executable() == other.executable()
+        && me.rent_epoch() == other.rent_epoch()
+}
+
+impl From<AccountSharedData> for Account {
+    fn from(other: AccountSharedData) -> Self {
+        Self {
+            lamports: other.lamports,
+            data: other.data,
+            owner: other.owner,
+            executable: other.executable,
+            rent_epoch: other.rent_epoch,
+        }
+    }
+}
+
+impl From<Account> for AccountSharedData {
+    fn from(other: Account) -> Self {
+        Self {
+            lamports: other.lamports,
+            data: other.data,
+            owner: other.owner,
+            executable: other.executable,
+            rent_epoch: other.rent_epoch,
+        }
+    }
+}
+
+pub trait WritableAccount: ReadableAccount {
+    fn set_lamports(&mut self, lamports: u64);
+    fn data_as_mut_slice(&mut self) -> &mut [u8];
+    fn set_owner(&mut self, owner: Pubkey);
+    fn set_executable(&mut self, executable: bool);
+    fn set_rent_epoch(&mut self, epoch: Epoch);
+    fn create(
+        lamports: u64,
+        data: Vec<u8>,
+        owner: Pubkey,
+        executable: bool,
+        rent_epoch: Epoch,
+    ) -> Self;
+}
+
+pub trait ReadableAccount: Sized {
+    fn lamports(&self) -> u64;
+    fn data(&self) -> &Vec<u8>;
+    fn owner(&self) -> &Pubkey;
+    fn executable(&self) -> bool;
+    fn rent_epoch(&self) -> Epoch;
+}
+
+impl ReadableAccount for Account {
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    fn data(&self) -> &Vec<u8> {
+        &self.data
+    }
+    fn owner(&self) -> &Pubkey {
+        &self.owner
+    }
+    fn executable(&self) -> bool {
+        self.executable
+    }
+    fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+}
+
+impl WritableAccount for Account {
+    fn set_lamports(&mut self, lamports: u64) {
+        self.lamports = lamports;
+    }
+    fn data_as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.data
+    }
+    fn set_owner(&mut self, owner: Pubkey) {
+        self.owner = owner;
+    }
+    fn set_executable(&mut self, executable: bool) {
+        self.executable = executable;
+    }
+    fn set_rent_epoch(&mut self, epoch: Epoch) {
+        self.rent_epoch = epoch;
+    }
+    fn create(
+        lamports: u64,
+        data: Vec<u8>,
+        owner: Pubkey,
+        executable: bool,
+        rent_epoch: Epoch,
+    ) -> Self {
+        Account {
+            lamports,
+            data,
+            owner,
+            executable,
+            rent_epoch,
+        }
+    }
+}
+
+impl WritableAccount for AccountSharedData {
+    fn set_lamports(&mut self, lamports: u64) {
+        self.lamports = lamports;
+    }
+    fn data_as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.data
+    }
+    fn set_owner(&mut self, owner: Pubkey) {
+        self.owner = owner;
+    }
+    fn set_executable(&mut self, executable: bool) {
+        self.executable = executable;
+    }
+    fn set_rent_epoch(&mut self, epoch: Epoch) {
+        self.rent_epoch = epoch;
+    }
+    fn create(
+        lamports: u64,
+        data: Vec<u8>,
+        owner: Pubkey,
+        executable: bool,
+        rent_epoch: Epoch,
+    ) -> Self {
+        AccountSharedData {
+            lamports,
+            data,
+            owner,
+            executable,
+            rent_epoch,
+        }
+    }
+}
+
+impl ReadableAccount for AccountSharedData {
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    fn data(&self) -> &Vec<u8> {
+        &self.data
+    }
+    fn owner(&self) -> &Pubkey {
+        &self.owner
+    }
+    fn executable(&self) -> bool {
+        self.executable
+    }
+    fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+}
+
+impl ReadableAccount for Ref<'_, AccountSharedData> {
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    fn data(&self) -> &Vec<u8> {
+        &self.data
+    }
+    fn owner(&self) -> &Pubkey {
+        &self.owner
+    }
+    fn executable(&self) -> bool {
+        self.executable
+    }
+    fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+}
+
+impl ReadableAccount for Ref<'_, Account> {
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    fn data(&self) -> &Vec<u8> {
+        &self.data
+    }
+    fn owner(&self) -> &Pubkey {
+        &self.owner
+    }
+    fn executable(&self) -> bool {
+        self.executable
+    }
+    fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+}
+
+fn debug_fmt<T: ReadableAccount>(item: &T, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let data_len = cmp::min(64, item.data().len());
+    let data_str = if data_len > 0 {
+        format!(" data: {}", hex::encode(item.data()[..data_len].to_vec()))
+    } else {
+        "".to_string()
+    };
+    write!(
+        f,
+        "Account {{ lamports: {} data.len: {} owner: {} executable: {} rent_epoch: {}{} }}",
+        item.lamports(),
+        data_len,
+        item.owner(),
+        item.executable(),
+        item.rent_epoch(),
+        data_str,
+    )
+}
+
 impl fmt::Debug for Account {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data_len = cmp::min(64, self.data.len());
-        let data_str = if data_len > 0 {
-            format!(" data: {}", hex::encode(self.data[..data_len].to_vec()))
-        } else {
-            "".to_string()
-        };
-        write!(
-            f,
-            "Account {{ lamports: {} data.len: {} owner: {} executable: {} rent_epoch: {}{} }}",
-            self.lamports,
-            self.data.len(),
-            self.owner,
-            self.executable,
-            self.rent_epoch,
-            data_str,
-        )
+        debug_fmt(self, f)
     }
+}
+
+impl fmt::Debug for AccountSharedData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        debug_fmt(self, f)
+    }
+}
+
+fn shared_new<T: WritableAccount>(lamports: u64, space: usize, owner: &Pubkey) -> T {
+    T::create(
+        lamports,
+        vec![0u8; space],
+        *owner,
+        bool::default(),
+        Epoch::default(),
+    )
+}
+
+fn shared_new_ref<T: WritableAccount>(
+    lamports: u64,
+    space: usize,
+    owner: &Pubkey,
+) -> Rc<RefCell<T>> {
+    Rc::new(RefCell::new(shared_new::<T>(lamports, space, owner)))
+}
+
+fn shared_new_data<T: serde::Serialize, U: WritableAccount>(
+    lamports: u64,
+    state: &T,
+    owner: &Pubkey,
+) -> Result<U, bincode::Error> {
+    let data = bincode::serialize(state)?;
+    Ok(U::create(
+        lamports,
+        data,
+        *owner,
+        bool::default(),
+        Epoch::default(),
+    ))
+}
+fn shared_new_ref_data<T: serde::Serialize, U: WritableAccount>(
+    lamports: u64,
+    state: &T,
+    owner: &Pubkey,
+) -> Result<RefCell<U>, bincode::Error> {
+    Ok(RefCell::new(shared_new_data::<T, U>(
+        lamports, state, owner,
+    )?))
+}
+
+fn shared_new_data_with_space<T: serde::Serialize, U: WritableAccount>(
+    lamports: u64,
+    state: &T,
+    space: usize,
+    owner: &Pubkey,
+) -> Result<U, bincode::Error> {
+    let mut account = shared_new::<U>(lamports, space, owner);
+
+    shared_serialize_data(&mut account, state)?;
+
+    Ok(account)
+}
+fn shared_new_ref_data_with_space<T: serde::Serialize, U: WritableAccount>(
+    lamports: u64,
+    state: &T,
+    space: usize,
+    owner: &Pubkey,
+) -> Result<RefCell<U>, bincode::Error> {
+    Ok(RefCell::new(shared_new_data_with_space::<T, U>(
+        lamports, state, space, owner,
+    )?))
+}
+
+fn shared_deserialize_data<T: serde::de::DeserializeOwned, U: ReadableAccount>(
+    account: &U,
+) -> Result<T, bincode::Error> {
+    bincode::deserialize(account.data())
+}
+
+fn shared_serialize_data<T: serde::Serialize, U: WritableAccount>(
+    account: &mut U,
+    state: &T,
+) -> Result<(), bincode::Error> {
+    if bincode::serialized_size(state)? > account.data().len() as u64 {
+        return Err(Box::new(bincode::ErrorKind::SizeLimit));
+    }
+    bincode::serialize_into(&mut account.data_as_mut_slice(), state)
 }
 
 impl Account {
     pub fn new(lamports: u64, space: usize, owner: &Pubkey) -> Self {
-        Self {
-            lamports,
-            data: vec![0u8; space],
-            owner: *owner,
-            ..Self::default()
-        }
+        shared_new(lamports, space, owner)
     }
     pub fn new_ref(lamports: u64, space: usize, owner: &Pubkey) -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self::new(lamports, space, owner)))
+        shared_new_ref(lamports, space, owner)
     }
-
     pub fn new_data<T: serde::Serialize>(
         lamports: u64,
         state: &T,
         owner: &Pubkey,
     ) -> Result<Self, bincode::Error> {
-        let data = bincode::serialize(state)?;
-        Ok(Self {
-            lamports,
-            data,
-            owner: *owner,
-            ..Self::default()
-        })
+        shared_new_data(lamports, state, owner)
     }
     pub fn new_ref_data<T: serde::Serialize>(
         lamports: u64,
         state: &T,
         owner: &Pubkey,
     ) -> Result<RefCell<Self>, bincode::Error> {
-        Ok(RefCell::new(Self::new_data(lamports, state, owner)?))
+        shared_new_ref_data(lamports, state, owner)
     }
-
     pub fn new_data_with_space<T: serde::Serialize>(
         lamports: u64,
         state: &T,
         space: usize,
         owner: &Pubkey,
     ) -> Result<Self, bincode::Error> {
-        let mut account = Self::new(lamports, space, owner);
-
-        account.serialize_data(state)?;
-
-        Ok(account)
+        shared_new_data_with_space(lamports, state, space, owner)
     }
     pub fn new_ref_data_with_space<T: serde::Serialize>(
         lamports: u64,
@@ -94,20 +383,58 @@ impl Account {
         space: usize,
         owner: &Pubkey,
     ) -> Result<RefCell<Self>, bincode::Error> {
-        Ok(RefCell::new(Self::new_data_with_space(
-            lamports, state, space, owner,
-        )?))
+        shared_new_ref_data_with_space(lamports, state, space, owner)
     }
-
     pub fn deserialize_data<T: serde::de::DeserializeOwned>(&self) -> Result<T, bincode::Error> {
-        bincode::deserialize(&self.data)
+        shared_deserialize_data(self)
     }
-
     pub fn serialize_data<T: serde::Serialize>(&mut self, state: &T) -> Result<(), bincode::Error> {
-        if bincode::serialized_size(state)? > self.data.len() as u64 {
-            return Err(Box::new(bincode::ErrorKind::SizeLimit));
-        }
-        bincode::serialize_into(&mut self.data[..], state)
+        shared_serialize_data(self, state)
+    }
+}
+
+impl AccountSharedData {
+    pub fn new(lamports: u64, space: usize, owner: &Pubkey) -> Self {
+        shared_new(lamports, space, owner)
+    }
+    pub fn new_ref(lamports: u64, space: usize, owner: &Pubkey) -> Rc<RefCell<Self>> {
+        shared_new_ref(lamports, space, owner)
+    }
+    pub fn new_data<T: serde::Serialize>(
+        lamports: u64,
+        state: &T,
+        owner: &Pubkey,
+    ) -> Result<Self, bincode::Error> {
+        shared_new_data(lamports, state, owner)
+    }
+    pub fn new_ref_data<T: serde::Serialize>(
+        lamports: u64,
+        state: &T,
+        owner: &Pubkey,
+    ) -> Result<RefCell<Self>, bincode::Error> {
+        shared_new_ref_data(lamports, state, owner)
+    }
+    pub fn new_data_with_space<T: serde::Serialize>(
+        lamports: u64,
+        state: &T,
+        space: usize,
+        owner: &Pubkey,
+    ) -> Result<Self, bincode::Error> {
+        shared_new_data_with_space(lamports, state, space, owner)
+    }
+    pub fn new_ref_data_with_space<T: serde::Serialize>(
+        lamports: u64,
+        state: &T,
+        space: usize,
+        owner: &Pubkey,
+    ) -> Result<RefCell<Self>, bincode::Error> {
+        shared_new_ref_data_with_space(lamports, state, space, owner)
+    }
+    pub fn deserialize_data<T: serde::de::DeserializeOwned>(&self) -> Result<T, bincode::Error> {
+        shared_deserialize_data(self)
+    }
+    pub fn serialize_data<T: serde::Serialize>(&mut self, state: &T) -> Result<(), bincode::Error> {
+        shared_serialize_data(self, state)
     }
 }
 
@@ -115,18 +442,37 @@ impl Account {
 pub fn create_account<S: Sysvar>(sysvar: &S, lamports: u64) -> Account {
     let data_len = S::size_of().max(bincode::serialized_size(sysvar).unwrap() as usize);
     let mut account = Account::new(lamports, data_len, &solana_program::sysvar::id());
-    to_account::<S>(sysvar, &mut account).unwrap();
+    to_account::<S, Account>(sysvar, &mut account).unwrap();
     account
 }
 
+/// Create an `Account` from a `Sysvar`.
+pub fn create_account_shared_data<S: Sysvar>(sysvar: &S, lamports: u64) -> AccountSharedData {
+    AccountSharedData::from(create_account(sysvar, lamports))
+}
+
 /// Create a `Sysvar` from an `Account`'s data.
-pub fn from_account<S: Sysvar>(account: &Account) -> Option<S> {
-    bincode::deserialize(&account.data).ok()
+pub fn from_account<S: Sysvar, T: ReadableAccount>(account: &T) -> Option<S> {
+    bincode::deserialize(account.data()).ok()
 }
 
 /// Serialize a `Sysvar` into an `Account`'s data.
-pub fn to_account<S: Sysvar>(sysvar: &S, account: &mut Account) -> Option<()> {
-    bincode::serialize_into(&mut account.data[..], sysvar).ok()
+pub fn to_account<S: Sysvar, T: WritableAccount>(sysvar: &S, account: &mut T) -> Option<()> {
+    bincode::serialize_into(account.data_as_mut_slice(), sysvar).ok()
+}
+
+/// Return the information required to construct an `AccountInfo`.  Used by the
+/// `AccountInfo` conversion implementations.
+impl solana_program::account_info::Account for AccountSharedData {
+    fn get(&mut self) -> (&mut u64, &mut [u8], &Pubkey, bool, Epoch) {
+        (
+            &mut self.lamports,
+            &mut self.data,
+            &self.owner,
+            self.executable,
+            self.rent_epoch,
+        )
+    }
 }
 
 /// Return the information required to construct an `AccountInfo`.  Used by the
@@ -144,7 +490,7 @@ impl solana_program::account_info::Account for Account {
 }
 
 /// Create `AccountInfo`s
-pub fn create_account_infos(accounts: &mut [(Pubkey, Account)]) -> Vec<AccountInfo> {
+pub fn create_account_infos(accounts: &mut [(Pubkey, AccountSharedData)]) -> Vec<AccountInfo> {
     accounts.iter_mut().map(Into::into).collect()
 }
 
@@ -167,4 +513,293 @@ pub fn create_is_signer_account_infos<'a>(
             )
         })
         .collect()
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    fn make_two_accounts(key: &Pubkey) -> (Account, AccountSharedData) {
+        let mut account1 = Account::new(1, 2, &key);
+        account1.executable = true;
+        account1.rent_epoch = 4;
+        let mut account2 = AccountSharedData::new(1, 2, key);
+        account2.executable = true;
+        account2.rent_epoch = 4;
+        assert!(accounts_equal(&account1, &account2));
+        (account1, account2)
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: Io(Kind(UnexpectedEof))"
+    )]
+    fn test_account_deserialize() {
+        let key = Pubkey::new_unique();
+        let (account1, _account2) = make_two_accounts(&key);
+        account1.deserialize_data::<String>().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: SizeLimit")]
+    fn test_account_serialize() {
+        let key = Pubkey::new_unique();
+        let (mut account1, _account2) = make_two_accounts(&key);
+        account1.serialize_data(&"hello world").unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: Io(Kind(UnexpectedEof))"
+    )]
+    fn test_account_shared_data_deserialize() {
+        let key = Pubkey::new_unique();
+        let (_account1, account2) = make_two_accounts(&key);
+        account2.deserialize_data::<String>().unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: SizeLimit")]
+    fn test_account_shared_data_serialize() {
+        let key = Pubkey::new_unique();
+        let (_account1, mut account2) = make_two_accounts(&key);
+        account2.serialize_data(&"hello world").unwrap();
+    }
+
+    #[test]
+    fn test_account_shared_data() {
+        let key = Pubkey::new_unique();
+        let (account1, account2) = make_two_accounts(&key);
+        assert!(accounts_equal(&account1, &account2));
+        let account = account1;
+        assert_eq!(account.lamports, 1);
+        assert_eq!(account.lamports(), 1);
+        assert_eq!(account.data.len(), 2);
+        assert_eq!(account.data().len(), 2);
+        assert_eq!(account.owner, key);
+        assert_eq!(account.owner(), &key);
+        assert_eq!(account.executable, true);
+        assert_eq!(account.executable(), true);
+        assert_eq!(account.rent_epoch, 4);
+        assert_eq!(account.rent_epoch(), 4);
+        let account = account2;
+        assert_eq!(account.lamports, 1);
+        assert_eq!(account.lamports(), 1);
+        assert_eq!(account.data.len(), 2);
+        assert_eq!(account.data().len(), 2);
+        assert_eq!(account.owner, key);
+        assert_eq!(account.owner(), &key);
+        assert_eq!(account.executable, true);
+        assert_eq!(account.executable(), true);
+        assert_eq!(account.rent_epoch, 4);
+        assert_eq!(account.rent_epoch(), 4);
+    }
+
+    // test clone and from for both types against expected
+    fn test_equal(
+        should_be_equal: bool,
+        account1: &Account,
+        account2: &AccountSharedData,
+        account_expected: &Account,
+    ) {
+        assert_eq!(should_be_equal, accounts_equal(account1, account2));
+        if should_be_equal {
+            assert!(accounts_equal(account_expected, account2));
+        }
+        assert_eq!(
+            accounts_equal(account_expected, account1),
+            accounts_equal(account_expected, &account1.clone())
+        );
+        assert_eq!(
+            accounts_equal(account_expected, account2),
+            accounts_equal(account_expected, &account2.clone())
+        );
+        assert_eq!(
+            accounts_equal(account_expected, account1),
+            accounts_equal(account_expected, &AccountSharedData::from(account1.clone()))
+        );
+        assert_eq!(
+            accounts_equal(account_expected, account2),
+            accounts_equal(account_expected, &Account::from(account2.clone()))
+        );
+    }
+
+    #[test]
+    #[allow(clippy::redundant_clone)]
+    fn test_account_shared_data_all_fields() {
+        let key = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
+        let key3 = Pubkey::new_unique();
+        let (mut account1, mut account2) = make_two_accounts(&key);
+        assert!(accounts_equal(&account1, &account2));
+
+        let mut account_expected = account1.clone();
+        assert!(accounts_equal(&account1, &account_expected));
+        assert!(accounts_equal(&account1, &account2.clone())); // test the clone here
+
+        for field_index in 0..5 {
+            for pass in 0..4 {
+                if field_index == 0 {
+                    if pass == 0 {
+                        account1.lamports += 1;
+                    } else if pass == 1 {
+                        account_expected.lamports += 1;
+                        account2.set_lamports(account2.lamports + 1);
+                    } else if pass == 2 {
+                        account1.set_lamports(account1.lamports + 1);
+                    } else if pass == 3 {
+                        account_expected.lamports += 1;
+                        account2.lamports += 1;
+                    }
+                } else if field_index == 1 {
+                    if pass == 0 {
+                        account1.data[0] += 1;
+                    } else if pass == 1 {
+                        account_expected.data[0] += 1;
+                        account2.data_as_mut_slice()[0] = account2.data[0] + 1;
+                    } else if pass == 2 {
+                        account1.data_as_mut_slice()[0] = account1.data[0] + 1;
+                    } else if pass == 3 {
+                        account_expected.data[0] += 1;
+                        account2.data[0] += 1;
+                    }
+                } else if field_index == 2 {
+                    if pass == 0 {
+                        account1.owner = key2;
+                    } else if pass == 1 {
+                        account_expected.owner = key2;
+                        account2.set_owner(key2);
+                    } else if pass == 2 {
+                        account1.set_owner(key3);
+                    } else if pass == 3 {
+                        account_expected.owner = key3;
+                        account2.owner = key3;
+                    }
+                } else if field_index == 3 {
+                    if pass == 0 {
+                        account1.executable = !account1.executable;
+                    } else if pass == 1 {
+                        account_expected.executable = !account_expected.executable;
+                        account2.set_executable(!account2.executable);
+                    } else if pass == 2 {
+                        account1.set_executable(!account1.executable);
+                    } else if pass == 3 {
+                        account_expected.executable = !account_expected.executable;
+                        account2.executable = !account2.executable;
+                    }
+                } else if field_index == 4 {
+                    if pass == 0 {
+                        account1.rent_epoch += 1;
+                    } else if pass == 1 {
+                        account_expected.rent_epoch += 1;
+                        account2.set_rent_epoch(account2.rent_epoch + 1);
+                    } else if pass == 2 {
+                        account1.set_rent_epoch(account1.rent_epoch + 1);
+                    } else if pass == 3 {
+                        account_expected.rent_epoch += 1;
+                        account2.rent_epoch += 1;
+                    }
+                }
+
+                let should_be_equal = pass == 1 || pass == 3;
+                test_equal(should_be_equal, &account1, &account2, &account_expected);
+
+                // test new_ref
+                if should_be_equal {
+                    assert!(accounts_equal(
+                        &Account::new_ref(
+                            account_expected.lamports(),
+                            account_expected.data().len(),
+                            account_expected.owner()
+                        )
+                        .borrow(),
+                        &AccountSharedData::new_ref(
+                            account_expected.lamports(),
+                            account_expected.data().len(),
+                            account_expected.owner()
+                        )
+                        .borrow()
+                    ));
+
+                    {
+                        // test new_data
+                        let account1_with_data = Account::new_data(
+                            account_expected.lamports(),
+                            &account_expected.data()[0],
+                            account_expected.owner(),
+                        )
+                        .unwrap();
+                        let account2_with_data = AccountSharedData::new_data(
+                            account_expected.lamports(),
+                            &account_expected.data()[0],
+                            account_expected.owner(),
+                        )
+                        .unwrap();
+
+                        assert!(accounts_equal(&account1_with_data, &account2_with_data));
+                        assert_eq!(
+                            account1_with_data.deserialize_data::<u8>().unwrap(),
+                            account2_with_data.deserialize_data::<u8>().unwrap()
+                        );
+                    }
+
+                    // test new_data_with_space
+                    assert!(accounts_equal(
+                        &Account::new_data_with_space(
+                            account_expected.lamports(),
+                            &account_expected.data()[0],
+                            1,
+                            account_expected.owner()
+                        )
+                        .unwrap(),
+                        &AccountSharedData::new_data_with_space(
+                            account_expected.lamports(),
+                            &account_expected.data()[0],
+                            1,
+                            account_expected.owner()
+                        )
+                        .unwrap()
+                    ));
+
+                    // test new_ref_data
+                    assert!(accounts_equal(
+                        &Account::new_ref_data(
+                            account_expected.lamports(),
+                            &account_expected.data()[0],
+                            account_expected.owner()
+                        )
+                        .unwrap()
+                        .borrow(),
+                        &AccountSharedData::new_ref_data(
+                            account_expected.lamports(),
+                            &account_expected.data()[0],
+                            account_expected.owner()
+                        )
+                        .unwrap()
+                        .borrow()
+                    ));
+
+                    //new_ref_data_with_space
+                    assert!(accounts_equal(
+                        &Account::new_ref_data_with_space(
+                            account_expected.lamports(),
+                            &account_expected.data()[0],
+                            1,
+                            account_expected.owner()
+                        )
+                        .unwrap()
+                        .borrow(),
+                        &AccountSharedData::new_ref_data_with_space(
+                            account_expected.lamports(),
+                            &account_expected.data()[0],
+                            1,
+                            account_expected.owner()
+                        )
+                        .unwrap()
+                        .borrow()
+                    ));
+                }
+            }
+        }
+    }
 }

--- a/sdk/src/account_utils.rs
+++ b/sdk/src/account_utils.rs
@@ -1,6 +1,7 @@
 //! useful extras for Account state
-use crate::{account::Account, instruction::InstructionError};
+use crate::{account::Account, account::AccountSharedData, instruction::InstructionError};
 use bincode::ErrorKind;
+use std::cell::Ref;
 
 /// Convenience trait to covert bincode errors to instruction errors.
 pub trait StateMut<T> {
@@ -28,20 +29,49 @@ where
     }
 }
 
+impl<T> StateMut<T> for AccountSharedData
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+{
+    fn state(&self) -> Result<T, InstructionError> {
+        self.deserialize_data()
+            .map_err(|_| InstructionError::InvalidAccountData)
+    }
+    fn set_state(&mut self, state: &T) -> Result<(), InstructionError> {
+        self.serialize_data(state).map_err(|err| match *err {
+            ErrorKind::SizeLimit => InstructionError::AccountDataTooSmall,
+            _ => InstructionError::GenericError,
+        })
+    }
+}
+
+impl<T> StateMut<T> for Ref<'_, AccountSharedData>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+{
+    fn state(&self) -> Result<T, InstructionError> {
+        self.deserialize_data()
+            .map_err(|_| InstructionError::InvalidAccountData)
+    }
+    fn set_state(&mut self, _state: &T) -> Result<(), InstructionError> {
+        panic!("illegal");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{account::Account, pubkey::Pubkey};
+    use crate::{account::AccountSharedData, pubkey::Pubkey};
 
     #[test]
     fn test_account_state() {
         let state = 42u64;
 
-        assert!(Account::default().set_state(&state).is_err());
-        let res = Account::default().state() as Result<u64, InstructionError>;
+        assert!(AccountSharedData::default().set_state(&state).is_err());
+        let res = AccountSharedData::default().state() as Result<u64, InstructionError>;
         assert!(res.is_err());
 
-        let mut account = Account::new(0, std::mem::size_of::<u64>(), &Pubkey::default());
+        let mut account = AccountSharedData::new(0, std::mem::size_of::<u64>(), &Pubkey::default());
 
         assert!(account.set_state(&state).is_ok());
         let stored_state: u64 = account.state().unwrap();

--- a/sdk/src/feature.rs
+++ b/sdk/src/feature.rs
@@ -1,21 +1,22 @@
-use crate::account::Account;
+use crate::account::AccountSharedData;
+use crate::account::ReadableAccount;
 pub use solana_program::feature::*;
 
-pub fn from_account(account: &Account) -> Option<Feature> {
-    if account.owner != id() {
+pub fn from_account<T: ReadableAccount>(account: &T) -> Option<Feature> {
+    if account.owner() != &id() {
         None
     } else {
-        bincode::deserialize(&account.data).ok()
+        bincode::deserialize(account.data()).ok()
     }
 }
 
-pub fn to_account(feature: &Feature, account: &mut Account) -> Option<()> {
+pub fn to_account(feature: &Feature, account: &mut AccountSharedData) -> Option<()> {
     bincode::serialize_into(&mut account.data[..], feature).ok()
 }
 
-pub fn create_account(feature: &Feature, lamports: u64) -> Account {
+pub fn create_account(feature: &Feature, lamports: u64) -> AccountSharedData {
     let data_len = Feature::size_of().max(bincode::serialized_size(feature).unwrap() as usize);
-    let mut account = Account::new(lamports, data_len, &id());
+    let mut account = AccountSharedData::new(lamports, data_len, &id());
     to_account(feature, &mut account).unwrap();
     account
 }
@@ -26,7 +27,7 @@ mod test {
 
     #[test]
     fn feature_deserialize_none() {
-        let just_initialized = Account::new(42, Feature::size_of(), &id());
+        let just_initialized = AccountSharedData::new(42, Feature::size_of(), &id());
         assert_eq!(
             from_account(&just_initialized),
             Some(Feature { activated_at: None })

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     account::Account,
+    account::AccountSharedData,
     clock::{UnixTimestamp, DEFAULT_TICKS_PER_SLOT},
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeRateGovernor,
@@ -98,7 +99,7 @@ pub fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
         GenesisConfig::new(
             &[(
                 faucet_keypair.pubkey(),
-                Account::new(lamports, 0, &system_program::id()),
+                AccountSharedData::new(lamports, 0, &system_program::id()),
             )],
             &[],
         ),
@@ -131,13 +132,14 @@ impl Default for GenesisConfig {
 
 impl GenesisConfig {
     pub fn new(
-        accounts: &[(Pubkey, Account)],
+        accounts: &[(Pubkey, AccountSharedData)],
         native_instruction_processors: &[(String, Pubkey)],
     ) -> Self {
         Self {
             accounts: accounts
                 .iter()
                 .cloned()
+                .map(|(key, account)| (key, Account::from(account)))
                 .collect::<BTreeMap<Pubkey, Account>>(),
             native_instruction_processors: native_instruction_processors.to_vec(),
             ..GenesisConfig::default()
@@ -201,8 +203,8 @@ impl GenesisConfig {
         file.write_all(&serialized)
     }
 
-    pub fn add_account(&mut self, pubkey: Pubkey, account: Account) {
-        self.accounts.insert(pubkey, account);
+    pub fn add_account(&mut self, pubkey: Pubkey, account: AccountSharedData) {
+        self.accounts.insert(pubkey, Account::from(account));
     }
 
     pub fn add_native_instruction_processor(&mut self, name: String, program_id: Pubkey) {
@@ -315,11 +317,11 @@ mod tests {
         let mut config = GenesisConfig::default();
         config.add_account(
             faucet_keypair.pubkey(),
-            Account::new(10_000, 0, &Pubkey::default()),
+            AccountSharedData::new(10_000, 0, &Pubkey::default()),
         );
         config.add_account(
             solana_sdk::pubkey::new_rand(),
-            Account::new(1, 0, &Pubkey::default()),
+            AccountSharedData::new(1, 0, &Pubkey::default()),
         );
         config.add_native_instruction_processor("hi".to_string(), solana_sdk::pubkey::new_rand());
 

--- a/sdk/src/native_loader.rs
+++ b/sdk/src/native_loader.rs
@@ -1,10 +1,10 @@
-use crate::account::Account;
+use crate::account::AccountSharedData;
 
 crate::declare_id!("NativeLoader1111111111111111111111111111111");
 
 /// Create an executable account with the given shared object name.
-pub fn create_loadable_account(name: &str, lamports: u64) -> Account {
-    Account {
+pub fn create_loadable_account(name: &str, lamports: u64) -> AccountSharedData {
+    AccountSharedData {
         lamports,
         owner: id(),
         data: name.as_bytes().to_vec(),

--- a/sdk/src/nonce_account.rs
+++ b/sdk/src/nonce_account.rs
@@ -1,5 +1,5 @@
 use crate::{
-    account::Account,
+    account::AccountSharedData,
     account_utils::StateMut,
     fee_calculator::FeeCalculator,
     hash::Hash,
@@ -7,9 +7,9 @@ use crate::{
 };
 use std::cell::RefCell;
 
-pub fn create_account(lamports: u64) -> RefCell<Account> {
+pub fn create_account(lamports: u64) -> RefCell<AccountSharedData> {
     RefCell::new(
-        Account::new_data_with_space(
+        AccountSharedData::new_data_with_space(
             lamports,
             &Versions::new_current(State::Uninitialized),
             State::size(),
@@ -19,7 +19,7 @@ pub fn create_account(lamports: u64) -> RefCell<Account> {
     )
 }
 
-pub fn verify_nonce_account(acc: &Account, hash: &Hash) -> bool {
+pub fn verify_nonce_account(acc: &AccountSharedData, hash: &Hash) -> bool {
     if acc.owner != crate::system_program::id() {
         return false;
     }
@@ -29,7 +29,7 @@ pub fn verify_nonce_account(acc: &Account, hash: &Hash) -> bool {
     }
 }
 
-pub fn fee_calculator_of(account: &Account) -> Option<FeeCalculator> {
+pub fn fee_calculator_of(account: &AccountSharedData) -> Option<FeeCalculator> {
     let state = StateMut::<Versions>::state(account)
         .ok()?
         .convert_to_current();
@@ -48,7 +48,7 @@ mod tests {
     fn test_verify_bad_account_owner_fails() {
         let program_id = Pubkey::new_unique();
         assert_ne!(program_id, crate::system_program::id());
-        let account = Account::new_data_with_space(
+        let account = AccountSharedData::new_data_with_space(
             42,
             &Versions::new_current(State::Uninitialized),
             State::size(),

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -1,5 +1,5 @@
 use solana_sdk::{
-    account::Account,
+    account::AccountSharedData,
     instruction::{CompiledInstruction, Instruction, InstructionError},
     keyed_account::KeyedAccount,
     message::Message,
@@ -36,7 +36,7 @@ pub trait InvokeContext {
         &mut self,
         message: &Message,
         instruction: &CompiledInstruction,
-        accounts: &[Rc<RefCell<Account>>],
+        accounts: &[Rc<RefCell<AccountSharedData>>],
         caller_pivileges: Option<&[bool]>,
     ) -> Result<(), InstructionError>;
     /// Get the program ID of the currently executing program
@@ -59,7 +59,7 @@ pub trait InvokeContext {
     /// Get the bank's active feature set
     fn is_feature_active(&self, feature_id: &Pubkey) -> bool;
     /// Get an account from a pre-account
-    fn get_account(&self, pubkey: &Pubkey) -> Option<RefCell<Account>>;
+    fn get_account(&self, pubkey: &Pubkey) -> Option<RefCell<AccountSharedData>>;
     /// Update timing
     fn update_timing(
         &mut self,
@@ -305,7 +305,7 @@ impl InvokeContext for MockInvokeContext {
         &mut self,
         _message: &Message,
         _instruction: &CompiledInstruction,
-        _accounts: &[Rc<RefCell<Account>>],
+        _accounts: &[Rc<RefCell<AccountSharedData>>],
         _caller_pivileges: Option<&[bool]>,
     ) -> Result<(), InstructionError> {
         Ok(())
@@ -333,7 +333,7 @@ impl InvokeContext for MockInvokeContext {
     fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
         true
     }
-    fn get_account(&self, _pubkey: &Pubkey) -> Option<RefCell<Account>> {
+    fn get_account(&self, _pubkey: &Pubkey) -> Option<RefCell<AccountSharedData>> {
         None
     }
     fn update_timing(

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -280,7 +280,7 @@ mod tests {
     use super::*;
     use solana_runtime::{bank::Bank, bank_client::BankClient};
     use solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         client::SyncClient,
         genesis_config::create_genesis_config,
         signature::{Keypair, Signer},
@@ -306,9 +306,13 @@ mod tests {
         fee_payer_keypair
     }
 
-    fn get_account_at<C: SyncClient>(client: &C, base_pubkey: &Pubkey, i: usize) -> Account {
+    fn get_account_at<C: SyncClient>(
+        client: &C,
+        base_pubkey: &Pubkey,
+        i: usize,
+    ) -> AccountSharedData {
         let account_address = derive_stake_account_address(&base_pubkey, i);
-        client.get_account(&account_address).unwrap().unwrap()
+        AccountSharedData::from(client.get_account(&account_address).unwrap().unwrap())
     }
 
     fn get_balances<C: SyncClient>(
@@ -332,7 +336,8 @@ mod tests {
         (0..num_accounts)
             .map(|i| {
                 let address = derive_stake_account_address(&base_pubkey, i);
-                let account = client.get_account(&address).unwrap().unwrap();
+                let account =
+                    AccountSharedData::from(client.get_account(&address).unwrap().unwrap());
                 (address, StakeState::lockup_from(&account).unwrap())
             })
             .collect()

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -12,7 +12,7 @@ use {
     solana_core::rpc::JsonRpcConfig,
     solana_faucet::faucet::{run_local_faucet_with_port, FAUCET_PORT},
     solana_sdk::{
-        account::Account,
+        account::AccountSharedData,
         clock::Slot,
         native_token::sol_to_lamports,
         pubkey::Pubkey,
@@ -385,7 +385,7 @@ fn main() {
         .ledger_path(&ledger_path)
         .add_account(
             faucet_pubkey,
-            Account::new(faucet_lamports, 0, &system_program::id()),
+            AccountSharedData::new(faucet_lamports, 0, &system_program::id()),
         )
         .rpc_config(JsonRpcConfig {
             enable_rpc_transaction_history: true,


### PR DESCRIPTION
#### Problem
We don't want to copy account and account data around unnecessarily.
Account structure is fixed for abi. It needs to remain.

#### Summary of Changes
Step 1 in creating a new AccountSharedData struct which holds data in an Arc.
This change intends to be as much as possible just a rename since the rename touches many files.
Subsequent changes will change the implementation of AccountSharedData and handle its fallout.
I accomplished this by creating a parallel AccountSharedData which is a duplicate of Account. This let me produce something that should be identical in performance and allow us to review the mass rename changes separately from what should be interesting changes.
#15714
Fixes #
