### PR TITLE
poh keeps track of tick start time and can calculate expected tick end time

### DIFF
--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -317,6 +317,7 @@ impl PohService {
                     // TODO: we could possibly get a reset or record request while we're here
                     std::hint::spin_loop();
                 }
+                assert!(Instant::now() >= tick_target_time);
                 timing.total_sleep_us += started_waiting.elapsed().as_nanos() as u64 / 1000;
 
                 timing.report(ticks_per_slot);

--- a/ledger/src/poh.rs
+++ b/ledger/src/poh.rs
@@ -54,7 +54,7 @@ impl Poh {
         tick_start_time: Instant,
         target_ns_per_tick: u64,
     ) -> Instant {
-        let offset_ns = target_ns_per_tick / hashes_per_tick * num_hashes;
+        let offset_ns = target_ns_per_tick * num_hashes / hashes_per_tick;
         tick_start_time + Duration::from_nanos(offset_ns)
     }
 

--- a/ledger/src/poh.rs
+++ b/ledger/src/poh.rs
@@ -58,10 +58,7 @@ impl Poh {
         tick_start_time + Duration::from_nanos(offset_ns)
     }
 
-    pub fn target_poh_time(
-        &self,
-        target_ns_per_tick: u64,
-    ) -> Instant {
+    pub fn target_poh_time(&self, target_ns_per_tick: u64) -> Instant {
         Self::calculate_target_poh_time(
             self.num_hashes(),
             self.hashes_per_tick(),

--- a/ledger/src/poh.rs
+++ b/ledger/src/poh.rs
@@ -69,6 +69,11 @@ impl Poh {
 
     pub fn hash(&mut self, max_num_hashes: u64) -> bool {
         let num_hashes = std::cmp::min(self.remaining_hashes - 1, max_num_hashes);
+        if self.num_hashes == 0 {
+            // caller may throttle when they start hashing
+            self.tick_start_time = Instant::now();
+        }
+
         for _ in 0..num_hashes {
             self.hash = hash(&self.hash.as_ref());
         }


### PR DESCRIPTION
#### Problem
poh can be reset or ticked by PohRecorder. The code in poh_service could be using inaccurate information.

#### Summary of Changes
poh_service uses information in poh directly. poh is the source of truth.
This infrastructure allows us to soon calculate expected tick time based on the slot time, as well as consistently sleep from ticks that occur in poh recorder as a result of a record.

Fixes #
