### PR TITLE
sdk: Add try_from_slice_unchecked for Borsh

### DIFF
--- a/sdk/program/src/borsh.rs
+++ b/sdk/program/src/borsh.rs
@@ -1,7 +1,13 @@
 #![allow(clippy::integer_arithmetic)]
 //! Borsh utils
-use borsh::schema::{BorshSchema, Declaration, Definition, Fields};
-use std::collections::HashMap;
+use {
+    borsh::{
+        maybestd::io::Error,
+        schema::{BorshSchema, Declaration, Definition, Fields},
+        BorshDeserialize,
+    },
+    std::collections::HashMap,
+};
 
 /// Get packed length for the given BorchSchema Declaration
 fn get_declaration_packed_len(
@@ -53,4 +59,11 @@ fn get_declaration_packed_len(
 pub fn get_packed_len<S: BorshSchema>() -> usize {
     let schema_container = S::schema_container();
     get_declaration_packed_len(&schema_container.declaration, &schema_container.definitions)
+}
+
+/// Deserializes without checking that the entire slice has been consumed
+pub fn try_from_slice_unchecked<T: BorshDeserialize>(data: &[u8]) -> Result<T, Error> {
+    let mut data_mut = data;
+    let result = T::deserialize(&mut data_mut)?;
+    Ok(result)
 }

--- a/sdk/program/src/borsh.rs
+++ b/sdk/program/src/borsh.rs
@@ -70,7 +70,7 @@ pub fn get_packed_len<S: BorshSchema>() -> usize {
 /// or equal to the expected size will properly deserialize. For example, if the
 /// user passes a buffer destined for a different type, the error won't get caught
 /// as easily.
-pub fn try_from_slice_unsized<T: BorshDeserialize>(data: &[u8]) -> Result<T, Error> {
+pub fn try_from_slice_unchecked<T: BorshDeserialize>(data: &[u8]) -> Result<T, Error> {
     let mut data_mut = data;
     let result = T::deserialize(&mut data_mut)?;
     Ok(result)
@@ -115,7 +115,7 @@ mod tests {
     }
 
     #[test]
-    fn unsized_deserialization() {
+    fn unchecked_deserialization() {
         let data = vec![
             Child { data: [0u8; 64] },
             Child { data: [1u8; 64] },
@@ -129,16 +129,16 @@ mod tests {
         parent.serialize(&mut bytes).unwrap();
         let deserialized = Parent::try_from_slice(&byte_vec).unwrap();
         assert_eq!(deserialized, parent);
-        let deserialized = try_from_slice_unsized::<Parent>(&byte_vec).unwrap();
+        let deserialized = try_from_slice_unchecked::<Parent>(&byte_vec).unwrap();
         assert_eq!(deserialized, parent);
 
-        // too big, only unsized works
+        // too big, only unchecked works
         let mut byte_vec = vec![0u8; 4 + get_packed_len::<Child>() * 10];
         let mut bytes = byte_vec.as_mut_slice();
         parent.serialize(&mut bytes).unwrap();
         let err = Parent::try_from_slice(&byte_vec).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidData);
-        let deserialized = try_from_slice_unsized::<Parent>(&byte_vec).unwrap();
+        let deserialized = try_from_slice_unchecked::<Parent>(&byte_vec).unwrap();
         assert_eq!(deserialized, parent);
     }
 

--- a/sdk/program/src/borsh.rs
+++ b/sdk/program/src/borsh.rs
@@ -67,3 +67,86 @@ pub fn try_from_slice_unchecked<T: BorshDeserialize>(data: &[u8]) -> Result<T, E
     let result = T::deserialize(&mut data_mut)?;
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        borsh::{maybestd::io::ErrorKind, BorshSchema, BorshSerialize},
+        std::mem::size_of,
+    };
+
+    #[derive(BorshSerialize, BorshDeserialize, BorshSchema)]
+    enum TestEnum {
+        NoValue,
+        Value(u32),
+        StructValue {
+            #[allow(dead_code)]
+            number: u64,
+            #[allow(dead_code)]
+            array: [u8; 8],
+        },
+    }
+
+    #[derive(BorshSerialize, BorshDeserialize, BorshSchema)]
+    struct TestStruct {
+        pub array: [u64; 16],
+        pub number: u128,
+        pub tuple: (u8, u16),
+        pub enumeration: TestEnum,
+    }
+
+    #[derive(Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
+    struct Child {
+        pub data: [u8; 64],
+    }
+
+    #[derive(Debug, PartialEq, BorshSerialize, BorshDeserialize, BorshSchema)]
+    struct Parent {
+        pub data: Vec<Child>,
+    }
+
+    #[test]
+    fn unchecked_deserialization() {
+        let data = vec![
+            Child { data: [0u8; 64] },
+            Child { data: [1u8; 64] },
+            Child { data: [2u8; 64] },
+        ];
+        let parent = Parent { data };
+
+        // exact size, both work
+        let mut byte_vec = vec![0u8; 4 + get_packed_len::<Child>() * 3];
+        let mut bytes = byte_vec.as_mut_slice();
+        parent.serialize(&mut bytes).unwrap();
+        let deserialized = Parent::try_from_slice(&byte_vec).unwrap();
+        assert_eq!(deserialized, parent);
+        let deserialized = try_from_slice_unchecked::<Parent>(&byte_vec).unwrap();
+        assert_eq!(deserialized, parent);
+
+        // too big, only unchecked works
+        let mut byte_vec = vec![0u8; 4 + get_packed_len::<Child>() * 10];
+        let mut bytes = byte_vec.as_mut_slice();
+        parent.serialize(&mut bytes).unwrap();
+        let err = Parent::try_from_slice(&byte_vec).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidData);
+        let deserialized = try_from_slice_unchecked::<Parent>(&byte_vec).unwrap();
+        assert_eq!(deserialized, parent);
+    }
+
+    #[test]
+    fn packed_len() {
+        assert_eq!(
+            get_packed_len::<TestEnum>(),
+            size_of::<u8>() + size_of::<u64>() + size_of::<u8>() * 8
+        );
+        assert_eq!(
+            get_packed_len::<TestStruct>(),
+            size_of::<u64>() * 16
+                + size_of::<u128>()
+                + size_of::<u8>()
+                + size_of::<u16>()
+                + get_packed_len::<TestEnum>()
+        );
+    }
+}


### PR DESCRIPTION
#### Problem

If we're using variable-sized structures on-chain, for example `Vec<>`, and we allocate 1000 bytes and don't immediately use all of them, Borsh fails deserialization because it doesn't read the entire slice.

#### Summary of Changes

Add a helper function.  This is a copy of https://github.com/near/borsh-rs/blob/3223286bae05d29162eaf37512966b9fa7d9cfdb/borsh/src/de/mod.rs#L30 which just removes the `is_empty()` check.

Fixes #
