### PR TITLE
Add tracer key for tracing transaction path through the network

### DIFF
--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -31,33 +31,7 @@ impl Default for TransactionSigVerifier {
 
 impl SigVerifier for TransactionSigVerifier {
     fn verify_batch(&self, mut batch: Vec<Packets>) -> Vec<Packets> {
-        let r = sigverify::ed25519_verify(&mut batch, &self.recycler, &self.recycler_out);
-        mark_disabled(&mut batch, &r);
+        sigverify::ed25519_verify(&mut batch, &self.recycler, &self.recycler_out);
         batch
-    }
-}
-
-pub fn mark_disabled(batches: &mut Vec<Packets>, r: &[Vec<u8>]) {
-    batches.iter_mut().zip(r).for_each(|(b, v)| {
-        b.packets.iter_mut().zip(v).for_each(|(p, f)| {
-            p.meta.discard = *f == 0;
-        })
-    });
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use solana_perf::packet::Packet;
-
-    #[test]
-    fn test_mark_disabled() {
-        let mut batch = Packets::default();
-        batch.packets.push(Packet::default());
-        let mut batches: Vec<Packets> = vec![batch];
-        mark_disabled(&mut batches, &[vec![0]]);
-        assert_eq!(batches[0].packets[0].meta.discard, true);
-        mark_disabled(&mut batches, &[vec![1]]);
-        assert_eq!(batches[0].packets[0].meta.discard, false);
     }
 }

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -31,7 +31,7 @@ impl Default for TransactionSigVerifier {
 
 impl SigVerifier for TransactionSigVerifier {
     fn verify_batch(&self, mut batch: Vec<Packets>) -> Vec<Packets> {
-        let r = sigverify::ed25519_verify(&batch, &self.recycler, &self.recycler_out);
+        let r = sigverify::ed25519_verify(&mut batch, &self.recycler, &self.recycler_out);
         mark_disabled(&mut batch, &r);
         batch
     }
@@ -39,10 +39,9 @@ impl SigVerifier for TransactionSigVerifier {
 
 pub fn mark_disabled(batches: &mut Vec<Packets>, r: &[Vec<u8>]) {
     batches.iter_mut().zip(r).for_each(|(b, v)| {
-        b.packets
-            .iter_mut()
-            .zip(v)
-            .for_each(|(p, f)| p.meta.discard = *f == 0)
+        b.packets.iter_mut().zip(v).for_each(|(p, f)| {
+            p.meta.discard = *f == 0;
+        })
     });
 }
 

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -4,8 +4,11 @@ use crate::sigverify_stage::SigVerifier;
 use solana_ledger::leader_schedule_cache::LeaderScheduleCache;
 use solana_ledger::shred::{OFFSET_OF_SHRED_SLOT, SIZE_OF_SHRED_SLOT};
 use solana_ledger::sigverify_shreds::verify_shreds_gpu;
-use solana_perf::packet::{limited_deserialize, Packets};
-use solana_perf::recycler_cache::RecyclerCache;
+use solana_perf::{
+    self,
+    packet::{limited_deserialize, Packets},
+    recycler_cache::RecyclerCache,
+};
 use solana_runtime::bank_forks::BankForks;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -67,7 +70,7 @@ impl SigVerifier for ShredSigVerifier {
         leader_slots.insert(std::u64::MAX, [0u8; 32]);
 
         let r = verify_shreds_gpu(&batches, &leader_slots, &self.recycler_cache);
-        sigverify::mark_disabled(&mut batches, &r);
+        solana_perf::sigverify::mark_disabled(&mut batches, &r);
         batches
     }
 }

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -45,8 +45,7 @@ pub struct DisabledSigVerifier {}
 
 impl SigVerifier for DisabledSigVerifier {
     fn verify_batch(&self, mut batch: Vec<Packets>) -> Vec<Packets> {
-        let r = sigverify::ed25519_verify_disabled(&batch);
-        sigverify::mark_disabled(&mut batch, &r);
+        sigverify::ed25519_verify_disabled(&mut batch);
         batch
     }
 }

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -19,7 +19,7 @@ fn bench_sigverify(bencher: &mut Bencher) {
     let recycler_out = Recycler::new_without_limit("");
     // verify packets
     bencher.iter(|| {
-        let _ans = sigverify::ed25519_verify(&batches, &recycler, &recycler_out);
+        let _ans = sigverify::ed25519_verify(&mut batches, &recycler, &recycler_out);
     })
 }
 

--- a/perf/benches/sigverify.rs
+++ b/perf/benches/sigverify.rs
@@ -13,7 +13,7 @@ fn bench_sigverify(bencher: &mut Bencher) {
     let tx = test_tx();
 
     // generate packet vector
-    let batches = to_packets_chunked(&std::iter::repeat(tx).take(128).collect::<Vec<_>>(), 128);
+    let mut batches = to_packets_chunked(&std::iter::repeat(tx).take(128).collect::<Vec<_>>(), 128);
 
     let recycler = Recycler::new_without_limit("");
     let recycler_out = Recycler::new_without_limit("");

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -188,6 +188,14 @@ impl<'a, T: Clone + Send + Sync + Default + Sized> IntoParallelIterator for &'a 
     }
 }
 
+impl<'a, T: Clone + Send + Sync + Default + Sized> IntoParallelIterator for &'a mut PinnedVec<T> {
+    type Iter = rayon::slice::IterMut<'a, T>;
+    type Item = &'a mut T;
+    fn into_par_iter(self) -> Self::Iter {
+        self.x.par_iter_mut()
+    }
+}
+
 impl<T: Clone + Default + Send + Sized> IntoParallelIterator for PinnedVec<T> {
     type Item = T;
     type Iter = rayon::vec::IntoIter<T>;

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -18,7 +18,14 @@ use solana_sdk::short_vec::decode_len;
 use solana_sdk::signature::Signature;
 #[cfg(test)]
 use solana_sdk::transaction::Transaction;
-use std::{mem::size_of, str::FromStr};
+use std::mem::size_of;
+
+// Representing key tKeYE4wtowRb8yRroZShTipE18YVnqwXjsSAoNsFU6g
+const TRACER_KEY_BYTES: [u8; 32] = [
+    13, 37, 180, 170, 252, 137, 36, 194, 183, 143, 161, 193, 201, 207, 211, 23, 189, 93, 33, 110,
+    155, 90, 30, 39, 116, 115, 238, 38, 126, 21, 232, 133,
+];
+const TRACER_KEY: Pubkey = Pubkey::new_from_array(TRACER_KEY_BYTES);
 
 lazy_static! {
     static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
@@ -26,8 +33,6 @@ lazy_static! {
         .thread_name(|ix| format!("sigverify_{}", ix))
         .build()
         .unwrap();
-    static ref TRACER_KEY: Pubkey =
-        Pubkey::from_str("tKeYE4wtowRb8yRroZShTipE18YVnqwXjsSAoNsFU6g").unwrap();
 }
 
 pub type TxOffset = PinnedVec<u32>;

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -123,11 +123,11 @@ fn verify_packet(packet: &mut Packet) {
             &packet.data[pubkey_start..pubkey_end],
             &packet.data[msg_start..msg_end],
         ) {
-            // Check for tracer pubkey here
             packet.meta.discard = true;
             return;
         }
 
+        // Check for tracer pubkey
         if !packet.meta.is_tracer_tx
             && &packet.data[pubkey_start..pubkey_end] == TRACER_KEY.as_ref()
         {

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -125,11 +125,10 @@ fn verify_packet(packet: &mut Packet) {
             return;
         }
 
-        if &packet.data[pubkey_start..pubkey_end] == TRACER_KEY.as_ref()
-            // Record the first signature in the transaction
-            && packet.meta.tracer_tx_signature.is_none()
+        if !packet.meta.is_tracer_tx
+            && &packet.data[pubkey_start..pubkey_end] == TRACER_KEY.as_ref()
         {
-            packet.meta.tracer_tx_signature = Some(signature);
+            packet.meta.is_tracer_tx = true;
         }
 
         pubkey_start += size_of::<Pubkey>();

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -87,6 +87,8 @@ fn verify_packet(packet: &mut Packet) {
     let mut pubkey_start = packet_offsets.pubkey_start as usize;
     let msg_start = packet_offsets.msg_start as usize;
 
+    packet.meta.discard = false;
+
     if packet_offsets.sig_len == 0 {
         packet.meta.discard = true;
         return;
@@ -104,6 +106,7 @@ fn verify_packet(packet: &mut Packet) {
 
         if pubkey_end >= packet.meta.size || sig_end >= packet.meta.size {
             packet.meta.discard = true;
+            return;
         }
 
         let signature = Signature::new(&packet.data[sig_start..sig_end]);
@@ -127,8 +130,6 @@ fn verify_packet(packet: &mut Packet) {
         pubkey_start += size_of::<Pubkey>();
         sig_start += size_of::<Signature>();
     }
-
-    packet.meta.discard = false;
 }
 
 pub fn batch_size(batches: &[Packets]) -> usize {

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -1,4 +1,4 @@
-use crate::clock::Slot;
+use crate::{clock::Slot, signature::Signature};
 use bincode::Result;
 use serde::Serialize;
 use std::{
@@ -24,6 +24,7 @@ pub struct Meta {
     pub v6: bool,
     pub seed: [u8; 32],
     pub slot: Slot,
+    pub tracer_tx_signature: Option<Signature>,
 }
 
 #[derive(Clone)]

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -1,4 +1,4 @@
-use crate::{clock::Slot, signature::Signature};
+use crate::clock::Slot;
 use bincode::Result;
 use serde::Serialize;
 use std::{
@@ -24,7 +24,7 @@ pub struct Meta {
     pub v6: bool,
     pub seed: [u8; 32],
     pub slot: Slot,
-    pub tracer_tx_signature: Option<Signature>,
+    pub is_tracer_tx: bool,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
#### Problem
Hard to trace what's going on in forwarding/transaction processing

#### Summary of Changes
Add a special signing key that will be detected in sigverify, will set a signature in the packet metadata, and later used for metric reporting in BankingStage (still TODO in follow-up PR)

Fixes #
