### PR TITLE
Allow incomplete_features lint in frozen-abi et. al

### DIFF
--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 #![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 #![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(incomplete_features)]
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 #![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 


### PR DESCRIPTION
#### Problem

The `specialization` feature is incomplete, triggering `incomplete_feature` lint warnings

#### Summary of Changes

`#[allow()]`