### PR TITLE
fix: allow strings in transaction error validation

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -369,7 +369,7 @@ const GetLeaderScheduleResult = record(string(), array(number()));
 /**
  * Transaction error or null
  */
-const TransactionErrorResult = nullable(pick({}));
+const TransactionErrorResult = nullable(union([pick({}), string()]));
 
 /**
  * Signature status for a transaction
@@ -1536,7 +1536,7 @@ export type SignatureResult = {
 /**
  * Transaction error
  */
-export type TransactionError = {};
+export type TransactionError = {} | string;
 
 /**
  * Transaction confirmation status


### PR DESCRIPTION
#### Problem
The current web3 transaction error validator assumes that all errors from RPC are instruction error objects. Due to https://github.com/solana-labs/solana/issues/16339 it's possible that string errors like "AccountInUse" are returned causing validation errors in clients.

#### Summary of Changes
- Add support for string based errors in validator

Fixes #
