### PR TITLE
Implement mnemonic support for solana-keygen grind (solana-labs#9325)

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -159,10 +159,11 @@ solana-keygen grind --starts-with e1v1s:1
 
 You may request that the generated vanity keypair be expressed as a seed phrase
 which allows recovery of the keypair from the seed phrase and an optionally
-supplied passphrase:
+supplied passphrase (note that this is significantly slower than grinding without
+a mnemonic):
 
 ```bash
-solana-keygen grind --mnemonic --starts-with e1v1s:1
+solana-keygen grind --use-mnemonic --starts-with e1v1s:1
 ```
 
 Depending on the string requested, it may take days to find a match...

--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -157,6 +157,14 @@ You can generate a custom vanity keypair using solana-keygen. For instance:
 solana-keygen grind --starts-with e1v1s:1
 ```
 
+You may request that the generated vanity keypair be expressed as a seed phrase
+which allows recovery of the keypair from the seed phrase and an optionally
+supplied passphrase:
+
+```bash
+solana-keygen grind --mnemonic --starts-with e1v1s:1
+```
+
 Depending on the string requested, it may take days to find a match...
 
 ---

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -212,7 +212,7 @@ fn grind_validator_starts_and_ends_with(v: String) -> Result<(), String> {
 }
 
 fn acquire_language(matches: &ArgMatches<'_>) -> Language {
-    match matches.value_of("language").unwrap() {
+    match matches.value_of(LANGUAGE_ARG.name).unwrap() {
         "english" => Language::English,
         "chinese-simplified" => Language::ChineseSimplified,
         "chinese-traditional" => Language::ChineseTraditional,
@@ -232,7 +232,7 @@ fn no_passphrase_and_message() -> (String, String) {
 fn acquire_passphrase_and_message(
     matches: &ArgMatches<'_>,
 ) -> Result<(String, String), Box<dyn error::Error>> {
-    if matches.is_present("no_passphrase") {
+    if matches.is_present(NO_PASSPHRASE_ARG.name) {
         Ok(no_passphrase_and_message())
     } else {
         match prompt_passphrase(
@@ -534,7 +534,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
             let mut path = dirs_next::home_dir().expect("home directory");
             let outfile = if matches.is_present("outfile") {
                 matches.value_of("outfile")
-            } else if matches.is_present("no_outfile") {
+            } else if matches.is_present(NO_OUTFILE_ARG.name) {
                 None
             } else {
                 path.extend(&[".config", "solana", "id.json"]);
@@ -547,7 +547,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
                 None => (),
             }
 
-            let word_count = value_t!(matches.value_of("word_count"), usize).unwrap();
+            let word_count = value_t!(matches.value_of(WORD_COUNT_ARG.name), usize).unwrap();
             let mnemonic_type = MnemonicType::for_word_count(word_count)?;
             let language = acquire_language(matches);
 
@@ -642,7 +642,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
 
             let use_mnemonic = matches.is_present("use_mnemonic");
 
-            let word_count = value_t!(matches.value_of("word_count"), usize).unwrap();
+            let word_count = value_t!(matches.value_of(WORD_COUNT_ARG.name), usize).unwrap();
             let mnemonic_type = MnemonicType::for_word_count(word_count)?;
             let language = acquire_language(matches);
 
@@ -651,7 +651,7 @@ fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
             } else {
                 no_passphrase_and_message()
             };
-            let no_outfile = matches.is_present("no_outfile");
+            let no_outfile = matches.is_present(NO_OUTFILE_ARG.name);
 
             let grind_matches_thread_safe = Arc::new(grind_matches);
             let attempts = Arc::new(AtomicU64::new(1));

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -55,7 +55,7 @@ const LANGUAGE_ARG: ArgConstant<'static> = ArgConstant {
 
 const NO_PASSPHRASE_ARG: ArgConstant<'static> = ArgConstant {
     long: "no-bip39-passphrase",
-    name: "no-passphrase",
+    name: "no_passphrase",
     help: "Do not prompt for a BIP39 passphrase",
 };
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -108,12 +108,12 @@ fn no_outfile_arg<'a, 'b>() -> Arg<'a, 'b> {
         .help(NO_OUTFILE_ARG.help)
 }
 
-trait NewGrindCommonArgs {
-    fn new_grind_common_args(self) -> Self;
+trait KeyGenerationCommonArgs {
+    fn key_generation_common_args(self) -> Self;
 }
 
-impl NewGrindCommonArgs for App<'_, '_> {
-    fn new_grind_common_args(self) -> Self {
+impl KeyGenerationCommonArgs for App<'_, '_> {
+    fn key_generation_common_args(self) -> Self {
         self.arg(word_count_arg())
             .arg(language_arg())
             .arg(no_passphrase_arg())
@@ -390,7 +390,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .long("silent")
                         .help("Do not display seed phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
                 )
-                .new_grind_common_args()
+                .key_generation_common_args()
         )
         .subcommand(
             SubCommand::with_name("grind")
@@ -445,7 +445,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                         .long("use-mnemonic")
                         .help("Generate using a mnemonic key phrase.  Expect a significant slowdown in this mode"),
                 )
-                .new_grind_common_args()
+                .key_generation_common_args()
         )
         .subcommand(
             SubCommand::with_name("pubkey")


### PR DESCRIPTION
#### Problem

solana-keygen does not support mnemonics

#### Summary of Changes

Modified the solana-keygen command line program to support a new "--mnemonic" and also all mnemonic-related command line options that the "new" command supports.  Additionally, added minor update to the docs to alert users to this new option.

Fixes #9325
