### PR TITLE
eliminate lock on record

### DIFF
--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -66,6 +66,8 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
         let (exit, poh_recorder, poh_service, _signal_receiver) =
             create_test_recorder(&bank, &blockstore, None);
 
+        let recorder = poh_recorder.lock().unwrap().recorder();
+
         let tx = test_tx();
         let len = 4096;
         let chunk_size = 1024;
@@ -88,6 +90,7 @@ fn bench_consume_buffered(bencher: &mut Bencher) {
                 &s,
                 None::<Box<dyn Fn()>>,
                 None,
+                &recorder,
             );
         });
 

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -2444,6 +2444,7 @@ mod tests {
         Blockstore::destroy(&ledger_path).unwrap();
     }
 
+    #[allow(clippy::type_complexity)]
     fn setup_conflicting_transactions(
         ledger_path: &Path,
     ) -> (

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -4,7 +4,7 @@
 use crate::{
     cluster_info::ClusterInfo,
     packet_hasher::PacketHasher,
-    poh_recorder::{PohRecorder, PohRecorderError, WorkingBankEntry},
+    poh_recorder::{PohRecorder, PohRecorderError, Recorder, WorkingBankEntry},
     poh_service::{self, PohService},
 };
 use crossbeam_channel::{Receiver as CrossbeamReceiver, RecvTimeoutError};
@@ -295,6 +295,7 @@ impl BankingStage {
         gossip_vote_sender: &ReplayVoteSender,
         test_fn: Option<impl Fn()>,
         banking_stage_stats: Option<&BankingStageStats>,
+        recorder: &Recorder,
     ) {
         let mut rebuffered_packets_len = 0;
         let mut new_tx_count = 0;
@@ -323,7 +324,7 @@ impl BankingStage {
                         Self::process_packets_transactions(
                             &bank,
                             &bank_creation_time,
-                            &poh_recorder,
+                            &recorder,
                             &msgs,
                             original_unprocessed_indexes.to_owned(),
                             transaction_status_sender.clone(),
@@ -428,6 +429,7 @@ impl BankingStage {
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: &ReplayVoteSender,
         banking_stage_stats: &BankingStageStats,
+        recorder: &Recorder,
     ) -> BufferedPacketsDecision {
         let bank_start;
         let (
@@ -467,6 +469,7 @@ impl BankingStage {
                     gossip_vote_sender,
                     None::<Box<dyn Fn()>>,
                     Some(banking_stage_stats),
+                    recorder,
                 );
             }
             BufferedPacketsDecision::Forward => {
@@ -544,6 +547,7 @@ impl BankingStage {
         gossip_vote_sender: ReplayVoteSender,
         duplicates: &Arc<Mutex<(LruCache<u64, ()>, PacketHasher)>>,
     ) {
+        let recorder = poh_recorder.lock().unwrap().recorder();
         let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let mut buffered_packets = VecDeque::with_capacity(batch_limit);
         let banking_stage_stats = BankingStageStats::new(id);
@@ -552,13 +556,14 @@ impl BankingStage {
                 let decision = Self::process_buffered_packets(
                     &my_pubkey,
                     &socket,
-                    poh_recorder,
+                    &poh_recorder,
                     cluster_info,
                     &mut buffered_packets,
                     enable_forwarding,
                     transaction_status_sender.clone(),
                     &gossip_vote_sender,
                     &banking_stage_stats,
+                    &recorder,
                 );
                 if matches!(decision, BufferedPacketsDecision::Hold)
                     || matches!(decision, BufferedPacketsDecision::ForwardAndHold)
@@ -592,6 +597,7 @@ impl BankingStage {
                 &mut buffered_packets,
                 &banking_stage_stats,
                 duplicates,
+                &recorder,
             ) {
                 Ok(()) | Err(RecvTimeoutError::Timeout) => (),
                 Err(RecvTimeoutError::Disconnected) => break,
@@ -625,7 +631,7 @@ impl BankingStage {
         bank_slot: Slot,
         txs: &[Transaction],
         results: &[TransactionExecutionResult],
-        poh: &Arc<Mutex<PohRecorder>>,
+        recorder: &Recorder,
     ) -> (Result<usize, PohRecorderError>, Vec<usize>) {
         let mut processed_generation = Measure::start("record::process_generation");
         let (processed_transactions, processed_transactions_indexes): (Vec<_>, Vec<_>) = results
@@ -655,10 +661,7 @@ impl BankingStage {
 
             let mut poh_record = Measure::start("record::poh_record");
             // record and unlock will unlock all the successful transactions
-            let res = poh
-                .lock()
-                .unwrap()
-                .record(bank_slot, hash, processed_transactions);
+            let res = recorder.record(bank_slot, hash, processed_transactions);
             match res {
                 Ok(()) => (),
                 Err(PohRecorderError::MaxHeightReached) => {
@@ -683,7 +686,7 @@ impl BankingStage {
 
     fn process_and_record_transactions_locked(
         bank: &Arc<Bank>,
-        poh: &Arc<Mutex<PohRecorder>>,
+        poh: &Recorder,
         batch: &TransactionBatch,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: &ReplayVoteSender,
@@ -802,7 +805,7 @@ impl BankingStage {
     pub fn process_and_record_transactions(
         bank: &Arc<Bank>,
         txs: &[Transaction],
-        poh: &Arc<Mutex<PohRecorder>>,
+        poh: &Recorder,
         chunk_offset: usize,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: &ReplayVoteSender,
@@ -846,7 +849,7 @@ impl BankingStage {
         bank: &Arc<Bank>,
         bank_creation_time: &Instant,
         transactions: &[Transaction],
-        poh: &Arc<Mutex<PohRecorder>>,
+        poh: &Recorder,
         transaction_status_sender: Option<TransactionStatusSender>,
         gossip_vote_sender: &ReplayVoteSender,
     ) -> (usize, Vec<usize>) {
@@ -1017,7 +1020,7 @@ impl BankingStage {
     fn process_packets_transactions(
         bank: &Arc<Bank>,
         bank_creation_time: &Instant,
-        poh: &Arc<Mutex<PohRecorder>>,
+        poh: &Recorder,
         msgs: &Packets,
         packet_indexes: Vec<usize>,
         transaction_status_sender: Option<TransactionStatusSender>,
@@ -1131,6 +1134,7 @@ impl BankingStage {
         buffered_packets: &mut UnprocessedPackets,
         banking_stage_stats: &BankingStageStats,
         duplicates: &Arc<Mutex<(LruCache<u64, ()>, PacketHasher)>>,
+        recorder: &Recorder,
     ) -> Result<(), RecvTimeoutError> {
         let mut recv_time = Measure::start("process_packets_recv");
         let mms = verified_receiver.recv_timeout(recv_timeout)?;
@@ -1173,7 +1177,7 @@ impl BankingStage {
                 Self::process_packets_transactions(
                     &bank,
                     &bank_creation_time,
-                    &poh,
+                    recorder,
                     &msgs,
                     packet_indexes,
                     transaction_status_sender.clone(),
@@ -1309,7 +1313,7 @@ pub fn create_test_recorder(
 ) {
     let exit = Arc::new(AtomicBool::new(false));
     let poh_config = Arc::new(poh_config.unwrap_or_default());
-    let (mut poh_recorder, entry_receiver) = PohRecorder::new(
+    let (mut poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
         bank.tick_height(),
         bank.last_blockhash(),
         bank.slot(),
@@ -1330,6 +1334,7 @@ pub fn create_test_recorder(
         bank.ticks_per_slot(),
         poh_service::DEFAULT_PINNED_CPU_CORE,
         poh_service::DEFAULT_HASHES_PER_BATCH,
+        record_receiver,
     );
 
     (exit, poh_recorder, poh_service, entry_receiver)
@@ -1684,6 +1689,8 @@ mod tests {
 
     #[test]
     fn test_bank_record_transactions() {
+        solana_logger::setup();
+
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
@@ -1701,7 +1708,8 @@ mod tests {
         {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
-            let (poh_recorder, entry_receiver) = PohRecorder::new(
+            let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
+                // TODO use record_receiver
                 bank.tick_height(),
                 bank.last_blockhash(),
                 bank.slot(),
@@ -1712,7 +1720,10 @@ mod tests {
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
             );
+            let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
+
+            let (poh_simulator, stop) = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
             let pubkey = solana_sdk::pubkey::new_rand();
@@ -1725,12 +1736,8 @@ mod tests {
             ];
 
             let mut results = vec![(Ok(()), None), (Ok(()), None)];
-            let _ = BankingStage::record_transactions(
-                bank.slot(),
-                &transactions,
-                &results,
-                &poh_recorder,
-            );
+            let _ =
+                BankingStage::record_transactions(bank.slot(), &transactions, &results, &recorder);
             let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
             assert_eq!(entry.transactions.len(), transactions.len());
 
@@ -1742,12 +1749,8 @@ mod tests {
                 )),
                 None,
             );
-            let (res, retryable) = BankingStage::record_transactions(
-                bank.slot(),
-                &transactions,
-                &results,
-                &poh_recorder,
-            );
+            let (res, retryable) =
+                BankingStage::record_transactions(bank.slot(), &transactions, &results, &recorder);
             res.unwrap();
             assert!(retryable.is_empty());
             let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
@@ -1755,12 +1758,8 @@ mod tests {
 
             // Other TransactionErrors should not be recorded
             results[0] = (Err(TransactionError::AccountNotFound), None);
-            let (res, retryable) = BankingStage::record_transactions(
-                bank.slot(),
-                &transactions,
-                &results,
-                &poh_recorder,
-            );
+            let (res, retryable) =
+                BankingStage::record_transactions(bank.slot(), &transactions, &results, &recorder);
             res.unwrap();
             assert!(retryable.is_empty());
             let (_bank, (entry, _tick_height)) = entry_receiver.recv().unwrap();
@@ -1773,7 +1772,7 @@ mod tests {
                 bank.slot() + 1,
                 &transactions,
                 &results,
-                &poh_recorder,
+                &recorder,
             );
             assert_matches!(res, Err(PohRecorderError::MaxHeightReached));
             // The first result was an error so it's filtered out. The second result was Ok(),
@@ -1781,6 +1780,9 @@ mod tests {
             assert_eq!(retryable, vec![1]);
             // Should receive nothing from PohRecorder b/c record failed
             assert!(entry_receiver.try_recv().is_err());
+
+            stop.store(true, Ordering::Relaxed);
+            let _ = poh_simulator.join();
         }
         Blockstore::destroy(&ledger_path).unwrap();
     }
@@ -2052,7 +2054,7 @@ mod tests {
         {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
-            let (poh_recorder, entry_receiver) = PohRecorder::new(
+            let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 bank.last_blockhash(),
                 bank.slot(),
@@ -2063,7 +2065,10 @@ mod tests {
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
             );
+            let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
+
+            let (poh_simulator, stop) = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
             let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
@@ -2071,7 +2076,7 @@ mod tests {
             BankingStage::process_and_record_transactions(
                 &bank,
                 &transactions,
-                &poh_recorder,
+                &recorder,
                 0,
                 None,
                 &gossip_vote_sender,
@@ -2108,7 +2113,7 @@ mod tests {
                 BankingStage::process_and_record_transactions(
                     &bank,
                     &transactions,
-                    &poh_recorder,
+                    &recorder,
                     0,
                     None,
                     &gossip_vote_sender,
@@ -2117,9 +2122,38 @@ mod tests {
                 Err(PohRecorderError::MaxHeightReached)
             );
 
+            stop.store(true, Ordering::Relaxed);
+            let _ = poh_simulator.join();
+
             assert_eq!(bank.get_balance(&pubkey), 1);
         }
         Blockstore::destroy(&ledger_path).unwrap();
+    }
+
+    use crate::poh_recorder::Record;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::mpsc::Receiver;
+
+    fn simulate_poh(
+        record_receiver: Receiver<Record>,
+        poh_recorder: &Arc<Mutex<PohRecorder>>,
+    ) -> (JoinHandle<()>, Arc<AtomicBool>) {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_ = stop.clone();
+        let poh_recorder = poh_recorder.clone();
+        let tick_producer = Builder::new()
+            .name("solana-simulate_poh".to_string())
+            .spawn(move || loop {
+                PohService::read_record_receiver_and_process(
+                    &poh_recorder,
+                    &record_receiver,
+                    Duration::from_millis(10),
+                );
+                if stop_.load(Ordering::Relaxed) {
+                    break;
+                }
+            });
+        (tick_producer.unwrap(), stop)
     }
 
     #[test]
@@ -2150,7 +2184,7 @@ mod tests {
         {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
-            let (poh_recorder, _entry_receiver) = PohRecorder::new(
+            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 bank.last_blockhash(),
                 bank.slot(),
@@ -2161,20 +2195,26 @@ mod tests {
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
             );
+            let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
+
+            let (poh_simulator, stop) = simulate_poh(record_receiver, &poh_recorder);
 
             let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
 
             let (result, unprocessed) = BankingStage::process_and_record_transactions(
                 &bank,
                 &transactions,
-                &poh_recorder,
+                &recorder,
                 0,
                 None,
                 &gossip_vote_sender,
             );
+
+            stop.store(true, Ordering::Relaxed);
+            let _ = poh_simulator.join();
 
             assert!(result.is_ok());
             assert_eq!(unprocessed.len(), 1);
@@ -2245,7 +2285,7 @@ mod tests {
         {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
-            let (poh_recorder, _entry_receiver) = PohRecorder::new(
+            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 bank.last_blockhash(),
                 bank.slot(),
@@ -2257,9 +2297,12 @@ mod tests {
                 &Arc::new(PohConfig::default()),
             );
 
-            // Poh Recorder has not working bank, so should throw MaxHeightReached error on
+            // Poh Recorder has no working bank, so should throw MaxHeightReached error on
             // record
-            let poh_recorder = Arc::new(Mutex::new(poh_recorder));
+            let recorder = poh_recorder.recorder();
+
+            let (poh_simulator, stop) =
+                simulate_poh(record_receiver, &Arc::new(Mutex::new(poh_recorder)));
 
             let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
 
@@ -2268,7 +2311,7 @@ mod tests {
                     &bank,
                     &Instant::now(),
                     &transactions,
-                    &poh_recorder,
+                    &recorder,
                     None,
                     &gossip_vote_sender,
                 );
@@ -2278,6 +2321,9 @@ mod tests {
             retryable_txs.sort_unstable();
             let expected: Vec<usize> = (0..transactions.len()).collect();
             assert_eq!(retryable_txs, expected);
+
+            stop.store(true, Ordering::Relaxed);
+            let _ = poh_simulator.join();
         }
 
         Blockstore::destroy(&ledger_path).unwrap();
@@ -2324,7 +2370,7 @@ mod tests {
             let blockstore = Blockstore::open(&ledger_path)
                 .expect("Expected to be able to open database ledger");
             let blockstore = Arc::new(blockstore);
-            let (poh_recorder, _entry_receiver) = PohRecorder::new(
+            let (poh_recorder, _entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 bank.last_blockhash(),
                 bank.slot(),
@@ -2335,7 +2381,10 @@ mod tests {
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
             );
+            let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
+
+            let (poh_simulator, stop) = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
 
@@ -2355,7 +2404,7 @@ mod tests {
             let _ = BankingStage::process_and_record_transactions(
                 &bank,
                 &transactions,
-                &poh_recorder,
+                &recorder,
                 0,
                 Some(TransactionStatusSender {
                     sender: transaction_status_sender,
@@ -2388,6 +2437,9 @@ mod tests {
                     assert_eq!(meta, None);
                 }
             }
+
+            stop.store(true, Ordering::Relaxed);
+            let _ = poh_simulator.join();
         }
         Blockstore::destroy(&ledger_path).unwrap();
     }
@@ -2410,7 +2462,7 @@ mod tests {
         let blockstore =
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger");
         let bank = Arc::new(Bank::new(&genesis_config));
-        let (poh_recorder, entry_receiver) = PohRecorder::new(
+        let (poh_recorder, entry_receiver, _record_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
             bank.slot(),
@@ -2441,6 +2493,7 @@ mod tests {
         {
             let (transactions, bank, poh_recorder, _entry_receiver) =
                 setup_conflicting_transactions(&ledger_path);
+            let recorder = poh_recorder.lock().unwrap().recorder();
             let num_conflicting_transactions = transactions.len();
             let mut packets_vec = to_packets_chunked(&transactions, num_conflicting_transactions);
             assert_eq!(packets_vec.len(), 1);
@@ -2468,6 +2521,7 @@ mod tests {
                 &gossip_vote_sender,
                 None::<Box<dyn Fn()>>,
                 None,
+                &recorder,
             );
             assert_eq!(buffered_packets[0].1.len(), num_conflicting_transactions);
             // When the poh recorder has a bank, should process all non conflicting buffered packets.
@@ -2483,6 +2537,7 @@ mod tests {
                     &gossip_vote_sender,
                     None::<Box<dyn Fn()>>,
                     None,
+                    &recorder,
                 );
                 if num_expected_unprocessed == 0 {
                     assert!(buffered_packets.is_empty())
@@ -2526,6 +2581,7 @@ mod tests {
             let interrupted_iteration = 1;
             poh_recorder.lock().unwrap().set_bank(&bank);
             let poh_recorder_ = poh_recorder.clone();
+            let recorder = poh_recorder_.lock().unwrap().recorder();
             let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
             // Start up thread to process the banks
             let t_consume = Builder::new()
@@ -2540,6 +2596,7 @@ mod tests {
                         &gossip_vote_sender,
                         test_fn,
                         None,
+                        &recorder,
                     );
 
                     // Check everything is correct. All indexes after `interrupted_iteration`

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -111,15 +111,13 @@ impl Recorder {
             self.result_sender.clone(),
         ));
         if res.is_err() {
-            return Err(PohRecorderError::MaxHeightReached); // TODO what error here
+            return Err(PohRecorderError::MaxHeightReached); // re-use an error that gives appropriate behavior
         }
         let res = self
             .result_receiver
-            .recv_timeout(std::time::Duration::from_millis(2000)); //TODO: consider timeout? _timeout(Duration::from_millis(4000));
+            .recv_timeout(std::time::Duration::from_millis(2000));
         match res {
-            Err(_err) => {
-                Err(PohRecorderError::MaxHeightReached) // TODO - what error here
-            }
+            Err(_err) => Err(PohRecorderError::MaxHeightReached),
             Ok(result) => result,
         }
     }

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -111,14 +111,14 @@ impl Recorder {
             self.result_sender.clone(),
         ));
         if res.is_err() {
-            return Err(PohRecorderError::InvalidCallingObject); // TODO what error here
+            return Err(PohRecorderError::MaxHeightReached); // TODO what error here
         }
         let res = self
             .result_receiver
             .recv_timeout(std::time::Duration::from_millis(2000)); //TODO: consider timeout? _timeout(Duration::from_millis(4000));
         match res {
             Err(_err) => {
-                Err(PohRecorderError::InvalidCallingObject) // TODO - what error here
+                Err(PohRecorderError::MaxHeightReached) // TODO - what error here
             }
             Ok(result) => result,
         }

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -178,11 +178,13 @@ impl PohService {
                     lock_time.stop();
                     total_lock_time_ns += lock_time.as_ns();
                     loop {
-                        let mut temp = Vec::new();
-                        std::mem::swap(&mut temp, &mut record.transactions);
-                        let res = poh_recorder_l.record(record.slot, record.mixin, temp);
-                        let _ = record.sender.send(res); // TODO what do we do on failure here?
-                        num_hashes += 1; // may have also ticked inside record
+                        let res = poh_recorder_l.record(
+                            record.slot,
+                            record.mixin,
+                            std::mem::take(&mut record.transactions),
+                        );
+                        let _ = record.sender.send(res); // what do we do on failure here? Ignore for now.
+                        num_hashes += 1; // note: may have also ticked inside record
 
                         let get_again = record_receiver.try_recv();
                         match get_again {

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -1,6 +1,7 @@
 //! The `poh_service` module implements a service that records the passing of
 //! "ticks", a measure of time in the PoH stream
 use crate::poh_recorder::{PohRecorder, Record};
+use solana_ledger::poh::Poh;
 use solana_measure::measure::Measure;
 use solana_sdk::poh_config::PohConfig;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -23,6 +24,54 @@ pub const DEFAULT_HASHES_PER_BATCH: u64 = 64;
 pub const DEFAULT_PINNED_CPU_CORE: usize = 0;
 
 const TARGET_SLOT_ADJUSTMENT_NS: u64 = 50_000_000;
+
+#[derive(Debug)]
+struct PohTiming {
+    num_ticks: u64,
+    num_hashes: u64,
+    total_sleep_us: u64,
+    total_lock_time_ns: u64,
+    total_hash_time_ns: u64,
+    total_tick_time_ns: u64,
+    last_metric: Instant,
+}
+
+impl PohTiming {
+    fn new() -> Self {
+        Self {
+            num_ticks: 0,
+            num_hashes: 0,
+            total_sleep_us: 0,
+            total_lock_time_ns: 0,
+            total_hash_time_ns: 0,
+            total_tick_time_ns: 0,
+            last_metric: Instant::now(),
+        }
+    }
+    fn report(&mut self, ticks_per_slot: u64) {
+        if self.last_metric.elapsed().as_millis() > 1000 {
+            let elapsed_us = self.last_metric.elapsed().as_micros() as u64;
+            let us_per_slot = (elapsed_us * ticks_per_slot) / self.num_ticks;
+            datapoint_info!(
+                "poh-service",
+                ("ticks", self.num_ticks as i64, i64),
+                ("hashes", self.num_hashes as i64, i64),
+                ("elapsed_us", us_per_slot, i64),
+                ("total_sleep_us", self.total_sleep_us, i64),
+                ("total_tick_time_us", self.total_tick_time_ns / 1000, i64),
+                ("total_lock_time_us", self.total_lock_time_ns / 1000, i64),
+                ("total_hash_time_us", self.total_hash_time_ns / 1000, i64),
+            );
+            self.total_sleep_us = 0;
+            self.num_ticks = 0;
+            self.num_hashes = 0;
+            self.total_tick_time_ns = 0;
+            self.total_lock_time_ns = 0;
+            self.total_hash_time_ns = 0;
+            self.last_metric = Instant::now();
+        }
+    }
+}
 
 impl PohService {
     pub fn new(
@@ -146,6 +195,80 @@ impl PohService {
         }
     }
 
+    fn record_or_hash(
+        next_record: &mut Option<Record>,
+        poh_recorder: &Arc<Mutex<PohRecorder>>,
+        timing: &mut PohTiming,
+        record_receiver: &Receiver<Record>,
+        hashes_per_batch: u64,
+        poh: &Arc<Mutex<Poh>>,
+    ) -> bool {
+        let mut next = None;
+        std::mem::swap(&mut next, next_record);
+        match next {
+            Some(mut record) => {
+                // received message to record
+                // so, record for as long as we have queued up record requests
+                let mut lock_time = Measure::start("lock");
+                let mut poh_recorder_l = poh_recorder.lock().unwrap();
+                lock_time.stop();
+                timing.total_lock_time_ns += lock_time.as_ns();
+                loop {
+                    let res = poh_recorder_l.record(
+                        record.slot,
+                        record.mixin,
+                        std::mem::take(&mut record.transactions),
+                    );
+                    let _ = record.sender.send(res); // what do we do on failure here? Ignore for now.
+                    timing.num_hashes += 1; // note: may have also ticked inside record
+
+                    let get_again = record_receiver.try_recv();
+                    match get_again {
+                        Ok(mut record2) => {
+                            // we already have second request to record, so record again while we still have the mutex
+                            std::mem::swap(&mut record2, &mut record);
+                        }
+                        Err(_) => {
+                            break;
+                        }
+                    }
+                }
+                // PohRecorder.record would have ticked if it needed to, so should_tick will be false
+            }
+            None => {
+                // did not receive instructions to record, so hash until we notice we've been asked to record (or we need to tick) and then remember what to record
+                let mut lock_time = Measure::start("lock");
+                let mut poh_l = poh.lock().unwrap();
+                lock_time.stop();
+                timing.total_lock_time_ns += lock_time.as_ns();
+                let mut should_tick;
+                loop {
+                    timing.num_hashes += hashes_per_batch;
+                    let mut hash_time = Measure::start("hash");
+                    should_tick = poh_l.hash(hashes_per_batch);
+                    hash_time.stop();
+                    timing.total_hash_time_ns += hash_time.as_ns();
+                    if should_tick {
+                        return true; // nothing else can be done. tick required.
+                    }
+                    // check to see if a record request has been sent
+                    let get_again = record_receiver.try_recv();
+                    match get_again {
+                        Ok(record) => {
+                            // remember the record we just received as the next record to occur
+                            *next_record = Some(record);
+                            break;
+                        }
+                        Err(_) => {
+                            continue;
+                        }
+                    }
+                }
+            }
+        };
+        false // should_tick = false for all code that reaches here
+    }
+
     fn tick_producer(
         poh_recorder: Arc<Mutex<PohRecorder>>,
         poh_exit: &AtomicBool,
@@ -156,119 +279,40 @@ impl PohService {
     ) {
         let poh = poh_recorder.lock().unwrap().poh.clone();
         let mut now = Instant::now();
-        let mut last_metric = Instant::now();
-        let mut num_ticks = 0;
-        let mut num_hashes = 0;
-        let mut total_sleep_us = 0;
-        let mut total_lock_time_ns = 0;
-        let mut total_hash_time_ns = 0;
-        let mut total_tick_time_ns = 0;
-        let mut try_again_mixin = None;
+        let mut timing = PohTiming::new();
+        let mut next_record = None;
         loop {
-            let should_tick = {
-                let mixin = if let Some(record) = try_again_mixin {
-                    try_again_mixin = None;
-                    Ok(record)
-                } else {
-                    record_receiver.try_recv()
-                };
-                if let Ok(mut record) = mixin {
-                    let mut lock_time = Measure::start("lock");
-                    let mut poh_recorder_l = poh_recorder.lock().unwrap();
-                    lock_time.stop();
-                    total_lock_time_ns += lock_time.as_ns();
-                    loop {
-                        let res = poh_recorder_l.record(
-                            record.slot,
-                            record.mixin,
-                            std::mem::take(&mut record.transactions),
-                        );
-                        let _ = record.sender.send(res); // what do we do on failure here? Ignore for now.
-                        num_hashes += 1; // note: may have also ticked inside record
-
-                        let get_again = record_receiver.try_recv();
-                        match get_again {
-                            Ok(mut record2) => {
-                                std::mem::swap(&mut record2, &mut record);
-                            }
-                            Err(_) => {
-                                break;
-                            }
-                        }
-                    }
-                    false // record will tick if it needs to
-                } else {
-                    let mut lock_time = Measure::start("lock");
-                    let mut poh_l = poh.lock().unwrap();
-                    lock_time.stop();
-                    total_lock_time_ns += lock_time.as_ns();
-                    let mut r;
-                    loop {
-                        num_hashes += hashes_per_batch;
-                        let mut hash_time = Measure::start("hash");
-                        r = poh_l.hash(hashes_per_batch);
-                        hash_time.stop();
-                        total_hash_time_ns += hash_time.as_ns();
-                        if r {
-                            break;
-                        }
-                        let get_again = record_receiver.try_recv();
-                        match get_again {
-                            Ok(inside) => {
-                                try_again_mixin = Some(inside);
-                                break;
-                            }
-                            Err(_) => {
-                                continue;
-                            }
-                        }
-                    }
-                    r
-                }
-            };
+            let should_tick = Self::record_or_hash(
+                &mut next_record,
+                &poh_recorder,
+                &mut timing,
+                &record_receiver,
+                hashes_per_batch,
+                &poh,
+            );
             if should_tick {
                 // Lock PohRecorder only for the final hash...
                 {
                     let mut lock_time = Measure::start("lock");
                     let mut poh_recorder_l = poh_recorder.lock().unwrap();
                     lock_time.stop();
-                    total_lock_time_ns += lock_time.as_ns();
+                    timing.total_lock_time_ns += lock_time.as_ns();
                     let mut tick_time = Measure::start("tick");
                     poh_recorder_l.tick();
                     tick_time.stop();
-                    total_tick_time_ns += tick_time.as_ns();
+                    timing.total_tick_time_ns += tick_time.as_ns();
                 }
-                num_ticks += 1;
+                timing.num_ticks += 1;
                 let elapsed_ns = now.elapsed().as_nanos() as u64;
                 // sleep is not accurate enough to get a predictable time.
                 // Kernel can not schedule the thread for a while.
                 while (now.elapsed().as_nanos() as u64) < target_tick_ns {
                     std::hint::spin_loop();
                 }
-                total_sleep_us += (now.elapsed().as_nanos() as u64 - elapsed_ns) / 1000;
+                timing.total_sleep_us += (now.elapsed().as_nanos() as u64 - elapsed_ns) / 1000;
                 now = Instant::now();
 
-                if last_metric.elapsed().as_millis() > 1000 {
-                    let elapsed_us = last_metric.elapsed().as_micros() as u64;
-                    let us_per_slot = (elapsed_us * ticks_per_slot) / num_ticks;
-                    datapoint_info!(
-                        "poh-service",
-                        ("ticks", num_ticks as i64, i64),
-                        ("hashes", num_hashes as i64, i64),
-                        ("elapsed_us", us_per_slot, i64),
-                        ("total_sleep_us", total_sleep_us, i64),
-                        ("total_tick_time_us", total_tick_time_ns / 1000, i64),
-                        ("total_lock_time_us", total_lock_time_ns / 1000, i64),
-                        ("total_hash_time_us", total_hash_time_ns / 1000, i64),
-                    );
-                    total_sleep_us = 0;
-                    num_ticks = 0;
-                    num_hashes = 0;
-                    total_tick_time_ns = 0;
-                    total_lock_time_ns = 0;
-                    total_hash_time_ns = 0;
-                    last_metric = Instant::now();
-                }
+                timing.report(ticks_per_slot);
                 if poh_exit.load(Ordering::Relaxed) {
                     break;
                 }

--- a/core/src/send_transaction_service.rs
+++ b/core/src/send_transaction_service.rs
@@ -801,7 +801,7 @@ mod test {
             );
             let bank = Arc::new(Bank::new(&genesis_config));
 
-            let (poh_recorder, _entry_receiver) = PohRecorder::new(
+            let (poh_recorder, _entry_receiver, _record_receiver) = PohRecorder::new(
                 0,
                 bank.last_blockhash(),
                 0,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -486,24 +486,25 @@ impl Validator {
         );
 
         let poh_config = Arc::new(genesis_config.poh_config.clone());
-        let (mut poh_recorder, entry_receiver) = PohRecorder::new_with_clear_signal(
-            bank.tick_height(),
-            bank.last_blockhash(),
-            bank.slot(),
-            leader_schedule_cache.next_leader_slot(
-                &id,
+        let (mut poh_recorder, entry_receiver, record_receiver) =
+            PohRecorder::new_with_clear_signal(
+                bank.tick_height(),
+                bank.last_blockhash(),
                 bank.slot(),
-                &bank,
-                Some(&blockstore),
-                GRACE_TICKS_FACTOR * MAX_GRACE_SLOTS,
-            ),
-            bank.ticks_per_slot(),
-            &id,
-            &blockstore,
-            blockstore.new_shreds_signals.first().cloned(),
-            &leader_schedule_cache,
-            &poh_config,
-        );
+                leader_schedule_cache.next_leader_slot(
+                    &id,
+                    bank.slot(),
+                    &bank,
+                    Some(&blockstore),
+                    GRACE_TICKS_FACTOR * MAX_GRACE_SLOTS,
+                ),
+                bank.ticks_per_slot(),
+                &id,
+                &blockstore,
+                blockstore.new_shreds_signals.first().cloned(),
+                &leader_schedule_cache,
+                &poh_config,
+            );
         if config.snapshot_config.is_some() {
             poh_recorder.set_bank(&bank);
         }
@@ -644,6 +645,7 @@ impl Validator {
             bank.ticks_per_slot(),
             config.poh_pinned_cpu_core,
             config.poh_hashes_per_batch,
+            record_receiver,
         );
         assert_eq!(
             blockstore.new_shreds_signals.len(),


### PR DESCRIPTION
#### Problem
PohRecorder.Record requires a PohRecorder mutex lock. This results in contention with poh. Poh locking delays cause drift.

#### Summary of Changes
Create a new PohRecorder 'Recorder' which can use non-blocking channels to record transactions in poh.

Fixes #
