### PR TITLE
Rpc: enable getConfirmedBlocks and getConfirmedBlocksWithLimit to return confirmed (not yet finalized) data

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -566,6 +566,24 @@ impl RpcClient {
         )
     }
 
+    pub fn get_confirmed_blocks_with_commitment(
+        &self,
+        start_slot: Slot,
+        end_slot: Option<Slot>,
+        commitment_config: CommitmentConfig,
+    ) -> ClientResult<Vec<Slot>> {
+        let json = if end_slot.is_some() {
+            json!([
+                start_slot,
+                end_slot,
+                self.maybe_map_commitment(commitment_config)?
+            ])
+        } else {
+            json!([start_slot, self.maybe_map_commitment(commitment_config)?])
+        };
+        self.send(RpcRequest::GetConfirmedBlocks, json)
+    }
+
     pub fn get_confirmed_blocks_with_limit(
         &self,
         start_slot: Slot,
@@ -574,6 +592,22 @@ impl RpcClient {
         self.send(
             RpcRequest::GetConfirmedBlocksWithLimit,
             json!([start_slot, limit]),
+        )
+    }
+
+    pub fn get_confirmed_blocks_with_limit_and_commitment(
+        &self,
+        start_slot: Slot,
+        limit: usize,
+        commitment_config: CommitmentConfig,
+    ) -> ClientResult<Vec<Slot>> {
+        self.send(
+            RpcRequest::GetConfirmedBlocksWithLimit,
+            json!([
+                start_slot,
+                limit,
+                self.maybe_map_commitment(commitment_config)?
+            ]),
         )
     }
 

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -178,16 +178,16 @@ impl EncodingConfig for RpcConfirmedTransactionConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum EndSlotOrCommitment {
+pub enum RpcConfirmedBlocksConfig {
     EndSlotOnly(Option<Slot>),
     CommitmentOnly(Option<CommitmentConfig>),
 }
 
-impl EndSlotOrCommitment {
+impl RpcConfirmedBlocksConfig {
     pub fn unzip(&self) -> (Option<Slot>, Option<CommitmentConfig>) {
         match &self {
-            EndSlotOrCommitment::EndSlotOnly(end_slot) => (*end_slot, None),
-            EndSlotOrCommitment::CommitmentOnly(commitment) => (None, *commitment),
+            RpcConfirmedBlocksConfig::EndSlotOnly(end_slot) => (*end_slot, None),
+            RpcConfirmedBlocksConfig::CommitmentOnly(commitment) => (None, *commitment),
         }
     }
 }

--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -2,7 +2,7 @@ use {
     crate::rpc_filter::RpcFilterType,
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
     solana_sdk::{
-        clock::Epoch,
+        clock::{Epoch, Slot},
         commitment_config::{CommitmentConfig, CommitmentLevel},
     },
     solana_transaction_status::{TransactionDetails, UiTransactionEncoding},
@@ -172,6 +172,22 @@ impl EncodingConfig for RpcConfirmedTransactionConfig {
         Self {
             encoding: *encoding,
             ..Self::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EndSlotOrCommitment {
+    EndSlotOnly(Option<Slot>),
+    CommitmentOnly(Option<CommitmentConfig>),
+}
+
+impl EndSlotOrCommitment {
+    pub fn unzip(&self) -> (Option<Slot>, Option<CommitmentConfig>) {
+        match &self {
+            EndSlotOrCommitment::EndSlotOnly(end_slot) => (*end_slot, None),
+            EndSlotOrCommitment::CommitmentOnly(commitment) => (None, *commitment),
         }
     }
 }

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -793,15 +793,22 @@ impl JsonRpcRequestProcessor {
         end_slot: Option<Slot>,
         commitment: Option<CommitmentConfig>,
     ) -> Result<Vec<Slot>> {
-        let _commitment = commitment.unwrap_or_default();
+        let commitment = commitment.unwrap_or_default();
+        check_is_at_least_confirmed(commitment)?;
+
         let highest_confirmed_root = self
             .block_commitment_cache
             .read()
             .unwrap()
             .highest_confirmed_root();
+
         let end_slot = min(
             end_slot.unwrap_or_else(|| start_slot.saturating_add(MAX_GET_CONFIRMED_BLOCKS_RANGE)),
-            highest_confirmed_root,
+            if commitment.is_finalized() {
+                highest_confirmed_root
+            } else {
+                self.bank(Some(CommitmentConfig::confirmed())).slot()
+            },
         );
         if end_slot < start_slot {
             return Ok(vec![]);
@@ -816,7 +823,8 @@ impl JsonRpcRequestProcessor {
         let lowest_blockstore_slot = self.blockstore.lowest_slot();
         if start_slot < lowest_blockstore_slot {
             // If the starting slot is lower than what's available in blockstore assume the entire
-            // [start_slot..end_slot] can be fetched from BigTable.
+            // [start_slot..end_slot] can be fetched from BigTable. This range should not ever run
+            // into unfinalized confirmed blocks due to MAX_GET_CONFIRMED_BLOCKS_RANGE
             if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
                 return self
                     .runtime
@@ -837,12 +845,27 @@ impl JsonRpcRequestProcessor {
             }
         }
 
-        Ok(self
+        // Finalized blocks
+        let mut blocks: Vec<_> = self
             .blockstore
             .rooted_slot_iterator(max(start_slot, lowest_blockstore_slot))
             .map_err(|_| Error::internal_error())?
             .filter(|&slot| slot <= end_slot && slot <= highest_confirmed_root)
-            .collect())
+            .collect();
+        let last_element = blocks.last().cloned().unwrap_or_default();
+
+        // Maybe add confirmed blocks
+        if commitment.is_confirmed() && last_element < end_slot {
+            let confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
+            let mut confirmed_blocks = confirmed_bank
+                .status_cache_ancestors()
+                .into_iter()
+                .filter(|&slot| slot <= end_slot && slot > last_element)
+                .collect();
+            blocks.append(&mut confirmed_blocks);
+        }
+
+        Ok(blocks)
     }
 
     pub fn get_confirmed_blocks_with_limit(
@@ -851,7 +874,9 @@ impl JsonRpcRequestProcessor {
         limit: usize,
         commitment: Option<CommitmentConfig>,
     ) -> Result<Vec<Slot>> {
-        let _commitment = commitment.unwrap_or_default();
+        let commitment = commitment.unwrap_or_default();
+        check_is_at_least_confirmed(commitment)?;
+
         if limit > MAX_GET_CONFIRMED_BLOCKS_RANGE as usize {
             return Err(Error::invalid_params(format!(
                 "Limit too large; max {}",
@@ -863,7 +888,8 @@ impl JsonRpcRequestProcessor {
 
         if start_slot < lowest_blockstore_slot {
             // If the starting slot is lower than what's available in blockstore assume the entire
-            // range can be fetched from BigTable.
+            // range can be fetched from BigTable. This range should not ever run into unfinalized
+            // confirmed blocks due to MAX_GET_CONFIRMED_BLOCKS_RANGE
             if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
                 return Ok(self
                     .runtime
@@ -878,13 +904,29 @@ impl JsonRpcRequestProcessor {
             .unwrap()
             .highest_confirmed_root();
 
-        Ok(self
+        // Finalized blocks
+        let mut blocks: Vec<_> = self
             .blockstore
             .rooted_slot_iterator(max(start_slot, lowest_blockstore_slot))
             .map_err(|_| Error::internal_error())?
             .take(limit)
             .filter(|&slot| slot <= highest_confirmed_root)
-            .collect())
+            .collect();
+
+        // Maybe add confirmed blocks
+        if commitment.is_confirmed() && blocks.len() < limit {
+            let last_element = blocks.last().cloned().unwrap_or_default();
+            let confirmed_bank = self.bank(Some(CommitmentConfig::confirmed()));
+            let mut confirmed_blocks = confirmed_bank
+                .status_cache_ancestors()
+                .into_iter()
+                .filter(|&slot| slot > last_element)
+                .collect();
+            blocks.append(&mut confirmed_blocks);
+            blocks.truncate(limit);
+        }
+
+        Ok(blocks)
     }
 
     pub fn get_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -2318,7 +2318,7 @@ pub mod rpc_full {
             &self,
             meta: Self::Metadata,
             start_slot: Slot,
-            config: Option<EndSlotOrCommitment>,
+            config: Option<RpcConfirmedBlocksConfig>,
             commitment: Option<CommitmentConfig>,
         ) -> Result<Vec<Slot>>;
 
@@ -2976,7 +2976,7 @@ pub mod rpc_full {
             &self,
             meta: Self::Metadata,
             start_slot: Slot,
-            config: Option<EndSlotOrCommitment>,
+            config: Option<RpcConfirmedBlocksConfig>,
             commitment: Option<CommitmentConfig>,
         ) -> Result<Vec<Slot>> {
             let (end_slot, maybe_commitment) =

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -795,7 +795,7 @@ impl JsonRpcRequestProcessor {
     ) -> Result<Vec<Slot>> {
         let _commitment = commitment.unwrap_or_default();
         let end_slot = min(
-            end_slot.unwrap_or(std::u64::MAX),
+            end_slot.unwrap_or_else(|| start_slot.saturating_add(MAX_GET_CONFIRMED_BLOCKS_RANGE)),
             self.block_commitment_cache
                 .read()
                 .unwrap()

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -687,6 +687,7 @@ Returns a list of confirmed blocks between two slots
 
 - `<u64>` - start_slot, as u64 integer
 - `<u64>` - (optional) end_slot, as u64 integer
+- (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 
@@ -717,6 +718,7 @@ Returns a list of confirmed blocks starting at the given slot
 
 - `<u64>` - start_slot, as u64 integer
 - `<u64>` - limit, as u64 integer
+- (optional) [Commitment](jsonrpc-api.md#configuring-state-commitment); "processed" is not supported. If parameter not provided, the default is "finalized".
 
 #### Results:
 


### PR DESCRIPTION
#### Problem
Similar to https://github.com/solana-labs/solana/pull/16142, `getConfirmedBlocks` and `getConfirmedBlocksWithLimit` do not included confirmed but not-yet-finalized blocks in the response list.

#### Summary of Changes
- Some plumbing to support optional commitment parameter in `getConfirmedBlocks`
- Expose confirmed data in `getConfirmedBlocks` and `getConfirmedBlocksWithLimit` via the commitment parameter
- Also, sneak in a couple fixes:
  - if no endSlot is provided to `getConfirmedBlocks` when startSlot is far in the past, return `MAX_GET_CONFIRMED_BLOCKS_RANGE` blocks instead of error
  - Check that blocks returned from Blockstore are actually finalized, not just local roots
