### PR TITLE
web3: clean up nullable typing and validate confirmation status string

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -106,7 +106,7 @@ declare module '@solana/web3.js' {
     slot: number;
     err: TransactionError | null;
     confirmations: number | null;
-    confirmationStatus: TransactionConfirmationStatus | null;
+    confirmationStatus?: TransactionConfirmationStatus;
   };
 
   export type ConfirmedSignatureInfo = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -119,7 +119,7 @@ declare module '@solana/web3.js' {
     slot: number,
     err: TransactionError | null,
     confirmations: number | null,
-    confirmationStatus: TransactionConfirmationStatus | null,
+    confirmationStatus?: TransactionConfirmationStatus,
   };
 
   declare export type ConfirmedSignatureInfo = {

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -1049,11 +1049,17 @@ const GetVoteAccounts = jsonRpcResult(
   }),
 );
 
+const ConfirmationStatus = union([
+  literal('processed'),
+  literal('confirmed'),
+  literal('finalized'),
+]);
+
 const SignatureStatusResponse = pick({
   slot: number(),
   confirmations: nullable(number()),
   err: TransactionErrorResult,
-  confirmationStatus: optional(nullable(string())),
+  confirmationStatus: optional(ConfirmationStatus),
 });
 
 /**
@@ -1496,19 +1502,32 @@ export type SignatureResult = {|
 export type TransactionError = {};
 
 /**
+ * Transaction confirmation status
+ * <pre>
+ *   'processed': Transaction landed in a block which has reached 1 confirmation by the connected node
+ *   'confirmed': Transaction landed in a block which has reached 1 confirmation by the cluster
+ *   'finalized': Transaction landed in a block which has been finalized by the cluster
+ * </pre>
+ */
+export type TransactionConfirmationStatus =
+  | 'processed'
+  | 'confirmed'
+  | 'finalized';
+
+/**
  * Signature status
  *
  * @typedef {Object} SignatureStatus
  * @property {number} slot when the transaction was processed
  * @property {number | null} confirmations the number of blocks that have been confirmed and voted on in the fork containing `slot` (TODO)
  * @property {TransactionError | null} err error, if any
- * @property {string | null} confirmationStatus the transaction's cluster confirmation status, if data available. Possible non-null responses: `processed`, `confirmed`, `finalized`
+ * @property {?TransactionConfirmationStatus} confirmationStatus the transaction's cluster confirmation status, if data available. Possible responses: `processed`, `confirmed`, `finalized`
  */
 export type SignatureStatus = {
   slot: number,
   confirmations: number | null,
   err: TransactionError | null,
-  confirmationStatus: string | null,
+  confirmationStatus?: TransactionConfirmationStatus,
 };
 
 /**

--- a/web3.js/src/connection.js
+++ b/web3.js/src/connection.js
@@ -408,15 +408,20 @@ const SignatureStatusResult = pick({
   err: TransactionErrorResult,
 });
 
+type Version = {
+  'solana-core': string,
+  'feature-set'?: number,
+};
+
 /**
  * Version info for a node
  *
  * @typedef {Object} Version
  * @property {string} solana-core Version of solana-core
  */
-const Version = pick({
+const VersionResult = pick({
   'solana-core': string(),
-  'feature-set': optional(nullable(number())),
+  'feature-set': optional(number()),
 });
 
 type SimulatedTransactionResponse = {
@@ -777,7 +782,7 @@ const TokenAmountResult = pick({
   amount: string(),
   uiAmount: nullable(number()),
   decimals: number(),
-  uiAmountString: optional(nullable(string())),
+  uiAmountString: optional(string()),
 });
 
 /**
@@ -808,7 +813,7 @@ const GetTokenLargestAccountsResult = jsonRpcResultAndContext(
       amount: string(),
       uiAmount: nullable(number()),
       decimals: number(),
-      uiAmountString: optional(nullable(string())),
+      uiAmountString: optional(string()),
     }),
   ),
 );
@@ -2394,7 +2399,7 @@ export class Connection {
    */
   async getVersion(): Promise<Version> {
     const unsafeRes = await this._rpcRequest('getVersion', []);
-    const res = create(unsafeRes, jsonRpcResult(Version));
+    const res = create(unsafeRes, jsonRpcResult(VersionResult));
     if (res.error) {
       throw new Error('failed to get version: ' + res.error.message);
     }


### PR DESCRIPTION
#### Summary of Changes
- `confirmationStatus` may not be set (`undefined`) but will never be `null`. 
- validate confirmation status strings

Fixes #
