### PR TITLE
merkle-tree: fix build when targeting bpf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4792,7 +4792,7 @@ version = "1.7.0"
 dependencies = [
  "fast-math",
  "hex",
- "solana-sdk",
+ "solana-program 1.7.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4792,6 +4792,7 @@ version = "1.7.0"
 dependencies = [
  "fast-math",
  "hex",
+ "matches",
  "solana-program 1.7.0",
 ]
 

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/solana-merkle-tree"
 edition = "2018"
 
 [dependencies]
-solana-sdk = { path = "../sdk", version = "=1.7.0" }
+solana-program = { path = "../sdk/program", version = "=1.7.0" }
 fast-math = "0.1"
 
 [dev-dependencies]

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -13,6 +13,10 @@ edition = "2018"
 solana-program = { path = "../sdk/program", version = "=1.7.0" }
 fast-math = "0.1"
 
+# This can go once the BPF toolchain target Rust 1.42.0+
+[target.bpfel-unknown-unknown.dependencies]
+matches = "0.1.8"
+
 [dev-dependencies]
 hex = "0.4.2"
 

--- a/merkle-tree/Xargo.toml
+++ b/merkle-tree/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -1,3 +1,8 @@
 #![allow(clippy::integer_arithmetic)]
+
+#[cfg(target_arch = "bpf")]
+#[macro_use]
+extern crate matches;
+
 pub mod merkle_tree;
 pub use merkle_tree::MerkleTree;

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -1,4 +1,4 @@
-use solana_sdk::hash::{hashv, Hash};
+use solana_program::hash::{hashv, Hash};
 
 // We need to discern between leaf and intermediate nodes to prevent trivial second
 // pre-image attacks.


### PR DESCRIPTION
#### Problem

`solana-merkle-tree` build fails when targeting bpf and someone wants to use it in a program :grimacing: 

#### Summary of Changes

Add `Xargo.toml`
Get `Hash` from `solana-program` instead of `solana-sdk`
Get `matches!()` from the `matches` crate when targeting bpf (until we're targeting Rust 1.42.0+)