### PR TITLE
fix: fix Buffer shim compatibility in browser

### DIFF
--- a/web3.js/rollup.config.js
+++ b/web3.js/rollup.config.js
@@ -78,10 +78,9 @@ function generateConfig(configType, format) {
           config.external = [
             /@babel\/runtime/,
             'bn.js',
-            // Bundled for `Buffer` consistency
-            // 'bs58',
-            // 'buffer',
-            // 'buffer-layout',
+            'bs58',
+            'buffer',
+            'buffer-layout',
             'crypto-hash',
             'jayson/lib/client/browser',
             'js-sha3',


### PR DESCRIPTION
#### Problem
By bundling `buffer` and related dependencies into browser modules, any `instanceof Buffer` checks will fail because downstream apps cannot resolve a single version of the `buffer` shim and end up using multiple incompatible copies.

Fixes: https://github.com/solana-labs/solana-web3.js/issues/1017
Related to: https://github.com/solana-labs/solana/issues/16255