### PR TITLE
potentially poll for new records per hash batch

### DIFF
--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -263,13 +263,10 @@ impl PohService {
                     }
                     // check to see if a record request has been sent
                     let get_again = record_receiver.try_recv();
-                    match get_again {
-                        Ok(record) => {
-                            // remember the record we just received as the next record to occur
-                            *next_record = Some(record);
-                            break;
-                        }
-                        Err(_) => (),
+                    if let Ok(record) = get_again {
+                        // remember the record we just received as the next record to occur
+                        *next_record = Some(record);
+                        break;
                     }
                     let delay_start = Instant::now();
                     let mut delay_ns_to_let_wallclock_catchup = poh_l
@@ -290,13 +287,10 @@ impl PohService {
                     loop {
                         // check to see if a record request has been sent
                         let get_again = record_receiver.try_recv();
-                        match get_again {
-                            Ok(record) => {
-                                // remember the record we just received as the next record to occur
-                                *next_record = Some(record);
-                                break;
-                            }
-                            Err(_) => (),
+                        if let Ok(record) = get_again {
+                            // remember the record we just received as the next record to occur
+                            *next_record = Some(record);
+                            break;
                         }
                         let waited_ns = delay_start.elapsed().as_nanos();
                         if waited_ns >= delay_ns_to_let_wallclock_catchup {


### PR DESCRIPTION
#### Problem
We want to improve tps, reduce excessive slot time.
#### Summary of Changes
After every hash batch, check to see if we are running ahead of schedule sufficiently. If so, release the poh lock and poll the record receiver until we are back on schedule (instead of busy waiting). This leaves poh with ticks available throughout the slot time and should greatly reduce any waiting at the end of a slot where we are unable to accept a record. It also means we can respond immediately when a record occurs.
Fixes #
