### PR TITLE
web3: strip internal types from external declaration

### DIFF
--- a/web3.js/rollup.config.js
+++ b/web3.js/rollup.config.js
@@ -28,6 +28,7 @@ function generateConfig(configType, format) {
       generateTypescript
         ? typescript({
             browserslist: false,
+            tsconfig: './tsconfig.d.json',
           })
         : undefined,
       babel({

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1266,7 +1266,7 @@ const ParsedConfirmedTransactionMetaResult = pick({
 /**
  * Expected JSON RPC response for the "getConfirmedBlock" message
  */
-export const GetConfirmedBlockRpcResult = jsonRpcResult(
+const GetConfirmedBlockRpcResult = jsonRpcResult(
   nullable(
     pick({
       blockhash: string(),

--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -398,6 +398,7 @@ export type StakeInstructionType =
 
 /**
  * An enumeration of valid stake InstructionType's
+ * @internal
  */
 export const STAKE_INSTRUCTION_LAYOUTS: {
   [type in StakeInstructionType]: InstructionType;

--- a/web3.js/src/system-program.ts
+++ b/web3.js/src/system-program.ts
@@ -546,6 +546,7 @@ export type SystemInstructionType =
 
 /**
  * An enumeration of valid system InstructionType's
+ * @internal
  */
 export const SYSTEM_INSTRUCTION_LAYOUTS: {
   [type in SystemInstructionType]: InstructionType;

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -104,9 +104,9 @@ export class TransactionInstruction {
 }
 
 /**
- * @internal
+ * Pair of signature and corresponding public key
  */
-type SignaturePubkeyPair = {
+export type SignaturePubkeyPair = {
   signature: Buffer | null;
   publicKey: PublicKey;
 };

--- a/web3.js/tsconfig.d.json
+++ b/web3.js/tsconfig.d.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "stripInternal": true,
+  }
+}


### PR DESCRIPTION
#### Problem
Internal types are unnecessarily exposed in TypeScript declarations

#### Summary of Changes
- Enable `stripInternal` option to suppress declarations for internal types

Fixes #
