### PR TITLE
Deprecate Instruction::new

### DIFF
--- a/docs/src/developing/programming-model/transactions.md
+++ b/docs/src/developing/programming-model/transactions.md
@@ -110,7 +110,7 @@ pub fn create_account(
         AccountMeta::new(*from_pubkey, true),
         AccountMeta::new(*to_pubkey, true),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::CreateAccount {
             lamports,

--- a/docs/src/proposals/program-instruction-macro.md
+++ b/docs/src/proposals/program-instruction-macro.md
@@ -95,7 +95,7 @@ pub fn transfer(from_account: Pubkey, to_account: Pubkey, lamports: u64) -> Inst
         AccountMeta::new(from_pubkey, true),
         AccountMeta::new(to_pubkey, false),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         test_program::id(),
         &SystemInstruction::Transfer { lamports },
         account_metas,
@@ -114,7 +114,7 @@ pub fn multisig(data_account: Pubkey, signers: &[Pubkey]) -> Instruction {
         account_metas.push(AccountMeta::new_readonly(pubkey, true));
     }
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         test_program::id(),
         &TestInstruction::Multisig,
         account_metas,
@@ -138,7 +138,7 @@ pub fn advance_nonce_account(
     if let Some(pubkey) = authorized_pubkey {
         account_metas.push(AccountMeta::new_readonly*nonce_authority, true));
     }
-    Instruction::new(
+    Instruction::new_with_bincode(
         test_program::id(),
         &TestInstruction::AdvanceNonceAccount,
         account_metas,

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -645,7 +645,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
         ("verify", Some(matches)) => {
             let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
             let simple_message = Message::new(
-                &[Instruction::new(
+                &[Instruction::new_with_bincode(
                     Pubkey::default(),
                     &0,
                     vec![AccountMeta::new(keypair.pubkey(), true)],

--- a/program-test/tests/cpi.rs
+++ b/program-test/tests/cpi.rs
@@ -22,7 +22,7 @@ fn invoker_process_instruction(
     let account_info_iter = &mut accounts.iter();
     let invoked_program_info = next_account_info(account_info_iter)?;
     invoke(
-        &Instruction::new(*invoked_program_info.key, &[0], vec![]),
+        &Instruction::new_with_bincode(*invoked_program_info.key, &[0], vec![]),
         &[invoked_program_info.clone()],
     )?;
     msg!("Processing invoker instruction after CPI");
@@ -58,7 +58,7 @@ async fn cpi() {
     );
 
     let mut test_state = program_test.start_with_context().await;
-    let instructions = vec![Instruction::new(
+    let instructions = vec![Instruction::new_with_bincode(
         invoker_program_id,
         &[0],
         vec![AccountMeta::new_readonly(invoked_program_id, false)],

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -92,7 +92,7 @@ async fn run_fuzz_instructions(
             program_id,
         );
         instructions.push(instruction);
-        instructions.push(Instruction::new(*program_id, &[0], vec![]));
+        instructions.push(Instruction::new_with_bincode(*program_id, &[0], vec![]));
         signer_keypairs.push(keypair);
     }
     // Process transaction on test network

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -58,7 +58,7 @@ async fn clock_sysvar_updated_from_warp() {
 
     let mut context = program_test.start_with_context().await;
     let expected_slot = 5_000_000;
-    let instruction = Instruction::new(
+    let instruction = Instruction::new_with_bincode(
         program_id,
         &expected_slot,
         vec![AccountMeta::new_readonly(clock::id(), false)],
@@ -83,7 +83,7 @@ async fn clock_sysvar_updated_from_warp() {
 
     // Warp to success!
     context.warp_to_slot(expected_slot).unwrap();
-    let instruction = Instruction::new(
+    let instruction = Instruction::new_with_bincode(
         program_id,
         &expected_slot,
         vec![AccountMeta::new_readonly(clock::id(), false)],

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -175,7 +175,7 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
     let mint_pubkey = mint_keypair.pubkey();
     let account_metas = vec![AccountMeta::new(mint_pubkey, true)];
 
-    let instruction = Instruction::new(invoke_program_id, &[u8::MAX, 0, 0, 0], account_metas);
+    let instruction = Instruction::new_with_bincode(invoke_program_id, &[u8::MAX, 0, 0, 0], account_metas);
     let message = Message::new(&[instruction], Some(&mint_pubkey));
 
     bank_client

--- a/programs/bpf/rust/caller_access/src/lib.rs
+++ b/programs/bpf/rust/caller_access/src/lib.rs
@@ -17,7 +17,7 @@ fn process_instruction(
 ) -> ProgramResult {
     if instruction_data.len() == 32 {
         let key = Pubkey::new_from_array(instruction_data.try_into().unwrap());
-        let ix = Instruction::new(key, &[2], vec![]);
+        let ix = Instruction::new_with_bincode(key, &[2], vec![]);
         let mut lamports = accounts[0].lamports();
         let owner = &accounts[0].owner;
         let mut data = accounts[0].try_borrow_mut_data()?;
@@ -36,7 +36,7 @@ fn process_instruction(
     } else {
         match instruction_data[0] {
             1 => {
-                let ix = Instruction::new(
+                let ix = Instruction::new_with_bincode(
                     *program_id,
                     &accounts[1].key.to_bytes(),
                     vec![AccountMeta::new_readonly(*program_id, false)],

--- a/programs/bpf/rust/spoof1/src/lib.rs
+++ b/programs/bpf/rust/spoof1/src/lib.rs
@@ -36,7 +36,7 @@ fn process_instruction(
         AccountMeta::new(*target.key, false),
         AccountMeta::new(*me.key, false),
     ];
-    let ix = Instruction::new(
+    let ix = Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::Transfer { lamports: 1 },
         account_metas,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -465,7 +465,7 @@ fn test_program_bpf_sanity() {
             AccountMeta::new(stake_history::id(), false),
             AccountMeta::new(rent::id(), false),
         ];
-        let instruction = Instruction::new(program_id, &1u8, account_metas);
+        let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas);
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         if program.1 {
             assert!(result.is_ok());
@@ -510,7 +510,7 @@ fn test_program_bpf_loader_deprecated() {
             program,
         );
         let account_metas = vec![AccountMeta::new(mint_keypair.pubkey(), true)];
-        let instruction = Instruction::new(program_id, &1u8, account_metas);
+        let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas);
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert!(result.is_ok());
     }
@@ -558,42 +558,42 @@ fn test_program_bpf_duplicate_accounts() {
         ];
 
         bank.store_account(&pubkey, &account);
-        let instruction = Instruction::new(program_id, &1u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
         assert!(result.is_ok());
         assert_eq!(data[0], 1);
 
         bank.store_account(&pubkey, &account);
-        let instruction = Instruction::new(program_id, &2u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[2], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
         assert!(result.is_ok());
         assert_eq!(data[0], 2);
 
         bank.store_account(&pubkey, &account);
-        let instruction = Instruction::new(program_id, &3u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[3], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let data = bank_client.get_account_data(&pubkey).unwrap().unwrap();
         assert!(result.is_ok());
         assert_eq!(data[0], 3);
 
         bank.store_account(&pubkey, &account);
-        let instruction = Instruction::new(program_id, &4u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[4], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let lamports = bank_client.get_balance(&pubkey).unwrap();
         assert!(result.is_ok());
         assert_eq!(lamports, 11);
 
         bank.store_account(&pubkey, &account);
-        let instruction = Instruction::new(program_id, &5u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[5], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let lamports = bank_client.get_balance(&pubkey).unwrap();
         assert!(result.is_ok());
         assert_eq!(lamports, 12);
 
         bank.store_account(&pubkey, &account);
-        let instruction = Instruction::new(program_id, &6u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[6], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let lamports = bank_client.get_balance(&pubkey).unwrap();
         assert!(result.is_ok());
@@ -630,32 +630,32 @@ fn test_program_bpf_error_handling() {
         let program_id = load_bpf_program(&bank_client, &bpf_loader::id(), &mint_keypair, program);
         let account_metas = vec![AccountMeta::new(mint_keypair.pubkey(), true)];
 
-        let instruction = Instruction::new(program_id, &1u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert!(result.is_ok());
 
-        let instruction = Instruction::new(program_id, &2u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[2], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
             TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
         );
 
-        let instruction = Instruction::new(program_id, &3u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[3], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
             TransactionError::InstructionError(0, InstructionError::Custom(0))
         );
 
-        let instruction = Instruction::new(program_id, &4u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[4], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
             TransactionError::InstructionError(0, InstructionError::Custom(42))
         );
 
-        let instruction = Instruction::new(program_id, &5u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[5], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let result = result.unwrap_err().unwrap();
         if TransactionError::InstructionError(0, InstructionError::InvalidInstructionData) != result
@@ -666,7 +666,7 @@ fn test_program_bpf_error_handling() {
             );
         }
 
-        let instruction = Instruction::new(program_id, &6u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[6], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let result = result.unwrap_err().unwrap();
         if TransactionError::InstructionError(0, InstructionError::InvalidInstructionData) != result
@@ -677,7 +677,7 @@ fn test_program_bpf_error_handling() {
             );
         }
 
-        let instruction = Instruction::new(program_id, &7u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[7], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         let result = result.unwrap_err().unwrap();
         if TransactionError::InstructionError(0, InstructionError::InvalidInstructionData) != result
@@ -688,14 +688,14 @@ fn test_program_bpf_error_handling() {
             );
         }
 
-        let instruction = Instruction::new(program_id, &8u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[8], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
             TransactionError::InstructionError(0, InstructionError::InvalidInstructionData)
         );
 
-        let instruction = Instruction::new(program_id, &9u8, account_metas.clone());
+        let instruction = Instruction::new_with_bytes(program_id, &[9], account_metas.clone());
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
@@ -800,12 +800,12 @@ fn test_program_bpf_invoke_sanity() {
 
         // success cases
 
-        let instruction = Instruction::new(
+        let instruction = Instruction::new_with_bytes(
             invoke_program_id,
             &[TEST_SUCCESS, bump_seed1, bump_seed2, bump_seed3],
             account_metas.clone(),
         );
-        let noop_instruction = Instruction::new(noop_program_id, &(), vec![]);
+        let noop_instruction = Instruction::new_with_bytes(noop_program_id, &[], vec![]);
         let message = Message::new(&[instruction, noop_instruction], Some(&mint_pubkey));
         let tx = Transaction::new(
             &[
@@ -880,7 +880,7 @@ fn test_program_bpf_invoke_sanity() {
                     &from_keypair,
                 ];
                 let instruction =
-                    Instruction::new(invoke_program_id, instruction_data, account_metas.clone());
+                    Instruction::new_with_bytes(invoke_program_id, instruction_data, account_metas.clone());
                 let message = Message::new(&[instruction], Some(&mint_pubkey));
                 let tx = Transaction::new(&signers, message.clone(), bank.last_blockhash());
                 let (result, inner_instructions) = process_transaction_and_record_inner(&bank, tx);
@@ -981,7 +981,7 @@ fn test_program_bpf_invoke_sanity() {
         let account = Account::new(84, 0, &solana_sdk::system_program::id());
         bank.store_account(&from_keypair.pubkey(), &account);
         bank.store_account(&derived_key1, &Account::default());
-        let instruction = Instruction::new(
+        let instruction = Instruction::new_with_bytes(
             invoke_program_id,
             &[
                 TEST_ALLOC_ACCESS_VIOLATION,
@@ -1057,7 +1057,7 @@ fn test_program_bpf_program_id_spoofing() {
         AccountMeta::new(to_pubkey, false),
     ];
 
-    let instruction = Instruction::new(malicious_swap_pubkey, &(), account_metas.clone());
+    let instruction = Instruction::new_with_bytes(malicious_swap_pubkey, &[], account_metas.clone());
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert_eq!(
         result.unwrap_err().unwrap(),
@@ -1097,7 +1097,7 @@ fn test_program_bpf_caller_has_access_to_cpi_program() {
         AccountMeta::new_readonly(caller_pubkey, false),
         AccountMeta::new_readonly(caller2_pubkey, false),
     ];
-    let instruction = Instruction::new(caller_pubkey, &[1_u8], account_metas.clone());
+    let instruction = Instruction::new_with_bytes(caller_pubkey, &[1], account_metas.clone());
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert_eq!(
         result.unwrap_err().unwrap(),
@@ -1137,7 +1137,7 @@ fn test_program_bpf_ro_modify() {
         AccountMeta::new(test_keypair.pubkey(), true),
     ];
 
-    let instruction = Instruction::new(program_pubkey, &[1_u8], account_metas.clone());
+    let instruction = Instruction::new_with_bytes(program_pubkey, &[1], account_metas.clone());
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let result = bank_client.send_and_confirm_message(&[&mint_keypair, &test_keypair], message);
     assert_eq!(
@@ -1145,7 +1145,7 @@ fn test_program_bpf_ro_modify() {
         TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
     );
 
-    let instruction = Instruction::new(program_pubkey, &[3_u8], account_metas.clone());
+    let instruction = Instruction::new_with_bytes(program_pubkey, &[3], account_metas.clone());
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let result = bank_client.send_and_confirm_message(&[&mint_keypair, &test_keypair], message);
     assert_eq!(
@@ -1153,7 +1153,7 @@ fn test_program_bpf_ro_modify() {
         TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
     );
 
-    let instruction = Instruction::new(program_pubkey, &[4_u8], account_metas.clone());
+    let instruction = Instruction::new_with_bytes(program_pubkey, &[4], account_metas.clone());
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let result = bank_client.send_and_confirm_message(&[&mint_keypair, &test_keypair], message);
     assert_eq!(
@@ -1187,7 +1187,7 @@ fn test_program_bpf_call_depth() {
         "solana_bpf_rust_call_depth",
     );
 
-    let instruction = Instruction::new(
+    let instruction = Instruction::new_with_bincode(
         program_id,
         &(BpfComputeBudget::default().max_call_depth - 1),
         vec![],
@@ -1195,7 +1195,7 @@ fn test_program_bpf_call_depth() {
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert!(result.is_ok());
 
-    let instruction = Instruction::new(
+    let instruction = Instruction::new_with_bincode(
         program_id,
         &BpfComputeBudget::default().max_call_depth,
         vec![],
@@ -1279,9 +1279,9 @@ fn test_program_bpf_instruction_introspection() {
         solana_sdk::sysvar::instructions::id(),
         false,
     )];
-    let instruction0 = Instruction::new(program_id, &[0u8, 0u8], account_metas.clone());
-    let instruction1 = Instruction::new(program_id, &[0u8, 1u8], account_metas.clone());
-    let instruction2 = Instruction::new(program_id, &[0u8, 2u8], account_metas);
+    let instruction0 = Instruction::new_with_bytes(program_id, &[0u8, 0u8], account_metas.clone());
+    let instruction1 = Instruction::new_with_bytes(program_id, &[0u8, 1u8], account_metas.clone());
+    let instruction2 = Instruction::new_with_bytes(program_id, &[0u8, 2u8], account_metas);
     let message = Message::new(
         &[instruction0, instruction1, instruction2],
         Some(&mint_keypair.pubkey()),
@@ -1294,7 +1294,7 @@ fn test_program_bpf_instruction_introspection() {
         solana_sdk::sysvar::instructions::id(),
         false,
     )];
-    let instruction = Instruction::new(program_id, &0u8, account_metas);
+    let instruction = Instruction::new_with_bytes(program_id, &[0], account_metas);
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert_eq!(
         result.unwrap_err().unwrap(),
@@ -1302,7 +1302,7 @@ fn test_program_bpf_instruction_introspection() {
     );
 
     // No accounts, should error
-    let instruction = Instruction::new(program_id, &0u8, vec![]);
+    let instruction = Instruction::new_with_bytes(program_id, &[0], vec![]);
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert!(result.is_err());
     assert_eq!(
@@ -1369,7 +1369,7 @@ fn test_program_bpf_test_use_latest_executor() {
     let message = Message::new(
         &[
             loader_instruction::finalize(&program_keypair.pubkey(), &bpf_loader::id()),
-            Instruction::new(panic_id, &0u8, vec![]),
+            Instruction::new_with_bytes(panic_id, &[0], vec![]),
         ],
         Some(&mint_keypair.pubkey()),
     );
@@ -1401,7 +1401,7 @@ fn test_program_bpf_test_use_latest_executor() {
 
     // Call the noop program, should get noop not panic
     let message = Message::new(
-        &[Instruction::new(program_keypair.pubkey(), &0u8, vec![])],
+        &[Instruction::new_with_bytes(program_keypair.pubkey(), &[0], vec![])],
         Some(&mint_keypair.pubkey()),
     );
     assert!(bank_client
@@ -1491,7 +1491,7 @@ fn test_program_bpf_test_use_latest_executor2() {
 
     // invoke program, verify not found
     let message = Message::new(
-        &[Instruction::new(program_keypair.pubkey(), &0u8, vec![])],
+        &[Instruction::new_with_bytes(program_keypair.pubkey(), &[0], vec![])],
         Some(&mint_keypair.pubkey()),
     );
     assert_eq!(
@@ -1526,7 +1526,7 @@ fn test_program_bpf_test_use_latest_executor2() {
 
     // Call the program, should get noop, not panic
     let message = Message::new(
-        &[Instruction::new(program_keypair.pubkey(), &0u8, vec![])],
+        &[Instruction::new_with_bytes(program_keypair.pubkey(), &[0], vec![])],
         Some(&mint_keypair.pubkey()),
     );
     assert!(bank_client
@@ -1563,7 +1563,7 @@ fn test_program_bpf_upgrade() {
         "solana_bpf_rust_upgradeable",
     );
 
-    let mut instruction = Instruction::new(
+    let mut instruction = Instruction::new_with_bytes(
         program_id,
         &[0],
         vec![
@@ -1659,7 +1659,7 @@ fn test_program_bpf_upgrade_and_invoke_in_same_tx() {
         "solana_bpf_rust_noop",
     );
 
-    let invoke_instruction = Instruction::new(
+    let invoke_instruction = Instruction::new_with_bytes(
         program_id,
         &[0],
         vec![
@@ -1747,7 +1747,7 @@ fn test_program_bpf_invoke_upgradeable_via_cpi() {
         "solana_bpf_rust_upgradeable",
     );
 
-    let mut instruction = Instruction::new(
+    let mut instruction = Instruction::new_with_bytes(
         invoke_and_return,
         &[0],
         vec![
@@ -1848,7 +1848,7 @@ fn test_program_bpf_disguised_as_bpf_loader() {
             program,
         );
         let account_metas = vec![AccountMeta::new_readonly(program_id, false)];
-        let instruction = Instruction::new(bpf_loader_deprecated::id(), &1u8, account_metas);
+        let instruction = Instruction::new_with_bytes(bpf_loader_deprecated::id(), &[1], account_metas);
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
@@ -1894,7 +1894,7 @@ fn test_program_bpf_upgrade_via_cpi() {
         "solana_bpf_rust_upgradeable",
     );
 
-    let mut instruction = Instruction::new(
+    let mut instruction = Instruction::new_with_bytes(
         invoke_and_return,
         &[0],
         vec![
@@ -1992,7 +1992,7 @@ fn test_program_bpf_upgrade_self_via_cpi() {
         "solana_bpf_rust_invoke_and_return",
     );
 
-    let mut invoke_instruction = Instruction::new(
+    let mut invoke_instruction = Instruction::new_with_bytes(
         program_id,
         &[0],
         vec![
@@ -2104,9 +2104,9 @@ fn test_program_upgradeable_locks() {
         let invoke_tx = Transaction::new(
             &[payer_keypair],
             Message::new(
-                &[Instruction::new(
+                &[Instruction::new_with_bytes(
                     program_keypair.pubkey(),
-                    &[0u8; 0],
+                    &[0; 0],
                     vec![],
                 )],
                 Some(&payer_keypair.pubkey()),
@@ -2208,7 +2208,7 @@ fn test_program_bpf_syscall_feature_activation() {
         &mint_keypair,
         "solana_bpf_rust_noop",
     );
-    let instruction = Instruction::new(program_id, &0u8, vec![]);
+    let instruction = Instruction::new_with_bytes(program_id, &[0], vec![]);
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     assert!(result.is_ok());
 
@@ -2217,7 +2217,7 @@ fn test_program_bpf_syscall_feature_activation() {
 
     let bank = Arc::new(bank);
     let bank_client = BankClient::new_shared(&bank);
-    let instruction = Instruction::new(program_id, &1u8, vec![]);
+    let instruction = Instruction::new_with_bytes(program_id, &[1], vec![]);
     let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
     println!("result: {:?}", result);
     assert!(result.is_ok());

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1654,7 +1654,7 @@ mod tests {
         bank.clear_signatures();
         bank.store_account(&buffer_address, &buffer_account);
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 bpf_loader_upgradeable::id(),
                 &UpgradeableLoaderInstruction::DeployWithMaxDataLen {
                     max_data_len: elf.len(),
@@ -1713,7 +1713,7 @@ mod tests {
         bank.store_account(&program_keypair.pubkey(), &program_account);
         bank.store_account(&programdata_address, &programdata_account);
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 bpf_loader_upgradeable::id(),
                 &UpgradeableLoaderInstruction::DeployWithMaxDataLen {
                     max_data_len: elf.len(),
@@ -1744,7 +1744,7 @@ mod tests {
         bank.store_account(&program_keypair.pubkey(), &program_account);
         bank.store_account(&programdata_address, &programdata_account);
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 bpf_loader_upgradeable::id(),
                 &UpgradeableLoaderInstruction::DeployWithMaxDataLen {
                     max_data_len: elf.len(),

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1793,7 +1793,7 @@ mod tests {
         assert_eq!(pubkey, *translated_pubkey);
 
         // Instruction
-        let instruction = Instruction::new(
+        let instruction = Instruction::new_with_bincode(
             solana_sdk::pubkey::new_rand(),
             &"foobar",
             vec![AccountMeta::new(solana_sdk::pubkey::new_rand(), false)],

--- a/programs/budget/src/budget_instruction.rs
+++ b/programs/budget/src/budget_instruction.rs
@@ -47,7 +47,7 @@ fn initialize_account(contract: &Pubkey, expr: BudgetExpr) -> Instruction {
         keys.push(AccountMeta::new(payment.to, false));
     }
     keys.push(AccountMeta::new(*contract, false));
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &BudgetInstruction::InitializeAccount(Box::new(expr)),
         keys,
@@ -136,7 +136,7 @@ pub fn apply_timestamp(
     if from != to {
         account_metas.push(AccountMeta::new(*to, false));
     }
-    Instruction::new(id(), &BudgetInstruction::ApplyTimestamp(dt), account_metas)
+    Instruction::new_with_bincode(id(), &BudgetInstruction::ApplyTimestamp(dt), account_metas)
 }
 
 pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruction {
@@ -147,7 +147,7 @@ pub fn apply_signature(from: &Pubkey, contract: &Pubkey, to: &Pubkey) -> Instruc
     if from != to {
         account_metas.push(AccountMeta::new(*to, false));
     }
-    Instruction::new(id(), &BudgetInstruction::ApplySignature, account_metas)
+    Instruction::new_with_bincode(id(), &BudgetInstruction::ApplySignature, account_metas)
 }
 
 /// Apply account data to a contract waiting on an AccountData witness.
@@ -157,7 +157,7 @@ pub fn apply_account_data(witness_pubkey: &Pubkey, contract: &Pubkey, to: &Pubke
         AccountMeta::new(*contract, false),
         AccountMeta::new(*to, false),
     ];
-    Instruction::new(id(), &BudgetInstruction::ApplyAccountData, account_metas)
+    Instruction::new_with_bincode(id(), &BudgetInstruction::ApplyAccountData, account_metas)
 }
 
 #[cfg(test)]

--- a/programs/config/src/config_instruction.rs
+++ b/programs/config/src/config_instruction.rs
@@ -9,7 +9,7 @@ use solana_sdk::{
 fn initialize_account<T: ConfigState>(config_pubkey: &Pubkey) -> Instruction {
     let account_metas = vec![AccountMeta::new(*config_pubkey, true)];
     let account_data = (ConfigKeys { keys: vec![] }, T::default());
-    Instruction::new(id(), &account_data, account_metas)
+    Instruction::new_with_bincode(id(), &account_data, account_metas)
 }
 
 /// Create a new, empty configuration account
@@ -46,5 +46,5 @@ pub fn store<T: ConfigState>(
         }
     }
     let account_data = (ConfigKeys { keys }, data);
-    Instruction::new(id(), &account_data, account_metas)
+    Instruction::new_with_bincode(id(), &account_data, account_metas)
 }

--- a/programs/exchange/src/exchange_instruction.rs
+++ b/programs/exchange/src/exchange_instruction.rs
@@ -59,7 +59,7 @@ pub fn account_request(owner: &Pubkey, new: &Pubkey) -> Instruction {
         AccountMeta::new(*owner, true),
         AccountMeta::new(*new, false),
     ];
-    Instruction::new(id(), &ExchangeInstruction::AccountRequest, account_metas)
+    Instruction::new_with_bincode(id(), &ExchangeInstruction::AccountRequest, account_metas)
 }
 
 pub fn transfer_request(
@@ -74,7 +74,7 @@ pub fn transfer_request(
         AccountMeta::new(*to, false),
         AccountMeta::new(*from, false),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &ExchangeInstruction::TransferRequest(token, tokens),
         account_metas,
@@ -95,7 +95,7 @@ pub fn trade_request(
         AccountMeta::new(*trade, false),
         AccountMeta::new(*src_account, false),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &ExchangeInstruction::OrderRequest(OrderRequestInfo {
             side,
@@ -112,7 +112,7 @@ pub fn order_cancellation(owner: &Pubkey, order: &Pubkey) -> Instruction {
         AccountMeta::new(*owner, true),
         AccountMeta::new(*order, false),
     ];
-    Instruction::new(id(), &ExchangeInstruction::OrderCancellation, account_metas)
+    Instruction::new_with_bincode(id(), &ExchangeInstruction::OrderCancellation, account_metas)
 }
 
 pub fn swap_request(
@@ -127,5 +127,5 @@ pub fn swap_request(
         AccountMeta::new(*from_trade, false),
         AccountMeta::new(*profit_account, false),
     ];
-    Instruction::new(id(), &ExchangeInstruction::SwapRequest, account_metas)
+    Instruction::new_with_bincode(id(), &ExchangeInstruction::SwapRequest, account_metas)
 }

--- a/programs/ownable/src/ownable_instruction.rs
+++ b/programs/ownable/src/ownable_instruction.rs
@@ -21,7 +21,7 @@ impl<T> DecodeError<T> for OwnableError {
 
 fn initialize_account(account_pubkey: &Pubkey, owner_pubkey: &Pubkey) -> Instruction {
     let keys = vec![AccountMeta::new(*account_pubkey, false)];
-    Instruction::new(crate::id(), &owner_pubkey, keys)
+    Instruction::new_with_bincode(crate::id(), &owner_pubkey, keys)
 }
 
 pub fn create_account(
@@ -48,5 +48,5 @@ pub fn set_owner(account_pubkey: &Pubkey, old_pubkey: &Pubkey, new_pubkey: &Pubk
         AccountMeta::new(*account_pubkey, false),
         AccountMeta::new(*old_pubkey, true),
     ];
-    Instruction::new(crate::id(), &new_pubkey, keys)
+    Instruction::new_with_bincode(crate::id(), &new_pubkey, keys)
 }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -184,7 +184,7 @@ pub struct AuthorizeWithSeedArgs {
 }
 
 fn initialize(stake_pubkey: &Pubkey, authorized: &Authorized, lockup: &Lockup) -> Instruction {
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &StakeInstruction::Initialize(*authorized, *lockup),
         vec![
@@ -248,7 +248,7 @@ fn _split(
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
 
-    Instruction::new(id(), &StakeInstruction::Split(lamports), account_metas)
+    Instruction::new_with_bincode(id(), &StakeInstruction::Split(lamports), account_metas)
 }
 
 pub fn split(
@@ -314,7 +314,7 @@ pub fn merge(
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
 
-    vec![Instruction::new(
+    vec![Instruction::new_with_bincode(
         id(),
         &StakeInstruction::Merge,
         account_metas,
@@ -382,7 +382,7 @@ pub fn authorize(
         account_metas.push(AccountMeta::new_readonly(*custodian_pubkey, true));
     }
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &StakeInstruction::Authorize(*new_authorized_pubkey, stake_authorize),
         account_metas,
@@ -415,7 +415,7 @@ pub fn authorize_with_seed(
         authority_owner: *authority_owner,
     };
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &StakeInstruction::AuthorizeWithSeed(args),
         account_metas,
@@ -435,7 +435,7 @@ pub fn delegate_stake(
         AccountMeta::new_readonly(crate::config::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
-    Instruction::new(id(), &StakeInstruction::DelegateStake, account_metas)
+    Instruction::new_with_bincode(id(), &StakeInstruction::DelegateStake, account_metas)
 }
 
 pub fn withdraw(
@@ -457,7 +457,7 @@ pub fn withdraw(
         account_metas.push(AccountMeta::new_readonly(*custodian_pubkey, true));
     }
 
-    Instruction::new(id(), &StakeInstruction::Withdraw(lamports), account_metas)
+    Instruction::new_with_bincode(id(), &StakeInstruction::Withdraw(lamports), account_metas)
 }
 
 pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> Instruction {
@@ -466,7 +466,7 @@ pub fn deactivate_stake(stake_pubkey: &Pubkey, authorized_pubkey: &Pubkey) -> In
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
-    Instruction::new(id(), &StakeInstruction::Deactivate, account_metas)
+    Instruction::new_with_bincode(id(), &StakeInstruction::Deactivate, account_metas)
 }
 
 pub fn set_lockup(
@@ -478,7 +478,7 @@ pub fn set_lockup(
         AccountMeta::new(*stake_pubkey, false),
         AccountMeta::new_readonly(*custodian_pubkey, true),
     ];
-    Instruction::new(id(), &StakeInstruction::SetLockup(*lockup), account_metas)
+    Instruction::new_with_bincode(id(), &StakeInstruction::SetLockup(*lockup), account_metas)
 }
 
 pub fn process_instruction(

--- a/programs/vest/src/vest_instruction.rs
+++ b/programs/vest/src/vest_instruction.rs
@@ -75,7 +75,7 @@ fn initialize_account(
     total_lamports: u64,
 ) -> Instruction {
     let keys = vec![AccountMeta::new(*contract_pubkey, false)];
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &VestInstruction::InitializeAccount {
             terminator_pubkey: *terminator_pubkey,
@@ -116,7 +116,7 @@ pub fn set_terminator(contract: &Pubkey, old_pubkey: &Pubkey, new_pubkey: &Pubke
         AccountMeta::new(*contract, false),
         AccountMeta::new(*old_pubkey, true),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &VestInstruction::SetTerminator(*new_pubkey),
         account_metas,
@@ -128,7 +128,7 @@ pub fn set_payee(contract: &Pubkey, old_pubkey: &Pubkey, new_pubkey: &Pubkey) ->
         AccountMeta::new(*contract, false),
         AccountMeta::new(*old_pubkey, true),
     ];
-    Instruction::new(id(), &VestInstruction::SetPayee(*new_pubkey), account_metas)
+    Instruction::new_with_bincode(id(), &VestInstruction::SetPayee(*new_pubkey), account_metas)
 }
 
 pub fn redeem_tokens(contract: &Pubkey, date_pubkey: &Pubkey, to: &Pubkey) -> Instruction {
@@ -137,7 +137,7 @@ pub fn redeem_tokens(contract: &Pubkey, date_pubkey: &Pubkey, to: &Pubkey) -> In
         AccountMeta::new_readonly(*date_pubkey, false),
         AccountMeta::new(*to, false),
     ];
-    Instruction::new(id(), &VestInstruction::RedeemTokens, account_metas)
+    Instruction::new_with_bincode(id(), &VestInstruction::RedeemTokens, account_metas)
 }
 
 pub fn terminate(contract: &Pubkey, from: &Pubkey, to: &Pubkey) -> Instruction {
@@ -148,7 +148,7 @@ pub fn terminate(contract: &Pubkey, from: &Pubkey, to: &Pubkey) -> Instruction {
     if from != to {
         account_metas.push(AccountMeta::new(*to, false));
     }
-    Instruction::new(id(), &VestInstruction::Terminate, account_metas)
+    Instruction::new_with_bincode(id(), &VestInstruction::Terminate, account_metas)
 }
 
 pub fn renege(contract: &Pubkey, from: &Pubkey, to: &Pubkey, lamports: u64) -> Instruction {
@@ -159,7 +159,7 @@ pub fn renege(contract: &Pubkey, from: &Pubkey, to: &Pubkey, lamports: u64) -> I
     if from != to {
         account_metas.push(AccountMeta::new(*to, false));
     }
-    Instruction::new(id(), &VestInstruction::Renege(lamports), account_metas)
+    Instruction::new_with_bincode(id(), &VestInstruction::Renege(lamports), account_metas)
 }
 
 pub fn vest_all(contract: &Pubkey, from: &Pubkey) -> Instruction {
@@ -167,5 +167,5 @@ pub fn vest_all(contract: &Pubkey, from: &Pubkey) -> Instruction {
         AccountMeta::new(*contract, false),
         AccountMeta::new(*from, true),
     ];
-    Instruction::new(id(), &VestInstruction::VestAll, account_metas)
+    Instruction::new_with_bincode(id(), &VestInstruction::VestAll, account_metas)
 }

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -121,7 +121,7 @@ fn initialize_account(vote_pubkey: &Pubkey, vote_init: &VoteInit) -> Instruction
         AccountMeta::new_readonly(vote_init.node_pubkey, true),
     ];
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &VoteInstruction::InitializeAccount(*vote_init),
         account_metas,
@@ -175,7 +175,7 @@ pub fn authorize(
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &VoteInstruction::Authorize(*new_authorized_pubkey, vote_authorize),
         account_metas,
@@ -193,7 +193,7 @@ pub fn update_validator_identity(
         AccountMeta::new_readonly(*authorized_withdrawer_pubkey, true),
     ];
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &VoteInstruction::UpdateValidatorIdentity,
         account_metas,
@@ -210,7 +210,7 @@ pub fn update_commission(
         AccountMeta::new_readonly(*authorized_withdrawer_pubkey, true),
     ];
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &VoteInstruction::UpdateCommission(commission),
         account_metas,
@@ -225,7 +225,7 @@ pub fn vote(vote_pubkey: &Pubkey, authorized_voter_pubkey: &Pubkey, vote: Vote) 
         AccountMeta::new_readonly(*authorized_voter_pubkey, true),
     ];
 
-    Instruction::new(id(), &VoteInstruction::Vote(vote), account_metas)
+    Instruction::new_with_bincode(id(), &VoteInstruction::Vote(vote), account_metas)
 }
 
 pub fn vote_switch(
@@ -241,7 +241,7 @@ pub fn vote_switch(
         AccountMeta::new_readonly(*authorized_voter_pubkey, true),
     ];
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &VoteInstruction::VoteSwitch(vote, proof_hash),
         account_metas,
@@ -260,7 +260,7 @@ pub fn withdraw(
         AccountMeta::new_readonly(*authorized_withdrawer_pubkey, true),
     ];
 
-    Instruction::new(id(), &VoteInstruction::Withdraw(lamports), account_metas)
+    Instruction::new_with_bincode(id(), &VoteInstruction::Withdraw(lamports), account_metas)
 }
 
 fn verify_rent_exemption(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5386,8 +5386,11 @@ pub(crate) mod tests {
             AccountMeta::new(keypair2.pubkey(), true),
             AccountMeta::new_readonly(read_only_keypair.pubkey(), false),
         ];
-        let deduct_instruction =
-            Instruction::new(mock_program_id, &MockInstruction::Deduction, account_metas);
+        let deduct_instruction = Instruction::new_with_bincode(
+            mock_program_id,
+            &MockInstruction::Deduction,
+            account_metas,
+        );
         Transaction::new_signed_with_payer(
             &[deduct_instruction],
             Some(&payer.pubkey()),
@@ -9788,7 +9791,7 @@ pub(crate) mod tests {
             AccountMeta::new(to_pubkey, false),
             AccountMeta::new(dup_pubkey, false),
         ];
-        let instruction = Instruction::new(mock_program_id, &10, account_metas);
+        let instruction = Instruction::new_with_bincode(mock_program_id, &10, account_metas);
         let tx = Transaction::new_signed_with_payer(
             &[instruction],
             Some(&mint_keypair.pubkey()),
@@ -9834,7 +9837,7 @@ pub(crate) mod tests {
             AccountMeta::new(dup_pubkey, false),
             AccountMeta::new(mock_program_id, false),
         ];
-        let instruction = Instruction::new(mock_program_id, &10, account_metas);
+        let instruction = Instruction::new_with_bincode(mock_program_id, &10, account_metas);
         let tx = Transaction::new_signed_with_payer(
             &[instruction],
             Some(&mint_keypair.pubkey()),
@@ -9860,7 +9863,8 @@ pub(crate) mod tests {
             AccountMeta::new(to_pubkey, false),
         ];
 
-        let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+        let instruction =
+            Instruction::new_with_bincode(solana_vote_program::id(), &10, account_metas);
         let mut tx = Transaction::new_signed_with_payer(
             &[instruction],
             Some(&mint_keypair.pubkey()),
@@ -9930,7 +9934,8 @@ pub(crate) mod tests {
             mock_ok_vote_processor,
         );
 
-        let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+        let instruction =
+            Instruction::new_with_bincode(solana_vote_program::id(), &10, account_metas);
         let mut tx = Transaction::new_signed_with_payer(
             &[instruction],
             Some(&mint_keypair.pubkey()),
@@ -9963,7 +9968,8 @@ pub(crate) mod tests {
             mock_ok_vote_processor,
         );
 
-        let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+        let instruction =
+            Instruction::new_with_bincode(solana_vote_program::id(), &10, account_metas);
         let mut tx = Transaction::new_signed_with_payer(
             &[instruction],
             Some(&mint_keypair.pubkey()),
@@ -10020,7 +10026,8 @@ pub(crate) mod tests {
             mock_ok_vote_processor,
         );
 
-        let instruction = Instruction::new(solana_vote_program::id(), &10, account_metas);
+        let instruction =
+            Instruction::new_with_bincode(solana_vote_program::id(), &10, account_metas);
         let mut tx = Transaction::new_signed_with_payer(
             &[instruction],
             Some(&mint_keypair.pubkey()),
@@ -10267,7 +10274,7 @@ pub(crate) mod tests {
         program2_account.executable = true;
         bank.store_account(&program2_pubkey, &program2_account);
 
-        let instruction = Instruction::new(program2_pubkey, &10, vec![]);
+        let instruction = Instruction::new_with_bincode(program2_pubkey, &10, vec![]);
         let tx = Transaction::new_signed_with_payer(
             &[instruction.clone(), instruction],
             Some(&mint_keypair.pubkey()),
@@ -11515,7 +11522,11 @@ pub(crate) mod tests {
         let bank = Bank::new(&genesis_config);
 
         let tx = Transaction::new_signed_with_payer(
-            &[Instruction::new(native_loader::id(), &(), vec![])],
+            &[Instruction::new_with_bincode(
+                native_loader::id(),
+                &(),
+                vec![],
+            )],
             Some(&mint_keypair.pubkey()),
             &[&mint_keypair],
             bank.last_blockhash(),
@@ -11544,7 +11555,7 @@ pub(crate) mod tests {
                     0,
                     &native_loader::id(),
                 ),
-                Instruction::new(
+                Instruction::new_with_bincode(
                     native_loader::id(),
                     &(),
                     vec![AccountMeta::new(to_keypair.pubkey(), false)],
@@ -11571,7 +11582,7 @@ pub(crate) mod tests {
                     100,
                     &native_loader::id(),
                 ),
-                Instruction::new(
+                Instruction::new_with_bincode(
                     native_loader::id(),
                     &(),
                     vec![AccountMeta::new(to_keypair.pubkey(), false)],

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -199,5 +199,5 @@ pub fn create_invoke_instruction<T: Serialize>(
     data: &T,
 ) -> Instruction {
     let account_metas = vec![AccountMeta::new(from_pubkey, true)];
-    Instruction::new(program_id, data, account_metas)
+    Instruction::new_with_bincode(program_id, data, account_metas)
 }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1170,7 +1170,11 @@ mod tests {
                 AccountMeta::new(keys[owned_index], false),
             ];
             let message = Message::new(
-                &[Instruction::new(program_ids[owned_index], &[0_u8], metas)],
+                &[Instruction::new_with_bytes(
+                    program_ids[owned_index],
+                    &[0],
+                    metas,
+                )],
                 None,
             );
 
@@ -1701,7 +1705,7 @@ mod tests {
             AccountMeta::new_readonly(to_pubkey, false),
         ];
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 mock_system_program_id,
                 &MockSystemInstruction::Correct,
                 account_metas.clone(),
@@ -1727,7 +1731,7 @@ mod tests {
         assert_eq!(accounts[1].borrow().lamports, 0);
 
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 mock_system_program_id,
                 &MockSystemInstruction::AttemptCredit { lamports: 50 },
                 account_metas.clone(),
@@ -1757,7 +1761,7 @@ mod tests {
         );
 
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 mock_system_program_id,
                 &MockSystemInstruction::AttemptDataChange { data: 50 },
                 account_metas,
@@ -1872,7 +1876,7 @@ mod tests {
 
         // Try to borrow mut the same account
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 mock_program_id,
                 &MockSystemInstruction::BorrowFail,
                 account_metas.clone(),
@@ -1902,7 +1906,7 @@ mod tests {
 
         // Try to borrow mut the same account in a safe way
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 mock_program_id,
                 &MockSystemInstruction::MultiBorrowMut,
                 account_metas.clone(),
@@ -1926,7 +1930,7 @@ mod tests {
 
         // Do work on the same account but at different location in keyed_accounts[]
         let message = Message::new(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 mock_program_id,
                 &MockSystemInstruction::DoWork {
                     lamports: 10,
@@ -2041,7 +2045,7 @@ mod tests {
 
         // not owned account modified by the caller (before the invoke)
         accounts[0].borrow_mut().data[0] = 1;
-        let instruction = Instruction::new(
+        let instruction = Instruction::new_with_bincode(
             callee_program_id,
             &MockInstruction::NoopSuccess,
             metas.clone(),
@@ -2079,7 +2083,8 @@ mod tests {
         ];
 
         for case in cases {
-            let instruction = Instruction::new(callee_program_id, &case.0, metas.clone());
+            let instruction =
+                Instruction::new_with_bincode(callee_program_id, &case.0, metas.clone());
             let message = Message::new(&[instruction], None);
             let caller_privileges = message
                 .account_keys

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -1353,7 +1353,7 @@ mod tests {
             AccountMeta::new(alice_pubkey, false),
             AccountMeta::new(mallory_pubkey, true),
         ];
-        let malicious_instruction = Instruction::new(
+        let malicious_instruction = Instruction::new_with_bincode(
             system_program::id(),
             &SystemInstruction::Transfer { lamports: 10 },
             account_metas,

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -10,7 +10,7 @@ use test::Bencher;
 
 fn make_instructions() -> Vec<Instruction> {
     let meta = AccountMeta::new(pubkey::new_rand(), false);
-    let inst = Instruction::new(pubkey::new_rand(), &[0; 10], vec![meta; 4]);
+    let inst = Instruction::new_with_bincode(pubkey::new_rand(), &[0; 10], vec![meta; 4]);
     vec![inst; 4]
 }
 

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -99,7 +99,7 @@ pub fn create_buffer(
             UpgradeableLoaderState::buffer_len(program_len)? as u64,
             &id(),
         ),
-        Instruction::new(
+        Instruction::new_with_bincode(
             id(),
             &UpgradeableLoaderInstruction::InitializeBuffer,
             vec![
@@ -118,7 +118,7 @@ pub fn write(
     offset: u32,
     bytes: Vec<u8>,
 ) -> Instruction {
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &UpgradeableLoaderInstruction::Write { offset, bytes },
         vec![
@@ -148,7 +148,7 @@ pub fn deploy_with_max_program_len(
             UpgradeableLoaderState::program_len()? as u64,
             &id(),
         ),
-        Instruction::new(
+        Instruction::new_with_bincode(
             id(),
             &UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len },
             vec![
@@ -173,7 +173,7 @@ pub fn upgrade(
     spill_address: &Pubkey,
 ) -> Instruction {
     let (programdata_address, _) = Pubkey::find_program_address(&[program_address.as_ref()], &id());
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &UpgradeableLoaderInstruction::Upgrade,
         vec![
@@ -198,7 +198,7 @@ pub fn set_buffer_authority(
     current_authority_address: &Pubkey,
     new_authority_address: &Pubkey,
 ) -> Instruction {
-    Instruction::new(
+    Instruction::new_with_bincode(
         id(),
         &UpgradeableLoaderInstruction::SetAuthority,
         vec![
@@ -224,7 +224,7 @@ pub fn set_upgrade_authority(
     if let Some(address) = new_authority_address {
         metas.push(AccountMeta::new_readonly(*address, false));
     }
-    Instruction::new(id(), &UpgradeableLoaderInstruction::SetAuthority, metas)
+    Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::SetAuthority, metas)
 }
 
 #[cfg(test)]

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -211,6 +211,10 @@ pub struct Instruction {
 }
 
 impl Instruction {
+    #[deprecated(
+        since = "1.6.0",
+        note = "Please use another `Instruction constructor instead"
+    )]
     pub fn new<T: Serialize>(program_id: Pubkey, data: &T, accounts: Vec<AccountMeta>) -> Self {
         Self::new_with_bincode(program_id, data, accounts)
     }

--- a/sdk/program/src/loader_instruction.rs
+++ b/sdk/program/src/loader_instruction.rs
@@ -37,7 +37,7 @@ pub fn write(
     bytes: Vec<u8>,
 ) -> Instruction {
     let account_metas = vec![AccountMeta::new(*account_pubkey, true)];
-    Instruction::new(
+    Instruction::new_with_bincode(
         *program_id,
         &LoaderInstruction::Write { offset, bytes },
         account_metas,
@@ -49,5 +49,5 @@ pub fn finalize(account_pubkey: &Pubkey, program_id: &Pubkey) -> Instruction {
         AccountMeta::new(*account_pubkey, true),
         AccountMeta::new_readonly(rent::id(), false),
     ];
-    Instruction::new(*program_id, &LoaderInstruction::Finalize, account_metas)
+    Instruction::new_with_bincode(*program_id, &LoaderInstruction::Finalize, account_metas)
 }

--- a/sdk/program/src/log.rs
+++ b/sdk/program/src/log.rs
@@ -3,7 +3,7 @@
 use crate::account_info::AccountInfo;
 
 #[macro_export]
-#[deprecated(since = "1.4.14", note = "use `msg` macro instead")]
+#[deprecated(since = "1.4.14", note = "Please use `msg` macro instead")]
 macro_rules! info {
     ($msg:expr) => {
         $crate::log::sol_log($msg)

--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -446,8 +446,8 @@ mod tests {
     fn test_message_unique_program_ids() {
         let program_id0 = Pubkey::default();
         let program_ids = get_program_ids(&[
-            Instruction::new(program_id0, &0, vec![]),
-            Instruction::new(program_id0, &0, vec![]),
+            Instruction::new_with_bincode(program_id0, &0, vec![]),
+            Instruction::new_with_bincode(program_id0, &0, vec![]),
         ]);
         assert_eq!(program_ids, vec![program_id0]);
     }
@@ -457,9 +457,9 @@ mod tests {
         let program_id0 = Pubkey::default();
         let program_id1 = Pubkey::new_unique();
         let program_ids = get_program_ids(&[
-            Instruction::new(program_id0, &0, vec![]),
-            Instruction::new(program_id1, &0, vec![]),
-            Instruction::new(program_id0, &0, vec![]),
+            Instruction::new_with_bincode(program_id0, &0, vec![]),
+            Instruction::new_with_bincode(program_id1, &0, vec![]),
+            Instruction::new_with_bincode(program_id0, &0, vec![]),
         ]);
         assert_eq!(program_ids, vec![program_id0, program_id1]);
     }
@@ -469,9 +469,9 @@ mod tests {
         let program_id0 = Pubkey::new_unique();
         let program_id1 = Pubkey::default(); // Key less than program_id0
         let program_ids = get_program_ids(&[
-            Instruction::new(program_id0, &0, vec![]),
-            Instruction::new(program_id1, &0, vec![]),
-            Instruction::new(program_id0, &0, vec![]),
+            Instruction::new_with_bincode(program_id0, &0, vec![]),
+            Instruction::new_with_bincode(program_id1, &0, vec![]),
+            Instruction::new_with_bincode(program_id0, &0, vec![]),
         ]);
         assert_eq!(program_ids, vec![program_id0, program_id1]);
     }
@@ -482,8 +482,8 @@ mod tests {
         let id0 = Pubkey::default();
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]),
             ],
             None,
         );
@@ -495,7 +495,7 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let keys = get_keys(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 program_id,
                 &0,
                 vec![AccountMeta::new(id0, true)],
@@ -510,7 +510,7 @@ mod tests {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
         let keys = get_keys(
-            &[Instruction::new(
+            &[Instruction::new_with_bincode(
                 program_id,
                 &0,
                 vec![AccountMeta::new(id0, false)],
@@ -526,8 +526,8 @@ mod tests {
         let id0 = Pubkey::default();
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, false)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]),
             ],
             None,
         );
@@ -540,8 +540,12 @@ mod tests {
         let id0 = Pubkey::default();
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id0, true)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]),
+                Instruction::new_with_bincode(
+                    program_id,
+                    &0,
+                    vec![AccountMeta::new_readonly(id0, true)],
+                ),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]),
             ],
             None,
         );
@@ -556,8 +560,12 @@ mod tests {
         let id0 = Pubkey::default();
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id0, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
+                Instruction::new_with_bincode(
+                    program_id,
+                    &0,
+                    vec![AccountMeta::new_readonly(id0, false)],
+                ),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, false)]),
             ],
             None,
         );
@@ -573,8 +581,8 @@ mod tests {
         let id1 = Pubkey::default(); // Key less than id0
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id1, false)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, false)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id1, false)]),
             ],
             None,
         );
@@ -588,9 +596,9 @@ mod tests {
         let id1 = Pubkey::new_unique();
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id1, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, false)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id1, false)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]),
             ],
             None,
         );
@@ -604,8 +612,8 @@ mod tests {
         let id1 = Pubkey::new_unique();
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id1, true)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, false)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id1, true)]),
             ],
             None,
         );
@@ -617,11 +625,11 @@ mod tests {
     fn test_message_signed_keys_len() {
         let program_id = Pubkey::default();
         let id0 = Pubkey::default();
-        let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]);
+        let ix = Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, false)]);
         let message = Message::new(&[ix], None);
         assert_eq!(message.header.num_required_signatures, 0);
 
-        let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
+        let ix = Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]);
         let message = Message::new(&[ix], Some(&id0));
         assert_eq!(message.header.num_required_signatures, 1);
     }
@@ -635,10 +643,18 @@ mod tests {
         let id3 = Pubkey::new_unique();
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id0, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id1, true)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id2, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id3, true)]),
+                Instruction::new_with_bincode(
+                    program_id,
+                    &0,
+                    vec![AccountMeta::new_readonly(id0, false)],
+                ),
+                Instruction::new_with_bincode(
+                    program_id,
+                    &0,
+                    vec![AccountMeta::new_readonly(id1, true)],
+                ),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id2, false)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id3, true)]),
             ],
             None,
         );
@@ -656,9 +672,9 @@ mod tests {
         let id1 = Pubkey::new_unique();
         let message = Message::new(
             &[
-                Instruction::new(program_id0, &0, vec![AccountMeta::new(id0, false)]),
-                Instruction::new(program_id1, &0, vec![AccountMeta::new(id1, true)]),
-                Instruction::new(program_id0, &0, vec![AccountMeta::new(id1, false)]),
+                Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id0, false)]),
+                Instruction::new_with_bincode(program_id1, &0, vec![AccountMeta::new(id1, true)]),
+                Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id1, false)]),
             ],
             Some(&id1),
         );
@@ -682,15 +698,15 @@ mod tests {
         let payer = Pubkey::new_unique();
         let id0 = Pubkey::default();
 
-        let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]);
+        let ix = Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, false)]);
         let message = Message::new(&[ix], Some(&payer));
         assert_eq!(message.header.num_required_signatures, 1);
 
-        let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
+        let ix = Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]);
         let message = Message::new(&[ix], Some(&payer));
         assert_eq!(message.header.num_required_signatures, 2);
 
-        let ix = Instruction::new(
+        let ix = Instruction::new_with_bincode(
             program_id,
             &0,
             vec![AccountMeta::new(payer, true), AccountMeta::new(id0, true)],
@@ -706,8 +722,16 @@ mod tests {
         let id1 = Pubkey::new_unique();
         let keys = get_keys(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id0, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id1, true)]),
+                Instruction::new_with_bincode(
+                    program_id,
+                    &0,
+                    vec![AccountMeta::new_readonly(id0, false)],
+                ),
+                Instruction::new_with_bincode(
+                    program_id,
+                    &0,
+                    vec![AccountMeta::new_readonly(id1, true)],
+                ),
             ],
             None,
         );
@@ -724,8 +748,8 @@ mod tests {
         let id = Pubkey::new_unique();
         let message = Message::new(
             &[
-                Instruction::new(program_id0, &0, vec![AccountMeta::new(id, false)]),
-                Instruction::new(program_id1, &0, vec![AccountMeta::new(id, true)]),
+                Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id, false)]),
+                Instruction::new_with_bincode(program_id1, &0, vec![AccountMeta::new(id, true)]),
             ],
             Some(&id),
         );
@@ -770,10 +794,18 @@ mod tests {
         let id3 = Pubkey::new_unique();
         let message = Message::new(
             &[
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id0, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new(id1, true)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id2, false)]),
-                Instruction::new(program_id, &0, vec![AccountMeta::new_readonly(id3, true)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, false)]),
+                Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id1, true)]),
+                Instruction::new_with_bincode(
+                    program_id,
+                    &0,
+                    vec![AccountMeta::new_readonly(id2, false)],
+                ),
+                Instruction::new_with_bincode(
+                    program_id,
+                    &0,
+                    vec![AccountMeta::new_readonly(id3, true)],
+                ),
             ],
             Some(&id1),
         );
@@ -793,10 +825,18 @@ mod tests {
         let id2 = Pubkey::new_unique();
         let id3 = Pubkey::new_unique();
         let instructions = vec![
-            Instruction::new(program_id0, &0, vec![AccountMeta::new(id0, false)]),
-            Instruction::new(program_id0, &0, vec![AccountMeta::new(id1, true)]),
-            Instruction::new(program_id1, &0, vec![AccountMeta::new_readonly(id2, false)]),
-            Instruction::new(program_id1, &0, vec![AccountMeta::new_readonly(id3, true)]),
+            Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id0, false)]),
+            Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id1, true)]),
+            Instruction::new_with_bincode(
+                program_id1,
+                &0,
+                vec![AccountMeta::new_readonly(id2, false)],
+            ),
+            Instruction::new_with_bincode(
+                program_id1,
+                &0,
+                vec![AccountMeta::new_readonly(id3, true)],
+            ),
         ];
 
         let message = Message::new(&instructions, Some(&id1));

--- a/sdk/program/src/system_instruction.rs
+++ b/sdk/program/src/system_instruction.rs
@@ -230,7 +230,7 @@ pub fn create_account(
         AccountMeta::new(*from_pubkey, true),
         AccountMeta::new(*to_pubkey, true),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::CreateAccount {
             lamports,
@@ -258,7 +258,7 @@ pub fn create_account_with_seed(
         AccountMeta::new_readonly(*base, true),
     ];
 
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::CreateAccountWithSeed {
             base: *base,
@@ -273,7 +273,7 @@ pub fn create_account_with_seed(
 
 pub fn assign(pubkey: &Pubkey, owner: &Pubkey) -> Instruction {
     let account_metas = vec![AccountMeta::new(*pubkey, true)];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::Assign { owner: *owner },
         account_metas,
@@ -290,7 +290,7 @@ pub fn assign_with_seed(
         AccountMeta::new(*address, false),
         AccountMeta::new_readonly(*base, true),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::AssignWithSeed {
             base: *base,
@@ -306,7 +306,7 @@ pub fn transfer(from_pubkey: &Pubkey, to_pubkey: &Pubkey, lamports: u64) -> Inst
         AccountMeta::new(*from_pubkey, true),
         AccountMeta::new(*to_pubkey, false),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::Transfer { lamports },
         account_metas,
@@ -326,7 +326,7 @@ pub fn transfer_with_seed(
         AccountMeta::new_readonly(*from_base, true),
         AccountMeta::new(*to_pubkey, false),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::TransferWithSeed {
             lamports,
@@ -339,7 +339,7 @@ pub fn transfer_with_seed(
 
 pub fn allocate(pubkey: &Pubkey, space: u64) -> Instruction {
     let account_metas = vec![AccountMeta::new(*pubkey, true)];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::Allocate { space },
         account_metas,
@@ -357,7 +357,7 @@ pub fn allocate_with_seed(
         AccountMeta::new(*address, false),
         AccountMeta::new_readonly(*base, true),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::AllocateWithSeed {
             base: *base,
@@ -395,7 +395,7 @@ pub fn create_nonce_account_with_seed(
             nonce::State::size() as u64,
             &system_program::id(),
         ),
-        Instruction::new(
+        Instruction::new_with_bincode(
             system_program::id(),
             &SystemInstruction::InitializeNonceAccount(*authority),
             vec![
@@ -421,7 +421,7 @@ pub fn create_nonce_account(
             nonce::State::size() as u64,
             &system_program::id(),
         ),
-        Instruction::new(
+        Instruction::new_with_bincode(
             system_program::id(),
             &SystemInstruction::InitializeNonceAccount(*authority),
             vec![
@@ -439,7 +439,7 @@ pub fn advance_nonce_account(nonce_pubkey: &Pubkey, authorized_pubkey: &Pubkey) 
         AccountMeta::new_readonly(recent_blockhashes::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::AdvanceNonceAccount,
         account_metas,
@@ -459,7 +459,7 @@ pub fn withdraw_nonce_account(
         AccountMeta::new_readonly(rent::id(), false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::WithdrawNonceAccount(lamports),
         account_metas,
@@ -475,7 +475,7 @@ pub fn authorize_nonce_account(
         AccountMeta::new(*nonce_pubkey, false),
         AccountMeta::new_readonly(*authorized_pubkey, true),
     ];
-    Instruction::new(
+    Instruction::new_with_bincode(
         system_program::id(),
         &SystemInstruction::AuthorizeNonceAccount(*new_authority),
         account_metas,

--- a/sdk/src/log.rs
+++ b/sdk/src/log.rs
@@ -3,7 +3,10 @@
 pub use solana_program::log::*;
 
 #[macro_export]
-#[deprecated(since = "1.4.3", note = "solana_program::log::info instead")]
+#[deprecated(
+    since = "1.4.3",
+    note = "Please use `solana_program::log::info` instead"
+)]
 macro_rules! info {
     ($msg:expr) => {
         $crate::log::sol_log($msg)

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -519,7 +519,7 @@ mod tests {
         let key = Keypair::new();
         let id0 = Pubkey::default();
         let program_id = solana_sdk::pubkey::new_rand();
-        let ix = Instruction::new(
+        let ix = Instruction::new_with_bincode(
             program_id,
             &0,
             vec![
@@ -596,7 +596,8 @@ mod tests {
             AccountMeta::new(keypair.pubkey(), true),
             AccountMeta::new(to, false),
         ];
-        let instruction = Instruction::new(program_id, &(1u8, 2u8, 3u8), account_metas);
+        let instruction =
+            Instruction::new_with_bincode(program_id, &(1u8, 2u8, 3u8), account_metas);
         let message = Message::new(&[instruction], Some(&keypair.pubkey()));
         Transaction::new(&[&keypair], message, Hash::default())
     }
@@ -693,7 +694,7 @@ mod tests {
     fn test_partial_sign_mismatched_key() {
         let keypair = Keypair::new();
         let fee_payer = solana_sdk::pubkey::new_rand();
-        let ix = Instruction::new(
+        let ix = Instruction::new_with_bincode(
             Pubkey::default(),
             &0,
             vec![AccountMeta::new(fee_payer, true)],
@@ -707,7 +708,7 @@ mod tests {
         let keypair0 = Keypair::new();
         let keypair1 = Keypair::new();
         let keypair2 = Keypair::new();
-        let ix = Instruction::new(
+        let ix = Instruction::new_with_bincode(
             Pubkey::default(),
             &0,
             vec![
@@ -737,7 +738,7 @@ mod tests {
         let program_id = Pubkey::default();
         let keypair0 = Keypair::new();
         let id0 = keypair0.pubkey();
-        let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
+        let ix = Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]);
         let message = Message::new(&[ix], Some(&id0));
         Transaction::new_unsigned(message).sign(&Vec::<&Keypair>::new(), Hash::default());
     }
@@ -748,7 +749,8 @@ mod tests {
         let program_id = Pubkey::default();
         let keypair0 = Keypair::new();
         let wrong_id = Pubkey::default();
-        let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(wrong_id, true)]);
+        let ix =
+            Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(wrong_id, true)]);
         let message = Message::new(&[ix], Some(&wrong_id));
         Transaction::new_unsigned(message).sign(&[&keypair0], Hash::default());
     }
@@ -758,7 +760,7 @@ mod tests {
         let program_id = Pubkey::default();
         let keypair0 = Keypair::new();
         let id0 = keypair0.pubkey();
-        let ix = Instruction::new(program_id, &0, vec![AccountMeta::new(id0, true)]);
+        let ix = Instruction::new_with_bincode(program_id, &0, vec![AccountMeta::new(id0, true)]);
         let message = Message::new(&[ix], Some(&id0));
         let mut tx = Transaction::new_unsigned(message);
         tx.sign(&[&keypair0], Hash::default());
@@ -775,7 +777,7 @@ mod tests {
         let keypair0 = Keypair::new();
         let id0 = keypair0.pubkey();
         let id1 = solana_sdk::pubkey::new_rand();
-        let ix = Instruction::new(
+        let ix = Instruction::new_with_bincode(
             program_id,
             &0,
             vec![
@@ -803,7 +805,7 @@ mod tests {
         let presigner_keypair = Keypair::new();
         let presigner_pubkey = presigner_keypair.pubkey();
 
-        let ix = Instruction::new(
+        let ix = Instruction::new_with_bincode(
             program_id,
             &0,
             vec![
@@ -826,7 +828,7 @@ mod tests {
 
         // Wrong key should error, not panic
         let another_pubkey = solana_sdk::pubkey::new_rand();
-        let ix = Instruction::new(
+        let ix = Instruction::new_with_bincode(
             program_id,
             &0,
             vec![


### PR DESCRIPTION
#### Problem

`Instruction::new` has a hidden dependency on bincode.  

#### Summary of Changes

Now that there are new constructors that are explicitly about how they treat the account data deprecate `Instruction::new`

This is a follow up to: https://github.com/solana-labs/solana/pull/15686

Fixes #
