### PR TITLE
Add helper for paring down signers to those requried by a tx message

### DIFF
--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -439,6 +439,15 @@ impl Message {
             accounts,
         })
     }
+
+    pub fn signer_keys(&self) -> Vec<&Pubkey> {
+        // Clamp in case we're working on un-`sanitize()`ed input
+        let last_key = self
+            .account_keys
+            .len()
+            .max(self.header.num_required_signatures as usize);
+        self.account_keys[..last_key].iter().collect()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

`Transaction::try_partial_sign()` fails when extraneous signers are passed.  Usually this indicates that the developer has made a mistake and the RightThing(TM) to do.  However, in the case of CLI apps where keys can have mixed roles, even in variants of the same transaction, this can be very inconvenient.

#### Summary of Changes

Add a helper for `CliSignerInfo` for paring down a signer list to only those referenced in a message

~TODO: CLI plumbing :face_with_head_bandage:~ Gonna punt the CLI plumbing 'til after a refactor