### PR TITLE
limits CrdsGossipPull::pull_request_time size

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -4763,18 +4763,32 @@ mod tests {
             rand_ci.shred_version = shred_version;
             rand_ci.wallclock = timestamp();
             CrdsValue::new_signed(CrdsData::ContactInfo(rand_ci), &keypair)
-        }).take(NO_ENTRIES).collect();
+        })
+        .take(NO_ENTRIES)
+        .collect();
         let timeouts = cluster_info.gossip.read().unwrap().make_timeouts_test();
-        assert_eq!((0, 0, NO_ENTRIES), cluster_info.handle_pull_response(
-            &entrypoint_pubkey,
-            data,
-            &timeouts
-        ));
+        assert_eq!(
+            (0, 0, NO_ENTRIES),
+            cluster_info.handle_pull_response(&entrypoint_pubkey, data, &timeouts)
+        );
 
         let now = timestamp();
         for peer in peers {
-            cluster_info.gossip.write().unwrap().mark_pull_request_creation_time(&peer, now);
+            cluster_info
+                .gossip
+                .write()
+                .unwrap()
+                .mark_pull_request_creation_time(&peer, now);
         }
-        assert_eq!(cluster_info.gossip.read().unwrap().pull.pull_request_time.len(), CRDS_UNIQUE_PUBKEY_CAPACITY);
+        assert_eq!(
+            cluster_info
+                .gossip
+                .read()
+                .unwrap()
+                .pull
+                .pull_request_time
+                .len(),
+            CRDS_UNIQUE_PUBKEY_CAPACITY
+        );
     }
 }

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -115,7 +115,7 @@ pub const DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS: u64 = 60_000;
 /// Minimum serialized size of a Protocol::PullResponse packet.
 const PULL_RESPONSE_MIN_SERIALIZED_SIZE: usize = 161;
 // Limit number of unique pubkeys in the crds table.
-const CRDS_UNIQUE_PUBKEY_CAPACITY: usize = 4096;
+pub(crate) const CRDS_UNIQUE_PUBKEY_CAPACITY: usize = 4096;
 /// Minimum stake that a node should have so that its CRDS values are
 /// propagated through gossip (few types are exempted).
 const MIN_STAKE_FOR_GOSSIP: u64 = solana_sdk::native_token::LAMPORTS_PER_SOL;

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -4749,7 +4749,7 @@ mod tests {
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(node.info));
         let entrypoint_pubkey = solana_sdk::pubkey::new_rand();
         let entrypoint = ContactInfo::new_localhost(&entrypoint_pubkey, timestamp());
-        cluster_info.set_entrypoint(entrypoint.clone());
+        cluster_info.set_entrypoint(entrypoint);
 
         let mut rng = rand::thread_rng();
         let shred_version = cluster_info.my_shred_version();

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -3466,6 +3466,7 @@ mod tests {
     };
     use itertools::izip;
     use rand::seq::SliceRandom;
+    use serial_test::serial;
     use solana_ledger::shred::Shredder;
     use solana_sdk::signature::{Keypair, Signer};
     use solana_vote_program::{vote_instruction, vote_state::Vote};
@@ -4744,6 +4745,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_pull_request_time_pruning() {
         let node = Node::new_localhost();
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(node.info));

--- a/core/src/crds.rs
+++ b/core/src/crds.rs
@@ -264,6 +264,11 @@ impl Crds {
             .map(move |i| self.table.index(*i))
     }
 
+    /// Returns number of known pubkeys (network size).
+    pub(crate) fn num_nodes(&self) -> usize {
+        self.records.len()
+    }
+
     pub fn len(&self) -> usize {
         self.table.len()
     }

--- a/core/src/crds_gossip.rs
+++ b/core/src/crds_gossip.rs
@@ -207,7 +207,7 @@ impl CrdsGossip {
             gossip_validators,
             &self.id,
             self.shred_version,
-            self.pull.pull_request_time.len(),
+            self.crds.num_nodes(),
             CRDS_GOSSIP_NUM_ACTIVE,
         )
     }
@@ -341,7 +341,7 @@ impl CrdsGossip {
         Self {
             crds: self.crds.clone(),
             push: self.push.mock_clone(),
-            pull: self.pull.clone(),
+            pull: self.pull.mock_clone(),
             ..*self
         }
     }

--- a/core/src/crds_gossip_pull.rs
+++ b/core/src/crds_gossip_pull.rs
@@ -174,7 +174,7 @@ pub struct ProcessPullStats {
 
 pub struct CrdsGossipPull {
     /// timestamp of last request
-    pull_request_time: LruCache<Pubkey, u64>,
+    pub(crate) pull_request_time: LruCache<Pubkey, u64>,
     /// hash and insert time
     pub purged_values: VecDeque<(Hash, u64)>,
     // Hash value and record time (ms) of the pull responses which failed to be


### PR DESCRIPTION
#### Problem
There is no pruning logic on CrdsGossipPull::pull_request_time
https://github.com/solana-labs/solana/blob/79ac1997d/core/src/crds_gossip_pull.rs#L172-L174
potentially allowing this to take too much memory.

Additionally, CrdsGossipPush::last_pushed_to is pruning recent push
timestamps:
https://github.com/solana-labs/solana/blob/79ac1997d/core/src/crds_gossip_push.rs#L275-L279
instead of the older ones.

#### Summary of Changes
* Changed the `CrdsGossipPull::pull_request_time` type from `HashMap` to `LruCache`.
* Similar logic for `CrdsGossipPush::last_pushed_to`.
* Limit the impact of last push/pull time in push/pull options.
