### PR TITLE
Keygen grind keypairs whose pubkey has a safe base58 encoding

### DIFF
--- a/sdk/src/signature.rs
+++ b/sdk/src/signature.rs
@@ -56,6 +56,23 @@ impl Keypair {
     pub fn secret(&self) -> &ed25519_dalek::SecretKey {
         &self.0.secret
     }
+
+    pub fn new_with_pubkey_criteria<G, V, T>(generator: G, validator: V) -> Option<(Self, T)>
+    where
+        G: Fn() -> (Self, T),
+        V: Fn(Pubkey) -> Option<bool>,
+    {
+        let mut maybe;
+        loop {
+            maybe = generator();
+            match validator(maybe.0.pubkey()) {
+                Some(valid) if valid => break,
+                None => return None,
+                _ => (),
+            }
+        }
+        Some(maybe)
+    }
 }
 
 /// Number of bytes in a signature


### PR DESCRIPTION
#### Problem

Address copypasta errors can lead to loss of funds due to many pubkeys' base58 representation decoding to 32-bytes despite missing chars

#### Summary of Changes

Grind keypairs whose base58 encoding always decode to too few bytes if a character is missing from either end