### PR TITLE
Explorer: use identicon and token layout for unlisted tokens

### DIFF
--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -7622,6 +7622,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eve-raphael": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+      "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA="
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -9766,6 +9771,36 @@
           "version": "12.19.16",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
           "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
+        }
+      }
+    },
+    "jazzicon": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jazzicon/-/jazzicon-1.5.0.tgz",
+      "integrity": "sha1-1/NrUWAj2znubqwRf0BU6Te2Xpk=",
+      "requires": {
+        "color": "^0.11.1",
+        "mersenne-twister": "^1.0.1",
+        "raphael": "^2.2.0"
+      },
+      "dependencies": {
+        "color": {
+          "version": "0.11.4",
+          "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+          "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+          "requires": {
+            "clone": "^1.0.2",
+            "color-convert": "^1.3.0",
+            "color-string": "^0.3.0"
+          }
+        },
+        "color-string": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+          "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+          "requires": {
+            "color-name": "^1.0.0"
+          }
         }
       }
     },
@@ -12967,6 +13002,11 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
+    "mersenne-twister": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
+      "integrity": "sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -15512,6 +15552,14 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raphael": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+      "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
+      "requires": {
+        "eve-raphael": "0.5.0"
+      }
     },
     "raw-body": {
       "version": "2.4.0",

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -2342,6 +2342,35 @@
         }
       }
     },
+    "@metamask/jazzicon": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/jazzicon/-/jazzicon-2.0.0.tgz",
+      "integrity": "sha512-7M+WSZWKcQAo0LEhErKf1z+D3YX0tEDAcGvcKbDyvDg34uvgeKR00mFNIYwAhdAS9t8YXxhxZgsrRBBg6X8UQg==",
+      "requires": {
+        "color": "^0.11.3",
+        "mersenne-twister": "^1.1.0"
+      },
+      "dependencies": {
+        "color": {
+          "version": "0.11.4",
+          "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+          "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+          "requires": {
+            "clone": "^1.0.2",
+            "color-convert": "^1.3.0",
+            "color-string": "^0.3.0"
+          }
+        },
+        "color-string": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+          "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+          "requires": {
+            "color-name": "^1.0.0"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -7622,11 +7651,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "eve-raphael": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
-      "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA="
-    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -9771,36 +9795,6 @@
           "version": "12.19.16",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
           "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q=="
-        }
-      }
-    },
-    "jazzicon": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/jazzicon/-/jazzicon-1.5.0.tgz",
-      "integrity": "sha1-1/NrUWAj2znubqwRf0BU6Te2Xpk=",
-      "requires": {
-        "color": "^0.11.1",
-        "mersenne-twister": "^1.0.1",
-        "raphael": "^2.2.0"
-      },
-      "dependencies": {
-        "color": {
-          "version": "0.11.4",
-          "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-          "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-          "requires": {
-            "clone": "^1.0.2",
-            "color-convert": "^1.3.0",
-            "color-string": "^0.3.0"
-          }
-        },
-        "color-string": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-          "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-          "requires": {
-            "color-name": "^1.0.0"
-          }
         }
       }
     },
@@ -15552,14 +15546,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raphael": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
-      "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
-      "requires": {
-        "eve-raphael": "0.5.0"
-      }
     },
     "raw-body": {
       "version": "2.4.0",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@metamask/jazzicon": "^2.0.0",
     "@project-serum/serum": "^0.13.33",
     "@react-hook/debounce": "^3.0.0",
     "@sentry/react": "^6.2.5",
@@ -33,7 +34,6 @@
     "coingecko-api": "^1.0.10",
     "cross-fetch": "^3.1.4",
     "humanize-duration-ts": "^2.1.1",
-    "jazzicon": "^1.5.0",
     "node-sass": "^4.14.1",
     "prettier": "^2.2.1",
     "react": "^17.0.2",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -33,6 +33,7 @@
     "coingecko-api": "^1.0.10",
     "cross-fetch": "^3.1.4",
     "humanize-duration-ts": "^2.1.1",
+    "jazzicon": "^1.5.0",
     "node-sass": "^4.14.1",
     "prettier": "^2.2.1",
     "react": "^17.0.2",

--- a/explorer/src/components/account/OwnedTokensCard.tsx
+++ b/explorer/src/components/account/OwnedTokensCard.tsx
@@ -14,8 +14,11 @@ import { Link } from "react-router-dom";
 import { Location } from "history";
 import { useTokenRegistry } from "providers/mints/token-registry";
 import { BigNumber } from "bignumber.js";
+import { Identicon } from "components/common/Identicon";
 
 type Display = "summary" | "detail" | null;
+
+const SMALL_IDENTICON_WIDTH = 16;
 
 const useQueryDisplay = (): Display => {
   const query = useQuery();
@@ -102,11 +105,17 @@ function HoldingsDetailTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
       <tr key={address}>
         {showLogos && (
           <td className="w-1 p-0 text-center">
-            {tokenDetails?.logoURI && (
+            {tokenDetails?.logoURI ? (
               <img
                 src={tokenDetails.logoURI}
                 alt="token icon"
                 className="token-icon rounded-circle border border-4 border-gray-dark"
+              />
+            ) : (
+              <Identicon
+                address={address}
+                className="avatar-img identicon-wrapper identicon-wrapper-small"
+                style={{ width: SMALL_IDENTICON_WIDTH }}
               />
             )}
           </td>
@@ -169,11 +178,17 @@ function HoldingsSummaryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
       <tr key={mintAddress}>
         {showLogos && (
           <td className="w-1 p-0 text-center">
-            {tokenDetails?.logoURI && (
+            {tokenDetails?.logoURI ? (
               <img
                 src={tokenDetails.logoURI}
                 alt="token icon"
                 className="token-icon rounded-circle border border-4 border-gray-dark"
+              />
+            ) : (
+              <Identicon
+                address={mintAddress}
+                className="avatar-img identicon-wrapper identicon-wrapper-small"
+                style={{ width: SMALL_IDENTICON_WIDTH }}
               />
             )}
           </td>

--- a/explorer/src/components/common/Identicon.tsx
+++ b/explorer/src/components/common/Identicon.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
 
 // @ts-ignore
-import Jazzicon from "jazzicon"; // TODO: Add definition file
+import Jazzicon from "@metamask/jazzicon";
 import bs58 from "bs58";
 import { PublicKey } from "@solana/web3.js";
 
@@ -15,7 +15,7 @@ export function Identicon(props: {
     typeof props.address === "string"
       ? props.address
       : props.address?.toBase58();
-  const ref = useRef<HTMLDivElement>();
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (address && ref.current) {
@@ -30,7 +30,5 @@ export function Identicon(props: {
     }
   }, [address, style, className]);
 
-  return (
-    <div className="identicon-wrapper" ref={ref as any} style={props.style} />
-  );
+  return <div className="identicon-wrapper" ref={ref} style={props.style} />;
 }

--- a/explorer/src/components/common/Identicon.tsx
+++ b/explorer/src/components/common/Identicon.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef } from "react";
+
+// @ts-ignore
+import Jazzicon from "jazzicon"; // TODO: Add definition file
+import bs58 from "bs58";
+import { PublicKey } from "@solana/web3.js";
+
+export function Identicon(props: {
+  address?: string | PublicKey;
+  style?: React.CSSProperties;
+  className?: string;
+}) {
+  const { style, className } = props;
+  const address =
+    typeof props.address === "string"
+      ? props.address
+      : props.address?.toBase58();
+  const ref = useRef<HTMLDivElement>();
+
+  useEffect(() => {
+    if (address && ref.current) {
+      ref.current.innerHTML = "";
+      ref.current.className = className || "";
+      ref.current.appendChild(
+        Jazzicon(
+          style?.width || 16,
+          parseInt(bs58.decode(address).toString("hex").slice(5, 15), 16)
+        )
+      );
+    }
+  }, [address, style, className]);
+
+  return (
+    <div className="identicon-wrapper" ref={ref as any} style={props.style} />
+  );
+}

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -114,7 +114,7 @@ export function AccountHeader({
   const tokenDetails = tokenRegistry.get(address);
   const account = info?.data;
   const data = account?.details?.data;
-  const isToken = data && data.program === "spl-token";
+  const isToken = data?.program === "spl-token" && data?.parsed.type === "mint";
 
   if (tokenDetails || isToken) {
     return (

--- a/explorer/src/pages/AccountDetailsPage.tsx
+++ b/explorer/src/pages/AccountDetailsPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { PublicKey } from "@solana/web3.js";
-import { FetchStatus } from "providers/cache";
+import { CacheEntry, FetchStatus } from "providers/cache";
 import {
   useFetchAccountInfo,
   useAccountInfo,
@@ -30,7 +30,9 @@ import { ConfigAccountSection } from "components/account/ConfigAccountSection";
 import { useFlaggedAccounts } from "providers/accounts/flagged-accounts";
 import { UpgradeableLoaderAccountSection } from "components/account/UpgradeableLoaderAccountSection";
 import { useTokenRegistry } from "providers/mints/token-registry";
+import { Identicon } from "components/common/Identicon";
 
+const IDENTICON_WIDTH = 64;
 const TABS_LOOKUP: { [id: string]: Tab } = {
   "spl-token:mint": {
     slug: "largest",
@@ -69,49 +71,77 @@ const TOKEN_TABS_HIDDEN = [
 
 type Props = { address: string; tab?: string };
 export function AccountDetailsPage({ address, tab }: Props) {
+  const fetchAccount = useFetchAccountInfo();
+  const { status } = useCluster();
+  const info = useAccountInfo(address);
   let pubkey: PublicKey | undefined;
 
   try {
     pubkey = new PublicKey(address);
   } catch (err) {}
 
+  // Fetch account on load
+  React.useEffect(() => {
+    if (!info && status === ClusterStatus.Connected && pubkey) {
+      fetchAccount(pubkey);
+    }
+  }, [address, status]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <div className="container mt-n3">
       <div className="header">
         <div className="header-body">
-          <AccountHeader address={address} />
+          <AccountHeader address={address} info={info} />
         </div>
       </div>
       {!pubkey ? (
         <ErrorCard text={`Address "${address}" is not valid`} />
       ) : (
-        <DetailsSections pubkey={pubkey} tab={tab} />
+        <DetailsSections pubkey={pubkey} tab={tab} info={info} />
       )}
     </div>
   );
 }
 
-export function AccountHeader({ address }: { address: string }) {
+export function AccountHeader({
+  address,
+  info,
+}: {
+  address: string;
+  info?: CacheEntry<Account>;
+}) {
   const { tokenRegistry } = useTokenRegistry();
   const tokenDetails = tokenRegistry.get(address);
-  if (tokenDetails) {
+  const account = info?.data;
+  const data = account?.details?.data;
+  const isToken = data && data.program === "spl-token";
+
+  if (tokenDetails || isToken) {
     return (
       <div className="row align-items-end">
-        {tokenDetails.logoURI && (
-          <div className="col-auto">
-            <div className="avatar avatar-lg header-avatar-top">
+        <div className="col-auto">
+          <div className="avatar avatar-lg header-avatar-top">
+            {tokenDetails?.logoURI ? (
               <img
                 src={tokenDetails.logoURI}
                 alt="token logo"
                 className="avatar-img rounded-circle border border-4 border-body"
               />
-            </div>
+            ) : (
+              <Identicon
+                address={address}
+                className="avatar-img rounded-circle border border-body identicon-wrapper"
+                style={{ width: IDENTICON_WIDTH }}
+              />
+            )}
           </div>
-        )}
+        </div>
 
         <div className="col mb-3 ml-n3 ml-md-n2">
           <h6 className="header-pretitle">Token</h6>
-          <h2 className="header-title">{tokenDetails.name}</h2>
+          <h2 className="header-title">
+            {tokenDetails?.name || "Unlisted Token"}
+          </h2>
         </div>
       </div>
     );
@@ -125,18 +155,19 @@ export function AccountHeader({ address }: { address: string }) {
   );
 }
 
-function DetailsSections({ pubkey, tab }: { pubkey: PublicKey; tab?: string }) {
+function DetailsSections({
+  pubkey,
+  tab,
+  info,
+}: {
+  pubkey: PublicKey;
+  tab?: string;
+  info?: CacheEntry<Account>;
+}) {
   const fetchAccount = useFetchAccountInfo();
   const address = pubkey.toBase58();
-  const info = useAccountInfo(address);
-  const { status } = useCluster();
   const location = useLocation();
   const { flaggedAccounts } = useFlaggedAccounts();
-
-  // Fetch account on load
-  React.useEffect(() => {
-    if (!info && status === ClusterStatus.Connected) fetchAccount(pubkey);
-  }, [address, status]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (!info || info.status === FetchStatus.Fetching) {
     return <LoadingCard />;

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -382,3 +382,7 @@ p.updated-time {
 .change-negative {
   color: $warning;
 }
+
+.identicon-wrapper {
+  display: flex;
+}

--- a/explorer/src/scss/_solana.scss
+++ b/explorer/src/scss/_solana.scss
@@ -386,3 +386,7 @@ p.updated-time {
 .identicon-wrapper {
   display: flex;
 }
+
+.identicon-wrapper-small {
+  margin-left: .4rem;
+}


### PR DESCRIPTION
#### Problem
Token mints that aren't listed in the spl-token-registry should have details pages that are similar to those that are listed.

#### Summary of Changes
- add jazzicon for unlisted images
- use standard token mint layout
- slight refactor account details page
- 
Fixes https://github.com/solana-labs/solana/issues/15764
