### PR TITLE
Cluster info shred spies

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -907,7 +907,8 @@ impl ClusterInfo {
 
     pub fn contact_info_trace(&self) -> String {
         let now = timestamp();
-        let mut spy_nodes = 0;
+        let mut shred_spy_nodes = 0;
+        let mut total_spy_nodes = 0;
         let mut different_shred_nodes = 0;
         let my_pubkey = self.id();
         let my_shred_version = self.my_shred_version();
@@ -915,8 +916,9 @@ impl ClusterInfo {
             .all_peers()
             .into_iter()
             .filter_map(|(node, last_updated)| {
-                if Self::is_spy_node(&node) {
-                    spy_nodes += 1;
+                let is_spy_node = Self::is_spy_node(&node);
+                if is_spy_node {
+                    total_spy_nodes += 1;
                 }
 
                 let node_version = self.get_node_version(&node.id);
@@ -924,6 +926,9 @@ impl ClusterInfo {
                     different_shred_nodes += 1;
                     None
                 } else {
+                    if is_spy_node {
+                        shred_spy_nodes += 1;
+                    }
                     fn addr_to_string(default_ip: &IpAddr, addr: &SocketAddr) -> String {
                         if ContactInfo::is_valid_address(addr) {
                             if &addr.ip() == default_ip {
@@ -972,9 +977,9 @@ impl ClusterInfo {
              {}\
              Nodes: {}{}{}",
             nodes.join(""),
-            nodes.len() - spy_nodes,
-            if spy_nodes > 0 {
-                format!("\nSpies: {}", spy_nodes)
+            nodes.len() - shred_spy_nodes,
+            if total_spy_nodes > 0 {
+                format!("\nSpies: {}", total_spy_nodes)
             } else {
                 "".to_string()
             },

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -907,9 +907,9 @@ impl ClusterInfo {
 
     pub fn contact_info_trace(&self) -> String {
         let now = timestamp();
-        let mut shred_spy_nodes = 0;
-        let mut total_spy_nodes = 0;
-        let mut different_shred_nodes = 0;
+        let mut shred_spy_nodes = 0usize;
+        let mut total_spy_nodes = 0usize;
+        let mut different_shred_nodes = 0usize;
         let my_pubkey = self.id();
         let my_shred_version = self.my_shred_version();
         let nodes: Vec<_> = self
@@ -918,16 +918,16 @@ impl ClusterInfo {
             .filter_map(|(node, last_updated)| {
                 let is_spy_node = Self::is_spy_node(&node);
                 if is_spy_node {
-                    total_spy_nodes += 1;
+                    total_spy_nodes = total_spy_nodes.saturating_add(1);
                 }
 
                 let node_version = self.get_node_version(&node.id);
                 if my_shred_version != 0 && (node.shred_version != 0 && node.shred_version != my_shred_version) {
-                    different_shred_nodes += 1;
+                    different_shred_nodes = different_shred_nodes.saturating_add(1);
                     None
                 } else {
                     if is_spy_node {
-                        shred_spy_nodes += 1;
+                        shred_spy_nodes = shred_spy_nodes.saturating_add(1);
                     }
                     fn addr_to_string(default_ip: &IpAddr, addr: &SocketAddr) -> String {
                         if ContactInfo::is_valid_address(addr) {
@@ -977,7 +977,7 @@ impl ClusterInfo {
              {}\
              Nodes: {}{}{}",
             nodes.join(""),
-            nodes.len() - shred_spy_nodes,
+            nodes.len().saturating_sub(shred_spy_nodes),
             if total_spy_nodes > 0 {
                 format!("\nSpies: {}", total_spy_nodes)
             } else {


### PR DESCRIPTION
#### Problem

During cluster restarts, there may be more spies than nodes on the correct shred version, resulting in gossip logs claiming we have some 18x10^12 nodes.  Which would be cool, but is wrong

#### Summary of Changes

Track total and same-shred spies separately
Replace the integer arithmetic
