### PR TITLE
Allow unbounded wallclock processing time in tests

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1463,7 +1463,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_banking_stage_entries_only() {
         solana_logger::setup();
         let GenesisConfigInfo {
@@ -1471,7 +1470,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10);
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_no_wallclock_throttle(&genesis_config));
         let start_hash = bank.last_blockhash();
         let (verified_sender, verified_receiver) = unbounded();
         let (vote_sender, vote_receiver) = unbounded();
@@ -1546,7 +1545,7 @@ mod tests {
             drop(poh_recorder);
 
             let mut blockhash = start_hash;
-            let bank = Bank::new(&genesis_config);
+            let bank = Arc::new(Bank::new_no_wallclock_throttle(&genesis_config));
             bank.process_transaction(&fund_tx).unwrap();
             //receive entries + ticks
             loop {
@@ -1581,7 +1580,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_banking_stage_entryfication() {
         solana_logger::setup();
         // In this attack we'll demonstrate that a verifier can interpret the ledger
@@ -1625,7 +1623,7 @@ mod tests {
 
             let entry_receiver = {
                 // start a banking_stage to eat verified receiver
-                let bank = Arc::new(Bank::new(&genesis_config));
+                let bank = Arc::new(Bank::new_no_wallclock_throttle(&genesis_config));
                 let blockstore = Arc::new(
                     Blockstore::open(&ledger_path)
                         .expect("Expected to be able to open database ledger"),
@@ -1669,7 +1667,7 @@ mod tests {
                 .map(|(_bank, (entry, _tick_height))| entry)
                 .collect();
 
-            let bank = Bank::new(&genesis_config);
+            let bank = Bank::new_no_wallclock_throttle(&genesis_config);
             for entry in &entries {
                 bank.process_transactions(&entry.transactions)
                     .iter()
@@ -2233,10 +2231,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        let mut bank = Bank::new(&genesis_config);
-        // Allow arbitrary transaction processing time for the purposes of this test
-        bank.ns_per_slot = std::u128::MAX;
-        let bank = Arc::new(Bank::new(&genesis_config));
+        let bank = Arc::new(Bank::new_no_wallclock_throttle(&genesis_config));
 
         let pubkey = solana_sdk::pubkey::new_rand();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -902,6 +902,21 @@ impl Bank {
         )
     }
 
+    pub fn new_no_wallclock_throttle(genesis_config: &GenesisConfig) -> Self {
+        let mut bank = Self::new_with_paths(
+            &genesis_config,
+            Vec::new(),
+            &[],
+            None,
+            None,
+            HashSet::new(),
+            false,
+        );
+
+        bank.ns_per_slot = std::u128::MAX;
+        bank
+    }
+
     #[cfg(test)]
     pub(crate) fn new_with_config(
         genesis_config: &GenesisConfig,


### PR DESCRIPTION
#### Problem
Tests are stalling in transaction procesing if banks hit the wallclock throttle

#### Summary of Changes
Allow test banks to have unbounded wallclock processing time
Fixes #
