### PR TITLE
Use more performant copy

### DIFF
--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1730,7 +1730,7 @@ fn call<'a>(
                     }
                     account_ref
                         .data
-                        .clone_from_slice(&account.data()[0..account_ref.data.len()]);
+                        .copy_from_slice(&account.data()[0..account_ref.data.len()]);
                 }
             }
         }


### PR DESCRIPTION
#### Problem

Copy is not as fast as it potentially could be

#### Summary of Changes

Use `copy_from_slice` instead of `clone_from_slice`, possibly more performant as per https://doc.rust-lang.org/std/primitive.slice.html#method.clone_from_slice (Thanks for noticing @jeffwashington)

Fixes #
