### PR TITLE
Fix account copy step in program test message processor

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -295,13 +295,13 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
         .map_err(|err| ProgramError::try_from(err).unwrap_or_else(|err| panic!("{}", err)))?;
 
         // Copy writeable account modifications back into the caller's AccountInfos
-        for (i, instruction_account) in instruction.accounts.iter().enumerate() {
-            if !instruction_account.is_writable {
+        for (i, account_pubkey) in message.account_keys.iter().enumerate() {
+            if !message.is_writable(i, true) {
                 continue;
             }
 
             for account_info in account_infos {
-                if *account_info.unsigned_key() == instruction_account.pubkey {
+                if account_info.unsigned_key() == account_pubkey {
                     let account = &accounts[i];
                     **account_info.try_borrow_mut_lamports().unwrap() = account.borrow().lamports;
 


### PR DESCRIPTION
#### Problem
The message processor doesn't index into the `SharedAccountData` vector according to message account keys, it uses instruction accounts instead which can contain duplicates and have a different order from message account keys.

This causes cryptic errors for users:
```
Account data resizing not supported yet: 165 -> 0
```

#### Summary of Changes
Index into shared account data list by message account key index

Fixes #
