### PR TITLE
Add trait for saturating arithmetic

### DIFF
--- a/sdk/src/arithmetic.rs
+++ b/sdk/src/arithmetic.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+/// A helper trait for primitive types that do not yet implement saturating arithmetic methods
+pub trait SaturatingArithmetic<T> {
+    fn sol_saturating_add(&self, rhs: Self) -> Self;
+    fn sol_saturating_sub(&self, rhs: Self) -> Self;
+    fn sol_saturating_mul(&self, rhs: T) -> Self;
+}
+
+/// Saturating arithmetic for Duration, until Rust support moves from nightly to stable
+/// Duration::MAX is constructed manually, as Duration consts are not yet stable either.
+impl SaturatingArithmetic<u32> for Duration {
+    fn sol_saturating_add(&self, rhs: Self) -> Self {
+        self.checked_add(rhs)
+            .unwrap_or_else(|| Self::new(u64::MAX, 1_000_000_000u32.saturating_sub(1)))
+    }
+    fn sol_saturating_sub(&self, rhs: Self) -> Self {
+        self.checked_sub(rhs).unwrap_or_else(|| Self::new(0, 0))
+    }
+    fn sol_saturating_mul(&self, rhs: u32) -> Self {
+        self.checked_mul(rhs)
+            .unwrap_or_else(|| Self::new(u64::MAX, 1_000_000_000u32.saturating_sub(1)))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_duration() {
+        let empty_duration = Duration::new(0, 0);
+        let max_duration = Duration::new(u64::MAX, 1_000_000_000 - 1);
+        let duration = Duration::new(u64::MAX, 0);
+
+        let add = duration.sol_saturating_add(duration);
+        assert_eq!(add, max_duration);
+
+        let sub = duration.sol_saturating_sub(max_duration);
+        assert_eq!(sub, empty_duration);
+
+        let mult = duration.sol_saturating_mul(u32::MAX);
+        assert_eq!(mult, max_duration);
+    }
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,6 +8,7 @@ pub use solana_program::*;
 
 pub mod account;
 pub mod account_utils;
+pub mod arithmetic;
 pub mod builtins;
 pub mod client;
 pub mod commitment_config;

--- a/sdk/src/poh_config.rs
+++ b/sdk/src/poh_config.rs
@@ -1,5 +1,4 @@
-#![allow(clippy::integer_arithmetic)]
-use crate::clock::DEFAULT_TICKS_PER_SECOND;
+use crate::{clock::DEFAULT_TICKS_PER_SECOND, unchecked_div_by_const};
 use std::time::Duration;
 
 #[derive(Serialize, Deserialize, Clone, Debug, AbiExample)]
@@ -29,8 +28,9 @@ impl PohConfig {
 
 impl Default for PohConfig {
     fn default() -> Self {
-        Self::new_sleep(Duration::from_micros(
-            1000 * 1000 / DEFAULT_TICKS_PER_SECOND,
-        ))
+        Self::new_sleep(Duration::from_micros(unchecked_div_by_const!(
+            1000 * 1000,
+            DEFAULT_TICKS_PER_SECOND
+        )))
     }
 }


### PR DESCRIPTION
#### Problem
The `Duration` type has saturating arithmetic coming, but they are not yet stable. We should include Durations in our to endeavor to prevent overflowing, but it is cumbersome to use `.checked_MATH().unwrap_or()` everywhere it's needed, especially as `Duration` consts MAX/ZERO are similarly not yet stable.

#### Summary of Changes
Add a helper trait with saturating-math methods that will be easy to replace with the standard methods when stable.

Addresses https://github.com/solana-labs/solana/pull/15736#discussion_r590890444
Toward #15368
