### PR TITLE
Faucet: Add address_cache and exclude loopback from ip limit

### DIFF
--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -78,7 +78,7 @@ async fn main() {
         let time = faucet1.lock().unwrap().time_slice;
         thread::sleep(time);
         debug!("clearing ip cache");
-        faucet1.lock().unwrap().clear_ip_cache();
+        faucet1.lock().unwrap().clear_caches();
     });
 
     run_faucet(faucet, faucet_addr, None).await;


### PR DESCRIPTION
#### Problem
Faucet requests via the `requestAirdrop` rpc endpoint all appear to have the same (loopback) IP; they will be overly limited by faucets running with a per-time-cap.

#### Summary of Changes
Add address_cache to faucet and also limit on request recipient address
Exclude loopback IP from ip limiting

Note, this is a quick stop-gap. Real solution is: https://github.com/solana-labs/solana/issues/1830
