### PR TITLE
fix: revert usage of toBytes to fix compatibility

### DIFF
--- a/web3.js/src/stake-program.ts
+++ b/web3.js/src/stake-program.ts
@@ -506,13 +506,13 @@ export class StakeProgram {
     const type = STAKE_INSTRUCTION_LAYOUTS.Initialize;
     const data = encodeData(type, {
       authorized: {
-        staker: toBuffer(authorized.staker.toBytes()),
-        withdrawer: toBuffer(authorized.withdrawer.toBytes()),
+        staker: toBuffer(authorized.staker.toBuffer()),
+        withdrawer: toBuffer(authorized.withdrawer.toBuffer()),
       },
       lockup: {
         unixTimestamp: lockup.unixTimestamp,
         epoch: lockup.epoch,
-        custodian: toBuffer(lockup.custodian.toBytes()),
+        custodian: toBuffer(lockup.custodian.toBuffer()),
       },
     });
     const instructionData = {
@@ -613,7 +613,7 @@ export class StakeProgram {
 
     const type = STAKE_INSTRUCTION_LAYOUTS.Authorize;
     const data = encodeData(type, {
-      newAuthorized: toBuffer(newAuthorizedPubkey.toBytes()),
+      newAuthorized: toBuffer(newAuthorizedPubkey.toBuffer()),
       stakeAuthorizationType: stakeAuthorizationType.index,
     });
 
@@ -649,10 +649,10 @@ export class StakeProgram {
 
     const type = STAKE_INSTRUCTION_LAYOUTS.AuthorizeWithSeed;
     const data = encodeData(type, {
-      newAuthorized: toBuffer(newAuthorizedPubkey.toBytes()),
+      newAuthorized: toBuffer(newAuthorizedPubkey.toBuffer()),
       stakeAuthorizationType: stakeAuthorizationType.index,
       authoritySeed: authoritySeed,
-      authorityOwner: toBuffer(authorityOwner.toBytes()),
+      authorityOwner: toBuffer(authorityOwner.toBuffer()),
     });
 
     const keys = [

--- a/web3.js/src/system-program.ts
+++ b/web3.js/src/system-program.ts
@@ -671,7 +671,7 @@ export class SystemProgram {
     const data = encodeData(type, {
       lamports: params.lamports,
       space: params.space,
-      programId: toBuffer(params.programId.toBytes()),
+      programId: toBuffer(params.programId.toBuffer()),
     });
 
     return new TransactionInstruction({
@@ -697,7 +697,7 @@ export class SystemProgram {
       data = encodeData(type, {
         lamports: params.lamports,
         seed: params.seed,
-        programId: toBuffer(params.programId.toBytes()),
+        programId: toBuffer(params.programId.toBuffer()),
       });
       keys = [
         {pubkey: params.fromPubkey, isSigner: false, isWritable: true},
@@ -731,9 +731,9 @@ export class SystemProgram {
     if ('basePubkey' in params) {
       const type = SYSTEM_INSTRUCTION_LAYOUTS.AssignWithSeed;
       data = encodeData(type, {
-        base: toBuffer(params.basePubkey.toBytes()),
+        base: toBuffer(params.basePubkey.toBuffer()),
         seed: params.seed,
-        programId: toBuffer(params.programId.toBytes()),
+        programId: toBuffer(params.programId.toBuffer()),
       });
       keys = [
         {pubkey: params.accountPubkey, isSigner: false, isWritable: true},
@@ -742,7 +742,7 @@ export class SystemProgram {
     } else {
       const type = SYSTEM_INSTRUCTION_LAYOUTS.Assign;
       data = encodeData(type, {
-        programId: toBuffer(params.programId.toBytes()),
+        programId: toBuffer(params.programId.toBuffer()),
       });
       keys = [{pubkey: params.accountPubkey, isSigner: true, isWritable: true}];
     }
@@ -763,11 +763,11 @@ export class SystemProgram {
   ): TransactionInstruction {
     const type = SYSTEM_INSTRUCTION_LAYOUTS.CreateWithSeed;
     const data = encodeData(type, {
-      base: toBuffer(params.basePubkey.toBytes()),
+      base: toBuffer(params.basePubkey.toBuffer()),
       seed: params.seed,
       lamports: params.lamports,
       space: params.space,
-      programId: toBuffer(params.programId.toBytes()),
+      programId: toBuffer(params.programId.toBuffer()),
     });
     let keys = [
       {pubkey: params.fromPubkey, isSigner: true, isWritable: true},
@@ -832,7 +832,7 @@ export class SystemProgram {
   ): TransactionInstruction {
     const type = SYSTEM_INSTRUCTION_LAYOUTS.InitializeNonceAccount;
     const data = encodeData(type, {
-      authorized: toBuffer(params.authorizedPubkey.toBytes()),
+      authorized: toBuffer(params.authorizedPubkey.toBuffer()),
     });
     const instructionData = {
       keys: [
@@ -907,7 +907,7 @@ export class SystemProgram {
   static nonceAuthorize(params: AuthorizeNonceParams): TransactionInstruction {
     const type = SYSTEM_INSTRUCTION_LAYOUTS.AuthorizeNonceAccount;
     const data = encodeData(type, {
-      authorized: toBuffer(params.newAuthorizedPubkey.toBytes()),
+      authorized: toBuffer(params.newAuthorizedPubkey.toBuffer()),
     });
 
     return new TransactionInstruction({
@@ -931,10 +931,10 @@ export class SystemProgram {
     if ('basePubkey' in params) {
       const type = SYSTEM_INSTRUCTION_LAYOUTS.AllocateWithSeed;
       data = encodeData(type, {
-        base: toBuffer(params.basePubkey.toBytes()),
+        base: toBuffer(params.basePubkey.toBuffer()),
         seed: params.seed,
         space: params.space,
-        programId: toBuffer(params.programId.toBytes()),
+        programId: toBuffer(params.programId.toBuffer()),
       });
       keys = [
         {pubkey: params.accountPubkey, isSigner: false, isWritable: true},

--- a/web3.js/src/transaction.ts
+++ b/web3.js/src/transaction.ts
@@ -569,7 +569,7 @@ export class Transaction {
         }
       } else {
         if (
-          !nacl.sign.detached.verify(signData, signature, publicKey.toBytes())
+          !nacl.sign.detached.verify(signData, signature, publicKey.toBuffer())
         ) {
           return false;
         }


### PR DESCRIPTION
#### Problem
web3.js v1.2 introduced the new `PublicKey.toBytes()` method for getting the raw bytes from public keys. Unfortunately, it's quite common for applications to pass a `PublicKey` from an older version of web3.js which doesn't have this method, breaking backwards compatibility.

#### Summary of Changes
- Fix backwards compatibility by using the old `toBuffer` method instead of `toBytes`

Fixes https://github.com/solana-labs/solana/issues/16207
