### PR TITLE
Convert blockstore TransactionStatus column family to protobufs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4710,6 +4710,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2 0.9.2",
+ "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-budget-program",
  "solana-frozen-abi 1.6.0",

--- a/core/src/transaction_status_service.rs
+++ b/core/src/transaction_status_service.rs
@@ -124,7 +124,7 @@ impl TransactionStatusService {
                         transaction.signatures[0],
                         writable_keys,
                         readonly_keys,
-                        &TransactionStatusMeta {
+                        TransactionStatusMeta {
                             status,
                             fee,
                             pre_balances,

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -64,6 +64,7 @@ features = ["lz4"]
 [dev-dependencies]
 assert_matches = "1.3.0"
 matches = "0.1.6"
+solana-account-decoder = { path = "../account-decoder", version = "1.6.0" }
 solana-budget-program = { path = "../programs/budget", version = "1.6.0" }
 
 [build-dependencies]

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1783,7 +1783,8 @@ impl Blockstore {
                     transaction,
                     meta: self
                         .read_transaction_status((signature, slot))
-                        .expect("Expect database get to succeed"),
+                        .ok()
+                        .flatten(),
                 }
             })
             .collect()

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -504,7 +504,7 @@ pub mod tests {
                         Signature::new(&random_bytes),
                         vec![&Pubkey::new(&random_bytes[0..32])],
                         vec![&Pubkey::new(&random_bytes[32..])],
-                        &TransactionStatusMeta::default(),
+                        TransactionStatusMeta::default(),
                     )
                     .unwrap();
             }
@@ -519,7 +519,7 @@ pub mod tests {
                         Signature::new(&random_bytes),
                         vec![&Pubkey::new(&random_bytes[0..32])],
                         vec![&Pubkey::new(&random_bytes[32..])],
-                        &TransactionStatusMeta::default(),
+                        TransactionStatusMeta::default(),
                     )
                     .unwrap();
             }
@@ -556,7 +556,7 @@ pub mod tests {
                         Signature::new(&random_bytes),
                         vec![&Pubkey::new(&random_bytes[0..32])],
                         vec![&Pubkey::new(&random_bytes[32..])],
-                        &TransactionStatusMeta::default(),
+                        TransactionStatusMeta::default(),
                     )
                     .unwrap();
             }
@@ -745,7 +745,7 @@ pub mod tests {
                     signature,
                     vec![&Pubkey::new(&random_bytes[0..32])],
                     vec![&Pubkey::new(&random_bytes[32..])],
-                    &TransactionStatusMeta::default(),
+                    TransactionStatusMeta::default(),
                 )
                 .unwrap();
         }
@@ -781,7 +781,7 @@ pub mod tests {
                     signature,
                     vec![&Pubkey::new(&random_bytes[0..32])],
                     vec![&Pubkey::new(&random_bytes[32..])],
-                    &TransactionStatusMeta::default(),
+                    TransactionStatusMeta::default(),
                 )
                 .unwrap();
         }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -17,7 +17,6 @@ use solana_sdk::{
     signature::Signature,
 };
 use solana_storage_proto::convert::generated;
-use solana_transaction_status::TransactionStatusMeta;
 use std::{collections::HashMap, fs, marker::PhantomData, path::Path, sync::Arc};
 use thiserror::Error;
 
@@ -418,10 +417,6 @@ pub trait TypedColumn: Column {
     type Type: Serialize + DeserializeOwned;
 }
 
-impl TypedColumn for columns::TransactionStatus {
-    type Type = TransactionStatusMeta;
-}
-
 impl TypedColumn for columns::AddressSignatures {
     type Type = blockstore_meta::AddressSignatureMeta;
 }
@@ -491,6 +486,9 @@ impl Column for columns::TransactionStatus {
 
 impl ColumnName for columns::TransactionStatus {
     const NAME: &'static str = TRANSACTION_STATUS_CF;
+}
+impl ProtobufColumn for columns::TransactionStatus {
+    type Type = generated::TransactionStatusMeta;
 }
 
 impl Column for columns::AddressSignatures {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -1,4 +1,4 @@
-use crate::StoredExtendedRewards;
+use crate::{StoredExtendedRewards, StoredTransactionStatusMeta};
 use solana_account_decoder::parse_token::{real_number_string_trimmed, UiTokenAmount};
 use solana_sdk::{
     hash::Hash,
@@ -309,6 +309,13 @@ impl From<TransactionStatusMeta> for generated::TransactionStatusMeta {
             pre_token_balances,
             post_token_balances,
         }
+    }
+}
+
+impl From<StoredTransactionStatusMeta> for generated::TransactionStatusMeta {
+    fn from(meta: StoredTransactionStatusMeta) -> Self {
+        let meta: TransactionStatusMeta = meta.into();
+        meta.into()
     }
 }
 

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -1,6 +1,13 @@
 use serde::{Deserialize, Serialize};
-use solana_sdk::deserialize_utils::default_on_eof;
-use solana_transaction_status::{Reward, RewardType};
+use solana_account_decoder::{
+    parse_token::{real_number_string_trimmed, UiTokenAmount},
+    StringAmount,
+};
+use solana_sdk::{deserialize_utils::default_on_eof, transaction::Result};
+use solana_transaction_status::{
+    InnerInstructions, Reward, RewardType, TransactionStatusMeta, TransactionTokenBalance,
+};
+use std::str::FromStr;
 
 pub mod convert;
 
@@ -47,6 +54,154 @@ impl From<Reward> for StoredExtendedReward {
             lamports,
             post_balance,
             reward_type,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct StoredTokenAmount {
+    pub ui_amount: f64,
+    pub decimals: u8,
+    pub amount: StringAmount,
+}
+
+impl From<StoredTokenAmount> for UiTokenAmount {
+    fn from(value: StoredTokenAmount) -> Self {
+        let StoredTokenAmount {
+            ui_amount,
+            decimals,
+            amount,
+        } = value;
+        let ui_amount_string =
+            real_number_string_trimmed(u64::from_str(&amount).unwrap_or(0), decimals);
+        Self {
+            ui_amount: Some(ui_amount),
+            decimals,
+            amount,
+            ui_amount_string,
+        }
+    }
+}
+
+impl From<UiTokenAmount> for StoredTokenAmount {
+    fn from(value: UiTokenAmount) -> Self {
+        let UiTokenAmount {
+            ui_amount,
+            decimals,
+            amount,
+            ..
+        } = value;
+        Self {
+            ui_amount: ui_amount.unwrap_or(0.0),
+            decimals,
+            amount,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct StoredTransactionTokenBalance {
+    pub account_index: u8,
+    pub mint: String,
+    pub ui_token_amount: StoredTokenAmount,
+}
+
+impl From<StoredTransactionTokenBalance> for TransactionTokenBalance {
+    fn from(value: StoredTransactionTokenBalance) -> Self {
+        let StoredTransactionTokenBalance {
+            account_index,
+            mint,
+            ui_token_amount,
+        } = value;
+        Self {
+            account_index,
+            mint,
+            ui_token_amount: ui_token_amount.into(),
+        }
+    }
+}
+
+impl From<TransactionTokenBalance> for StoredTransactionTokenBalance {
+    fn from(value: TransactionTokenBalance) -> Self {
+        let TransactionTokenBalance {
+            account_index,
+            mint,
+            ui_token_amount,
+        } = value;
+        Self {
+            account_index,
+            mint,
+            ui_token_amount: ui_token_amount.into(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct StoredTransactionStatusMeta {
+    pub status: Result<()>,
+    pub fee: u64,
+    pub pre_balances: Vec<u64>,
+    pub post_balances: Vec<u64>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub inner_instructions: Option<Vec<InnerInstructions>>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub log_messages: Option<Vec<String>>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub pre_token_balances: Option<Vec<StoredTransactionTokenBalance>>,
+    #[serde(deserialize_with = "default_on_eof")]
+    pub post_token_balances: Option<Vec<StoredTransactionTokenBalance>>,
+}
+
+impl From<StoredTransactionStatusMeta> for TransactionStatusMeta {
+    fn from(value: StoredTransactionStatusMeta) -> Self {
+        let StoredTransactionStatusMeta {
+            status,
+            fee,
+            pre_balances,
+            post_balances,
+            inner_instructions,
+            log_messages,
+            pre_token_balances,
+            post_token_balances,
+        } = value;
+        Self {
+            status,
+            fee,
+            pre_balances,
+            post_balances,
+            inner_instructions,
+            log_messages,
+            pre_token_balances: pre_token_balances
+                .map(|balances| balances.into_iter().map(|balance| balance.into()).collect()),
+            post_token_balances: post_token_balances
+                .map(|balances| balances.into_iter().map(|balance| balance.into()).collect()),
+        }
+    }
+}
+
+impl From<TransactionStatusMeta> for StoredTransactionStatusMeta {
+    fn from(value: TransactionStatusMeta) -> Self {
+        let TransactionStatusMeta {
+            status,
+            fee,
+            pre_balances,
+            post_balances,
+            inner_instructions,
+            log_messages,
+            pre_token_balances,
+            post_token_balances,
+        } = value;
+        Self {
+            status,
+            fee,
+            pre_balances,
+            post_balances,
+            inner_instructions,
+            log_messages,
+            pre_token_balances: pre_token_balances
+                .map(|balances| balances.into_iter().map(|balance| balance.into()).collect()),
+            post_token_balances: post_token_balances
+                .map(|balances| balances.into_iter().map(|balance| balance.into()).collect()),
         }
     }
 }


### PR DESCRIPTION
#### Problem
It is very difficult to version the TransactionStatusMeta struct (especially any of the Vec fields) and keep Blockstore (bincode) deserialization backward compatible.

#### Summary of Changes
- Convert TransactionStatus column family to protobuf
- Add StoredTransactionStatusMeta structs and converters to retain new TokenAmount rpc changes while supporting legacy Blockstore deserialization
- Also, prevent node panic if TransactionStatus cf data cannot be deserialized on `get_confirmed_block` request; just return meta: None instead.