### PR TITLE
fix: add TokenAmount.uiAmountString

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -285,9 +285,10 @@ declare module '@solana/web3.js' {
   };
 
   export type TokenAmount = {
-    uiAmount: number;
+    uiAmount: number | null;
     decimals: number;
     amount: string;
+    uiAmountString?: string;
   };
 
   export type TokenAccountBalancePair = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -298,9 +298,10 @@ declare module '@solana/web3.js' {
   };
 
   declare export type TokenAmount = {
-    uiAmount: number,
+    uiAmount: number | null,
     decimals: number,
     amount: string,
+    uiAmountString?: string,
   };
 
   declare export type TokenAccountBalancePair = {

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -765,7 +765,8 @@ const GetSupplyRpcResult = jsonRpcResultAndContext(
 type TokenAmount = {
   amount: string,
   decimals: number,
-  uiAmount: number,
+  uiAmount: number | null,
+  uiAmountString?: string,
 };
 
 /**
@@ -773,8 +774,9 @@ type TokenAmount = {
  */
 const TokenAmountResult = pick({
   amount: string(),
-  uiAmount: number(),
+  uiAmount: nullable(number()),
   decimals: number(),
+  uiAmountString: optional(nullable(string())),
 });
 
 /**


### PR DESCRIPTION
#### Problem
New TokenAmount.uiAmountString field is not exposed

#### Summary of Changes
Add it to web3.js struct/types
Allow TokenAmount.uiAmount to be null
