### PR TITLE
Remove old function: account_balance_for_capitalization

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -587,15 +587,9 @@ impl Accounts {
             |total_capitalization: &mut u64, (_pubkey, loaded_account, _slot)| {
                 let lamports = loaded_account.lamports();
                 if Self::is_loadable(lamports) {
-                    let account_cap = AccountsDb::account_balance_for_capitalization(
-                        lamports,
-                        &loaded_account.owner(),
-                        loaded_account.executable(),
-                    );
-
                     *total_capitalization = AccountsDb::checked_iterative_sum_for_capitalization(
                         *total_capitalization,
-                        account_cap,
+                        lamports,
                     );
                 }
             },

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3617,15 +3617,6 @@ impl AccountsDb {
         AccountsHash::checked_cast_for_capitalization(balances.map(|b| b as u128).sum::<u128>())
     }
 
-    // remove this by inlining and remove extra unused params upto all callchain
-    pub fn account_balance_for_capitalization(
-        lamports: u64,
-        _owner: &Pubkey,
-        _executable: bool,
-    ) -> u64 {
-        lamports
-    }
-
     fn calculate_accounts_hash(
         &self,
         slot: Slot,
@@ -3671,13 +3662,7 @@ impl AccountsDb {
                                             |loaded_account| {
                                                 let loaded_hash = loaded_account
                                                     .loaded_hash(self.expected_cluster_type());
-                                                let balance =
-                                                    Self::account_balance_for_capitalization(
-                                                        account_info.lamports,
-                                                        loaded_account.owner(),
-                                                        loaded_account.executable(),
-                                                    );
-
+                                                let balance = account_info.lamports;
                                                 if check_hash {
                                                     let computed_hash = loaded_account
                                                         .compute_hash(
@@ -3863,11 +3848,7 @@ impl AccountsDb {
                 let balance = if zero_raw_lamports {
                     crate::accounts_hash::ZERO_RAW_LAMPORTS_SENTINEL
                 } else {
-                    Self::account_balance_for_capitalization(
-                        raw_lamports,
-                        loaded_account.owner(),
-                        loaded_account.executable(),
-                    )
+                    raw_lamports
                 };
 
                 let source_item = CalculateHashIntermediate::new(
@@ -8244,69 +8225,6 @@ pub mod tests {
         for x in 0..3 {
             assert!(store_counts[&x].0 >= 1);
         }
-    }
-
-    #[test]
-    fn test_account_balance_for_capitalization_normal() {
-        // system accounts
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(10, &Pubkey::default(), false),
-            10
-        );
-        // any random program data accounts
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                10,
-                &solana_sdk::pubkey::new_rand(),
-                false,
-            ),
-            10
-        );
-    }
-
-    #[test]
-    fn test_account_balance_for_capitalization_sysvar() {
-        let normal_sysvar = solana_sdk::account::create_account_for_test(
-            &solana_sdk::slot_history::SlotHistory::default(),
-        );
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                normal_sysvar.lamports,
-                &normal_sysvar.owner,
-                normal_sysvar.executable,
-            ),
-            1
-        );
-
-        // transactions can send any lamports to sysvars although this is not sensible.
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(10, &solana_sdk::sysvar::id(), false),
-            10
-        );
-    }
-
-    #[test]
-    fn test_account_balance_for_capitalization_native_program() {
-        let normal_native_program =
-            solana_sdk::native_loader::create_loadable_account_for_test("foo");
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                normal_native_program.lamports,
-                &normal_native_program.owner,
-                normal_native_program.executable,
-            ),
-            1
-        );
-
-        // test maliciously assigned bogus native loader account
-        assert_eq!(
-            AccountsDb::account_balance_for_capitalization(
-                1,
-                &solana_sdk::native_loader::id(),
-                false,
-            ),
-            1
-        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
This function currently returns one of its' parameters and is thus useless.

#### Summary of Changes
Removed all instances of function, and replaced with the parameter instead

Address's Ryo's comment here:
https://github.com/solana-labs/solana/pull/16157#discussion_r607047216