### PR TITLE
drop poh lock after record

### DIFF
--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -424,6 +424,7 @@ impl PohRecorder {
                 self.record_lock_contention_us += timing::duration_as_us(&now.elapsed());
                 let now = Instant::now();
                 let res = poh_lock.record(mixin);
+                drop(poh_lock);
                 self.record_us += timing::duration_as_us(&now.elapsed());
                 if let Some(poh_entry) = res {
                     let entry = Entry {


### PR DESCRIPTION
#### Problem
Keeping poh lock longer than we need to after a record. @sakridge found this.

#### Summary of Changes
drop it
Fixes #
