### PR TITLE
Fix BPF ELF layout

### DIFF
--- a/sdk/bpf/rust/bpf.ld
+++ b/sdk/bpf/rust/bpf.ld
@@ -1,6 +1,6 @@
 PHDRS
 {
-  text PT_LOAD  ;
+  text PT_LOAD ;
   rodata PT_LOAD ;
   dynamic PT_DYNAMIC ;
 }
@@ -10,11 +10,6 @@ SECTIONS
   . = SIZEOF_HEADERS;
   .text : { *(.text*) } :text
   .rodata : { *(.rodata*) } :rodata
+  .data.rel.ro : { *(.data.rel.ro*) } :rodata
   .dynamic : { *(.dynamic) } :dynamic
-  .data.rel.ro : { *(.data.rel.ro*) } :dynamic
-  .dynsym : { *(.dynsym) } :dynamic
-  .dynstr : { *(.dynstr) } :dynamic
-  .gnu.hash : { *(.gnu.hash) } :dynamic
-  .rel.dyn : { *(.rel.dyn) } :dynamic
-  .hash : { *(.hash) } :dynamic
 }

--- a/sdk/bpf/scripts/dump.sh
+++ b/sdk/bpf/scripts/dump.sh
@@ -7,17 +7,17 @@ source "$bpf_sdk"/env.sh
 so=$1
 dump=$2
 if [[ -z $so ]] || [[ -z $dump ]]; then
-  echo "Usage: $0 bpf-program.so dump.txt"
+  echo "Usage: $0 bpf-program.so dump.txt" >&2 
   exit 1
 fi
 
 if [[ ! -r $so ]]; then
-  echo "Error: File not found or readable: $so"
+  echo "Error: File not found or readable: $so" >&2 
   exit 1
 fi
 
 if ! command -v rustfilt > /dev/null; then
-  echo "Error: rustfilt not found.  It can be installed by running: cargo install rustfilt"
+  echo "Error: rustfilt not found.  It can be installed by running: cargo install rustfilt" >&2 
   exit 1
 fi
 
@@ -38,8 +38,9 @@ dump_mangled=$dump.mangled
 rm -f "$dump_mangled"
 
 if [[ ! -f "$dump" ]]; then
-  echo "Error: Failed to create $dump"
+  echo "Error: Failed to create $dump" >&2 
   exit 1
 fi
 
-echo "Wrote $dump"
+echo >&2
+echo "Wrote $dump" >&2 

--- a/sdk/bpf/scripts/dump.sh
+++ b/sdk/bpf/scripts/dump.sh
@@ -7,17 +7,17 @@ source "$bpf_sdk"/env.sh
 so=$1
 dump=$2
 if [[ -z $so ]] || [[ -z $dump ]]; then
-  echo "Usage: $0 bpf-program.so dump.txt" >&2 
+  echo "Usage: $0 bpf-program.so dump.txt" >&2
   exit 1
 fi
 
 if [[ ! -r $so ]]; then
-  echo "Error: File not found or readable: $so" >&2 
+  echo "Error: File not found or readable: $so" >&2
   exit 1
 fi
 
 if ! command -v rustfilt > /dev/null; then
-  echo "Error: rustfilt not found.  It can be installed by running: cargo install rustfilt" >&2 
+  echo "Error: rustfilt not found.  It can be installed by running: cargo install rustfilt" >&2
   exit 1
 fi
 
@@ -38,9 +38,9 @@ dump_mangled=$dump.mangled
 rm -f "$dump_mangled"
 
 if [[ ! -f "$dump" ]]; then
-  echo "Error: Failed to create $dump" >&2 
+  echo "Error: Failed to create $dump" >&2
   exit 1
 fi
 
 echo >&2
-echo "Wrote $dump" >&2 
+echo "Wrote $dump" >&2


### PR DESCRIPTION
#### Problem

readelf reports that the BPF ELF has bad offsets in some sections.  In most cases this isn't a problem, the bad offsets are not in parts we touch.  Except if a .bss section is introduced with rw data, then the ELF loader fails on the bad offset instead of reporting that the developer introduced rw data.

#### Summary of Changes

- Restructure the ELF with the linker file to fix the readelf warnings and the ELF loading premature failure.
- Also ensure that errors/status from the dump script makes it out to the user

Fixes #
