### PR TITLE
reduce locking on get_rooted_entries

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -685,9 +685,11 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
     }
 
     pub fn get_rooted_entries(&self, slice: SlotSlice<T>, max: Option<Slot>) -> SlotList<T> {
+        let max = max.unwrap_or(Slot::MAX);
+        let lock = &self.roots_tracker.read().unwrap().roots;
         slice
             .iter()
-            .filter(|(slot, _)| self.is_root(*slot) && max.map_or(true, |max| *slot <= max))
+            .filter(|(slot, _)| *slot <= max && lock.contains(slot))
             .cloned()
             .collect()
     }


### PR DESCRIPTION
#### Problem
get_rooted_entries is called during clean and perhaps other times. The current implementation acquires and releases the lock with each check.
#### Summary of Changes
Get the read lock and check all slots as tightly as possible.
Fixes #
