### PR TITLE
CI: Let `cargo-install-all.sh` resolve stable

### DIFF
--- a/ci/publish-tarball.sh
+++ b/ci/publish-tarball.sh
@@ -83,7 +83,7 @@ echo --- Creating release tarball
   export CHANNEL
 
   source ci/rust-version.sh stable
-  scripts/cargo-install-all.sh +"$rust_stable" "${RELEASE_BASENAME}"
+  scripts/cargo-install-all.sh stable "${RELEASE_BASENAME}"
 
   tar cvf "${TARBALL_BASENAME}"-$TARGET.tar "${RELEASE_BASENAME}"
   bzip2 "${TARBALL_BASENAME}"-$TARGET.tar


### PR DESCRIPTION
#### Problem

`ci/publish-tarball.sh` is broken after https://github.com/solana-labs/solana/commit/6cd4bc5e602ab0d076a681168ddf83ffd7750c75

#### Summary of Changes

Let `scripts/cargo-install-all.sh` resolve stable Rust version
