### PR TITLE
`solana-install update` now updates a named release to the latest patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4647,7 +4647,7 @@ dependencies = [
  "reqwest 0.10.8",
  "semver 0.9.0",
  "serde",
- "serde_derive",
+ "serde_json",
  "serde_yaml",
  "solana-clap-utils",
  "solana-client",

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -22,8 +22,8 @@ indicatif = "0.15.0"
 lazy_static = "1.4.0"
 nix = "0.19.0"
 reqwest = { version = "0.10.8", default-features = false, features = ["blocking", "rustls-tls", "json"] }
-serde = "1.0.122"
-serde_derive = "1.0.103"
+serde = { version = "1.0.122", features = ["derive"] }
+serde_json = "1.0.62"
 serde_yaml = "0.8.13"
 solana-clap-utils = { path = "../clap-utils", version = "1.6.0" }
 solana-client = { path = "../client", version = "1.6.0" }

--- a/install/src/config.rs
+++ b/install/src/config.rs
@@ -1,9 +1,11 @@
-use crate::update_manifest::UpdateManifest;
-use serde_derive::{Deserialize, Serialize};
-use solana_sdk::pubkey::Pubkey;
-use std::fs::{create_dir_all, File};
-use std::io::{self, Write};
-use std::path::{Path, PathBuf};
+use {
+    crate::update_manifest::UpdateManifest,
+    serde::{Deserialize, Serialize},
+    solana_sdk::pubkey::Pubkey,
+    std::fs::{create_dir_all, File},
+    std::io::{self, Write},
+    std::path::{Path, PathBuf},
+};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum ExplicitRelease {

--- a/install/src/lib.rs
+++ b/install/src/lib.rs
@@ -2,10 +2,12 @@
 #[macro_use]
 extern crate lazy_static;
 
-use clap::{crate_description, crate_name, App, AppSettings, Arg, ArgMatches, SubCommand};
-use solana_clap_utils::{
-    input_parsers::pubkey_of,
-    input_validators::{is_pubkey, is_url},
+use {
+    clap::{crate_description, crate_name, App, AppSettings, Arg, ArgMatches, SubCommand},
+    solana_clap_utils::{
+        input_parsers::pubkey_of,
+        input_validators::{is_pubkey, is_url},
+    },
 };
 
 mod build_env;
@@ -158,9 +160,7 @@ pub fn main() -> Result<(), String> {
                     Arg::with_name("local_info_only")
                         .short("l")
                         .long("local")
-                        .help(
-                        "only display local information, don't check the cluster for new updates",
-                    ),
+                        .help("only display local information, don't check for updates"),
                 )
                 .arg(
                     Arg::with_name("eval")
@@ -262,7 +262,7 @@ pub fn main() -> Result<(), String> {
             )
         }
         ("gc", Some(_matches)) => command::gc(config_file),
-        ("update", Some(_matches)) => command::update(config_file).map(|_| ()),
+        ("update", Some(_matches)) => command::update(config_file, false).map(|_| ()),
         ("run", Some(matches)) => {
             let program_name = matches.value_of("program_name").unwrap();
             let program_arguments = matches

--- a/install/src/update_manifest.rs
+++ b/install/src/update_manifest.rs
@@ -1,14 +1,16 @@
-use serde_derive::{Deserialize, Serialize};
-use solana_config_program::ConfigState;
-use solana_sdk::{
-    hash::Hash,
-    pubkey::Pubkey,
-    signature::{Signable, Signature},
+use {
+    serde::{Deserialize, Serialize},
+    solana_config_program::ConfigState,
+    solana_sdk::{
+        hash::Hash,
+        pubkey::Pubkey,
+        signature::{Signable, Signature},
+    },
+    std::{borrow::Cow, error, io},
 };
-use std::{borrow::Cow, error, io};
 
 /// Information required to download and apply a given update
-#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 pub struct UpdateManifest {
     pub timestamp_secs: u64, // When the release was deployed in seconds since UNIX EPOCH
     pub download_url: String, // Download URL to the release tar.bz2


### PR DESCRIPTION
Fixes #15797

#### 1.5.x update example:
```
$ solana-install init 1.5.11
  ✨ 1.5.11 initialized
$ solana-install info
Configuration: /Users/mvines/.config/solana/install/config.yml
Active release directory: /Users/mvines/.local/share/solana/install/active_release
• Release version: 1.5.11
• Release URL: https://github.com/solana-labs/solana/releases/download/v1.5.11/solana-release-x86_64-apple-darwin.tar.bz2
• Release commit: 96e587c
  🎁 Update available: 1.5.14
$ solana-install update
  ✨ Update successful to 1.5.14
$ solana-install info
Configuration: /Users/mvines/.config/solana/install/config.yml
Active release directory: /Users/mvines/.local/share/solana/install/active_release
• Release version: 1.5.14
• Release URL: https://github.com/solana-labs/solana/releases/download/v1.5.14/solana-release-x86_64-apple-darwin.tar.bz2
• Release commit: 7f1368e
Install is up to date. 1.5.14 is the latest compatible release
```


#### 1.4.x will not update to 1.5.x:
```
$ solana-install init 1.4.28
  ✨ 1.4.28 initialized
$ solana-install info
Configuration: /Users/mvines/.config/solana/install/config.yml
Active release directory: /Users/mvines/.local/share/solana/install/active_release
• Release version: 1.4.28
• Release URL: https://github.com/solana-labs/solana/releases/download/v1.4.28/solana-release-x86_64-apple-darwin.tar.bz2
• Release commit: b56bbf2
Install is up to date. 1.4.28 is the latest compatible release
```

