### PR TITLE
explorer: use uiAmountString in token balances component

### DIFF
--- a/explorer/src/components/transaction/TokenBalancesCard.tsx
+++ b/explorer/src/components/transaction/TokenBalancesCard.tsx
@@ -64,7 +64,7 @@ export function TokenBalancesCard({ signature }: SignatureProps) {
           <BalanceDelta delta={delta} />
         </td>
         <td>
-          {balance.uiAmount} {units}
+          {balance.uiAmountString} {units}
         </td>
       </tr>
     );


### PR DESCRIPTION
#### Problem
![Explorer-Solana (13)](https://user-images.githubusercontent.com/188792/111102384-34aec180-8509-11eb-9f84-22c9ea525769.png)

Post balances in the token balance components are using uiAmount, which can be null.

#### Summary of Changes
![Explorer-Solana (14)](https://user-images.githubusercontent.com/188792/111102372-2d87b380-8509-11eb-9707-5e94e96ec8da.png)

Use new uiAmountString instead.