### PR TITLE
Signature ellipsis for transaction history

### DIFF
--- a/explorer/src/components/account/TransactionHistoryCard.tsx
+++ b/explorer/src/components/account/TransactionHistoryCard.tsx
@@ -121,8 +121,8 @@ export function TransactionHistoryCard({ pubkey }: { pubkey: PublicKey }) {
         </button>
       </div>
 
-      <div className="table-responsive mb-0">
-        <table className="table table-sm table-nowrap card-table">
+      <div className="table-responsive-sm mb-0">
+        <table className="table table-sm table-nowrap">
           <thead>
             <tr>
               <th className="text-muted w-1">Slot</th>

--- a/explorer/src/components/common/Signature.tsx
+++ b/explorer/src/components/common/Signature.tsx
@@ -14,7 +14,7 @@ type Props = {
 export function Signature({ signature, alignRight, link, truncate }: Props) {
   return (
     <div
-      className={`d-flex align-items-center ${
+      className={`d-inline align-items-center ${
         alignRight ? "justify-content-end" : ""
       }`}
     >

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -353,3 +353,10 @@ pre.data-wrap, pre.json-wrap {
 pre.json-wrap {
   max-width: 36rem;
 }
+
+td {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
#### Problem
Horizontal scrollbar on history looks horrible, page too heavy when overlooking an account.

#### Summary of Changes
Trying out some stuff to make it look like this

![image](https://user-images.githubusercontent.com/8245419/111589826-7a290280-8819-11eb-9fc1-ec0d0d5ef5ae.png)

Who reads the full signature anyway?

I imagine we would even truncate more of it on small media, as we still want to be able to browse without a horizontal scrollbar

I can't quite get how to do that cleanly though. Also this frees some space, if the web rpc ends up giving fee and sol balance change per transaction we can make something close to etherscan

Fixes #14975
