### PR TITLE
make AccountSharedData.data private to abstract storage

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -22,7 +22,7 @@ use solana_runtime::{
     },
 };
 use solana_sdk::{
-    account::AccountSharedData,
+    account::{AccountSharedData, ReadableAccount},
     bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
     client::SyncClient,
     clock::{DEFAULT_SLOTS_PER_EPOCH, MAX_PROCESSING_AGE},

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -990,10 +990,10 @@ fn test_program_bpf_invoke_sanity() {
         assert_eq!(invoke_program_id, account.owner);
         assert_eq!(
             MAX_PERMITTED_DATA_INCREASE,
-            bank.get_account(&derived_key1).unwrap().data.len()
+            bank.get_account(&derived_key1).unwrap().data().len()
         );
         for i in 0..20 {
-            assert_eq!(i as u8, account.data[i]);
+            assert_eq!(i as u8, account.data()[i]);
         }
 
         // Attempt to realloc into unauthorized address space

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1559,7 +1559,7 @@ mod tests {
     }
 
     fn truncate_data(account: &mut AccountSharedData, len: usize) {
-        let mut data = account.data.to_vec();
+        let mut data = account.data().to_vec();
         data.truncate(len);
         account.set_data(data);
     }
@@ -3291,7 +3291,11 @@ mod tests {
         );
         assert_eq!(0, buffer_account.borrow().lamports());
         assert_eq!(2, recipient_account.borrow().lamports());
-        assert!(buffer_account.borrow().data.iter().all(|&value| value == 0));
+        assert!(buffer_account
+            .borrow()
+            .data()
+            .iter()
+            .all(|&value| value == 0));
 
         // Case: close with wrong authority
         buffer_account

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -448,7 +448,7 @@ mod tests {
             assert_eq!(account.lamports, de_keyed_account.lamports().unwrap());
             assert_eq!(
                 &account.data()[..],
-                &de_keyed_account.try_account_ref().unwrap().data[..]
+                &de_keyed_account.try_account_ref().unwrap().data()[..]
             );
             assert_eq!(account.owner, de_keyed_account.owner().unwrap());
             assert_eq!(account.executable, de_keyed_account.executable().unwrap());
@@ -507,7 +507,7 @@ mod tests {
             assert_eq!(account.lamports, de_keyed_account.lamports().unwrap());
             assert_eq!(
                 &account.data()[..],
-                &de_keyed_account.try_account_ref().unwrap().data[..]
+                &de_keyed_account.try_account_ref().unwrap().data()[..]
             );
             assert_eq!(account.owner, de_keyed_account.owner().unwrap());
             assert_eq!(account.executable, de_keyed_account.executable().unwrap());

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -413,7 +413,7 @@ pub mod tests {
 
         // Vote account too big
         let cache_data = vote_account.data().to_vec();
-        let mut pushed = vote_account.data.to_vec();
+        let mut pushed = vote_account.data().to_vec();
         pushed.push(0);
         vote_account.set_data(pushed);
         stakes.store(&vote_pubkey, &vote_account, true, true);

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -29,7 +29,7 @@ pub struct AccountSharedData {
     /// lamports in the account
     pub lamports: u64,
     /// data held in this account
-    pub data: Arc<Vec<u8>>,
+    data: Arc<Vec<u8>>,
     /// the program that owns this account. If executable, the program that loads this account.
     pub owner: Pubkey,
     /// this account's data contains a loaded program (and is now read-only)


### PR DESCRIPTION
#### Problem
All the work has been done to allow abstracting/hiding the implementation of the data on an account. Making it private now will retain the ability to change the storage format of an account in the (near?) future.

#### Summary of Changes
make data private. Callers use existing accessor methods.

Fixes #
