### PR TITLE
Explorer: reduce heroku slug size

### DIFF
--- a/explorer/.slug-post-clean
+++ b/explorer/.slug-post-clean
@@ -1,0 +1,4 @@
+src
+public
+README.md
+node_modules


### PR DESCRIPTION
#### Problem
Heroku slug sizes are greater than 500MB, preventing deploys.

#### Summary of Changes
Don't include certain files and directories.
