### PR TITLE
Add GetSlotLeaders RPC method

### DIFF
--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -39,6 +39,7 @@ pub enum RpcRequest {
     GetSignatureStatuses,
     GetSlot,
     GetSlotLeader,
+    GetSlotLeaders,
     GetStorageTurn,
     GetStorageTurnRate,
     GetSlotsPerSegment,
@@ -96,6 +97,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetSignatureStatuses => "getSignatureStatuses",
             RpcRequest::GetSlot => "getSlot",
             RpcRequest::GetSlotLeader => "getSlotLeader",
+            RpcRequest::GetSlotLeaders => "getSlotLeaders",
             RpcRequest::GetStorageTurn => "getStorageTurn",
             RpcRequest::GetStorageTurnRate => "getStorageTurnRate",
             RpcRequest::GetSlotsPerSegment => "getSlotsPerSegment",
@@ -128,6 +130,7 @@ pub const MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS2_LIMIT: usize = 1_000;
 pub const MAX_MULTIPLE_ACCOUNTS: usize = 100;
 pub const NUM_LARGEST_ACCOUNTS: usize = 20;
 pub const MAX_GET_PROGRAM_ACCOUNT_FILTERS: usize = 4;
+pub const MAX_GET_SLOT_LEADERS: usize = 5000;
 
 // Validators that are this number of slots behind are considered delinquent
 pub const DELINQUENT_VALIDATOR_SLOT_DISTANCE: u64 = 128;

--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -18,7 +18,7 @@ use jsonrpc_http_server::{
 };
 use regex::Regex;
 use solana_client::rpc_cache::LargestAccountsCache;
-use solana_ledger::blockstore::Blockstore;
+use solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache};
 use solana_metrics::inc_new_counter_info;
 use solana_runtime::{
     bank_forks::{BankForks, SnapshotConfig},
@@ -275,6 +275,7 @@ impl JsonRpcService {
         send_transaction_retry_ms: u64,
         send_transaction_leader_forward_count: u64,
         max_slots: Arc<MaxSlots>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -354,6 +355,7 @@ impl JsonRpcService {
             optimistically_confirmed_bank,
             largest_accounts_cache,
             max_slots,
+            leader_schedule_cache,
         );
 
         let leader_info =
@@ -518,6 +520,7 @@ mod tests {
             1000,
             1,
             Arc::new(MaxSlots::default()),
+            Arc::new(LeaderScheduleCache::default()),
         );
         let thread = rpc_service.thread_hdl.thread();
         assert_eq!(thread.name().unwrap(), "solana-jsonrpc");

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -541,6 +541,7 @@ impl Validator {
                     config.send_transaction_retry_ms,
                     config.send_transaction_leader_forward_count,
                     max_slots.clone(),
+                    leader_schedule_cache.clone(),
                 )),
                 if config.rpc_config.minimal_api {
                     None

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -52,6 +52,7 @@ gives a convenient interface for the RPC methods.
 - [getSignatureStatuses](jsonrpc-api.md#getsignaturestatuses)
 - [getSlot](jsonrpc-api.md#getslot)
 - [getSlotLeader](jsonrpc-api.md#getslotleader)
+- [getSlotLeaders](jsonrpc-api.md#getslotleaders)
 - [getStakeActivation](jsonrpc-api.md#getstakeactivation)
 - [getSupply](jsonrpc-api.md#getsupply)
 - [getTokenAccountBalance](jsonrpc-api.md#gettokenaccountbalance)
@@ -2250,6 +2251,53 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
 Result:
 ```json
 {"jsonrpc":"2.0","result":"ENvAW7JScgYq6o4zKZwewtkzzJgDzuJAFxYasvmEQdpS","id":1}
+```
+
+### getSlotLeaders
+
+Returns the slot leaders for a given slot range
+
+#### Parameters:
+
+- `<u64>` - Start slot, as u64 integer
+- `<u64>` - Limit, as u64 integer
+
+#### Results:
+
+- `<array<string>>` - Node identity public keys as base-58 encoded strings
+
+#### Example:
+
+If the current slot is #99, query the next 10 leaders with the following request:
+
+Request:
+```bash
+curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
+  {"jsonrpc":"2.0","id":1, "method":"getSlotLeaders", "params":[100, 10]}
+'
+```
+
+Result:
+
+The first leader returned is the leader for slot #100:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": [
+    "ChorusmmK7i1AxXeiTtQgQZhQNiXYU84ULeaYF1EH15n",
+    "ChorusmmK7i1AxXeiTtQgQZhQNiXYU84ULeaYF1EH15n",
+    "ChorusmmK7i1AxXeiTtQgQZhQNiXYU84ULeaYF1EH15n",
+    "ChorusmmK7i1AxXeiTtQgQZhQNiXYU84ULeaYF1EH15n",
+    "Awes4Tr6TX8JDzEhCZY2QVNimT6iD1zWHzf1vNyGvpLM",
+    "Awes4Tr6TX8JDzEhCZY2QVNimT6iD1zWHzf1vNyGvpLM",
+    "Awes4Tr6TX8JDzEhCZY2QVNimT6iD1zWHzf1vNyGvpLM",
+    "Awes4Tr6TX8JDzEhCZY2QVNimT6iD1zWHzf1vNyGvpLM",
+    "DWvDTSh3qfn88UoQTEKRV2JnLt5jtJAVoiCo3ivtMwXP",
+    "DWvDTSh3qfn88UoQTEKRV2JnLt5jtJAVoiCo3ivtMwXP"
+  ],
+  "id": 1
+}
 ```
 
 ### getStakeActivation

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -195,6 +195,10 @@ impl LeaderScheduleCache {
         }
     }
 
+    pub fn get_epoch_leader_schedule(&self, epoch: Epoch) -> Option<Arc<LeaderSchedule>> {
+        self.cached_schedules.read().unwrap().0.get(&epoch).cloned()
+    }
+
     fn get_epoch_schedule_else_compute(
         &self,
         epoch: Epoch,
@@ -205,8 +209,7 @@ impl LeaderScheduleCache {
                 return Some(fixed_schedule.leader_schedule.clone());
             }
         }
-        let epoch_schedule = self.cached_schedules.read().unwrap().0.get(&epoch).cloned();
-
+        let epoch_schedule = self.get_epoch_leader_schedule(epoch);
         if epoch_schedule.is_some() {
             epoch_schedule
         } else if let Some(epoch_schedule) = self.compute_epoch_schedule(epoch, bank) {


### PR DESCRIPTION
#### Problem
No way to get the upcoming leaders without fetching the entire leader schedule. It's also a pain for clients to get upcoming leaders across epoch boundaries.

#### Summary of Changes
- Add new `getSlotLeaders` method which is similar to `getSlotLeader` but fetches leaders for a given slot range
- Use leader schedule cache to avoid expensive leader schedule computation and reduce memory overhead

Fixes https://github.com/solana-labs/solana/issues/16048
