### PR TITLE
explorer: Add token symbol to token label

### DIFF
--- a/explorer/src/utils/tx.ts
+++ b/explorer/src/utils/tx.ts
@@ -148,6 +148,19 @@ export function programLabel(
   }
 }
 
+export function tokenLabel(
+  address: string,
+  tokenRegistry?: TokenInfoMap
+): string | undefined {
+  if (!tokenRegistry) return;
+  const tokenInfo = tokenRegistry.get(address);
+  if (!tokenInfo) return;
+  if (tokenInfo.name === tokenInfo.symbol) {
+    return tokenInfo.name;
+  }
+  return `${tokenInfo.name} (${tokenInfo.symbol})`;
+}
+
 export function addressLabel(
   address: string,
   cluster: Cluster,
@@ -158,7 +171,7 @@ export function addressLabel(
     LOADER_IDS[address] ||
     SYSVAR_IDS[address] ||
     SYSVAR_ID[address] ||
-    tokenRegistry?.get(address)?.name ||
+    tokenLabel(address, tokenRegistry) ||
     SerumMarketRegistry.get(address, cluster)
   );
 }


### PR DESCRIPTION
#### Problem
Unclear from address label that a token is actually a token when it just has a name like "Bonfida".

#### Changes
Add token symbol after name like so: "Bonfida (FIDA)"

![Screen Shot 2021-03-14 at 10 08 29 AM](https://user-images.githubusercontent.com/1076145/111055112-8590cc80-84ad-11eb-94cf-2cc8346f047b.png)
