### PR TITLE
poll checking for new record in poh service after every batch of hashes instead of busy waiting

### DIFF
--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -122,6 +122,10 @@ impl PohService {
                         ticks_per_slot,
                         hashes_per_batch,
                         record_receiver,
+                        Self::target_ns_per_tick(
+                            ticks_per_slot,
+                            poh_config.target_tick_duration.as_nanos() as u64,
+                        ),
                     );
                 }
                 poh_exit_.store(true, Ordering::Relaxed);
@@ -210,6 +214,7 @@ impl PohService {
         record_receiver: &Receiver<Record>,
         hashes_per_batch: u64,
         poh: &Arc<Mutex<Poh>>,
+        target_ns_per_tick: u64,
     ) -> bool {
         match next_record.take() {
             Some(mut record) => {
@@ -254,6 +259,7 @@ impl PohService {
                     timing.num_hashes += hashes_per_batch;
                     let mut hash_time = Measure::start("hash");
                     let should_tick = poh_l.hash(hashes_per_batch);
+                    let ideal_time = poh_l.target_poh_time(target_ns_per_tick);
                     hash_time.stop();
                     timing.total_hash_time_ns += hash_time.as_ns();
                     if should_tick {
@@ -268,10 +274,31 @@ impl PohService {
                             *next_record = Some(record);
                             break;
                         }
-                        Err(_) => {
-                            continue;
+                        Err(_) => (),
+                    }
+
+                    // check to see if we need to busy wait to catch up to ideal
+                    let wait_start = Instant::now();
+                    if ideal_time <= wait_start {
+                        continue;
+                    }
+
+                    // yes, busy wait, polling for new records and after dropping poh lock
+                    drop(poh_l);
+                    while ideal_time > Instant::now() {
+                        // check to see if a record request has been sent
+                        let get_again = record_receiver.try_recv();
+                        match get_again {
+                            Ok(record) => {
+                                // remember the record we just received as the next record to occur
+                                *next_record = Some(record);
+                                break;
+                            }
+                            Err(_) => (),
                         }
                     }
+                    timing.total_sleep_us += wait_start.elapsed().as_micros() as u64;
+                    break;
                 }
             }
         };
@@ -284,6 +311,7 @@ impl PohService {
         ticks_per_slot: u64,
         hashes_per_batch: u64,
         record_receiver: Receiver<Record>,
+        target_ns_per_tick: u64,
     ) {
         let poh = poh_recorder.lock().unwrap().poh.clone();
         let mut timing = PohTiming::new();
@@ -296,6 +324,7 @@ impl PohService {
                 &record_receiver,
                 hashes_per_batch,
                 &poh,
+                target_ns_per_tick,
             );
             if should_tick {
                 // Lock PohRecorder only for the final hash. record_or_hash will lock PohRecorder for record calls but not for hashing.


### PR DESCRIPTION
#### Problem
busy waiting with no ability to be interrupted can miss events.
Longer, less frequent busy waits causes hashes to not be uniformly spaced within a tick.
#### Summary of Changes
Check on progress after each batch of hashes in poh_service. If we are ahead, busy wait polling for record events. This spreads out the busy waiting and we can be productive during busy waits and respond more quickly to record events.
Fixes #
