### PR TITLE
Add BPf loader finalize test via inner instruction

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2709,6 +2709,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-finalize"
+version = "1.6.0"
+dependencies = [
+ "solana-program 1.6.0",
+]
+
+[[package]]
 name = "solana-bpf-rust-instruction-introspection"
 version = "1.6.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "rust/dup_accounts",
     "rust/error_handling",
     "rust/external_spend",
+    "rust/finalize",
     "rust/instruction_introspection",
     "rust/invoke",
     "rust/invoke_and_error",

--- a/programs/bpf/benches/bpf_loader.rs
+++ b/programs/bpf/benches/bpf_loader.rs
@@ -175,7 +175,8 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
     let mint_pubkey = mint_keypair.pubkey();
     let account_metas = vec![AccountMeta::new(mint_pubkey, true)];
 
-    let instruction = Instruction::new_with_bincode(invoke_program_id, &[u8::MAX, 0, 0, 0], account_metas);
+    let instruction =
+        Instruction::new_with_bincode(invoke_program_id, &[u8::MAX, 0, 0, 0], account_metas);
     let message = Message::new(&[instruction], Some(&mint_pubkey));
 
     bank_client

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -68,6 +68,7 @@ fn main() {
             "dup_accounts",
             "error_handling",
             "external_spend",
+            "finalize",
             "instruction_introspection",
             "invoke",
             "invoke_and_error",

--- a/programs/bpf/rust/finalize/Cargo.toml
+++ b/programs/bpf/rust/finalize/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "solana-bpf-rust-finalize"
+version = "1.6.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+edition = "2018"
+
+[dependencies]
+solana-program = { path = "../../../../sdk/program", version = "1.6.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/finalize/Xargo.toml
+++ b/programs/bpf/rust/finalize/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/programs/bpf/rust/finalize/src/lib.rs
+++ b/programs/bpf/rust/finalize/src/lib.rs
@@ -1,0 +1,25 @@
+//! @brief Example Rust-based BPF sanity program that finalizes a BPF program
+
+#![allow(unreachable_code)]
+
+extern crate solana_program;
+use solana_program::{
+    account_info::AccountInfo, bpf_loader, entrypoint, entrypoint::ProgramResult,
+    loader_instruction, msg, program::invoke, pubkey::Pubkey,
+};
+
+entrypoint!(process_instruction);
+fn process_instruction(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    msg!("Finalize a program");
+    invoke(
+        &loader_instruction::finalize(&accounts[0].key.clone(), &bpf_loader::id()),
+        accounts,
+    )?;
+    msg!("check executable");
+    assert!(accounts[0].executable);
+    Ok(())
+}


### PR DESCRIPTION
#### Problem


#### Summary of Changes

Add a test to verify that inner instructions cannot finalize a program, can flip later if that capability is enabled

Fixes #
