### PR TITLE
update timings only on outer call

### DIFF
--- a/runtime/benches/message_processor.rs
+++ b/runtime/benches/message_processor.rs
@@ -24,7 +24,8 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
             false,
             &Rent::default(),
             &post,
-            &mut ExecuteDetailsTimings::default()
+            &mut ExecuteDetailsTimings::default(),
+            false,
         ),
         Ok(())
     );
@@ -37,6 +38,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
             &Rent::default(),
             &post,
             &mut ExecuteDetailsTimings::default(),
+            false,
         )
         .unwrap();
     });
@@ -60,6 +62,7 @@ fn bench_verify_account_changes_data(bencher: &mut Bencher) {
             &Rent::default(),
             &post,
             &mut ExecuteDetailsTimings::default(),
+            false,
         )
         .unwrap();
     });

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1002,7 +1002,14 @@ impl MessageProcessor {
                                 .map_err(|_| InstructionError::AccountBorrowOutstanding)?;
                         }
                         let account = account.borrow();
-                        pre_account.verify(&program_id, is_writable, &rent, &account, timings, false)?;
+                        pre_account.verify(
+                            &program_id,
+                            is_writable,
+                            &rent,
+                            &account,
+                            timings,
+                            false,
+                        )?;
                         pre_sum += u128::from(pre_account.lamports());
                         post_sum += u128::from(account.lamports);
                         if is_writable && !account.executable {
@@ -1372,6 +1379,7 @@ mod tests {
                 &self.rent,
                 &self.post,
                 &mut ExecuteDetailsTimings::default(),
+                false,
             )
         }
     }

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -104,6 +104,7 @@ impl PreAccount {
         rent: &Rent,
         post: &AccountSharedData,
         timings: &mut ExecuteDetailsTimings,
+        outermost_call: bool,
     ) -> Result<(), InstructionError> {
         let pre = self.account.borrow();
 
@@ -186,17 +187,19 @@ impl PreAccount {
             return Err(InstructionError::RentEpochModified);
         }
 
-        timings.total_account_count += 1;
-        timings.total_data_size += post.data().len();
-        if owner_changed
-            || lamports_changed
-            || data_len_changed
-            || executable_changed
-            || rent_epoch_changed
-            || self.changed
-        {
-            timings.changed_account_count += 1;
-            timings.data_size_changed += post.data().len();
+        if outermost_call {
+            timings.total_account_count += 1;
+            timings.total_data_size += post.data().len();
+            if owner_changed
+                || lamports_changed
+                || data_len_changed
+                || executable_changed
+                || rent_epoch_changed
+                || self.changed
+            {
+                timings.changed_account_count += 1;
+                timings.data_size_changed += post.data().len();
+            }
         }
 
         Ok(())
@@ -950,6 +953,7 @@ impl MessageProcessor {
                     rent,
                     &account,
                     timings,
+                    true,
                 )?;
                 pre_sum += u128::from(pre_accounts[unique_index].lamports());
                 post_sum += u128::from(account.lamports);
@@ -998,7 +1002,7 @@ impl MessageProcessor {
                                 .map_err(|_| InstructionError::AccountBorrowOutstanding)?;
                         }
                         let account = account.borrow();
-                        pre_account.verify(&program_id, is_writable, &rent, &account, timings)?;
+                        pre_account.verify(&program_id, is_writable, &rent, &account, timings, false)?;
                         pre_sum += u128::from(pre_account.lamports());
                         post_sum += u128::from(account.lamports);
                         if is_writable && !account.executable {


### PR DESCRIPTION
#### Problem
we are double counting metrics for executing transactions if there is are inner programs
#### Summary of Changes
only count metrics on outer calls
Fixes #
