### PR TITLE
Cleanup cpi to message_processor interface

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1021,6 +1021,8 @@ fn test_program_bpf_invoke_sanity() {
 #[cfg(feature = "bpf_rust")]
 #[test]
 fn test_program_bpf_program_id_spoofing() {
+    solana_logger::setup();
+
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,
@@ -1074,6 +1076,8 @@ fn test_program_bpf_program_id_spoofing() {
 #[cfg(feature = "bpf_rust")]
 #[test]
 fn test_program_bpf_caller_has_access_to_cpi_program() {
+    solana_logger::setup();
+
     let GenesisConfigInfo {
         genesis_config,
         mint_keypair,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -438,7 +438,7 @@ fn process_loader_upgradeable_instruction(
                     programdata_len as u64,
                     program_id,
                 ),
-                &[payer, programdata, system],
+                &[payer.clone(), programdata.clone(), system.clone()],
                 &[&[program.unsigned_key().as_ref(), &[bump_seed]]],
             )?;
 

--- a/runtime/benches/message_processor.rs
+++ b/runtime/benches/message_processor.rs
@@ -16,13 +16,12 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     let pre = PreAccount::new(
         &pubkey::new_rand(),
         &Account::new(0, BUFSIZE, &owner),
-        false,
     );
     let post = Account::new(0, BUFSIZE, &owner);
     assert_eq!(
         pre.verify(
             &owner,
-            Some(false),
+            false,
             &Rent::default(),
             &post,
             &mut ExecuteDetailsTimings::default()
@@ -34,7 +33,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     bencher.iter(|| {
         pre.verify(
             &owner,
-            Some(false),
+            false,
             &Rent::default(),
             &post,
             &mut ExecuteDetailsTimings::default(),
@@ -53,12 +52,11 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     let pre = PreAccount::new(
         &pubkey::new_rand(),
         &Account::new(0, BUFSIZE, &owner),
-        false,
     );
     bencher.iter(|| {
         pre.verify(
             &non_owner,
-            Some(false),
+            false,
             &Rent::default(),
             &post,
             &mut ExecuteDetailsTimings::default(),

--- a/runtime/benches/message_processor.rs
+++ b/runtime/benches/message_processor.rs
@@ -13,10 +13,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
 
     let owner = pubkey::new_rand();
     let non_owner = pubkey::new_rand();
-    let pre = PreAccount::new(
-        &pubkey::new_rand(),
-        &Account::new(0, BUFSIZE, &owner),
-    );
+    let pre = PreAccount::new(&pubkey::new_rand(), &Account::new(0, BUFSIZE, &owner));
     let post = Account::new(0, BUFSIZE, &owner);
     assert_eq!(
         pre.verify(
@@ -49,10 +46,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
     let summary = bencher.bench(|_bencher| {}).unwrap();
     info!("data compare {} ns/iter", summary.median);
 
-    let pre = PreAccount::new(
-        &pubkey::new_rand(),
-        &Account::new(0, BUFSIZE, &owner),
-    );
+    let pre = PreAccount::new(&pubkey::new_rand(), &Account::new(0, BUFSIZE, &owner));
     bencher.iter(|| {
         pre.verify(
             &non_owner,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -87,16 +87,8 @@ pub mod stake_program_v3 {
     solana_sdk::declare_id!("Ego6nTu7WsBcZBvVqJQKp6Yku2N3mrfG8oYCfaLZkAeK");
 }
 
-pub mod use_loaded_executables {
-    solana_sdk::declare_id!("3Jq7mE2chDpf6oeEDsuGK7orTYEgyQjCPvaRppTNdVGK");
-}
-
 pub mod turbine_retransmit_peers_patch {
     solana_sdk::declare_id!("5Lu3JnWSFwRYpXzwDMkanWSk6XqSuF2i5fpnVhzB5CTc");
-}
-
-pub mod track_writable_deescalation {
-    solana_sdk::declare_id!("HVPSxqskEtRLRT2ZeEMmkmt9FWqoFX4vrN6f5VaadLED");
 }
 
 pub mod require_custodian_for_locked_stake_authorize {
@@ -147,9 +139,7 @@ lazy_static! {
         (simple_capitalization::id(), "simple capitalization"),
         (bpf_loader_upgradeable_program::id(), "upgradeable bpf loader"),
         (stake_program_v3::id(), "solana_stake_program v3"),
-        (use_loaded_executables::id(), "use loaded executable accounts"),
         (turbine_retransmit_peers_patch::id(), "turbine retransmit peers patch #14631"),
-        (track_writable_deescalation::id(), "track account writable deescalation"),
         (require_custodian_for_locked_stake_authorize::id(), "require custodian to authorize withdrawer change for locked stake"),
         (spl_token_v2_self_transfer_fix::id(), "spl-token self-transfer fix"),
         (matching_buffer_upgrade_authorities::id(), "Upgradeable buffer and program authorities must match"),

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct KeyedAccount<'a> {
     is_signer: bool, // Transaction was signed by this account's key
     is_writable: bool,

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -1,8 +1,7 @@
 use solana_sdk::{
     account::Account,
-    instruction::{CompiledInstruction, Instruction, InstructionError},
+    instruction::{Instruction, InstructionError},
     keyed_account::KeyedAccount,
-    message::Message,
     pubkey::Pubkey,
 };
 use std::{cell::RefCell, fmt::Debug, rc::Rc, sync::Arc};
@@ -34,10 +33,8 @@ pub trait InvokeContext {
     /// Verify and update PreAccount state based on program execution
     fn verify_and_update(
         &mut self,
-        message: &Message,
-        instruction: &CompiledInstruction,
-        accounts: &[Rc<RefCell<Account>>],
-        caller_pivileges: Option<&[bool]>,
+        instruction: &Instruction,
+        keyed_accounts: &[KeyedAccount],
     ) -> Result<(), InstructionError>;
     /// Get the program ID of the currently executing program
     fn get_caller(&self) -> Result<&Pubkey, InstructionError>;
@@ -303,10 +300,8 @@ impl InvokeContext for MockInvokeContext {
     }
     fn verify_and_update(
         &mut self,
-        _message: &Message,
-        _instruction: &CompiledInstruction,
-        _accounts: &[Rc<RefCell<Account>>],
-        _caller_pivileges: Option<&[bool]>,
+        _instruction: &Instruction,
+        _keyed_accounts: &[KeyedAccount],
     ) -> Result<(), InstructionError> {
         Ok(())
     }


### PR DESCRIPTION
#### Problem

The MessageProcessor interface for cross-program invocation takes a `Message` even though callers have an `Instruction`.  Callers must then manufacture a `Message`. 

#### Summary of Changes

- Simplify the interface by passing KeyedAccounts instead that carry the caller and callee's signer/write privileges.  This work is also cleanup work in prep for mapping KeyedAccount's to programs.

Fixes #
