### PR TITLE
feat: support commitment in getConfirmed methods

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -220,6 +220,15 @@ export type Commitment =
   | 'max'; // Deprecated as of v1.5.5
 
 /**
+ * A subset of Commitment levels, which are at least optimistically confirmed
+ * <pre>
+ *   'confirmed': Query the most recent block which has reached 1 confirmation by the cluster
+ *   'finalized': Query the most recent block which has been finalized by the cluster
+ * </pre>
+ */
+export type Finality = 'confirmed' | 'finalized';
+
+/**
  * Filter for largest accounts query
  * <pre>
  *   'circulating':    Return the largest accounts that are part of the circulating supply

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -1408,7 +1408,7 @@ describe('Connection', () => {
 
       await mockRpcResponse({
         method: 'getConfirmedTransaction',
-        params: [confirmedTransaction, 'jsonParsed'],
+        params: [confirmedTransaction, {encoding: 'jsonParsed'}],
         value: getMockData({
           parsed: {},
           program: 'spl-token',
@@ -1428,7 +1428,7 @@ describe('Connection', () => {
 
       await mockRpcResponse({
         method: 'getConfirmedTransaction',
-        params: [confirmedTransaction, 'jsonParsed'],
+        params: [confirmedTransaction, {encoding: 'jsonParsed'}],
         value: getMockData({
           accounts: [
             'EeJqWk5pczNjsqqY3jia9xfFNG1dD68te4s8gsdCuEk7',


### PR DESCRIPTION
#### Problem
Various solana rpc methods that used to only return finalized data now support confirmed commitment. But solana-web3 does not expose a commitment parameter for these methods.

#### Summary of Changes
Add commitment to methods that target `getConfirmedBlock`, `getConfirmedTransaction`, and `getConfirmedSignaturesForAddress2` endpoints.
