### PR TITLE
v1.5: Build full SPL in CI

### DIFF
--- a/scripts/build-downstream-projects.sh
+++ b/scripts/build-downstream-projects.sh
@@ -65,15 +65,8 @@ spl() {
     ./patch.crates-io.sh "$solana_dir"
 
     $cargo build
-
-    # Generic `cargo test`/`cargo test-bpf` disabled due to BPF VM interface changes between Solana 1.4
-    # and 1.5...
-    #$cargo test
-    #$cargo_test_bpf
-
-    $cargo_test_bpf --manifest-path token/program/Cargo.toml
-    $cargo_test_bpf --manifest-path associated-token-account/program/Cargo.toml
-    $cargo_test_bpf --manifest-path feature-proposal/program/Cargo.toml
+    $cargo test
+    $cargo_test_bpf
   )
 }
 


### PR DESCRIPTION
Not building the full SPL in CI allowed for breaking changes to sneak into master/v1.6 (cc: https://github.com/solana-labs/solana/pull/15886).  In the meantime, batten down the hatches on v1.5 to avoid the same thing occurring there