### PR TITLE
Explorer: account for custom endpoint possible conditions in stakehistory

### DIFF
--- a/explorer/src/pages/ClusterStatsPage.tsx
+++ b/explorer/src/pages/ClusterStatsPage.tsx
@@ -98,7 +98,11 @@ function StakingComponent() {
     return <LoadingCard />;
   } else if (typeof supply === "string") {
     return <ErrorCard text={supply} retry={fetchData} />;
-  } else if (stakeInfo.status === FetchStatus.FetchFailed) {
+  } else if (
+    stakeInfo.status === FetchStatus.FetchFailed ||
+    (stakeInfo.status === FetchStatus.Fetched &&
+      (!stakeHistory.length || stakeHistory.length < 1))
+  ) {
     return (
       <ErrorCard text={"Failed to fetch active stake"} retry={fetchData} />
     );


### PR DESCRIPTION
#### Problem
I believe https://sentry.io/organizations/solana/issues/2299223711/?project=5390542&referrer=slack is happening where local clusters don't have stake history. 

#### Summary of Changes
The alternative to this fix would be to hide the stake column altogether, but for now we will show an error box. 

