### PR TITLE
AccountSharedData construction changes

### DIFF
--- a/account-decoder/src/lib.rs
+++ b/account-decoder/src/lib.rs
@@ -224,10 +224,10 @@ mod test {
     fn test_base64_zstd() {
         let encoded_account = UiAccount::encode(
             &Pubkey::default(),
-            AccountSharedData {
+            AccountSharedData::from(Account {
                 data: vec![0; 1024],
-                ..AccountSharedData::default()
-            },
+                ..Account::default()
+            }),
             UiAccountEncoding::Base64Zstd,
             None,
             None,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1253,7 +1253,7 @@ pub mod test {
         },
     };
     use solana_sdk::{
-        account::{AccountSharedData, WritableAccount},
+        account::{Account, AccountSharedData, WritableAccount},
         clock::Slot,
         hash::Hash,
         pubkey::Pubkey,
@@ -2255,10 +2255,10 @@ pub mod test {
     #[test]
     fn test_stake_is_updated_for_entire_branch() {
         let mut voted_stakes = HashMap::new();
-        let account = AccountSharedData {
+        let account = AccountSharedData::from(Account {
             lamports: 1,
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         let set: HashSet<u64> = vec![0u64, 1u64].into_iter().collect();
         let ancestors: HashMap<u64, HashSet<u64>> = [(2u64, set)].iter().cloned().collect();
         Tower::update_ancestor_voted_stakes(&mut voted_stakes, 2, account.lamports, &ancestors);

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -3100,6 +3100,7 @@ pub mod tests {
         accounts_background_service::AbsRequestSender, commitment::BlockCommitment,
     };
     use solana_sdk::{
+        account::Account,
         clock::MAX_RECENT_BLOCKHASHES,
         fee_calculator::DEFAULT_BURN_PERCENT,
         hash::{hash, Hash},
@@ -5614,12 +5615,12 @@ pub mod tests {
             close_authority: COption::Some(owner),
         };
         TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = AccountSharedData {
+        let token_account = AccountSharedData::from(Account {
             lamports: 111,
             data: account_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         let token_account_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_account_pubkey, &token_account);
 
@@ -5633,12 +5634,12 @@ pub mod tests {
             freeze_authority: COption::Some(owner),
         };
         Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = AccountSharedData {
+        let mint_account = AccountSharedData::from(Account {
             lamports: 111,
             data: mint_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
 
         let req = format!(
@@ -5710,12 +5711,12 @@ pub mod tests {
             close_authority: COption::Some(owner),
         };
         TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = AccountSharedData {
+        let token_account = AccountSharedData::from(Account {
             lamports: 111,
             data: account_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         let token_with_different_mint_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_with_different_mint_pubkey, &token_account);
 
@@ -5929,12 +5930,12 @@ pub mod tests {
             freeze_authority: COption::Some(owner),
         };
         Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = AccountSharedData {
+        let mint_account = AccountSharedData::from(Account {
             lamports: 111,
             data: mint_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         bank.store_account(
             &Pubkey::from_str(&new_mint.to_string()).unwrap(),
             &mint_account,
@@ -5951,12 +5952,12 @@ pub mod tests {
             close_authority: COption::Some(owner),
         };
         TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = AccountSharedData {
+        let token_account = AccountSharedData::from(Account {
             lamports: 111,
             data: account_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         let token_with_smaller_balance = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_with_smaller_balance, &token_account);
 
@@ -6015,12 +6016,12 @@ pub mod tests {
             close_authority: COption::Some(owner),
         };
         TokenAccount::pack(token_account, &mut account_data).unwrap();
-        let token_account = AccountSharedData {
+        let token_account = AccountSharedData::from(Account {
             lamports: 111,
             data: account_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         let token_account_pubkey = solana_sdk::pubkey::new_rand();
         bank.store_account(&token_account_pubkey, &token_account);
 
@@ -6034,12 +6035,12 @@ pub mod tests {
             freeze_authority: COption::Some(owner),
         };
         Mint::pack(mint_state, &mut mint_data).unwrap();
-        let mint_account = AccountSharedData {
+        let mint_account = AccountSharedData::from(Account {
             lamports: 111,
             data: mint_data.to_vec(),
             owner: spl_token_id_v2_0(),
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         bank.store_account(&Pubkey::from_str(&mint.to_string()).unwrap(), &mint_account);
 
         let req = format!(

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -13,7 +13,7 @@ use {
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
     },
     solana_sdk::{
-        account::AccountSharedData,
+        account::{Account, AccountSharedData},
         clock::{Slot, DEFAULT_MS_PER_SLOT},
         commitment_config::CommitmentConfig,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -133,7 +133,7 @@ impl TestValidatorGenesis {
     ) -> &mut Self {
         self.add_account(
             address,
-            AccountSharedData {
+            AccountSharedData::from(Account {
                 lamports,
                 data: solana_program_test::read_file(
                     solana_program_test::find_file(filename).unwrap_or_else(|| {
@@ -143,7 +143,7 @@ impl TestValidatorGenesis {
                 owner,
                 executable: false,
                 rent_epoch: 0,
-            },
+            }),
         )
     }
 
@@ -158,14 +158,14 @@ impl TestValidatorGenesis {
     ) -> &mut Self {
         self.add_account(
             address,
-            AccountSharedData {
+            AccountSharedData::from(Account {
                 lamports,
                 data: base64::decode(data_base64)
                     .unwrap_or_else(|err| panic!("Failed to base64 decode: {}", err)),
                 owner,
                 executable: false,
                 rent_epoch: 0,
-            },
+            }),
         )
     }
 
@@ -285,13 +285,13 @@ impl TestValidator {
             let data = solana_program_test::read_file(&program.program_path);
             accounts.insert(
                 program.program_id,
-                AccountSharedData {
+                AccountSharedData::from(Account {
                     lamports: Rent::default().minimum_balance(data.len()).min(1),
                     data,
                     owner: program.loader,
                     executable: true,
                     rent_epoch: 0,
-                },
+                }),
             );
         }
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -19,7 +19,7 @@ use solana_ledger::{
 };
 use solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE;
 use solana_sdk::{
-    account::AccountSharedData,
+    account::{Account, AccountSharedData},
     clock,
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeRateGovernor,
@@ -618,13 +618,13 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         });
                     genesis_config.add_account(
                         address,
-                        AccountSharedData {
+                        AccountSharedData::from(Account {
                             lamports: genesis_config.rent.minimum_balance(program_data.len()),
                             data: program_data,
                             executable: true,
                             owner: loader,
                             rent_epoch: 0,
-                        },
+                        }),
                     );
                 }
                 _ => unreachable!(),

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -20,7 +20,7 @@ use {
         genesis_utils::{create_genesis_config_with_leader, GenesisConfigInfo},
     },
     solana_sdk::{
-        account::{AccountSharedData, ReadableAccount},
+        account::{Account, AccountSharedData, ReadableAccount},
         clock::Slot,
         genesis_config::GenesisConfig,
         keyed_account::KeyedAccount,
@@ -239,13 +239,13 @@ impl program_stubs::SyscallStubs for SyscallStubs {
         stable_log::program_invoke(&logger, &program_id, invoke_context.invoke_depth());
 
         fn ai_to_a(ai: &AccountInfo) -> AccountSharedData {
-            AccountSharedData {
+            AccountSharedData::from(Account {
                 lamports: ai.lamports(),
                 data: ai.try_borrow_data().unwrap().to_vec(),
                 owner: *ai.owner,
                 executable: ai.executable,
                 rent_epoch: ai.rent_epoch,
-            }
+            })
         }
         let executables = vec![(program_id, RefCell::new(ai_to_a(program_account_info)))];
 
@@ -483,7 +483,7 @@ impl ProgramTest {
     ) {
         self.add_account(
             address,
-            AccountSharedData {
+            AccountSharedData::from(Account {
                 lamports,
                 data: read_file(find_file(filename).unwrap_or_else(|| {
                     panic!("Unable to locate {}", filename);
@@ -491,7 +491,7 @@ impl ProgramTest {
                 owner,
                 executable: false,
                 rent_epoch: 0,
-            },
+            }),
         );
     }
 
@@ -506,14 +506,14 @@ impl ProgramTest {
     ) {
         self.add_account(
             address,
-            AccountSharedData {
+            AccountSharedData::from(Account {
                 lamports,
                 data: base64::decode(data_base64)
                     .unwrap_or_else(|err| panic!("Failed to base64 decode: {}", err)),
                 owner,
                 executable: false,
                 rent_epoch: 0,
-            },
+            }),
         );
     }
 
@@ -569,13 +569,13 @@ impl ProgramTest {
 
             self.add_account(
                 program_id,
-                AccountSharedData {
+                AccountSharedData::from(Account {
                     lamports: Rent::default().minimum_balance(data.len()).min(1),
                     data,
                     owner: loader,
                     executable: true,
                     rent_epoch: 0,
-                },
+                }),
             );
         } else {
             info!("\"{}\" program loaded as native code", program_name);

--- a/program-test/src/programs.rs
+++ b/program-test/src/programs.rs
@@ -1,4 +1,8 @@
-use solana_sdk::{account::AccountSharedData, pubkey::Pubkey, rent::Rent};
+use solana_sdk::{
+    account::{Account, AccountSharedData},
+    pubkey::Pubkey,
+    rent::Rent,
+};
 
 mod spl_token {
     solana_sdk::declare_id!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
@@ -35,13 +39,13 @@ pub fn spl_programs(rent: &Rent) -> Vec<(Pubkey, AccountSharedData)> {
         .map(|(program_id, elf)| {
             (
                 *program_id,
-                AccountSharedData {
+                AccountSharedData::from(Account {
                     lamports: rent.minimum_balance(elf.len()).min(1),
                     data: elf.to_vec(),
                     owner: solana_program::bpf_loader::id(),
                     executable: true,
                     rent_epoch: 0,
-                },
+                }),
             )
         })
         .collect()

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -251,7 +251,10 @@ pub fn deserialize_parameters_aligned(
 mod tests {
     use super::*;
     use solana_sdk::{
-        account::AccountSharedData, account_info::AccountInfo, bpf_loader, entrypoint::deserialize,
+        account::{Account, AccountSharedData},
+        account_info::AccountInfo,
+        bpf_loader,
+        entrypoint::deserialize,
     };
     use std::{
         cell::RefCell,
@@ -271,35 +274,35 @@ mod tests {
             solana_sdk::pubkey::new_rand(),
         ];
         let accounts = [
-            RefCell::new(AccountSharedData {
+            RefCell::new(AccountSharedData::from(Account {
                 lamports: 1,
                 data: vec![1u8, 2, 3, 4, 5],
                 owner: bpf_loader::id(),
                 executable: false,
                 rent_epoch: 100,
-            }),
+            })),
             // dup of first
-            RefCell::new(AccountSharedData {
+            RefCell::new(AccountSharedData::from(Account {
                 lamports: 1,
                 data: vec![1u8, 2, 3, 4, 5],
                 owner: bpf_loader::id(),
                 executable: false,
                 rent_epoch: 100,
-            }),
-            RefCell::new(AccountSharedData {
+            })),
+            RefCell::new(AccountSharedData::from(Account {
                 lamports: 2,
                 data: vec![11u8, 12, 13, 14, 15, 16, 17, 18, 19],
                 owner: bpf_loader::id(),
                 executable: true,
                 rent_epoch: 200,
-            }),
-            RefCell::new(AccountSharedData {
+            })),
+            RefCell::new(AccountSharedData::from(Account {
                 lamports: 3,
                 data: vec![],
                 owner: bpf_loader::id(),
                 executable: false,
                 rent_epoch: 3100,
-            }),
+            })),
         ];
 
         let keyed_accounts: Vec<_> = keys

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -10,7 +10,7 @@ use solana_rbpf::{
 };
 use solana_runtime::message_processor::MessageProcessor;
 use solana_sdk::{
-    account::{AccountSharedData, ReadableAccount},
+    account::{Account, AccountSharedData, ReadableAccount},
     account_info::AccountInfo,
     account_utils::StateMut,
     bpf_loader, bpf_loader_deprecated,
@@ -1007,13 +1007,13 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedRust<'a> {
             };
 
             Ok((
-                Rc::new(RefCell::new(AccountSharedData {
+                Rc::new(RefCell::new(AccountSharedData::from(Account {
                     lamports: *lamports,
                     data: data.to_vec(),
                     executable: account_info.executable,
                     owner: *owner,
                     rent_epoch: account_info.rent_epoch,
-                })),
+                }))),
                 Some(AccountReferences {
                     lamports,
                     owner,
@@ -1290,13 +1290,13 @@ impl<'a> SyscallInvokeSigned<'a> for SyscallInvokeSignedC<'a> {
             )?;
 
             Ok((
-                Rc::new(RefCell::new(AccountSharedData {
+                Rc::new(RefCell::new(AccountSharedData::from(Account {
                     lamports: *lamports,
                     data: data.to_vec(),
                     executable: account_info.executable,
                     owner: *owner,
                     rent_epoch: account_info.rent_epoch,
-                })),
+                }))),
                 Some(AccountReferences {
                     lamports,
                     owner,

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -247,7 +247,7 @@ mod tests {
     use crate::id;
     use solana_runtime::bank::Bank;
     use solana_runtime::bank_client::BankClient;
-    use solana_sdk::account::AccountSharedData;
+    use solana_sdk::account::{Account, AccountSharedData};
     use solana_sdk::client::SyncClient;
     use solana_sdk::genesis_config::create_genesis_config;
     use solana_sdk::hash::hash;
@@ -540,11 +540,11 @@ mod tests {
     fn test_pay_when_account_data() {
         let (bank, alice_keypair) = create_bank(42);
         let game_pubkey = solana_sdk::pubkey::new_rand();
-        let game_account = AccountSharedData {
+        let game_account = AccountSharedData::from(Account {
             lamports: 1,
             data: vec![1, 2, 3],
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         bank.store_account(&game_pubkey, &game_account);
         assert_eq!(
             bank.get_account(&game_pubkey).unwrap().data(),

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -134,7 +134,7 @@ mod tests {
     use bincode::serialized_size;
     use serde_derive::{Deserialize, Serialize};
     use solana_sdk::{
-        account::AccountSharedData,
+        account::{Account, AccountSharedData},
         keyed_account::create_keyed_is_signer_accounts,
         process_instruction::MockInvokeContext,
         signature::{Keypair, Signer},
@@ -183,11 +183,11 @@ mod tests {
             } => space,
             _ => panic!("Not a CreateAccount system instruction"),
         };
-        let config_account = RefCell::new(AccountSharedData {
+        let config_account = RefCell::new(AccountSharedData::from(Account {
             data: vec![0; space as usize],
             owner: id(),
-            ..AccountSharedData::default()
-        });
+            ..Account::default()
+        }));
         let accounts = vec![(&config_pubkey, true, &config_account)];
         let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
         assert_eq!(
@@ -338,10 +338,10 @@ mod tests {
         let my_config = MyConfig::new(42);
 
         let instruction = config_instruction::store(&config_pubkey, false, keys, &my_config);
-        let signer0_account = RefCell::new(AccountSharedData {
+        let signer0_account = RefCell::new(AccountSharedData::from(Account {
             owner: id(),
-            ..AccountSharedData::default()
-        });
+            ..Account::default()
+        }));
         let accounts = vec![(&signer0_pubkey, true, &signer0_account)];
         let keyed_accounts = create_keyed_is_signer_accounts(&accounts);
         assert_eq!(

--- a/programs/config/src/lib.rs
+++ b/programs/config/src/lib.rs
@@ -5,7 +5,11 @@ pub mod date_instruction;
 
 use bincode::{deserialize, serialize, serialized_size};
 use serde_derive::{Deserialize, Serialize};
-use solana_sdk::{account::AccountSharedData, pubkey::Pubkey, short_vec};
+use solana_sdk::{
+    account::{Account, AccountSharedData},
+    pubkey::Pubkey,
+    short_vec,
+};
 
 solana_sdk::declare_id!("Config1111111111111111111111111111111111111");
 
@@ -43,10 +47,10 @@ pub fn create_config_account<T: ConfigState>(
 ) -> AccountSharedData {
     let mut data = serialize(&ConfigKeys { keys }).unwrap();
     data.extend_from_slice(&serialize(config_data).unwrap());
-    AccountSharedData {
+    AccountSharedData::from(Account {
         lamports,
         data,
         owner: id(),
-        ..AccountSharedData::default()
-    }
+        ..Account::default()
+    })
 }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -622,7 +622,7 @@ mod tests {
     use super::*;
     use bincode::serialize;
     use solana_sdk::{
-        account::{self, AccountSharedData},
+        account::{self, Account, AccountSharedData},
         process_instruction::MockInvokeContext,
         rent::Rent,
         sysvar::stake_history::StakeHistory,
@@ -635,10 +635,10 @@ mod tests {
     }
 
     fn create_default_stake_account() -> RefCell<AccountSharedData> {
-        RefCell::new(AccountSharedData {
+        RefCell::new(AccountSharedData::from(Account {
             owner: id(),
-            ..AccountSharedData::default()
-        })
+            ..Account::default()
+        }))
     }
 
     fn invalid_stake_state_pubkey() -> Pubkey {
@@ -673,25 +673,25 @@ mod tests {
                 } else if sysvar::rent::check_id(&meta.pubkey) {
                     account::create_account_shared_data(&Rent::default(), 1)
                 } else if meta.pubkey == invalid_stake_state_pubkey() {
-                    AccountSharedData {
+                    AccountSharedData::from(Account {
                         owner: id(),
-                        ..AccountSharedData::default()
-                    }
+                        ..Account::default()
+                    })
                 } else if meta.pubkey == invalid_vote_state_pubkey() {
-                    AccountSharedData {
+                    AccountSharedData::from(Account {
                         owner: solana_vote_program::id(),
-                        ..AccountSharedData::default()
-                    }
+                        ..Account::default()
+                    })
                 } else if meta.pubkey == spoofed_stake_state_pubkey() {
-                    AccountSharedData {
+                    AccountSharedData::from(Account {
                         owner: spoofed_stake_program_id(),
-                        ..AccountSharedData::default()
-                    }
+                        ..Account::default()
+                    })
                 } else {
-                    AccountSharedData {
+                    AccountSharedData::from(Account {
                         owner: id(),
-                        ..AccountSharedData::default()
-                    }
+                        ..Account::default()
+                    })
                 })
             })
             .collect();

--- a/programs/vote/src/vote_instruction.rs
+++ b/programs/vote/src/vote_instruction.rs
@@ -342,7 +342,7 @@ pub fn process_instruction(
 mod tests {
     use super::*;
     use solana_sdk::{
-        account::{self, AccountSharedData},
+        account::{self, Account, AccountSharedData},
         process_instruction::MockInvokeContext,
         rent::Rent,
     };
@@ -376,15 +376,15 @@ mod tests {
                 } else if sysvar::rent::check_id(&meta.pubkey) {
                     account::create_account_shared_data(&Rent::free(), 1)
                 } else if meta.pubkey == invalid_vote_state_pubkey() {
-                    AccountSharedData {
+                    AccountSharedData::from(Account {
                         owner: invalid_vote_state_pubkey(),
-                        ..AccountSharedData::default()
-                    }
+                        ..Account::default()
+                    })
                 } else {
-                    AccountSharedData {
+                    AccountSharedData::from(Account {
                         owner: id(),
-                        ..AccountSharedData::default()
-                    }
+                        ..Account::default()
+                    })
                 })
             })
             .collect();

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -16,7 +16,7 @@ use dashmap::{
 use log::*;
 use rand::{thread_rng, Rng};
 use solana_sdk::{
-    account::AccountSharedData,
+    account::{Account, AccountSharedData},
     account_utils::StateMut,
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     clock::Slot,
@@ -167,10 +167,10 @@ impl Accounts {
         let mut data = message.serialize_instructions();
         // add room for current instruction index.
         data.resize(data.len() + 2, 0);
-        AccountSharedData {
+        AccountSharedData::from(Account {
             data,
-            ..AccountSharedData::default()
-        }
+            ..Account::default()
+        })
     }
 
     fn load_transaction(
@@ -1036,7 +1036,7 @@ mod tests {
     use super::*;
     use crate::rent_collector::RentCollector;
     use solana_sdk::{
-        account::AccountSharedData,
+        account::{AccountSharedData, WritableAccount},
         epoch_schedule::EpochSchedule,
         fee_calculator::FeeCalculator,
         genesis_config::ClusterType,
@@ -2016,10 +2016,8 @@ mod tests {
             nonce::state::Data::default(),
         ));
         let account = AccountSharedData::new_data(42, &data, &system_program::id()).unwrap();
-        let pre_account = AccountSharedData {
-            lamports: 43,
-            ..account.clone()
-        };
+        let mut pre_account = account.clone();
+        pre_account.set_lamports(43);
         (
             Pubkey::default(),
             pre_account,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -5048,7 +5048,7 @@ pub mod tests {
     use assert_matches::assert_matches;
     use rand::{thread_rng, Rng};
     use solana_sdk::{
-        account::{AccountSharedData, ReadableAccount, WritableAccount},
+        account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
         hash::HASH_BYTES,
         pubkey::PUBKEY_BYTES,
     };
@@ -5406,10 +5406,10 @@ pub mod tests {
             let idx = thread_rng().gen_range(0, 99);
             let ancestors = vec![(0, 0)].into_iter().collect();
             let account = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
-            let default_account = AccountSharedData {
+            let default_account = AccountSharedData::from(Account {
                 lamports: (idx + 1) as u64,
-                ..AccountSharedData::default()
-            };
+                ..Account::default()
+            });
             assert_eq!((default_account, 0), account);
         }
 
@@ -5422,10 +5422,10 @@ pub mod tests {
             let account0 = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
             let ancestors = vec![(1, 1)].into_iter().collect();
             let account1 = db.load_slow(&ancestors, &pubkeys[idx]).unwrap();
-            let default_account = AccountSharedData {
+            let default_account = AccountSharedData::from(Account {
                 lamports: (idx + 1) as u64,
-                ..AccountSharedData::default()
-            };
+                ..Account::default()
+            });
             assert_eq!(&default_account, &account0.0);
             assert_eq!(&default_account, &account1.0);
         }
@@ -5620,10 +5620,10 @@ pub mod tests {
                     let ancestors = vec![(slot, 0)].into_iter().collect();
                     assert!(accounts.load_slow(&ancestors, &pubkeys[idx]).is_none());
                 } else {
-                    let default_account = AccountSharedData {
+                    let default_account = AccountSharedData::from(Account {
                         lamports: account.lamports,
-                        ..AccountSharedData::default()
-                    };
+                        ..Account::default()
+                    });
                     assert_eq!(default_account, account);
                 }
             }
@@ -5712,10 +5712,10 @@ pub mod tests {
         create_account(&db, &mut pubkeys, 0, 1, 0, 0);
         let ancestors = vec![(0, 0)].into_iter().collect();
         let account = db.load_slow(&ancestors, &pubkeys[0]).unwrap();
-        let default_account = AccountSharedData {
+        let default_account = AccountSharedData::from(Account {
             lamports: 1,
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         assert_eq!((default_account, 0), account);
     }
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -5,7 +5,7 @@ use log::*;
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
 use solana_sdk::{
-    account::{AccountSharedData, ReadableAccount},
+    account::{Account, AccountSharedData, ReadableAccount},
     clock::{Epoch, Slot},
     hash::Hash,
     pubkey::Pubkey,
@@ -84,13 +84,13 @@ pub struct StoredAccountMeta<'a> {
 impl<'a> StoredAccountMeta<'a> {
     /// Return a new Account by copying all the data referenced by the `StoredAccountMeta`.
     pub fn clone_account(&self) -> AccountSharedData {
-        AccountSharedData {
+        AccountSharedData::from(Account {
             lamports: self.account_meta.lamports,
             owner: self.account_meta.owner,
             executable: self.account_meta.executable,
             rent_epoch: self.account_meta.rent_epoch,
             data: self.data.to_vec(),
-        }
+        })
     }
 
     fn sanitize(&self) -> bool {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -32,7 +32,7 @@ use solana_measure::measure::Measure;
 use solana_metrics::{datapoint_debug, inc_new_counter_debug, inc_new_counter_info};
 use solana_sdk::{
     account::{
-        create_account_shared_data as create_account, from_account, AccountSharedData,
+        create_account_shared_data as create_account, from_account, Account, AccountSharedData,
         ReadableAccount,
     },
     clock::{
@@ -4828,13 +4828,13 @@ impl Bank {
         };
 
         if reconfigure_token2_native_mint {
-            let mut native_mint_account = solana_sdk::account::AccountSharedData {
+            let mut native_mint_account = solana_sdk::account::AccountSharedData::from(Account {
                 owner: inline_spl_token_v2_0::id(),
                 data: inline_spl_token_v2_0::native_mint::ACCOUNT_DATA.to_vec(),
                 lamports: sol_to_lamports(1.),
                 executable: false,
                 rent_epoch: self.epoch() + 1,
-            };
+            });
 
             // As a workaround for
             // https://github.com/solana-labs/solana-program-library/issues/374, ensure that the
@@ -11093,20 +11093,18 @@ pub(crate) mod tests {
         // Setup original token account
         bank.store_account_and_update_capitalization(
             &inline_spl_token_v2_0::id(),
-            &AccountSharedData {
+            &AccountSharedData::from(Account {
                 lamports: 100,
-                ..AccountSharedData::default()
-            },
+                ..Account::default()
+            }),
         );
         assert_eq!(bank.get_balance(&inline_spl_token_v2_0::id()), 100);
 
         // Setup new token account
-        let new_token_account = AccountSharedData {
+        let new_token_account = AccountSharedData::from(Account {
             lamports: 123,
-            data: vec![1, 2, 3],
-            executable: true,
-            ..AccountSharedData::default()
-        };
+            ..Account::default()
+        });
         bank.store_account_and_update_capitalization(
             &inline_spl_token_v2_0::new_token_program::id(),
             &new_token_account,

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1095,6 +1095,7 @@ impl MessageProcessor {
 mod tests {
     use super::*;
     use solana_sdk::{
+        account::Account,
         instruction::{AccountMeta, Instruction, InstructionError},
         message::Message,
         native_loader::create_loadable_account,
@@ -1261,18 +1262,18 @@ mod tests {
                 is_writable: true,
                 pre: PreAccount::new(
                     &solana_sdk::pubkey::new_rand(),
-                    &AccountSharedData {
+                    &AccountSharedData::from(Account {
                         owner: *owner,
                         lamports: std::u64::MAX,
                         data: vec![],
-                        ..AccountSharedData::default()
-                    },
+                        ..Account::default()
+                    }),
                 ),
-                post: AccountSharedData {
+                post: AccountSharedData::from(Account {
                     owner: *owner,
                     lamports: std::u64::MAX,
-                    ..AccountSharedData::default()
-                },
+                    ..Account::default()
+                }),
             }
         }
         pub fn read_only(mut self) -> Self {

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -123,6 +123,7 @@ impl RentCollector {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use solana_sdk::account::Account;
 
     #[test]
     fn test_collect_from_account_created_and_existing() {
@@ -131,11 +132,11 @@ mod tests {
         let new_epoch = 3;
 
         let (mut created_account, mut existing_account) = {
-            let account = AccountSharedData {
+            let account = AccountSharedData::from(Account {
                 lamports: old_lamports,
                 rent_epoch: old_epoch,
-                ..AccountSharedData::default()
-            };
+                ..Account::default()
+            });
 
             (account.clone(), account)
         };

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -446,7 +446,7 @@ mod tests {
     use crate::{bank::Bank, bank_client::BankClient};
     use bincode::serialize;
     use solana_sdk::{
-        account::{self, AccountSharedData},
+        account::{self, Account, AccountSharedData},
         client::SyncClient,
         fee_calculator::FeeCalculator,
         genesis_config::create_genesis_config,
@@ -912,10 +912,10 @@ mod tests {
         let from_account = AccountSharedData::new_ref(100, 0, &system_program::id());
 
         let populated_key = solana_sdk::pubkey::new_rand();
-        let populated_account = AccountSharedData {
+        let populated_account = AccountSharedData::from(Account {
             data: vec![0, 1, 2, 3],
-            ..AccountSharedData::default()
-        }
+            ..Account::default()
+        })
         .into();
 
         let signers = [from, populated_key]


### PR DESCRIPTION
#### Problem
We construct accounts in many combinations of the 5 fields.
We want to abstract away the data field and hide it. Doing so requires allowing construction somehow.
#### Summary of Changes
Reuse the existing Account struct and AccountSharedData::from() to allow rust-like construction of AccountSharedData without adding new structs or methods.
Fixes #
