### PR TITLE
Bump bpf-tools to version v1.5

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -1236,7 +1236,7 @@ fn assert_instruction_count() {
             ("multiple_static", 8),
             ("noop", 45),
             ("relative_call", 10),
-            ("sanity", 176),
+            ("sanity", 175),
             ("sanity++", 177),
             ("struct_pass", 8),
             ("struct_ret", 22),
@@ -1245,16 +1245,16 @@ fn assert_instruction_count() {
     #[cfg(feature = "bpf_rust")]
     {
         programs.extend_from_slice(&[
-            ("solana_bpf_rust_128bit", 581),
-            ("solana_bpf_rust_alloc", 8941),
+            ("solana_bpf_rust_128bit", 572),
+            ("solana_bpf_rust_alloc", 8906),
             ("solana_bpf_rust_dep_crate", 2),
-            ("solana_bpf_rust_external_spend", 522),
+            ("solana_bpf_rust_external_spend", 498),
             ("solana_bpf_rust_iter", 724),
             ("solana_bpf_rust_many_args", 237),
-            ("solana_bpf_rust_noop", 496),
-            ("solana_bpf_rust_param_passing", 54),
-            ("solana_bpf_rust_ristretto", 19246),
-            ("solana_bpf_rust_sanity", 952),
+            ("solana_bpf_rust_noop", 472),
+            ("solana_bpf_rust_param_passing", 46),
+            ("solana_bpf_rust_ristretto", 19220),
+            ("solana_bpf_rust_sanity", 894),
         ]);
     }
 

--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -92,7 +92,7 @@ if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
 fi
 
 # Install Rust-BPF
-version=v1.4
+version=v1.5
 if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
   (
     set -e

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -260,7 +260,7 @@ fn build_bpf_package(config: &Config, target_directory: &Path, package: &cargo_m
     install_if_missing(
         &config,
         "bpf-tools",
-        "v1.4",
+        "v1.5",
         "https://github.com/solana-labs/bpf-tools/releases/download",
         &PathBuf::from(bpf_tools_filename),
     )


### PR DESCRIPTION
The new version of bpf-tools eliminates the separate
rust-bpf-sysroot. The Rust standard libraries for the BPF target are
built in tree when the compiler is built.  The standard libraries code
is slightly more optimized and some reduction of compute budget can be
expected with this version of bpf-tools.

#### Problem

#### Summary of Changes

Fixes #
