### PR TITLE
Show flags for accounts in tx by solana confirm

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -138,13 +138,13 @@ fn format_account_mode(message: &Message, index: usize) -> String {
         } else {
             "-"
         },
-        // account {may/may not} be executable on-chain while {not being/being}
-        // designated as program-id in the message...
+        // account may be executable on-chain while not being
+        // designated as a program-id in the message
         if message.maybe_executable(index) {
             "x"
         } else {
-            // programs to be executed inside CPI cannot be marked as
-            // executable...
+            // programs to be executed via CPI cannot be identified as
+            // executable from the message
             "-"
         },
     )
@@ -205,7 +205,7 @@ pub fn write_transaction<W: io::Write>(
             format_account_mode(message, account_index),
             account,
             if Some(account_index) == fee_payer_index {
-                " (Fee payer)"
+                " (fee payer)"
             } else {
                 ""
             },

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -138,9 +138,9 @@ fn format_account_mode(message: &Message, index: usize) -> String {
         } else {
             "-"
         },
+        // account {may/may not} be executable on-chain while {not being/being}
+        // designated as program-id in the message...
         if message.maybe_executable(index) {
-            // account may not be executable on-chain while being designated as
-            // program-id in the message...
             "x"
         } else {
             // programs to be executed inside CPI cannot be marked as

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1987,6 +1987,17 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                         .takes_value(true)
                         .required(true)
                         .help("The transaction signature to confirm"),
+                )
+                .after_help(// Formatted specifically for the manually-indented heredoc string
+                   "Note: This will show more detailed information for finalized transactions with verbose mode (-v/--verbose).\
+                  \n\
+                  \nAccount's mode legend in the details:\
+                  \n  |srwx|\
+                  \n    s: this account correctly signed\
+                  \n    r: this account is marked to be read (always true)\
+                  \n    w: this account is marked to be written\
+                  \n    x: this account is marked to be executed via program_id (CPI's program_id can't be marked, though)\
+                   "
                 ),
         )
         .subcommand(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1991,12 +1991,12 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 .after_help(// Formatted specifically for the manually-indented heredoc string
                    "Note: This will show more detailed information for finalized transactions with verbose mode (-v/--verbose).\
                   \n\
-                  \nAccount's mode legend in the details:\
+                  \nAccount modes:\
                   \n  |srwx|\
-                  \n    s: this account correctly signed\
-                  \n    r: this account is marked to be read (always true)\
-                  \n    w: this account is marked to be written\
-                  \n    x: this account is marked to be executed via program_id (CPI's program_id can't be marked, though)\
+                  \n    s: signed\
+                  \n    r: readable (always true)\
+                  \n    w: writable\
+                  \n    x: executable, according to message program-ids (CPI program-ids cannot be marked)\
                    "
                 ),
         )

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1996,7 +1996,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                   \n    s: signed\
                   \n    r: readable (always true)\
                   \n    w: writable\
-                  \n    x: executable, according to message program-ids (CPI program-ids cannot be marked)\
+                  \n    x: program account (inner instructions excluded)\
                    "
                 ),
         )

--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -319,6 +319,10 @@ impl Message {
             .position(|&&pubkey| pubkey == self.account_keys[index])
     }
 
+    pub fn is_executable(&self, i: usize) -> bool {
+        self.program_position(i).is_some()
+    }
+
     pub fn is_writable(&self, i: usize) -> bool {
         i < (self.header.num_required_signatures - self.header.num_readonly_signed_accounts)
             as usize

--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -319,7 +319,7 @@ impl Message {
             .position(|&&pubkey| pubkey == self.account_keys[index])
     }
 
-    pub fn is_executable(&self, i: usize) -> bool {
+    pub fn maybe_executable(&self, i: usize) -> bool {
         self.program_position(i).is_some()
     }
 


### PR DESCRIPTION
#### Problem

Currently, `solana confirm` is hard to use to know which account is read-only/read-write etc.

In other words, my fav. CLI isn't on par with explorer... ;)

#### Summary of Changes

Add such a handy string with courtesy/tradition of the unix file permission formatting (like `ls` and `pmap`).

##### example: plain-old transfer

BEFORE

```
$ solana confirm -v R2zfQFUMNyh1CvTUF2Z9SUM2YxaT1ddabV15vtG831Wd1foy2qweHYsrzXLz6woAYpcWKZkBpTsNREeNFwroNmZ
...

Transaction executed in slot 68580808:
  Block Time: 2021-03-11T22:02:57+09:00
  Recent Blockhash: HCtVyqbWtvxdYPjAnian5vUhbr9qEj5oum9X9MX8EXkq
  Signature 0: R2zfQFUMNyh1CvTUF2Z9SUM2YxaT1ddabV15vtG831Wd1foy2qweHYsrzXLz6woAYpcWKZkBpTsNREeNFwroNmZ
  MessageHeader { num_required_signatures: 1, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 1 }
  Account 0: GMpQzT92L96tY4AdxTgbBBcLWGdNFJ7WyQhKww3LooKS
  Account 1: 4qsDThYutMJ4xb6QcFcifzFqrqn26AT7SZWrWnwDddu9
  Account 2: 11111111111111111111111111111111
  Instruction 0
    Program: 11111111111111111111111111111111 (2)
    Account 0: GMpQzT92L96tY4AdxTgbBBcLWGdNFJ7WyQhKww3LooKS (0)
    Account 1: 4qsDThYutMJ4xb6QcFcifzFqrqn26AT7SZWrWnwDddu9 (1)
    Transfer { lamports: 1 }
  Status: Ok
    Fee: ◎0.000005
    Account 0 balance: ◎61.573964952 -> ◎61.573959951
    Account 1 balance: ◎0
    Account 2 balance: ◎0.000000001
  Log Messages:
    Program 11111111111111111111111111111111 invoke [1]
    Program 11111111111111111111111111111111 success

Finalized
```

AFTER

```
$ solana confirm -v R2zfQFUMNyh1CvTUF2Z9SUM2YxaT1ddabV15vtG831Wd1foy2qweHYsrzXLz6woAYpcWKZkBpTsNREeNFwroNmZ
...

Transaction executed in slot 68580808:
  Block Time: 2021-03-11T22:02:57+09:00
  Recent Blockhash: HCtVyqbWtvxdYPjAnian5vUhbr9qEj5oum9X9MX8EXkq
  Signature 0: R2zfQFUMNyh1CvTUF2Z9SUM2YxaT1ddabV15vtG831Wd1foy2qweHYsrzXLz6woAYpcWKZkBpTsNREeNFwroNmZ
  Account 0: srw- GMpQzT92L96tY4AdxTgbBBcLWGdNFJ7WyQhKww3LooKS (Fee payer)
  Account 1: -rw- 4qsDThYutMJ4xb6QcFcifzFqrqn26AT7SZWrWnwDddu9
  Account 2: -r-x 11111111111111111111111111111111
  Instruction 0
    Program:   11111111111111111111111111111111 (2)
    Account 0: GMpQzT92L96tY4AdxTgbBBcLWGdNFJ7WyQhKww3LooKS (0)
    Account 1: 4qsDThYutMJ4xb6QcFcifzFqrqn26AT7SZWrWnwDddu9 (1)
    Transfer { lamports: 1 }
  Status: Ok
    Fee: ◎0.000005
    Account 0 balance: ◎61.573964952 -> ◎61.573959951
    Account 1 balance: ◎0
    Account 2 balance: ◎0.000000001
  Log Messages:
    Program 11111111111111111111111111111111 invoke [1]
    Program 11111111111111111111111111111111 success

Finalized
```

##### example: spl-token transfer

BEFORE

```
$ solana confirm -v 59pnEPUFKBzPnzPxgMdX1uKo4vwGvAUAH5UXiTkeYU33uxLvhJnYot1SCbQRfu6fr7BLx9qkNUXzEzL4BS339yrs
...

Transaction executed in slot 68576648:
  Block Time: 2021-03-11T21:23:22+09:00
  Recent Blockhash: 9KLDfvKT3E45HMkmeqWypPP1xwkxBpfz67jVVf1Hi4gq
  Signature 0: 59pnEPUFKBzPnzPxgMdX1uKo4vwGvAUAH5UXiTkeYU33uxLvhJnYot1SCbQRfu6fr7BLx9qkNUXzEzL4BS339yrs
  MessageHeader { num_required_signatures: 1, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 2 }
  Account 0: HdGsWDaxSDBesEYXmAYsG7WZYkKxUv3qhGJgmXSXnm3d
  Account 1: E8M9T6rm6FM8up97gtWcfr44cXm69EeEfeAuYgF7ioPC
  Account 2: FxkZ6yC7FAKYzS8i7EKCRmEZb5DqG4aZrvb2KEQvu3QD
  Account 3: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
  Account 4: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  Instruction 0
    Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (4)
    Account 0: E8M9T6rm6FM8up97gtWcfr44cXm69EeEfeAuYgF7ioPC (1)
    Account 1: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v (3)
    Account 2: FxkZ6yC7FAKYzS8i7EKCRmEZb5DqG4aZrvb2KEQvu3QD (2)
    Account 3: HdGsWDaxSDBesEYXmAYsG7WZYkKxUv3qhGJgmXSXnm3d (0)
    Data: [12, 234, 87, 4, 5, 0, 0, 0, 0, 6]
  Status: Ok
    Fee: ◎0.000005
    Account 0 balance: ◎15.181297797 -> ◎15.181292797
    Account 1 balance: ◎12.75977496
    Account 2 balance: ◎0.00203928
    Account 3 balance: ◎1.1034616
    Account 4 balance: ◎1.1305824
  Log Messages:
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]
    Program log: Instruction: TransferChecked
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4133 of 200000 compute units
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success

Finalized


```

AFTER

```
$ solana confirm -v 59pnEPUFKBzPnzPxgMdX1uKo4vwGvAUAH5UXiTkeYU33uxLvhJnYot1SCbQRfu6fr7BLx9qkNUXzEzL4BS339yrs
...

Transaction executed in slot 68576648:
  Block Time: 2021-03-11T21:23:22+09:00
  Recent Blockhash: 9KLDfvKT3E45HMkmeqWypPP1xwkxBpfz67jVVf1Hi4gq
  Signature 0: 59pnEPUFKBzPnzPxgMdX1uKo4vwGvAUAH5UXiTkeYU33uxLvhJnYot1SCbQRfu6fr7BLx9qkNUXzEzL4BS339yrs
  Account 0: srw- HdGsWDaxSDBesEYXmAYsG7WZYkKxUv3qhGJgmXSXnm3d (Fee payer)
  Account 1: -rw- E8M9T6rm6FM8up97gtWcfr44cXm69EeEfeAuYgF7ioPC
  Account 2: -rw- FxkZ6yC7FAKYzS8i7EKCRmEZb5DqG4aZrvb2KEQvu3QD
  Account 3: -r-- EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
  Account 4: -r-x TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  Instruction 0
    Program:   TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (4)
    Account 0: E8M9T6rm6FM8up97gtWcfr44cXm69EeEfeAuYgF7ioPC (1)
    Account 1: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v (3)
    Account 2: FxkZ6yC7FAKYzS8i7EKCRmEZb5DqG4aZrvb2KEQvu3QD (2)
    Account 3: HdGsWDaxSDBesEYXmAYsG7WZYkKxUv3qhGJgmXSXnm3d (0)
    Data: [12, 234, 87, 4, 5, 0, 0, 0, 0, 6]
  Status: Ok
    Fee: ◎0.000005
    Account 0 balance: ◎15.181297797 -> ◎15.181292797
    Account 1 balance: ◎12.75977496
    Account 2 balance: ◎0.00203928
    Account 3 balance: ◎1.1034616
    Account 4 balance: ◎1.1305824
  Log Messages:
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]
    Program log: Instruction: TransferChecked
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4133 of 200000 compute units
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success


Finalized
```


##### example: associated token creation (complex sample)

BEFORE

```
$ solana confirm -v 3gEgaTo5Zui7Ui2KRC9mPACEqoTNT31Ei81eC7Ss1rrj4CFTkkYgsCiX8hYJwV5JqScJeZqeMmZt4j1AahV8675N
...

Transaction executed in slot 68581873:
  Block Time: 2021-03-11T22:12:51+09:00
  Recent Blockhash: ESpMtEm6uGSWwcdEK667w2MbL28zqU2ethTqM527p3Ka
  Signature 0: 3gEgaTo5Zui7Ui2KRC9mPACEqoTNT31Ei81eC7Ss1rrj4CFTkkYgsCiX8hYJwV5JqScJeZqeMmZt4j1AahV8675N
  MessageHeader { num_required_signatures: 1, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 5 }
  Account 0: zp19PFFVJrDqA9BG7aG7cUSU7VhfWhmkgVWBEt98JaL
  Account 1: HgXK5ML4eUVBh6UWFYkvgPigVCM2wDzg8B8tFxgEYj5M
  Account 2: z3dn17yLaGMKffVogeFHQ9zWVcXgqgf3PQnDsNs2g6M
  Account 3: 11111111111111111111111111111111
  Account 4: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  Account 5: SysvarRent111111111111111111111111111111111
  Account 6: ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL
  Instruction 0
    Program: ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL (6)
    Account 0: zp19PFFVJrDqA9BG7aG7cUSU7VhfWhmkgVWBEt98JaL (0)
    Account 1: HgXK5ML4eUVBh6UWFYkvgPigVCM2wDzg8B8tFxgEYj5M (1)
    Account 2: zp19PFFVJrDqA9BG7aG7cUSU7VhfWhmkgVWBEt98JaL (0)
    Account 3: z3dn17yLaGMKffVogeFHQ9zWVcXgqgf3PQnDsNs2g6M (2)
    Account 4: 11111111111111111111111111111111 (3)
    Account 5: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (4)
    Account 6: SysvarRent111111111111111111111111111111111 (5)
    Data: []
  Status: Ok
    Fee: ◎0.000005
    Account 0 balance: ◎0.420097706 -> ◎0.418053426
    Account 1 balance: ◎0 -> ◎0.00203928
    Account 2 balance: ◎10.0014616
    Account 3 balance: ◎0.000000001
    Account 4 balance: ◎1.1305824
    Account 5 balance: ◎0.000000001
    Account 6 balance: ◎0.89817408
  Log Messages:
...
```

 AFTER

```
$ solana confirm -v 3gEgaTo5Zui7Ui2KRC9mPACEqoTNT31Ei81eC7Ss1rrj4CFTkkYgsCiX8hYJwV5JqScJeZqeMmZt4j1AahV8675N
...


Transaction executed in slot 68581873:
  Block Time: 2021-03-11T22:12:51+09:00
  Recent Blockhash: ESpMtEm6uGSWwcdEK667w2MbL28zqU2ethTqM527p3Ka
  Signature 0: 3gEgaTo5Zui7Ui2KRC9mPACEqoTNT31Ei81eC7Ss1rrj4CFTkkYgsCiX8hYJwV5JqScJeZqeMmZt4j1AahV8675N
  Account 0: srw- zp19PFFVJrDqA9BG7aG7cUSU7VhfWhmkgVWBEt98JaL (Fee payer)
  Account 1: -rw- HgXK5ML4eUVBh6UWFYkvgPigVCM2wDzg8B8tFxgEYj5M
  Account 2: -r-- z3dn17yLaGMKffVogeFHQ9zWVcXgqgf3PQnDsNs2g6M
  Account 3: -r-- 11111111111111111111111111111111
  Account 4: -r-- TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
  Account 5: -r-- SysvarRent111111111111111111111111111111111
  Account 6: -r-x ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL
  Instruction 0
    Program:   ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL (6)
    Account 0: zp19PFFVJrDqA9BG7aG7cUSU7VhfWhmkgVWBEt98JaL (0)
    Account 1: HgXK5ML4eUVBh6UWFYkvgPigVCM2wDzg8B8tFxgEYj5M (1)
    Account 2: zp19PFFVJrDqA9BG7aG7cUSU7VhfWhmkgVWBEt98JaL (0)
    Account 3: z3dn17yLaGMKffVogeFHQ9zWVcXgqgf3PQnDsNs2g6M (2)
    Account 4: 11111111111111111111111111111111 (3)
    Account 5: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (4)
    Account 6: SysvarRent111111111111111111111111111111111 (5)
    Data: []
  Status: Ok
    Fee: ◎0.000005
    Account 0 balance: ◎0.420097706 -> ◎0.418053426
    Account 1 balance: ◎0 -> ◎0.00203928
    Account 2 balance: ◎10.0014616
    Account 3 balance: ◎0.000000001
    Account 4 balance: ◎1.1305824
    Account 5 balance: ◎0.000000001
    Account 6 balance: ◎0.89817408
  Log Messages:
    Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]
    Program log: Transfer 2039280 lamports to the associated token account
    Program 11111111111111111111111111111111 invoke [2]
    Program 11111111111111111111111111111111 success
    Program log: Allocate space for the associated token account
    Program 11111111111111111111111111111111 invoke [2]
    Program 11111111111111111111111111111111 success
    Program log: Assign the associated token account to the SPL Token program
    Program 11111111111111111111111111111111 invoke [2]
    Program 11111111111111111111111111111111 success
    Program log: Initialize the associated token account
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]
    Program log: Instruction: InitializeAccount
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3920 of 177038 compute units
    Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success
    Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 27531 of 200000 compute units
    Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success

...

Finalized
```