### PR TITLE
read only account cache for executable accounts - improve replay

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -215,7 +215,7 @@ impl Accounts {
                     } else {
                         let (account, rent) = self
                             .accounts_db
-                            .load(ancestors, key) // replace this, too
+                            .load(ancestors, key)
                             .map(|(mut account, _)| {
                                 if message.is_writable(i, demote_sysvar_write_locks) {
                                     let rent_due = rent_collector
@@ -342,7 +342,7 @@ impl Accounts {
 
             let program = match self
                 .accounts_db
-                .load(ancestors, &program_id) // read only cache
+                .load(ancestors, &program_id)
                 .map(|(account, _)| account)
             {
                 Some(program) => program,

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -368,7 +368,6 @@ impl Accounts {
                     if let Some(program) = self
                         .accounts_db
                         .load_and_keep_in_read_only_cache(ancestors, &programdata_address)
-                        .map(|account| account)
                     {
                         accounts.insert(0, (programdata_address, program));
                     } else {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -215,7 +215,7 @@ impl Accounts {
                     } else {
                         let (account, rent) = self
                             .accounts_db
-                            .load(ancestors, key)
+                            .load(ancestors, key) // replace this, too
                             .map(|(mut account, _)| {
                                 if message.is_writable(i, demote_sysvar_write_locks) {
                                     let rent_due = rent_collector
@@ -342,7 +342,7 @@ impl Accounts {
 
             let program = match self
                 .accounts_db
-                .load(ancestors, &program_id)
+                .load(ancestors, &program_id) // read only cache
                 .map(|(account, _)| account)
             {
                 Some(program) => program,
@@ -367,7 +367,8 @@ impl Accounts {
                 {
                     if let Some(program) = self
                         .accounts_db
-                        .load_and_keep_in_read_only_cache(ancestors, &programdata_address)
+                        .load(ancestors, &programdata_address)
+                        .map(|(account, _)| account)
                     {
                         accounts.insert(0, (programdata_address, program));
                     } else {

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -367,8 +367,8 @@ impl Accounts {
                 {
                     if let Some(program) = self
                         .accounts_db
-                        .load(ancestors, &programdata_address)
-                        .map(|(account, _)| account)
+                        .load_and_keep_in_read_only_cache(ancestors, &programdata_address)
+                        .map(|account| account)
                     {
                         accounts.insert(0, (programdata_address, program));
                     } else {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8595,14 +8595,6 @@ pub mod tests {
             .unwrap();
         assert_eq!(account.lamports, 0);
         assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
-
-        // Flush, then clean again. Should not need another root to initiate the cleaning
-        // because `accounts_index.uncleaned_roots` should be correct
-        db.flush_accounts_cache(true, None);
-        db.clean_accounts(None);
-        assert!(db
-            .do_load(&Ancestors::default(), &account_key, Some(0))
-            .is_none());
     }
 
     #[test]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4364,6 +4364,16 @@ impl AccountsDb {
                     self.stats.store_total_data.swap(0, Ordering::Relaxed),
                     i64
                 ),
+                (
+                    "read_only_accounts_cache_entries",
+                    self.read_only_accounts_cache.cache_len(),
+                    i64
+                ),
+                (
+                    "read_only_accounts_cache_data_size",
+                    self.read_only_accounts_cache.data_size(),
+                    i64
+                ),
             );
 
             let recycle_stores = self.recycle_stores.read().unwrap();

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -703,7 +703,7 @@ impl ReadOnlyAccountsCache {
     }
 
     pub fn store(&self, pubkey: &Pubkey, account: &AccountSharedData) {
-        self.cache.insert(pubkey.clone(), account.clone());
+        self.cache.insert(*pubkey, account.clone());
     }
 
     pub fn remove(&self, pubkey: &Pubkey) {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4322,6 +4322,8 @@ impl AccountsDb {
                 Ordering::Relaxed,
             ) == Ok(last)
         {
+            let (read_only_cache_hits, read_only_cache_misses) =
+                self.read_only_accounts_cache.get_and_reset_stats();
             datapoint_info!(
                 "accounts_db_store_timings",
                 (
@@ -4372,6 +4374,16 @@ impl AccountsDb {
                 (
                     "read_only_accounts_cache_data_size",
                     self.read_only_accounts_cache.data_size(),
+                    i64
+                ),
+                (
+                    "read_only_cache_hits",
+                    read_only_cache_hits,
+                    i64
+                ),
+                (
+                    "read_only_cache_misses",
+                    read_only_cache_misses,
                     i64
                 ),
             );

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4377,12 +4377,12 @@ impl AccountsDb {
                     i64
                 ),
                 (
-                    "read_only_cache_hits",
+                    "read_only_accounts_cache_hits",
                     read_only_cache_hits,
                     i64
                 ),
                 (
-                    "read_only_cache_misses",
+                    "read_only_accounts_cache_misses",
                     read_only_cache_misses,
                     i64
                 ),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -288,13 +288,6 @@ impl<'a> LoadedAccount<'a> {
             },
         }
     }
-
-    pub fn from_cache(&self) -> bool {
-        match self {
-            LoadedAccount::Stored(_) => false,
-            LoadedAccount::Cached(_) => true,
-        }
-    }
 }
 
 #[derive(Clone, Default, Debug)]

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4376,11 +4376,7 @@ impl AccountsDb {
                     self.read_only_accounts_cache.data_size(),
                     i64
                 ),
-                (
-                    "read_only_accounts_cache_hits",
-                    read_only_cache_hits,
-                    i64
-                ),
+                ("read_only_accounts_cache_hits", read_only_cache_hits, i64),
                 (
                     "read_only_accounts_cache_misses",
                     read_only_cache_misses,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2308,12 +2308,6 @@ impl AccountsDb {
         }
     }
 
-    /*
-    fn clear_read_only_cache(&mut self) {
-        self.read_only_accounts_cache = ReadOnlyAccountsCache::default();
-    }
-    */
-
     fn do_load(
         &self,
         ancestors: &Ancestors,
@@ -8604,7 +8598,7 @@ pub mod tests {
         db.add_root(0);
         db.add_root(1);
 
-        assert!(db.read_only_accounts_cache.cache.len() == 0);
+        assert!(db.read_only_accounts_cache.cache.is_empty());
         let account = db
             .load_and_keep_in_read_only_cache(&Ancestors::default(), &account_key)
             .unwrap();
@@ -8616,7 +8610,7 @@ pub mod tests {
         assert_eq!(account.lamports, 1);
         assert!(db.read_only_accounts_cache.cache.len() == 1);
         db.store_cached(1, &[(&account_key, &zero_lamport_account)]);
-        assert!(db.read_only_accounts_cache.cache.len() == 0);
+        assert!(db.read_only_accounts_cache.cache.is_empty());
         let account = db
             .load_and_keep_in_read_only_cache(&Ancestors::default(), &account_key)
             .unwrap();
@@ -8730,7 +8724,7 @@ pub mod tests {
         // entry in slot 1 is blocking cleanup of the zero-lamport account.
         let max_root = None;
         assert_eq!(
-            db.do_load(&Ancestors::default(), &zero_lamport_account_key, max_root)
+            db.do_load(&Ancestors::default(), &zero_lamport_account_key, max_root,)
                 .unwrap()
                 .0
                 .lamports,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2282,9 +2282,11 @@ impl AccountsDb {
             // `lock` released here
         };
 
-        let result = self.read_only_accounts_cache.load(pubkey, slot);
-        if let Some(account) = result {
-            return Some((account, slot));
+        if self.caching_enabled && store_id != CACHE_VIRTUAL_STORAGE_ID {
+            let result = self.read_only_accounts_cache.load(pubkey, slot);
+            if let Some(account) = result {
+                return Some((account, slot));
+            }
         }
 
         //TODO: thread this as a ref

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -25,6 +25,7 @@ pub mod loader_utils;
 pub mod log_collector;
 pub mod message_processor;
 mod native_loader;
+mod read_only_accounts_cache;
 pub mod rent_collector;
 pub mod secondary_index;
 pub mod serde_snapshot;

--- a/runtime/src/read_only_accounts_cache.rs
+++ b/runtime/src/read_only_accounts_cache.rs
@@ -3,7 +3,7 @@
 use dashmap::DashMap;
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, Ordering},
         Arc, RwLock,
     },
     time::Instant,
@@ -26,8 +26,8 @@ pub struct ReadOnlyAccountsCache {
     cache: DashMap<(Pubkey, Slot), ReadOnlyAccountCacheEntry>,
     max_data_size: usize,
     data_size: Arc<RwLock<usize>>,
-    hits: AtomicUsize,
-    misses: AtomicUsize,
+    hits: AtomicU64,
+    misses: AtomicU64,
 }
 
 impl ReadOnlyAccountsCache {
@@ -36,8 +36,8 @@ impl ReadOnlyAccountsCache {
             max_data_size,
             cache: DashMap::default(),
             data_size: Arc::new(RwLock::new(0)),
-            hits: AtomicUsize::new(0),
-            misses: AtomicUsize::new(0),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
         }
     }
 
@@ -115,7 +115,7 @@ impl ReadOnlyAccountsCache {
         *self.data_size.read().unwrap()
     }
 
-    pub fn get_and_reset_stats(&self) -> (usize, usize) {
+    pub fn get_and_reset_stats(&self) -> (u64, u64) {
         let hits = self.hits.swap(0, Ordering::Relaxed);
         let misses = self.misses.swap(0, Ordering::Relaxed);
         (hits, misses)

--- a/runtime/src/read_only_accounts_cache.rs
+++ b/runtime/src/read_only_accounts_cache.rs
@@ -1,0 +1,168 @@
+//! ReadOnlyAccountsCache used to store accounts, such as executable accounts,
+//! which can be large, loaded many times, and rarely change.
+use dashmap::DashMap;
+use std::{
+    sync::{Arc, RwLock},
+    time::Instant,
+};
+
+use solana_sdk::{
+    account::{AccountSharedData, ReadableAccount},
+    pubkey::Pubkey,
+};
+
+#[derive(Debug)]
+pub struct ReadOnlyAccountCacheEntry {
+    pub account: AccountSharedData,
+    pub last_used: Arc<RwLock<Instant>>,
+}
+
+#[derive(Debug)]
+pub struct ReadOnlyAccountsCache {
+    cache: DashMap<Pubkey, ReadOnlyAccountCacheEntry>,
+    max_data_size: usize,
+    data_size: Arc<RwLock<usize>>,
+}
+
+impl ReadOnlyAccountsCache {
+    pub fn new(max_data_size: usize) -> Self {
+        Self {
+            max_data_size,
+            cache: DashMap::default(),
+            data_size: Arc::new(RwLock::new(0)),
+        }
+    }
+
+    pub fn load(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+        self.cache.get(pubkey).map(|account_ref| {
+            let value = account_ref.value();
+            // remember last use
+            let now = Instant::now();
+            *value.last_used.write().unwrap() = now;
+            value.account.clone()
+        })
+    }
+
+    pub fn store(&self, pubkey: &Pubkey, account: &AccountSharedData) {
+        let len = account.data().len();
+        self.cache.insert(
+            *pubkey,
+            ReadOnlyAccountCacheEntry {
+                account: account.clone(),
+                last_used: Arc::new(RwLock::new(Instant::now())),
+            },
+        );
+
+        // maybe purge after we insert. Insert may have replaced.
+        let new_size = self.maybe_purge_lru_items(len);
+        *self.data_size.write().unwrap() = new_size;
+    }
+
+    pub fn remove(&self, pubkey: &Pubkey) {
+        // does not keep track of data size reduction here.
+        // data size will be recomputed the next time we store and we think we may now be too large.
+        self.cache.remove(pubkey);
+    }
+
+    fn maybe_purge_lru_items(&self, new_item_len: usize) -> usize {
+        let mut new_size = *self.data_size.read().unwrap() + new_item_len;
+        if new_size <= self.max_data_size {
+            return new_size;
+        }
+
+        // purge in lru order
+        let mut lru = Vec::with_capacity(self.cache.len());
+        new_size = 0;
+        for item in self.cache.iter() {
+            let value = item.value();
+            let item_len = value.account.data().len();
+            new_size += item_len;
+            lru.push((*value.last_used.read().unwrap(), item_len, *item.key()));
+        }
+        if new_size > self.max_data_size {
+            lru.sort();
+            for oldest in lru.into_iter() {
+                self.remove(&oldest.2);
+                new_size = new_size.saturating_sub(oldest.1);
+                if new_size <= self.max_data_size {
+                    break;
+                }
+            }
+        }
+        new_size
+    }
+
+    pub fn cache_len(&self) -> usize {
+        self.cache.len()
+    }
+
+    pub fn data_size(&self) -> usize {
+        *self.data_size.read().unwrap()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use solana_sdk::account::{accounts_equal, Account};
+    #[test]
+    fn test_read_only_accounts_cache() {
+        solana_logger::setup();
+        let max = 100;
+        let cache = ReadOnlyAccountsCache::new(max);
+        assert!(cache.load(&Pubkey::default()).is_none());
+        assert_eq!(0, cache.cache_len());
+        assert_eq!(0, cache.data_size());
+        cache.remove(&Pubkey::default()); // assert no panic
+        let key1 = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
+        let key3 = Pubkey::new_unique();
+        let account1 = AccountSharedData::from(Account {
+            data: vec![0; max],
+            ..Account::default()
+        });
+        let mut account2 = account1.clone();
+        account2.lamports += 1; // so they compare differently
+        let mut account3 = account1.clone();
+        account3.lamports += 4; // so they compare differently
+        cache.store(&key1, &account1);
+        assert_eq!(100, cache.data_size());
+        assert!(accounts_equal(&cache.load(&key1).unwrap(), &account1));
+        assert_eq!(1, cache.cache_len());
+        cache.store(&key2, &account2);
+        assert_eq!(100, cache.data_size());
+        assert!(accounts_equal(&cache.load(&key2).unwrap(), &account2));
+        assert_eq!(1, cache.cache_len());
+        cache.store(&key2, &account1); // overwrite key2 with account1
+        assert_eq!(100, cache.data_size());
+        assert!(accounts_equal(&cache.load(&key2).unwrap(), &account1));
+        assert_eq!(1, cache.cache_len());
+        cache.remove(&key2);
+        assert_eq!(100, cache.data_size());
+        assert_eq!(0, cache.cache_len());
+
+        // can store 2 items, 3rd item kicks oldest item out
+        let max = 200;
+        let cache = ReadOnlyAccountsCache::new(max);
+        cache.store(&key1, &account1);
+        assert_eq!(100, cache.data_size());
+        assert!(accounts_equal(&cache.load(&key1).unwrap(), &account1));
+        assert_eq!(1, cache.cache_len());
+        cache.store(&key2, &account2);
+        assert_eq!(200, cache.data_size());
+        assert!(accounts_equal(&cache.load(&key1).unwrap(), &account1));
+        assert!(accounts_equal(&cache.load(&key2).unwrap(), &account2));
+        assert_eq!(2, cache.cache_len());
+        cache.store(&key2, &account1); // overwrite key2 with account1
+        assert_eq!(200, cache.data_size());
+        assert!(accounts_equal(&cache.load(&key1).unwrap(), &account1));
+        assert!(accounts_equal(&cache.load(&key2).unwrap(), &account1));
+        assert_eq!(2, cache.cache_len());
+        cache.store(&key3, &account3);
+        assert_eq!(200, cache.data_size());
+        assert!(cache.load(&key1).is_none()); // was lru purged
+        assert!(accounts_equal(&cache.load(&key2).unwrap(), &account1));
+        assert!(accounts_equal(&cache.load(&key3).unwrap(), &account3));
+        assert_eq!(2, cache.cache_len());
+    }
+}


### PR DESCRIPTION
Problem
During replay, we load things like programs from accounts, sometimes many (375) times during 1 slot. If we don't load them from the cache, then we load them from a store on each load. Loading from a store always requires copying data from the store to new memory. An example data size on programs is 500k.

Summary of Changes
Loaded accounts are kept in the read only cache for potential future loads.

We brainstormed on this a few weeks ago and decided to keep the read only cache separate from the existing cache.

Fixes #