### PR TITLE
Use spl-memo v3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4188,7 +4188,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "solana_rbpf",
- "spl-memo 3.0.1",
+ "spl-memo",
  "tempfile",
  "thiserror",
  "tiny-bip39 0.7.3",
@@ -4227,7 +4227,7 @@ dependencies = [
  "solana-stake-program",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-memo 3.0.1",
+ "spl-memo",
 ]
 
 [[package]]
@@ -5383,8 +5383,7 @@ dependencies = [
  "solana-stake-program",
  "solana-vote-program",
  "spl-associated-token-account",
- "spl-memo 2.0.1",
- "spl-memo 3.0.1",
+ "spl-memo",
  "spl-token",
  "thiserror",
 ]
@@ -5537,15 +5536,6 @@ checksum = "4adc47eebe5d2b662cbaaba1843719c28a67e5ec5d0460bc3ca60900a51f74e2"
 dependencies = [
  "solana-program 1.6.4",
  "spl-token",
-]
-
-[[package]]
-name = "spl-memo"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2b771f6146dec14ef5fbf498f9374652c54badc3befc8c40c1d426dd45d720"
-dependencies = [
- "solana-program 1.6.4",
 ]
 
 [[package]]

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2917,7 +2917,7 @@ dependencies = [
  "solana-stake-program",
  "solana-transaction-status",
  "solana-vote-program",
- "spl-memo 3.0.1",
+ "spl-memo",
 ]
 
 [[package]]
@@ -3364,8 +3364,7 @@ dependencies = [
  "solana-stake-program",
  "solana-vote-program",
  "spl-associated-token-account",
- "spl-memo 2.0.1",
- "spl-memo 3.0.1",
+ "spl-memo",
  "spl-token",
  "thiserror",
 ]
@@ -3435,15 +3434,6 @@ checksum = "4adc47eebe5d2b662cbaaba1843719c28a67e5ec5d0460bc3ca60900a51f74e2"
 dependencies = [
  "solana-program 1.6.4",
  "spl-token",
-]
-
-[[package]]
-name = "spl-memo"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb2b771f6146dec14ef5fbf498f9374652c54badc3befc8c40c1d426dd45d720"
-dependencies = [
- "solana-program 1.6.4",
 ]
 
 [[package]]

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -24,8 +24,7 @@ solana-runtime = { path = "../runtime", version = "=1.7.0" }
 solana-stake-program = { path = "../programs/stake", version = "=1.7.0" }
 solana-vote-program = { path = "../programs/vote", version = "=1.7.0" }
 spl-associated-token-account-v1-0 = { package = "spl-associated-token-account", version = "=1.0.2", features = ["no-entrypoint"] }
-spl-memo-v1-0 = { package = "spl-memo", version = "=2.0.1", features = ["no-entrypoint"] }
-spl-memo-v3-0 = { package = "spl-memo", version = "=3.0.1", features = ["no-entrypoint"] }
+spl-memo = { version = "=3.0.1", features = ["no-entrypoint"] }
 spl-token-v2-0 = { package = "spl-token", version = "=3.1.0", features = ["no-entrypoint"] }
 thiserror = "1.0"
 

--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -21,9 +21,8 @@ lazy_static! {
     static ref BPF_LOADER_PROGRAM_ID: Pubkey = solana_sdk::bpf_loader::id();
     static ref BPF_UPGRADEABLE_LOADER_PROGRAM_ID: Pubkey = solana_sdk::bpf_loader_upgradeable::id();
     static ref MEMO_V1_PROGRAM_ID: Pubkey =
-        Pubkey::from_str(&spl_memo_v1_0::id().to_string()).unwrap();
-    static ref MEMO_V3_PROGRAM_ID: Pubkey =
-        Pubkey::from_str(&spl_memo_v3_0::id().to_string()).unwrap();
+        Pubkey::from_str(&spl_memo::v1::id().to_string()).unwrap();
+    static ref MEMO_V3_PROGRAM_ID: Pubkey = Pubkey::from_str(&spl_memo::id().to_string()).unwrap();
     static ref STAKE_PROGRAM_ID: Pubkey = solana_stake_program::id();
     static ref SYSTEM_PROGRAM_ID: Pubkey = system_program::id();
     static ref TOKEN_PROGRAM_ID: Pubkey = spl_token_id_v2_0();


### PR DESCRIPTION
#### Problem
solana-transaction-status requires 2 imports of spl-memo simply to get the 2 historical program ids. Now that spl-memo v3.0.1 exists, only one import is needed.

#### Summary of Changes
Use spl-memo v3.0.1 to get both v1 and v3 program ids.
Will need rebase on https://github.com/solana-labs/solana/pull/16291
