### PR TITLE
stops consuming pinned vectors with a recycler

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -2816,7 +2816,7 @@ impl ClusterInfo {
         let packets: Vec<_> = requests_receiver.recv_timeout(RECV_TIMEOUT)?.packets.into();
         let mut packets = VecDeque::from(packets);
         while let Ok(packet) = requests_receiver.try_recv() {
-            packets.extend(packet.packets.into_iter());
+            packets.extend(packet.packets.iter().cloned());
             let excess_count = packets.len().saturating_sub(MAX_GOSSIP_TRAFFIC);
             if excess_count > 0 {
                 packets.drain(0..excess_count);

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -59,7 +59,8 @@ impl VerifiedVotePackets {
         }
         let packets = votes
             .into_iter()
-            .flat_map(|(_, (_, packets))| packets.packets.clone())
+            .flat_map(|(_, (_, packets))| &packets.packets)
+            .cloned()
             .collect();
         (new_update_version, Packets::new(packets))
     }

--- a/ledger/src/entry.rs
+++ b/ledger/src/entry.rs
@@ -283,9 +283,9 @@ impl EntryVerificationState {
                             .zip(entries)
                             .all(|((hash, tx_hash), answer)| {
                                 if answer.num_hashes == 0 {
-                                    hash == answer.hash
+                                    *hash == answer.hash
                                 } else {
-                                    let mut poh = Poh::new(hash, None);
+                                    let mut poh = Poh::new(*hash, None);
                                     if let Some(mixin) = tx_hash {
                                         poh.record(*mixin).unwrap().hash == answer.hash
                                     } else {

--- a/perf/src/cuda_runtime.rs
+++ b/perf/src/cuda_runtime.rs
@@ -78,21 +78,18 @@ impl<T: Default + Clone + Sized> Reset for PinnedVec<T> {
 impl<T: Clone + Default + Sized> From<PinnedVec<T>> for Vec<T> {
     fn from(mut pinned_vec: PinnedVec<T>) -> Self {
         if pinned_vec.pinned {
+            // If the vector is pinned and has a recycler, just return a clone
+            // so that the next allocation of a PinnedVec will recycle an
+            // already pinned one.
+            if pinned_vec.recycler.strong_count() != 0 {
+                return pinned_vec.x.clone();
+            }
             unpin(pinned_vec.x.as_mut_ptr());
             pinned_vec.pinned = false;
         }
         pinned_vec.pinnable = false;
         pinned_vec.recycler = Weak::default();
         std::mem::take(&mut pinned_vec.x)
-    }
-}
-
-impl<T: Clone + Default + Sized> IntoIterator for PinnedVec<T> {
-    type Item = T;
-    type IntoIter = std::vec::IntoIter<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        <Self as Into<Vec<T>>>::into(self).into_iter()
     }
 }
 
@@ -148,15 +145,6 @@ impl<'a, T: Clone + Send + Sync + Default + Sized> IntoParallelIterator for &'a 
     type Item = &'a mut T;
     fn into_par_iter(self) -> Self::Iter {
         self.x.par_iter_mut()
-    }
-}
-
-impl<T: Clone + Default + Send + Sized> IntoParallelIterator for PinnedVec<T> {
-    type Item = T;
-    type Iter = rayon::vec::IntoIter<T>;
-
-    fn into_par_iter(self) -> Self::Iter {
-        <Self as Into<Vec<T>>>::into(self).into_par_iter()
     }
 }
 


### PR DESCRIPTION
#### Problem
If the vector is pinned and has a recycler, `From<PinnedVec>`
implementation of `Vec` should clone (instead of consuming) the underlying
vector so that the next allocation of a `PinnedVec` will recycle an
already pinned one.

#### Summary of Changes
* Clone if the vector is pinned and has a recycler.
* Also, removed consuming iterators. The reference ones are already sufficient and are less error prone.