### PR TITLE
Explorer: confirmed block timestamp tooltip was incorrect

### DIFF
--- a/explorer/src/pages/TransactionDetailsPage.tsx
+++ b/explorer/src/pages/TransactionDetailsPage.tsx
@@ -244,7 +244,7 @@ function StatusCard({
               <InfoTooltip
                 bottom
                 right
-                text="Timestamps are available for confirmed blocks within the past 5 epochs"
+                text="Timestamps are only available for confirmed blocks"
               >
                 Unavailable
               </InfoTooltip>


### PR DESCRIPTION
#### Problem
This is no longer true:
<img width="272" alt="Screen Shot 2021-02-26 at 7 36 30 PM" src="https://user-images.githubusercontent.com/3030561/109373075-0fb02280-786a-11eb-9248-5b5f393d51b3.png">

#### Summary of Changes
Updated to: Timestamps are only available for confirmed blocks

Fixes https://github.com/solana-labs/solana/issues/15572