### PR TITLE
Print the rust version when building bpf programs

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -111,6 +111,7 @@ if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   fi
   touch bpf-tools-$version.md
   set -ex
+  ./bpf-tools/rust/bin/rustc --version
   ./bpf-tools/rust/bin/rustc --print sysroot
   set +e
   rustup toolchain uninstall bpf


### PR DESCRIPTION
#### Problem
It's not clear which rustc version is used to compile bpf programs. This is useful for knowing which rust features are available in programs.

#### Summary of Changes
Print the rust version

Fixes #
