### PR TITLE
program-test: Fix warp and staking issue

### DIFF
--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -164,6 +164,8 @@ async fn stake_rewards_from_warp() {
     let program_test = ProgramTest::default();
 
     let mut context = program_test.start_with_context().await;
+    // warp once to make sure stake config doesn't get rent-collected
+    context.warp_to_slot(100).unwrap();
     let mut instructions = vec![];
     let validator_keypair = Keypair::new();
     instructions.push(system_instruction::create_account(


### PR DESCRIPTION
#### Problem

Since program-test creates a test genesis and then modifies fees and rent,
some of the genesis accounts get rent-collected after warping.  Most
notably, `StakeConfig` gets rent-collected, causing any stake operations
to fail after warp.

#### Summary of Changes

Create genesis with the `Rent` and `FeeRateGovernor` actually used by the bank, which automatically puts enough lamports in the genesis accounts.

Fixes #

cc @ysavchenko