### PR TITLE
Slow down `solana-validator monitor` refresh interval when talking to a real node

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -30,7 +30,7 @@ use {
         path::{Path, PathBuf},
         process::exit,
         sync::mpsc::channel,
-        time::{SystemTime, UNIX_EPOCH},
+        time::{Duration, SystemTime, UNIX_EPOCH},
     },
 };
 
@@ -413,7 +413,7 @@ fn main() {
     match genesis.start_with_mint_address(mint_address) {
         Ok(test_validator) => {
             if let Some(dashboard) = dashboard {
-                dashboard.run();
+                dashboard.run(Duration::from_millis(250));
             }
             test_validator.join();
         }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2100,7 +2100,7 @@ pub fn main() {
                 );
                 exit(1);
             });
-            dashboard.run();
+            dashboard.run(Duration::from_secs(2));
         }
         Operation::WaitForRestartWindow {
             min_idle_time_in_minutes,


### PR DESCRIPTION
It's nice to get smooth feedback when running `solana-test-validator` but poking a real validator 5x times a second is excessive
