### PR TITLE
Add AccountSharedData stub for forwards compatibility with the v1.6 release line

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -111,6 +111,14 @@ impl Account {
     }
 }
 
+// AccountSharedData stub for forwards compatibility with the v1.6 release line
+pub struct AccountSharedData {}
+impl AccountSharedData {
+    pub fn new_ref(lamports: u64, space: usize, owner: &Pubkey) -> Rc<RefCell<Account>> {
+        Rc::new(RefCell::new(Account::new(lamports, space, owner)))
+    }
+}
+
 /// Create an `Account` from a `Sysvar`.
 pub fn create_account<S: Sysvar>(sysvar: &S, lamports: u64) -> Account {
     let data_len = S::size_of().max(bincode::serialized_size(sysvar).unwrap() as usize);


### PR DESCRIPTION
The introduction of `AccountSharedData` broke the SPL shared memory program tests.   These tests really shouldn't be using KeyedAccount in the first place and neither should any 3rd party downstream user.  

The best thing to do about this seems to be to add a `AccountSharedData` shim into 1.5.15 and then adapt the shared memory program tests to use it (like [this](https://github.com/solana-labs/solana-program-library/pull/1456/commits/267a46f10ca9b1ff741127f1eb3314af16d8e299)).  This'll unblock landing https://github.com/solana-labs/solana/pull/15886, which will catch `sdk/` issues like this next time so we can figure what to do before breaking downstream.  