### PR TITLE
explorer: Fix midnight timestamps

### DIFF
--- a/explorer/src/utils/date.ts
+++ b/explorer/src/utils/date.ts
@@ -12,7 +12,7 @@ export function displayTimestamp(
     hour: "numeric",
     minute: "numeric",
     second: "numeric",
-    hour12: false,
+    hourCycle: "h23",
     timeZoneName: shortTimeZoneName ? "short" : "long",
   }).format(expireDate);
   return `${dateString} at ${timeString}`;
@@ -33,7 +33,7 @@ export function displayTimestampUtc(
     hour: "numeric",
     minute: "numeric",
     second: "numeric",
-    hour12: false,
+    hourCycle: "h23",
     timeZone: "UTC",
     timeZoneName: shortTimeZoneName ? "short" : "long",
   }).format(expireDate);


### PR DESCRIPTION
#### Problem
Timestamps at midnight display as "24:00:00" instead of "00:00:00"

Before

<img width="1190" alt="Screen Shot 2021-03-14 at 10 57 03 AM" src="https://user-images.githubusercontent.com/1076145/111055773-35693880-84b4-11eb-8068-4c3a708ab862.png">

After

<img width="1171" alt="Screen Shot 2021-03-14 at 10 57 10 AM" src="https://user-images.githubusercontent.com/1076145/111055774-369a6580-84b4-11eb-81ef-35b61147acb3.png">
