### PR TITLE
validator: Add --force and --monitor options to `exit` subcommand

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -202,8 +202,8 @@ killNodes() {
   # Try to use the RPC exit API to cleanly exit the first two nodes
   # (dynamic nodes, -x, are just killed)
   echo "--- RPC exit"
-  $solana_validator --ledger "$SOLANA_CONFIG_DIR"/bootstrap-validator exit || true
-  $solana_validator --ledger "$SOLANA_CONFIG_DIR"/validator exit || true
+  $solana_validator --ledger "$SOLANA_CONFIG_DIR"/bootstrap-validator exit --force || true
+  $solana_validator --ledger "$SOLANA_CONFIG_DIR"/validator exit --force || true
 
   # Give the nodes a splash of time to cleanly exit before killing them
   sleep 2

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -26,7 +26,7 @@ while [[ $($solana_cli --url http://localhost:8899 slot --commitment recent) -le
   sleep 1
 done
 
-$solana_validator --ledger config/ledger exit || true
+$solana_validator --ledger config/ledger exit --force || true
 
 wait $pid
 


### PR DESCRIPTION
Wait for a good restart window before requesting the validator exit:
```
$ solana-validator -l ledger exit
```

Request the validator exit immediately:
```
$ solana-validator -l ledger exit -f/--force
```

Wait for a good restart window before requesting the validator exit, then monitor the validator over IPC (useful when you've got a setup where the validator is automatically restarted):
```
$ solana-validator -l ledger exit --monitor/-m
```

For finer grain control, the `solana-validator -l ledger wait-for-restart-window` command is still available. 

