### PR TITLE
fix: fix static properties in flow type declaration

### DIFF
--- a/web3.js/src/loader.ts
+++ b/web3.js/src/loader.ts
@@ -10,6 +10,13 @@ import {sleep} from './util/sleep';
 import type {Connection} from './connection';
 import {SystemProgram} from './system-program';
 
+// Keep program chunks under PACKET_DATA_SIZE, leaving enough room for the
+// rest of the Transaction fields
+//
+// TODO: replace 300 with a proper constant for the size of the other
+// Transaction fields
+const CHUNK_SIZE = PACKET_DATA_SIZE - 300;
+
 /**
  * Program loader interface
  */
@@ -22,14 +29,7 @@ export class Loader {
   /**
    * Amount of program data placed in each load Transaction
    */
-  static get chunkSize(): number {
-    // Keep program chunks under PACKET_DATA_SIZE, leaving enough room for the
-    // rest of the Transaction fields
-    //
-    // TODO: replace 300 with a proper constant for the size of the other
-    // Transaction fields
-    return PACKET_DATA_SIZE - 300;
-  }
+  static chunkSize: number = CHUNK_SIZE;
 
   /**
    * Minimum number of signatures required to load a program not including

--- a/web3.js/src/secp256k1-program.ts
+++ b/web3.js/src/secp256k1-program.ts
@@ -79,9 +79,9 @@ export class Secp256k1Program {
   /**
    * Public key that identifies the secp256k1 program
    */
-  static get programId(): PublicKey {
-    return new PublicKey('KeccakSecp256k11111111111111111111111111111');
-  }
+  static programId: PublicKey = new PublicKey(
+    'KeccakSecp256k11111111111111111111111111111',
+  );
 
   /**
    * Construct an Ethereum address from a secp256k1 public key buffer.

--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -485,9 +485,9 @@ export class StakeProgram {
   /**
    * Public key that identifies the Stake program
    */
-  static get programId(): PublicKey {
-    return new PublicKey('Stake11111111111111111111111111111111111111');
-  }
+  static programId: PublicKey = new PublicKey(
+    'Stake11111111111111111111111111111111111111',
+  );
 
   /**
    * Max space of a Stake account
@@ -496,9 +496,7 @@ export class StakeProgram {
    * `std::mem::size_of::<StakeState>()`:
    * https://docs.rs/solana-stake-program/1.4.4/solana_stake_program/stake_state/enum.StakeState.html
    */
-  static get space(): number {
-    return 200;
-  }
+  static space: number = 200;
 
   /**
    * Generate an Initialize instruction to add to a Stake Create transaction

--- a/web3.js/src/system-program.ts
+++ b/web3.js/src/system-program.ts
@@ -659,9 +659,9 @@ export class SystemProgram {
   /**
    * Public key that identifies the System program
    */
-  static get programId(): PublicKey {
-    return new PublicKey('11111111111111111111111111111111');
-  }
+  static programId: PublicKey = new PublicKey(
+    '11111111111111111111111111111111',
+  );
 
   /**
    * Generate a transaction instruction that creates a new account


### PR DESCRIPTION
#### Problem
The `flowgen` tool doesn't generate flow type declarations properly for static getters

#### Summary of Changes
Replace static getters with normal static properties

Fixes #
