### PR TITLE
Default --ledger arg to "ledger" for `solana-validator` and `solana-ledger-tool`

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -221,7 +221,8 @@ impl BigTableSubCommand for App<'_, '_> {
         self.subcommand(
             SubCommand::with_name("bigtable")
                 .about("Ledger data on a BigTable instance")
-                .setting(AppSettings::ArgRequiredElseHelp)
+                .setting(AppSettings::InferSubcommands)
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     SubCommand::with_name("upload")
                         .about("Upload the ledger to BigTable")

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::integer_arithmetic)]
 use clap::{
-    crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App, Arg,
-    ArgMatches, SubCommand,
+    crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App, AppSettings,
+    Arg, ArgMatches, SubCommand,
 };
 use itertools::Itertools;
 use log::*;
@@ -811,6 +811,9 @@ fn main() {
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
+        .setting(AppSettings::InferSubcommands)
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .setting(AppSettings::VersionlessSubcommands)
         .arg(
             Arg::with_name("ledger_path")
                 .short("l")
@@ -818,7 +821,8 @@ fn main() {
                 .value_name("DIR")
                 .takes_value(true)
                 .global(true)
-                .help("Use DIR for ledger location"),
+                .default_value("ledger")
+                .help("Use DIR as ledger location"),
         )
         .arg(
             Arg::with_name("wal_recovery_mode")
@@ -1355,7 +1359,11 @@ fn main() {
 
     // Canonicalize ledger path to avoid issues with symlink creation
     let ledger_path = fs::canonicalize(&ledger_path).unwrap_or_else(|err| {
-        eprintln!("Unable to access ledger path: {:?}", err);
+        eprintln!(
+            "Unable to access ledger path '{}': {}",
+            ledger_path.display(),
+            err
+        );
         exit(1);
     });
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1042,7 +1042,8 @@ pub fn main() {
                 .value_name("DIR")
                 .takes_value(true)
                 .required(true)
-                .help("Use DIR as persistent ledger location"),
+                .default_value("ledger")
+                .help("Use DIR as ledger location"),
         )
         .arg(
             Arg::with_name("entrypoint")


### PR DESCRIPTION
#### Problem
I'm annoyed about having to always type `-l ledger` when running a `solana-validator` or `solana-ledger-tool` command, as 95% of my ledgers live in the directory `ledger/` from cwd. 

#### Summary of Changes
Be selfish and canonize my preferred usage pattern