### PR TITLE
Download snapshot files with a `tmp-` prefix so they'll automatically be cleaned up if interrupted

### DIFF
--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -34,9 +34,18 @@ pub fn download_file(
     }
     let download_start = Instant::now();
 
-    fs::create_dir_all(destination_file.parent().unwrap()).map_err(|err| err.to_string())?;
+    fs::create_dir_all(destination_file.parent().expect("parent"))
+        .map_err(|err| err.to_string())?;
 
-    let temp_destination_file = destination_file.with_extension("tmp");
+    let mut temp_destination_file = destination_file.to_path_buf();
+    temp_destination_file.set_file_name(format!(
+        "tmp-{}",
+        destination_file
+            .file_name()
+            .expect("file_name")
+            .to_str()
+            .expect("to_str")
+    ));
 
     let progress_bar = new_spinner_progress_bar();
     if use_progress_bar {


### PR DESCRIPTION
#### Problem
```
$ ls -l ledger/*.tmp
-rw-rw-r-- 1 mvines mvines  70613932 Jan 23 04:51 ledger/snapshot-61946977-GiuNmagY5QScs8m8QknAeHGcoivp5TXtpnjdRwbrrsa3.tar.tmp
-rw-r--r-- 1 mvines mvines 449382828 Jan 27 15:49 ledger/snapshot-62659488-95ygMe7qnVXsXdGisBFWXtnhCiZLGvC2HUogDSWCKXzx.tar.tmp
```

#### Summary of Changes
By sneakily naming temporary files with the `tmp-` prefix instead of a `.tmp` extension, an interrupted snapshot download will be named `tmp-snapshot-62659488-95ygMe7qnVXsXdGisBFWXtnhCiZLGvC2HUogDSWCKXzx.tar.bz2` and get automatically cleaned up by the existing [remove_tmp_snapshot_archives](https://github.com/solana-labs/solana/blob/4bbeb9c033e4618e8be0ce9d9ad5e7edbc90f48b/runtime/src/snapshot_utils.rs#L206) snapshot cleanup logic 