### PR TITLE
pre-load accounts for transaction

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -2927,7 +2927,18 @@ impl AccountsDb {
         pubkey: &Pubkey,
         load_hint: LoadHint,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.do_load(ancestors, pubkey, None, load_hint)
+        let load_into_read_only_cache_only = false;
+        self.do_load(
+            ancestors,
+            pubkey,
+            None,
+            load_hint,
+            load_into_read_only_cache_only,
+        )
+    }
+
+    pub fn load_accounts_into_read_only_cache(&self, ancestors: &Ancestors, pubkey: &Pubkey) {
+        self.do_load(ancestors, pubkey, None, LoadHint::Unspecified, true);
     }
 
     pub fn load_with_fixed_root(
@@ -3272,6 +3283,7 @@ impl AccountsDb {
         pubkey: &Pubkey,
         max_root: Option<Slot>,
         load_hint: LoadHint,
+        load_into_read_only_cache_only: bool,
     ) -> Option<(AccountSharedData, Slot)> {
         #[cfg(not(test))]
         assert!(max_root.is_none());
@@ -3280,10 +3292,19 @@ impl AccountsDb {
             self.read_index_for_accessor_or_load_slow(ancestors, pubkey, max_root, false)?;
         // Notice the subtle `?` at previous line, we bail out pretty early if missing.
 
-        if self.caching_enabled && store_id != CACHE_VIRTUAL_STORAGE_ID {
-            let result = self.read_only_accounts_cache.load(pubkey, slot);
-            if let Some(account) = result {
-                return Some((account, slot));
+        if self.caching_enabled {
+            if load_into_read_only_cache_only {
+                if store_id == CACHE_VIRTUAL_STORAGE_ID {
+                    return None;
+                }
+                if self.read_only_accounts_cache.in_cache(pubkey, slot) {
+                    return None;
+                }
+            } else if store_id != CACHE_VIRTUAL_STORAGE_ID {
+                let result = self.read_only_accounts_cache.load(pubkey, slot);
+                if let Some(account) = result {
+                    return Some((account, slot));
+                }
             }
         }
 
@@ -10875,6 +10896,7 @@ pub mod tests {
                 &account_key,
                 Some(0),
                 LoadHint::Unspecified,
+                false,
             )
             .unwrap();
         assert_eq!(account.0.lamports(), 0);
@@ -10890,7 +10912,8 @@ pub mod tests {
                 &Ancestors::default(),
                 &account_key,
                 Some(0),
-                LoadHint::Unspecified
+                LoadHint::Unspecified,
+                false,
             )
             .is_none());
     }
@@ -10965,7 +10988,8 @@ pub mod tests {
                 &Ancestors::default(),
                 &zero_lamport_account_key,
                 max_root,
-                load_hint
+                load_hint,
+                false,
             )
             .unwrap()
             .0
@@ -11093,6 +11117,7 @@ pub mod tests {
                 &account_key,
                 Some(0),
                 LoadHint::Unspecified,
+                false,
             )
             .unwrap();
         assert_eq!(account.0.lamports(), zero_lamport_account.lamports());
@@ -11106,6 +11131,7 @@ pub mod tests {
                 &account_key,
                 Some(max_scan_root),
                 LoadHint::Unspecified,
+                false,
             )
             .unwrap();
         assert_eq!(account.0.lamports(), slot1_account.lamports());
@@ -11120,6 +11146,7 @@ pub mod tests {
                 &account_key,
                 Some(max_scan_root),
                 LoadHint::Unspecified,
+                false,
             )
             .unwrap();
         assert_eq!(account.0.lamports(), slot1_account.lamports());
@@ -11132,7 +11159,8 @@ pub mod tests {
                 &scan_ancestors,
                 &account_key,
                 Some(max_scan_root),
-                LoadHint::Unspecified
+                LoadHint::Unspecified,
+                false,
             )
             .is_none());
     }
@@ -11281,7 +11309,8 @@ pub mod tests {
                     &Ancestors::default(),
                     key,
                     Some(last_dead_slot),
-                    LoadHint::Unspecified
+                    LoadHint::Unspecified,
+                    false,
                 )
                 .is_some());
         }
@@ -11309,7 +11338,8 @@ pub mod tests {
                     &Ancestors::default(),
                     key,
                     Some(last_dead_slot),
-                    LoadHint::Unspecified
+                    LoadHint::Unspecified,
+                    false,
                 )
                 .is_none());
         }
@@ -11848,7 +11878,9 @@ pub mod tests {
                         .store(thread_rng().gen_range(0, 10) as u64, Ordering::Relaxed);
 
                     // Load should never be unable to find this key
-                    let loaded_account = db.do_load(&ancestors, &pubkey, None, load_hint).unwrap();
+                    let loaded_account = db
+                        .do_load(&ancestors, &pubkey, None, load_hint, false)
+                        .unwrap();
                     // slot + 1 == account.lamports because of the account-cache-flush thread
                     assert_eq!(
                         loaded_account.0.lamports(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4983,6 +4983,13 @@ impl Bank {
         &self.rc.accounts.accounts_db.thread_pool_clean
     }
 
+    pub fn load_accounts_into_read_only_cache(&self, key: &Pubkey) {
+        self.rc
+            .accounts
+            .accounts_db
+            .load_accounts_into_read_only_cache(&self.ancestors, key);
+    }
+
     pub fn update_accounts_hash_with_index_option(
         &self,
         use_index: bool,

--- a/runtime/src/read_only_accounts_cache.rs
+++ b/runtime/src/read_only_accounts_cache.rs
@@ -92,6 +92,10 @@ impl ReadOnlyAccountsCache {
         std::mem::size_of::<ReadOnlyAccountCacheEntry>() + std::mem::size_of::<RwLock<Instant>>()
     }
 
+    pub fn in_cache(&self, pubkey: &Pubkey, slot: Slot) -> bool {
+        self.cache.contains_key(&(*pubkey, slot))
+    }
+
     pub fn load(&self, pubkey: &Pubkey, slot: Slot) -> Option<AccountSharedData> {
         self.cache
             .get(&(*pubkey, slot))


### PR DESCRIPTION
#### Problem
My thinking is anytime we know the work that is coming and it is expensive and the results can be inexpensively held and the work has no dependencies, then there may be value in starting it as early as possible and doing it in parallel.  Your new machine has what 4x the cpus my colo machine has? Maybe moore’s law keeps giving us more cpus :wink: Some of the work may be io bound (load from store), store. I figure with copy on write data and a read only cache, we have the tools now to efficiently pipeline tx verify.
#### Summary of Changes

Fixes #
