### PR TITLE
rpc: Add config options limiting getConfirmedBlock response data

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -4,9 +4,9 @@ use crate::{
     mock_sender::{MockSender, Mocks},
     rpc_config::RpcAccountInfoConfig,
     rpc_config::{
-        RpcGetConfirmedSignaturesForAddress2Config, RpcLargestAccountsConfig,
-        RpcProgramAccountsConfig, RpcSendTransactionConfig, RpcSimulateTransactionConfig,
-        RpcTokenAccountsFilter,
+        RpcConfirmedBlockConfig, RpcGetConfirmedSignaturesForAddress2Config,
+        RpcLargestAccountsConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig,
+        RpcSimulateTransactionConfig, RpcTokenAccountsFilter,
     },
     rpc_request::{RpcError, RpcRequest, RpcResponseErrorData, TokenAccountsFilter},
     rpc_response::*,
@@ -33,7 +33,8 @@ use solana_sdk::{
     transaction::{self, uses_durable_nonce, Transaction},
 };
 use solana_transaction_status::{
-    EncodedConfirmedBlock, EncodedConfirmedTransaction, TransactionStatus, UiTransactionEncoding,
+    EncodedConfirmedBlock, EncodedConfirmedTransaction, TransactionStatus, UiConfirmedBlock,
+    UiTransactionEncoding,
 };
 use solana_vote_program::vote_state::MAX_LOCKOUT_HISTORY;
 use std::{
@@ -505,6 +506,14 @@ impl RpcClient {
         encoding: UiTransactionEncoding,
     ) -> ClientResult<EncodedConfirmedBlock> {
         self.send(RpcRequest::GetConfirmedBlock, json!([slot, encoding]))
+    }
+
+    pub fn get_configured_confirmed_block(
+        &self,
+        slot: Slot,
+        config: RpcConfirmedBlockConfig,
+    ) -> ClientResult<UiConfirmedBlock> {
+        self.send(RpcRequest::GetConfirmedBlock, json!([slot, config]))
     }
 
     pub fn get_confirmed_blocks(

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -4,7 +4,7 @@ use solana_sdk::{
     clock::Epoch,
     commitment_config::{CommitmentConfig, CommitmentLevel},
 };
-use solana_transaction_status::UiTransactionEncoding;
+use solana_transaction_status::{TransactionDetails, UiTransactionEncoding};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -127,20 +127,6 @@ impl<T: EncodingConfig + Default + Copy> RpcEncodingConfigWrapper<T> {
 
 pub trait EncodingConfig {
     fn new_with_encoding(encoding: &Option<UiTransactionEncoding>) -> Self;
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum TransactionDetails {
-    All,
-    Signatures,
-    None,
-}
-
-impl Default for TransactionDetails {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -134,7 +134,7 @@ pub trait EncodingConfig {
 pub struct RpcConfirmedBlockConfig {
     pub encoding: Option<UiTransactionEncoding>,
     pub transaction_details: Option<TransactionDetails>,
-    pub no_rewards: Option<bool>,
+    pub rewards: Option<bool>,
 }
 
 impl EncodingConfig for RpcConfirmedBlockConfig {

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -146,6 +146,15 @@ impl EncodingConfig for RpcConfirmedBlockConfig {
     }
 }
 
+impl RpcConfirmedBlockConfig {
+    pub fn rewards_only() -> Self {
+        Self {
+            transaction_details: Some(TransactionDetails::None),
+            ..Self::default()
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcConfirmedTransactionConfig {

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -129,16 +129,33 @@ pub trait EncodingConfig {
     fn new_with_encoding(encoding: &Option<UiTransactionEncoding>) -> Self;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransactionDetails {
+    All,
+    Signatures,
+    None,
+}
+
+impl Default for TransactionDetails {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcConfirmedBlockConfig {
     pub encoding: Option<UiTransactionEncoding>,
+    pub transaction_details: Option<TransactionDetails>,
+    pub no_rewards: Option<bool>,
 }
 
 impl EncodingConfig for RpcConfirmedBlockConfig {
     fn new_with_encoding(encoding: &Option<UiTransactionEncoding>) -> Self {
         Self {
             encoding: *encoding,
+            ..Self::default()
         }
     }
 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -726,7 +726,7 @@ impl JsonRpcRequestProcessor {
             .unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Json);
         let transaction_details = config.transaction_details.unwrap_or_default();
-        let show_rewards = !config.no_rewards.unwrap_or_default();
+        let show_rewards = config.rewards.unwrap_or(true);
         if self.config.enable_rpc_transaction_history
             && slot
                 <= self
@@ -5176,7 +5176,7 @@ pub mod tests {
             json!(RpcConfirmedBlockConfig {
                 encoding: None,
                 transaction_details: Some(TransactionDetails::Signatures),
-                no_rewards: Some(true),
+                rewards: Some(false),
             })
         );
         let res = io.handle_request_sync(&req, meta.clone());
@@ -5196,7 +5196,7 @@ pub mod tests {
             json!(RpcConfirmedBlockConfig {
                 encoding: None,
                 transaction_details: Some(TransactionDetails::None),
-                no_rewards: Some(false),
+                rewards: Some(true),
             })
         );
         let res = io.handle_request_sync(&req, meta);

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -460,6 +460,8 @@ Returns identity and transaction information about a confirmed block in the ledg
 - `<object>` - (optional) Configuration object containing the following optional fields:
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (*slow*), "base64". If parameter not provided, the default encoding is "json".
   "jsonParsed" encoding attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
+  - (optional) `transactionDetails: <string>` - level of transaction detail to return, either "all", "signatures", or "none". If parameter not provided, the default detail level is "all".
+  - (optional) `noRewards: bool` - whether to skip returning rewards for epoch-boundary blocks. If parameter not provided, the default returns rewards.
 
 #### Results:
 
@@ -470,7 +472,7 @@ The result field will be an object with the following fields:
   - `blockhash: <string>` - the blockhash of this block, as base-58 encoded string
   - `previousBlockhash: <string>` - the blockhash of this block's parent, as base-58 encoded string; if the parent block is not available due to ledger cleanup, this field will return "11111111111111111111111111111111"
   - `parentSlot: <u64>` - the slot index of this block's parent
-  - `transactions: <array>` - an array of JSON objects containing:
+  - `transactions: <array>` - present if "all" transaction details are requested; an array of JSON objects containing:
     - `transaction: <object|[string,encoding]>` - [Transaction](#transaction-structure) object, either in JSON format or encoded binary data, depending on encoding parameter
     - `meta: <object>` - transaction status metadata object, containing `null` or:
       - `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24)
@@ -484,7 +486,8 @@ The result field will be an object with the following fields:
       - DEPRECATED: `status: <object>` - Transaction status
         - `"Ok": <null>` - Transaction was successful
         - `"Err": <ERR>` - Transaction failed with TransactionError
-  - `rewards: <array>` - an array of JSON objects containing:
+  - `signatures: <array>` - present if "signatures" are requested for transaction details; an array of signatures strings, corresponding to the transaction order in the block
+  - `rewards: <array>` - present if rewards are not suppressed; an array of JSON objects containing:
     - `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
     - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
     - `postBalance: <u64>` - account balance in lamports after the reward was applied
@@ -496,7 +499,7 @@ The result field will be an object with the following fields:
 Request:
 ```bash
 curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
-  {"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, {"encoding": "json"}]}
+  {"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, {"encoding": "json","transactionDetails":"all","noRewards":true}]}
 '
 ```
 
@@ -509,7 +512,6 @@ Result:
     "blockhash": "3Eq21vXNB5s86c62bVuUfTeaMif1N2kUqRPBmGRJhyTA",
     "parentSlot": 429,
     "previousBlockhash": "mfcyqEXB3DnHXki6KjjmZck6YjmZLvpAByy2fj4nh6B",
-    "rewards": [],
     "transactions": [
       {
         "meta": {

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -460,8 +460,8 @@ Returns identity and transaction information about a confirmed block in the ledg
 - `<object>` - (optional) Configuration object containing the following optional fields:
   - (optional) `encoding: <string>` - encoding for each returned Transaction, either "json", "jsonParsed", "base58" (*slow*), "base64". If parameter not provided, the default encoding is "json".
   "jsonParsed" encoding attempts to use program-specific instruction parsers to return more human-readable and explicit data in the `transaction.message.instructions` list. If "jsonParsed" is requested but a parser cannot be found, the instruction falls back to regular JSON encoding (`accounts`, `data`, and `programIdIndex` fields).
-  - (optional) `transactionDetails: <string>` - level of transaction detail to return, either "all", "signatures", or "none". If parameter not provided, the default detail level is "all".
-  - (optional) `noRewards: bool` - whether to skip returning rewards for epoch-boundary blocks. If parameter not provided, the default returns rewards.
+  - (optional) `transactionDetails: <string>` - level of transaction detail to return, either "full", "signatures", or "none". If parameter not provided, the default detail level is "full".
+  - (optional) `rewards: bool` - whether to populate the `rewards` array. If parameter not provided, the default includes rewards.
 
 #### Results:
 
@@ -472,7 +472,7 @@ The result field will be an object with the following fields:
   - `blockhash: <string>` - the blockhash of this block, as base-58 encoded string
   - `previousBlockhash: <string>` - the blockhash of this block's parent, as base-58 encoded string; if the parent block is not available due to ledger cleanup, this field will return "11111111111111111111111111111111"
   - `parentSlot: <u64>` - the slot index of this block's parent
-  - `transactions: <array>` - present if "all" transaction details are requested; an array of JSON objects containing:
+  - `transactions: <array>` - present if "full" transaction details are requested; an array of JSON objects containing:
     - `transaction: <object|[string,encoding]>` - [Transaction](#transaction-structure) object, either in JSON format or encoded binary data, depending on encoding parameter
     - `meta: <object>` - transaction status metadata object, containing `null` or:
       - `err: <object | null>` - Error if transaction failed, null if transaction succeeded. [TransactionError definitions](https://github.com/solana-labs/solana/blob/master/sdk/src/transaction.rs#L24)
@@ -487,7 +487,7 @@ The result field will be an object with the following fields:
         - `"Ok": <null>` - Transaction was successful
         - `"Err": <ERR>` - Transaction failed with TransactionError
   - `signatures: <array>` - present if "signatures" are requested for transaction details; an array of signatures strings, corresponding to the transaction order in the block
-  - `rewards: <array>` - present if rewards are not suppressed; an array of JSON objects containing:
+  - `rewards: <array>` - present if rewards are requested; an array of JSON objects containing:
     - `pubkey: <string>` - The public key, as base-58 encoded string, of the account that received the reward
     - `lamports: <i64>`- number of reward lamports credited or debited by the account, as a i64
     - `postBalance: <u64>` - account balance in lamports after the reward was applied
@@ -499,7 +499,7 @@ The result field will be an object with the following fields:
 Request:
 ```bash
 curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
-  {"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, {"encoding": "json","transactionDetails":"all","noRewards":true}]}
+  {"jsonrpc": "2.0","id":1,"method":"getConfirmedBlock","params":[430, {"encoding": "json","transactionDetails":"full","rewards":false}]}
 '
 ```
 

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -375,6 +375,35 @@ pub struct EncodedConfirmedBlock {
     pub block_time: Option<UnixTimestamp>,
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UiConfirmedBlock {
+    pub previous_blockhash: String,
+    pub blockhash: String,
+    pub parent_slot: Slot,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transactions: Option<Vec<EncodedTransactionWithStatusMeta>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signatures: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rewards: Option<Rewards>,
+    pub block_time: Option<UnixTimestamp>,
+}
+
+impl From<EncodedConfirmedBlock> for UiConfirmedBlock {
+    fn from(block: EncodedConfirmedBlock) -> Self {
+        Self {
+            previous_blockhash: block.previous_blockhash,
+            blockhash: block.blockhash,
+            parent_slot: block.parent_slot,
+            transactions: Some(block.transactions),
+            signatures: None,
+            rewards: Some(block.rewards),
+            block_time: block.block_time,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfirmedTransaction {

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -362,6 +362,48 @@ impl ConfirmedBlock {
             block_time: self.block_time,
         }
     }
+
+    pub fn configure(
+        self,
+        encoding: UiTransactionEncoding,
+        transaction_details: TransactionDetails,
+        show_rewards: bool,
+    ) -> UiConfirmedBlock {
+        let (transactions, signatures) = match transaction_details {
+            TransactionDetails::All => (
+                Some(
+                    self.transactions
+                        .into_iter()
+                        .map(|tx| tx.encode(encoding))
+                        .collect(),
+                ),
+                None,
+            ),
+            TransactionDetails::Signatures => (
+                None,
+                Some(
+                    self.transactions
+                        .into_iter()
+                        .map(|tx| tx.transaction.signatures[0].to_string())
+                        .collect(),
+                ),
+            ),
+            TransactionDetails::None => (None, None),
+        };
+        UiConfirmedBlock {
+            previous_blockhash: self.previous_blockhash,
+            blockhash: self.blockhash,
+            parent_slot: self.parent_slot,
+            transactions,
+            signatures,
+            rewards: if show_rewards {
+                Some(self.rewards)
+            } else {
+                None
+            },
+            block_time: self.block_time,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -401,6 +443,20 @@ impl From<EncodedConfirmedBlock> for UiConfirmedBlock {
             rewards: Some(block.rewards),
             block_time: block.block_time,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TransactionDetails {
+    All,
+    Signatures,
+    None,
+}
+
+impl Default for TransactionDetails {
+    fn default() -> Self {
+        Self::All
     }
 }
 

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -370,7 +370,7 @@ impl ConfirmedBlock {
         show_rewards: bool,
     ) -> UiConfirmedBlock {
         let (transactions, signatures) = match transaction_details {
-            TransactionDetails::All => (
+            TransactionDetails::Full => (
                 Some(
                     self.transactions
                         .into_iter()
@@ -449,14 +449,14 @@ impl From<EncodedConfirmedBlock> for UiConfirmedBlock {
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TransactionDetails {
-    All,
+    Full,
     Signatures,
     None,
 }
 
 impl Default for TransactionDetails {
     fn default() -> Self {
-        Self::All
+        Self::Full
     }
 }
 


### PR DESCRIPTION
#### Problem
The `getConfirmedBlock` RPC response can be quite massive when considering transaction details and metadata as well as a ton of reward information for blocks on the epoch boundary. Not all consumers will need this information but currently everyone has to pay the cost of bandwidth and response time.

#### Summary of Changes
- Extend `RpcConfirmedBlockConfig` to support different levels of transaction details: all, signatures, or none
- Extend `RpcConfirmedBlockConfig` to allow suppressing reward info
- Add RpcClient method, and use in cli when fetching epoch rewards. Client methods returning `EncodedConfirmedBlock` are still supported.

Fixes #15817 
