### PR TITLE
test-validator: Add --slots-per-epoch argument

### DIFF
--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -16,6 +16,7 @@ use {
         account::{Account, AccountSharedData},
         clock::{Slot, DEFAULT_MS_PER_SLOT},
         commitment_config::CommitmentConfig,
+        epoch_schedule::EpochSchedule,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
         hash::Hash,
         native_token::sol_to_lamports,
@@ -52,6 +53,7 @@ pub struct TestValidatorGenesis {
     no_bpf_jit: bool,
     accounts: HashMap<Pubkey, AccountSharedData>,
     programs: Vec<ProgramInfo>,
+    epoch_schedule: Option<EpochSchedule>,
     pub validator_exit: Arc<RwLock<ValidatorExit>>,
     pub start_progress: Arc<RwLock<ValidatorStartProgress>>,
 }
@@ -69,6 +71,11 @@ impl TestValidatorGenesis {
 
     pub fn fee_rate_governor(&mut self, fee_rate_governor: FeeRateGovernor) -> &mut Self {
         self.fee_rate_governor = fee_rate_governor;
+        self
+    }
+
+    pub fn epoch_schedule(&mut self, epoch_schedule: EpochSchedule) -> &mut Self {
+        self.epoch_schedule = Some(epoch_schedule);
         self
     }
 
@@ -313,7 +320,9 @@ impl TestValidator {
             solana_sdk::genesis_config::ClusterType::Development,
             accounts.into_iter().collect(),
         );
-        genesis_config.epoch_schedule = solana_sdk::epoch_schedule::EpochSchedule::without_warmup();
+        genesis_config.epoch_schedule = config
+            .epoch_schedule
+            .unwrap_or_else(EpochSchedule::without_warmup);
 
         let ledger_path = match &config.ledger_path {
             None => create_new_tmp_ledger!(&genesis_config).0,

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -11,7 +11,7 @@ extern crate solana_vest_program;
 use clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg, ArgMatches};
 use solana_clap_utils::{
     input_parsers::{cluster_type_of, pubkey_of, pubkeys_of, unix_timestamp_from_rfc3339_datetime},
-    input_validators::{is_pubkey_or_keypair, is_rfc3339_datetime, is_valid_percentage},
+    input_validators::{is_pubkey_or_keypair, is_rfc3339_datetime, is_slot, is_valid_percentage},
 };
 use solana_genesis::{genesis_accounts::add_genesis_accounts, Base64Account};
 use solana_ledger::{
@@ -328,6 +328,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             Arg::with_name("slots_per_epoch")
                 .long("slots-per-epoch")
                 .value_name("SLOTS")
+                .validator(is_slot)
                 .takes_value(true)
                 .help("The number of slots in an epoch"),
         )

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -14,6 +14,7 @@ use {
     solana_sdk::{
         account::AccountSharedData,
         clock::Slot,
+        epoch_schedule::EpochSchedule,
         native_token::sol_to_lamports,
         pubkey::Pubkey,
         rpc_port,
@@ -147,6 +148,17 @@ fn main() {
                 .help("Disable the just-in-time compiler and instead use the interpreter for BPF"),
         )
         .arg(
+            Arg::with_name("slots_per_epoch")
+                .long("slots-per-epoch")
+                .value_name("SLOTS")
+                .validator(is_slot)
+                .takes_value(true)
+                .help(
+                    "Override the number of slots in an epoch. \
+                       If the ledger already exists then this parameter is silently ignored",
+                ),
+        )
+        .arg(
             Arg::with_name("clone_account")
                 .long("clone")
                 .short("c")
@@ -205,6 +217,7 @@ fn main() {
         Output::Dashboard
     };
     let rpc_port = value_t_or_exit!(matches, "rpc_port", u16);
+    let slots_per_epoch = value_t!(matches, "slots_per_epoch", Slot).ok();
 
     let faucet_addr = Some(SocketAddr::new(
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
@@ -359,6 +372,7 @@ fn main() {
             ("bpf_program", "--bpf-program"),
             ("clone_account", "--clone"),
             ("mint_address", "--mint"),
+            ("slots_per_epoch", "--slots-per-epoch"),
         ] {
             if matches.is_present(name) {
                 println!("{} argument ignored, ledger already exists", long);
@@ -420,6 +434,14 @@ fn main() {
 
     if let Some(warp_slot) = warp_slot {
         genesis.warp_slot(warp_slot);
+    }
+
+    if let Some(slots_per_epoch) = slots_per_epoch {
+        genesis.epoch_schedule(EpochSchedule::custom(
+            slots_per_epoch,
+            slots_per_epoch,
+            /* enable_warmup_epochs = */ false,
+        ));
     }
 
     match genesis.start_with_mint_address(mint_address) {


### PR DESCRIPTION
2 days / epoch will be super annoying for stake pool testing.  `solana-test-validator --slots-per-epoch 32 ...` will make waiting for stake to warmup much more palatable  