### PR TITLE
feat: add support for signature received notifications

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -403,6 +403,11 @@ const SignatureStatusResult = pick({
   err: TransactionErrorResult,
 });
 
+/**
+ * Transaction signature received notification
+ */
+const SignatureReceivedResult = literal('receivedSignature');
+
 export type Version = {
   'solana-core': string;
   'feature-set'?: number;
@@ -1007,7 +1012,9 @@ const SlotNotificationResult = pick({
  */
 const SignatureNotificationResult = pick({
   subscription: number(),
-  result: notificationResultAndContext(SignatureStatusResult),
+  result: notificationResultAndContext(
+    union([SignatureStatusResult, SignatureReceivedResult]),
+  ),
 });
 
 /**
@@ -1460,13 +1467,38 @@ export type SignatureResultCallback = (
   context: Context,
 ) => void;
 
+export type SignatureStatusNotification = {
+  type: 'status';
+  result: SignatureResult;
+};
+
+export type SignatureReceivedNotification = {
+  type: 'received';
+};
+
+/**
+ * Callback function for signature notifications
+ */
+export type SignatureSubscriptionCallback = (
+  notification: SignatureStatusNotification | SignatureReceivedNotification,
+  context: Context,
+) => void;
+
+/**
+ * Callback function for signature notifications
+ */
+export type SignatureSubscriptionOptions = {
+  commitment?: Commitment;
+  enableReceivedNotification?: boolean;
+};
+
 /**
  * @internal
  */
 type SignatureSubscriptionInfo = {
   signature: TransactionSignature; // TransactionSignature as a base 58 string
-  callback: SignatureResultCallback;
-  commitment?: Commitment;
+  callback: SignatureSubscriptionCallback;
+  options?: SignatureSubscriptionOptions;
   subscriptionId: SubscriptionId | null; // null when there's no current server subscription id
 };
 
@@ -2940,11 +2972,9 @@ export class Connection {
 
     for (let id of signatureKeys) {
       const sub = this._signatureSubscriptions[id];
-      this._subscribe(
-        sub,
-        'signatureSubscribe',
-        this._buildArgs([sub.signature], sub.commitment),
-      );
+      const args: any[] = [sub.signature];
+      if (sub.options) args.push(sub.options);
+      this._subscribe(sub, 'signatureSubscribe', args);
     }
 
     for (let id of rootKeys) {
@@ -3145,11 +3175,26 @@ export class Connection {
     const res = create(notification, SignatureNotificationResult);
     for (const [id, sub] of Object.entries(this._signatureSubscriptions)) {
       if (sub.subscriptionId === res.subscription) {
-        // Signatures subscriptions are auto-removed by the RPC service so
-        // no need to explicitly send an unsubscribe message
-        delete this._signatureSubscriptions[Number(id)];
-        this._updateSubscriptions();
-        sub.callback(res.result.value, res.result.context);
+        if (res.result.value === 'receivedSignature') {
+          sub.callback(
+            {
+              type: 'received',
+            },
+            res.result.context,
+          );
+        } else {
+          // Signatures subscriptions are auto-removed by the RPC service so
+          // no need to explicitly send an unsubscribe message
+          delete this._signatureSubscriptions[Number(id)];
+          this._updateSubscriptions();
+          sub.callback(
+            {
+              type: 'status',
+              result: res.result.value,
+            },
+            res.result.context,
+          );
+        }
         return;
       }
     }
@@ -3171,8 +3216,38 @@ export class Connection {
     const id = ++this._signatureSubscriptionCounter;
     this._signatureSubscriptions[id] = {
       signature,
+      callback: (notification, context) => {
+        if (notification.type === 'status') {
+          callback(notification.result, context);
+        }
+      },
+      options: {commitment},
+      subscriptionId: null,
+    };
+    this._updateSubscriptions();
+    return id;
+  }
+
+  /**
+   * Register a callback to be invoked when a transaction is
+   * received and/or processed.
+   *
+   * @param signature Transaction signature string in base 58
+   * @param callback Function to invoke on signature notifications
+   * @param options Enable received notifications and set the commitment
+   *   level that signature must reach before notification
+   * @return subscription id
+   */
+  onSignatureWithOptions(
+    signature: TransactionSignature,
+    callback: SignatureSubscriptionCallback,
+    options?: SignatureSubscriptionOptions,
+  ): number {
+    const id = ++this._signatureSubscriptionCounter;
+    this._signatureSubscriptions[id] = {
+      signature,
       callback,
-      commitment,
+      options,
       subscriptionId: null,
     };
     this._updateSubscriptions();

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1460,18 +1460,24 @@ type SlotSubscriptionInfo = {
 };
 
 /**
- * Callback function for signature notifications
+ * Callback function for signature status notifications
  */
 export type SignatureResultCallback = (
   signatureResult: SignatureResult,
   context: Context,
 ) => void;
 
+/**
+ * Signature status notification with transaction result
+ */
 export type SignatureStatusNotification = {
   type: 'status';
   result: SignatureResult;
 };
 
+/**
+ * Signature received notification
+ */
 export type SignatureReceivedNotification = {
   type: 'received';
 };
@@ -1485,7 +1491,7 @@ export type SignatureSubscriptionCallback = (
 ) => void;
 
 /**
- * Callback function for signature notifications
+ * Signature subscription options
  */
 export type SignatureSubscriptionOptions = {
   commitment?: Commitment;


### PR DESCRIPTION
#### Problem
Lack of support for signature received notifications which indicate that a transaction landed in a slot

#### Summary of Changes
- Added new `onSignatureWithOptions` method which accepts an options object which can enable the received notification.

Fixes #
