### PR TITLE
set target hash/sec to half of capability for auto

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -463,7 +463,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             ClusterType::Development => {
                 let hashes_per_tick =
                     compute_hashes_per_tick(poh_config.target_tick_duration, 1_000_000);
-                poh_config.hashes_per_tick = Some(hashes_per_tick);
+                poh_config.hashes_per_tick = Some(hashes_per_tick / 2); // use 50% of peak ability
             }
             ClusterType::Devnet | ClusterType::Testnet | ClusterType::MainnetBeta => {
                 poh_config.hashes_per_tick = Some(clock::DEFAULT_HASHES_PER_TICK);


### PR DESCRIPTION
#### Problem
Working on poh, slot drift, high tps. In tests like bench-tps, config says auto hashes_per_tick. For auto, we want to use 50% of the ability so we have time for the poh thread to be interrupted with lock contention, waiting on record, tick, etc.
@sakridge wrote this code initially as an experiment.
#### Summary of Changes
set auto hashes/tick to 50% of max
Fixes #
