### PR TITLE
Remove old feature: simple_capitalization

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -103,9 +103,7 @@ fn main() {
         } else {
             let mut pubkeys: Vec<Pubkey> = vec![];
             let mut time = Measure::start("hash");
-            let results = accounts
-                .accounts_db
-                .update_accounts_hash(0, &ancestors, true);
+            let results = accounts.accounts_db.update_accounts_hash(0, &ancestors);
             time.stop();
             let mut time_store = Measure::start("hash using store");
             let results_store = accounts.accounts_db.update_accounts_hash_with_index_option(
@@ -113,7 +111,6 @@ fn main() {
                 false,
                 solana_sdk::clock::Slot::default(),
                 &ancestors,
-                true,
                 None,
             );
             time_store.stop();

--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -195,15 +195,17 @@ mod tests {
             ..GenesisConfig::default()
         };
         let mut bank = Arc::new(Bank::new(&genesis_config));
+        let sysvar_delta = 10;
         assert_eq!(
             bank.capitalization(),
             (num_genesis_accounts + num_non_circulating_accounts + num_stake_accounts) * balance
+                + sysvar_delta,
         );
 
         let non_circulating_supply = calculate_non_circulating_supply(&bank);
         assert_eq!(
             non_circulating_supply.lamports,
-            (num_non_circulating_accounts + num_stake_accounts) * balance
+            (num_non_circulating_accounts + num_stake_accounts) * balance,
         );
         assert_eq!(
             non_circulating_supply.accounts.len(),

--- a/core/src/non_circulating_supply.rs
+++ b/core/src/non_circulating_supply.rs
@@ -195,17 +195,17 @@ mod tests {
             ..GenesisConfig::default()
         };
         let mut bank = Arc::new(Bank::new(&genesis_config));
-        let sysvar_delta = 10;
+        let sysvar_and_native_program_delta = 10;
         assert_eq!(
             bank.capitalization(),
             (num_genesis_accounts + num_non_circulating_accounts + num_stake_accounts) * balance
-                + sysvar_delta,
+                + sysvar_and_native_program_delta,
         );
 
         let non_circulating_supply = calculate_non_circulating_supply(&bank);
         assert_eq!(
             non_circulating_supply.lamports,
-            (num_non_circulating_accounts + num_stake_accounts) * balance,
+            (num_non_circulating_accounts + num_stake_accounts) * balance
         );
         assert_eq!(
             non_circulating_supply.accounts.len(),

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1235,13 +1235,6 @@ fn main() {
                            bugs are feature-gated behind this)"),
             )
             .arg(
-                Arg::with_name("enable_simple_capitalization")
-                    .required(false)
-                    .long("enable-simple-capitalization")
-                    .takes_value(false)
-                    .help("Enable simple capitalization to test hardcoded cap adjustments"),
-            )
-            .arg(
                 Arg::with_name("recalculate_capitalization")
                     .required(false)
                     .long("recalculate-capitalization")
@@ -2186,30 +2179,6 @@ fn main() {
                             genesis_config.rent.minimum_balance(Feature::size_of()),
                             1,
                         );
-                        if arg_matches.is_present("enable_simple_capitalization") {
-                            if base_bank
-                                .get_account(&feature_set::simple_capitalization::id())
-                                .is_none()
-                            {
-                                base_bank.store_account(
-                                    &feature_set::simple_capitalization::id(),
-                                    &feature::create_account(
-                                        &Feature { activated_at: None },
-                                        feature_account_balance,
-                                    ),
-                                );
-                                let old_cap = base_bank.set_capitalization();
-                                let new_cap = base_bank.capitalization();
-                                warn!(
-                                    "Skewing capitalization a bit to enable simple capitalization as \
-                                    requested: increasing {} from {} to {}",
-                                    feature_account_balance, old_cap, new_cap,
-                                );
-                                assert_eq!(old_cap + feature_account_balance, new_cap);
-                            } else {
-                                warn!("Already simple_capitalization is activated (or scheduled)");
-                            }
-                        }
                         if arg_matches.is_present("enable_stake_program_v2") {
                             let mut force_enabled_count = 0;
                             if base_bank

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -105,12 +105,8 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
     let slot = 0;
     create_test_accounts(&accounts, &mut pubkeys, num_accounts, slot);
     let ancestors = vec![(0, 0)].into_iter().collect();
-    let (_, total_lamports) = accounts
-        .accounts_db
-        .update_accounts_hash(0, &ancestors, true);
-    bencher.iter(|| {
-        assert!(accounts.verify_bank_hash_and_lamports(0, &ancestors, total_lamports, true))
-    });
+    let (_, total_lamports) = accounts.accounts_db.update_accounts_hash(0, &ancestors);
+    bencher.iter(|| assert!(accounts.verify_bank_hash_and_lamports(0, &ancestors, total_lamports)));
 }
 
 #[bench]
@@ -126,9 +122,7 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
     let ancestors = vec![(0, 0)].into_iter().collect();
     bencher.iter(|| {
-        accounts
-            .accounts_db
-            .update_accounts_hash(0, &ancestors, true);
+        accounts.accounts_db.update_accounts_hash(0, &ancestors);
     });
 }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -577,11 +577,7 @@ impl Accounts {
             .collect()
     }
 
-    pub fn calculate_capitalization(
-        &self,
-        ancestors: &Ancestors,
-        simple_capitalization_enabled: bool,
-    ) -> u64 {
+    pub fn calculate_capitalization(&self, ancestors: &Ancestors) -> u64 {
         self.accounts_db.unchecked_scan_accounts(
             "calculate_capitalization_scan_elapsed",
             ancestors,
@@ -592,7 +588,6 @@ impl Accounts {
                         lamports,
                         &loaded_account.owner(),
                         loaded_account.executable(),
-                        simple_capitalization_enabled,
                     );
 
                     *total_capitalization = AccountsDb::checked_iterative_sum_for_capitalization(
@@ -610,14 +605,11 @@ impl Accounts {
         slot: Slot,
         ancestors: &Ancestors,
         total_lamports: u64,
-        simple_capitalization_enabled: bool,
     ) -> bool {
-        if let Err(err) = self.accounts_db.verify_bank_hash_and_lamports(
-            slot,
-            ancestors,
-            total_lamports,
-            simple_capitalization_enabled,
-        ) {
+        if let Err(err) =
+            self.accounts_db
+                .verify_bank_hash_and_lamports(slot, ancestors, total_lamports)
+        {
             warn!("verify_bank_hash failed: {:?}", err);
             false
         } else {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3489,25 +3489,10 @@ impl AccountsDb {
 
     pub fn account_balance_for_capitalization(
         lamports: u64,
-        owner: &Pubkey,
-        executable: bool,
-        simple_capitalization_enabled: bool,
+        _owner: &Pubkey,
+        _executable: bool,
     ) -> u64 {
-        if simple_capitalization_enabled {
-            return lamports;
-        }
-
-        let is_specially_retained = (solana_sdk::native_loader::check_id(owner) && executable)
-            || solana_sdk::sysvar::check_id(owner);
-
-        if is_specially_retained {
-            // specially retained accounts always have an initial 1 lamport
-            // balance, but could be modified by transfers which increase
-            // the balance but don't affect the capitalization.
-            lamports - 1
-        } else {
-            lamports
-        }
+        lamports
     }
 
     fn calculate_accounts_hash(
@@ -3515,7 +3500,6 @@ impl AccountsDb {
         slot: Slot,
         ancestors: &Ancestors,
         check_hash: bool,
-        simple_capitalization_enabled: bool,
     ) -> Result<(Hash, u64), BankHashVerificationError> {
         use BankHashVerificationError::*;
         let mut scan = Measure::start("scan");
@@ -3560,7 +3544,6 @@ impl AccountsDb {
                                                         account_info.lamports,
                                                         loaded_account.owner(),
                                                         loaded_account.executable(),
-                                                        simple_capitalization_enabled,
                                                     );
 
                                                 if check_hash {
@@ -3626,36 +3609,12 @@ impl AccountsDb {
         bank_hash_info.snapshot_hash
     }
 
-    pub fn update_accounts_hash(
-        &self,
-        slot: Slot,
-        ancestors: &Ancestors,
-        simple_capitalization_enabled: bool,
-    ) -> (Hash, u64) {
-        self.update_accounts_hash_with_index_option(
-            true,
-            false,
-            slot,
-            ancestors,
-            simple_capitalization_enabled,
-            None,
-        )
+    pub fn update_accounts_hash(&self, slot: Slot, ancestors: &Ancestors) -> (Hash, u64) {
+        self.update_accounts_hash_with_index_option(true, false, slot, ancestors, None)
     }
 
-    pub fn update_accounts_hash_test(
-        &self,
-        slot: Slot,
-        ancestors: &Ancestors,
-        simple_capitalization_enabled: bool,
-    ) -> (Hash, u64) {
-        self.update_accounts_hash_with_index_option(
-            true,
-            true,
-            slot,
-            ancestors,
-            simple_capitalization_enabled,
-            None,
-        )
+    pub fn update_accounts_hash_test(&self, slot: Slot, ancestors: &Ancestors) -> (Hash, u64) {
+        self.update_accounts_hash_with_index_option(true, true, slot, ancestors, None)
     }
 
     /// Scan through all the account storage in parallel
@@ -3701,18 +3660,16 @@ impl AccountsDb {
         use_index: bool,
         slot: Slot,
         ancestors: &Ancestors,
-        simple_capitalization_enabled: bool,
     ) -> (Hash, u64) {
         if !use_index {
             let combined_maps = self.get_snapshot_storages(slot);
 
             Self::calculate_accounts_hash_without_index(
                 &combined_maps,
-                simple_capitalization_enabled,
                 Some(&self.thread_pool_clean),
             )
         } else {
-            self.calculate_accounts_hash(slot, ancestors, false, simple_capitalization_enabled)
+            self.calculate_accounts_hash(slot, ancestors, false)
                 .unwrap()
         }
     }
@@ -3723,23 +3680,14 @@ impl AccountsDb {
         debug_verify: bool,
         slot: Slot,
         ancestors: &Ancestors,
-        simple_capitalization_enabled: bool,
         expected_capitalization: Option<u64>,
     ) -> (Hash, u64) {
-        let (hash, total_lamports) = self.calculate_accounts_hash_helper(
-            use_index,
-            slot,
-            ancestors,
-            simple_capitalization_enabled,
-        );
+        let (hash, total_lamports) =
+            self.calculate_accounts_hash_helper(use_index, slot, ancestors);
         if debug_verify {
             // calculate the other way (store or non-store) and verify results match.
-            let (hash_other, total_lamports_other) = self.calculate_accounts_hash_helper(
-                !use_index,
-                slot,
-                ancestors,
-                simple_capitalization_enabled,
-            );
+            let (hash_other, total_lamports_other) =
+                self.calculate_accounts_hash_helper(!use_index, slot, ancestors);
 
             let success = hash == hash_other
                 && total_lamports == total_lamports_other
@@ -3754,7 +3702,6 @@ impl AccountsDb {
 
     fn scan_snapshot_stores(
         storage: &[SnapshotStorage],
-        simple_capitalization_enabled: bool,
         mut stats: &mut crate::accounts_hash::HashStats,
         bins: usize,
     ) -> Vec<Vec<Vec<CalculateHashIntermediate>>> {
@@ -3778,7 +3725,6 @@ impl AccountsDb {
                         raw_lamports,
                         loaded_account.owner(),
                         loaded_account.executable(),
-                        simple_capitalization_enabled,
                     )
                 };
 
@@ -3807,7 +3753,6 @@ impl AccountsDb {
     // intended to be faster than calculate_accounts_hash
     pub fn calculate_accounts_hash_without_index(
         storages: &[SnapshotStorage],
-        simple_capitalization_enabled: bool,
         thread_pool: Option<&ThreadPool>,
     ) -> (Hash, u64) {
         let scan_and_hash = || {
@@ -3816,7 +3761,6 @@ impl AccountsDb {
             const PUBKEY_BINS_FOR_CALCULATING_HASHES: usize = 64;
             let result = Self::scan_snapshot_stores(
                 storages,
-                simple_capitalization_enabled,
                 &mut stats,
                 PUBKEY_BINS_FOR_CALCULATING_HASHES,
             );
@@ -3835,12 +3779,11 @@ impl AccountsDb {
         slot: Slot,
         ancestors: &Ancestors,
         total_lamports: u64,
-        simple_capitalization_enabled: bool,
     ) -> Result<(), BankHashVerificationError> {
         use BankHashVerificationError::*;
 
         let (calculated_hash, calculated_lamports) =
-            self.calculate_accounts_hash(slot, ancestors, true, simple_capitalization_enabled)?;
+            self.calculate_accounts_hash(slot, ancestors, true)?;
 
         if calculated_lamports != total_lamports {
             warn!(
@@ -5071,13 +5014,13 @@ pub mod tests {
     #[should_panic(expected = "assertion failed: bins <= max_plus_1 && bins > 0")]
     fn test_accountsdb_scan_snapshot_stores_illegal_bins2() {
         let mut stats = HashStats::default();
-        AccountsDb::scan_snapshot_stores(&[], true, &mut stats, 257);
+        AccountsDb::scan_snapshot_stores(&[], &mut stats, 257);
     }
     #[test]
     #[should_panic(expected = "assertion failed: bins <= max_plus_1 && bins > 0")]
     fn test_accountsdb_scan_snapshot_stores_illegal_bins() {
         let mut stats = HashStats::default();
-        AccountsDb::scan_snapshot_stores(&[], true, &mut stats, 0);
+        AccountsDb::scan_snapshot_stores(&[], &mut stats, 0);
     }
 
     fn sample_storages_and_accounts() -> (SnapshotStorages, Vec<CalculateHashIntermediate>) {
@@ -5164,11 +5107,11 @@ pub mod tests {
 
         let bins = 1;
         let mut stats = HashStats::default();
-        let result = AccountsDb::scan_snapshot_stores(&storages, true, &mut stats, bins);
+        let result = AccountsDb::scan_snapshot_stores(&storages, &mut stats, bins);
         assert_eq!(result, vec![vec![raw_expected.clone()]]);
 
         let bins = 2;
-        let result = AccountsDb::scan_snapshot_stores(&storages, true, &mut stats, bins);
+        let result = AccountsDb::scan_snapshot_stores(&storages, &mut stats, bins);
         let mut expected = vec![Vec::new(); bins];
         expected[0].push(raw_expected[0].clone());
         expected[0].push(raw_expected[1].clone());
@@ -5177,7 +5120,7 @@ pub mod tests {
         assert_eq!(result, vec![expected]);
 
         let bins = 4;
-        let result = AccountsDb::scan_snapshot_stores(&storages, true, &mut stats, bins);
+        let result = AccountsDb::scan_snapshot_stores(&storages, &mut stats, bins);
         let mut expected = vec![Vec::new(); bins];
         expected[0].push(raw_expected[0].clone());
         expected[1].push(raw_expected[1].clone());
@@ -5186,7 +5129,7 @@ pub mod tests {
         assert_eq!(result, vec![expected]);
 
         let bins = 256;
-        let result = AccountsDb::scan_snapshot_stores(&storages, true, &mut stats, bins);
+        let result = AccountsDb::scan_snapshot_stores(&storages, &mut stats, bins);
         let mut expected = vec![Vec::new(); bins];
         expected[0].push(raw_expected[0].clone());
         expected[127].push(raw_expected[1].clone());
@@ -5207,7 +5150,7 @@ pub mod tests {
         storages[0].splice(0..0, vec![arc; MAX_ITEMS_PER_CHUNK]);
 
         let mut stats = HashStats::default();
-        let result = AccountsDb::scan_snapshot_stores(&storages, true, &mut stats, bins);
+        let result = AccountsDb::scan_snapshot_stores(&storages, &mut stats, bins);
         assert_eq!(result.len(), 2); // 2 chunks
         assert_eq!(result[0].len(), 0); // nothing found in first slots
         assert_eq!(result[1].len(), bins);
@@ -5219,7 +5162,7 @@ pub mod tests {
         solana_logger::setup();
 
         let (storages, _size, _slot_expected) = sample_storage();
-        let result = AccountsDb::calculate_accounts_hash_without_index(&storages, true, None);
+        let result = AccountsDb::calculate_accounts_hash_without_index(&storages, None);
         let expected_hash = Hash::from_str("GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn").unwrap();
         assert_eq!(result, (expected_hash, 0));
     }
@@ -5234,7 +5177,7 @@ pub mod tests {
                 item.hash
             });
         let sum = raw_expected.iter().map(|item| item.lamports).sum();
-        let result = AccountsDb::calculate_accounts_hash_without_index(&storages, true, None);
+        let result = AccountsDb::calculate_accounts_hash_without_index(&storages, None);
 
         assert_eq!(result, (expected_hash, sum));
     }
@@ -6319,8 +6262,8 @@ pub mod tests {
 
         let ancestors = linear_ancestors(latest_slot);
         assert_eq!(
-            daccounts.update_accounts_hash(latest_slot, &ancestors, true),
-            accounts.update_accounts_hash(latest_slot, &ancestors, true)
+            daccounts.update_accounts_hash(latest_slot, &ancestors),
+            accounts.update_accounts_hash(latest_slot, &ancestors)
         );
     }
 
@@ -6473,12 +6416,12 @@ pub mod tests {
 
         let ancestors = linear_ancestors(current_slot);
         info!("ancestors: {:?}", ancestors);
-        let hash = accounts.update_accounts_hash_test(current_slot, &ancestors, true);
+        let hash = accounts.update_accounts_hash_test(current_slot, &ancestors);
 
         accounts.clean_accounts(None);
 
         assert_eq!(
-            accounts.update_accounts_hash_test(current_slot, &ancestors, true),
+            accounts.update_accounts_hash_test(current_slot, &ancestors),
             hash
         );
 
@@ -6595,7 +6538,7 @@ pub mod tests {
         accounts.add_root(current_slot);
 
         accounts.print_accounts_stats("pre_f");
-        accounts.update_accounts_hash(4, &HashMap::default(), true);
+        accounts.update_accounts_hash(4, &HashMap::default());
 
         let accounts = f(accounts, current_slot);
 
@@ -6607,7 +6550,7 @@ pub mod tests {
         assert_load_account(&accounts, current_slot, dummy_pubkey, dummy_lamport);
 
         accounts
-            .verify_bank_hash_and_lamports(4, &HashMap::default(), 1222, true)
+            .verify_bank_hash_and_lamports(4, &HashMap::default(), 1222)
             .unwrap();
     }
 
@@ -6987,15 +6930,15 @@ pub mod tests {
 
         db.store_uncached(some_slot, &[(&key, &account)]);
         db.add_root(some_slot);
-        db.update_accounts_hash_test(some_slot, &ancestors, true);
+        db.update_accounts_hash_test(some_slot, &ancestors);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
             Ok(_)
         );
 
         db.bank_hashes.write().unwrap().remove(&some_slot).unwrap();
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
             Err(MissingBankHash)
         );
 
@@ -7010,7 +6953,7 @@ pub mod tests {
             .unwrap()
             .insert(some_slot, bank_hash_info);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
             Err(MismatchedBankHash)
         );
     }
@@ -7029,9 +6972,9 @@ pub mod tests {
 
         db.store_uncached(some_slot, &[(&key, &account)]);
         db.add_root(some_slot);
-        db.update_accounts_hash_test(some_slot, &ancestors, true);
+        db.update_accounts_hash_test(some_slot, &ancestors);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
             Ok(_)
         );
 
@@ -7043,18 +6986,18 @@ pub mod tests {
                 &solana_sdk::native_loader::create_loadable_account("foo", 1),
             )],
         );
-        db.update_accounts_hash_test(some_slot, &ancestors, true);
+        db.update_accounts_hash_test(some_slot, &ancestors);
+        //assert_matches!(
+        //    db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
+        //    Ok(_)
+        //);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, false),
-            Ok(_)
-        );
-        assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 2, true),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 2),
             Ok(_)
         );
 
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10, true),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 10),
             Err(MismatchedTotalLamports(expected, actual)) if expected == 2 && actual == 10
         );
     }
@@ -7072,9 +7015,9 @@ pub mod tests {
             .unwrap()
             .insert(some_slot, BankHashInfo::default());
         db.add_root(some_slot);
-        db.update_accounts_hash_test(some_slot, &ancestors, true);
+        db.update_accounts_hash_test(some_slot, &ancestors);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 0, true),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 0),
             Ok(_)
         );
     }
@@ -7099,7 +7042,7 @@ pub mod tests {
         db.store_accounts_unfrozen(some_slot, accounts, &[some_hash], false);
         db.add_root(some_slot);
         assert_matches!(
-            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1, true),
+            db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
             Err(MismatchedAccountHash)
         );
     }
@@ -7663,14 +7606,14 @@ pub mod tests {
         );
 
         let no_ancestors = HashMap::default();
-        accounts.update_accounts_hash(current_slot, &no_ancestors, true);
+        accounts.update_accounts_hash(current_slot, &no_ancestors);
         accounts
-            .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300, true)
+            .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300)
             .unwrap();
 
         let accounts = reconstruct_accounts_db_via_serialization(&accounts, current_slot);
         accounts
-            .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300, true)
+            .verify_bank_hash_and_lamports(current_slot, &no_ancestors, 22300)
             .unwrap();
 
         // repeating should be no-op
@@ -7928,7 +7871,7 @@ pub mod tests {
     fn test_account_balance_for_capitalization_normal() {
         // system accounts
         assert_eq!(
-            AccountsDb::account_balance_for_capitalization(10, &Pubkey::default(), false, true),
+            AccountsDb::account_balance_for_capitalization(10, &Pubkey::default(), false),
             10
         );
         // any random program data accounts
@@ -7937,7 +7880,6 @@ pub mod tests {
                 10,
                 &solana_sdk::pubkey::new_rand(),
                 false,
-                true,
             ),
             10
         );
@@ -7945,7 +7887,6 @@ pub mod tests {
             AccountsDb::account_balance_for_capitalization(
                 10,
                 &solana_sdk::pubkey::new_rand(),
-                false,
                 false,
             ),
             10
@@ -7963,37 +7904,13 @@ pub mod tests {
                 normal_sysvar.lamports,
                 &normal_sysvar.owner,
                 normal_sysvar.executable,
-                false,
-            ),
-            0
-        );
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                normal_sysvar.lamports,
-                &normal_sysvar.owner,
-                normal_sysvar.executable,
-                true,
             ),
             1
         );
 
         // currently transactions can send any lamports to sysvars although this is not sensible.
         assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                10,
-                &solana_sdk::sysvar::id(),
-                false,
-                false
-            ),
-            9
-        );
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                10,
-                &solana_sdk::sysvar::id(),
-                false,
-                true
-            ),
+            AccountsDb::account_balance_for_capitalization(10, &solana_sdk::sysvar::id(), false,),
             10
         );
     }
@@ -8006,16 +7923,6 @@ pub mod tests {
                 normal_native_program.lamports,
                 &normal_native_program.owner,
                 normal_native_program.executable,
-                false,
-            ),
-            0
-        );
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                normal_native_program.lamports,
-                &normal_native_program.owner,
-                normal_native_program.executable,
-                true,
             ),
             1
         );
@@ -8026,16 +7933,6 @@ pub mod tests {
                 1,
                 &solana_sdk::native_loader::id(),
                 false,
-                false,
-            ),
-            1
-        );
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                1,
-                &solana_sdk::native_loader::id(),
-                false,
-                true,
             ),
             1
         );

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3487,6 +3487,7 @@ impl AccountsDb {
         AccountsHash::checked_cast_for_capitalization(balances.map(|b| b as u128).sum::<u128>())
     }
 
+    // remove this by inlining and remove extra unused params upto all callchain
     pub fn account_balance_for_capitalization(
         lamports: u64,
         _owner: &Pubkey,
@@ -6987,10 +6988,6 @@ pub mod tests {
             )],
         );
         db.update_accounts_hash_test(some_slot, &ancestors);
-        //assert_matches!(
-        //    db.verify_bank_hash_and_lamports(some_slot, &ancestors, 1),
-        //    Ok(_)
-        //);
         assert_matches!(
             db.verify_bank_hash_and_lamports(some_slot, &ancestors, 2),
             Ok(_)
@@ -7883,14 +7880,6 @@ pub mod tests {
             ),
             10
         );
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                10,
-                &solana_sdk::pubkey::new_rand(),
-                false,
-            ),
-            10
-        );
     }
 
     #[test]
@@ -7908,9 +7897,9 @@ pub mod tests {
             1
         );
 
-        // currently transactions can send any lamports to sysvars although this is not sensible.
+        // transactions can send any lamports to sysvars although this is not sensible.
         assert_eq!(
-            AccountsDb::account_balance_for_capitalization(10, &solana_sdk::sysvar::id(), false,),
+            AccountsDb::account_balance_for_capitalization(10, &solana_sdk::sysvar::id(), false),
             10
         );
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1336,11 +1336,7 @@ impl Bank {
         let old_account = self.get_sysvar_account(pubkey);
         let new_account = updater(&old_account);
 
-        if !self.simple_capitalization_enabled() {
-            self.store_account(pubkey, &new_account);
-        } else {
-            self.store_account_and_update_capitalization(pubkey, &new_account);
-        }
+        self.store_account_and_update_capitalization(pubkey, &new_account);
     }
 
     fn inherit_specially_retained_account_balance(
@@ -2232,11 +2228,7 @@ impl Bank {
             name,
             self.inherit_specially_retained_account_balance(&existing_genuine_program),
         );
-        if !self.simple_capitalization_enabled() {
-            self.store_account(&program_id, &account);
-        } else {
-            self.store_account_and_update_capitalization(&program_id, &account);
-        }
+        self.store_account_and_update_capitalization(&program_id, &account);
 
         debug!("Added native program {} under {:?}", name, program_id);
     }
@@ -4194,7 +4186,6 @@ impl Bank {
             self.slot(),
             &self.ancestors,
             self.capitalization(),
-            self.simple_capitalization_enabled(),
         )
     }
 
@@ -4225,9 +4216,7 @@ impl Bank {
     }
 
     pub fn calculate_capitalization(&self) -> u64 {
-        self.rc
-            .accounts
-            .calculate_capitalization(&self.ancestors, self.simple_capitalization_enabled())
+        self.rc.accounts.calculate_capitalization(&self.ancestors)
     }
 
     pub fn calculate_and_verify_capitalization(&self) -> bool {
@@ -4275,7 +4264,6 @@ impl Bank {
                 debug_verify,
                 self.slot(),
                 &self.ancestors,
-                self.simple_capitalization_enabled(),
                 Some(self.capitalization()),
             );
         assert_eq!(total_lamports, self.capitalization());
@@ -4612,28 +4600,6 @@ impl Bank {
             .is_active(&feature_set::check_init_vote_data::id())
     }
 
-    pub fn simple_capitalization_enabled(&self) -> bool {
-        self.simple_capitalization_enabled_at_genesis()
-            || self
-                .feature_set
-                .is_active(&feature_set::simple_capitalization::id())
-    }
-
-    fn simple_capitalization_enabled_at_genesis(&self) -> bool {
-        // genesis builtin initialization codepath is called even before the initial
-        // feature activation, so we need to peek this flag at very early bank
-        // initialization phase for the development genesis case
-        if let Some(account) = self.get_account(&feature_set::simple_capitalization::id()) {
-            if let Some(feature) = feature::from_account(&account) {
-                if feature.activated_at == Some(0) {
-                    return true;
-                }
-            }
-        }
-
-        false
-    }
-
     pub fn deactivate_feature(&mut self, id: &Pubkey) {
         let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
         feature_set.active.remove(&id);
@@ -4678,10 +4644,6 @@ impl Bank {
             // bugs which again creates bad stake accounts..
 
             self.rewrite_stakes();
-        }
-
-        if new_feature_activations.contains(&feature_set::simple_capitalization::id()) {
-            self.adjust_capitalization_for_existing_specially_retained_accounts();
         }
 
         self.ensure_feature_builtins(init_finish_or_warp, &new_feature_activations);
@@ -4785,40 +4747,6 @@ impl Bank {
             }
         }
     }
-
-    fn adjust_capitalization_for_existing_specially_retained_accounts(&self) {
-        use solana_sdk::{bpf_loader, bpf_loader_deprecated, secp256k1_program};
-        let mut existing_sysvar_account_count = 8;
-        let mut existing_native_program_account_count = 4;
-
-        if self.get_account(&sysvar::rewards::id()).is_some() {
-            existing_sysvar_account_count += 1;
-        }
-
-        if self.get_account(&bpf_loader::id()).is_some() {
-            existing_native_program_account_count += 1;
-        }
-
-        if self.get_account(&bpf_loader_deprecated::id()).is_some() {
-            existing_native_program_account_count += 1;
-        }
-
-        if self.get_account(&secp256k1_program::id()).is_some() {
-            existing_native_program_account_count += 1;
-        }
-
-        info!(
-            "Adjusted capitalization for existing {} sysvars and {} native programs from {}",
-            existing_sysvar_account_count,
-            existing_native_program_account_count,
-            self.capitalization()
-        );
-        self.capitalization.fetch_add(
-            existing_sysvar_account_count + existing_native_program_account_count,
-            Relaxed,
-        );
-    }
-
     fn reconfigure_token2_native_mint(&mut self) {
         let reconfigure_token2_native_mint = match self.cluster_type() {
             ClusterType::Development => true,
@@ -5204,9 +5132,14 @@ pub(crate) mod tests {
             cluster_type: ClusterType::MainnetBeta,
             ..GenesisConfig::default()
         }));
-        assert_eq!(bank.capitalization(), 42 * 42);
+        let sysvar_lamports_at_slot0 = 10;
+        assert_eq!(bank.capitalization(), 42 * 42 + sysvar_lamports_at_slot0);
         let bank1 = Bank::new_from_parent(&bank, &Pubkey::default(), 1);
-        assert_eq!(bank1.capitalization(), 42 * 42);
+        let sysvar_lamports_at_slot1 = 2;
+        assert_eq!(
+            bank1.capitalization(),
+            42 * 42 + sysvar_lamports_at_slot0 + sysvar_lamports_at_slot1
+        );
     }
 
     #[test]
@@ -5492,19 +5425,6 @@ pub(crate) mod tests {
         assert_eq!(bank.capitalization(), bank.calculate_capitalization());
     }
 
-    fn assert_capitalization_diff_with_new_bank(
-        bank: &Bank,
-        updater: impl Fn() -> Bank,
-        asserter: impl Fn(u64, u64),
-    ) -> Bank {
-        let old = bank.capitalization();
-        let bank = updater();
-        let new = bank.capitalization();
-        asserter(old, new);
-        assert_eq!(bank.capitalization(), bank.calculate_capitalization());
-        bank
-    }
-
     #[test]
     fn test_store_account_and_update_capitalization_missing() {
         let (genesis_config, _mint_keypair) = create_genesis_config(0);
@@ -5707,7 +5627,6 @@ pub(crate) mod tests {
             burn_percent: 10,
         };
 
-        genesis_config.disable_cap_altering_features_for_preciseness();
         let mut bank = Bank::new(&genesis_config);
         // Enable rent collection
         bank.rent_collector.epoch = 5;
@@ -5793,8 +5712,9 @@ pub(crate) mod tests {
 
         let current_capitalization = bank.capitalization.load(Relaxed);
 
+        let sysvar_delta = 1;
         assert_eq!(
-            previous_capitalization - current_capitalization,
+            previous_capitalization - current_capitalization + sysvar_delta,
             burned_portion
         );
 
@@ -6700,11 +6620,6 @@ pub(crate) mod tests {
                 .map(|(slot, _)| *slot)
                 .collect::<Vec<Slot>>()
         }
-
-        fn first_slot_in_next_epoch(&self) -> Slot {
-            self.epoch_schedule()
-                .get_first_slot_in_epoch(self.epoch() + 1)
-        }
     }
 
     #[test]
@@ -6882,7 +6797,11 @@ pub(crate) mod tests {
         // not being eagerly-collected for exact rewards calculation
         bank.restore_old_behavior_for_fragile_tests();
 
-        assert_eq!(bank.capitalization(), 42 * 1_000_000_000);
+        let sysvar_lamports_at_slot0 = 10;
+        assert_eq!(
+            bank.capitalization(),
+            42 * 1_000_000_000 + sysvar_lamports_at_slot0
+        );
         assert!(bank.rewards.read().unwrap().is_empty());
 
         let ((vote_id, mut vote_account), (stake_id, stake_account)) =
@@ -6933,7 +6852,7 @@ pub(crate) mod tests {
         assert_ne!(bank1.capitalization(), bank.capitalization());
 
         // verify the inflation is represented in validator_points *
-        let inflation = bank1.capitalization() - bank.capitalization();
+        // let inflation = bank1.capitalization() - bank.capitalization();
 
         let rewards = bank1
             .get_account(&sysvar::rewards::id())
@@ -6950,10 +6869,10 @@ pub(crate) mod tests {
         );
 
         // verify the rewards are the right size
-        assert!(
-            ((rewards.validator_point_value * validator_points as f64) - inflation as f64).abs()
-                < 1.0 // rounding, truncating
-        );
+        //assert!(
+        //    ((rewards.validator_point_value * validator_points as f64) - (inflation + sysvar_lamports_at_slot0) as f64).abs()
+        //        < 1.0 // rounding, truncating
+        //);
 
         // verify validator rewards show up in bank1.rewards vector
         assert_eq!(
@@ -7001,7 +6920,11 @@ pub(crate) mod tests {
         // not being eagerly-collected for exact rewards calculation
         bank.restore_old_behavior_for_fragile_tests();
 
-        assert_eq!(bank.capitalization(), 42 * 1_000_000_000);
+        let sysvar_lamports_at_slot0 = 10;
+        assert_eq!(
+            bank.capitalization(),
+            42 * 1_000_000_000 + sysvar_lamports_at_slot0
+        );
         assert!(bank.rewards.read().unwrap().is_empty());
 
         let vote_id = solana_sdk::pubkey::new_rand();
@@ -7417,7 +7340,6 @@ pub(crate) mod tests {
         let (expected_fee_collected, expected_fee_burned) =
             genesis_config.fee_rate_governor.burn(expected_fee_paid);
 
-        genesis_config.disable_cap_altering_features_for_preciseness();
         let mut bank = Bank::new(&genesis_config);
 
         let capitalization = bank.capitalization();
@@ -7447,7 +7369,11 @@ pub(crate) mod tests {
         ); // Leader collects fee after the bank is frozen
 
         // verify capitalization
-        assert_eq!(capitalization - expected_fee_burned, bank.capitalization());
+        let sysvar_delta = 1;
+        assert_eq!(
+            capitalization - expected_fee_burned + sysvar_delta,
+            bank.capitalization()
+        );
 
         assert_eq!(
             *bank.rewards.read().unwrap(),
@@ -8218,7 +8144,8 @@ pub(crate) mod tests {
         assert_eq!(None, bank3.get_account_modified_since_parent(&pubkey));
     }
 
-    fn do_test_bank_update_sysvar_account(simple_capitalization_enabled: bool) {
+    #[test]
+    fn test_bank_update_sysvar_account() {
         use sysvar::clock::Clock;
 
         let dummy_clock_id = solana_sdk::pubkey::new_rand();
@@ -8228,9 +8155,7 @@ pub(crate) mod tests {
         let expected_next_slot = expected_previous_slot + 1;
 
         // First, initialize the clock sysvar
-        if simple_capitalization_enabled {
-            activate_all_features(&mut genesis_config);
-        }
+        activate_all_features(&mut genesis_config);
         let bank1 = Arc::new(Bank::new(&genesis_config));
         assert_eq!(bank1.calculate_capitalization(), bank1.capitalization());
 
@@ -8255,12 +8180,7 @@ pub(crate) mod tests {
                 );
             },
             |old, new| {
-                // only if simple_capitalization_enabled, cap should increment
-                if simple_capitalization_enabled {
-                    assert_eq!(old + 1, new);
-                } else {
-                    assert_eq!(old, new);
-                }
+                assert_eq!(old + 1, new);
             },
         );
 
@@ -8346,16 +8266,6 @@ pub(crate) mod tests {
                 assert_eq!(old, new);
             },
         );
-    }
-
-    #[test]
-    fn test_bank_update_sysvar_account_with_simple_capitalization_disabled() {
-        do_test_bank_update_sysvar_account(false)
-    }
-
-    #[test]
-    fn test_bank_update_sysvar_account_with_simple_capitalization_enabled() {
-        do_test_bank_update_sysvar_account(true);
     }
 
     #[test]
@@ -10576,11 +10486,10 @@ pub(crate) mod tests {
         assert_eq!(bank.get_account_modified_slot(&loader_id).unwrap().1, slot);
     }
 
-    fn do_test_add_native_program(simple_capitalization_enabled: bool) {
+    #[test]
+    fn test_add_native_program() {
         let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
-        if simple_capitalization_enabled {
-            activate_all_features(&mut genesis_config);
-        }
+        activate_all_features(&mut genesis_config);
 
         let slot = 123;
         let program_id = solana_sdk::pubkey::new_rand();
@@ -10596,11 +10505,7 @@ pub(crate) mod tests {
             &bank,
             || bank.add_native_program("mock_program", &program_id, false),
             |old, new| {
-                if simple_capitalization_enabled {
-                    assert_eq!(old + 1, new);
-                } else {
-                    assert_eq!(old, new);
-                }
+                assert_eq!(old + 1, new);
             },
         );
 
@@ -10641,16 +10546,6 @@ pub(crate) mod tests {
             bank.get_account_modified_slot(&program_id).unwrap().1,
             bank.parent_slot()
         );
-    }
-
-    #[test]
-    fn test_add_native_program_with_simple_capitalization_disabled() {
-        do_test_add_native_program(false);
-    }
-
-    #[test]
-    fn test_add_native_program_with_simple_capitalization_enabled() {
-        do_test_add_native_program(true);
     }
 
     #[test]
@@ -10814,7 +10709,6 @@ pub(crate) mod tests {
             reward_pubkey,
             Account::new(u64::MAX, 0, &solana_sdk::pubkey::new_rand()),
         );
-        genesis_config.disable_cap_altering_features_for_preciseness();
         let bank0 = Bank::new(&genesis_config);
         // because capitalization has been reset with bogus capitalization calculation allowing overflows,
         // deliberately substract 1 lamport to simulate it
@@ -10830,8 +10724,9 @@ pub(crate) mod tests {
 
         // assert that everything gets in order....
         assert!(bank1.get_account(&reward_pubkey).is_none());
+        let sysvar_delta = 1;
         assert_eq!(
-            bank0.capitalization() + 1 + 1_000_000_000,
+            bank0.capitalization() + 1 + 1_000_000_000 + sysvar_delta,
             bank1.capitalization()
         );
         assert_eq!(bank1.capitalization(), bank1.calculate_capitalization());
@@ -11147,116 +11042,6 @@ pub(crate) mod tests {
         let versioned = VoteStateVersions::new_current(vote_state);
         VoteState::to(&versioned, &mut vote_account).unwrap();
         bank.store_account(vote_pubkey, &vote_account);
-    }
-
-    #[test]
-    fn test_simple_capitalization_adjustment_minimum_genesis_set() {
-        solana_logger::setup();
-
-        let (mut genesis_config, _mint_keypair) = create_genesis_config(0);
-        let feature_balance =
-            std::cmp::max(genesis_config.rent.minimum_balance(Feature::size_of()), 1);
-
-        // inhibit deprecated rewards sysvar creation altogether
-        genesis_config.accounts.insert(
-            feature_set::deprecate_rewards_sysvar::id(),
-            Account::from(feature::create_account(
-                &Feature {
-                    activated_at: Some(0),
-                },
-                feature_balance,
-            )),
-        );
-
-        let bank0 = Bank::new(&genesis_config);
-        let bank1 = Arc::new(new_from_parent(&Arc::new(bank0)));
-
-        // schedule activation of simple capitalization
-        bank1.store_account_and_update_capitalization(
-            &feature_set::simple_capitalization::id(),
-            &feature::create_account(&Feature { activated_at: None }, feature_balance),
-        );
-
-        // 12 is minimum adjusted cap increase in adjust_capitalization_for_existing_specially_retained_accounts
-        assert_capitalization_diff_with_new_bank(
-            &bank1,
-            || Bank::new_from_parent(&bank1, &Pubkey::default(), bank1.first_slot_in_next_epoch()),
-            |old, new| assert_eq!(old + 12, new),
-        );
-    }
-
-    #[test]
-    fn test_simple_capitalization_adjustment_full_set() {
-        solana_logger::setup();
-
-        let (mut genesis_config, _mint_keypair) = create_genesis_config(0);
-        let feature_balance =
-            std::cmp::max(genesis_config.rent.minimum_balance(Feature::size_of()), 1);
-
-        // activate all features but simple capitalization
-        activate_all_features(&mut genesis_config);
-        genesis_config
-            .accounts
-            .remove(&feature_set::simple_capitalization::id());
-        // intentionally create deprecated rewards sysvar creation
-        genesis_config
-            .accounts
-            .remove(&feature_set::deprecate_rewards_sysvar::id());
-
-        // intentionally create bogus native programs
-        #[allow(clippy::unnecessary_wraps)]
-        fn mock_process_instruction(
-            _program_id: &Pubkey,
-            _keyed_accounts: &[KeyedAccount],
-            _data: &[u8],
-            _invoke_context: &mut dyn InvokeContext,
-        ) -> std::result::Result<(), solana_sdk::instruction::InstructionError> {
-            Ok(())
-        }
-        let builtins = Builtins {
-            genesis_builtins: vec![
-                Builtin::new(
-                    "mock bpf",
-                    solana_sdk::bpf_loader::id(),
-                    mock_process_instruction,
-                ),
-                Builtin::new(
-                    "mock bpf",
-                    solana_sdk::bpf_loader_deprecated::id(),
-                    mock_process_instruction,
-                ),
-            ],
-            feature_builtins: (vec![]),
-        };
-
-        let bank0 = Arc::new(Bank::new_with_paths(
-            &genesis_config,
-            Vec::new(),
-            &[],
-            None,
-            Some(&builtins),
-            HashSet::new(),
-            false,
-        ));
-        // move to next epoch to create now deprecated rewards sysvar intentionally
-        let bank1 = Arc::new(Bank::new_from_parent(
-            &bank0,
-            &Pubkey::default(),
-            bank0.first_slot_in_next_epoch(),
-        ));
-
-        // schedule activation of simple capitalization
-        bank1.store_account_and_update_capitalization(
-            &feature_set::simple_capitalization::id(),
-            &feature::create_account(&Feature { activated_at: None }, feature_balance),
-        );
-
-        // 16 is maximum adjusted cap increase in adjust_capitalization_for_existing_specially_retained_accounts
-        assert_capitalization_diff_with_new_bank(
-            &bank1,
-            || Bank::new_from_parent(&bank1, &Pubkey::default(), bank1.first_slot_in_next_epoch()),
-            |old, new| assert_eq!(old + 16, new),
-        );
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5120,7 +5120,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_bank_capitalization() {
-        let bank = Arc::new(Bank::new(&GenesisConfig {
+        let bank0 = Arc::new(Bank::new(&GenesisConfig {
             accounts: (0..42)
                 .map(|_| {
                     (
@@ -5132,13 +5132,16 @@ pub(crate) mod tests {
             cluster_type: ClusterType::MainnetBeta,
             ..GenesisConfig::default()
         }));
-        let sysvar_lamports_at_slot0 = 10;
-        assert_eq!(bank.capitalization(), 42 * 42 + sysvar_lamports_at_slot0);
-        let bank1 = Bank::new_from_parent(&bank, &Pubkey::default(), 1);
-        let sysvar_lamports_at_slot1 = 2;
+        let sysvar_and_native_proram_delta0 = 10;
+        assert_eq!(
+            bank0.capitalization(),
+            42 * 42 + sysvar_and_native_proram_delta0
+        );
+        let bank1 = Bank::new_from_parent(&bank0, &Pubkey::default(), 1);
+        let sysvar_and_native_proram_delta1 = 2;
         assert_eq!(
             bank1.capitalization(),
-            42 * 42 + sysvar_lamports_at_slot0 + sysvar_lamports_at_slot1
+            42 * 42 + sysvar_and_native_proram_delta0 + sysvar_and_native_proram_delta1,
         );
     }
 
@@ -5712,9 +5715,9 @@ pub(crate) mod tests {
 
         let current_capitalization = bank.capitalization.load(Relaxed);
 
-        let sysvar_delta = 1;
+        let sysvar_and_native_proram_delta = 1;
         assert_eq!(
-            previous_capitalization - current_capitalization + sysvar_delta,
+            previous_capitalization - current_capitalization + sysvar_and_native_proram_delta,
             burned_portion
         );
 
@@ -6797,10 +6800,10 @@ pub(crate) mod tests {
         // not being eagerly-collected for exact rewards calculation
         bank.restore_old_behavior_for_fragile_tests();
 
-        let sysvar_lamports_at_slot0 = 10;
+        let sysvar_and_native_proram_delta = 10;
         assert_eq!(
             bank.capitalization(),
-            42 * 1_000_000_000 + sysvar_lamports_at_slot0
+            42 * 1_000_000_000 + sysvar_and_native_proram_delta
         );
         assert!(bank.rewards.read().unwrap().is_empty());
 
@@ -6852,7 +6855,9 @@ pub(crate) mod tests {
         assert_ne!(bank1.capitalization(), bank.capitalization());
 
         // verify the inflation is represented in validator_points *
-        // let inflation = bank1.capitalization() - bank.capitalization();
+        let sysvar_and_native_proram_delta = 2;
+        let inflation =
+            bank1.capitalization() - bank.capitalization() - sysvar_and_native_proram_delta;
 
         let rewards = bank1
             .get_account(&sysvar::rewards::id())
@@ -6869,10 +6874,8 @@ pub(crate) mod tests {
         );
 
         // verify the rewards are the right size
-        //assert!(
-        //    ((rewards.validator_point_value * validator_points as f64) - (inflation + sysvar_lamports_at_slot0) as f64).abs()
-        //        < 1.0 // rounding, truncating
-        //);
+        let total_rewards = rewards.validator_point_value * validator_points as f64;
+        assert!((total_rewards - inflation as f64).abs() < 1.0); // rounding, truncating
 
         // verify validator rewards show up in bank1.rewards vector
         assert_eq!(
@@ -6920,10 +6923,10 @@ pub(crate) mod tests {
         // not being eagerly-collected for exact rewards calculation
         bank.restore_old_behavior_for_fragile_tests();
 
-        let sysvar_lamports_at_slot0 = 10;
+        let sysvar_and_native_proram_delta = 10;
         assert_eq!(
             bank.capitalization(),
-            42 * 1_000_000_000 + sysvar_lamports_at_slot0
+            42 * 1_000_000_000 + sysvar_and_native_proram_delta
         );
         assert!(bank.rewards.read().unwrap().is_empty());
 
@@ -7369,9 +7372,9 @@ pub(crate) mod tests {
         ); // Leader collects fee after the bank is frozen
 
         // verify capitalization
-        let sysvar_delta = 1;
+        let sysvar_and_native_proram_delta = 1;
         assert_eq!(
-            capitalization - expected_fee_burned + sysvar_delta,
+            capitalization - expected_fee_burned + sysvar_and_native_proram_delta,
             bank.capitalization()
         );
 
@@ -10724,9 +10727,9 @@ pub(crate) mod tests {
 
         // assert that everything gets in order....
         assert!(bank1.get_account(&reward_pubkey).is_none());
-        let sysvar_delta = 1;
+        let sysvar_and_native_proram_delta = 1;
         assert_eq!(
-            bank0.capitalization() + 1 + 1_000_000_000 + sysvar_delta,
+            bank0.capitalization() + 1 + 1_000_000_000 + sysvar_and_native_proram_delta,
             bank1.capitalization()
         );
         assert_eq!(bank1.capitalization(), bank1.calculate_capitalization());

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -26,7 +26,6 @@ pub struct AccountsPackagePre {
     pub snapshot_output_dir: PathBuf,
     pub expected_capitalization: u64,
     pub hash_for_testing: Option<Hash>,
-    pub simple_capitalization_testing: bool,
 }
 
 impl AccountsPackagePre {
@@ -43,7 +42,6 @@ impl AccountsPackagePre {
         snapshot_output_dir: PathBuf,
         expected_capitalization: u64,
         hash_for_testing: Option<Hash>,
-        simple_capitalization_testing: bool,
     ) -> Self {
         Self {
             slot,
@@ -57,7 +55,6 @@ impl AccountsPackagePre {
             snapshot_output_dir,
             expected_capitalization,
             hash_for_testing,
-            simple_capitalization_testing,
         }
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -186,7 +186,6 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
         snapshot_package_output_path.as_ref().to_path_buf(),
         bank.capitalization(),
         hash_for_testing,
-        bank.simple_capitalization_enabled(),
     );
 
     Ok(package)
@@ -969,7 +968,6 @@ pub fn process_accounts_package_pre(
     if let Some(expected_hash) = accounts_package.hash_for_testing {
         let (hash, lamports) = AccountsDb::calculate_accounts_hash_without_index(
             &accounts_package.storages,
-            accounts_package.simple_capitalization_testing,
             thread_pool,
         );
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -71,10 +71,6 @@ pub mod filter_stake_delegation_accounts {
     solana_sdk::declare_id!("GE7fRxmW46K6EmCD9AMZSbnaJ2e3LfqCZzdHi9hmYAgi");
 }
 
-pub mod simple_capitalization {
-    solana_sdk::declare_id!("9r69RnnxABmpcPFfj1yhg4n9YFR2MNaLdKJCC6v3Speb");
-}
-
 pub mod bpf_loader_upgradeable_program {
     solana_sdk::declare_id!("FbhK8HN9qvNHvJcoFVHAEUCNkagHvu7DTWzdnLuVQ5u4");
 }
@@ -123,7 +119,6 @@ lazy_static! {
         (stake_program_v2::id(), "solana_stake_program v2"),
         (rewrite_stake::id(), "rewrite stake"),
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
-        (simple_capitalization::id(), "simple capitalization"),
         (bpf_loader_upgradeable_program::id(), "upgradeable bpf loader"),
         (stake_program_v3::id(), "solana_stake_program v3"),
         (turbine_retransmit_peers_patch::id(), "turbine retransmit peers patch #14631"),

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -151,11 +151,6 @@ impl GenesisConfig {
         hash(&serialized)
     }
 
-    pub fn disable_cap_altering_features_for_preciseness(&mut self) {
-        self.accounts
-            .remove(&crate::feature_set::simple_capitalization::id());
-    }
-
     fn genesis_filename(ledger_path: &Path) -> PathBuf {
         Path::new(ledger_path).join("genesis.bin")
     }


### PR DESCRIPTION
#### Problem

There is important planned rent change (will backport to v1.5) with another feature gate; and there are too many feature flags.

#### Summary of Changes

Clean up before the next one!

Because of the blocked change, this clean will also be v1.5-back-ported.

this is 2 of 2 of this old feature cleaning: https://github.com/solana-labs/solana/pull/15754

Also, this passed live-cluter test.

Fixes #
