### PR TITLE
Use OrderedIterator to produce TransactionLogInfo

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -12241,4 +12241,79 @@ pub(crate) mod tests {
             genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
         );
     }
+
+    #[test]
+    fn test_tx_log_order() {
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(
+            1_000_000_000_000_000,
+            &Pubkey::new_unique(),
+            bootstrap_validator_stake_lamports(),
+        );
+        let bank = Arc::new(Bank::new(&genesis_config));
+        *bank.transaction_log_collector_config.write().unwrap() = TransactionLogCollectorConfig {
+            mentioned_addresses: HashSet::new(),
+            filter: TransactionLogCollectorFilter::All,
+        };
+        let blockhash = bank.last_blockhash();
+
+        let sender0 = Keypair::new();
+        let sender1 = Keypair::new();
+        bank.transfer(100, &mint_keypair, &sender0.pubkey())
+            .unwrap();
+        bank.transfer(100, &mint_keypair, &sender1.pubkey())
+            .unwrap();
+
+        let recipient0 = Pubkey::new_unique();
+        let recipient1 = Pubkey::new_unique();
+        let tx0 = system_transaction::transfer(&sender0, &recipient0, 10, blockhash);
+        let success_sig = tx0.signatures[0];
+        let tx1 = system_transaction::transfer(&sender1, &recipient1, 110, blockhash); // Should produce insufficient funds log
+        let failure_sig = tx1.signatures[0];
+        let txs = vec![tx0, tx1];
+
+        // Use non-sequential batch ordering
+        let batch = bank.prepare_batch(&txs, Some(vec![1, 0]));
+
+        let log_results = bank
+            .load_execute_and_commit_transactions(
+                &batch,
+                MAX_PROCESSING_AGE,
+                false,
+                false,
+                true,
+                &mut ExecuteTimings::default(),
+            )
+            .3;
+        assert_eq!(log_results.len(), 2);
+        assert!(log_results[0]
+            .clone()
+            .pop()
+            .unwrap()
+            .contains(&"failed".to_string()));
+        assert!(log_results[1]
+            .clone()
+            .pop()
+            .unwrap()
+            .contains(&"success".to_string()));
+
+        let stored_logs = &bank.transaction_log_collector.read().unwrap().logs;
+        let success_log_info = stored_logs
+            .iter()
+            .find(|transaction_log_info| transaction_log_info.signature == success_sig)
+            .unwrap();
+        assert!(success_log_info.result.is_ok());
+        let success_log = success_log_info.log_messages.clone().pop().unwrap();
+        assert!(success_log.contains(&"success".to_string()));
+        let failure_log_info = stored_logs
+            .iter()
+            .find(|transaction_log_info| transaction_log_info.signature == failure_sig)
+            .unwrap();
+        assert!(failure_log_info.result.is_err());
+        let failure_log = failure_log_info.log_messages.clone().pop().unwrap();
+        assert!(failure_log.contains(&"failed".to_string()));
+    }
 }


### PR DESCRIPTION
#### Problem
The solana runtime randomizes the order that transactions within an entry are processed (#4978). However, transaction-log handling uses a straight transaction Iterator to prepare TransactionLogInfos for storage:
https://github.com/solana-labs/solana/blob/99f0d29dd17a2726c881abb9e387e189da66f128/runtime/src/bank.rs#L2991
If a batch contains multiple transactions, they could be paired with incorrect results and logs to populate `Bank::transaction_log_collector.logs`.

Incidentally, this doesn't affect the logs that are stored in Blockstore by the TransactionStatusService, as the log_results vec is generated within an OrderedIterator: https://github.com/solana-labs/solana/blob/99f0d29dd17a2726c881abb9e387e189da66f128/runtime/src/bank.rs#L2941

So it is only evidenced in Log subscriptions at the moment.

#### Summary of Changes
- Use OrderedIterator for TransactionLog handling in `Bank::load_and_execute_transactions()`

Fixes #15698
