### PR TITLE
fix: add TokenAccountBalancePair.uiAmountString

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -295,7 +295,8 @@ declare module '@solana/web3.js' {
     address: PublicKey;
     amount: string;
     decimals: number;
-    uiAmount: number;
+    uiAmount: number | null;
+    uiAmountString?: string;
   };
 
   export type AccountChangeCallback = (

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -308,7 +308,8 @@ declare module '@solana/web3.js' {
     address: PublicKey,
     amount: string,
     decimals: number,
-    uiAmount: number,
+    uiAmount: number | null,
+    uiAmountString?: string,
   };
 
   declare type AccountChangeCallback = (

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -760,7 +760,8 @@ const GetSupplyRpcResult = jsonRpcResultAndContext(
  * @typedef {Object} TokenAmount
  * @property {string} amount Raw amount of tokens as string ignoring decimals
  * @property {number} decimals Number of decimals configured for token's mint
- * @property {number} uiAmount Token account as float, accounts for decimals
+ * @property {number | null} uiAmount Token amount as float, accounts for decimals
+ * @property {string | undefined} uiAmountString Token amount as string, accounts for decimals
  */
 type TokenAmount = {
   amount: string,
@@ -786,13 +787,15 @@ const TokenAmountResult = pick({
  * @property {PublicKey} address Address of the token account
  * @property {string} amount Raw amount of tokens as string ignoring decimals
  * @property {number} decimals Number of decimals configured for token's mint
- * @property {number} uiAmount Token account as float, accounts for decimals
+ * @property {number | null} uiAmount Token amount as float, accounts for decimals
+ * @property {string | undefined} uiAmountString Token amount as string, accounts for decimals
  */
 type TokenAccountBalancePair = {
   address: PublicKey,
   amount: string,
   decimals: number,
   uiAmount: number,
+  uiAmountString?: string,
 };
 
 /**
@@ -803,8 +806,9 @@ const GetTokenLargestAccountsResult = jsonRpcResultAndContext(
     pick({
       address: PublicKeyFromString,
       amount: string(),
-      uiAmount: number(),
+      uiAmount: nullable(number()),
       decimals: number(),
+      uiAmountString: optional(nullable(string())),
     }),
   ),
 );


### PR DESCRIPTION
#### Problem
New TokenAccountBalancePair.uiAmountString field is not exposed

#### Summary of Changes
Add it to web3.js struct/types
Also, fixup TokenAmount docs
