### PR TITLE
fix: add until param to getConfirmedSignaturesForAddress2

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -119,6 +119,8 @@ export type ConfirmedSignaturesForAddress2Options = {
    * @remark If not provided the search starts from the highest max confirmed block.
    */
   before?: TransactionSignature;
+  /** Search until this transaction signature is reached, if found before `limit`. */
+  until?: TransactionSignature;
   /** Maximum transaction signatures to return (between 1 and 1,000, default: 1,000). */
   limit?: number;
 };


### PR DESCRIPTION
#### Problem
The `getConfirmedSignaturesForAddress2` rpc offers an until parameter, but this is not exposed via solana-web3.js

#### Summary of Changes
Add it

Fixes #12417
