### PR TITLE
Remove old way of account hashing

### DIFF
--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -2,7 +2,6 @@ use dashmap::DashMap;
 use solana_sdk::{
     account::{AccountSharedData, ReadableAccount},
     clock::Slot,
-    genesis_config::ClusterType,
     hash::Hash,
     pubkey::Pubkey,
 };
@@ -114,7 +113,7 @@ pub struct CachedAccountInner {
 }
 
 impl CachedAccountInner {
-    pub fn hash(&self, cluster_type: ClusterType) -> Hash {
+    pub fn hash(&self) -> Hash {
         let hash = self.hash.read().unwrap();
         match *hash {
             Some(hash) => hash,
@@ -124,7 +123,6 @@ impl CachedAccountInner {
                     self.slot,
                     &self.account,
                     &self.pubkey,
-                    &cluster_type,
                 );
                 *self.hash.write().unwrap() = Some(hash);
                 hash

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -10261,25 +10261,25 @@ pub(crate) mod tests {
             if bank.slot == 0 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "6oxxAqridoSSPQ1rnEh8qBhQpMmLUve3X4fsNNr2gExE"
+                    "Cn7Wmi7w1n9NbK7RGnTQ4LpbJ2LtoJoc1sufiTwb57Ya"
                 );
             }
             if bank.slot == 32 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "7AkMgAb2v4tuoiSf3NnVgaBxSvp7XidbrSwsPEn4ENTp"
+                    "BXupB8XsZukMTnDbKshJ8qPCydWnc8BKtSj7YTJ6gAH"
                 );
             }
             if bank.slot == 64 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "2JzWWRBtQgdXboaACBRXNNKsHeBtn57uYmqH1AgGUkdG"
+                    "EDkKefgSMSV1NhxnGnJP7R5AGZ2JZD6oxnoZtGuEGBCU"
                 );
             }
             if bank.slot == 128 {
                 assert_eq!(
                     bank.hash().to_string(),
-                    "FQnVhDVjhCyfBxFb3bdm3CLiuCePvWuW5TGDsLBZnKAo"
+                    "AtWu4tubU9zGFChfHtQghQx3RVWtMQu6Rj49rQymFc4z"
                 );
                 break;
             }

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -979,7 +979,6 @@ pub fn process_accounts_package_pre(
         let (hash, lamports) = AccountsDb::calculate_accounts_hash_without_index(
             &accounts_package.storages,
             thread_pool,
-            accounts_package.cluster_type,
         );
 
         assert_eq!(accounts_package.expected_capitalization, lamports);

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -113,7 +113,7 @@ fn test_bad_bank_hash() {
         for (key, account) in &account_refs {
             assert_eq!(
                 db.load_account_hash(&ancestors, &key),
-                AccountsDb::hash_account(some_slot, &account, &key, &ClusterType::Development)
+                AccountsDb::hash_account(some_slot, &account, &key)
             );
         }
         existing.clear();


### PR DESCRIPTION
Account data hashing used to use different ways of hashing on different
clusters.  That is no longer the case, but the old code still existed.
This commit removes that old, now used code.

**NOTE** The golden hash values in bank.rs needed to be updated.  Since the original code that selected the hash algorithm used `if >` instead of `if >=`, this meant that the genesis block's hash _always_ used the old hashing method, which is no longer valid.

The new golden hash values in `accounts_db.rs` were also validated by
changing `if slot >` to `if slot >=` on `master` and running `cargo test`,
then confirming the actual values matched the golden values in this commit.

Validated by running `cargo test` from within `runtime`.

(This work was originally based on PR #16375 from @jeffwashington)