### PR TITLE
Explorer: upgradeable loader buffer data and program data display

### DIFF
--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -295,13 +295,14 @@ function DataContainer({
       <div className="container">
         <div className="header">
           <div className="header-body">
-            <Copyable text={data} />
-            <h3
-              className="card-header-title"
-              style={{ display: "inline-block" }}
-            >
-              {title} <small className="text-muted">({type})</small>
-            </h3>
+            <Copyable text={data}>
+              <h3
+                className="card-header-title"
+                style={{ display: "inline-block" }}
+              >
+                {title} <small className="text-muted">({type})</small>
+              </h3>
+            </Copyable>
           </div>
         </div>
       </div>

--- a/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
+++ b/explorer/src/components/account/UpgradeableLoaderAccountSection.tsx
@@ -13,6 +13,7 @@ import { Slot } from "components/common/Slot";
 import { addressLabel } from "utils/tx";
 import { useCluster } from "providers/cluster";
 import { ErrorCard } from "components/common/ErrorCard";
+import { Copyable } from "components/common/Copyable";
 
 export function UpgradeableLoaderAccountSection({
   account,
@@ -145,61 +146,68 @@ export function UpgradeableProgramDataSection({
 }) {
   const refresh = useFetchAccountInfo();
   return (
-    <div className="card">
-      <div className="card-header">
-        <h3 className="card-header-title mb-0 d-flex align-items-center">
-          Program Executable Data Account
-        </h3>
-        <button
-          className="btn btn-white btn-sm"
-          onClick={() => refresh(account.pubkey)}
-        >
-          <span className="fe fe-refresh-cw mr-2"></span>
-          Refresh
-        </button>
-      </div>
+    <>
+      <div className="card">
+        <div className="card-header">
+          <h3 className="card-header-title mb-0 d-flex align-items-center">
+            Program Executable Data Account
+          </h3>
+          <button
+            className="btn btn-white btn-sm"
+            onClick={() => refresh(account.pubkey)}
+          >
+            <span className="fe fe-refresh-cw mr-2"></span>
+            Refresh
+          </button>
+        </div>
 
-      <TableCardBody>
-        <tr>
-          <td>Address</td>
-          <td className="text-lg-right">
-            <Address pubkey={account.pubkey} alignRight raw />
-          </td>
-        </tr>
-        <tr>
-          <td>Balance (SOL)</td>
-          <td className="text-lg-right text-uppercase">
-            {lamportsToSolString(account.lamports || 0)}
-          </td>
-        </tr>
-        {account.details?.space !== undefined && (
+        <TableCardBody>
           <tr>
-            <td>Data (Bytes)</td>
-            <td className="text-lg-right">{account.details.space}</td>
-          </tr>
-        )}
-        <tr>
-          <td>Upgradeable</td>
-          <td className="text-lg-right">
-            {programData.authority !== null ? "Yes" : "No"}
-          </td>
-        </tr>
-        <tr>
-          <td>Last Deployed Slot</td>
-          <td className="text-lg-right">
-            <Slot slot={programData.slot} link />
-          </td>
-        </tr>
-        {programData.authority !== null && (
-          <tr>
-            <td>Upgrade Authority</td>
+            <td>Address</td>
             <td className="text-lg-right">
-              <Address pubkey={programData.authority} alignRight link />
+              <Address pubkey={account.pubkey} alignRight raw />
             </td>
           </tr>
-        )}
-      </TableCardBody>
-    </div>
+          <tr>
+            <td>Balance (SOL)</td>
+            <td className="text-lg-right text-uppercase">
+              {lamportsToSolString(account.lamports || 0)}
+            </td>
+          </tr>
+          {account.details?.space !== undefined && (
+            <tr>
+              <td>Data (Bytes)</td>
+              <td className="text-lg-right">{account.details.space}</td>
+            </tr>
+          )}
+          <tr>
+            <td>Upgradeable</td>
+            <td className="text-lg-right">
+              {programData.authority !== null ? "Yes" : "No"}
+            </td>
+          </tr>
+          <tr>
+            <td>Last Deployed Slot</td>
+            <td className="text-lg-right">
+              <Slot slot={programData.slot} link />
+            </td>
+          </tr>
+          {programData.authority !== null && (
+            <tr>
+              <td>Upgrade Authority</td>
+              <td className="text-lg-right">
+                <Address pubkey={programData.authority} alignRight link />
+              </td>
+            </tr>
+          )}
+        </TableCardBody>
+      </div>
+      <DataContainer
+        title="Program Data"
+        data={programData.data[0]}
+        type={programData.data[1]}
+      />
+    </>
   );
 }
 
@@ -212,56 +220,94 @@ export function UpgradeableProgramBufferSection({
 }) {
   const refresh = useFetchAccountInfo();
   return (
-    <div className="card">
-      <div className="card-header">
-        <h3 className="card-header-title mb-0 d-flex align-items-center">
-          Program Deploy Buffer Account
-        </h3>
-        <button
-          className="btn btn-white btn-sm"
-          onClick={() => refresh(account.pubkey)}
-        >
-          <span className="fe fe-refresh-cw mr-2"></span>
-          Refresh
-        </button>
-      </div>
+    <>
+      <div className="card">
+        <div className="card-header">
+          <h3 className="card-header-title mb-0 d-flex align-items-center">
+            Program Deploy Buffer Account
+          </h3>
+          <button
+            className="btn btn-white btn-sm"
+            onClick={() => refresh(account.pubkey)}
+          >
+            <span className="fe fe-refresh-cw mr-2"></span>
+            Refresh
+          </button>
+        </div>
 
-      <TableCardBody>
-        <tr>
-          <td>Address</td>
-          <td className="text-lg-right">
-            <Address pubkey={account.pubkey} alignRight raw />
-          </td>
-        </tr>
-        <tr>
-          <td>Balance (SOL)</td>
-          <td className="text-lg-right text-uppercase">
-            {lamportsToSolString(account.lamports || 0)}
-          </td>
-        </tr>
-        {account.details?.space !== undefined && (
+        <TableCardBody>
           <tr>
-            <td>Data (Bytes)</td>
-            <td className="text-lg-right">{account.details.space}</td>
-          </tr>
-        )}
-        {programBuffer.authority !== null && (
-          <tr>
-            <td>Deploy Authority</td>
+            <td>Address</td>
             <td className="text-lg-right">
-              <Address pubkey={programBuffer.authority} alignRight link />
+              <Address pubkey={account.pubkey} alignRight raw />
             </td>
           </tr>
-        )}
-        {account.details && (
           <tr>
-            <td>Owner</td>
-            <td className="text-lg-right">
-              <Address pubkey={account.details.owner} alignRight link />
+            <td>Balance (SOL)</td>
+            <td className="text-lg-right text-uppercase">
+              {lamportsToSolString(account.lamports || 0)}
             </td>
           </tr>
-        )}
-      </TableCardBody>
-    </div>
+          {account.details?.space !== undefined && (
+            <tr>
+              <td>Data (Bytes)</td>
+              <td className="text-lg-right">{account.details.space}</td>
+            </tr>
+          )}
+          {programBuffer.authority !== null && (
+            <tr>
+              <td>Deploy Authority</td>
+              <td className="text-lg-right">
+                <Address pubkey={programBuffer.authority} alignRight link />
+              </td>
+            </tr>
+          )}
+          {account.details && (
+            <tr>
+              <td>Owner</td>
+              <td className="text-lg-right">
+                <Address pubkey={account.details.owner} alignRight link />
+              </td>
+            </tr>
+          )}
+        </TableCardBody>
+      </div>
+      <DataContainer
+        title="Buffer Data"
+        data={programBuffer.data[0]}
+        type={programBuffer.data[1]}
+      />
+    </>
+  );
+}
+
+function DataContainer({
+  title,
+  data,
+  type,
+}: {
+  title: string;
+  data: string;
+  type: string;
+}) {
+  return (
+    <>
+      <div className="container">
+        <div className="header">
+          <div className="header-body">
+            <Copyable text={data} />
+            <h3
+              className="card-header-title"
+              style={{ display: "inline-block" }}
+            >
+              {title} <small className="text-muted">({type})</small>
+            </h3>
+          </div>
+        </div>
+      </div>
+      <div className="card">
+        <div className="data-view">{data}</div>
+      </div>
+    </>
   );
 }

--- a/explorer/src/components/common/Copyable.tsx
+++ b/explorer/src/components/common/Copyable.tsx
@@ -8,7 +8,7 @@ export function Copyable({
   replaceText,
 }: {
   text: string;
-  children?: ReactNode;
+  children: ReactNode;
   replaceText?: boolean;
 }) {
   const [state, setState] = useState<CopyState>("copy");
@@ -60,7 +60,7 @@ export function Copyable({
             <CopyIcon />
           </span>
         </span>
-        {children && children}
+        {children}
       </>
     );
   }

--- a/explorer/src/components/common/Copyable.tsx
+++ b/explorer/src/components/common/Copyable.tsx
@@ -8,7 +8,7 @@ export function Copyable({
   replaceText,
 }: {
   text: string;
-  children: ReactNode;
+  children?: ReactNode;
   replaceText?: boolean;
 }) {
   const [state, setState] = useState<CopyState>("copy");
@@ -60,7 +60,7 @@ export function Copyable({
             <CopyIcon />
           </span>
         </span>
-        {children}
+        {children && children}
       </>
     );
   }

--- a/explorer/src/components/transaction/ProgramLogSection.tsx
+++ b/explorer/src/components/transaction/ProgramLogSection.tsx
@@ -20,7 +20,7 @@ export function ProgramLogSection({ signature }: SignatureProps) {
         </div>
       </div>
       <div className="card">
-        <ul className="log-messages">
+        <ul className="data-view log-messages">
           {logMessages.map((message, key) => (
             <li key={key}>{message.replace(/^Program log: /, "")}</li>
           ))}

--- a/explorer/src/scss/_solana-dark-overrides.scss
+++ b/explorer/src/scss/_solana-dark-overrides.scss
@@ -8,7 +8,7 @@ code, pre {
   color: $white;
 }
 
-ul.log-messages {
+.data-view {
   background-color: $black-dark;
   color: $white;
 }

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -10,18 +10,22 @@ code, pre {
   color: $black;
 }
 
-ul.log-messages {
+.data-view {
   padding: 0.66rem;
   margin: 1rem;
   border-radius: $border-radius;
   background-color: $gray-200;
   color: $black;
-  list-style: none;
   min-height: 12.5rem;
   max-height: 20rem;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   font-size: 0.8125rem;
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+ul.log-messages {
+  list-style: none;
 }
 
 .popover-container {

--- a/explorer/src/validators/accounts/upgradeable-program.ts
+++ b/explorer/src/validators/accounts/upgradeable-program.ts
@@ -9,6 +9,8 @@ import {
   union,
   coerce,
   create,
+  array,
+  string,
 } from "superstruct";
 import { ParsedInfo } from "validators";
 import { PublicKeyFromString } from "validators/pubkey";
@@ -27,7 +29,7 @@ export const ProgramAccount = type({
 export type ProgramDataAccountInfo = Infer<typeof ProgramDataAccountInfo>;
 export const ProgramDataAccountInfo = type({
   authority: nullable(PublicKeyFromString),
-  // don't care about data yet
+  data: array(string()),
   slot: number(),
 });
 
@@ -40,7 +42,7 @@ export const ProgramDataAccount = type({
 export type ProgramBufferAccountInfo = Infer<typeof ProgramBufferAccountInfo>;
 export const ProgramBufferAccountInfo = type({
   authority: nullable(PublicKeyFromString),
-  // don't care about data yet
+  data: array(string()),
 });
 
 export type ProgramBufferAccount = Infer<typeof ProgramBufferAccount>;


### PR DESCRIPTION
#### Problem
The various accounts involved with a deployed upgradeable program are mysterious on the explorer.
Example (buffer account): https://explorer.solana.com/address/B8Qe8miJufJQcZMqSGoRGNGscrzcgrKjQFoU7fWjbP1q?cluster=devnet

#### Summary of Changes
Display data, data type, and allow user to copy. 

Fixes https://github.com/solana-labs/solana/issues/15198