### PR TITLE
increment_cargo_version.sh tune ups

### DIFF
--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -23,6 +23,7 @@ ignores=(
   .cargo
   target
   web3.js/examples
+  node_modules
 )
 
 not_paths=()
@@ -30,10 +31,10 @@ for ignore in "${ignores[@]}"; do
   not_paths+=(-not -path "*/$ignore/*")
 done
 
-# shellcheck disable=2207,SC2068 # Don't want a positional arg if `not-paths` is empty
-Cargo_tomls=($(find . -mindepth 2 -name Cargo.toml ${not_paths[@]}))
-# shellcheck disable=2207,SC2068 # Don't want a positional arg if `not-paths` is empty
-markdownFiles=($(find . -name "*.md" ${not_paths[@]}))
+# shellcheck disable=2207
+Cargo_tomls=($(find . -mindepth 2 -name Cargo.toml "${not_paths[@]}"))
+# shellcheck disable=2207
+markdownFiles=($(find . -name "*.md" "${not_paths[@]}"))
 
 # Collect the name of all the internal crates
 crates=()

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -32,8 +32,8 @@ done
 
 # shellcheck disable=2207,SC2068 # Don't want a positional arg if `not-paths` is empty
 Cargo_tomls=($(find . -mindepth 2 -name Cargo.toml ${not_paths[@]}))
-# shellcheck disable=2207
-markdownFiles=($(find . -name "*.md"))
+# shellcheck disable=2207,SC2068 # Don't want a positional arg if `not-paths` is empty
+markdownFiles=($(find . -name "*.md" ${not_paths[@]}))
 
 # Collect the name of all the internal crates
 crates=()

--- a/scripts/increment-cargo-version.sh
+++ b/scripts/increment-cargo-version.sh
@@ -105,6 +105,17 @@ check)
   ;;
 esac
 
+# Version bumps should occur in their own commit. Disallow bumping version
+# in dirty working trees. Gate after arg parsing to prevent breaking the
+# `check` subcommand.
+(
+  set +e
+  if ! git diff --exit-code; then
+    echo -e "\nError: Working tree is dirty. Commit or discard changes before bumping version." 1>&2
+    exit 1
+  fi
+)
+
 newVersion="$MAJOR.$MINOR.$PATCH$SPECIAL"
 
 # Update all the Cargo.toml files


### PR DESCRIPTION
#### Problems

`./scripts/increment-cargo-version.sh` goes digging through any `node_modules` dirs in tree (with many `*.md` hits!), needlessly extending its runtime

Version bump changes should be isolated in their own commit, but `./scripts/increment-cargo-version.sh` will run on a dirty working tree, potentially burying unintended changes in a massive diff.

#### Summary of Changes

* Ignore `*/node_modules/*`
* Prevent version bumps in dirty working trees

```
$ ./scripts/increment-cargo-version.sh patch
diff --git a/ci/README.md b/ci/README.md
index 88064a0dc..77f905101 100644
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,4 +1,4 @@
-
+dirty
 Our CI infrastructure is built around [BuildKite](https://buildkite.com) with some
 additional GitHub integration provided by https://github.com/mvines/ci-gate


Error: Working tree is dirty. Commit or discard changes before bumping version.
```