### PR TITLE
Cleanup use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4985,7 +4985,6 @@ dependencies = [
  "solana-banks-server",
  "solana-bpf-loader-program",
  "solana-logger 1.7.0",
- "solana-program 1.7.0",
  "solana-runtime",
  "solana-sdk",
  "solana-stake-program",

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -18,7 +18,6 @@ solana-banks-client = { path = "../banks-client", version = "=1.7.0" }
 solana-banks-server = { path = "../banks-server", version = "=1.7.0" }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.7.0" }
 solana-logger = { path = "../logger", version = "=1.7.0" }
-solana-program = { path = "../sdk/program", version = "=1.7.0" }
 solana-runtime = { path = "../runtime", version = "=1.7.0" }
 solana-sdk = { path = "../sdk", version = "=1.7.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.7.0" }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -7,20 +7,6 @@ use {
     log::*,
     solana_banks_client::start_client,
     solana_banks_server::banks_server::start_local_server,
-    solana_program::{
-        account_info::AccountInfo,
-        entrypoint::ProgramResult,
-        fee_calculator::{FeeCalculator, FeeRateGovernor},
-        hash::Hash,
-        instruction::Instruction,
-        instruction::InstructionError,
-        message::Message,
-        native_token::sol_to_lamports,
-        program_error::ProgramError,
-        program_stubs,
-        pubkey::Pubkey,
-        rent::Rent,
-    },
     solana_runtime::{
         bank::{Bank, Builtin, ExecuteTimings},
         bank_forks::BankForks,
@@ -29,13 +15,24 @@ use {
     },
     solana_sdk::{
         account::{Account, AccountSharedData, ReadableAccount},
+        account_info::AccountInfo,
         clock::Slot,
+        entrypoint::ProgramResult,
         feature_set::demote_sysvar_write_locks,
+        fee_calculator::{FeeCalculator, FeeRateGovernor},
         genesis_config::{ClusterType, GenesisConfig},
+        hash::Hash,
+        instruction::Instruction,
+        instruction::InstructionError,
         keyed_account::KeyedAccount,
+        message::Message,
+        native_token::sol_to_lamports,
         process_instruction::{
             stable_log, BpfComputeBudget, InvokeContext, ProcessInstructionWithContext,
         },
+        program_error::ProgramError,
+        pubkey::Pubkey,
+        rent::Rent,
         signature::{Keypair, Signer},
     },
     solana_vote_program::vote_state::{VoteState, VoteStateVersions},
@@ -94,7 +91,7 @@ fn get_invoke_context<'a>() -> &'a mut dyn InvokeContext {
 }
 
 pub fn builtin_process_instruction(
-    process_instruction: solana_program::entrypoint::ProcessInstruction,
+    process_instruction: solana_sdk::entrypoint::ProcessInstruction,
     program_id: &Pubkey,
     keyed_accounts: &[KeyedAccount],
     input: &[u8],
@@ -185,7 +182,7 @@ macro_rules! processor {
 }
 
 struct SyscallStubs {}
-impl program_stubs::SyscallStubs for SyscallStubs {
+impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
     fn sol_log(&self, message: &str) {
         let invoke_context = get_invoke_context();
         let logger = invoke_context.get_logger();
@@ -529,7 +526,7 @@ impl ProgramTest {
         program_id: Pubkey,
         process_instruction: Option<ProcessInstructionWithContext>,
     ) {
-        let loader = solana_program::bpf_loader::id();
+        let loader = solana_sdk::bpf_loader::id();
         let program_file = find_file(&format!("{}.so", program_name));
 
         if process_instruction.is_none() && program_file.is_none() {
@@ -604,7 +601,7 @@ impl ProgramTest {
             static ONCE: Once = Once::new();
 
             ONCE.call_once(|| {
-                program_stubs::set_syscall_stubs(Box::new(SyscallStubs {}));
+                solana_sdk::program_stubs::set_syscall_stubs(Box::new(SyscallStubs {}));
             });
         }
 

--- a/program-test/src/programs.rs
+++ b/program-test/src/programs.rs
@@ -42,7 +42,7 @@ pub fn spl_programs(rent: &Rent) -> Vec<(Pubkey, AccountSharedData)> {
                 AccountSharedData::from(Account {
                     lamports: rent.minimum_balance(elf.len()).min(1),
                     data: elf.to_vec(),
-                    owner: solana_program::bpf_loader::id(),
+                    owner: solana_sdk::bpf_loader::id(),
                     executable: true,
                     rent_epoch: 0,
                 }),

--- a/program-test/tests/fuzz.rs
+++ b/program-test/tests/fuzz.rs
@@ -1,11 +1,11 @@
 use {
     solana_banks_client::BanksClient,
-    solana_program::{
-        account_info::AccountInfo, entrypoint::ProgramResult, hash::Hash, instruction::Instruction,
-        msg, pubkey::Pubkey, rent::Rent, system_instruction,
-    },
     solana_program_test::{processor, ProgramTest},
-    solana_sdk::{signature::Keypair, signature::Signer, transaction::Transaction},
+    solana_sdk::{
+        account_info::AccountInfo, entrypoint::ProgramResult, hash::Hash, instruction::Instruction,
+        msg, pubkey::Pubkey, rent::Rent, signature::Keypair, signature::Signer, system_instruction,
+        transaction::Transaction,
+    },
 };
 
 #[allow(clippy::unnecessary_wraps)]
@@ -57,16 +57,16 @@ fn simulate_fuzz_with_context() {
         processor!(process_instruction),
     );
 
-    let mut test_state = rt.block_on(async { program_test.start_with_context().await });
+    let mut context = rt.block_on(async { program_test.start_with_context().await });
 
     // the honggfuzz `fuzz!` macro does not allow for async closures,
     // so we have to use the runtime directly to run async functions
     rt.block_on(async {
         run_fuzz_instructions(
             &[1, 2, 3, 4, 5],
-            &mut test_state.banks_client,
-            &test_state.payer,
-            test_state.last_blockhash,
+            &mut context.banks_client,
+            &context.payer,
+            context.last_blockhash,
             &program_id,
         )
         .await

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::integer_arithmetic)]
 use {
-    solana_program::{
+    solana_program_test::{processor, ProgramTest, ProgramTestError},
+    solana_sdk::{
         account_info::{next_account_info, AccountInfo},
         clock::Clock,
         entrypoint::ProgramResult,
@@ -8,12 +9,9 @@ use {
         program_error::ProgramError,
         pubkey::Pubkey,
         rent::Rent,
+        signature::{Keypair, Signer},
         system_instruction, system_program,
         sysvar::{clock, Sysvar},
-    },
-    solana_program_test::{processor, ProgramTest, ProgramTestError},
-    solana_sdk::{
-        signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError},
     },
     solana_stake_program::{


### PR DESCRIPTION
#### Problem

#### Summary of Changes

- Consolidate use in program-test
- Use default for MockInvokeContext to avoid requiring changing instantiation if new members are added

Fixes #
