### PR TITLE
chore: stop building on npm prepare

### DIFF
--- a/web3.js/.travis/script.sh
+++ b/web3.js/.travis/script.sh
@@ -3,6 +3,8 @@
 set -ex
 solana --version
 
+npm run clean
+npm run build
 ls -l lib
 test -r lib/index.iife.js
 test -r lib/index.cjs.js

--- a/web3.js/package.json
+++ b/web3.js/package.json
@@ -49,7 +49,6 @@
     "lint:fix": "npm run pretty:fix && eslint . --fix",
     "lint:watch": "watch 'npm run lint:fix' . --wait=1 --ignoreDirectoryPattern=/doc/",
     "ok": "run-s lint test doc",
-    "prepare": "run-s clean build",
     "pretty": "prettier --check '{,{src,test}/**/}*.{j,t}s'",
     "pretty:fix": "prettier --write '{,{src,test}/**/}*.{j,t}s'",
     "re": "semantic-release --repository-url git@github.com:solana-labs/solana-web3.js.git",


### PR DESCRIPTION
#### Problem
`npm prepare` is typically used to generate assets / code when publishing or installing packages, we already publish everything a client needs, so this step isn't necessary