### PR TITLE
Skip deserialization of readonly accounts

### DIFF
--- a/programs/bpf/c/src/invoke/invoke.c
+++ b/programs/bpf/c/src/invoke/invoke.c
@@ -17,7 +17,6 @@ static const uint8_t TEST_INSTRUCTION_META_TOO_LARGE = 10;
 static const uint8_t TEST_RETURN_ERROR = 11;
 static const uint8_t TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER = 12;
 static const uint8_t TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE = 13;
-static const uint8_t TEST_WRITE_DEESCALATION = 14;
 
 static const int MINT_INDEX = 0;
 static const int ARGUMENT_INDEX = 1;
@@ -272,6 +271,24 @@ extern uint64_t entrypoint(const uint8_t *input) {
         sol_assert(accounts[ARGUMENT_INDEX].data[i] == 0);
       }
     }
+    sol_log("Test writable deescalation");
+    {
+      uint8_t buffer[10];
+      for (int i = 0; i < 10; i++) {
+        buffer[i] = accounts[INVOKED_ARGUMENT_INDEX].data[i];
+      }
+      SolAccountMeta arguments[] = {
+          {accounts[INVOKED_ARGUMENT_INDEX].key, false, false}};
+      uint8_t data[] = {WRITE_ACCOUNT, 10};
+      const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
+                                          arguments, SOL_ARRAY_SIZE(arguments),
+                                          data, SOL_ARRAY_SIZE(data)};
+      sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
+
+      for (int i = 0; i < 10; i++) {
+        sol_assert(buffer[i] == accounts[INVOKED_ARGUMENT_INDEX].data[i]);
+      }
+    }
     break;
   }
   case TEST_PRIVILEGE_ESCALATION_SIGNER: {
@@ -474,7 +491,6 @@ extern uint64_t entrypoint(const uint8_t *input) {
     sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
     break;
   }
-
   case TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER: {
     sol_log("Test privilege deescalation escalation signer");
     sol_assert(true == accounts[INVOKED_ARGUMENT_INDEX].is_signer);
@@ -503,19 +519,6 @@ extern uint64_t entrypoint(const uint8_t *input) {
                                         data, SOL_ARRAY_SIZE(data)};
     sol_assert(SUCCESS ==
                sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts)));
-    break;
-  }
-
-  case TEST_WRITE_DEESCALATION: {
-    sol_log("Test writable deescalation");
-
-    SolAccountMeta arguments[] = {
-        {accounts[INVOKED_ARGUMENT_INDEX].key, false, false}};
-    uint8_t data[] = {WRITE_ACCOUNT, 10};
-    const SolInstruction instruction = {accounts[INVOKED_PROGRAM_INDEX].key,
-                                        arguments, SOL_ARRAY_SIZE(arguments),
-                                        data, SOL_ARRAY_SIZE(data)};
-    sol_invoke(&instruction, accounts, SOL_ARRAY_SIZE(accounts));
     break;
   }
   default:

--- a/programs/bpf/c/src/invoked/invoked.c
+++ b/programs/bpf/c/src/invoked/invoked.c
@@ -160,7 +160,7 @@ extern uint64_t entrypoint(const uint8_t *input) {
   }
 
   case VERIFY_PRIVILEGE_ESCALATION: {
-    sol_log("Should never get here!");
+    sol_log("Verify privilege escalation");
     break;
   }
 

--- a/programs/bpf/rust/invoked/src/processor.rs
+++ b/programs/bpf/rust/invoked/src/processor.rs
@@ -199,7 +199,6 @@ fn process_instruction(
         }
         NESTED_INVOKE => {
             msg!("nested invoke");
-
             const ARGUMENT_INDEX: usize = 0;
             const INVOKED_ARGUMENT_INDEX: usize = 1;
             const INVOKED_PROGRAM_INDEX: usize = 3;
@@ -231,8 +230,10 @@ fn process_instruction(
         }
         WRITE_ACCOUNT => {
             msg!("write account");
+            const ARGUMENT_INDEX: usize = 0;
+
             for i in 0..instruction_data[1] {
-                accounts[0].data.borrow_mut()[i as usize] = instruction_data[1];
+                accounts[ARGUMENT_INDEX].data.borrow_mut()[i as usize] = instruction_data[1];
             }
         }
         _ => panic!(),

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -227,7 +227,13 @@ fn run_program(
             vm.execute_program_jit(&mut instruction_meter)
         };
         assert_eq!(SUCCESS, result.unwrap());
-        deserialize_parameters(&bpf_loader::id(), parameter_accounts, &parameter_bytes).unwrap();
+        deserialize_parameters(
+            &bpf_loader::id(),
+            parameter_accounts,
+            &parameter_bytes,
+            true,
+        )
+        .unwrap();
         if i == 1 {
             assert_eq!(instruction_count, vm.get_total_instruction_count());
         }
@@ -736,7 +742,6 @@ fn test_program_bpf_invoke_sanity() {
     const TEST_RETURN_ERROR: u8 = 11;
     const TEST_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER: u8 = 12;
     const TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE: u8 = 13;
-    const TEST_WRITE_DEESCALATION: u8 = 14;
 
     #[allow(dead_code)]
     #[derive(Debug)]
@@ -854,10 +859,12 @@ fn test_program_bpf_invoke_sanity() {
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
+                invoked_program_id.clone(),
             ],
             Languages::Rust => vec![
                 solana_sdk::system_program::id(),
                 solana_sdk::system_program::id(),
+                invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
@@ -973,12 +980,6 @@ fn test_program_bpf_invoke_sanity() {
         do_invoke_failure_test_local(
             TEST_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE,
             TransactionError::InstructionError(0, InstructionError::PrivilegeEscalation),
-            &[invoked_program_id.clone()],
-        );
-
-        do_invoke_failure_test_local(
-            TEST_WRITE_DEESCALATION,
-            TransactionError::InstructionError(0, InstructionError::ReadonlyDataModified),
             &[invoked_program_id.clone()],
         );
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -30,6 +30,7 @@ use solana_sdk::{
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     clock::Clock,
     entrypoint::SUCCESS,
+    feature_set::skip_ro_deserialization,
     ic_logger_msg, ic_msg,
     instruction::InstructionError,
     keyed_account::{from_keyed_account, next_keyed_account, KeyedAccount},
@@ -818,7 +819,12 @@ impl Executor for BpfExecutor {
             execute_time.stop();
         }
         let mut deserialize_time = Measure::start("deserialize");
-        deserialize_parameters(loader_id, parameter_accounts, &parameter_bytes)?;
+        deserialize_parameters(
+            loader_id,
+            parameter_accounts,
+            &parameter_bytes,
+            invoke_context.is_feature_active(&skip_ro_deserialization::id()),
+        )?;
         deserialize_time.stop();
         invoke_context.update_timing(
             serialize_time.as_us(),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -111,6 +111,10 @@ pub mod cpi_share_ro_and_exec_accounts {
     solana_sdk::declare_id!("6VgVBi3uRVqp56TtEwNou8idgdmhCD1aYqX8FaJ1fnJb");
 }
 
+pub mod skip_ro_deserialization {
+    solana_sdk::declare_id!("6Sw5JV84f7QkDe8gvRxpcPWFnPpfpgEnNziiy8sELaCp");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -139,6 +143,7 @@ lazy_static! {
         (check_init_vote_data::id(), "check initialized Vote data"),
         (check_program_owner::id(), "limit programs to operating on accounts owned by itself"),
         (cpi_share_ro_and_exec_accounts::id(), "Share RO and Executable accounts during cross-program invocations"),
+        (skip_ro_deserialization::id(), "Skip deserialization of read-only accounts"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

BPF loader deserializes accounts that were passed to the program as readonly.  Now that write-deescalation is enforced deserializing an account that the caller shouldn't write to is a waste.

#### Summary of Changes

Skip the deserialization of any accounts passed to the program as read-only and thus ignore any local changes they may have made to the local copy

Fixes #
