### PR TITLE
fix: compute pre/post token balances on all accounts if token program present

### DIFF
--- a/transaction-status/src/token_balances.rs
+++ b/transaction-status/src/token_balances.rs
@@ -59,25 +59,16 @@ pub fn collect_token_balances(
 
     for (_, transaction) in OrderedIterator::new(batch.transactions(), batch.iteration_order()) {
         let account_keys = &transaction.message.account_keys;
-        let mut fetch_account_hash: HashMap<u8, bool> = HashMap::new();
-        for instruction in transaction.message.instructions.iter() {
-            if let Some(program_id) = account_keys.get(instruction.program_id_index as usize) {
-                if is_token_program(&program_id) {
-                    for account in &instruction.accounts {
-                        fetch_account_hash.insert(*account, true);
-                    }
-                }
-            }
-        }
+        let has_token_program = account_keys.iter().any(|p| is_token_program(p));
 
         let mut transaction_balances: Vec<TransactionTokenBalance> = vec![];
-        for index in fetch_account_hash.keys() {
-            if let Some(account_id) = account_keys.get(*index as usize) {
+        if has_token_program {
+            for (index, account_id) in account_keys.iter().enumerate() {
                 if let Some((mint, ui_token_amount)) =
                     collect_token_balance_from_account(&bank, account_id, &mut mint_decimals)
                 {
                     transaction_balances.push(TransactionTokenBalance {
-                        account_index: *index,
+                        account_index: index as u8,
                         mint,
                         ui_token_amount,
                     });

--- a/transaction-status/src/token_balances.rs
+++ b/transaction-status/src/token_balances.rs
@@ -64,6 +64,10 @@ pub fn collect_token_balances(
         let mut transaction_balances: Vec<TransactionTokenBalance> = vec![];
         if has_token_program {
             for (index, account_id) in account_keys.iter().enumerate() {
+                if is_token_program(account_id) {
+                    continue;
+                }
+
                 if let Some((mint, ui_token_amount)) =
                     collect_token_balance_from_account(&bank, account_id, &mut mint_decimals)
                 {

--- a/transaction-status/src/token_balances.rs
+++ b/transaction-status/src/token_balances.rs
@@ -64,7 +64,9 @@ pub fn collect_token_balances(
         let mut transaction_balances: Vec<TransactionTokenBalance> = vec![];
         if has_token_program {
             for (index, account_id) in account_keys.iter().enumerate() {
-                if is_token_program(account_id) {
+                if is_token_program(account_id)
+                    || transaction.message.program_ids().contains(&account_id)
+                {
                     continue;
                 }
 


### PR DESCRIPTION
#### Problem
SPL Token balance changes from inner instructions are not included in {pre,post}TokenBalances.

#### Summary of Changes
Previously, account balance queries were performed only if token program was involved at the instruction level. This change queries all accounts when the token program is present in the transaction.

Fixes https://github.com/solana-labs/solana/issues/15760