### PR TITLE
Bump tokio to 1.1 in ledger crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,12 +475,6 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
-
-[[package]]
-name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
@@ -4730,7 +4724,8 @@ dependencies = [
  "solana-vote-program",
  "tempfile",
  "thiserror",
- "tokio 0.3.5",
+ "tokio 1.1.1",
+ "tokio-stream",
  "trees",
 ]
 
@@ -6091,28 +6086,6 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12a3eb39ee2c231be64487f1fcbe726c8f2514876a55480a5ab8559fc374252"
-dependencies = [
- "autocfg 1.0.0",
- "bytes 0.6.0",
- "futures-core",
- "lazy_static",
- "libc",
- "memchr 2.3.3",
- "mio 0.7.6",
- "num_cpus",
- "parking_lot 0.11.0",
- "pin-project-lite 0.2.4",
- "signal-hook-registry",
- "slab",
- "tokio-macros 0.3.1",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "tokio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
@@ -6189,17 +6162,6 @@ name = "tokio-macros"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.6",
- "syn 1.0.60",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.6",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -52,7 +52,8 @@ solana-storage-proto = { path = "../storage-proto", version = "=1.7.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.7.0" }
 tempfile = "3.1.0"
 thiserror = "1.0"
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
+tokio-stream = "0.1"
 trees = "0.2.1"
 
 [dependencies.rocksdb]

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -168,7 +168,7 @@ pub async fn upload_confirmed_blocks(
     use futures::stream::StreamExt;
 
     let mut stream =
-        tokio::stream::iter(receiver.into_iter()).chunks(NUM_BLOCKS_TO_UPLOAD_IN_PARALLEL);
+        tokio_stream::iter(receiver.into_iter()).chunks(NUM_BLOCKS_TO_UPLOAD_IN_PARALLEL);
 
     while let Some(blocks) = stream.next().await {
         if exit.load(Ordering::Relaxed) {


### PR DESCRIPTION
#### Problem
Old tokio version in ledger crate causes a node panic if `bigtable.get_confirmed_blocks()` ever fails (eg dropped connection, etc), since it is called in newer tokio via core/src/bigtable_upload_service

#### Summary of Changes
Bump ledger tokio version to match the rest of the project

Fixes #15924
