### PR TITLE
account data arc, arc inside account_data

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1559,8 +1559,9 @@ mod tests {
     }
 
     fn truncate_data(account: &mut AccountSharedData, len: usize) {
-        // when account data becomes copy on write, this operation will be more complicated
-        account.data.truncate(len);
+        let mut data = account.data.to_vec();
+        data.truncate(len);
+        account.set_data(data);
     }
 
     #[test]

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -413,7 +413,9 @@ pub mod tests {
 
         // Vote account too big
         let cache_data = vote_account.data().to_vec();
-        vote_account.data.push(0);
+        let mut pushed = vote_account.data.to_vec();
+        pushed.push(0);
+        vote_account.set_data(pushed);
         stakes.store(&vote_pubkey, &vote_account, true, true);
 
         {

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -1,4 +1,4 @@
-use crate::{clock::Epoch, pubkey::Pubkey};
+use crate::{account_data::AccountData, clock::Epoch, pubkey::Pubkey};
 use solana_program::{account_info::AccountInfo, sysvar::Sysvar};
 use std::{cell::Ref, cell::RefCell, cmp, fmt, rc::Rc};
 
@@ -30,8 +30,7 @@ pub struct AccountSharedData {
     /// lamports in the account
     pub lamports: u64,
     /// data held in this account
-    #[serde(with = "serde_bytes")]
-    pub data: Vec<u8>, // will be: Arc<Vec<u8>>,
+    pub data: AccountData,
     /// the program that owns this account. If executable, the program that loads this account.
     pub owner: Pubkey,
     /// this account's data contains a loaded program (and is now read-only)
@@ -52,10 +51,12 @@ pub fn accounts_equal<T: ReadableAccount, U: ReadableAccount>(me: &T, other: &U)
 }
 
 impl From<AccountSharedData> for Account {
-    fn from(other: AccountSharedData) -> Self {
+    fn from(mut other: AccountSharedData) -> Self {
+        let mut data_empty = vec![];
+        std::mem::swap(&mut data_empty, &mut other.data);
         Self {
             lamports: other.lamports,
-            data: other.data,
+            data: data_empty,
             owner: other.owner,
             executable: other.executable,
             rent_epoch: other.rent_epoch,
@@ -67,7 +68,7 @@ impl From<Account> for AccountSharedData {
     fn from(other: Account) -> Self {
         Self {
             lamports: other.lamports,
-            data: other.data,
+            data: other.data.into(),
             owner: other.owner,
             executable: other.executable,
             rent_epoch: other.rent_epoch,
@@ -154,7 +155,7 @@ impl WritableAccount for AccountSharedData {
         self.lamports = lamports;
     }
     fn data_as_mut_slice(&mut self) -> &mut [u8] {
-        &mut self.data
+        &mut self.data[..]
     }
     fn set_owner(&mut self, owner: Pubkey) {
         self.owner = owner;
@@ -174,7 +175,7 @@ impl WritableAccount for AccountSharedData {
     ) -> Self {
         AccountSharedData {
             lamports,
-            data,
+            data: data.into(),
             owner,
             executable,
             rent_epoch,
@@ -396,20 +397,16 @@ impl Account {
 impl AccountSharedData {
     /// make account's data equal to 'data'. This may require resizing and copying data.
     pub fn set_data_from_slice(&mut self, data: &[u8]) {
+        pub fn data_resize_and_copy_from_slice(&mut self, data: &[u8]) {
         let len = self.data.len();
         let len_different = len != data.len();
-        if len_different {
-            // if the resize causes a reallocation and copy, it would be better to create a new copy of the final data
-            //  rather than resize (+ copy current) and then copy over below.
-            // however, the implementation of account's data is soon to be copy on write, so the tradeoffs will soon be different.
-            self.data.resize(data.len(), 0);
+        let different = len_different || data != &self.data[..];
+        if different {
+            self.data = data.to_vec().into();
         }
-        // we could compare here to determine whether we need to modify the original data or not. In the current implementation, that would
-        //  not make a positive difference.
-        self.data.copy_from_slice(data);
     }
     pub fn set_data(&mut self, data: Vec<u8>) {
-        self.data = data;
+        self.data = data.into();
     }
     pub fn new(lamports: u64, space: usize, owner: &Pubkey) -> Self {
         shared_new(lamports, space, owner)
@@ -691,7 +688,7 @@ pub mod tests {
                         account1.data_as_mut_slice()[0] = account1.data[0] + 1;
                     } else if pass == 3 {
                         account_expected.data[0] += 1;
-                        account2.data[0] += 1;
+                        account2.data_as_mut_slice()[0] += 1;
                     }
                 } else if field_index == 2 {
                     if pass == 0 {

--- a/sdk/src/account_data.rs
+++ b/sdk/src/account_data.rs
@@ -1,0 +1,109 @@
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+use std::{
+    ops::{Deref, DerefMut, Index, IndexMut},
+    slice::SliceIndex,
+    sync::Arc,
+};
+
+#[derive(Debug, Default, AbiExample)]
+pub struct AccountData {
+    data: Arc<Vec<u8>>,
+}
+
+impl AccountData {}
+
+impl From<Vec<u8>> for AccountData {
+    fn from(data: Vec<u8>) -> Self {
+        Self { data: data.into() }
+    }
+}
+// TODO this could be expensive
+impl From<AccountData> for Vec<u8> {
+    fn from(account_data: AccountData) -> Self {
+        account_data.data.to_vec()
+    }
+}
+
+impl Deref for AccountData {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+impl DerefMut for AccountData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Arc::make_mut(&mut self.data) as _
+    }
+}
+
+impl AsRef<[u8]> for AccountData {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl<I> Index<I> for AccountData
+where
+    I: SliceIndex<[u8]>,
+{
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        self.data.index(index)
+    }
+}
+
+impl<I> IndexMut<I> for AccountData
+where
+    I: SliceIndex<[u8]>,
+{
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        // Invalidate the cache since the data may be mutated.
+        let data = Arc::make_mut(&mut self.data);
+        data.index_mut(index)
+    }
+}
+
+impl Clone for AccountData {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+        }
+    }
+}
+
+impl PartialEq<AccountData> for AccountData {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl Eq for AccountData {}
+
+impl Serialize for AccountData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serde_bytes::serialize(&self.data[..], serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AccountData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let data = serde_bytes::deserialize::<Vec<u8>, D>(deserializer)?;
+        Ok(Self::from(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: Add tests.
+}

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -7,6 +7,7 @@ extern crate self as solana_sdk;
 pub use solana_program::*;
 
 pub mod account;
+pub mod account_data;
 pub mod account_utils;
 pub mod arithmetic;
 pub mod builtins;


### PR DESCRIPTION
#### Problem
This is the version where AccountSharedData has:
AccountData has:
`Arc<Vec<u8>>`

as compared to:
`Arc<AccountData>`
[PR](https://github.com/solana-labs/solana/pull/15800)
#### Summary of Changes

Fixes #
