### PR TITLE
Sanitize instruction index when loading instruction from sysvar

### DIFF
--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -404,7 +404,10 @@ impl Message {
         data: &[u8],
     ) -> Result<Instruction, SanitizeError> {
         let mut current = 0;
-        let _num_instructions = read_u16(&mut current, &data)?;
+        let num_instructions = read_u16(&mut current, &data)?;
+        if index >= num_instructions as usize {
+            return Err(SanitizeError::IndexOutOfBounds);
+        }
 
         // index into the instruction byte-offset table.
         current += index * 2;
@@ -860,6 +863,25 @@ mod tests {
                 *instruction
             );
         }
+    }
+
+    #[test]
+    fn test_decompile_instructions_out_of_bounds() {
+        solana_logger::setup();
+        let program_id0 = Pubkey::new_unique();
+        let id0 = Pubkey::new_unique();
+        let id1 = Pubkey::new_unique();
+        let instructions = vec![
+            Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id0, false)]),
+            Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id1, true)]),
+        ];
+
+        let message = Message::new(&instructions, Some(&id1));
+        let serialized = message.serialize_instructions();
+        assert_eq!(
+            Message::deserialize_instruction(instructions.len(), &serialized).unwrap_err(),
+            SanitizeError::IndexOutOfBounds,
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
The `sysvar::instructions::load_instruction_at` sdk method doesn't sanitize the index when loading an instruction. Context: https://github.com/solana-labs/solana-program-library/pull/1444#discussion_r595775422

#### Summary of Changes
- Return sanitization error if index is not below the number of instructions

Fixes #
