### PR TITLE
fix: handle empty rpc batch requests properly

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -722,6 +722,9 @@ function createRpcRequest(client: RpcClient): RpcRequest {
 function createRpcBatchRequest(client: RpcClient): RpcBatchRequest {
   return (requests: RpcParams[]) => {
     return new Promise((resolve, reject) => {
+      // Do nothing if requests is empty
+      if (requests.length === 0) resolve([]);
+
       const batch = requests.map((params: RpcParams) => {
         return client.request(params.methodName, params.args);
       });

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -894,7 +894,7 @@ describe('Connection', () => {
       ],
     });
 
-    const result = await connection.getParsedConfirmedTransactions([
+    let result = await connection.getParsedConfirmedTransactions([
       confirmedTransaction,
       confirmedTransaction,
     ]);
@@ -913,6 +913,14 @@ describe('Connection', () => {
     if (result[1] !== null) {
       expect(result[1].transaction.signatures).not.to.be.null;
     }
+
+    result = await connection.getParsedConfirmedTransactions([]);
+    if (!result) {
+      expect(result).to.be.ok;
+      return;
+    }
+
+    expect(result).to.be.empty;
   });
 
   it('get confirmed transaction', async () => {


### PR DESCRIPTION
#### Problem
When a request batch is empty, the rpc-client library we use returns `undefined` rather than an empty response list, which causes errors

#### Summary of Changes
- Exit early if request batch is empty

Fixes #
