### PR TITLE
TransactionRecorder uses unique channel so we can use Recv instead of RecvTimeout

### DIFF
--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -105,6 +105,20 @@ impl TransactionRecorder {
         mixin: Hash,
         transactions: Vec<Transaction>,
     ) -> Result<()> {
+        let mut t = solana_measure::measure::Measure::start("");
+        for _ in 0..1_000_000 {
+            let (result_sender, result_receiver) = channel();
+            let t = TransactionRecorder {
+                // shared
+                record_sender: self.record_sender.clone(),
+                // unique to this caller
+                result_sender,
+                result_receiver,
+            };
+        }
+        t.stop();
+        panic!("creating channels: {}", t.as_us());
+    
         let res = self.record_sender.send(Record::new(
             mixin,
             transactions,

--- a/core/src/poh_recorder.rs
+++ b/core/src/poh_recorder.rs
@@ -77,9 +77,6 @@ impl Record {
 pub struct TransactionRecorder {
     // shared by all users of PohRecorder
     pub record_sender: Sender<Record>,
-    // unique to this caller
-    pub result_sender: Sender<Result<()>>,
-    pub result_receiver: Receiver<Result<()>>,
 }
 
 impl Clone for TransactionRecorder {
@@ -90,13 +87,9 @@ impl Clone for TransactionRecorder {
 
 impl TransactionRecorder {
     pub fn new(record_sender: Sender<Record>) -> Self {
-        let (result_sender, result_receiver) = channel();
         Self {
             // shared
             record_sender,
-            // unique to this caller
-            result_sender,
-            result_receiver,
         }
     }
     pub fn record(
@@ -105,6 +98,7 @@ impl TransactionRecorder {
         mixin: Hash,
         transactions: Vec<Transaction>,
     ) -> Result<()> {
+        // create a new channel so that there is only 1 sender and when it goes out of scope, the receiver fails
         let (result_sender, result_receiver) = channel();
         let res =
             self.record_sender


### PR DESCRIPTION
#### Problem
Get rid of sender.clone on TransactionRecorder to handle test shutdown cases better.
#### Summary of Changes
Allocate a new channel for each record. This means when the sender is dropped, the receiver will fail. Previously, we had a clone, and there was still a sender in existence, so the receiver never finished during shutdown. This necessitated a timeout. Timeouts can cause trouble.
I measured the cost to create channels, and it mesured low. ~60ns (I tested creating 1M of them).

Fixes #
