### PR TITLE
Rpc: support extended config for getConfirmedBlock

### DIFF
--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -111,24 +111,48 @@ pub struct RpcGetConfirmedSignaturesForAddress2Config {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum RpcConfirmedBlockConfigWrapper {
+pub enum RpcEncodingConfigWrapper<T> {
     Deprecated(Option<UiTransactionEncoding>),
-    Current(Option<RpcConfirmedBlockConfig>),
+    Current(Option<T>),
 }
 
-impl RpcConfirmedBlockConfigWrapper {
-    pub fn encoding(&self) -> Option<UiTransactionEncoding> {
+impl<T: EncodingConfig + Default + Copy> RpcEncodingConfigWrapper<T> {
+    pub fn convert_to_current(&self) -> T {
         match self {
-            RpcConfirmedBlockConfigWrapper::Deprecated(encoding) => *encoding,
-            RpcConfirmedBlockConfigWrapper::Current(config) => {
-                config.as_ref().and_then(|config| config.encoding)
-            }
+            RpcEncodingConfigWrapper::Deprecated(encoding) => T::new_with_encoding(encoding),
+            RpcEncodingConfigWrapper::Current(config) => config.unwrap_or_default(),
         }
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub trait EncodingConfig {
+    fn new_with_encoding(encoding: &Option<UiTransactionEncoding>) -> Self;
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcConfirmedBlockConfig {
     pub encoding: Option<UiTransactionEncoding>,
+}
+
+impl EncodingConfig for RpcConfirmedBlockConfig {
+    fn new_with_encoding(encoding: &Option<UiTransactionEncoding>) -> Self {
+        Self {
+            encoding: *encoding,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcConfirmedTransactionConfig {
+    pub encoding: Option<UiTransactionEncoding>,
+}
+
+impl EncodingConfig for RpcConfirmedTransactionConfig {
+    fn new_with_encoding(encoding: &Option<UiTransactionEncoding>) -> Self {
+        Self {
+            encoding: *encoding,
+        }
+    }
 }

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -108,3 +108,27 @@ pub struct RpcGetConfirmedSignaturesForAddress2Config {
     pub until: Option<String>,  // Signature as base-58 string
     pub limit: Option<usize>,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RpcConfirmedBlockConfigWrapper {
+    Deprecated(Option<UiTransactionEncoding>),
+    Current(Option<RpcConfirmedBlockConfig>),
+}
+
+impl RpcConfirmedBlockConfigWrapper {
+    pub fn encoding(&self) -> Option<UiTransactionEncoding> {
+        match self {
+            RpcConfirmedBlockConfigWrapper::Deprecated(encoding) => *encoding,
+            RpcConfirmedBlockConfigWrapper::Current(config) => {
+                config.as_ref().and_then(|config| config.encoding)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcConfirmedBlockConfig {
+    pub encoding: Option<UiTransactionEncoding>,
+}

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -719,9 +719,11 @@ impl JsonRpcRequestProcessor {
     pub fn get_confirmed_block(
         &self,
         slot: Slot,
-        encoding: Option<UiTransactionEncoding>,
+        config: Option<RpcConfirmedBlockConfigWrapper>,
     ) -> Result<Option<EncodedConfirmedBlock>> {
-        let encoding = encoding.unwrap_or(UiTransactionEncoding::Json);
+        let encoding = config
+            .and_then(|config| config.encoding())
+            .unwrap_or(UiTransactionEncoding::Json);
         if self.config.enable_rpc_transaction_history
             && slot
                 <= self
@@ -2178,7 +2180,7 @@ pub mod rpc_full {
             &self,
             meta: Self::Metadata,
             slot: Slot,
-            encoding: Option<UiTransactionEncoding>,
+            config: Option<RpcConfirmedBlockConfigWrapper>,
         ) -> Result<Option<EncodedConfirmedBlock>>;
 
         #[rpc(meta, name = "getBlockTime")]
@@ -2786,10 +2788,10 @@ pub mod rpc_full {
             &self,
             meta: Self::Metadata,
             slot: Slot,
-            encoding: Option<UiTransactionEncoding>,
+            config: Option<RpcConfirmedBlockConfigWrapper>,
         ) -> Result<Option<EncodedConfirmedBlock>> {
             debug!("get_confirmed_block rpc request received: {:?}", slot);
-            meta.get_confirmed_block(slot, encoding)
+            meta.get_confirmed_block(slot, config)
         }
 
         fn get_confirmed_blocks(

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -457,7 +457,8 @@ Returns identity and transaction information about a confirmed block in the ledg
 #### Parameters:
 
 - `<u64>` - slot, as u64 integer
-- `<string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (*slow*), "base64". If parameter not provided, the default encoding is "json".
+- `<object>` - (optional) Configuration object containing the following optional fields:
+  - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (*slow*), "base64". If parameter not provided, the default encoding is "json".
   "jsonParsed" encoding attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
 
 #### Results:
@@ -495,7 +496,7 @@ The result field will be an object with the following fields:
 Request:
 ```bash
 curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
-  {"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, "json"]}
+  {"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, {"encoding": "json"}]}
 '
 ```
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -850,9 +850,9 @@ Returns transaction details for a confirmed transaction
 #### Parameters:
 
 - `<string>` - transaction signature as base-58 encoded string
-- `<string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (*slow*), "base64". If parameter not provided, the default encoding is "json".
+- `<object>` - (optional) Configuration object containing the following optional fields:
+  - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (*slow*), "base64". If parameter not provided, the default encoding is "json".
   "jsonParsed" encoding attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
-- `<string>` - (optional) encoding for the returned Transaction, either "json", "jsonParsed", "base58" (*slow*), or "base64". If parameter not provided, the default encoding is JSON.
 
 #### Results:
 


### PR DESCRIPTION
#### Problem
#15817 requests customizing `getConfirmedBlock` responses, but the current request structure is difficult to extended with additional optional parameters.

#### Summary of Changes
- Add a wrapper enum that supports the previous encoding input (string) as well as an alternate config object, which can be extended with additional optional parameters
