### PR TITLE
makes test_pull_request_time_pruning smaller

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -4757,7 +4757,7 @@ mod tests {
         let shred_version = cluster_info.my_shred_version();
         let mut peers: Vec<Pubkey> = vec![];
 
-        const NO_ENTRIES: usize = 20000;
+        const NO_ENTRIES: usize = CRDS_UNIQUE_PUBKEY_CAPACITY + 128;
         let data: Vec<_> = repeat_with(|| {
             let keypair = Keypair::new();
             peers.push(keypair.pubkey());


### PR DESCRIPTION
#### Problem
`test_pull_request_time_pruning` seems flaky on ci.
Locally the test always passes, but probably on buildkite it takes longer time and some of the crds values hit their timeout, and so the first assert fails.

#### Summary of Changes
Made the test smaller.
