### PR TITLE
Return sysvars via syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4977,6 +4977,7 @@ version = "1.7.0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
+ "bincode",
  "chrono",
  "chrono-humanize",
  "log 0.4.11",

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -10,6 +10,7 @@ version = "1.7.0"
 [dependencies]
 async-trait = "0.1.42"
 base64 = "0.12.3"
+bincode = "1.3.1"
 chrono = "0.4.19"
 chrono-humanize = "0.1.1"
 log = "0.4.11"

--- a/program-test/tests/sysvar.rs
+++ b/program-test/tests/sysvar.rs
@@ -1,0 +1,62 @@
+use {
+    solana_program_test::{processor, ProgramTest},
+    solana_sdk::{
+        account_info::AccountInfo,
+        clock::Clock,
+        entrypoint::ProgramResult,
+        instruction::Instruction,
+        msg,
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        rent::Rent,
+        signature::Signer,
+        sysvar::{fees::Fees, Sysvar},
+        transaction::Transaction,
+    },
+};
+
+// Process instruction to invoke into another program
+fn sysvar_getter_process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _input: &[u8],
+) -> ProgramResult {
+    msg!("sysvar_getter");
+
+    let clock = Clock::get()?;
+    assert_eq!(42, clock.slot);
+
+    assert_eq!(Fees::get(), Err(ProgramError::UnsupportedSysvar));
+
+    let rent = Rent::get()?;
+    assert_eq!(rent, Rent::default());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_sysvar() {
+    let program_id = Pubkey::new_unique();
+    let program_test = ProgramTest::new(
+        "sysvar_getter",
+        program_id,
+        processor!(sysvar_getter_process_instruction),
+    );
+
+    let mut context = program_test.start_with_context().await;
+    context.warp_to_slot(42).unwrap();
+    let instructions = vec![Instruction::new_with_bincode(program_id, &(), vec![])];
+
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -114,7 +114,7 @@ impl ExecuteTimings {
 }
 
 type BankStatusCache = StatusCache<Signature, Result<()>>;
-#[frozen_abi(digest = "EcB9J7sm37t1R47vLcvGuNeiRciB4Efq1EDWDWL6Bp5h")]
+#[frozen_abi(digest = "4mSWwHd4RrLjCXH7RFrm6K3wZSsi9DfVJK3Ngz9jKk7D")]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 type TransactionAccountRefCells = Vec<Rc<RefCell<AccountSharedData>>>;
 type TransactionAccountDepRefCells = Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>;
@@ -2933,6 +2933,8 @@ impl Bank {
                         self.feature_set.clone(),
                         bpf_compute_budget,
                         &mut timings.details,
+                        self.rc.accounts.clone(),
+                        &self.ancestors,
                     );
 
                     if enable_log_recording {

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -250,11 +250,6 @@ impl ComputeMeter for ThisComputeMeter {
         self.remaining
     }
 }
-#[derive(Default)]
-pub struct SysvarsHolder {
-    pub clock: Option<Clock>,
-    pub rent: Option<Rent>,
-}
 pub struct ThisInvokeContext<'a> {
     program_ids: Vec<Pubkey>,
     rent: Rent,

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -82,7 +82,7 @@ pub type UnixTimestamp = i64;
 ///  as the network progresses).
 ///
 #[repr(C)]
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+#[derive(Serialize, Clone, Copy, Deserialize, Debug, Default, PartialEq)]
 pub struct Clock {
     /// the current network/bank Slot
     pub slot: Slot,

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -211,6 +211,10 @@ pub enum InstructionError {
     /// Program arithmetic overflowed
     #[error("Program arithmetic overflowed")]
     ArithmeticOverflow,
+
+    /// Unsupported sysvar
+    #[error("Unsupported sysvar")]
+    UnsupportedSysvar,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/sdk/program/src/program_error.rs
+++ b/sdk/program/src/program_error.rs
@@ -43,6 +43,8 @@ pub enum ProgramError {
     BorshIoError(String),
     #[error("An account does not have enough lamports to be rent-exempt")]
     AccountNotRentExempt,
+    #[error("Unsupported sysvar")]
+    UnsupportedSysvar,
 }
 
 pub trait PrintProgramError {
@@ -79,6 +81,7 @@ impl PrintProgramError for ProgramError {
             Self::InvalidSeeds => msg!("Error: InvalidSeeds"),
             Self::BorshIoError(_) => msg!("Error: BorshIoError"),
             Self::AccountNotRentExempt => msg!("Error: AccountNotRentExempt"),
+            Self::UnsupportedSysvar => msg!("Error: UnsupportedSysvar"),
         }
     }
 }
@@ -107,6 +110,7 @@ pub const MAX_SEED_LENGTH_EXCEEDED: u64 = to_builtin!(13);
 pub const INVALID_SEEDS: u64 = to_builtin!(14);
 pub const BORSH_IO_ERROR: u64 = to_builtin!(15);
 pub const ACCOUNT_NOT_RENT_EXEMPT: u64 = to_builtin!(16);
+pub const UNSUPPORTED_SYSVAR: u64 = to_builtin!(17);
 
 impl From<ProgramError> for u64 {
     fn from(error: ProgramError) -> Self {
@@ -126,6 +130,7 @@ impl From<ProgramError> for u64 {
             ProgramError::InvalidSeeds => INVALID_SEEDS,
             ProgramError::BorshIoError(_) => BORSH_IO_ERROR,
             ProgramError::AccountNotRentExempt => ACCOUNT_NOT_RENT_EXEMPT,
+            ProgramError::UnsupportedSysvar => UNSUPPORTED_SYSVAR,
 
             ProgramError::Custom(error) => {
                 if error == 0 {
@@ -154,6 +159,7 @@ impl From<u64> for ProgramError {
             ACCOUNT_BORROW_FAILED => ProgramError::AccountBorrowFailed,
             MAX_SEED_LENGTH_EXCEEDED => ProgramError::MaxSeedLengthExceeded,
             INVALID_SEEDS => ProgramError::InvalidSeeds,
+            UNSUPPORTED_SYSVAR => ProgramError::UnsupportedSysvar,
             CUSTOM_ZERO => ProgramError::Custom(0),
             _ => ProgramError::Custom(error as u32),
         }
@@ -180,6 +186,7 @@ impl TryFrom<InstructionError> for ProgramError {
             Self::Error::MaxSeedLengthExceeded => Ok(Self::MaxSeedLengthExceeded),
             Self::Error::BorshIoError(err) => Ok(Self::BorshIoError(err)),
             Self::Error::AccountNotRentExempt => Ok(Self::AccountNotRentExempt),
+            Self::Error::UnsupportedSysvar => Ok(Self::UnsupportedSysvar),
             _ => Err(error),
         }
     }
@@ -206,6 +213,7 @@ where
             ACCOUNT_BORROW_FAILED => InstructionError::AccountBorrowFailed,
             MAX_SEED_LENGTH_EXCEEDED => InstructionError::MaxSeedLengthExceeded,
             INVALID_SEEDS => InstructionError::InvalidSeeds,
+            UNSUPPORTED_SYSVAR => InstructionError::UnsupportedSysvar,
             _ => {
                 // A valid custom error has no bits set in the upper 32
                 if error >> BUILTIN_BIT_SHIFT == 0 {

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -2,7 +2,10 @@
 
 #![cfg(not(target_arch = "bpf"))]
 
-use crate::{account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction};
+use crate::{
+    account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
+    program_error::UNSUPPORTED_SYSVAR, pubkey::Pubkey,
+};
 use std::sync::{Arc, RwLock};
 
 lazy_static::lazy_static! {
@@ -30,6 +33,10 @@ pub trait SyscallStubs: Sync + Send {
     ) -> ProgramResult {
         sol_log("SyscallStubs: sol_invoke_signed() not available");
         Ok(())
+    }
+
+    fn sol_get_sysvar(&self, _id: &Pubkey, _var_addr: *mut u8) -> u64 {
+        UNSUPPORTED_SYSVAR
     }
 }
 
@@ -60,4 +67,8 @@ pub(crate) fn sol_invoke_signed(
         .read()
         .unwrap()
         .sol_invoke_signed(instruction, account_infos, signers_seeds)
+}
+
+pub(crate) fn sol_get_sysvar(id: &Pubkey, var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS.read().unwrap().sol_get_sysvar(id, var_addr)
 }

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -6,4 +6,14 @@ use crate::sysvar::Sysvar;
 
 crate::declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);
 
-impl Sysvar for Clock {}
+impl Sysvar for Clock {
+    #[cfg(target_arch = "bpf")]
+    fn call_syscall(var_addr: *mut u8) -> u64 {
+        unsafe {
+            extern "C" {
+                fn sol_get_clock_sysvar(var_addr: *mut u8) -> u64;
+            }
+            sol_get_clock_sysvar(var_addr)
+        }
+    }
+}

--- a/sdk/program/src/sysvar/fees.rs
+++ b/sdk/program/src/sysvar/fees.rs
@@ -5,7 +5,7 @@ use crate::{fee_calculator::FeeCalculator, sysvar::Sysvar};
 crate::declare_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
 
 #[repr(C)]
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
 pub struct Fees {
     pub fee_calculator: FeeCalculator,
 }

--- a/sdk/program/src/sysvar/rent.rs
+++ b/sdk/program/src/sysvar/rent.rs
@@ -6,4 +6,14 @@ use crate::sysvar::Sysvar;
 
 crate::declare_sysvar_id!("SysvarRent111111111111111111111111111111111", Rent);
 
-impl Sysvar for Rent {}
+impl Sysvar for Rent {
+    #[cfg(target_arch = "bpf")]
+    fn call_syscall(var_addr: *mut u8) -> u64 {
+        unsafe {
+            extern "C" {
+                fn sol_get_rent_sysvar(var_addr: *mut u8) -> u64;
+            }
+            sol_get_rent_sysvar(var_addr)
+        }
+    }
+}

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -127,6 +127,10 @@ pub mod demote_sysvar_write_locks {
     solana_sdk::declare_id!("86LJYRuq2zgtHuL3FccR6hqFJQMQkFoun4knAxcPiF1P");
 }
 
+pub mod sysvar_via_syscall {
+    solana_sdk::declare_id!("7411E6gFQLDhQkdRjmpXwM1hzHMMoYQUjHicmvGPC1Nf");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -159,6 +163,7 @@ lazy_static! {
         (cpi_data_cost::id(), "charge the compute budget for data passed via CPI"),
         (upgradeable_close_instruction::id(), "close upgradeable buffer accounts"),
         (demote_sysvar_write_locks::id(), "demote builtins and sysvar write locks to readonly #15497"),
+        (sysvar_via_syscall::id(), "Provide sysvars via syscalls"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/keyed_account.rs
+++ b/sdk/src/keyed_account.rs
@@ -240,6 +240,9 @@ mod tests {
         fn check_id(pubkey: &crate::pubkey::Pubkey) -> bool {
             check_id(pubkey)
         }
+        fn id() -> Pubkey {
+            id()
+        }
     }
     impl Sysvar for TestSysvar {}
 

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -141,7 +141,7 @@ pub struct BpfComputeBudget {
     pub max_cpi_instruction_size: usize,
     /// Number of account data bytes per conpute unit charged during a cross-program invocation
     pub cpi_bytes_per_unit: u64,
-    /// Base number of compute units consumed to to get a sysvar
+    /// Base number of compute units consumed to get a sysvar
     pub sysvar_base_cost: u64,
 }
 impl Default for BpfComputeBudget {

--- a/sdk/src/process_instruction.rs
+++ b/sdk/src/process_instruction.rs
@@ -1,13 +1,15 @@
 use solana_sdk::{
     account::AccountSharedData,
+    clock::Clock,
     instruction::{CompiledInstruction, Instruction, InstructionError},
     keyed_account::KeyedAccount,
     message::Message,
     pubkey::Pubkey,
+    rent::Rent,
 };
 use std::{cell::RefCell, fmt::Debug, rc::Rc, sync::Arc};
 
-// Prototype of a native loader entry point
+/// Prototype of a native loader entry point
 ///
 /// program_id: Program ID of the currently executing program
 /// keyed_accounts: Accounts passed as part of the instruction
@@ -22,6 +24,13 @@ pub type LoaderEntrypoint = unsafe extern "C" fn(
 
 pub type ProcessInstructionWithContext =
     fn(&Pubkey, &[KeyedAccount], &[u8], &mut dyn InvokeContext) -> Result<(), InstructionError>;
+
+// Possible sysvar values returned by get_sysvar
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Sysvars {
+    Clock(Clock),
+    Rent(Rent),
+}
 
 /// Invocation context passed to loaders
 pub trait InvokeContext {
@@ -68,6 +77,8 @@ pub trait InvokeContext {
         execute_us: u64,
         deserialize_us: u64,
     );
+    /// Get sysvar
+    fn get_sysvar(&mut self, pubkey: &Pubkey) -> Option<Rc<Sysvars>>;
 }
 
 /// Convenience macro to log a message with an `Rc<RefCell<dyn Logger>>`
@@ -130,6 +141,8 @@ pub struct BpfComputeBudget {
     pub max_cpi_instruction_size: usize,
     /// Number of account data bytes per conpute unit charged during a cross-program invocation
     pub cpi_bytes_per_unit: u64,
+    /// Base number of compute units consumed to to get a sysvar
+    pub sysvar_base_cost: u64,
 }
 impl Default for BpfComputeBudget {
     fn default() -> Self {
@@ -152,6 +165,7 @@ impl BpfComputeBudget {
             log_pubkey_units: 100,
             max_cpi_instruction_size: 1280, // IPv6 Min MTU size
             cpi_bytes_per_unit: 250,        // ~50MB at 200,000 units
+            sysvar_base_cost: 100,
         }
     }
 }
@@ -277,7 +291,9 @@ pub struct MockInvokeContext {
     pub bpf_compute_budget: BpfComputeBudget,
     pub compute_meter: MockComputeMeter,
     pub programs: Vec<(Pubkey, ProcessInstructionWithContext)>,
+    pub accounts: Vec<(Pubkey, Rc<RefCell<AccountSharedData>>)>,
     pub invoke_depth: usize,
+    pub sysvars: Vec<(Pubkey, Option<Rc<Sysvars>>)>,
 }
 impl Default for MockInvokeContext {
     fn default() -> Self {
@@ -289,7 +305,9 @@ impl Default for MockInvokeContext {
                 remaining: std::i64::MAX as u64,
             },
             programs: vec![],
+            accounts: vec![],
             invoke_depth: 0,
+            sysvars: vec![],
         }
     }
 }
@@ -336,7 +354,12 @@ impl InvokeContext for MockInvokeContext {
     fn is_feature_active(&self, _feature_id: &Pubkey) -> bool {
         true
     }
-    fn get_account(&self, _pubkey: &Pubkey) -> Option<Rc<RefCell<AccountSharedData>>> {
+    fn get_account(&self, pubkey: &Pubkey) -> Option<Rc<RefCell<AccountSharedData>>> {
+        for (key, account) in self.accounts.iter() {
+            if key == pubkey {
+                return Some(account.clone());
+            }
+        }
         None
     }
     fn update_timing(
@@ -346,5 +369,10 @@ impl InvokeContext for MockInvokeContext {
         _execute_us: u64,
         _deserialize_us: u64,
     ) {
+    }
+    fn get_sysvar(&mut self, pubkey: &Pubkey) -> Option<Rc<Sysvars>> {
+        self.sysvars
+            .iter()
+            .find_map(|(key, sysvar)| if pubkey == key { sysvar.clone() } else { None })
     }
 }

--- a/storage-proto/proto/solana.storage.transaction_by_addr.rs
+++ b/storage-proto/proto/solana.storage.transaction_by_addr.rs
@@ -118,4 +118,5 @@ pub enum InstructionErrorType {
     AccountNotRentExempt = 45,
     InvalidAccountOwner = 46,
     ArithmeticOverflow = 47,
+    UnsupportedSysvar = 48,
 }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -510,6 +510,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
                     45 => InstructionError::AccountNotRentExempt,
                     46 => InstructionError::InvalidAccountOwner,
                     47 => InstructionError::ArithmeticOverflow,
+                    48 => InstructionError::UnsupportedSysvar,
                     _ => return Err("Invalid InstructionError"),
                 };
 
@@ -738,6 +739,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                             }
                             InstructionError::ArithmeticOverflow => {
                                 tx_by_addr::InstructionErrorType::ArithmeticOverflow
+                            }
+                            InstructionError::UnsupportedSysvar => {
+                                tx_by_addr::InstructionErrorType::UnsupportedSysvar
                             }
                         } as i32,
                         custom: match instruction_error {


### PR DESCRIPTION
#### Problem

Requiring developers to include sysvars in their instructions complicates composibility and requires programs to pass the sysvar accounts between programs when an intermediate might not actually need them.

Also, because of the bincode serialization of the sysvar data and the lack of a C parser we currently don't support sysvars in C BPF programs.

#### Summary of Changes

- Allow a program to call a syscall to obtain the sysvar.
- Do so in a way that does NOT require the bincode deserialization in-program

Needed by: https://github.com/solana-labs/solana/pull/15927

Fixes #15755
