### PR TITLE
Charge compute budget for bytes passed via cpi

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1110,6 +1110,7 @@ mod tests {
                 stack_frame_size: 4096,
                 log_pubkey_units: 100,
                 max_cpi_instruction_size: usize::MAX,
+                cpi_bytes_per_unit: 250,
             },
             Rc::new(RefCell::new(Executors::default())),
             None,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -115,6 +115,10 @@ pub mod require_stake_for_gossip {
     solana_sdk::declare_id!("6oNzd5Z3M2L1xo4Q5hoox7CR2DuW7m1ETLWH5jHJthwa");
 }
 
+pub mod cpi_data_cost {
+    solana_sdk::declare_id!("Hrg5bXePPGiAVWZfDHbvjqytSeyBDPAGAQ7v6N5i4gCX");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -141,9 +145,10 @@ lazy_static! {
         (warp_timestamp_again::id(), "warp timestamp again, adjust bounding to 25% fast 80% slow #15204"),
         (check_init_vote_data::id(), "check initialized Vote data"),
         (check_program_owner::id(), "limit programs to operating on accounts owned by itself"),
-        (cpi_share_ro_and_exec_accounts::id(), "Share RO and Executable accounts during cross-program invocations"),
-        (skip_ro_deserialization::id(), "Skip deserialization of read-only accounts"),
+        (cpi_share_ro_and_exec_accounts::id(), "share RO and Executable accounts during cross-program invocations"),
+        (skip_ro_deserialization::id(), "skip deserialization of read-only accounts"),
         (require_stake_for_gossip::id(), "require stakes for propagating crds values through gossip #15561"),
+        (cpi_data_cost::id(), "charge the compute budger for data passed via CPI"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -128,6 +128,8 @@ pub struct BpfComputeBudget {
     pub log_pubkey_units: u64,
     /// Maximum cross-program invocation instruction size
     pub max_cpi_instruction_size: usize,
+    /// Number of account data bytes per conpute unit charged during a cross-program invocation
+    pub cpi_bytes_per_unit: u64,
 }
 impl Default for BpfComputeBudget {
     fn default() -> Self {
@@ -149,6 +151,7 @@ impl BpfComputeBudget {
             stack_frame_size: 4_096,
             log_pubkey_units: 100,
             max_cpi_instruction_size: 1280, // IPv6 Min MTU size
+            cpi_bytes_per_unit: 250,        // ~50MB at 200,000 units
         }
     }
 }


### PR DESCRIPTION
#### Problem

Data passed to CPI calls don't account for the data copies

#### Summary of Changes

Charge compute budget units based on the amount of data passed to an inner instruction. 

Fixes #
