### PR TITLE
Explorer: make new stats card look okay on mobile

### DIFF
--- a/explorer/src/pages/ClusterStatsPage.tsx
+++ b/explorer/src/pages/ClusterStatsPage.tsx
@@ -127,7 +127,7 @@ function StakingComponent() {
   return (
     <div className="card staking-card">
       <div className="card-body">
-        <div className="d-flex">
+        <div className="d-flex flex-sm-row flex-column">
           <div className="p-2 flex-fill">
             <h4>Circulating Supply</h4>
             <h1>
@@ -138,6 +138,7 @@ function StakingComponent() {
               <em>{circulatingPercentage}%</em> is circulating
             </h5>
           </div>
+          <hr className="hidden-xs-up" />
           <div className="p-2 flex-fill">
             <h4>Active Stake</h4>
             <h1>
@@ -150,6 +151,7 @@ function StakingComponent() {
               </h5>
             )}
           </div>
+          <hr className="hidden-xs-up" />
           {solanaInfo && (
             <div className="p-2 flex-fill">
               <h4>Price</h4>


### PR DESCRIPTION
#### Problem
The new staking addition on cluster stats is not formatted properly for mobile.

#### Summary of Changes
![Explorer-Solana (24)](https://user-images.githubusercontent.com/188792/112522758-3ecb8e00-8d5b-11eb-80f6-b4620417a26d.png)
