### PR TITLE
get rid of data copy

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -258,7 +258,7 @@ pub fn deserialize_parameters_aligned(
             start += size_of::<Pubkey>(); // owner
             account.lamports = LittleEndian::read_u64(&buffer[start..]);
             start += size_of::<u64>(); // lamports
-            let pre_len = account.data_as_mut_slice().len();
+            let pre_len = account.data().len();
             let post_len = LittleEndian::read_u64(&buffer[start..]) as usize;
             start += size_of::<u64>(); // data length
             let mut data_end = start + pre_len;

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -1,11 +1,7 @@
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use solana_sdk::{
-    account::{ReadableAccount, WritableAccount},
-    bpf_loader_deprecated,
-    entrypoint::MAX_PERMITTED_DATA_INCREASE,
-    instruction::InstructionError,
-    keyed_account::KeyedAccount,
-    pubkey::Pubkey,
+    account::ReadableAccount, bpf_loader_deprecated, entrypoint::MAX_PERMITTED_DATA_INCREASE,
+    instruction::InstructionError, keyed_account::KeyedAccount, pubkey::Pubkey,
 };
 use std::{
     io::prelude::*,


### PR DESCRIPTION
#### Problem
Code migration left a location where we unnecessarily cause a data copy to be made.
#### Summary of Changes
Don't cause a copy to be made.
Fixes #
