### PR TITLE
Wait for 90 percent of stake before starting

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1365,7 +1365,7 @@ fn wait_for_supermajority(
 
         let gossip_stake_percent = get_stake_percent_in_gossip(&bank, &cluster_info, i % 10 == 0);
 
-        if gossip_stake_percent >= 80 {
+        if gossip_stake_percent >= 90 {
             break;
         }
         // The normal RPC health checks don't apply as the node is waiting, so feign health to


### PR DESCRIPTION
#### Problem

80% is problematic because it leaves very little margin for a ~40/40 split on two forks when starting the network. If the network cannot obtain at least 38% on one of the forks, then one 35% partition could stall waiting for the other to reach the desired level.

#### Summary of Changes

Increase wait-for-supermajority to 90% stake to give more margin on restart.

Fixes #
