### PR TITLE
Return sysvars via syscalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,10 +4986,13 @@ version = "1.7.0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
+ "bincode",
  "chrono",
  "chrono-humanize",
  "log 0.4.11",
  "mio 0.7.6",
+ "serde",
+ "serde_derive",
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -10,10 +10,13 @@ version = "1.7.0"
 [dependencies]
 async-trait = "0.1.42"
 base64 = "0.12.3"
+bincode = "1.3.1"
 chrono = "0.4.19"
 chrono-humanize = "0.1.1"
 log = "0.4.11"
 mio = "0.7.6"
+serde = "1.0.112"
+serde_derive = "1.0.103"
 solana-banks-client = { path = "../banks-client", version = "=1.7.0" }
 solana-banks-server = { path = "../banks-server", version = "=1.7.0" }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=1.7.0" }

--- a/program-test/tests/sysvar.rs
+++ b/program-test/tests/sysvar.rs
@@ -1,0 +1,72 @@
+use {
+    solana_program_test::{processor, ProgramTest},
+    solana_sdk::{
+        account_info::AccountInfo,
+        clock::Clock,
+        entrypoint::ProgramResult,
+        epoch_schedule::EpochSchedule,
+        fee_calculator::FeeCalculator,
+        instruction::Instruction,
+        msg,
+        pubkey::Pubkey,
+        rent::Rent,
+        signature::Signer,
+        sysvar::{fees::Fees, Sysvar},
+        transaction::Transaction,
+    },
+};
+
+// Process instruction to invoke into another program
+fn sysvar_getter_process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _input: &[u8],
+) -> ProgramResult {
+    msg!("sysvar_getter");
+
+    let clock = Clock::get()?;
+    assert_eq!(42, clock.slot);
+
+    let epoch_schedule = EpochSchedule::get()?;
+    assert_eq!(epoch_schedule, EpochSchedule::default());
+
+    let fees = Fees::get()?;
+    assert_eq!(
+        fees.fee_calculator,
+        FeeCalculator {
+            lamports_per_signature: 5000
+        }
+    );
+
+    let rent = Rent::get()?;
+    assert_eq!(rent, Rent::default());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_sysvar() {
+    let program_id = Pubkey::new_unique();
+    let program_test = ProgramTest::new(
+        "sysvar_getter",
+        program_id,
+        processor!(sysvar_getter_process_instruction),
+    );
+
+    let mut context = program_test.start_with_context().await;
+    context.warp_to_slot(42).unwrap();
+    let instructions = vec![Instruction::new_with_bincode(program_id, &(), vec![])];
+
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    context
+        .banks_client
+        .process_transaction(transaction)
+        .await
+        .unwrap();
+}

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -3370,10 +3370,13 @@ version = "1.7.0"
 dependencies = [
  "async-trait",
  "base64 0.12.3",
+ "bincode",
  "chrono",
  "chrono-humanize",
  "log",
  "mio 0.7.7",
+ "serde",
+ "serde_derive",
  "solana-banks-client",
  "solana-banks-server",
  "solana-bpf-loader-program",

--- a/programs/bpf/rust/sysvar/src/lib.rs
+++ b/programs/bpf/rust/sysvar/src/lib.rs
@@ -29,6 +29,8 @@ pub fn process_instruction(
         sysvar::clock::id().log();
         let clock = Clock::from_account_info(&accounts[2]).unwrap();
         assert_ne!(clock, Clock::default());
+        let got_clock = Clock::get()?;
+        assert_eq!(clock, got_clock);
     }
 
     // Epoch Schedule
@@ -37,6 +39,8 @@ pub fn process_instruction(
         sysvar::epoch_schedule::id().log();
         let epoch_schedule = EpochSchedule::from_account_info(&accounts[3]).unwrap();
         assert_eq!(epoch_schedule, EpochSchedule::default());
+        let got_epoch_schedule = EpochSchedule::get()?;
+        assert_eq!(epoch_schedule, got_epoch_schedule);
     }
 
     // Fees
@@ -44,8 +48,10 @@ pub fn process_instruction(
         msg!("Fees identifier:");
         sysvar::fees::id().log();
         let fees = Fees::from_account_info(&accounts[4]).unwrap();
-        let fee_calculator = fees.fee_calculator;
+        let fee_calculator = fees.fee_calculator.clone();
         assert_ne!(fee_calculator, FeeCalculator::default());
+        let got_fees = Fees::get()?;
+        assert_eq!(fees, got_fees);
     }
 
     // Instructions
@@ -68,6 +74,8 @@ pub fn process_instruction(
         sysvar::rent::id().log();
         let rent = Rent::from_account_info(&accounts[7]).unwrap();
         assert_eq!(rent, Rent::default());
+        let got_rent = Rent::get()?;
+        assert_eq!(rent, got_rent);
     }
 
     // Slot Hashes

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -15,10 +15,12 @@ use solana_sdk::{
     account_utils::StateMut,
     bpf_loader, bpf_loader_deprecated,
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
+    clock::Clock,
     entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
+    epoch_schedule::EpochSchedule,
     feature_set::{
         cpi_data_cost, cpi_share_ro_and_exec_accounts, demote_sysvar_write_locks,
-        ristretto_mul_syscall_enabled,
+        ristretto_mul_syscall_enabled, sysvar_via_syscall,
     },
     hash::{Hasher, HASH_BYTES},
     ic_msg,
@@ -27,6 +29,8 @@ use solana_sdk::{
     native_loader,
     process_instruction::{stable_log, ComputeMeter, InvokeContext, Logger},
     pubkey::{Pubkey, PubkeyError, MAX_SEEDS},
+    rent::Rent,
+    sysvar::{self, fees::Fees, Sysvar, SysvarId},
 };
 use std::{
     alloc::Layout,
@@ -127,6 +131,19 @@ pub fn register_syscalls(
             .register_syscall_by_name(b"sol_ristretto_mul", SyscallRistrettoMul::call)?;
     }
 
+    if invoke_context.is_feature_active(&sysvar_via_syscall::id()) {
+        syscall_registry
+            .register_syscall_by_name(b"sol_get_clock_sysvar", SyscallGetClockSysvar::call)?;
+        syscall_registry.register_syscall_by_name(
+            b"sol_get_epoch_schedule_sysvar",
+            SyscallGetEpochScheduleSysvar::call,
+        )?;
+        syscall_registry
+            .register_syscall_by_name(b"sol_get_fees_sysvar", SyscallGetFeesSysvar::call)?;
+        syscall_registry
+            .register_syscall_by_name(b"sol_get_rent_sysvar", SyscallGetRentSysvar::call)?;
+    }
+
     syscall_registry
         .register_syscall_by_name(b"sol_invoke_signed_c", SyscallInvokeSignedC::call)?;
     syscall_registry
@@ -137,8 +154,8 @@ pub fn register_syscalls(
 }
 
 macro_rules! bind_feature_gated_syscall_context_object {
-    ($vm:expr, $invoke_context:expr, $feature_id:expr, $syscall_context_object:expr $(,)?) => {
-        if $invoke_context.is_feature_active($feature_id) {
+    ($vm:expr, $is_feature_active:expr, $syscall_context_object:expr $(,)?) => {
+        if $is_feature_active {
             match $vm.bind_syscall_context_object($syscall_context_object, None) {
                 Err(EbpfError::SyscallNotRegistered(_)) | Ok(()) => {}
                 Err(err) => {
@@ -234,8 +251,7 @@ pub fn bind_syscall_context_objects<'a>(
 
     bind_feature_gated_syscall_context_object!(
         vm,
-        invoke_context,
-        &ristretto_mul_syscall_enabled::id(),
+        invoke_context.is_feature_active(&ristretto_mul_syscall_enabled::id()),
         Box::new(SyscallRistrettoMul {
             cost: 0,
             compute_meter: invoke_context.get_compute_meter(),
@@ -243,9 +259,44 @@ pub fn bind_syscall_context_objects<'a>(
         }),
     );
 
-    // Cross-program invocation syscalls
+    let is_sysvar_via_syscall_active = invoke_context.is_feature_active(&sysvar_via_syscall::id());
 
     let invoke_context = Rc::new(RefCell::new(invoke_context));
+
+    bind_feature_gated_syscall_context_object!(
+        vm,
+        is_sysvar_via_syscall_active,
+        Box::new(SyscallGetClockSysvar {
+            invoke_context: invoke_context.clone(),
+            loader_id,
+        }),
+    );
+    bind_feature_gated_syscall_context_object!(
+        vm,
+        is_sysvar_via_syscall_active,
+        Box::new(SyscallGetEpochScheduleSysvar {
+            invoke_context: invoke_context.clone(),
+            loader_id,
+        }),
+    );
+    bind_feature_gated_syscall_context_object!(
+        vm,
+        is_sysvar_via_syscall_active,
+        Box::new(SyscallGetFeesSysvar {
+            invoke_context: invoke_context.clone(),
+            loader_id,
+        }),
+    );
+    bind_feature_gated_syscall_context_object!(
+        vm,
+        is_sysvar_via_syscall_active,
+        Box::new(SyscallGetRentSysvar {
+            invoke_context: invoke_context.clone(),
+            loader_id,
+        }),
+    );
+
+    // Cross-program invocation syscalls
     vm.bind_syscall_context_object(
         Box::new(SyscallInvokeSignedC {
             callers_keyed_accounts,
@@ -828,6 +879,136 @@ impl<'a> SyscallObject<BpfError> for SyscallRistrettoMul<'a> {
         *output = point * scalar;
 
         *result = Ok(0);
+    }
+}
+
+fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId>(
+    id: &Pubkey,
+    var_addr: u64,
+    loader_id: &Pubkey,
+    memory_mapping: &MemoryMapping,
+    invoke_context: Rc<RefCell<&mut dyn InvokeContext>>,
+) -> Result<u64, EbpfError<BpfError>> {
+    let mut invoke_context = invoke_context
+        .try_borrow_mut()
+        .map_err(|_| SyscallError::InvokeContextBorrowFailed)?;
+
+    invoke_context.get_compute_meter().consume(
+        invoke_context.get_bpf_compute_budget().sysvar_base_cost + size_of::<T>() as u64,
+    )?;
+    let var = translate_type_mut::<T>(memory_mapping, var_addr, loader_id)?;
+
+    let sysvar_data = invoke_context.get_sysvar_data(id).ok_or_else(|| {
+        ic_msg!(invoke_context, "Unable to get Sysvar {}", id);
+        SyscallError::InstructionError(InstructionError::UnsupportedSysvar)
+    })?;
+
+    *var = bincode::deserialize(&sysvar_data).map_err(|e| {
+        ic_msg!(invoke_context, "Unable to get Sysvar {}: {:?}", id, e);
+        SyscallError::InstructionError(InstructionError::UnsupportedSysvar)
+    })?;
+
+    Ok(SUCCESS)
+}
+
+/// Get a Clock sysvar
+struct SyscallGetClockSysvar<'a> {
+    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+    loader_id: &'a Pubkey,
+}
+impl<'a> SyscallObject<BpfError> for SyscallGetClockSysvar<'a> {
+    fn call(
+        &mut self,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &MemoryMapping,
+        result: &mut Result<u64, EbpfError<BpfError>>,
+    ) {
+        *result = get_sysvar::<Clock>(
+            &sysvar::clock::id(),
+            var_addr,
+            self.loader_id,
+            memory_mapping,
+            self.invoke_context.clone(),
+        );
+    }
+}
+/// Get a EpochSchedule sysvar
+struct SyscallGetEpochScheduleSysvar<'a> {
+    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+    loader_id: &'a Pubkey,
+}
+impl<'a> SyscallObject<BpfError> for SyscallGetEpochScheduleSysvar<'a> {
+    fn call(
+        &mut self,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &MemoryMapping,
+        result: &mut Result<u64, EbpfError<BpfError>>,
+    ) {
+        *result = get_sysvar::<EpochSchedule>(
+            &sysvar::epoch_schedule::id(),
+            var_addr,
+            self.loader_id,
+            memory_mapping,
+            self.invoke_context.clone(),
+        );
+    }
+}
+/// Get a Fees sysvar
+struct SyscallGetFeesSysvar<'a> {
+    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+    loader_id: &'a Pubkey,
+}
+impl<'a> SyscallObject<BpfError> for SyscallGetFeesSysvar<'a> {
+    fn call(
+        &mut self,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &MemoryMapping,
+        result: &mut Result<u64, EbpfError<BpfError>>,
+    ) {
+        *result = get_sysvar::<Fees>(
+            &sysvar::fees::id(),
+            var_addr,
+            self.loader_id,
+            memory_mapping,
+            self.invoke_context.clone(),
+        );
+    }
+}
+/// Get a Rent sysvar
+struct SyscallGetRentSysvar<'a> {
+    invoke_context: Rc<RefCell<&'a mut dyn InvokeContext>>,
+    loader_id: &'a Pubkey,
+}
+impl<'a> SyscallObject<BpfError> for SyscallGetRentSysvar<'a> {
+    fn call(
+        &mut self,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &MemoryMapping,
+        result: &mut Result<u64, EbpfError<BpfError>>,
+    ) {
+        *result = get_sysvar::<Rent>(
+            &sysvar::rent::id(),
+            var_addr,
+            self.loader_id,
+            memory_mapping,
+            self.invoke_context.clone(),
+        );
     }
 }
 
@@ -1745,8 +1926,9 @@ mod tests {
     use solana_rbpf::{memory_region::MemoryRegion, vm::Config};
     use solana_sdk::{
         bpf_loader,
+        fee_calculator::FeeCalculator,
         hash::hashv,
-        process_instruction::{MockComputeMeter, MockLogger},
+        process_instruction::{MockComputeMeter, MockInvokeContext, MockLogger},
     };
     use std::str::FromStr;
 
@@ -2459,5 +2641,176 @@ mod tests {
             ))),
             result
         );
+    }
+
+    #[test]
+    fn test_syscall_get_sysvar() {
+        // Test clock sysvar
+        {
+            let got_clock = Clock::default();
+            let got_clock_va = 2048;
+
+            let memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion {
+                    host_addr: &got_clock as *const _ as u64,
+                    vm_addr: got_clock_va,
+                    len: size_of::<Clock>() as u64,
+                    vm_gap_shift: 63,
+                    is_writable: true,
+                }],
+                &DEFAULT_CONFIG,
+            );
+
+            let src_clock = Clock {
+                slot: 1,
+                epoch_start_timestamp: 2,
+                epoch: 3,
+                leader_schedule_epoch: 4,
+                unix_timestamp: 5,
+            };
+            let mut invoke_context = MockInvokeContext::default();
+            let mut data = vec![];
+            bincode::serialize_into(&mut data, &src_clock).unwrap();
+            invoke_context
+                .sysvars
+                .push((sysvar::clock::id(), Some(Rc::new(data))));
+
+            let mut syscall = SyscallGetClockSysvar {
+                invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
+                loader_id: &bpf_loader::id(),
+            };
+            let mut result: Result<u64, EbpfError<BpfError>> = Ok(0);
+
+            syscall.call(got_clock_va, 0, 0, 0, 0, &memory_mapping, &mut result);
+            result.unwrap();
+            assert_eq!(got_clock, src_clock);
+        }
+
+        // Test epoch_schedule sysvar
+        {
+            let got_epochschedule = EpochSchedule::default();
+            let got_epochschedule_va = 2048;
+
+            let memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion {
+                    host_addr: &got_epochschedule as *const _ as u64,
+                    vm_addr: got_epochschedule_va,
+                    len: size_of::<EpochSchedule>() as u64,
+                    vm_gap_shift: 63,
+                    is_writable: true,
+                }],
+                &DEFAULT_CONFIG,
+            );
+
+            let src_epochschedule = EpochSchedule {
+                slots_per_epoch: 1,
+                leader_schedule_slot_offset: 2,
+                warmup: false,
+                first_normal_epoch: 3,
+                first_normal_slot: 4,
+            };
+            let mut invoke_context = MockInvokeContext::default();
+            let mut data = vec![];
+            bincode::serialize_into(&mut data, &src_epochschedule).unwrap();
+            invoke_context
+                .sysvars
+                .push((sysvar::epoch_schedule::id(), Some(Rc::new(data))));
+
+            let mut syscall = SyscallGetEpochScheduleSysvar {
+                invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
+                loader_id: &bpf_loader::id(),
+            };
+            let mut result: Result<u64, EbpfError<BpfError>> = Ok(0);
+
+            syscall.call(
+                got_epochschedule_va,
+                0,
+                0,
+                0,
+                0,
+                &memory_mapping,
+                &mut result,
+            );
+            result.unwrap();
+            assert_eq!(got_epochschedule, src_epochschedule);
+        }
+
+        // Test fees sysvar
+        {
+            let got_fees = Fees::default();
+            let got_fees_va = 2048;
+
+            let memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion {
+                    host_addr: &got_fees as *const _ as u64,
+                    vm_addr: got_fees_va,
+                    len: size_of::<Fees>() as u64,
+                    vm_gap_shift: 63,
+                    is_writable: true,
+                }],
+                &DEFAULT_CONFIG,
+            );
+
+            let src_fees = Fees {
+                fee_calculator: FeeCalculator {
+                    lamports_per_signature: 1,
+                },
+            };
+            let mut invoke_context = MockInvokeContext::default();
+            let mut data = vec![];
+            bincode::serialize_into(&mut data, &src_fees).unwrap();
+            invoke_context
+                .sysvars
+                .push((sysvar::fees::id(), Some(Rc::new(data))));
+
+            let mut syscall = SyscallGetFeesSysvar {
+                invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
+                loader_id: &bpf_loader::id(),
+            };
+            let mut result: Result<u64, EbpfError<BpfError>> = Ok(0);
+
+            syscall.call(got_fees_va, 0, 0, 0, 0, &memory_mapping, &mut result);
+            result.unwrap();
+            assert_eq!(got_fees, src_fees);
+        }
+
+        // Test rent sysvar
+        {
+            let got_rent = Rent::default();
+            let got_rent_va = 2048;
+
+            let memory_mapping = MemoryMapping::new(
+                vec![MemoryRegion {
+                    host_addr: &got_rent as *const _ as u64,
+                    vm_addr: got_rent_va,
+                    len: size_of::<Rent>() as u64,
+                    vm_gap_shift: 63,
+                    is_writable: true,
+                }],
+                &DEFAULT_CONFIG,
+            );
+
+            let src_rent = Rent {
+                lamports_per_byte_year: 1,
+                exemption_threshold: 2.0,
+                burn_percent: 3,
+            };
+            let mut invoke_context = MockInvokeContext::default();
+            let mut data = vec![];
+            bincode::serialize_into(&mut data, &src_rent).unwrap();
+            invoke_context
+                .sysvars
+                .push((sysvar::rent::id(), Some(Rc::new(data))));
+
+            let mut syscall = SyscallGetRentSysvar {
+                invoke_context: Rc::new(RefCell::new(&mut invoke_context)),
+                loader_id: &bpf_loader::id(),
+            };
+            let mut result: Result<u64, EbpfError<BpfError>> = Ok(0);
+
+            syscall.call(got_rent_va, 0, 0, 0, 0, &memory_mapping, &mut result);
+            result.unwrap();
+            assert_eq!(got_rent, src_rent);
+        }
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2933,6 +2933,8 @@ impl Bank {
                         self.feature_set.clone(),
                         bpf_compute_budget,
                         &mut timings.details,
+                        self.rc.accounts.clone(),
+                        &self.ancestors,
                     );
 
                     if enable_log_recording {

--- a/sdk/program/src/clock.rs
+++ b/sdk/program/src/clock.rs
@@ -82,7 +82,7 @@ pub type UnixTimestamp = i64;
 ///  as the network progresses).
 ///
 #[repr(C)]
-#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
+#[derive(Serialize, Clone, Deserialize, Debug, Default, PartialEq)]
 pub struct Clock {
     /// the current network/bank Slot
     pub slot: Slot,

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -2,7 +2,10 @@
 
 #![cfg(not(target_arch = "bpf"))]
 
-use crate::{account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction};
+use crate::{
+    account_info::AccountInfo, entrypoint::ProgramResult, instruction::Instruction,
+    program_error::UNSUPPORTED_SYSVAR,
+};
 use std::sync::{Arc, RwLock};
 
 lazy_static::lazy_static! {
@@ -30,6 +33,19 @@ pub trait SyscallStubs: Sync + Send {
     ) -> ProgramResult {
         sol_log("SyscallStubs: sol_invoke_signed() not available");
         Ok(())
+    }
+
+    fn sol_get_clock_sysvar(&self, _var_addr: *mut u8) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
+    fn sol_get_epoch_schedule_sysvar(&self, _var_addr: *mut u8) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
+    fn sol_get_fees_sysvar(&self, _var_addr: *mut u8) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
+    fn sol_get_rent_sysvar(&self, _var_addr: *mut u8) -> u64 {
+        UNSUPPORTED_SYSVAR
     }
 }
 
@@ -60,4 +76,23 @@ pub(crate) fn sol_invoke_signed(
         .read()
         .unwrap()
         .sol_invoke_signed(instruction, account_infos, signers_seeds)
+}
+
+pub(crate) fn sol_get_clock_sysvar(var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS.read().unwrap().sol_get_clock_sysvar(var_addr)
+}
+
+pub(crate) fn sol_get_epoch_schedule_sysvar(var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_get_epoch_schedule_sysvar(var_addr)
+}
+
+pub(crate) fn sol_get_fees_sysvar(var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS.read().unwrap().sol_get_fees_sysvar(var_addr)
+}
+
+pub(crate) fn sol_get_rent_sysvar(var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS.read().unwrap().sol_get_rent_sysvar(var_addr)
 }

--- a/sdk/program/src/sysvar/clock.rs
+++ b/sdk/program/src/sysvar/clock.rs
@@ -2,8 +2,10 @@
 //!
 pub use crate::clock::Clock;
 
-use crate::sysvar::Sysvar;
+use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
 
 crate::declare_sysvar_id!("SysvarC1ock11111111111111111111111111111111", Clock);
 
-impl Sysvar for Clock {}
+impl Sysvar for Clock {
+    impl_sysvar_get!(sol_get_clock_sysvar);
+}

--- a/sdk/program/src/sysvar/epoch_schedule.rs
+++ b/sdk/program/src/sysvar/epoch_schedule.rs
@@ -1,8 +1,11 @@
 //! This account contains the current cluster rent
 //!
 pub use crate::epoch_schedule::EpochSchedule;
-use crate::sysvar::Sysvar;
+
+use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
 
 crate::declare_sysvar_id!("SysvarEpochSchedu1e111111111111111111111111", EpochSchedule);
 
-impl Sysvar for EpochSchedule {}
+impl Sysvar for EpochSchedule {
+    impl_sysvar_get!(sol_get_epoch_schedule_sysvar);
+}

--- a/sdk/program/src/sysvar/fees.rs
+++ b/sdk/program/src/sysvar/fees.rs
@@ -1,11 +1,13 @@
 //! This account contains the current cluster fees
 //!
-use crate::{fee_calculator::FeeCalculator, sysvar::Sysvar};
+use crate::{
+    fee_calculator::FeeCalculator, impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar,
+};
 
 crate::declare_sysvar_id!("SysvarFees111111111111111111111111111111111", Fees);
 
 #[repr(C)]
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct Fees {
     pub fee_calculator: FeeCalculator,
 }
@@ -17,4 +19,6 @@ impl Fees {
     }
 }
 
-impl Sysvar for Fees {}
+impl Sysvar for Fees {
+    impl_sysvar_get!(sol_get_fees_sysvar);
+}

--- a/sdk/program/src/sysvar/rent.rs
+++ b/sdk/program/src/sysvar/rent.rs
@@ -2,8 +2,10 @@
 //!
 pub use crate::rent::Rent;
 
-use crate::sysvar::Sysvar;
+use crate::{impl_sysvar_get, program_error::ProgramError, sysvar::Sysvar};
 
 crate::declare_sysvar_id!("SysvarRent111111111111111111111111111111111", Rent);
 
-impl Sysvar for Rent {}
+impl Sysvar for Rent {
+    impl_sysvar_get!(sol_get_rent_sysvar);
+}

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -127,6 +127,10 @@ pub mod demote_sysvar_write_locks {
     solana_sdk::declare_id!("86LJYRuq2zgtHuL3FccR6hqFJQMQkFoun4knAxcPiF1P");
 }
 
+pub mod sysvar_via_syscall {
+    solana_sdk::declare_id!("7411E6gFQLDhQkdRjmpXwM1hzHMMoYQUjHicmvGPC1Nf");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -159,6 +163,7 @@ lazy_static! {
         (cpi_data_cost::id(), "charge the compute budget for data passed via CPI"),
         (upgradeable_close_instruction::id(), "close upgradeable buffer accounts"),
         (demote_sysvar_write_locks::id(), "demote builtins and sysvar write locks to readonly #15497"),
+        (sysvar_via_syscall::id(), "Provide sysvars via syscalls"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Requiring developers to include sysvars in their instructions complicates composibility and requires programs to pass the sysvar accounts between programs when an intermediate might not actually need them.

Also, because of the bincode serialization of the sysvar data and the lack of a C parser we currently don't support sysvars in C BPF programs.

#### Summary of Changes

- Allow a program to call a syscall to obtain the sysvar.
- Do so in a way that does NOT require the bincode deserialization in-program
- Sysvars clock, epoch_schedule, fees, and rent are currently supported and new simple `repr(C)` sysvars can use this same mechanism in the future.  Large or complex sysvar types will need a different mechanism to map the sysvar memory into the program's memory space.

Needed by: https://github.com/solana-labs/solana/pull/15927

Fixes #15755
