### PR TITLE
Default to the BPF JIT. Use the `solana-validator --no-bpf-jit` flag to disable

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -746,10 +746,10 @@ fn main() {
         .long("no-snapshot")
         .takes_value(false)
         .help("Do not start from a local snapshot if present");
-    let bpf_jit_arg = Arg::with_name("bpf_jit")
-        .long("bpf-jit")
+    let no_bpf_jit_arg = Arg::with_name("no_bpf_jit")
+        .long("no-bpf-jit")
         .takes_value(false)
-        .help("Process with JIT instead of interpreter");
+        .help("Disable the just-in-time compiler and instead use the interpreter for BP");
     let no_accounts_db_caching_arg = Arg::with_name("no_accounts_db_caching")
         .long("no-accounts-db-caching")
         .takes_value(false)
@@ -1019,7 +1019,7 @@ fn main() {
             .arg(&halt_at_slot_arg)
             .arg(&hard_forks_arg)
             .arg(&no_accounts_db_caching_arg)
-            .arg(&bpf_jit_arg)
+            .arg(&no_bpf_jit_arg)
             .arg(&allow_dead_slots_arg)
             .arg(&max_genesis_archive_unpacked_size_arg)
             .arg(
@@ -1684,7 +1684,7 @@ fn main() {
                 dev_halt_at_slot: value_t!(arg_matches, "halt_at_slot", Slot).ok(),
                 new_hard_forks: hardforks_of(arg_matches, "hard_forks"),
                 poh_verify: !arg_matches.is_present("skip_poh_verify"),
-                bpf_jit: arg_matches.is_present("bpf_jit"),
+                bpf_jit: !matches.is_present("no_bpf_jit"),
                 accounts_db_caching_enabled: !arg_matches.is_present("no_accounts_db_caching"),
                 allow_dead_slots: arg_matches.is_present("allow_dead_slots"),
                 ..ProcessOptions::default()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1581,10 +1581,18 @@ pub fn main() {
                 ),
         )
         .arg(
+            Arg::with_name("no_bpf_jit")
+                .long("no-bpf-jit")
+                .takes_value(false)
+                .help("Disable the just-in-time compiler and instead use the interpreter for BPF"),
+        )
+        .arg(
+            // legacy nop argument
             Arg::with_name("bpf_jit")
                 .long("bpf-jit")
+                .hidden(true)
                 .takes_value(false)
-                .help("Use the just-in-time compiler instead of the interpreter for BPF."),
+                .conflicts_with("no_bpf_jit")
         )
         .arg(
             Arg::with_name("poh_pinned_cpu_core")
@@ -1920,7 +1928,7 @@ pub fn main() {
         poh_verify: !matches.is_present("skip_poh_verify"),
         debug_keys,
         contact_debug_interval,
-        bpf_jit: matches.is_present("bpf_jit"),
+        bpf_jit: !matches.is_present("no_bpf_jit"),
         send_transaction_retry_ms: value_t_or_exit!(matches, "rpc_send_transaction_retry_ms", u64),
         send_transaction_leader_forward_count: value_t_or_exit!(
             matches,


### PR DESCRIPTION
1.6 seems like a good release train to enable the BPF JIT by default.  We've had mainnet-beta nodes running with the JIT enabled for months now with no real issues.  It's time!