### PR TITLE
feat: add filters to getProgramAccounts and getParsedProgramAccounts

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1369,12 +1369,12 @@ export type StakeActivationData = {
 };
 
 /**
- * Data slice object for getProgramAccounts
+ * Data slice argument for getProgramAccounts
  */
 export type DataSlice = {
-  /** offset of data slice limit */
+  /** offset of data slice */
   offset: number;
-  /** length of data slice limit  */
+  /** length of data slice */
   length: number;
 };
 

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -1369,6 +1369,63 @@ export type StakeActivationData = {
 };
 
 /**
+ * Data slice object for getProgramAccounts
+ */
+export type DataSlice = {
+  /** offset of data slice limit */
+  offset: number;
+  /** length of data slice limit  */
+  length: number;
+};
+
+/**
+ * Memory comparison filter for getProgramAccounts
+ */
+export type MemcmpFilter = {
+  memcmp: {
+    /** offset into program account data to start comparison */
+    offset: number;
+    /** data to match, as base-58 encoded string and limited to less than 129 bytes */
+    bytes: string;
+  };
+};
+
+/**
+ * Data size comparison filter for getProgramAccounts
+ */
+export type DataSizeFilter = {
+  /** Size of data for program account data length comparison */
+  dataSize: number;
+};
+
+/**
+ * A filter object for getProgramAccounts
+ */
+export type GetProgramAccountsFilter = MemcmpFilter | DataSizeFilter;
+
+/**
+ * Configuration object for getProgramAccounts requests
+ */
+export type GetProgramAccountsConfig = {
+  /** Optional commitment level */
+  commitment?: Commitment;
+  /** Optional encoding for account data (default base64) */
+  encoding?: 'base64' | 'jsonParsed';
+  /** Optional data slice to limit the returned account data */
+  dataSlice?: DataSlice;
+  /** Optional array of filters to apply to accounts */
+  filters?: GetProgramAccountsFilter[];
+};
+
+/**
+ * Configuration object for getParsedProgramAccounts
+ */
+export type GetParsedProgramAccountsConfig = Exclude<
+  GetProgramAccountsConfig,
+  'encoding' | 'dataSlice'
+>;
+
+/**
  * Information describing an account
  */
 export type AccountInfo<T> = {
@@ -2080,9 +2137,24 @@ export class Connection {
    */
   async getProgramAccounts(
     programId: PublicKey,
-    commitment?: Commitment,
+    config?: GetProgramAccountsConfig,
   ): Promise<Array<{pubkey: PublicKey; account: AccountInfo<Buffer>}>> {
-    const args = this._buildArgs([programId.toBase58()], commitment, 'base64');
+    const extra: Pick<GetProgramAccountsConfig, 'dataSlice' | 'filters'> = {};
+
+    if (config && config.dataSlice) {
+      extra.dataSlice = config.dataSlice;
+    }
+
+    if (config && config.filters) {
+      extra.filters = config.filters;
+    }
+
+    const args = this._buildArgs(
+      [programId.toBase58()],
+      (config && config.commitment) || undefined,
+      (config && config.encoding) || 'base64',
+      extra,
+    );
     const unsafeRes = await this._rpcRequest('getProgramAccounts', args);
     const res = create(unsafeRes, jsonRpcResult(array(KeyedAccountInfoResult)));
     if ('error' in res) {
@@ -2103,17 +2175,24 @@ export class Connection {
    */
   async getParsedProgramAccounts(
     programId: PublicKey,
-    commitment?: Commitment,
+    config?: GetParsedProgramAccountsConfig,
   ): Promise<
     Array<{
       pubkey: PublicKey;
       account: AccountInfo<Buffer | ParsedAccountData>;
     }>
   > {
+    const extra: Pick<GetParsedProgramAccountsConfig, 'filters'> = {};
+
+    if (config && config.filters) {
+      extra.filters = config.filters;
+    }
+
     const args = this._buildArgs(
       [programId.toBase58()],
-      commitment,
+      (config && config.commitment) || undefined,
       'jsonParsed',
+      extra,
     );
     const unsafeRes = await this._rpcRequest('getProgramAccounts', args);
     const res = create(

--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2137,22 +2137,32 @@ export class Connection {
    */
   async getProgramAccounts(
     programId: PublicKey,
-    config?: GetProgramAccountsConfig,
+    configOrCommitment?: GetProgramAccountsConfig | Commitment,
   ): Promise<Array<{pubkey: PublicKey; account: AccountInfo<Buffer>}>> {
     const extra: Pick<GetProgramAccountsConfig, 'dataSlice' | 'filters'> = {};
 
-    if (config && config.dataSlice) {
-      extra.dataSlice = config.dataSlice;
-    }
+    let commitment;
+    let encoding;
+    if (configOrCommitment) {
+      if (typeof configOrCommitment === 'string') {
+        commitment = configOrCommitment;
+      } else {
+        commitment = configOrCommitment.commitment;
+        encoding = configOrCommitment.encoding;
 
-    if (config && config.filters) {
-      extra.filters = config.filters;
+        if (configOrCommitment.dataSlice) {
+          extra.dataSlice = configOrCommitment.dataSlice;
+        }
+        if (configOrCommitment.filters) {
+          extra.filters = configOrCommitment.filters;
+        }
+      }
     }
 
     const args = this._buildArgs(
       [programId.toBase58()],
-      (config && config.commitment) || undefined,
-      (config && config.encoding) || 'base64',
+      commitment,
+      encoding || 'base64',
       extra,
     );
     const unsafeRes = await this._rpcRequest('getProgramAccounts', args);
@@ -2175,7 +2185,7 @@ export class Connection {
    */
   async getParsedProgramAccounts(
     programId: PublicKey,
-    config?: GetParsedProgramAccountsConfig,
+    configOrCommitment?: GetParsedProgramAccountsConfig | Commitment,
   ): Promise<
     Array<{
       pubkey: PublicKey;
@@ -2184,13 +2194,22 @@ export class Connection {
   > {
     const extra: Pick<GetParsedProgramAccountsConfig, 'filters'> = {};
 
-    if (config && config.filters) {
-      extra.filters = config.filters;
+    let commitment;
+    if (configOrCommitment) {
+      if (typeof configOrCommitment === 'string') {
+        commitment = configOrCommitment;
+      } else {
+        commitment = configOrCommitment.commitment;
+
+        if (configOrCommitment.filters) {
+          extra.filters = configOrCommitment.filters;
+        }
+      }
     }
 
     const args = this._buildArgs(
       [programId.toBase58()],
-      (config && config.commitment) || undefined,
+      commitment,
       'jsonParsed',
       extra,
     );

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -221,6 +221,57 @@ describe('Connection', () => {
         method: 'getProgramAccounts',
         params: [
           programId.publicKey.toBase58(),
+          {commitment: 'confirmed', encoding: 'base64'},
+        ],
+        value: [
+          {
+            account: {
+              data: ['', 'base64'],
+              executable: false,
+              lamports: LAMPORTS_PER_SOL - feeCalculator.lamportsPerSignature,
+              owner: programId.publicKey.toBase58(),
+              rentEpoch: 20,
+            },
+            pubkey: account0.publicKey.toBase58(),
+          },
+          {
+            account: {
+              data: ['', 'base64'],
+              executable: false,
+              lamports:
+                0.5 * LAMPORTS_PER_SOL - feeCalculator.lamportsPerSignature,
+              owner: programId.publicKey.toBase58(),
+              rentEpoch: 20,
+            },
+            pubkey: account1.publicKey.toBase58(),
+          },
+        ],
+      });
+
+      const programAccounts = await connection.getProgramAccounts(
+        programId.publicKey,
+        'confirmed',
+      );
+      expect(programAccounts).to.have.length(2);
+      programAccounts.forEach(function (keyedAccount) {
+        if (keyedAccount.pubkey.equals(account0.publicKey)) {
+          expect(keyedAccount.account.lamports).to.eq(
+            LAMPORTS_PER_SOL - feeCalculator.lamportsPerSignature,
+          );
+        } else {
+          expect(keyedAccount.pubkey).to.eql(account1.publicKey);
+          expect(keyedAccount.account.lamports).to.eq(
+            0.5 * LAMPORTS_PER_SOL - feeCalculator.lamportsPerSignature,
+          );
+        }
+      });
+    }
+
+    {
+      await mockRpcResponse({
+        method: 'getProgramAccounts',
+        params: [
+          programId.publicKey.toBase58(),
           {
             commitment: 'confirmed',
             encoding: 'base64',
@@ -1758,7 +1809,6 @@ describe('Connection', () => {
         const mintOwner = new Account();
         const accountOwner = new Account();
         const token = await Token.createMint(
-          // @ts-ignore
           connection,
           payerAccount,
           mintOwner.publicKey,
@@ -1771,7 +1821,6 @@ describe('Connection', () => {
         await token.mintTo(tokenAccount, mintOwner, [], 11111);
 
         const token2 = await Token.createMint(
-          // @ts-ignore
           connection,
           payerAccount,
           mintOwner.publicKey,


### PR DESCRIPTION
#### Problem
The `getProgramAccounts` JSONRPC method supports optional server-side filtering, but web3 doesn't expose them.

#### Summary of Changes
Expose filters for getProgramAccounts and getParsedProgramAccounts.

Fixes https://github.com/solana-labs/solana/issues/15388
