### PR TITLE
use Account for test since it borrows mut ref to data

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -111,9 +111,14 @@ pub fn builtin_process_instruction(
     set_invoke_context(invoke_context);
 
     // Copy all the accounts into a HashMap to ensure there are no duplicates
-    let mut accounts: HashMap<Pubkey, AccountSharedData> = keyed_accounts
+    let mut accounts: HashMap<Pubkey, Account> = keyed_accounts
         .iter()
-        .map(|ka| (*ka.unsigned_key(), ka.account.borrow().clone()))
+        .map(|ka| {
+            (
+                *ka.unsigned_key(),
+                Account::from(ka.account.borrow().clone()),
+            )
+        })
         .collect();
 
     // Create shared references to each account's lamports/data/owner


### PR DESCRIPTION
#### Problem
There is a test that works with mut refs to members of account. This doesn't work well with an abstracted data field which isn't directly a vec.

#### Summary of Changes
Rework the test to use the legacy Account struct.

Fixes #
