### PR TITLE
Increase snapshot interval to make run-sanity.sh less flaky

### DIFF
--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -7,7 +7,7 @@ source multinode-demo/common.sh
 
 rm -rf config/run/init-completed config/ledger config/snapshot-ledger
 
-timeout 120 ./run.sh &
+SOLANA_RUN_SH_VALIDATOR_ARGS="--snapshot-interval-slots 200" timeout 120 ./run.sh &
 pid=$!
 
 attempts=20
@@ -16,6 +16,8 @@ while [[ ! -f config/run/init-completed ]]; do
   if ((--attempts == 0)); then
      echo "Error: validator failed to boot"
      exit 1
+  else
+    echo "Checking init"
   fi
 done
 
@@ -24,6 +26,7 @@ snapshot_slot=1
 # wait a bit longer than snapshot_slot
 while [[ $($solana_cli --url http://localhost:8899 slot --commitment recent) -le $((snapshot_slot + 1)) ]]; do
   sleep 1
+  echo "Checking slot"
 done
 
 $solana_validator --ledger config/ledger exit --force || true


### PR DESCRIPTION
#### Problem

The `$solana_validator --ledger config/ledger exit --force || true` part of run-sanity.sh does a rebuild of the validator and it can take longer than it takes the validator to get to slot 100 and make a new snapshot. At this point, the snapshot create will load the slot 100 snapshot and then find it cannot create a snapshot at slot 1 since it's behind the slot 100 snapshot.

#### Summary of Changes

Make the snapshot interval 200 to make it less flaky.

Fixes #