### PR TITLE
Speed up net.sh builds

### DIFF
--- a/cargo
+++ b/cargo
@@ -3,16 +3,16 @@
 # shellcheck source=ci/rust-version.sh
 here=$(dirname "$0")
 
-source "${here}"/ci/rust-version.sh all
-
 toolchain=
 case "$1" in
   stable)
+    source "${here}"/ci/rust-version.sh stable
     # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
     toolchain="$rust_stable"
     shift
     ;;
   nightly)
+    source "${here}"/ci/rust-version.sh nightly
     # shellcheck disable=SC2054 # rust_nightly is sourced from rust-version.sh
     toolchain="$rust_nightly"
     shift
@@ -22,6 +22,7 @@ case "$1" in
     shift
     ;;
   *)
+    source "${here}"/ci/rust-version.sh stable
     # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh
     toolchain="$rust_stable"
     ;;

--- a/cargo
+++ b/cargo
@@ -17,10 +17,6 @@ case "$1" in
     toolchain="$rust_nightly"
     shift
     ;;
-  +*)
-    toolchain="${1#+}"
-    shift
-    ;;
   *)
     source "${here}"/ci/rust-version.sh stable
     # shellcheck disable=SC2054 # rust_stable is sourced from rust-version.sh

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -7,8 +7,6 @@ src_root="$(readlink -f "${here}/..")"
 
 cd "${src_root}"
 
-source ci/rust-version.sh stable
-
 cargo_audit_ignores=(
   # failure is officially deprecated/unmaintained
   #
@@ -42,4 +40,4 @@ cargo_audit_ignores=(
   --ignore RUSTSEC-2020-0146
 
 )
-scripts/cargo-for-all-lock-files.sh +"$rust_stable" audit "${cargo_audit_ignores[@]}"
+scripts/cargo-for-all-lock-files.sh stable audit "${cargo_audit_ignores[@]}"

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -45,7 +45,7 @@ export RUSTFLAGS="-D warnings -A incomplete_features"
 # Only force up-to-date lock files on edge
 if [[ $CI_BASE_BRANCH = "$EDGE_CHANNEL" ]]; then
   # Exclude --benches as it's not available in rust stable yet
-  if _ scripts/cargo-for-all-lock-files.sh +"$rust_stable" check --locked --tests --bins --examples; then
+  if _ scripts/cargo-for-all-lock-files.sh stable check --locked --tests --bins --examples; then
     true
   else
     check_status=$?
@@ -56,7 +56,7 @@ if [[ $CI_BASE_BRANCH = "$EDGE_CHANNEL" ]]; then
   fi
 
   # Ensure nightly and --benches
-  _ scripts/cargo-for-all-lock-files.sh +"$rust_nightly" check --locked --all-targets
+  _ scripts/cargo-for-all-lock-files.sh nightly check --locked --all-targets
 else
   echo "Note: cargo-for-all-lock-files.sh skipped because $CI_BASE_BRANCH != $EDGE_CHANNEL"
 fi

--- a/net/net.sh
+++ b/net/net.sh
@@ -42,7 +42,7 @@ Operate a configured testnet
  startnode    - Start an individual node (previously stopped with stopNode)
  stopnode     - Stop an individual node
  startclients - Start client nodes only
- prepare      - Prepare deploy
+ prepare      - Prepare software deployment. (Build/download software the software release)
  update       - Deploy a new software update to the cluster
  upgrade      - Upgrade software on bootstrap validator. (Restart bootstrap validator manually to run it)
 
@@ -191,7 +191,7 @@ build() {
 
     $MAYBE_DOCKER bash -c "
       set -ex
-      scripts/cargo-install-all.sh farf $buildVariant --testnet
+      scripts/cargo-install-all.sh farf $buildVariant --validator-only
     "
   )
 

--- a/net/net.sh
+++ b/net/net.sh
@@ -42,6 +42,7 @@ Operate a configured testnet
  startnode    - Start an individual node (previously stopped with stopNode)
  stopnode     - Stop an individual node
  startclients - Start client nodes only
+ prepare      - Prepare deploy
  update       - Deploy a new software update to the cluster
  upgrade      - Upgrade software on bootstrap validator. (Restart bootstrap validator manually to run it)
 
@@ -185,12 +186,12 @@ build() {
 
     buildVariant=
     if $debugBuild; then
-      buildVariant=debug
+      buildVariant=--debug
     fi
 
     $MAYBE_DOCKER bash -c "
       set -ex
-      scripts/cargo-install-all.sh farf \"$buildVariant\"
+      scripts/cargo-install-all.sh farf $buildVariant --testnet
     "
   )
 
@@ -1054,6 +1055,9 @@ restart)
 start)
   prepareDeploy
   deploy
+  ;;
+prepare)
+  prepareDeploy
   ;;
 sanity)
   sanity

--- a/net/net.sh
+++ b/net/net.sh
@@ -42,7 +42,7 @@ Operate a configured testnet
  startnode    - Start an individual node (previously stopped with stopNode)
  stopnode     - Stop an individual node
  startclients - Start client nodes only
- prepare      - Prepare software deployment. (Build/download software the software release)
+ prepare      - Prepare software deployment. (Build/download the software release)
  update       - Deploy a new software update to the cluster
  upgrade      - Upgrade software on bootstrap validator. (Restart bootstrap validator manually to run it)
 

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -23,12 +23,16 @@ maybeRustVersion=
 installDir=
 buildVariant=release
 maybeReleaseFlag=--release
+testnetMode=
 
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
     if [[ $1 = --debug ]]; then
       maybeReleaseFlag=
       buildVariant=debug
+      shift
+    elif [[ $1 = --testnet ]]; then
+      testnetMode=true
       shift
     else
       usage "Unknown option: $1"
@@ -71,36 +75,36 @@ if [[ $CI_OS_NAME = windows ]]; then
   )
 else
   ./fetch-perf-libs.sh
-  (
-    set -x
-    # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-    $cargo $maybeRustVersion build $maybeReleaseFlag
-  )
-
 
   BINS=(
-    cargo-build-bpf
-    cargo-test-bpf
     solana
     solana-bench-exchange
     solana-bench-tps
-    solana-dos
     solana-faucet
     solana-gossip
     solana-install
-    solana-install-init
     solana-keygen
     solana-ledger-tool
     solana-log-analyzer
     solana-net-shaper
-    solana-stake-accounts
-    solana-stake-monitor
     solana-sys-tuner
-    solana-test-validator
-    solana-tokens
     solana-validator
-    solana-watchtower
   )
+
+  # Speed up net.sh deploys by excluding unused binaries
+  if [[ -z "$testnetMode" ]]; then
+    BINS+=(
+      cargo-build-bpf
+      cargo-test-bpf
+      solana-dos
+      solana-install-init
+      solana-stake-accounts
+      solana-stake-monitor
+      solana-test-validator
+      solana-tokens
+      solana-watchtower
+    )
+  fi
 
   #XXX: Ensure `solana-genesis` is built LAST!
   # See https://github.com/solana-labs/solana/issues/5826
@@ -118,8 +122,12 @@ mkdir -p "$installDir/bin"
   set -x
   # shellcheck disable=SC2086 # Don't want to double quote $rust_version
   "$cargo" $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
-  # shellcheck disable=SC2086 # Don't want to double quote $rust_version
-  "$cargo" $maybeRustVersion install spl-token-cli --root "$installDir"
+
+  # Exclude `spl-token` binary for net.sh builds
+  if [[ -z "$testnetMode" ]]; then
+    # shellcheck disable=SC2086 # Don't want to double quote $rust_version
+    "$cargo" $maybeRustVersion install spl-token-cli --root "$installDir"
+  fi
 )
 
 for bin in "${BINS[@]}"; do

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -23,7 +23,7 @@ maybeRustVersion=
 installDir=
 buildVariant=release
 maybeReleaseFlag=--release
-testnetMode=
+validatorOnly=
 
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
@@ -31,8 +31,8 @@ while [[ -n $1 ]]; do
       maybeReleaseFlag=
       buildVariant=debug
       shift
-    elif [[ $1 = --testnet ]]; then
-      testnetMode=true
+    elif [[ $1 = --validator-only ]]; then
+      validatorOnly=true
       shift
     else
       usage "Unknown option: $1"
@@ -92,7 +92,7 @@ else
   )
 
   # Speed up net.sh deploys by excluding unused binaries
-  if [[ -z "$testnetMode" ]]; then
+  if [[ -z "$validatorOnly" ]]; then
     BINS+=(
       cargo-build-bpf
       cargo-test-bpf
@@ -124,7 +124,7 @@ mkdir -p "$installDir/bin"
   "$cargo" $maybeRustVersion build $maybeReleaseFlag "${binArgs[@]}"
 
   # Exclude `spl-token` binary for net.sh builds
-  if [[ -z "$testnetMode" ]]; then
+  if [[ -z "$validatorOnly" ]]; then
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
     "$cargo" $maybeRustVersion install spl-token-cli --root "$installDir"
   fi

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -14,7 +14,7 @@ usage() {
     echo "Error: $*"
   fi
   cat <<EOF
-usage: $0 [+<cargo version>] [--debug] <install directory>
+usage: $0 [+<cargo version>] [--debug] [--validator-only] <install directory>
 EOF
   exit $exitcode
 }


### PR DESCRIPTION
#### Problem
net.sh builds the world when it doesn't need to

#### Summary of Changes
- Add `--validator-only` flag to `cargo-install-all.sh` to build fewer things
- Update `cargo` script to only install necessary rust binaries
- Add `prepare` subcommand to `net.sh` to prepare a local build

Fixes #
