### PR TITLE
solana-test-validator: Reduce test-validator ledger size

### DIFF
--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -48,10 +48,6 @@ impl LedgerCleanupService {
         compaction_interval: Option<u64>,
         max_compaction_jitter: Option<u64>,
     ) -> Self {
-        info!(
-            "LedgerCleanupService active. Max Ledger Slots {}",
-            max_ledger_shreds
-        );
         let exit = exit.clone();
         let mut last_purge_slot = 0;
         let mut last_compaction_slot = 0;
@@ -59,6 +55,11 @@ impl LedgerCleanupService {
         let compaction_interval = compaction_interval.unwrap_or(DEFAULT_COMPACTION_SLOT_INTERVAL);
         let last_compact_slot = Arc::new(AtomicU64::new(0));
         let last_compact_slot2 = last_compact_slot.clone();
+
+        info!(
+            "LedgerCleanupService active. max ledger shreds={}, compaction interval={}",
+            max_ledger_shreds, compaction_interval,
+        );
 
         let exit_compact = exit.clone();
         let blockstore_compact = blockstore.clone();

--- a/core/src/test_validator.rs
+++ b/core/src/test_validator.rs
@@ -422,6 +422,10 @@ impl TestValidator {
             warp_slot: config.warp_slot,
             bpf_jit: !config.no_bpf_jit,
             validator_exit: config.validator_exit.clone(),
+            rocksdb_compaction_interval: Some(100), // Compact every 100 slots
+            max_ledger_shreds: Some(10_000), /* 10,000 was derived empirically by watching the size
+                                             of the rocksdb/ directory self-limit itself to the
+                                             40MB-150MB range when running `solana-test-validator` */
             no_wait_for_vote_to_start_leader: true,
             ..ValidatorConfig::default()
         };


### PR DESCRIPTION
Leaving a `solana-test-validator` running idle overnight shouldn't produce a 12GB test-ledger/.  Turn down the max shred limit significantly to avoid this

