### PR TITLE
Hash stored accounts in bg

### DIFF
--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -127,11 +127,9 @@ pub struct CachedAccountInner {
 
 impl CachedAccountInner {
     pub fn hash(&self) -> Hash {
-        error!("locking to read hash");
         let hash = self.hash.read().unwrap();
         match *hash {
             Some(hash) => {
-                error!("done locking to read hash");
                 hash
             },
             None => {
@@ -142,9 +140,7 @@ impl CachedAccountInner {
                     &self.pubkey,
                     &self.cluster_type,
                 );
-                error!("write locking to set hash");
                 *self.hash.write().unwrap() = Some(hash.clone());
-                error!("done write locking to set hash");
                 hash
             }
         }

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -1,5 +1,4 @@
 use dashmap::DashMap;
-use log::error;
 use solana_sdk::{
     account::{AccountSharedData, ReadableAccount},
     clock::Slot,
@@ -296,7 +295,9 @@ pub mod tests {
             inserted_slot,
             &Pubkey::new_unique(),
             AccountSharedData::new(1, 0, &Pubkey::default()),
-            Hash::default(),
+            Some(Hash::default()),
+            inserted_slot,
+            ClusterType::Development,
         );
         // If the cache is told the size limit is 0, it should return the one slot
         let removed = cache.remove_slots_le(0);
@@ -314,7 +315,9 @@ pub mod tests {
             inserted_slot,
             &Pubkey::new_unique(),
             AccountSharedData::new(1, 0, &Pubkey::default()),
-            Hash::default(),
+            Some(Hash::default()),
+            inserted_slot,
+            ClusterType::Development,
         );
 
         // If the cache is told the size limit is 0, it should return nothing because there's only

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -1,4 +1,5 @@
 use dashmap::DashMap;
+use log::error;
 use solana_sdk::{
     account::{AccountSharedData, ReadableAccount},
     clock::Slot,
@@ -14,7 +15,6 @@ use std::{
         Arc, RwLock,
     },
 };
-use log::error;
 
 pub type SlotCache = Arc<SlotCacheInner>;
 
@@ -72,10 +72,7 @@ impl SlotCacheInner {
             cluster_type,
             pubkey: *pubkey,
         });
-        self.cache.insert(
-            *pubkey,
-            item.clone(),
-        );
+        self.cache.insert(*pubkey, item.clone());
         item
     }
 
@@ -129,9 +126,7 @@ impl CachedAccountInner {
     pub fn hash(&self) -> Hash {
         let hash = self.hash.read().unwrap();
         match *hash {
-            Some(hash) => {
-                hash
-            },
+            Some(hash) => hash,
             None => {
                 drop(hash);
                 let hash = crate::accounts_db::AccountsDb::hash_account(

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -134,7 +134,7 @@ impl CachedAccountInner {
                     &self.pubkey,
                     &self.cluster_type,
                 );
-                *self.hash.write().unwrap() = Some(hash.clone());
+                *self.hash.write().unwrap() = Some(hash);
                 hash
             }
         }

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -135,6 +135,7 @@ impl CachedAccountInner {
                 hash
             },
             None => {
+                drop(hash);
                 let hash = crate::accounts_db::AccountsDb::hash_account(
                     self.hash_slot,
                     &self.account,

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -105,18 +105,13 @@ impl Deref for SlotCacheInner {
     }
 }
 
-pub struct LazyHash {
-    pub account: Arc<AccountSharedData>,
-    pub hash: RwLock<Hash>,
-}
-
 pub type CachedAccount = Arc<CachedAccountInner>;
 
 #[derive(Debug)]
 pub struct CachedAccountInner {
     pub account: AccountSharedData,
     hash: RwLock<Option<Hash>>,
-    pub hash_slot: Slot,
+    hash_slot: Slot,
     cluster_type: ClusterType,
     pubkey: Pubkey,
 }

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -175,7 +175,6 @@ impl AccountsCache {
         pubkey: &Pubkey,
         account: AccountSharedData,
         hash: Option<Hash>,
-        hash_slot: Slot,
         cluster_type: ClusterType,
     ) -> CachedAccount {
         let slot_cache = self.slot_cache(slot).unwrap_or_else(||
@@ -189,7 +188,7 @@ impl AccountsCache {
                 .or_insert(Arc::new(SlotCacheInner::default()))
                 .clone());
 
-        slot_cache.insert(pubkey, account, hash, hash_slot, cluster_type)
+        slot_cache.insert(pubkey, account, hash, slot, cluster_type)
     }
 
     pub fn load(&self, slot: Slot, pubkey: &Pubkey) -> Option<CachedAccount> {
@@ -291,7 +290,6 @@ pub mod tests {
             &Pubkey::new_unique(),
             AccountSharedData::new(1, 0, &Pubkey::default()),
             Some(Hash::default()),
-            inserted_slot,
             ClusterType::Development,
         );
         // If the cache is told the size limit is 0, it should return the one slot
@@ -311,7 +309,6 @@ pub mod tests {
             &Pubkey::new_unique(),
             AccountSharedData::new(1, 0, &Pubkey::default()),
             Some(Hash::default()),
-            inserted_slot,
             ClusterType::Development,
         );
 

--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -53,7 +53,7 @@ impl SlotCacheInner {
         pubkey: &Pubkey,
         account: AccountSharedData,
         hash: Option<Hash>,
-        hash_slot: Slot,
+        slot: Slot,
         cluster_type: ClusterType,
     ) -> CachedAccount {
         if self.cache.contains_key(pubkey) {
@@ -67,7 +67,7 @@ impl SlotCacheInner {
         let item = Arc::new(CachedAccountInner {
             account,
             hash: RwLock::new(hash),
-            hash_slot,
+            slot,
             cluster_type,
             pubkey: *pubkey,
         });
@@ -111,7 +111,7 @@ pub type CachedAccount = Arc<CachedAccountInner>;
 pub struct CachedAccountInner {
     pub account: AccountSharedData,
     hash: RwLock<Option<Hash>>,
-    hash_slot: Slot,
+    slot: Slot,
     cluster_type: ClusterType,
     pubkey: Pubkey,
 }
@@ -124,7 +124,7 @@ impl CachedAccountInner {
             None => {
                 drop(hash);
                 let hash = crate::accounts_db::AccountsDb::hash_account(
-                    self.hash_slot,
+                    self.slot,
                     &self.account,
                     &self.pubkey,
                     &self.cluster_type,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -19,7 +19,7 @@
 //! commit for each slot entry would be indexed.
 
 use crate::{
-    accounts_cache::{AccountsCache, CachedAccount, CachedAccountInner, SlotCache},
+    accounts_cache::{AccountsCache, CachedAccount, SlotCache},
     accounts_hash::{AccountsHash, CalculateHashIntermediate, HashStats, PreviousPass},
     accounts_index::{
         AccountIndex, AccountsIndex, AccountsIndexRootsStats, Ancestors, IndexKey, IsCached,
@@ -57,7 +57,7 @@ use std::{
     ops::{Range, RangeBounds},
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
-    sync::mpsc::{channel, Receiver, SendError, Sender, SyncSender},
+    sync::mpsc::{channel, Receiver, Sender},
     sync::{Arc, Mutex, MutexGuard, RwLock},
     thread::{Builder, JoinHandle},
     time::Instant,

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -695,8 +695,6 @@ pub struct AccountsDb {
 
     sender_bg_hasher: Option<Mutex<Sender<CachedAccount>>>,
 
-    store_hasher: Option<Arc<JoinHandle<()>>>,
-
     recycle_stores: RwLock<RecycleStores>,
 
     /// distribute the accounts across storage lists
@@ -1074,7 +1072,6 @@ impl Default for AccountsDb {
             accounts_index: AccountsIndex::default(),
             storage: AccountStorage::default(),
             accounts_cache: AccountsCache::default(),
-            store_hasher: None,
             sender_bg_hasher: None,
             recycle_stores: RwLock::new(RecycleStores::default()),
             uncleaned_pubkeys: DashMap::new(),

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -59,7 +59,7 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     sync::{Arc, Mutex, MutexGuard, RwLock},
-    thread::{Builder, JoinHandle},
+    thread::Builder,
     time::Instant,
 };
 use tempfile::TempDir;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3400,10 +3400,10 @@ impl AccountsDb {
             None => &empty,
         };
 
-        (0..len)
-            .into_iter()
-            .map(|i| {
-                let (meta, account) = &accounts_and_meta_to_store[i];
+        accounts_and_meta_to_store
+            .iter()
+            .enumerate()
+            .map(|(i, (meta, account))| {
                 let hash = if hashes.is_empty() {
                     None
                 } else {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3391,30 +3391,21 @@ impl AccountsDb {
         accounts_and_meta_to_store: &[(StoredMeta, &AccountSharedData)],
     ) -> Vec<AccountInfo> {
         let len = accounts_and_meta_to_store.len();
-        let empty = vec![];
-        let hashes = match hashes {
-            Some(hashes) => {
-                assert_eq!(hashes.len(), len);
-                hashes
-            }
-            None => &empty,
-        };
+        let hashes = hashes.map(|hashes| {
+            assert_eq!(hashes.len(), len);
+            hashes
+        });
 
         accounts_and_meta_to_store
             .iter()
             .enumerate()
             .map(|(i, (meta, account))| {
-                let hash = if hashes.is_empty() {
-                    None
-                } else {
-                    Some(hashes[i])
-                };
+                let hash = hashes.map(|hashes| hashes[i]);
                 let cached_account = self.accounts_cache.store(
                     slot,
                     &meta.pubkey,
                     (*account).clone(),
                     hash,
-                    slot,
                     self.expected_cluster_type(),
                 );
                 // hash this account in the bg

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -2,6 +2,7 @@ use crate::bank_forks::ArchiveFormat;
 use crate::snapshot_utils::SnapshotVersion;
 use crate::{accounts_db::SnapshotStorages, bank::BankSlotDelta};
 use solana_sdk::clock::Slot;
+use solana_sdk::genesis_config::ClusterType;
 use solana_sdk::hash::Hash;
 use std::{
     path::PathBuf,
@@ -26,6 +27,7 @@ pub struct AccountsPackagePre {
     pub snapshot_output_dir: PathBuf,
     pub expected_capitalization: u64,
     pub hash_for_testing: Option<Hash>,
+    pub cluster_type: ClusterType,
 }
 
 impl AccountsPackagePre {
@@ -42,6 +44,7 @@ impl AccountsPackagePre {
         snapshot_output_dir: PathBuf,
         expected_capitalization: u64,
         hash_for_testing: Option<Hash>,
+        cluster_type: ClusterType,
     ) -> Self {
         Self {
             slot,
@@ -55,6 +58,7 @@ impl AccountsPackagePre {
             snapshot_output_dir,
             expected_capitalization,
             hash_for_testing,
+            cluster_type,
         }
     }
 }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -187,6 +187,7 @@ pub fn package_snapshot<P: AsRef<Path>, Q: AsRef<Path>>(
         snapshot_package_output_path.as_ref().to_path_buf(),
         bank.capitalization(),
         hash_for_testing,
+        bank.cluster_type(),
     );
 
     Ok(package)
@@ -978,6 +979,7 @@ pub fn process_accounts_package_pre(
         let (hash, lamports) = AccountsDb::calculate_accounts_hash_without_index(
             &accounts_package.storages,
             thread_pool,
+            accounts_package.cluster_type,
         );
 
         assert_eq!(accounts_package.expected_capitalization, lamports);


### PR DESCRIPTION
Problem
While processing a slot, the same account can be written to many times.
Hashing accounts is not free and gets expensive with large data. Hashing an account that is not the final update is not usually necessary.

Summary of Changes
When an account is stored to the accounts_cache, don't hash the contents first - instead use None. When a caller requires a hash, and a hash hasn't been calculated, calculate it and store it. A background thread processes items that are added to the accounts_cache, calculates the hash and updates the cached item in accounts_cache.

Fixes #