### PR TITLE
Remove old function: account_balance_for_capitalization

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -587,15 +587,9 @@ impl Accounts {
             |total_capitalization: &mut u64, (_pubkey, loaded_account, _slot)| {
                 let lamports = loaded_account.lamports();
                 if Self::is_loadable(lamports) {
-                    let account_cap = AccountsDb::account_balance_for_capitalization(
-                        lamports,
-                        &loaded_account.owner(),
-                        loaded_account.executable(),
-                    );
-
                     *total_capitalization = AccountsDb::checked_iterative_sum_for_capitalization(
                         *total_capitalization,
-                        account_cap,
+                        lamports,
                     );
                 }
             },


### PR DESCRIPTION
#### Problem
This function currently returns one of its' parameters and is thus useless.

#### Summary of Changes
Removed all instances of function, and replaced with the parameter instead. Ryo called this out here:
https://github.com/solana-labs/solana/pull/16157#discussion_r607047216