### PR TITLE
Remove unprocessed transactions from log notifications

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3000,7 +3000,10 @@ impl Bank {
                     }
                 }
             }
-            if transaction_log_collector_config.filter != TransactionLogCollectorFilter::None {
+
+            if Self::can_commit(r) // Skip log collection for unprocessed transactions
+                && transaction_log_collector_config.filter != TransactionLogCollectorFilter::None
+            {
                 let mut transaction_log_collector = self.transaction_log_collector.write().unwrap();
                 let transaction_log_index = transaction_log_collector.logs.len();
 


### PR DESCRIPTION
#### Problem
Log subscriptions are sent notifications for non-processing related transaction errors which are not valuable to the client. This commonly includes "AccountInUse" errors because even transactions which don't obtain account locks are being iterated over when sending log notifications. This is causing unexpected error types as reported in this issue: solana-labs/solana-web3.js#1019

#### Summary of Changes
Only notify log events for transactions that were processed

Fixes https://github.com/solana-labs/solana/issues/16339
