### PR TITLE
web3: add PublicKey.toBytes and fix buffer incompatibility

### DIFF
--- a/web3.js/src/message.ts
+++ b/web3.js/src/message.ts
@@ -7,6 +7,7 @@ import type {Blockhash} from './blockhash';
 import * as Layout from './layout';
 import {PACKET_DATA_SIZE} from './transaction';
 import * as shortvec from './util/shortvec-encoding';
+import {toBuffer} from './util/to-buffer';
 
 /**
  * The message header, identifying signed and read-only account
@@ -160,7 +161,7 @@ export class Message {
         this.header.numReadonlyUnsignedAccounts,
       ]),
       keyCount: Buffer.from(keyCount),
-      keys: this.accountKeys.map(key => key.toBuffer()),
+      keys: this.accountKeys.map(key => toBuffer(key.toBytes())),
       recentBlockhash: bs58.decode(this.recentBlockhash),
     };
 

--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -4,6 +4,8 @@ import nacl from 'tweetnacl';
 import {sha256} from 'crypto-hash';
 import {Buffer} from 'buffer';
 
+import {toBuffer} from './util/to-buffer';
+
 /**
  * Maximum length of derived pubkey seed
  */
@@ -48,7 +50,14 @@ export class PublicKey {
    * Return the base-58 representation of the public key
    */
   toBase58(): string {
-    return bs58.encode(this.toBuffer());
+    return bs58.encode(this.toBytes());
+  }
+
+  /**
+   * Return the byte array representation of the public key
+   */
+  toBytes(): Uint8Array {
+    return this.toBuffer();
   }
 
   /**
@@ -101,7 +110,7 @@ export class PublicKey {
       if (seed.length > MAX_SEED_LENGTH) {
         throw new Error(`Max seed length exceeded`);
       }
-      buffer = Buffer.concat([buffer, Buffer.from(seed)]);
+      buffer = Buffer.concat([buffer, toBuffer(seed)]);
     });
     buffer = Buffer.concat([
       buffer,

--- a/web3.js/src/secp256k1-program.ts
+++ b/web3.js/src/secp256k1-program.ts
@@ -195,14 +195,8 @@ export class Secp256k1Program {
       `Private key must be ${PRIVATE_KEY_BYTES} bytes but received ${pkey.length} bytes`,
     );
 
-    let privateKey;
-    if (Array.isArray(pkey)) {
-      privateKey = Uint8Array.from(pkey);
-    } else {
-      privateKey = pkey;
-    }
-
     try {
+      const privateKey = toBuffer(pkey);
       const publicKey = publicKeyCreate(privateKey, false).slice(1); // throw away leading byte
       const messageHash = Buffer.from(
         keccak_256.update(toBuffer(message)).digest(),

--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -10,6 +10,7 @@ import {
   SYSVAR_STAKE_HISTORY_PUBKEY,
 } from './sysvar';
 import {Transaction, TransactionInstruction} from './transaction';
+import {toBuffer} from './util/to-buffer';
 
 /**
  * Address of the stake config account which configures the rate
@@ -506,13 +507,13 @@ export class StakeProgram {
     const type = STAKE_INSTRUCTION_LAYOUTS.Initialize;
     const data = encodeData(type, {
       authorized: {
-        staker: authorized.staker.toBuffer(),
-        withdrawer: authorized.withdrawer.toBuffer(),
+        staker: toBuffer(authorized.staker.toBytes()),
+        withdrawer: toBuffer(authorized.withdrawer.toBytes()),
       },
       lockup: {
         unixTimestamp: lockup.unixTimestamp,
         epoch: lockup.epoch,
-        custodian: lockup.custodian.toBuffer(),
+        custodian: toBuffer(lockup.custodian.toBytes()),
       },
     });
     const instructionData = {
@@ -613,7 +614,7 @@ export class StakeProgram {
 
     const type = STAKE_INSTRUCTION_LAYOUTS.Authorize;
     const data = encodeData(type, {
-      newAuthorized: newAuthorizedPubkey.toBuffer(),
+      newAuthorized: toBuffer(newAuthorizedPubkey.toBytes()),
       stakeAuthorizationType: stakeAuthorizationType.index,
     });
 
@@ -649,10 +650,10 @@ export class StakeProgram {
 
     const type = STAKE_INSTRUCTION_LAYOUTS.AuthorizeWithSeed;
     const data = encodeData(type, {
-      newAuthorized: newAuthorizedPubkey.toBuffer(),
+      newAuthorized: toBuffer(newAuthorizedPubkey.toBytes()),
       stakeAuthorizationType: stakeAuthorizationType.index,
       authoritySeed: authoritySeed,
-      authorityOwner: authorityOwner.toBuffer(),
+      authorityOwner: toBuffer(authorityOwner.toBytes()),
     });
 
     const keys = [

--- a/web3.js/src/system-program.ts
+++ b/web3.js/src/system-program.ts
@@ -6,6 +6,7 @@ import {NONCE_ACCOUNT_LENGTH} from './nonce-account';
 import {PublicKey} from './publickey';
 import {SYSVAR_RECENT_BLOCKHASHES_PUBKEY, SYSVAR_RENT_PUBKEY} from './sysvar';
 import {Transaction, TransactionInstruction} from './transaction';
+import {toBuffer} from './util/to-buffer';
 
 /**
  * Create account system transaction params
@@ -669,7 +670,7 @@ export class SystemProgram {
     const data = encodeData(type, {
       lamports: params.lamports,
       space: params.space,
-      programId: params.programId.toBuffer(),
+      programId: toBuffer(params.programId.toBytes()),
     });
 
     return new TransactionInstruction({
@@ -695,7 +696,7 @@ export class SystemProgram {
       data = encodeData(type, {
         lamports: params.lamports,
         seed: params.seed,
-        programId: params.programId.toBuffer(),
+        programId: toBuffer(params.programId.toBytes()),
       });
       keys = [
         {pubkey: params.fromPubkey, isSigner: false, isWritable: true},
@@ -729,9 +730,9 @@ export class SystemProgram {
     if ('basePubkey' in params) {
       const type = SYSTEM_INSTRUCTION_LAYOUTS.AssignWithSeed;
       data = encodeData(type, {
-        base: params.basePubkey.toBuffer(),
+        base: toBuffer(params.basePubkey.toBytes()),
         seed: params.seed,
-        programId: params.programId.toBuffer(),
+        programId: toBuffer(params.programId.toBytes()),
       });
       keys = [
         {pubkey: params.accountPubkey, isSigner: false, isWritable: true},
@@ -739,7 +740,9 @@ export class SystemProgram {
       ];
     } else {
       const type = SYSTEM_INSTRUCTION_LAYOUTS.Assign;
-      data = encodeData(type, {programId: params.programId.toBuffer()});
+      data = encodeData(type, {
+        programId: toBuffer(params.programId.toBytes()),
+      });
       keys = [{pubkey: params.accountPubkey, isSigner: true, isWritable: true}];
     }
 
@@ -759,11 +762,11 @@ export class SystemProgram {
   ): TransactionInstruction {
     const type = SYSTEM_INSTRUCTION_LAYOUTS.CreateWithSeed;
     const data = encodeData(type, {
-      base: params.basePubkey.toBuffer(),
+      base: toBuffer(params.basePubkey.toBytes()),
       seed: params.seed,
       lamports: params.lamports,
       space: params.space,
-      programId: params.programId.toBuffer(),
+      programId: toBuffer(params.programId.toBytes()),
     });
     let keys = [
       {pubkey: params.fromPubkey, isSigner: true, isWritable: true},
@@ -828,7 +831,7 @@ export class SystemProgram {
   ): TransactionInstruction {
     const type = SYSTEM_INSTRUCTION_LAYOUTS.InitializeNonceAccount;
     const data = encodeData(type, {
-      authorized: params.authorizedPubkey.toBuffer(),
+      authorized: toBuffer(params.authorizedPubkey.toBytes()),
     });
     const instructionData = {
       keys: [
@@ -903,7 +906,7 @@ export class SystemProgram {
   static nonceAuthorize(params: AuthorizeNonceParams): TransactionInstruction {
     const type = SYSTEM_INSTRUCTION_LAYOUTS.AuthorizeNonceAccount;
     const data = encodeData(type, {
-      authorized: params.newAuthorizedPubkey.toBuffer(),
+      authorized: toBuffer(params.newAuthorizedPubkey.toBytes()),
     });
 
     return new TransactionInstruction({
@@ -927,10 +930,10 @@ export class SystemProgram {
     if ('basePubkey' in params) {
       const type = SYSTEM_INSTRUCTION_LAYOUTS.AllocateWithSeed;
       data = encodeData(type, {
-        base: params.basePubkey.toBuffer(),
+        base: toBuffer(params.basePubkey.toBytes()),
         seed: params.seed,
         space: params.space,
-        programId: params.programId.toBuffer(),
+        programId: toBuffer(params.programId.toBytes()),
       });
       keys = [
         {pubkey: params.accountPubkey, isSigner: false, isWritable: true},

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -569,7 +569,7 @@ export class Transaction {
         }
       } else {
         if (
-          !nacl.sign.detached.verify(signData, signature, publicKey.toBuffer())
+          !nacl.sign.detached.verify(signData, signature, publicKey.toBytes())
         ) {
           return false;
         }


### PR DESCRIPTION
#### Problem
`PublicKey.toBuffer` returns a bundled `Buffer` instance in browser environments which causes incompatibility issues if used for `buffer-layout` encoding in external packages because it will not pass `instanceof Buffer` checks.

#### Summary of Changes
- Update every `buffer-layout` public key encoding call to an explicit conversion to the bundled `Buffer` instance
- Add `PublicKey.toBytes` method which is typed as `Uint8Array` to provide an alternative to `toBuffer` which should only be used in Node.js environments

Fixes #
