### PR TITLE
Move obsolete rpc endpoints to separate api for removal

### DIFF
--- a/core/src/rpc_service.rs
+++ b/core/src/rpc_service.rs
@@ -6,7 +6,7 @@ use crate::{
     max_slots::MaxSlots,
     optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
     poh_recorder::PohRecorder,
-    rpc::{rpc_full::*, rpc_minimal::*, *},
+    rpc::{rpc_full::*, rpc_minimal::*, rpc_obsolete_v1_7::*, *},
     rpc_health::*,
     send_transaction_service::{LeaderInfo, SendTransactionService},
     validator::ValidatorExit,
@@ -341,6 +341,7 @@ impl JsonRpcService {
             };
 
         let minimal_api = config.minimal_api;
+        let obsolete_v1_7_api = config.obsolete_v1_7_api;
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             config,
             snapshot_config.clone(),
@@ -402,6 +403,9 @@ impl JsonRpcService {
                 io.extend_with(rpc_minimal::MinimalImpl.to_delegate());
                 if !minimal_api {
                     io.extend_with(rpc_full::FullImpl.to_delegate());
+                }
+                if obsolete_v1_7_api {
+                    io.extend_with(rpc_obsolete_v1_7::ObsoleteV1_7Impl.to_delegate());
                 }
 
                 let request_middleware = RpcRequestMiddleware::new(

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -26,7 +26,6 @@ gives a convenient interface for the RPC methods.
 - [getConfirmedBlock](jsonrpc-api.md#getconfirmedblock)
 - [getConfirmedBlocks](jsonrpc-api.md#getconfirmedblocks)
 - [getConfirmedBlocksWithLimit](jsonrpc-api.md#getconfirmedblockswithlimit)
-- [getConfirmedSignaturesForAddress](jsonrpc-api.md#getconfirmedsignaturesforaddress)
 - [getConfirmedSignaturesForAddress2](jsonrpc-api.md#getconfirmedsignaturesforaddress2)
 - [getConfirmedTransaction](jsonrpc-api.md#getconfirmedtransaction)
 - [getEpochInfo](jsonrpc-api.md#getepochinfo)
@@ -738,58 +737,6 @@ curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
 Result:
 ```json
 {"jsonrpc":"2.0","result":[5,6,7],"id":1}
-```
-
-### getConfirmedSignaturesForAddress
-
-**DEPRECATED: Please use getConfirmedSignaturesForAddress2 instead**
-
-Returns a list of all the confirmed signatures for transactions involving an
-address, within a specified Slot range. Max range allowed is 10,000 Slots
-
-#### Parameters:
-
-- `<string>` - account address as base-58 encoded string
-- `<u64>` - start slot, inclusive
-- `<u64>` - end slot, inclusive
-
-#### Results:
-
-The result field will be an array of:
-
-- `<string>` - transaction signature as base-58 encoded string
-
-The signatures will be ordered based on the Slot in which they were confirmed in, from lowest to highest Slot
-
-#### Example:
-
-Request:
-```bash
-curl http://localhost:8899 -X POST -H "Content-Type: application/json" -d '
-  {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "getConfirmedSignaturesForAddress",
-    "params": [
-      "6H94zdiaYfRfPfKjYLjyr2VFBg6JHXygy84r3qhc3NsC",
-      0,
-      100
-    ]
-  }
-'
-```
-
-Result:
-```json
-{
-  "jsonrpc": "2.0",
-  "result": [
-    "35YGay1Lwjwgxe9zaH6APSHbt9gYQUCtBWTNL3aVwVGn9xTFw2fgds7qK5AL29mP63A9j3rh8KpN1TgSR62XCaby",
-    "4bJdGN8Tt2kLWZ3Fa1dpwPSEkXWWTSszPSf1rRVsCwNjxbbUdwTeiWtmi8soA26YmwnKD4aAxNp8ci1Gjpdv4gsr",
-    "4LQ14a7BYY27578Uj8LPCaVhSdJGLn9DJqnUJHpy95FMqdKf9acAhUhecPQNjNUy6VoNFUbvwYkPociFSf87cWbG"
-  ],
-  "id": 1
-}
 ```
 
 ### getConfirmedSignaturesForAddress2

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1164,6 +1164,12 @@ pub fn main() {
                 .help("Only expose the RPC methods required to serve snapshots to other nodes"),
         )
         .arg(
+            Arg::with_name("obsolete_v1_7_rpc_api")
+                .long("--enable-rpc-obsolete_v1_7")
+                .takes_value(false)
+                .help("Enable the obsolete RPC methods removed in v1.7"),
+        )
+        .arg(
             Arg::with_name("private_rpc")
                 .long("--private-rpc")
                 .takes_value(false)
@@ -2064,6 +2070,7 @@ pub fn main() {
                 solana_net_utils::parse_host_port(address).expect("failed to parse faucet address")
             }),
             minimal_api: matches.is_present("minimal_rpc_api"),
+            obsolete_v1_7_api: matches.is_present("obsolete_v1_7_rpc_api"),
             max_multiple_accounts: Some(value_t_or_exit!(
                 matches,
                 "rpc_max_multiple_accounts",


### PR DESCRIPTION
#### Problem
Deprecated endpoints are lingering in the `rpc_full` module.

#### Summary of Changes
- Move these endpoints to `rpc_obsolete_v1_7`
- Only enable `rpc_obsolete_v1_7` when `solana-validator --enable-rpc-obsolete_v1_7 ...`
