### PR TITLE
web3: require programId and keys for TransactionInstruction

### DIFF
--- a/web3.js/module.d.ts
+++ b/web3.js/module.d.ts
@@ -662,8 +662,8 @@ declare module '@solana/web3.js' {
   };
 
   export type TransactionInstructionCtorFields = {
-    keys?: Array<AccountMeta>;
-    programId?: PublicKey;
+    keys: Array<AccountMeta>;
+    programId: PublicKey;
     data?: Buffer;
   };
 
@@ -672,7 +672,7 @@ declare module '@solana/web3.js' {
     programId: PublicKey;
     data: Buffer;
 
-    constructor(opts?: TransactionInstructionCtorFields);
+    constructor(opts: TransactionInstructionCtorFields);
   }
 
   export type SignaturePubkeyPair = {

--- a/web3.js/module.flow.js
+++ b/web3.js/module.flow.js
@@ -663,8 +663,8 @@ declare module '@solana/web3.js' {
   };
 
   declare type TransactionInstructionCtorFields = {|
-    keys: ?Array<AccountMeta>,
-    programId?: PublicKey,
+    keys: Array<AccountMeta>,
+    programId: PublicKey,
     data?: Buffer,
   |};
 
@@ -673,9 +673,7 @@ declare module '@solana/web3.js' {
     programId: PublicKey;
     data: Buffer;
 
-    constructor(
-      opts?: TransactionInstructionCtorFields,
-    ): TransactionInstruction;
+    constructor(opts: TransactionInstructionCtorFields): TransactionInstruction;
   }
 
   declare type SignaturePubkeyPair = {|

--- a/web3.js/src/transaction.js
+++ b/web3.js/src/transaction.js
@@ -53,13 +53,13 @@ export type AccountMeta = {
  * List of TransactionInstruction object fields that may be initialized at construction
  *
  * @typedef {Object} TransactionInstructionCtorFields
- * @property {?Array<PublicKey>} keys
- * @property {?PublicKey} programId
+ * @property {Array<PublicKey>} keys
+ * @property {PublicKey} programId
  * @property {?Buffer} data
  */
 export type TransactionInstructionCtorFields = {|
-  keys?: Array<AccountMeta>,
-  programId?: PublicKey,
+  keys: Array<AccountMeta>,
+  programId: PublicKey,
   data?: Buffer,
 |};
 
@@ -83,7 +83,7 @@ export class TransactionInstruction {
    * Public keys to include in this transaction
    * Boolean represents whether this pubkey needs to sign the transaction
    */
-  keys: Array<AccountMeta> = [];
+  keys: Array<AccountMeta>;
 
   /**
    * Program Id to execute
@@ -95,8 +95,12 @@ export class TransactionInstruction {
    */
   data: Buffer = Buffer.alloc(0);
 
-  constructor(opts?: TransactionInstructionCtorFields) {
-    opts && Object.assign(this, opts);
+  constructor(opts: TransactionInstructionCtorFields) {
+    this.programId = opts.programId;
+    this.keys = opts.keys;
+    if (opts.data) {
+      this.data = opts.data;
+    }
   }
 }
 
@@ -234,6 +238,14 @@ export class Transaction {
       feePayer = this.signatures[0].publicKey;
     } else {
       throw new Error('Transaction fee payer required');
+    }
+
+    for (let i = 0; i < this.instructions.length; i++) {
+      if (this.instructions[i].programId === undefined) {
+        throw new Error(
+          `Transaction instruction index ${i} has undefined program id`,
+        );
+      }
     }
 
     const programIds: string[] = [];


### PR DESCRIPTION
#### Problem
The `TransactionInstruction` class claims to always have a defined `programId` but can be constructed without one. This is unnecessary because there's no reason a `TransactionInstruction` should be constructed without a program id or key list.

#### Summary of Changes
- Require `TransactionInstruction` to have defined programId

Fixes #
