### PR TITLE
Explorer: token holdings summary table sums tokens correctly

### DIFF
--- a/explorer/src/components/account/OwnedTokensCard.tsx
+++ b/explorer/src/components/account/OwnedTokensCard.tsx
@@ -151,12 +151,14 @@ function HoldingsSummaryTable({ tokens }: { tokens: TokenInfoWithPubkey[] }) {
     const mintAddress = token.mint.toBase58();
     const totalByMint = mappedTokens.get(mintAddress);
 
-    let amount = new BigNumber(token.tokenAmount.uiAmountString);
+    let amount = token.tokenAmount.uiAmountString;
     if (totalByMint !== undefined) {
-      amount.plus(totalByMint);
+      amount = new BigNumber(totalByMint)
+        .plus(token.tokenAmount.uiAmountString)
+        .toString();
     }
 
-    mappedTokens.set(mintAddress, amount.toString());
+    mappedTokens.set(mintAddress, amount);
   }
 
   const detailsList: React.ReactNode[] = [];

--- a/explorer/src/components/account/TokenHistoryCard.tsx
+++ b/explorer/src/components/account/TokenHistoryCard.tsx
@@ -317,12 +317,14 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
   };
 
   const filterOptions: string[] = [ALL_TOKENS];
-  const nameLookup: { [mint: string]: string } = {};
+  const nameLookup: Map<string, string> = new Map();
 
   tokens.forEach((token) => {
-    const pubkey = token.info.mint.toBase58();
-    filterOptions.push(pubkey);
-    nameLookup[pubkey] = formatTokenName(pubkey, cluster, tokenRegistry);
+    const address = token.info.mint.toBase58();
+    if (!nameLookup.has(address)) {
+      filterOptions.push(address);
+      nameLookup.set(address, formatTokenName(address, cluster, tokenRegistry));
+    }
   });
 
   return (
@@ -333,7 +335,7 @@ const FilterDropdown = ({ filter, toggle, show, tokens }: FilterProps) => {
         type="button"
         onClick={toggle}
       >
-        {filter === ALL_TOKENS ? "All Tokens" : nameLookup[filter]}
+        {filter === ALL_TOKENS ? "All Tokens" : nameLookup.get(filter)}
       </button>
       <div
         className={`token-filter dropdown-menu-right dropdown-menu${


### PR DESCRIPTION
#### Problem
The summary view seems to only display the first account for a mint, and the rpc node sometimes returns these in a differing order, causing more confusion. 

#### Summary of Changes
![Explorer-Solana (43)](https://user-images.githubusercontent.com/188792/114259157-deeefd00-9980-11eb-8abc-e3d4fb75b9bc.png)

Token amounts are summed correctly.

https://explorer.solana.com/address/HviyUppKBEsQTbXwa2chhdH1SiEsyZnSS6aqsiqTsTdS/tokens?display=detail

Fixes https://github.com/solana-labs/solana/issues/16316
