### PR TITLE
Replace RootsTracker HashSet

### DIFF
--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -55,7 +55,7 @@ async fn clock_sysvar_updated_from_warp() {
     );
 
     let mut context = program_test.start_with_context().await;
-    let expected_slot = 5_000_000;
+    let expected_slot = 100_000;
     let instruction = Instruction::new_with_bincode(
         program_id,
         &expected_slot,

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -200,13 +200,9 @@ impl RollingBitField {
         }
     }
 
-    fn get_address(&self, key: &u64) -> u64 {
-        Self::calc_address(self.max_width, key)
-    }
-
     // find the array index
-    fn calc_address(max_width: u64, key: &u64) -> u64 {
-        key % max_width
+    fn get_address(&self, key: &u64) -> u64 {
+        key % self.max_width
     }
 
     fn check_range(&self, key: u64) {
@@ -240,7 +236,7 @@ impl RollingBitField {
         let address = self.get_address(key);
         let value = self.bits.get(address);
         if value {
-            self.count -= 1; // this will underflow if it tries to go below 0. That is like an assert.
+            self.count -= 1;
             self.bits.set(address, false);
             self.purge(key);
         }
@@ -282,8 +278,8 @@ impl RollingBitField {
     pub fn get_all(&self) -> Vec<u64> {
         let mut all = Vec::with_capacity(self.count);
         for key in self.min..self.max {
-            if self.contains(&(key as u64)) {
-                all.push(key as u64);
+            if self.contains(&key) {
+                all.push(key);
                 if all.len() == self.count {
                     break;
                 }

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -246,6 +246,7 @@ impl RollingBitField {
         }
     }
 
+    // after removing 'key' where 'key' = min, make min the correct new min value
     fn purge(&mut self, key: &u64) {
         if key == &self.min && self.count > 0 {
             let start = self.min;
@@ -261,10 +262,8 @@ impl RollingBitField {
     pub fn contains(&self, key: &u64) -> bool {
         let address = self.get_address(key);
         let result = self.bits.get(address);
-        if result && (self.count == 0 || key < &self.min || key >= &self.max) {
-            return false;
-        }
-        result
+        // a contains call outside min and max is allowed. The answer will be false.
+        result && (key >= &self.min && key < &self.max)
     }
 
     pub fn len(&self) -> usize {
@@ -1350,7 +1349,7 @@ pub mod tests {
         let mut bitfield = RollingBitField::new(2097152);
         let mut hash = HashSet::new();
 
-        let min = 101_000.clone();
+        let min = 101_000;
         let width = 400_000;
         let dead = 19;
 

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1370,9 +1370,8 @@ pub mod tests {
             if slot % dead == 0 {
                 continue;
             }
-            let s2 = slot.clone();
-            hash.insert(s2);
-            bitfield.insert(s2);
+            hash.insert(slot);
+            bitfield.insert(slot);
         }
 
         let max = slot + 1;
@@ -1424,9 +1423,8 @@ pub mod tests {
             if slot % dead == 0 {
                 continue;
             }
-            let s2 = slot.clone();
-            hash.insert(s2);
-            bitfield.insert(s2);
+            hash.insert(slot);
+            bitfield.insert(slot);
         }
 
         let max = slot + 1;

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -3,6 +3,7 @@ use crate::{
     inline_spl_token_v2_0::{self, SPL_TOKEN_ACCOUNT_MINT_OFFSET, SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
     secondary_index::*,
 };
+use bv::BitVec;
 use dashmap::DashSet;
 use ouroboros::self_referencing;
 use solana_measure::measure::Measure;
@@ -172,8 +173,6 @@ impl<T: 'static + Clone + IsCached> WriteAccountMapEntry<T> {
         self.slot_list_mut(|list| list.push((slot, account_info)));
     }
 }
-
-use bv::BitVec;
 
 #[derive(Debug, Default)]
 pub struct RollingBitField {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -319,12 +319,6 @@ impl RootsTracker {
             previous_uncleaned_roots: HashSet::new(),
         }
     }
-    pub fn roots_clear(&mut self) {
-        self.roots.clear();
-        self.max_root = 0;
-        self.uncleaned_roots = HashSet::new();
-        self.previous_uncleaned_roots = HashSet::new();
-    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
#### Problem
with a readonly accounts cache (meaning the store has previously been loaded), large cpu time is spent looking in 400k hashsets millions of times. We could do better.
#### Summary of Changes
Replace RootsTracker HashSet with BitVec based lookup.
Fixes #
