### PR TITLE
Close buffer accounts

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1392,7 +1392,7 @@ impl fmt::Display for CliAccountBalances {
         writeln!(
             f,
             "{}",
-            style(format!("{:<44}  {}", "Address", "Balance",)).bold()
+            style(format!("{:<44}  {}", "Address", "Balance")).bold()
         )?;
         for account in &self.accounts {
             writeln!(
@@ -1684,6 +1684,8 @@ pub struct CliUpgradeableBuffer {
     pub address: String,
     pub authority: String,
     pub data_len: usize,
+    pub lamports: u64,
+    pub use_lamports_unit: bool,
 }
 impl QuietDisplay for CliUpgradeableBuffer {}
 impl VerboseDisplay for CliUpgradeableBuffer {}
@@ -1694,9 +1696,51 @@ impl fmt::Display for CliUpgradeableBuffer {
         writeln_name_value(f, "Authority:", &self.authority)?;
         writeln_name_value(
             f,
+            "Balance:",
+            &build_balance_message(self.lamports, self.use_lamports_unit, true),
+        )?;
+        writeln_name_value(
+            f,
             "Data Length:",
             &format!("{:?} ({:#x?}) bytes", self.data_len, self.data_len),
         )?;
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliUpgradeableBuffers {
+    pub buffers: Vec<CliUpgradeableBuffer>,
+    pub use_lamports_unit: bool,
+}
+impl QuietDisplay for CliUpgradeableBuffers {}
+impl VerboseDisplay for CliUpgradeableBuffers {}
+impl fmt::Display for CliUpgradeableBuffers {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f)?;
+        writeln!(
+            f,
+            "{}",
+            style(format!(
+                "{:<44} | {:<44} | {}",
+                "Buffer Address", "Authority", "Balance"
+            ))
+            .bold()
+        )?;
+        for buffer in self.buffers.iter() {
+            writeln!(
+                f,
+                "{}",
+                &format!(
+                    "{:<44} | {:<44} | {}",
+                    buffer.address,
+                    buffer.authority,
+                    build_balance_message(buffer.lamports, self.use_lamports_unit, true)
+                )
+            )?;
+        }
         Ok(())
     }
 }

--- a/docs/src/cli/deploy-a-program.md
+++ b/docs/src/cli/deploy-a-program.md
@@ -124,20 +124,25 @@ call to `deploy`.
 Deployment failures will print an error message specifying the seed phrase
 needed to recover the generated intermediate buffer's keypair:
 
-```bash
-=======================================================================
-To resume a failed deploy, recover the ephemeral keypair file with
-`solana-keygen recover` and the following 12-word seed phrase,
-then pass it as the [BUFFER_SIGNER] argument to `solana deploy` or `solana write-buffer`
-=======================================================================
-spy axis cream equip bonus daring muffin fish noise churn broken diesel
-=======================================================================
+```
+==================================================================================
+Recover the intermediate account's ephemeral keypair file with
+`solana-keygen recover` and the following 12-word seed phrase:
+==================================================================================
+valley flat great hockey share token excess clever benefit traffic avocado athlete
+==================================================================================
+To resume a deploy, pass the recovered keypair as
+the [PROGRAM_ADDRESS_SIGNER] argument to `solana deploy` or
+as the [BUFFER_SIGNER] to `solana program deploy` or `solana write-buffer'.
+Or to recover the account's lamports, pass it as the
+[BUFFER_ACCOUNT_ADDRESS] argument to `solana program drain`.
+==================================================================================
 ```
 
 To recover the keypair:
 
 ```bash
-$ solana-keypair recover -o <KEYPAIR_PATH>
+solana-keypair recover -o <KEYPAIR_PATH>
 ```
 
 When asked, enter the 12-word seed phrase.
@@ -145,7 +150,57 @@ When asked, enter the 12-word seed phrase.
 Then issue a new `deploy` command and specify the buffer:
 
 ```bash
-$ solana program deploy --buffer <KEYPAIR_PATH> <PROGRAM_FILEPATH>
+solana program deploy --buffer <KEYPAIR_PATH> <PROGRAM_FILEPATH>
+```
+
+### Closing buffer accounts and reclaiming their lamports
+
+If deployment fails there will be a left over buffer account that holds
+lamports.  The buffer account can either be used to [resume a
+deploy](#resuming-a-failed-deploy) or closed.  When closed, the full balance of
+the buffer account will be transferred to the recipient's account.
+
+The buffer account's authority must be present to close a buffer account, to
+list all the open buffer accounts that match the default authority:
+
+```bash
+solana program show --buffers
+```
+
+To specify a different authority:
+
+```bash
+solana program show --buffers --buffer-authority <AURTHORITY_ADRESS>
+```
+
+To close a single account:
+
+```bash
+solana program close <BUFFER_ADDRESS>
+```
+
+To close a single account and specify a different authority than the default:
+
+```bash
+solana program close <BUFFER_ADDRESS> --buffer-authority <KEYPAIR_FILEPATH>
+```
+
+To close a single account and specify a different recipient than the default:
+
+```bash
+solana program close <BUFFER_ADDRESS> --recipient <RECIPIENT_ADDRESS>
+```
+
+To close all the buffer accounts associated with the current authority:
+
+```bash
+solana program close --buffers
+```
+
+To show all buffer accounts regardless of the authority
+
+```bash
+solana program show --buffers --all
 ```
 
 ### Set a program's upgrade authority

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -30,7 +30,7 @@ use solana_sdk::{
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     clock::Clock,
     entrypoint::SUCCESS,
-    feature_set::skip_ro_deserialization,
+    feature_set::{skip_ro_deserialization, upgradeable_close_instruction},
     ic_logger_msg, ic_msg,
     instruction::InstructionError,
     keyed_account::{from_keyed_account, next_keyed_account, KeyedAccount},
@@ -566,11 +566,9 @@ fn process_loader_upgradeable_instruction(
             programdata.try_account_ref_mut()?.data_as_mut_slice()
                 [programdata_data_offset..programdata_data_offset + buffer_data_len]
                 .copy_from_slice(&buffer.try_account_ref()?.data()[buffer_data_offset..]);
-            for i in &mut programdata.try_account_ref_mut()?.data_as_mut_slice()
+            programdata.try_account_ref_mut()?.data_as_mut_slice()
                 [programdata_data_offset + buffer_data_len..]
-            {
-                *i = 0
-            }
+                .fill(0);
 
             // Fund ProgramData to rent-exemption, spill the rest
 
@@ -634,11 +632,48 @@ fn process_loader_upgradeable_instruction(
                 }
                 _ => {
                     ic_logger_msg!(logger, "Account does not support authorities");
-                    return Err(InstructionError::InvalidAccountData);
+                    return Err(InstructionError::InvalidArgument);
                 }
             }
 
             ic_logger_msg!(logger, "New authority {:?}", new_authority);
+        }
+        UpgradeableLoaderInstruction::Close => {
+            if !invoke_context.is_feature_active(&upgradeable_close_instruction::id()) {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+            let close_account = next_keyed_account(account_iter)?;
+            let recipient_account = next_keyed_account(account_iter)?;
+            let authority = next_keyed_account(account_iter)?;
+
+            if close_account.unsigned_key() == recipient_account.unsigned_key() {
+                ic_logger_msg!(logger, "Recipient is the same as the account being closed");
+                return Err(InstructionError::InvalidArgument);
+            }
+
+            if let UpgradeableLoaderState::Buffer { authority_address } = close_account.state()? {
+                if authority_address.is_none() {
+                    ic_logger_msg!(logger, "Buffer is immutable");
+                    return Err(InstructionError::Immutable);
+                }
+                if authority_address != Some(*authority.unsigned_key()) {
+                    ic_logger_msg!(logger, "Incorrect buffer authority provided");
+                    return Err(InstructionError::IncorrectAuthority);
+                }
+                if authority.signer_key().is_none() {
+                    ic_logger_msg!(logger, "Buffer authority did not sign");
+                    return Err(InstructionError::MissingRequiredSignature);
+                }
+
+                recipient_account.try_account_ref_mut()?.lamports += close_account.lamports()?;
+                close_account.try_account_ref_mut()?.lamports = 0;
+                close_account.try_account_ref_mut()?.data.fill(0);
+            } else {
+                ic_logger_msg!(logger, "Account does not support closing");
+                return Err(InstructionError::InvalidArgument);
+            }
+
+            ic_logger_msg!(logger, "Closed {}", close_account.unsigned_key());
         }
     }
 
@@ -3011,7 +3046,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(
-            Err(InstructionError::InvalidAccountData),
+            Err(InstructionError::InvalidArgument),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
                 &[
@@ -3184,7 +3219,7 @@ mod tests {
             })
             .unwrap();
         assert_eq!(
-            Err(InstructionError::InvalidAccountData),
+            Err(InstructionError::InvalidArgument),
             process_instruction(
                 &bpf_loader_upgradeable::id(),
                 &[
@@ -3210,6 +3245,87 @@ mod tests {
                 &[
                     KeyedAccount::new(&buffer_address, false, &buffer_account),
                     KeyedAccount::new_readonly(&authority_address, true, &authority_account),
+                ],
+                &instruction,
+                &mut MockInvokeContext::default()
+            )
+        );
+    }
+
+    #[test]
+    fn test_bpf_loader_upgradeable_close() {
+        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap();
+        let authority_address = Pubkey::new_unique();
+        let authority_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
+        let recipient_address = Pubkey::new_unique();
+        let recipient_account = AccountSharedData::new_ref(1, 0, &Pubkey::new_unique());
+        let buffer_address = Pubkey::new_unique();
+        let buffer_account = AccountSharedData::new_ref(
+            1,
+            UpgradeableLoaderState::buffer_len(0).unwrap(),
+            &bpf_loader_upgradeable::id(),
+        );
+
+        // Case: close a buffer account
+        buffer_account
+            .borrow_mut()
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address),
+            })
+            .unwrap();
+        assert_eq!(
+            Ok(()),
+            process_instruction(
+                &bpf_loader_upgradeable::id(),
+                &[
+                    KeyedAccount::new(&buffer_address, false, &buffer_account),
+                    KeyedAccount::new(&recipient_address, false, &recipient_account),
+                    KeyedAccount::new_readonly(&authority_address, true, &authority_account),
+                ],
+                &instruction,
+                &mut MockInvokeContext::default()
+            )
+        );
+        assert_eq!(0, buffer_account.borrow().lamports());
+        assert_eq!(2, recipient_account.borrow().lamports());
+        assert!(buffer_account.borrow().data.iter().all(|&value| value == 0));
+
+        // Case: close with wrong authority
+        buffer_account
+            .borrow_mut()
+            .set_state(&UpgradeableLoaderState::Buffer {
+                authority_address: Some(authority_address),
+            })
+            .unwrap();
+        assert_eq!(
+            Err(InstructionError::IncorrectAuthority),
+            process_instruction(
+                &bpf_loader_upgradeable::id(),
+                &[
+                    KeyedAccount::new(&buffer_address, false, &buffer_account),
+                    KeyedAccount::new(&recipient_address, false, &recipient_account),
+                    KeyedAccount::new_readonly(&Pubkey::new_unique(), true, &authority_account),
+                ],
+                &instruction,
+                &mut MockInvokeContext::default()
+            )
+        );
+
+        // Case: close but not a buffer account
+        buffer_account
+            .borrow_mut()
+            .set_state(&UpgradeableLoaderState::Program {
+                programdata_address: Pubkey::new_unique(),
+            })
+            .unwrap();
+        assert_eq!(
+            Err(InstructionError::InvalidArgument),
+            process_instruction(
+                &bpf_loader_upgradeable::id(),
+                &[
+                    KeyedAccount::new(&buffer_address, false, &buffer_account),
+                    KeyedAccount::new(&recipient_address, false, &recipient_account),
+                    KeyedAccount::new_readonly(&Pubkey::new_unique(), true, &authority_account),
                 ],
                 &instruction,
                 &mut MockInvokeContext::default()

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -227,6 +227,20 @@ pub fn set_upgrade_authority(
     Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::SetAuthority, metas)
 }
 
+/// Returns the instructions required to close an account
+pub fn close(
+    close_address: &Pubkey,
+    recipient_address: &Pubkey,
+    authority_address: &Pubkey,
+) -> Instruction {
+    let metas = vec![
+        AccountMeta::new(*close_address, false),
+        AccountMeta::new(*recipient_address, false),
+        AccountMeta::new_readonly(*authority_address, true),
+    ];
+    Instruction::new_with_bincode(id(), &UpgradeableLoaderInstruction::Close, metas)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/program/src/loader_upgradeable_instruction.rs
+++ b/sdk/program/src/loader_upgradeable_instruction.rs
@@ -107,4 +107,13 @@ pub enum UpgradeableLoaderInstruction {
     ///   2. `[]` The new authority, optional, if omitted then the program will
     ///      not be upgradeable.
     SetAuthority,
+
+    /// Closes an account owned by the upgradeable loader of all lamports and
+    /// withdraws all the lamports
+    ///
+    /// # Account references
+    ///   0. `[writable]` The account to close.
+    ///   1. `[writable]` The account to deposit the closed account's lamports.
+    ///   2. `[signer]` The account's authority.
+    Close,
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -119,6 +119,10 @@ pub mod cpi_data_cost {
     solana_sdk::declare_id!("Hrg5bXePPGiAVWZfDHbvjqytSeyBDPAGAQ7v6N5i4gCX");
 }
 
+pub mod upgradeable_close_instruction {
+    solana_sdk::declare_id!("FsPaByos3gA9bUEhp3EimQpQPCoSvCEigHod496NmABQ");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -149,6 +153,7 @@ lazy_static! {
         (skip_ro_deserialization::id(), "skip deserialization of read-only accounts"),
         (require_stake_for_gossip::id(), "require stakes for propagating crds values through gossip #15561"),
         (cpi_data_cost::id(), "charge the compute budget for data passed via CPI"),
+        (upgradeable_close_instruction::id(), "close upgradeable buffer accounts"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -131,6 +131,17 @@ pub fn parse_bpf_upgradeable_loader(
                 }),
             })
         }
+        UpgradeableLoaderInstruction::Close => {
+            check_num_bpf_upgradeable_loader_accounts(&instruction.accounts, 3)?;
+            Ok(ParsedInstructionEnum {
+                instruction_type: "close".to_string(),
+                info: json!({
+                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "recipient": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "authority": account_keys[instruction.accounts[2] as usize].to_string()
+                }),
+            })
+        }
     }
 }
 
@@ -348,6 +359,21 @@ mod test {
                     "account": keys[1].to_string(),
                     "authority": keys[0].to_string(),
                     "newAuthority": Value::Null,
+                }),
+            }
+        );
+        assert!(parse_bpf_upgradeable_loader(&message.instructions[0], &keys[0..1]).is_err());
+
+        let instruction = solana_sdk::bpf_loader_upgradeable::close(&keys[0], &keys[1], &keys[2]);
+        let message = Message::new(&[instruction], None);
+        assert_eq!(
+            parse_bpf_upgradeable_loader(&message.instructions[0], &keys[..3]).unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "close".to_string(),
+                info: json!({
+                    "account": keys[1].to_string(),
+                    "recipient": keys[2].to_string(),
+                    "authority": keys[0].to_string(),
                 }),
             }
         );


### PR DESCRIPTION
#### Problem

Once a buffer account is created there is no way to recover the lamports from it except to deploy it.

#### Summary of Changes

- Add a close instruction to the upgradeable loader that will close buffer accounts.
- Add cli tooling to close accounts
- Add cli tooling to show a list of buffer accounts

Fixes #
