### PR TITLE
Explorer: vote timestamp is nullable hotfix

### DIFF
--- a/explorer/src/components/instruction/vote/types.ts
+++ b/explorer/src/components/instruction/vote/types.ts
@@ -1,6 +1,14 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 
-import { array, number, optional, pick, string, StructType } from "superstruct";
+import {
+  array,
+  nullable,
+  number,
+  optional,
+  pick,
+  string,
+  StructType,
+} from "superstruct";
 import { Pubkey } from "validators/pubkey";
 
 export type InitializeInfo = StructType<typeof InitializeInfo>;
@@ -32,7 +40,7 @@ export const VoteInfo = pick({
   vote: pick({
     hash: string(),
     slots: array(number()),
-    timestamp: optional(number()),
+    timestamp: optional(nullable(number())),
   }),
 });
 


### PR DESCRIPTION
#### Problem
It appears the timestamp is returned as null on older vote instructions.
 
#### Summary of Changes
Make timestamp nullable in the superstruct definition. 
