### PR TITLE
validator: Add authorized-voter add/remove-all commands

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -106,7 +106,7 @@ struct SkippedSlotsInfo {
 pub struct ReplayStageConfig {
     pub my_pubkey: Pubkey,
     pub vote_account: Pubkey,
-    pub authorized_voter_keypairs: Vec<Arc<Keypair>>,
+    pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     pub exit: Arc<AtomicBool>,
     pub subscriptions: Arc<RpcSubscriptions>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
@@ -531,7 +531,7 @@ impl ReplayStage {
                             &mut tower,
                             &mut progress,
                             &vote_account,
-                            &authorized_voter_keypairs,
+                            &authorized_voter_keypairs.read().unwrap(),
                             &cluster_info,
                             &blockstore,
                             &leader_schedule_cache,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -100,7 +100,7 @@ impl Tvu {
     #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
     pub fn new(
         vote_account: &Pubkey,
-        authorized_voter_keypairs: Vec<Arc<Keypair>>,
+        authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
         bank_forks: &Arc<RwLock<BankForks>>,
         cluster_info: &Arc<ClusterInfo>,
         sockets: Sockets,
@@ -389,7 +389,7 @@ pub mod tests {
         let tower = Tower::new_with_key(&target1_keypair.pubkey());
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
-            vec![Arc::new(vote_keypair)],
+            Arc::new(RwLock::new(vec![Arc::new(vote_keypair)])),
             &bank_forks,
             &cref1,
             {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1408,22 +1408,17 @@ fn report_target_features() {
         not(target_os = "macos")
     ))]
     {
-        unsafe { check_avx() };
-    }
-}
-
-// Validator binaries built on a machine with AVX support will generate invalid opcodes
-// when run on machines without AVX causing a non-obvious process abort.  Instead detect
-// the mismatch and error cleanly.
-#[target_feature(enable = "avx")]
-unsafe fn check_avx() {
-    if is_x86_feature_detected!("avx") {
-        info!("AVX detected");
-    } else {
-        error!(
-            "Your machine does not have AVX support, please rebuild from source on your machine"
-        );
-        abort();
+        // Validator binaries built on a machine with AVX support will generate invalid opcodes
+        // when run on machines without AVX causing a non-obvious process abort.  Instead detect
+        // the mismatch and error cleanly.
+        if is_x86_feature_detected!("avx") {
+            info!("AVX detected");
+        } else {
+            error!(
+                "Your machine does not have AVX support, please rebuild from source on your machine"
+            );
+            abort();
+        }
     }
 }
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -213,7 +213,7 @@ impl LocalCluster {
             &leader_keypair,
             &leader_ledger_path,
             &leader_vote_keypair.pubkey(),
-            vec![leader_vote_keypair.clone()],
+            Arc::new(RwLock::new(vec![leader_vote_keypair.clone()])),
             vec![],
             &leader_config,
             true, // should_check_duplicate_instance
@@ -355,7 +355,7 @@ impl LocalCluster {
             &validator_keypair,
             &ledger_path,
             &voting_keypair.pubkey(),
-            vec![voting_keypair.clone()],
+            Arc::new(RwLock::new(vec![voting_keypair.clone()])),
             vec![self.entry_point_info.clone()],
             &config,
             true, // should_check_duplicate_instance
@@ -670,7 +670,7 @@ impl Cluster for LocalCluster {
             &validator_info.keypair,
             &validator_info.ledger_path,
             &validator_info.voting_keypair.pubkey(),
-            vec![validator_info.voting_keypair.clone()],
+            Arc::new(RwLock::new(vec![validator_info.voting_keypair.clone()])),
             entry_point_info
                 .map(|entry_point_info| vec![entry_point_info])
                 .unwrap_or_default(),

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -403,6 +403,7 @@ fn main() {
             start_progress: genesis.start_progress.clone(),
             start_time: std::time::SystemTime::now(),
             validator_exit: genesis.validator_exit.clone(),
+            authorized_voter_keypairs: genesis.authorized_voter_keypairs.clone(),
         },
     );
     let dashboard = if output == Output::Dashboard {


### PR DESCRIPTION
Add new `authorized-voter` subcommand to give dynamic control over the validator's ability to vote:

1.  Remove all authorized voters, halting the validators ability to vote **at runtime:**
`$ solana-validator authorized-voter remove-all`

2. Add a new authorized voter.  Can be used to restore a validator's ability to vote, or simply to handle a new `solana vote-authorize-voter` command without needing to restart your node:
`$ solana-validator authorized-voter add path/to/keypair.json`