### PR TITLE
a few missed set_data calls

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -3833,7 +3833,7 @@ pub mod tests {
         let address = solana_sdk::pubkey::new_rand();
         let data = vec![1, 2, 3, 4, 5];
         let mut account = AccountSharedData::new(42, 5, &Pubkey::default());
-        account.data = data.clone();
+        account.set_data(data.clone());
         bank.store_account(&address, &account);
 
         let req = format!(
@@ -3890,7 +3890,7 @@ pub mod tests {
         let address = Pubkey::new(&[9; 32]);
         let data = vec![1, 2, 3, 4, 5];
         let mut account = AccountSharedData::new(42, 5, &Pubkey::default());
-        account.data = data.clone();
+        account.set_data(data.clone());
         bank.store_account(&address, &account);
 
         let non_existent_address = Pubkey::new(&[8; 32]);

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -726,7 +726,7 @@ pub mod tests {
         let owner = Pubkey::default();
         let data_len = 3_u64;
         let mut account = AccountSharedData::new(0, data_len as usize, &owner);
-        account.data = b"abc".to_vec();
+        account.set_data(b"abc".to_vec());
         let stored_meta = StoredMeta {
             write_version: 0,
             pubkey,


### PR DESCRIPTION
#### Problem
We are moving AccountSharedData::data to a different implementation and we need to hide 'data'.
AccountSharedData::set_data was already added.  A few callers weren't changed.

#### Summary of Changes
Change the callers.

Fixes #
