### PR TITLE
solana transfer now requires --allow-unfunded-recipient if the recipient doesn't exist

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1157,7 +1157,7 @@ fn process_transfer(
     let (recent_blockhash, fee_calculator) =
         blockhash_query.get_blockhash_and_fee_calculator(rpc_client, config.commitment)?;
 
-    if !allow_unfunded_recipient {
+    if !sign_only && !allow_unfunded_recipient {
         let recipient_balance = rpc_client
             .get_balance_with_commitment(to, config.commitment)?
             .value;

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -294,6 +294,7 @@ fn test_create_account_with_seed() {
         from: 0,
         sign_only: true,
         dump_transaction_message: true,
+        allow_unfunded_recipient: true,
         no_wait: false,
         blockhash_query: BlockhashQuery::None(nonce_hash),
         nonce_account: Some(nonce_address),
@@ -318,6 +319,7 @@ fn test_create_account_with_seed() {
         from: 0,
         sign_only: false,
         dump_transaction_message: true,
+        allow_unfunded_recipient: true,
         no_wait: false,
         blockhash_query: BlockhashQuery::FeeCalculator(
             blockhash_query::Source::NonceAccount(nonce_address),

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -72,6 +72,7 @@ fn test_vote_authorize_and_withdraw() {
         from: 0,
         sign_only: false,
         dump_transaction_message: false,
+        allow_unfunded_recipient: true,
         no_wait: false,
         blockhash_query: BlockhashQuery::All(blockhash_query::Source::Cluster),
         nonce_account: None,

--- a/docs/src/cli/transfer-tokens.md
+++ b/docs/src/cli/transfer-tokens.md
@@ -71,7 +71,7 @@ with the private keypair corresponding to the sender's public key in the
 transaction.
 
 ```bash
-solana transfer --from <KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> 5 --url https://devnet.solana.com --fee-payer <KEYPAIR>
+solana transfer --from <KEYPAIR> <RECIPIENT_ACCOUNT_ADDRESS> 5 --allow-unfunded-recipient --url https://devnet.solana.com --fee-payer <KEYPAIR>
 ```
 
 where you replace `<KEYPAIR>` with the path to a keypair in your first wallet,
@@ -118,7 +118,7 @@ Save this seed phrase to recover your new keypair:
 clump panic cousin hurt coast charge engage fall eager urge win love   # If this was a real wallet, never share these words on the internet like this!
 ====================================================================
 
-$ solana transfer --from my_solana_wallet.json 7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv 5 --url https://devnet.solana.com --fee-payer my_solana_wallet.json  # Transferring tokens to the public address of the paper wallet
+$ solana transfer --from my_solana_wallet.json 7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv 5 --allow-unfunded-recipient --url https://devnet.solana.com --fee-payer my_solana_wallet.json  # Transferring tokens to the public address of the paper wallet
 3gmXvykAd1nCQQ7MjosaHLf69Xyaqyq1qw2eu1mgPyYXd5G4v1rihhg1CiRw35b9fHzcftGKKEu4mbUeXY2pEX2z  # This is the transaction signature
 
 $ solana balance DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK --url https://devnet.solana.com

--- a/docs/src/integrations/exchange.md
+++ b/docs/src/integrations/exchange.md
@@ -388,7 +388,7 @@ will wait and track progress on stderr until the transaction has been finalized
 by the cluster. If the transaction fails, it will report any transaction errors.
 
 ```bash
-solana transfer <USER_ADDRESS> <AMOUNT> --keypair <KEYPAIR> --url http://localhost:8899
+solana transfer <USER_ADDRESS> <AMOUNT> --allow-unfunded-recipient --keypair <KEYPAIR> --url http://localhost:8899
 ```
 
 The [Solana Javascript SDK](https://github.com/solana-labs/solana-web3.js)
@@ -420,7 +420,7 @@ In the command-line tool, pass the `--no-wait` argument to send a transfer
 asynchronously, and include your recent blockhash with the `--blockhash` argument:
 
 ```bash
-solana transfer <USER_ADDRESS> <AMOUNT> --no-wait --blockhash <RECENT_BLOCKHASH> --keypair <KEYPAIR> --url http://localhost:8899
+solana transfer <USER_ADDRESS> <AMOUNT> --no-wait --allow-unfunded-recipient --blockhash <RECENT_BLOCKHASH> --keypair <KEYPAIR> --url http://localhost:8899
 ```
 
 You can also build, sign, and serialize the transaction manually, and fire it off to

--- a/multinode-demo/delegate-stake.sh
+++ b/multinode-demo/delegate-stake.sh
@@ -102,7 +102,9 @@ if ((airdrops_enabled)); then
     echo "--keypair argument must be provided"
     exit 1
   fi
-  $solana_cli "${common_args[@]}" --keypair "$SOLANA_CONFIG_DIR/faucet.json" transfer "$keypair" "$stake_sol"
+  $solana_cli \
+    "${common_args[@]}" --keypair "$SOLANA_CONFIG_DIR/faucet.json" \
+    transfer --allow-unfunded-recipient "$keypair" "$stake_sol"
 fi
 
 if [[ -n $keypair ]]; then

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -274,7 +274,9 @@ setup_validator_accounts() {
       echo "Adding $node_sol to validator identity account:"
       (
         set -x
-        $solana_cli --keypair "$SOLANA_CONFIG_DIR/faucet.json" --url "$rpc_url" transfer "$identity" "$node_sol"
+        $solana_cli \
+          --keypair "$SOLANA_CONFIG_DIR/faucet.json" --url "$rpc_url" \
+          transfer --allow-unfunded-recipient "$identity" "$node_sol"
       ) || return $?
     fi
 


### PR DESCRIPTION
#### Problem
Users are losing funds because we never implemented https://github.com/solana-labs/solana/issues/6970

#### Summary of Changes
```
$ solana-keygen new -o ./new-account.json
$ solana transfer ./new-account.json 1
Error: The recipient address (9WtBoGqU1PwAvZwRGiS17zEhr8srDw8KdbSMxHkBpQuk) is not funded. Add `--allow-unfunded-recipient` to complete the transfer 
$ solana transfer ./new-account.json 1 --allow-unfunded-recipient
Signature: 4Z8xMnFqQKmHepZg6cotwHXdKJyTAtgv7DdKGWK4Y9aTAfJKTZku1RE56VWH41fx6enwVDaZQ6tgcMU8REmdPzVu
```

This now aligns with how `spl-token transfer` works as well.

#### Migration plan:
* Backport the `--allow-unfunded-recipient` flag to v1.5 as a hidden/ignored argument (https://github.com/solana-labs/solana/pull/16060)
* Update Exchange docs to suggest `--allow-unfunded-recipient` be now used, and update known users
* Backport this full PR to v1.6

This is a breaking change to the CLI, but a loss of funds is worse.
