### PR TITLE
Implement mnemonic support for solana-keygen grind (solana-labs#9325)

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -157,6 +157,14 @@ You can generate a custom vanity keypair using solana-keygen. For instance:
 solana-keygen grind --starts-with e1v1s:1
 ```
 
+You may request that the generated vanity keypair be expressed as a seed phrase
+which allows recovery of the keypair from the seed phrase and an optionally
+supplied passphrase:
+
+```bash
+solana-keygen grind --mnemonic --starts-with e1v1s:1
+```
+
 Depending on the string requested, it may take days to find a match...
 
 ---

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -131,6 +131,39 @@ fn grind_validator_starts_and_ends_with(v: String) -> Result<(), String> {
     Ok(())
 }
 
+fn acquire_language(matches: &ArgMatches<'_>) -> Language {
+    match matches.value_of("language").unwrap() {
+        "english" => Language::English,
+        "chinese-simplified" => Language::ChineseSimplified,
+        "chinese-traditional" => Language::ChineseTraditional,
+        "japanese" => Language::Japanese,
+        "spanish" => Language::Spanish,
+        "korean" => Language::Korean,
+        "french" => Language::French,
+        "italian" => Language::Italian,
+        _ => unreachable!(),
+    }
+}
+
+fn no_passphrase_and_message() -> (String, String) {
+    (NO_PASSPHRASE.to_string(), "".to_string())
+}
+
+fn acquire_passphrase_and_message(matches: &ArgMatches<'_>) -> Result<(String, String), Box<dyn error::Error>> {
+    if matches.is_present("no_passphrase") {
+        Ok(no_passphrase_and_message())
+    } else {
+        match prompt_passphrase(
+            "\nFor added security, enter a BIP39 passphrase\n\
+             \nNOTE! This passphrase improves security of the recovery seed phrase NOT the\n\
+             keypair file itself, which is stored as insecure plain text\n\
+             \nBIP39 Passphrase (empty for none): ") {
+            Ok(passphrase) => { println!(); Ok((passphrase, " and your BIP39 passphrase".to_string())) },
+            Err(e) => Err(e)
+        }
+    }
+}
+
 fn grind_print_info(grind_matches: &[GrindMatch], num_threads: usize) {
     println!("Searching with {} threads for:", num_threads);
     for gm in grind_matches {
@@ -349,7 +382,47 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .validator(is_parsable::<usize>)
                         .default_value(&default_num_threads)
                         .help("Specify the number of grind threads"),
-                ),
+                )
+                .arg(
+                    Arg::with_name("mnemonic")
+                        .long("mnemonic")
+                        .alias("use-mnemonic")
+                        .help("Generate using a mnemonic key phrase"),
+                )
+                .arg(
+                    Arg::with_name("word_count")
+                        .requires_all(&["mnemonic"])
+                        .long("word-count")
+                        .possible_values(&["12", "15", "18", "21", "24"])
+                        .default_value("12")
+                        .value_name("NUMBER")
+                        .takes_value(true)
+                        .help("(requires mnemonic) Specify the number of words that will be present in the generated seed phrase"),
+                )
+                .arg(
+                    Arg::with_name("language")
+                        .requires_all(&["mnemonic"])
+                        .long("language")
+                        .possible_values(&["english", "chinese-simplified", "chinese-traditional", "japanese", "spanish", "korean", "french", "italian"])
+                        .default_value("english")
+                        .value_name("LANGUAGE")
+                        .takes_value(true)
+                        .help("(requires mnemonic) Specify the mnemonic lanaguage that will be present in the generated seed phrase"),
+                )
+                .arg(
+                    Arg::with_name("no_passphrase")
+                        .requires_all(&["mnemonic"])
+                        .long("no-bip39-passphrase")
+                        .alias("no-passphrase")
+                        .help("(requires mnemonic) Do not prompt for a BIP39 passphrase"),
+                )
+                .arg(
+                    Arg::with_name("no_outfile")
+                        .requires_all(&["mnemonic"])
+                        .long("no-outfile")
+                        .conflicts_with_all(&["outfile", "silent"])
+                        .help("(requires mnemonic) Only print a seed phrase and pubkey. Do not output a keypair file"),
+                )
         )
         .subcommand(
             SubCommand::with_name("pubkey")
@@ -453,41 +526,14 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
 
             let word_count = value_t!(matches.value_of("word_count"), usize).unwrap();
             let mnemonic_type = MnemonicType::for_word_count(word_count)?;
-            let language = match matches.value_of("language").unwrap() {
-                "english" => Language::English,
-                "chinese-simplified" => Language::ChineseSimplified,
-                "chinese-traditional" => Language::ChineseTraditional,
-                "japanese" => Language::Japanese,
-                "spanish" => Language::Spanish,
-                "korean" => Language::Korean,
-                "french" => Language::French,
-                "italian" => Language::Italian,
-                _ => unreachable!(),
-            };
+            let language = acquire_language(matches);
 
             let silent = matches.is_present("silent");
             if !silent {
                 println!("Generating a new keypair");
             }
             let mnemonic = Mnemonic::new(mnemonic_type, language);
-            let passphrase = if matches.is_present("no_passphrase") {
-                NO_PASSPHRASE.to_string()
-            } else {
-                let passphrase = prompt_passphrase(
-                    "\nFor added security, enter a BIP39 passphrase\n\
-                    \nNOTE! This passphrase improves security of the recovery seed phrase NOT the\n\
-                    keypair file itself, which is stored as insecure plain text\n\
-                    \nBIP39 Passphrase (empty for none): ",
-                )?;
-                println!();
-                passphrase
-            };
-
-            let passphrase_message = if passphrase == NO_PASSPHRASE {
-                "".to_string()
-            } else {
-                " and your BIP39 passphrase".to_string()
-            };
+            let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches).unwrap();
 
             let seed = Seed::new(&mnemonic, &passphrase);
             let keypair = keypair_from_seed(seed.as_bytes())?;
@@ -571,6 +617,16 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
                 num_threads,
             );
 
+            let use_mnemonic = matches.is_present("mnemonic");
+
+            let word_count = value_t!(matches.value_of("word_count"), usize).unwrap();
+            let mnemonic_type = MnemonicType::for_word_count(word_count)?;
+            let language = acquire_language(matches);
+            
+            let (passphrase, passphrase_message) = if use_mnemonic { acquire_passphrase_and_message(matches).unwrap() } else
+                                                                   { no_passphrase_and_message() };
+            let no_outfile = matches.is_present("no_outfile");
+            
             let grind_matches_thread_safe = Arc::new(grind_matches);
             let attempts = Arc::new(AtomicU64::new(1));
             let found = Arc::new(AtomicU64::new(0));
@@ -583,6 +639,8 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
                     let attempts = attempts.clone();
                     let found = found.clone();
                     let grind_matches_thread_safe = grind_matches_thread_safe.clone();
+                    let passphrase = passphrase.clone();
+                    let passphrase_message = passphrase_message.clone();
 
                     thread::spawn(move || loop {
                         if done.load(Ordering::Relaxed) {
@@ -597,7 +655,13 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
                                 found.load(Ordering::Relaxed),
                             );
                         }
-                        let keypair = Keypair::new();
+                        let (keypair, phrase) = if use_mnemonic {
+                            let mnemonic = Mnemonic::new(mnemonic_type, language);
+                            let seed = Seed::new(&mnemonic, &passphrase);
+                            (keypair_from_seed(seed.as_bytes()).unwrap(), mnemonic.phrase().to_string())
+                        } else {
+                            (Keypair::new(), "".to_string())
+                        };
                         let mut pubkey = bs58::encode(keypair.pubkey()).into_string();
                         if ignore_case {
                             pubkey = pubkey.to_lowercase();
@@ -623,12 +687,21 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
                                 grind_matches_thread_safe[i]
                                     .count
                                     .fetch_sub(1, Ordering::Relaxed);
-                                println!(
-                                    "Wrote keypair to {}",
-                                    &format!("{}.json", keypair.pubkey())
-                                );
-                                write_keypair_file(&keypair, &format!("{}.json", keypair.pubkey()))
+                                if !no_outfile {
+                                    write_keypair_file(&keypair, &format!("{}.json", keypair.pubkey()))
                                     .unwrap();
+                                    println!(
+                                        "Wrote keypair to {}",
+                                        &format!("{}.json", keypair.pubkey())
+                                    );
+                                }
+                                if use_mnemonic {
+                                    let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
+                                    println!(
+                                        "{}\nSave this seed phrase{} to recover your new keypair:\n{}\n{}",
+                                        &divider, passphrase_message, phrase, &divider
+                                    );
+                                }
                             }
                         }
                         if total_matches_found == grind_matches_thread_safe.len() {


### PR DESCRIPTION
#### Problem

solana-keygen does not support mnemonics

#### Summary of Changes

Modified the solana-keygen command line program to support a new "--mnemonic" and also all mnemonic-related command line options that the "new" command supports.

Fixes #9325
