### PR TITLE
bpf: Add failing test for calling get_packed_len in BPF

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2788,6 +2788,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-rust-packed-len"
+version = "1.7.0"
+dependencies = [
+ "borsh",
+ "solana-program 1.7.0",
+]
+
+[[package]]
 name = "solana-bpf-rust-panic"
 version = "1.7.0"
 dependencies = [

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "rust/many_args_dep",
     "rust/mem",
     "rust/noop",
+    "rust/packed_len",
     "rust/panic",
     "rust/param_passing",
     "rust/param_passing_dep",

--- a/programs/bpf/build.rs
+++ b/programs/bpf/build.rs
@@ -79,6 +79,7 @@ fn main() {
             "many_args",
             "mem",
             "noop",
+            "packed_len",
             "panic",
             "param_passing",
             "rand",

--- a/programs/bpf/rust/packed_len/Cargo.toml
+++ b/programs/bpf/rust/packed_len/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "solana-bpf-rust-packed-len"
+version = "1.7.0"
+description = "Solana BPF test program written in Rust"
+authors = ["Solana Maintainers <maintainers@solana.foundation>"]
+repository = "https://github.com/solana-labs/solana"
+license = "Apache-2.0"
+homepage = "https://solana.com/"
+documentation = "https://docs.rs/solana-bpf-rust-packed-len"
+edition = "2018"
+
+[dependencies]
+borsh = "0.8"
+solana-program = { path = "../../../../sdk/program", version = "=1.7.0" }
+
+[lib]
+crate-type = ["cdylib"]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/programs/bpf/rust/packed_len/src/lib.rs
+++ b/programs/bpf/rust/packed_len/src/lib.rs
@@ -1,0 +1,27 @@
+//! @brief Example Rust-based BPF program calling get_packed_len
+
+extern crate solana_program;
+use {
+    borsh::BorshSchema,
+    solana_program::{
+        account_info::AccountInfo, borsh::get_packed_len, entrypoint, entrypoint::ProgramResult,
+        msg, pubkey::Pubkey,
+    },
+};
+
+#[derive(BorshSchema)]
+struct ExampleStruct {
+    _data: u8,
+}
+
+entrypoint!(process_instruction);
+#[allow(clippy::unnecessary_wraps)]
+fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    let len = get_packed_len::<ExampleStruct>();
+    msg!("{}", len);
+    Ok(())
+}

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1252,6 +1252,7 @@ fn assert_instruction_count() {
             ("solana_bpf_rust_iter", 724),
             ("solana_bpf_rust_many_args", 237),
             ("solana_bpf_rust_noop", 496),
+            ("solana_bpf_rust_packed_len", 600), // no idea since it fails
             ("solana_bpf_rust_param_passing", 54),
             ("solana_bpf_rust_ristretto", 19246),
             ("solana_bpf_rust_sanity", 952),


### PR DESCRIPTION
#### Problem

Calling `solana_program::get_packed_len()` in a program causes the runtime to error out while loading the ELF. Before running any code, the runtime fails with:

```
thread 'assert_instruction_count' panicked at 'called `Result::unwrap()` on an `Err` value: ElfError(FailedToParse("read-write: bad offset 11139531056"))', tests/programs.rs:208:68
```

#### Summary of Changes

Add a failing test. 

Fixes #
