### PR TITLE
rework BankClient.get_account_data

### DIFF
--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -113,7 +113,10 @@ impl SyncClient for BankClient {
     }
 
     fn get_account_data(&self, pubkey: &Pubkey) -> Result<Option<Vec<u8>>> {
-        Ok(self.bank.get_account(pubkey).map(|account| account.data))
+        Ok(self
+            .bank
+            .get_account(pubkey)
+            .map(|account| Account::from(account).data))
     }
 
     fn get_account(&self, pubkey: &Pubkey) -> Result<Option<Account>> {


### PR DESCRIPTION
#### Problem
Some code returns a vec for an account which has only one reference. This is difficult to efficiently support as account data changes.

#### Summary of Changes
Use equivalent code which supports no unnecessary copy.

Fixes #
