### PR TITLE
Support getBlockTime for unfinalized blocks

### DIFF
--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -876,7 +876,12 @@ impl JsonRpcRequestProcessor {
             self.check_slot_cleaned_up(&result, slot)?;
             Ok(result.ok().unwrap_or(None))
         } else {
-            Err(RpcCustomError::BlockNotAvailable { slot }.into())
+            let r_bank_forks = self.bank_forks.read().unwrap();
+            if let Some(bank) = r_bank_forks.get(slot) {
+                Ok(Some(bank.clock().unix_timestamp))
+            } else {
+                Err(RpcCustomError::BlockNotAvailable { slot }.into())
+            }
         }
     }
 

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -377,7 +377,7 @@ Result:
 
 ### getBlockTime
 
-Returns the estimated production time of a confirmed block.
+Returns the estimated production time of a block.
 
 Each validator reports their UTC time to the ledger on a regular interval by
 intermittently adding a timestamp to a Vote for a particular block. A requested


### PR DESCRIPTION
#### Problem
The `getBlockTime` rpc only returns successful results for finalized blocks. The node has this data for confirmed and even processed blocks, but it isn't exposed.

#### Summary of Changes
- Return block time data for processed and confirmed blocks as well

Fixes #14870
