### PR TITLE
test-validator: Notice the user when the --mint, --bpf-program, or --clone arguments are ignored

### DIFF
--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -354,6 +354,18 @@ fn main() {
         });
     }
 
+    if TestValidatorGenesis::ledger_exists(&ledger_path) {
+        for (name, long) in &[
+            ("bpf_program", "--bpf-program"),
+            ("clone_account", "--clone"),
+            ("mint_address", "--mint"),
+        ] {
+            if matches.is_present(name) {
+                println!("{} argument ignored, ledger already exists", long);
+            }
+        }
+    }
+
     let mut genesis = TestValidatorGenesis::default();
 
     admin_rpc_service::run(


### PR DESCRIPTION
--mint, --bpf-program, or --clone arguments are ignored when the `test-ledger/` already exists, tell the user about this