### PR TITLE
Bump bpf-tools to version v1.4

### DIFF
--- a/programs/bpf/rust/mem/src/lib.rs
+++ b/programs/bpf/rust/mem/src/lib.rs
@@ -58,6 +58,9 @@ pub extern "C" fn entrypoint(_input: *mut u8) -> u64 {
         let buf = &mut [1_u8, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         compiler_builtins::mem::memmove(&mut buf[0] as *mut u8, &mut buf[9] as *mut u8, 9);
         assert_eq!(buf[..9], buf[9..]);
+        let buf = &mut [0_u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        compiler_builtins::mem::memmove(&mut buf[1] as *mut u8, &mut buf[0] as *mut u8, 9);
+        assert_eq!(&mut [0_u8, 0, 1, 2, 3, 4, 5, 6, 7, 8], buf);
         let buf = &mut [1_u8, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         compiler_builtins::mem::memmove(&mut buf[9] as *mut u8, &mut buf[0] as *mut u8, 9);
         assert_eq!(buf[..9], buf[9..]);

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -92,7 +92,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.3
+version=v1.4
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -260,7 +260,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     install_if_missing(
         &config,
         "bpf-tools",
-        "v1.3",
+        "v1.4",
         "https://github.com/solana-labs/bpf-tools/releases/download",
         &PathBuf::from(bpf_tools_filename),
     )


### PR DESCRIPTION
#### Problem

memmove implementation incorrectly moves data when source and destination overlap and moved data size is not evenly divided by 8.

#### Summary of Changes

Bump version of bpf-tools to the version that includes the fix.

