### PR TITLE
Fix cargo-build/test-bpf --workspace

### DIFF
--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -44,14 +44,10 @@ test-stable-perf)
   ./cargo-build-bpf --manifest-path sdk/Cargo.toml
 
   # BPF Program unit tests
-  for program in programs/bpf/rust/*; do
-    if [ -d "${program}" ]; then
-      _ "$cargo" test --manifest-path "$program"/Cargo.toml
-      _ cargo-build-bpf --manifest-path "$program"/Cargo.toml --bpf-sdk sdk/bpf
-    fi
-  done
+  "$cargo" test --manifest-path programs/bpf/Cargo.toml
+  cargo-build-bpf --manifest-path programs/bpf/Cargo.toml --bpf-sdk sdk/bpf
 
-  # BPF program tests
+  # BPF program system tests
   _ make -C programs/bpf/c tests
   _ "$cargo" stable test \
     --manifest-path programs/bpf/Cargo.toml \

--- a/sdk/cargo-build-bpf/src/main.rs
+++ b/sdk/cargo-build-bpf/src/main.rs
@@ -401,8 +401,14 @@ fn build_bpf(config: Config, manifest_path: Option<PathBuf>) {
         .packages
         .iter()
         .filter(|package| {
-            package.manifest_path.with_file_name("Xargo.toml").exists()
-                && metadata.workspace_members.contains(&package.id)
+            if metadata.workspace_members.contains(&package.id) {
+                for target in package.targets.iter() {
+                    if target.kind.contains(&"cdylib".to_string()) {
+                        return true;
+                    }
+                }
+            }
+            false
         })
         .collect::<Vec<_>>();
 

--- a/sdk/cargo-test-bpf/src/main.rs
+++ b/sdk/cargo-test-bpf/src/main.rs
@@ -152,8 +152,14 @@ fn test_bpf(config: Config, manifest_path: Option<PathBuf>) {
         .packages
         .iter()
         .filter(|package| {
-            package.manifest_path.with_file_name("Xargo.toml").exists()
-                && metadata.workspace_members.contains(&package.id)
+            if metadata.workspace_members.contains(&package.id) {
+                for target in package.targets.iter() {
+                    if target.kind.contains(&"cdylib".to_string()) {
+                        return true;
+                    }
+                }
+            }
+            false
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
#### Problem

cargo-build-bpf and cargo-test-bpf are broken when attempting to build the workspace with `--workspace`

#### Summary of Changes

`Xargo.toml` no longer exists, only build workspace members that also are of type `cdylib`

Fixes #
