### PR TITLE
validator: Use a const for wait for supermajority threshold

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -78,6 +78,7 @@ use std::{
 };
 
 const MAX_COMPLETED_DATA_SETS_IN_CHANNEL: usize = 100_000;
+const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 90;
 
 #[derive(Debug)]
 pub struct ValidatorConfig {
@@ -1358,14 +1359,15 @@ fn wait_for_supermajority(
     for i in 1.. {
         if i % 10 == 1 {
             info!(
-                "Waiting for 80% of activated stake at slot {} to be in gossip...",
+                "Waiting for {}% of activated stake at slot {} to be in gossip...",
+                WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT,
                 bank.slot()
             );
         }
 
         let gossip_stake_percent = get_stake_percent_in_gossip(&bank, &cluster_info, i % 10 == 0);
 
-        if gossip_stake_percent >= 90 {
+        if gossip_stake_percent >= WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT {
             break;
         }
         // The normal RPC health checks don't apply as the node is waiting, so feign health to


### PR DESCRIPTION
#### Problem

`--wait-for-supermajority` stake threshold log message is out of sync with its value

#### Summary of Changes

Use a constant