### PR TITLE
docs: Encourage use of the default --ledger location

### DIFF
--- a/docs/src/clusters.md
+++ b/docs/src/clusters.md
@@ -40,11 +40,11 @@ solana config set --url https://devnet.solana.com
 
 ```bash
 $ solana-validator \
-    --identity ~/validator-keypair.json \
-    --vote-account ~/vote-account-keypair.json \
+    --identity validator-keypair.json \
+    --vote-account vote-account-keypair.json \
     --trusted-validator dv1LfzJvDF7S1fBKpFgKoKXK5yoSosmkAdfbxBo1GqJ \
     --no-untrusted-rpc \
-    --ledger ~/validator-ledger \
+    --ledger ledger \
     --rpc-port 8899 \
     --dynamic-port-range 8000-8010 \
     --entrypoint entrypoint.devnet.solana.com:8001 \
@@ -85,14 +85,14 @@ solana config set --url https://testnet.solana.com
 
 ```bash
 $ solana-validator \
-    --identity ~/validator-keypair.json \
-    --vote-account ~/vote-account-keypair.json \
+    --identity validator-keypair.json \
+    --vote-account vote-account-keypair.json \
     --trusted-validator 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on \
     --trusted-validator 7XSY3MrYnK8vq693Rju17bbPkCN3Z7KvvfvJx4kdrsSY \
     --trusted-validator Ft5fbkqNa76vnsjYNwjDZUXoTWpP7VYm3mtsaQckQADN \
     --trusted-validator 9QxCLckBiJc783jnMvXZubK4wH86Eqqvashtrwvcsgkv \
     --no-untrusted-rpc \
-    --ledger ~/validator-ledger \
+    --ledger ledger \
     --rpc-port 8899 \
     --dynamic-port-range 8000-8010 \
     --entrypoint entrypoint.testnet.solana.com:8001 \
@@ -143,7 +143,7 @@ $ solana-validator \
     --trusted-validator DE1bawNcRJB9rVm3buyMVfr8mBEoyyu73NBovf2oXJsJ \
     --trusted-validator CakcnaRDHka2gXyfbEd2d3xsvkJkqsLw2akB3zsN1D2S \
     --no-untrusted-rpc \
-    --ledger ~/validator-ledger \
+    --ledger ledger \
     --rpc-port 8899 \
     --private-rpc \
     --dynamic-port-range 8000-8010 \

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -254,7 +254,6 @@ Connect to the cluster by running:
 solana-validator \
   --identity ~/validator-keypair.json \
   --vote-account ~/vote-account-keypair.json \
-  --ledger ~/validator-ledger \
   --rpc-port 8899 \
   --entrypoint devnet.solana.com:8001 \
   --limit-ledger-size \
@@ -263,6 +262,9 @@ solana-validator \
 
 To force validator logging to the console add a `--log -` argument, otherwise
 the validator will automatically log to a file.
+
+The ledger will be placed in the `ledger/` directory by default, use the
+`--ledger` argument to specify a different location.
 
 > Note: You can use a
 > [paper wallet seed phrase](../wallet-guide/paper-wallet.md)


### PR DESCRIPTION
The docs recommend `--ledger ~/validator-ledger` but the default in the software is `--ledger ledger`.  Recommend the default.