### PR TITLE
program: Correct clamp in Message::signer_keys()

### DIFF
--- a/sdk/program/src/message.rs
+++ b/sdk/program/src/message.rs
@@ -451,7 +451,7 @@ impl Message {
         let last_key = self
             .account_keys
             .len()
-            .max(self.header.num_required_signatures as usize);
+            .min(self.header.num_required_signatures as usize);
         self.account_keys[..last_key].iter().collect()
     }
 }


### PR DESCRIPTION
#### Problem

`Message::signer_keys()` always returns all keys

#### Summary of Changes

Fix clamp logic
