### PR TITLE
web3.js: add support for batch getParsedConfirmedTransactions

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -63,6 +63,13 @@ export const BLOCKHASH_CACHE_TIMEOUT_MS = 30 * 1000;
 
 type RpcRequest = (methodName: string, args: Array<any>) => any;
 
+type RpcBatchRequest = (requests: RpcParams[]) => any;
+
+type RpcParams = {
+  methodName: string,
+  args: Array<any>,
+};
+
 export type TokenAccountsFilter =
   | {
       mint: PublicKey;
@@ -642,7 +649,7 @@ export type PerfSample = {
   samplePeriodSecs: number;
 };
 
-function createRpcRequest(url: string, useHttps: boolean): RpcRequest {
+function createRpcClient(url: string, useHttps: boolean): RpcClient {
   let agentManager: AgentManager | undefined;
   if (!process.env.BROWSER) {
     agentManager = new AgentManager(useHttps);
@@ -692,9 +699,13 @@ function createRpcRequest(url: string, useHttps: boolean): RpcRequest {
     }
   }, {});
 
+  return clientBrowser;
+}
+
+function createRpcRequest(client: RpcClient): RpcRequest {
   return (method, args) => {
     return new Promise((resolve, reject) => {
-      clientBrowser.request(method, args, (err: any, response: any) => {
+      client.request(method, args, (err: any, response: any) => {
         if (err) {
           reject(err);
           return;
@@ -703,6 +714,25 @@ function createRpcRequest(url: string, useHttps: boolean): RpcRequest {
       });
     });
   };
+}
+
+function createRpcBatchRequest(client: RpcClient): RpcBatchRequest {
+  return (requests: RpcParams[]) => {
+    return new Promise((resolve, reject) => {
+      const batch = requests.map((params: RpcParams) => {
+        return client.request(params.methodName, params.args);
+      });
+
+      client.request(batch, (err: any, response: any) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve(response);
+      });
+    })
+  }
 }
 
 /**
@@ -1591,7 +1621,9 @@ export type ConfirmedSignatureInfo = {
 export class Connection {
   /** @internal */ _commitment?: Commitment;
   /** @internal */ _rpcEndpoint: string;
+  /** @internal */ _rpcClient: RpcClient;
   /** @internal */ _rpcRequest: RpcRequest;
+  /** @internal */ _rpcBatchRequest: RpcBatchRequest;
   /** @internal */ _rpcWebSocket: RpcWebSocketClient;
   /** @internal */ _rpcWebSocketConnected: boolean = false;
   /** @internal */ _rpcWebSocketHeartbeat: ReturnType<
@@ -1647,7 +1679,10 @@ export class Connection {
     let url = urlParse(endpoint);
     const useHttps = url.protocol === 'https:';
 
-    this._rpcRequest = createRpcRequest(url.href, useHttps);
+
+    this._rpcClient = createRpcClient(url.href, useHttps);
+    this._rpcRequest = createRpcRequest(this._rpcClient);
+    this._rpcBatchRequest = createRpcBatchRequest(this._rpcClient);
     this._commitment = commitment;
     this._blockhashInfo = {
       recentBlockhash: null,

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -65,9 +65,9 @@ type RpcRequest = (methodName: string, args: Array<any>) => any;
 
 type RpcBatchRequest = (requests: RpcParams[]) => any;
 
-type RpcParams = {
-  methodName: string,
-  args: Array<any>,
+export type RpcParams = {
+  methodName: string;
+  args: Array<any>;
 };
 
 export type TokenAccountsFilter =
@@ -731,8 +731,8 @@ function createRpcBatchRequest(client: RpcClient): RpcBatchRequest {
 
         resolve(response);
       });
-    })
-  }
+    });
+  };
 }
 
 /**
@@ -1679,7 +1679,6 @@ export class Connection {
     let url = urlParse(endpoint);
     const useHttps = url.protocol === 'https:';
 
-
     this._rpcClient = createRpcClient(url.href, useHttps);
     this._rpcRequest = createRpcRequest(this._rpcClient);
     this._rpcBatchRequest = createRpcBatchRequest(this._rpcClient);
@@ -2519,8 +2518,6 @@ export class Connection {
     return res.result;
   }
 
-
-
   /**
    * Fetch parsed transaction details for a confirmed transaction
    */
@@ -2546,16 +2543,16 @@ export class Connection {
   async getParsedConfirmedTransactions(
     signatures: TransactionSignature[],
   ): Promise<any> {
-    const batch = signatures.map((signature) => {
+    const batch = signatures.map(signature => {
       return {
         methodName: 'getConfirmedTransaction',
-        args: [signature, 'jsonParsed']
-      }
+        args: [signature, 'jsonParsed'],
+      };
     });
 
     const unsafeRes = await this._rpcBatchRequest(batch);
     const res = unsafeRes.map((unsafeRes: any) => {
-      const res = create(unsafeRes, GetParsedConfirmedTransactionRpcResult)
+      const res = create(unsafeRes, GetParsedConfirmedTransactionRpcResult);
       if ('error' in res) {
         throw new Error(
           'failed to get confirmed transactions: ' + res.error.message,

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -728,7 +728,6 @@ function createRpcBatchRequest(client: RpcClient): RpcBatchRequest {
           reject(err);
           return;
         }
-
         resolve(response);
       });
     });

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -65,6 +65,9 @@ type RpcRequest = (methodName: string, args: Array<any>) => any;
 
 type RpcBatchRequest = (requests: RpcParams[]) => any;
 
+/**
+ * @internal
+ */
 export type RpcParams = {
   methodName: string;
   args: Array<any>;
@@ -2541,7 +2544,7 @@ export class Connection {
    */
   async getParsedConfirmedTransactions(
     signatures: TransactionSignature[],
-  ): Promise<any> {
+  ): Promise<(ParsedConfirmedTransaction | null)[]> {
     const batch = signatures.map(signature => {
       return {
         methodName: 'getConfirmedTransaction',

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2519,6 +2519,8 @@ export class Connection {
     return res.result;
   }
 
+
+
   /**
    * Fetch parsed transaction details for a confirmed transaction
    */
@@ -2536,6 +2538,33 @@ export class Connection {
       );
     }
     return res.result;
+  }
+
+  /**
+   * Fetch parsed transaction details for a batch of confirmed transactions
+   */
+  async getParsedConfirmedTransactions(
+    signatures: TransactionSignature[],
+  ): Promise<any> {
+    const batch = signatures.map((signature) => {
+      return {
+        methodName: 'getConfirmedTransaction',
+        args: [signature, 'jsonParsed']
+      }
+    });
+
+    const unsafeRes = await this._rpcBatchRequest(batch);
+    const res = unsafeRes.map((unsafeRes: any) => {
+      const res = create(unsafeRes, GetParsedConfirmedTransactionRpcResult)
+      if ('error' in res) {
+        throw new Error(
+          'failed to get confirmed transactions: ' + res.error.message,
+        );
+      }
+      return res.result;
+    });
+
+    return res;
   }
 
   /**

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -905,8 +905,14 @@ describe('Connection', () => {
     }
 
     expect(result).to.be.length(2);
-    expect(result[0].transaction.signatures).not.to.be.null;
-    expect(result[1].transaction.signatures).not.to.be.null;
+    expect(result[0]).to.not.be.null;
+    expect(result[1]).to.not.be.null;
+    if (result[0] !== null) {
+      expect(result[0].transaction.signatures).not.to.be.null;
+    }
+    if (result[1] !== null) {
+      expect(result[1].transaction.signatures).not.to.be.null;
+    }
   });
 
   it('get confirmed transaction', async () => {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -650,7 +650,7 @@ describe('Connection', () => {
     }
   });
 
-  it.only('get parsed confirmed transactions', async () => {
+  it('get parsed confirmed transactions', async () => {
     await mockRpcResponse({
       method: 'getSlot',
       params: [],
@@ -661,66 +661,66 @@ describe('Connection', () => {
       continue;
     }
 
+    await mockRpcResponse({
+      method: 'getConfirmedBlock',
+      params: [1],
+      value: {
+        blockTime: 1614281964,
+        blockhash: '57zQNBZBEiHsCZFqsaY6h176ioXy5MsSLmcvHkEyaLGy',
+        previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
+        parentSlot: 0,
+        transactions: [
+          {
+            meta: {
+              fee: 10000,
+              postBalances: [499260347380, 15298080, 1, 1, 1],
+              preBalances: [499260357380, 15298080, 1, 1, 1],
+              status: {Ok: null},
+              err: null,
+            },
+            transaction: {
+              message: {
+                accountKeys: [
+                  'va12u4o9DipLEB2z4fuoHszroq1U9NcAB9aooFDPJSf',
+                  '57zQNBZBEiHsCZFqsaY6h176ioXy5MsSLmcvHkEyaLGy',
+                  'SysvarS1otHashes111111111111111111111111111',
+                  'SysvarC1ock11111111111111111111111111111111',
+                  'Vote111111111111111111111111111111111111111',
+                ],
+                header: {
+                  numReadonlySignedAccounts: 0,
+                  numReadonlyUnsignedAccounts: 3,
+                  numRequiredSignatures: 2,
+                },
+                instructions: [
+                  {
+                    accounts: [1, 2, 3],
+                    data:
+                      '37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7',
+                    programIdIndex: 4,
+                  },
+                ],
+                recentBlockhash: 'GeyAFFRY3WGpmam2hbgrKw4rbU2RKzfVLm5QLSeZwTZE',
+              },
+              signatures: [
+                'w2Zeq8YkpyB463DttvfzARD7k9ZxGEwbsEw4boEK7jDp3pfoxZbTdLFSsEPhzXhpCcjGi2kHtHFobgX49MMhbWt',
+                '4oCEqwGrMdBeMxpzuWiukCYqSfV4DsSKXSiVVCh1iJ6pS772X7y219JZP3mgqBz5PhsvprpKyhzChjYc3VSBQXzG',
+              ],
+            },
+          },
+        ],
+      },
+    });
+
     // Find a block that has a transaction, usually Block 1
     let slot = 0;
-    let confirmedTransactions = [];
-    while (confirmedTransactions.length < 2) {
-      await mockRpcResponse({
-        method: 'getConfirmedBlock',
-        params: [++slot],
-        value: {
-          blockTime: 1614281964,
-          blockhash: '57zQNBZBEiHsCZFqsaY6h176ioXy5MsSLmcvHkEyaLGy',
-          previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
-          parentSlot: 0,
-          transactions: [
-            {
-              meta: {
-                fee: 10000,
-                postBalances: [499260347380, 15298080, 1, 1, 1],
-                preBalances: [499260357380, 15298080, 1, 1, 1],
-                status: {Ok: null},
-                err: null,
-              },
-              transaction: {
-                message: {
-                  accountKeys: [
-                    'va12u4o9DipLEB2z4fuoHszroq1U9NcAB9aooFDPJSf',
-                    '57zQNBZBEiHsCZFqsaY6h176ioXy5MsSLmcvHkEyaLGy',
-                    'SysvarS1otHashes111111111111111111111111111',
-                    'SysvarC1ock11111111111111111111111111111111',
-                    'Vote111111111111111111111111111111111111111',
-                  ],
-                  header: {
-                    numReadonlySignedAccounts: 0,
-                    numReadonlyUnsignedAccounts: 3,
-                    numRequiredSignatures: 2,
-                  },
-                  instructions: [
-                    {
-                      accounts: [1, 2, 3],
-                      data:
-                        '37u9WtQpcm6ULa3VtWDFAWoQc1hUvybPrA3dtx99tgHvvcE7pKRZjuGmn7VX2tC3JmYDYGG7',
-                      programIdIndex: 4,
-                    },
-                  ],
-                  recentBlockhash:
-                    'GeyAFFRY3WGpmam2hbgrKw4rbU2RKzfVLm5QLSeZwTZE',
-                },
-                signatures: [
-                  'w2Zeq8YkpyB463DttvfzARD7k9ZxGEwbsEw4boEK7jDp3pfoxZbTdLFSsEPhzXhpCcjGi2kHtHFobgX49MMhbWt',
-                  '4oCEqwGrMdBeMxpzuWiukCYqSfV4DsSKXSiVVCh1iJ6pS772X7y219JZP3mgqBz5PhsvprpKyhzChjYc3VSBQXzG',
-                ],
-              },
-            },
-          ],
-        },
-      });
-
+    let confirmedTransaction: string | undefined;
+    while (!confirmedTransaction) {
+      slot++;
       const block = await connection.getConfirmedBlock(slot);
       for (const tx of block.transactions) {
         if (tx.transaction.signature) {
-          confirmedTransactions.push(bs58.encode(tx.transaction.signature));
+          confirmedTransaction = bs58.encode(tx.transaction.signature);
         }
       }
     }
@@ -894,11 +894,19 @@ describe('Connection', () => {
       ],
     });
 
-    const result = await connection.getParsedConfirmedTransactions(
-      confirmedTransactions,
-    );
+    const result = await connection.getParsedConfirmedTransactions([
+      confirmedTransaction,
+      confirmedTransaction,
+    ]);
+
+    if (!result) {
+      expect(result).to.be.ok;
+      return;
+    }
 
     expect(result).to.be.length(2);
+    expect(result[0].transaction.signature).not.to.be.null;
+    expect(result[1].transaction.signature).not.to.be.null;
   });
 
   it('get confirmed transaction', async () => {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -905,8 +905,8 @@ describe('Connection', () => {
     }
 
     expect(result).to.be.length(2);
-    expect(result[0].transaction.signature).not.to.be.null;
-    expect(result[1].transaction.signature).not.to.be.null;
+    expect(result[0].transaction.signatures).not.to.be.null;
+    expect(result[1].transaction.signatures).not.to.be.null;
   });
 
   it('get confirmed transaction', async () => {

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -1,8 +1,8 @@
 import bs58 from 'bs58';
 import invariant from 'assert';
-import { Buffer } from 'buffer';
-import { Token, u64 } from '@solana/spl-token';
-import { expect, use } from 'chai';
+import {Buffer} from 'buffer';
+import {Token, u64} from '@solana/spl-token';
+import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import {
@@ -17,8 +17,8 @@ import {
   StakeProgram,
   sendAndConfirmTransaction,
 } from '../src';
-import { DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND } from '../src/timing';
-import { MOCK_PORT, url } from './url';
+import {DEFAULT_TICKS_PER_SLOT, NUM_TICKS_PER_SECOND} from '../src/timing';
+import {MOCK_PORT, url} from './url';
 import {
   BLOCKHASH_CACHE_TIMEOUT_MS,
   Commitment,
@@ -27,7 +27,7 @@ import {
   InflationGovernor,
   SlotInfo,
 } from '../src/connection';
-import { sleep } from '../src/util/sleep';
+import {sleep} from '../src/util/sleep';
 import {
   helpers,
   mockErrorMessage,
@@ -36,8 +36,8 @@ import {
   mockRpcResponse,
   mockServer,
 } from './mocks/rpc-http';
-import { stubRpcWebSocket, restoreRpcWebSocket } from './mocks/rpc-websockets';
-import type { TransactionSignature } from '../src/transaction';
+import {stubRpcWebSocket, restoreRpcWebSocket} from './mocks/rpc-websockets';
+import type {TransactionSignature} from '../src/transaction';
 import type {
   SignatureStatus,
   TransactionError,
@@ -93,7 +93,7 @@ describe('Connection', () => {
 
     await mockRpcResponse({
       method: 'getAccountInfo',
-      params: [account.publicKey.toBase58(), { encoding: 'base64' }],
+      params: [account.publicKey.toBase58(), {encoding: 'base64'}],
       value: null,
       withContext: true,
     });
@@ -102,7 +102,7 @@ describe('Connection', () => {
 
     await mockRpcResponse({
       method: 'getAccountInfo',
-      params: [account.publicKey.toBase58(), { encoding: 'jsonParsed' }],
+      params: [account.publicKey.toBase58(), {encoding: 'jsonParsed'}],
       value: null,
       withContext: true,
     });
@@ -160,7 +160,7 @@ describe('Connection', () => {
       });
     }
 
-    const feeCalculator = (await helpers.recentBlockhash({ connection }))
+    const feeCalculator = (await helpers.recentBlockhash({connection}))
       .feeCalculator;
 
     {
@@ -168,7 +168,7 @@ describe('Connection', () => {
         method: 'getProgramAccounts',
         params: [
           programId.publicKey.toBase58(),
-          { commitment: 'confirmed', encoding: 'base64' },
+          {commitment: 'confirmed', encoding: 'base64'},
         ],
         value: [
           {
@@ -219,7 +219,7 @@ describe('Connection', () => {
         method: 'getProgramAccounts',
         params: [
           programId.publicKey.toBase58(),
-          { commitment: 'confirmed', encoding: 'jsonParsed' },
+          {commitment: 'confirmed', encoding: 'jsonParsed'},
         ],
         value: [
           {
@@ -316,7 +316,7 @@ describe('Connection', () => {
   it('get epoch info', async () => {
     await mockRpcResponse({
       method: 'getEpochInfo',
-      params: [{ commitment: 'confirmed' }],
+      params: [{commitment: 'confirmed'}],
       value: {
         epoch: 0,
         slotIndex: 1,
@@ -539,7 +539,7 @@ describe('Connection', () => {
               fee: 10000,
               postBalances: [499260347380, 15298080, 1, 1, 1],
               preBalances: [499260357380, 15298080, 1, 1, 1],
-              status: { Ok: null },
+              status: {Ok: null},
               err: null,
             },
             transaction: {
@@ -626,7 +626,7 @@ describe('Connection', () => {
     // getConfirmedSignaturesForAddress2 tests...
     await mockRpcResponse({
       method: 'getConfirmedSignaturesForAddress2',
-      params: [address.toBase58(), { limit: 1 }],
+      params: [address.toBase58(), {limit: 1}],
       value: [
         {
           signature: expectedSignature,
@@ -639,7 +639,7 @@ describe('Connection', () => {
 
     const confirmedSignatures2 = await connection.getConfirmedSignaturesForAddress2(
       address,
-      { limit: 1 },
+      {limit: 1},
     );
     expect(confirmedSignatures2).to.have.length(1);
     if (mockServer) {
@@ -665,7 +665,6 @@ describe('Connection', () => {
     let slot = 0;
     let confirmedTransactions = [];
     while (confirmedTransactions.length < 2) {
-
       await mockRpcResponse({
         method: 'getConfirmedBlock',
         params: [++slot],
@@ -680,7 +679,7 @@ describe('Connection', () => {
                 fee: 10000,
                 postBalances: [499260347380, 15298080, 1, 1, 1],
                 preBalances: [499260357380, 15298080, 1, 1, 1],
-                status: { Ok: null },
+                status: {Ok: null},
                 err: null,
               },
               transaction: {
@@ -705,7 +704,8 @@ describe('Connection', () => {
                       programIdIndex: 4,
                     },
                   ],
-                  recentBlockhash: 'GeyAFFRY3WGpmam2hbgrKw4rbU2RKzfVLm5QLSeZwTZE',
+                  recentBlockhash:
+                    'GeyAFFRY3WGpmam2hbgrKw4rbU2RKzfVLm5QLSeZwTZE',
                 },
                 signatures: [
                   'w2Zeq8YkpyB463DttvfzARD7k9ZxGEwbsEw4boEK7jDp3pfoxZbTdLFSsEPhzXhpCcjGi2kHtHFobgX49MMhbWt',
@@ -926,7 +926,7 @@ describe('Connection', () => {
               fee: 10000,
               postBalances: [499260347380, 15298080, 1, 1, 1],
               preBalances: [499260357380, 15298080, 1, 1, 1],
-              status: { Ok: null },
+              status: {Ok: null},
               err: null,
             },
             transaction: {
@@ -1014,7 +1014,7 @@ describe('Connection', () => {
           fee: 10000,
           postBalances: [499260347380, 15298080, 1, 1, 1],
           preBalances: [499260357380, 15298080, 1, 1, 1],
-          status: { Ok: null },
+          status: {Ok: null},
           err: null,
         },
       },
@@ -1099,7 +1099,7 @@ describe('Connection', () => {
                 instructions: [inner],
               },
             ],
-            status: { Ok: null },
+            status: {Ok: null},
             err: null,
           },
         };
@@ -1201,7 +1201,7 @@ describe('Connection', () => {
               fee: 10000,
               postBalances: [499260347380, 15298080, 1, 1, 1],
               preBalances: [499260357380, 15298080, 1, 1, 1],
-              status: { Ok: null },
+              status: {Ok: null},
               err: null,
             },
             transaction: {
@@ -1269,7 +1269,7 @@ describe('Connection', () => {
   it('get recent blockhash', async () => {
     const commitments: Commitment[] = ['processed', 'confirmed', 'finalized'];
     for (const commitment of commitments) {
-      const { blockhash, feeCalculator } = await helpers.recentBlockhash({
+      const {blockhash, feeCalculator} = await helpers.recentBlockhash({
         connection,
         commitment,
       });
@@ -1279,10 +1279,10 @@ describe('Connection', () => {
   });
 
   it('get fee calculator', async () => {
-    const { blockhash } = await helpers.recentBlockhash({ connection });
+    const {blockhash} = await helpers.recentBlockhash({connection});
     await mockRpcResponse({
       method: 'getFeeCalculatorForBlockhash',
-      params: [blockhash, { commitment: 'confirmed' }],
+      params: [blockhash, {commitment: 'confirmed'}],
       value: {
         feeCalculator: {
           lamportsPerSignature: 5000,
@@ -1496,7 +1496,7 @@ describe('Connection', () => {
           expect(parsedTx).not.to.be.null;
           return;
         }
-        const { signatures, message } = parsedTx.transaction;
+        const {signatures, message} = parsedTx.transaction;
         expect(signatures[0]).to.eq(testSignature);
         const ix = message.instructions[0];
         if ('parsed' in ix) {
@@ -1546,7 +1546,7 @@ describe('Connection', () => {
         const tokenAccounts = await connection.getParsedProgramAccounts(
           TOKEN_PROGRAM_ID,
         );
-        tokenAccounts.forEach(({ account }) => {
+        tokenAccounts.forEach(({account}) => {
           expect(account.owner).to.eql(TOKEN_PROGRAM_ID);
           const data = account.data;
           if (data instanceof Buffer) {
@@ -1564,7 +1564,7 @@ describe('Connection', () => {
             mint: testToken.publicKey,
           })
         ).value;
-        tokenAccounts.forEach(({ account }) => {
+        tokenAccounts.forEach(({account}) => {
           expect(account.owner).to.eql(TOKEN_PROGRAM_ID);
           const data = account.data;
           if (data instanceof Buffer) {
@@ -1652,7 +1652,7 @@ describe('Connection', () => {
     await mockRpcResponse({
       method: 'getStakeActivation',
       params: [publicKey.toBase58(), {}],
-      error: { message: 'account not delegated' },
+      error: {message: 'account not delegated'},
     });
 
     await expect(connection.getStakeActivation(publicKey)).to.be.rejected;
@@ -1761,7 +1761,7 @@ describe('Connection', () => {
     await mockRpcResponse({
       method: 'getVersion',
       params: [],
-      value: { 'solana-core': '0.20.4' },
+      value: {'solana-core': '0.20.4'},
     });
 
     const version = await connection.getVersion();
@@ -1779,7 +1779,7 @@ describe('Connection', () => {
 
     await mockRpcResponse({
       method: 'getBalance',
-      params: [account.publicKey.toBase58(), { commitment: 'confirmed' }],
+      params: [account.publicKey.toBase58(), {commitment: 'confirmed'}],
       value: LAMPORTS_PER_SOL,
       withContext: true,
     });
@@ -1791,7 +1791,7 @@ describe('Connection', () => {
       method: 'getAccountInfo',
       params: [
         account.publicKey.toBase58(),
-        { commitment: 'confirmed', encoding: 'base64' },
+        {commitment: 'confirmed', encoding: 'base64'},
       ],
       value: {
         owner: '11111111111111111111111111111111',
@@ -1819,7 +1819,7 @@ describe('Connection', () => {
       method: 'getAccountInfo',
       params: [
         account.publicKey.toBase58(),
-        { commitment: 'confirmed', encoding: 'jsonParsed' },
+        {commitment: 'confirmed', encoding: 'jsonParsed'},
       ],
       value: {
         owner: '11111111111111111111111111111111',
@@ -1874,7 +1874,7 @@ describe('Connection', () => {
     });
 
     // This should fail because the account is already created
-    const expectedErr = { InstructionError: [0, { Custom: 0 }] };
+    const expectedErr = {InstructionError: [0, {Custom: 0}]};
     const confirmResult = (
       await helpers.processTransaction({
         connection,
@@ -1895,7 +1895,7 @@ describe('Connection', () => {
         {
           slot: 0,
           confirmations: 11,
-          status: { Err: expectedErr },
+          status: {Err: expectedErr},
           err: expectedErr,
         },
       ],
@@ -1939,7 +1939,7 @@ describe('Connection', () => {
         connection,
         transaction,
         [accountFrom],
-        { preflightCommitment: 'confirmed' },
+        {preflightCommitment: 'confirmed'},
       );
 
       // Send again and ensure that new blockhash is used
@@ -1956,7 +1956,7 @@ describe('Connection', () => {
         connection,
         transaction2,
         [accountFrom],
-        { preflightCommitment: 'confirmed' },
+        {preflightCommitment: 'confirmed'},
       );
 
       expect(signature).not.to.eq(signature2);
@@ -2058,7 +2058,7 @@ describe('Connection', () => {
       signature = await connection.sendTransaction(
         transaction,
         [accountFrom, accountTo],
-        { skipPreflight: true },
+        {skipPreflight: true},
       );
 
       await connection.confirmTransaction(signature);


### PR DESCRIPTION
#### Problem
There is not currently support for fetching many confirmed transactions at once.

#### Summary of Changes
This solution uses batched JSON-RPC requests to query getConfirmedTransaction.
