### PR TITLE
Explorer: hide irrelevant delegation information displayed for inactive stake

### DIFF
--- a/explorer/src/components/account/StakeAccountSection.tsx
+++ b/explorer/src/components/account/StakeAccountSection.tsx
@@ -139,7 +139,7 @@ function OverviewCard({
             <td>Status</td>
             <td className="text-lg-right">
               {isFullyInactivated(stakeAccount, activation)
-                ? "Initialized"
+                ? "Not delegated"
                 : displayStatus(stakeAccountType, activation)}
             </td>
           </tr>

--- a/explorer/src/components/account/StakeAccountSection.tsx
+++ b/explorer/src/components/account/StakeAccountSection.tsx
@@ -98,7 +98,7 @@ function OverviewCard({
   const refresh = useFetchAccountInfo();
   const { stake } = stakeAccount;
 
-  const displayStakeStatus =
+  const displayAsInitialized =
     activation &&
     stake &&
     stake.delegation.stake.toString() === activation.inactive.toString();
@@ -140,11 +140,13 @@ function OverviewCard({
           </tr>
         )}
         {!stakeAccount.meta ||
-          (displayStakeStatus && (
+          (displayAsInitialized && (
             <tr>
               <td>Status</td>
               <td className="text-lg-right">
-                {displayStatus(stakeAccountType, activation)}
+                {displayAsInitialized
+                  ? "Initialized"
+                  : displayStatus(stakeAccountType, activation)}
               </td>
             </tr>
           ))}

--- a/explorer/src/components/account/StakeAccountSection.tsx
+++ b/explorer/src/components/account/StakeAccountSection.tsx
@@ -25,7 +25,7 @@ export function StakeAccountSection({
   stakeAccountType: StakeAccountType;
   activation?: StakeActivationData;
 }) {
-  const showDelegation =
+  const hideDelegation =
     stakeAccountType !== "delegated" ||
     isFullyInactivated(stakeAccount, activation);
   return (
@@ -36,9 +36,9 @@ export function StakeAccountSection({
         stakeAccount={stakeAccount}
         stakeAccountType={stakeAccountType}
         activation={activation}
-        showDelegation={showDelegation}
+        hideDelegation={hideDelegation}
       />
-      {showDelegation && (
+      {!hideDelegation && (
         <DelegationCard
           stakeAccount={stakeAccount}
           activation={activation}
@@ -91,13 +91,13 @@ function OverviewCard({
   stakeAccount,
   stakeAccountType,
   activation,
-  showDelegation,
+  hideDelegation,
 }: {
   account: Account;
   stakeAccount: StakeAccountInfo;
   stakeAccountType: StakeAccountType;
   activation?: StakeActivationData;
-  showDelegation: boolean;
+  hideDelegation: boolean;
 }) {
   const refresh = useFetchAccountInfo();
   return (
@@ -134,7 +134,7 @@ function OverviewCard({
             {lamportsToSolString(stakeAccount.meta.rentExemptReserve)}
           </td>
         </tr>
-        {showDelegation && (
+        {hideDelegation && (
           <tr>
             <td>Status</td>
             <td className="text-lg-right">


### PR DESCRIPTION
#### Problem
Explorer shows delegation information for inactive stake accounts, which is irrelevant when the account is in that state and may mislead or confuse the user

![Screenshot from 2020-11-20 13-46-24](https://user-images.githubusercontent.com/490004/99848435-03b01880-2b37-11eb-9635-d73fe23e76e8.png)

#### Summary of Changes
- Move account status under the "Stake Account" heading, since it is always relevant
- Hide the remainder of the Delegation information when `inactive_stake == delegated_stake`, as if the account state were `Initialized`, which is how it looks to the cluster

Example: https://explorer.solana.com/address/Hfsw8KWRB9A1Fpzxj4WSbyhad4eqqtXQJigpQq4Conku

![Explorer-Solana (44)](https://user-images.githubusercontent.com/188792/114282907-b22bfb80-99fb-11eb-8309-5c516a7a4da9.png)

Fixes https://github.com/solana-labs/solana/issues/16044 https://github.com/solana-labs/solana/issues/13740
