### PR TITLE
Wallclock BankingStage Throttle

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -81,6 +81,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         bencher.iter(move || {
             let _ignored = BankingStage::consume_buffered_packets(
                 &my_pubkey,
+                None,
                 &poh_recorder,
                 &mut packets,
                 None,
@@ -154,6 +155,9 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
 
     let (verified_sender, verified_receiver) = unbounded();
     let (vote_sender, vote_receiver) = unbounded();
+    let mut bank = Bank::new(&genesis_config);
+    // Allow arbitrary transaction processing time for the purposes of this bench
+    bank.max_tx_ingestion_time = None;
     let bank = Arc::new(Bank::new(&genesis_config));
 
     debug!("threads: {} txs: {}", num_threads, txes);

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -81,7 +81,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         bencher.iter(move || {
             let _ignored = BankingStage::consume_buffered_packets(
                 &my_pubkey,
-                None,
+                std::u128::MAX,
                 &poh_recorder,
                 &mut packets,
                 None,
@@ -157,7 +157,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
     let (vote_sender, vote_receiver) = unbounded();
     let mut bank = Bank::new(&genesis_config);
     // Allow arbitrary transaction processing time for the purposes of this bench
-    bank.max_tx_ingestion_time = None;
+    bank.ns_per_slot = std::u128::MAX;
     let bank = Arc::new(Bank::new(&genesis_config));
 
     debug!("threads: {} txs: {}", num_threads, txes);

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -98,7 +98,14 @@ impl PohRecorder {
             self.grace_ticks = grace_ticks;
             self.leader_first_tick_height = leader_first_tick_height;
             self.leader_last_tick_height = leader_last_tick_height;
+
+            datapoint_info!(
+                "leader-slot-start-to-cleared-elapsed-ms",
+                ("slot", bank.slot(), i64),
+                ("elapsed", working_bank.start.elapsed().as_millis(), i64),
+            );
         }
+
         if let Some(ref signal) = self.clear_bank_signal {
             let _ = signal.try_send(true);
         }

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -540,7 +540,7 @@ impl PohRecorder {
     // if it's still processing transactions
     pub fn get_bank_still_processing_txs(bank_start: &Option<BankStart>) -> Option<&Arc<Bank>> {
         bank_start.as_ref().and_then(|(bank, bank_creation_time)| {
-            if Bank::is_bank_still_processing_txs(bank_creation_time, bank.max_tx_ingestion_time) {
+            if Bank::should_bank_still_be_processing_txs(bank_creation_time, bank.ns_per_slot) {
                 Some(bank)
             } else {
                 None

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -661,8 +661,10 @@ mod tests {
                 &Arc::new(PohConfig::default()),
             );
 
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank,
+                start,
                 min_tick_height: 2,
                 max_tick_height: 3,
             };
@@ -695,8 +697,10 @@ mod tests {
                 &Arc::new(PohConfig::default()),
             );
 
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank: bank.clone(),
+                start,
                 min_tick_height: 2,
                 max_tick_height: 3,
             };
@@ -751,8 +755,10 @@ mod tests {
             assert_eq!(poh_recorder.tick_cache.last().unwrap().1, 4);
             assert_eq!(poh_recorder.tick_height, 4);
 
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank,
+                start,
                 min_tick_height: 2,
                 max_tick_height: 3,
             };
@@ -791,8 +797,10 @@ mod tests {
                 &Arc::new(PohConfig::default()),
             );
 
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank: bank.clone(),
+                start,
                 min_tick_height: 2,
                 max_tick_height: 3,
             };
@@ -827,8 +835,10 @@ mod tests {
                 &Arc::new(PohConfig::default()),
             );
 
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank: bank.clone(),
+                start,
                 min_tick_height: 1,
                 max_tick_height: 2,
             };
@@ -867,8 +877,10 @@ mod tests {
                 &Arc::new(PohConfig::default()),
             );
 
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank: bank.clone(),
+                start,
                 min_tick_height: 1,
                 max_tick_height: 2,
             };
@@ -911,8 +923,10 @@ mod tests {
                 &Arc::new(PohConfig::default()),
             );
 
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank: bank.clone(),
+                start,
                 min_tick_height: 1,
                 max_tick_height: 2,
             };
@@ -953,8 +967,10 @@ mod tests {
                 &Arc::new(PohConfig::default()),
             );
 
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank,
+                start,
                 min_tick_height: 2,
                 max_tick_height: 3,
             };
@@ -1075,8 +1091,10 @@ mod tests {
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
             );
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank,
+                start,
                 min_tick_height: 2,
                 max_tick_height: 3,
             };
@@ -1144,8 +1162,10 @@ mod tests {
 
             let end_slot = 3;
             let max_tick_height = (end_slot + 1) * ticks_per_slot;
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank: bank.clone(),
+                start,
                 min_tick_height: 1,
                 max_tick_height,
             };

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -208,8 +208,10 @@ mod tests {
             );
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
             let exit = Arc::new(AtomicBool::new(false));
+            let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank: bank.clone(),
+                start,
                 min_tick_height: bank.tick_height(),
                 max_tick_height: std::u64::MAX,
             };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -89,7 +89,8 @@ use std::{
         atomic::{AtomicBool, AtomicU64, Ordering::Relaxed},
         LockResult, RwLockWriteGuard, {Arc, RwLock, RwLockReadGuard},
     },
-    time::Duration,
+    time::{Duration, Instant},
+    sync::Mutex,
 };
 
 pub const SECONDS_PER_YEAR: f64 = 365.25 * 24.0 * 60.0 * 60.0;
@@ -880,6 +881,8 @@ pub struct Bank {
     pub drop_callback: RwLock<OptionalDropCallback>,
 
     pub freeze_started: AtomicBool,
+
+    pub process_transactions_start: Mutex<Option<Instant>>,
 }
 
 impl Default for BlockhashQueue {
@@ -1070,6 +1073,7 @@ impl Bank {
                     .map(|drop_callback| drop_callback.clone_box()),
             )),
             freeze_started: AtomicBool::new(false),
+            process_transactions_start: Mutex::new(None),
         };
 
         datapoint_info!(
@@ -1217,6 +1221,7 @@ impl Bank {
             feature_set: new(),
             drop_callback: RwLock::new(OptionalDropCallback(None)),
             freeze_started: AtomicBool::new(fields.hash != Hash::default()),
+            process_transactions_start: Mutex::new(None),
         };
         bank.finish_init(genesis_config, additional_builtins);
 
@@ -1322,6 +1327,18 @@ impl Bank {
 
     pub fn freeze_started(&self) -> bool {
         self.freeze_started.load(Relaxed)
+    }
+
+    pub fn process_transactions_elapsed(&self, should_start_if_first: bool) -> u64 {
+        let mut start = self.process_transactions_start.lock().unwrap();
+        if let Some(start) = *start {
+            start.elapsed().as_ms()
+        } else {
+            if should_start_if_first {
+                *start = Some(Instant::now());
+            }
+            0
+        }
     }
 
     pub fn status_cache_ancestors(&self) -> Vec<u64> {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -38,7 +38,7 @@ use solana_sdk::{
     clock::{
         Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, DEFAULT_TICKS_PER_SECOND,
         MAX_PROCESSING_AGE, MAX_RECENT_BLOCKHASHES, MAX_TRANSACTION_FORWARDING_DELAY,
-        SECONDS_PER_DAY,
+        SECONDS_PER_DAY, SLOT_MS,
     },
     epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
@@ -880,6 +880,8 @@ pub struct Bank {
     pub drop_callback: RwLock<OptionalDropCallback>,
 
     pub freeze_started: AtomicBool,
+
+    pub max_tx_ingestion_time: Option<u64>,
 }
 
 impl Default for BlockhashQueue {
@@ -1070,6 +1072,7 @@ impl Bank {
                     .map(|drop_callback| drop_callback.clone_box()),
             )),
             freeze_started: AtomicBool::new(false),
+            max_tx_ingestion_time: parent.max_tx_ingestion_time,
         };
 
         datapoint_info!(
@@ -1217,6 +1220,7 @@ impl Bank {
             feature_set: new(),
             drop_callback: RwLock::new(OptionalDropCallback(None)),
             freeze_started: AtomicBool::new(fields.hash != Hash::default()),
+            max_tx_ingestion_time: Some(SLOT_MS),
         };
         bank.finish_init(genesis_config, additional_builtins);
 

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -6,7 +6,7 @@ pub const DEFAULT_TICKS_PER_SECOND: u64 = 160;
 
 pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
 
-pub const SLOT_MS: u64 = (DEFAULT_TICKS_PER_SLOT * 1000) / DEFAULT_TICKS_PER_SLOT;
+pub const SLOT_MS: u64 = (DEFAULT_TICKS_PER_SLOT * 1000) / DEFAULT_TICKS_PER_SECOND;
 
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
 // every 400 ms. A fast voting cadence ensures faster finality and convergence

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -6,6 +6,8 @@ pub const DEFAULT_TICKS_PER_SECOND: u64 = 160;
 
 pub const MS_PER_TICK: u64 = 1000 / DEFAULT_TICKS_PER_SECOND;
 
+pub const SLOT_MS: u64 = (DEFAULT_TICKS_PER_SLOT * 1000) / DEFAULT_TICKS_PER_SLOT;
+
 // At 160 ticks/s, 64 ticks per slot implies that leader rotation and voting will happen
 // every 400 ms. A fast voting cadence ensures faster finality and convergence
 pub const DEFAULT_TICKS_PER_SLOT: u64 = 64;


### PR DESCRIPTION
#### Problem
PoH can drift behind the target wallclock duration, allowing BankingStage to process too many transactions in a slot.

#### Summary of Changes
Add wallclock throttle to BankingStage

Fixes #
