### PR TITLE
Faucet: repurpose cap and slice args to apply to single IPs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-version",
+ "spl-memo 3.0.1",
  "thiserror",
  "tokio 1.1.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,7 +4458,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-version",
- "spl-memo 3.0.1",
+ "spl-memo",
  "thiserror",
  "tokio 1.1.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4252,6 +4252,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-clap-utils",
+ "solana-faucet",
  "solana-logger 1.7.0",
  "solana-net-utils",
  "solana-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana-version",
+ "thiserror",
  "tokio 1.1.1",
 ]
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1018,11 +1018,21 @@ fn process_airdrop(
         faucet_addr
     );
 
-    request_and_confirm_airdrop(&rpc_client, faucet_addr, &pubkey, lamports, &config)?;
+    let pre_balance = rpc_client.get_balance(&pubkey)?;
+
+    let signature =
+        request_and_confirm_airdrop(&rpc_client, faucet_addr, &pubkey, lamports, &config)?;
+    println!("{}", signature);
 
     let current_balance = rpc_client.get_balance(&pubkey)?;
 
-    Ok(build_balance_message(current_balance, false, true))
+    if current_balance < pre_balance.saturating_add(lamports) {
+        println!("Balance unchanged");
+        println!("Run `solana confirm -v <SIGNATURE>` for more info");
+        Ok("".to_string())
+    } else {
+        Ok(build_balance_message(current_balance, false, true))
+    }
 }
 
 fn process_balance(

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -35,6 +35,7 @@ use solana_client::{
 };
 #[cfg(not(test))]
 use solana_faucet::faucet::request_airdrop_transaction;
+use solana_faucet::faucet::FaucetError;
 #[cfg(test)]
 use solana_faucet::faucet_mock::request_airdrop_transaction;
 use solana_remote_wallet::remote_wallet::RemoteWalletManager;
@@ -1020,18 +1021,22 @@ fn process_airdrop(
 
     let pre_balance = rpc_client.get_balance(&pubkey)?;
 
-    let signature =
-        request_and_confirm_airdrop(&rpc_client, faucet_addr, &pubkey, lamports, &config)?;
-    println!("{}", signature);
+    let result = request_and_confirm_airdrop(&rpc_client, faucet_addr, &pubkey, lamports);
+    if let Ok(signature) = result {
+        let signature_cli_message = log_instruction_custom_error::<SystemError>(result, &config)?;
+        println!("{}", signature_cli_message);
 
-    let current_balance = rpc_client.get_balance(&pubkey)?;
+        let current_balance = rpc_client.get_balance(&pubkey)?;
 
-    if current_balance < pre_balance.saturating_add(lamports) {
-        println!("Balance unchanged");
-        println!("Run `solana confirm -v <SIGNATURE>` for more info");
-        Ok("".to_string())
+        if current_balance < pre_balance.saturating_add(lamports) {
+            println!("Balance unchanged");
+            println!("Run `solana confirm -v {:?}` for more info", signature);
+            Ok("".to_string())
+        } else {
+            Ok(build_balance_message(current_balance, false, true))
+        }
     } else {
-        Ok(build_balance_message(current_balance, false, true))
+        log_instruction_custom_error::<SystemError>(result, &config)
     }
 }
 
@@ -1962,7 +1967,7 @@ impl FaucetKeypair {
         to_pubkey: &Pubkey,
         lamports: u64,
         blockhash: Hash,
-    ) -> Result<Self, Box<dyn error::Error>> {
+    ) -> Result<Self, FaucetError> {
         let transaction = request_airdrop_transaction(faucet_addr, to_pubkey, lamports, blockhash)?;
         Ok(Self { transaction })
     }
@@ -1996,8 +2001,7 @@ pub fn request_and_confirm_airdrop(
     faucet_addr: &SocketAddr,
     to_pubkey: &Pubkey,
     lamports: u64,
-    config: &CliConfig,
-) -> ProcessResult {
+) -> ClientResult<Signature> {
     let (blockhash, _fee_calculator) = rpc_client.get_recent_blockhash()?;
     let keypair = {
         let mut retries = 5;
@@ -2011,8 +2015,7 @@ pub fn request_and_confirm_airdrop(
         }
     }?;
     let tx = keypair.airdrop_transaction();
-    let result = rpc_client.send_and_confirm_transaction_with_spinner(&tx);
-    log_instruction_custom_error::<SystemError>(result, &config)
+    rpc_client.send_and_confirm_transaction_with_spinner(&tx)
 }
 
 pub fn log_instruction_custom_error<E>(

--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -74,7 +74,6 @@ fn full_battery_tests(
         &faucet_addr,
         &config_payer.signers[0].pubkey(),
         2000,
-        &config_payer,
     )
     .unwrap();
     check_recent_balance(2000, &rpc_client, &config_payer.signers[0].pubkey());
@@ -228,7 +227,6 @@ fn test_create_account_with_seed() {
     let offline_nonce_authority_signer = keypair_from_seed(&[1u8; 32]).unwrap();
     let online_nonce_creator_signer = keypair_from_seed(&[2u8; 32]).unwrap();
     let to_address = Pubkey::new(&[3u8; 32]);
-    let config = CliConfig::recent_for_tests();
 
     // Setup accounts
     let rpc_client =
@@ -238,7 +236,6 @@ fn test_create_account_with_seed() {
         &faucet_addr,
         &offline_nonce_authority_signer.pubkey(),
         42,
-        &config,
     )
     .unwrap();
     request_and_confirm_airdrop(
@@ -246,7 +243,6 @@ fn test_create_account_with_seed() {
         &faucet_addr,
         &online_nonce_creator_signer.pubkey(),
         4242,
-        &config,
     )
     .unwrap();
     check_recent_balance(42, &rpc_client, &offline_nonce_authority_signer.pubkey());

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -42,7 +42,6 @@ fn test_stake_delegation_force() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         100_000,
-        &config,
     )
     .unwrap();
 
@@ -136,7 +135,6 @@ fn test_seed_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config_validator.signers[0].pubkey(),
         100_000,
-        &config_validator,
     )
     .unwrap();
     check_recent_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
@@ -222,7 +220,6 @@ fn test_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config_validator.signers[0].pubkey(),
         100_000,
-        &config_validator,
     )
     .unwrap();
     check_recent_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
@@ -313,7 +310,6 @@ fn test_offline_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config_validator.signers[0].pubkey(),
         100_000,
-        &config_offline,
     )
     .unwrap();
     check_recent_balance(100_000, &rpc_client, &config_validator.signers[0].pubkey());
@@ -323,7 +319,6 @@ fn test_offline_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config_offline.signers[0].pubkey(),
         100_000,
-        &config_validator,
     )
     .unwrap();
     check_recent_balance(100_000, &rpc_client, &config_offline.signers[0].pubkey());
@@ -445,7 +440,6 @@ fn test_nonced_stake_delegation_and_deactivation() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         100_000,
-        &config,
     )
     .unwrap();
 
@@ -561,7 +555,6 @@ fn test_stake_authorize() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         100_000,
-        &config,
     )
     .unwrap();
 
@@ -579,7 +572,6 @@ fn test_stake_authorize() {
         &faucet_addr,
         &config_offline.signers[0].pubkey(),
         100_000,
-        &config,
     )
     .unwrap();
 
@@ -844,16 +836,13 @@ fn test_stake_authorize_with_fee_payer() {
     config_offline.command = CliCommand::ClusterVersion;
     process_command(&config_offline).unwrap_err();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &default_pubkey, 100_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &default_pubkey, 100_000).unwrap();
     check_recent_balance(100_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &payer_pubkey, 100_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &payer_pubkey, 100_000).unwrap();
     check_recent_balance(100_000, &rpc_client, &payer_pubkey);
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
     check_recent_balance(100_000, &rpc_client, &offline_pubkey);
 
     check_ready(&rpc_client);
@@ -973,13 +962,11 @@ fn test_stake_split() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         500_000,
-        &config,
     )
     .unwrap();
     check_recent_balance(500_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
     check_recent_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
@@ -1122,13 +1109,11 @@ fn test_stake_set_lockup() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         500_000,
-        &config,
     )
     .unwrap();
     check_recent_balance(500_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
     check_recent_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create stake account, identity is authority
@@ -1386,13 +1371,11 @@ fn test_offline_nonced_create_stake_account_and_withdraw() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         200_000,
-        &config,
     )
     .unwrap();
     check_recent_balance(200_000, &rpc_client, &config.signers[0].pubkey());
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 100_000).unwrap();
     check_recent_balance(100_000, &rpc_client, &offline_pubkey);
 
     // Create nonce account

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -38,8 +38,7 @@ fn test_transfer() {
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::new(&[1u8; 32]);
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000).unwrap();
     check_recent_balance(50_000, &rpc_client, &sender_pubkey);
     check_recent_balance(0, &rpc_client, &recipient_pubkey);
 
@@ -95,7 +94,7 @@ fn test_transfer() {
     process_command(&offline).unwrap_err();
 
     let offline_pubkey = offline.signers[0].pubkey();
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 50, &config).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_pubkey, 50).unwrap();
     check_recent_balance(50, &rpc_client, &offline_pubkey);
 
     // Offline transfer
@@ -281,25 +280,17 @@ fn test_transfer_multisession_signing() {
     let offline_from_signer = keypair_from_seed(&[2u8; 32]).unwrap();
     let offline_fee_payer_signer = keypair_from_seed(&[3u8; 32]).unwrap();
     let from_null_signer = NullSigner::new(&offline_from_signer.pubkey());
-    let config = CliConfig::recent_for_tests();
 
     // Setup accounts
     let rpc_client =
         RpcClient::new_with_commitment(test_validator.rpc_url(), CommitmentConfig::processed());
-    request_and_confirm_airdrop(
-        &rpc_client,
-        &faucet_addr,
-        &offline_from_signer.pubkey(),
-        43,
-        &config,
-    )
-    .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &offline_from_signer.pubkey(), 43)
+        .unwrap();
     request_and_confirm_airdrop(
         &rpc_client,
         &faucet_addr,
         &offline_fee_payer_signer.pubkey(),
         3,
-        &config,
     )
     .unwrap();
     check_recent_balance(43, &rpc_client, &offline_from_signer.pubkey());
@@ -418,8 +409,7 @@ fn test_transfer_all() {
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::new(&[1u8; 32]);
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000).unwrap();
     check_recent_balance(50_000, &rpc_client, &sender_pubkey);
     check_recent_balance(0, &rpc_client, &recipient_pubkey);
 
@@ -466,8 +456,7 @@ fn test_transfer_unfunded_recipient() {
     let sender_pubkey = config.signers[0].pubkey();
     let recipient_pubkey = Pubkey::new(&[1u8; 32]);
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 50_000).unwrap();
     check_recent_balance(50_000, &rpc_client, &sender_pubkey);
     check_recent_balance(0, &rpc_client, &recipient_pubkey);
 
@@ -522,9 +511,8 @@ fn test_transfer_with_seed() {
     )
     .unwrap();
 
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 1, &config).unwrap();
-    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &derived_address, 50_000, &config)
-        .unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &sender_pubkey, 1).unwrap();
+    request_and_confirm_airdrop(&rpc_client, &faucet_addr, &derived_address, 50_000).unwrap();
     check_recent_balance(1, &rpc_client, &sender_pubkey);
     check_recent_balance(50_000, &rpc_client, &derived_address);
     check_recent_balance(0, &rpc_client, &recipient_pubkey);

--- a/cli/tests/vote.rs
+++ b/cli/tests/vote.rs
@@ -35,7 +35,6 @@ fn test_vote_authorize_and_withdraw() {
         &faucet_addr,
         &config.signers[0].pubkey(),
         100_000,
-        &config,
     )
     .unwrap();
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -26,6 +26,7 @@ serde_derive = "1.0.103"
 serde_json = "1.0.56"
 solana-account-decoder = { path = "../account-decoder", version = "=1.7.0" }
 solana-clap-utils = { path = "../clap-utils", version = "=1.7.0" }
+solana-faucet = { path = "../faucet", version = "=1.7.0" }
 solana-net-utils = { path = "../net-utils", version = "=1.7.0" }
 solana-sdk = { path = "../sdk", version = "=1.7.0" }
 solana-transaction-status = { path = "../transaction-status", version = "=1.7.0" }

--- a/client/src/client_error.rs
+++ b/client/src/client_error.rs
@@ -1,5 +1,6 @@
 use {
     crate::rpc_request,
+    solana_faucet::faucet::FaucetError,
     solana_sdk::{
         signature::SignerError, transaction::TransactionError, transport::TransportError,
     },
@@ -23,6 +24,8 @@ pub enum ClientErrorKind {
     SigningError(#[from] SignerError),
     #[error(transparent)]
     TransactionError(#[from] TransactionError),
+    #[error(transparent)]
+    FaucetError(#[from] FaucetError),
     #[error("Custom: {0}")]
     Custom(String),
 }
@@ -46,6 +49,7 @@ impl From<ClientErrorKind> for TransportError {
             ClientErrorKind::RpcError(err) => Self::Custom(format!("{:?}", err)),
             ClientErrorKind::SerdeJson(err) => Self::Custom(format!("{:?}", err)),
             ClientErrorKind::SigningError(err) => Self::Custom(format!("{:?}", err)),
+            ClientErrorKind::FaucetError(err) => Self::Custom(format!("{:?}", err)),
             ClientErrorKind::Custom(err) => Self::Custom(format!("{:?}", err)),
         }
     }
@@ -155,6 +159,15 @@ impl From<SignerError> for ClientError {
 
 impl From<TransactionError> for ClientError {
     fn from(err: TransactionError) -> Self {
+        Self {
+            request: None,
+            kind: err.into(),
+        }
+    }
+}
+
+impl From<FaucetError> for ClientError {
+    fn from(err: FaucetError) -> Self {
         Self {
             request: None,
             kind: err.into(),

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -22,6 +22,7 @@ solana-logger = { path = "../logger", version = "=1.7.0" }
 solana-metrics = { path = "../metrics", version = "=1.7.0" }
 solana-sdk = { path = "../sdk", version = "=1.7.0" }
 solana-version = { path = "../version", version = "=1.7.0" }
+thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 
 [lib]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -22,6 +22,7 @@ solana-logger = { path = "../logger", version = "=1.7.0" }
 solana-metrics = { path = "../metrics", version = "=1.7.0" }
 solana-sdk = { path = "../sdk", version = "=1.7.0" }
 solana-version = { path = "../version", version = "=1.7.0" }
+spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -1,14 +1,16 @@
-use clap::{crate_description, crate_name, App, Arg};
-use solana_clap_utils::input_parsers::{lamports_of_sol, value_of};
-use solana_faucet::{
-    faucet::{run_faucet, Faucet, FAUCET_PORT},
-    socketaddr,
-};
-use solana_sdk::signature::read_keypair_file;
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    sync::{Arc, Mutex},
-    thread,
+use {
+    clap::{crate_description, crate_name, App, Arg},
+    solana_clap_utils::input_parsers::{lamports_of_sol, value_of},
+    solana_faucet::{
+        faucet::{run_faucet, Faucet, FAUCET_PORT},
+        socketaddr,
+    },
+    solana_sdk::signature::read_keypair_file,
+    std::{
+        net::{Ipv4Addr, SocketAddr},
+        sync::{Arc, Mutex},
+        thread,
+    },
 };
 
 #[tokio::main]

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -1,5 +1,6 @@
 use {
     clap::{crate_description, crate_name, App, Arg},
+    log::*,
     solana_clap_utils::input_parsers::{lamports_of_sol, value_of},
     solana_faucet::{
         faucet::{run_faucet, Faucet, FAUCET_PORT},
@@ -76,7 +77,8 @@ async fn main() {
     thread::spawn(move || loop {
         let time = faucet1.lock().unwrap().time_slice;
         thread::sleep(time);
-        faucet1.lock().unwrap().clear_request_count();
+        debug!("clearing ip cache");
+        faucet1.lock().unwrap().clear_ip_cache();
     });
 
     run_faucet(faucet, faucet_addr, None).await;

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -4,31 +4,33 @@
 //! checking requests against a request cap for a given time time_slice
 //! and (to come) an IP rate limit.
 
-use bincode::{deserialize, serialize, serialized_size};
-use byteorder::{ByteOrder, LittleEndian};
-use log::*;
-use serde_derive::{Deserialize, Serialize};
-use solana_metrics::datapoint_info;
-use solana_sdk::{
-    hash::Hash,
-    message::Message,
-    packet::PACKET_DATA_SIZE,
-    pubkey::Pubkey,
-    signature::{Keypair, Signer},
-    system_instruction,
-    transaction::Transaction,
-};
-use std::{
-    io::{self, Error, ErrorKind, Read, Write},
-    net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream},
-    sync::{mpsc::Sender, Arc, Mutex},
-    thread,
-    time::Duration,
-};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream as TokioTcpStream},
-    runtime::Runtime,
+use {
+    bincode::{deserialize, serialize, serialized_size},
+    byteorder::{ByteOrder, LittleEndian},
+    log::*,
+    serde_derive::{Deserialize, Serialize},
+    solana_metrics::datapoint_info,
+    solana_sdk::{
+        hash::Hash,
+        message::Message,
+        packet::PACKET_DATA_SIZE,
+        pubkey::Pubkey,
+        signature::{Keypair, Signer},
+        system_instruction,
+        transaction::Transaction,
+    },
+    std::{
+        io::{self, Error, ErrorKind, Read, Write},
+        net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream},
+        sync::{mpsc::Sender, Arc, Mutex},
+        thread,
+        time::Duration,
+    },
+    tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream as TokioTcpStream},
+        runtime::Runtime,
+    },
 };
 
 #[macro_export]

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -65,10 +65,10 @@ pub enum FaucetError {
     #[error("invalid transaction_length from faucet: {0}")]
     InvalidTransactionLength(usize),
 
-    #[error("request too large; req: {0} SOL cap: {1} SOL")]
+    #[error("request too large; req: ◎{0}, cap: ◎{1}")]
     PerRequestCapExceeded(f64, f64),
 
-    #[error("IP limit reached; req: {0} SOL ip: {1} current: {2} SOL cap: {3} SOL")]
+    #[error("IP limit reached; req: ◎{0}, ip: {1}, current: ◎{2}, cap: ◎{3}")]
     PerTimeCapExceeded(f64, IpAddr, f64, f64),
 }
 
@@ -190,9 +190,11 @@ impl Faucet {
                 if let Some(cap) = self.per_request_cap {
                     if lamports > cap {
                         let memo = format!(
-                            "request too large; req: {} SOL cap: {} SOL",
-                            lamports_to_sol(lamports),
-                            lamports_to_sol(cap),
+                            "{}",
+                            FaucetError::PerRequestCapExceeded(
+                                lamports_to_sol(lamports),
+                                lamports_to_sol(cap),
+                            )
                         );
                         let memo_instruction = Instruction {
                             program_id: Pubkey::new(&spl_memo::id().to_bytes()),
@@ -528,7 +530,7 @@ mod tests {
 
             assert_eq!(message.instructions.len(), 1);
             let parsed_memo = std::str::from_utf8(&message.instructions[0].data).unwrap();
-            let expected_memo = "request too large; req: 0.000000002 SOL cap: 0.000000001 SOL";
+            let expected_memo = "request too large; req: ◎0.000000002, cap: ◎0.000000001";
             assert_eq!(parsed_memo, expected_memo);
             assert_eq!(memo, expected_memo);
         } else {

--- a/faucet/src/faucet_mock.rs
+++ b/faucet/src/faucet_mock.rs
@@ -1,9 +1,12 @@
-use solana_sdk::{
-    hash::Hash, pubkey::Pubkey, signature::Keypair, system_transaction, transaction::Transaction,
-};
-use std::{
-    io::{Error, ErrorKind},
-    net::SocketAddr,
+use {
+    solana_sdk::{
+        hash::Hash, pubkey::Pubkey, signature::Keypair, system_transaction,
+        transaction::Transaction,
+    },
+    std::{
+        io::{Error, ErrorKind},
+        net::SocketAddr,
+    },
 };
 
 pub fn request_airdrop_transaction(

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -707,6 +707,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "ed25519"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1456,12 @@ dependencies = [
  "subtle 2.2.2",
  "typenum",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -2165,6 +2198,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.1",
+ "redox_syscall 0.2.4",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2502,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -2898,6 +2953,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-cli-config"
+version = "1.7.0"
+dependencies = [
+ "dirs-next",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
+ "url",
+]
+
+[[package]]
 name = "solana-cli-output"
 version = "1.7.0"
 dependencies = [
@@ -2940,6 +3007,7 @@ dependencies = [
  "serde_json",
  "solana-account-decoder",
  "solana-clap-utils",
+ "solana-faucet",
  "solana-net-utils",
  "solana-sdk",
  "solana-transaction-status",
@@ -2984,6 +3052,27 @@ dependencies = [
  "syn 1.0.60",
  "tokio 0.1.22",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "solana-faucet"
+version = "1.7.0"
+dependencies = [
+ "bincode",
+ "byteorder 1.3.4",
+ "clap",
+ "log",
+ "serde",
+ "serde_derive",
+ "solana-clap-utils",
+ "solana-cli-config",
+ "solana-logger 1.7.0",
+ "solana-metrics",
+ "solana-sdk",
+ "solana-version",
+ "spl-memo",
+ "thiserror",
+ "tokio 1.1.1",
 ]
 
 [[package]]
@@ -4261,6 +4350,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
The solana-faucet `ip_cache` was never used for anything, but a per-IP rate limit would be pretty useful for testnet.

#### Summary of Changes
Update `ip_cache` to track request totals; apply cap and slice args to IPs, rejecting requests that exceed the per-slice cap.

Closes #16332
