### PR TITLE
Fix channel panic in tests

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1390,6 +1390,7 @@ pub fn create_test_recorder(
         blockstore,
         &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
         &poh_config,
+        exit.clone(),
     );
     poh_recorder.set_bank(&bank);
 
@@ -1792,11 +1793,12 @@ mod tests {
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
+                Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
-            let (poh_simulator, exit) = simulate_poh(record_receiver, &poh_recorder);
+            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
             let pubkey = solana_sdk::pubkey::new_rand();
@@ -1866,7 +1868,11 @@ mod tests {
             // Should receive nothing from PohRecorder b/c record failed
             assert!(entry_receiver.try_recv().is_err());
 
-            exit.store(true, Ordering::Relaxed);
+            poh_recorder
+                .lock()
+                .unwrap()
+                .is_exited
+                .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
         }
         Blockstore::destroy(&ledger_path).unwrap();
@@ -2058,11 +2064,12 @@ mod tests {
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
+                Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
-            let (poh_simulator, exit) = simulate_poh(record_receiver, &poh_recorder);
+            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
             let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
@@ -2117,7 +2124,11 @@ mod tests {
                 Err(PohRecorderError::MaxHeightReached)
             );
 
-            exit.store(true, Ordering::Relaxed);
+            poh_recorder
+                .lock()
+                .unwrap()
+                .is_exited
+                .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
 
             assert_eq!(bank.get_balance(&pubkey), 1);
@@ -2128,10 +2139,9 @@ mod tests {
     fn simulate_poh(
         record_receiver: CrossbeamReceiver<Record>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
-    ) -> (JoinHandle<()>, Arc<AtomicBool>) {
-        let exit = Arc::new(AtomicBool::new(false));
-        let exit_ = exit.clone();
+    ) -> JoinHandle<()> {
         let poh_recorder = poh_recorder.clone();
+        let is_exited = poh_recorder.lock().unwrap().is_exited.clone();
         let tick_producer = Builder::new()
             .name("solana-simulate_poh".to_string())
             .spawn(move || loop {
@@ -2140,11 +2150,11 @@ mod tests {
                     &record_receiver,
                     Duration::from_millis(10),
                 );
-                if exit_.load(Ordering::Relaxed) {
+                if is_exited.load(Ordering::Relaxed) {
                     break;
                 }
             });
-        (tick_producer.unwrap(), exit)
+        tick_producer.unwrap()
     }
 
     #[test]
@@ -2185,13 +2195,14 @@ mod tests {
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
+                Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
 
-            let (poh_simulator, exit) = simulate_poh(record_receiver, &poh_recorder);
+            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
 
@@ -2204,7 +2215,11 @@ mod tests {
                 &gossip_vote_sender,
             );
 
-            exit.store(true, Ordering::Relaxed);
+            poh_recorder
+                .lock()
+                .unwrap()
+                .is_exited
+                .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
 
             assert!(result.is_ok());
@@ -2286,14 +2301,14 @@ mod tests {
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
+                Arc::new(AtomicBool::default()),
             );
 
             // Poh Recorder has no working bank, so should throw MaxHeightReached error on
             // record
             let recorder = poh_recorder.recorder();
 
-            let (poh_simulator, exit) =
-                simulate_poh(record_receiver, &Arc::new(Mutex::new(poh_recorder)));
+            let poh_simulator = simulate_poh(record_receiver, &Arc::new(Mutex::new(poh_recorder)));
 
             let (gossip_vote_sender, _gossip_vote_receiver) = unbounded();
 
@@ -2313,7 +2328,7 @@ mod tests {
             let expected: Vec<usize> = (0..transactions.len()).collect();
             assert_eq!(retryable_txs, expected);
 
-            exit.store(true, Ordering::Relaxed);
+            recorder.is_exited.store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
         }
 
@@ -2371,11 +2386,12 @@ mod tests {
                 &blockstore,
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
+                Arc::new(AtomicBool::default()),
             );
             let recorder = poh_recorder.recorder();
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
-            let (poh_simulator, exit) = simulate_poh(record_receiver, &poh_recorder);
+            let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
             poh_recorder.lock().unwrap().set_working_bank(working_bank);
 
@@ -2430,7 +2446,11 @@ mod tests {
                 }
             }
 
-            exit.store(true, Ordering::Relaxed);
+            poh_recorder
+                .lock()
+                .unwrap()
+                .is_exited
+                .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
         }
         Blockstore::destroy(&ledger_path).unwrap();
@@ -2445,7 +2465,6 @@ mod tests {
         Arc<Mutex<PohRecorder>>,
         Receiver<WorkingBankEntry>,
         JoinHandle<()>,
-        Arc<AtomicBool>,
     ) {
         Blockstore::destroy(&ledger_path).unwrap();
         let genesis_config_info = create_slow_genesis_config(10_000);
@@ -2457,6 +2476,7 @@ mod tests {
         let blockstore =
             Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger");
         let bank = Arc::new(Bank::new_no_wallclock_throttle(&genesis_config));
+        let exit = Arc::new(AtomicBool::default());
         let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
             bank.tick_height(),
             bank.last_blockhash(),
@@ -2467,6 +2487,7 @@ mod tests {
             &Arc::new(blockstore),
             &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
             &Arc::new(PohConfig::default()),
+            exit,
         );
         let poh_recorder = Arc::new(Mutex::new(poh_recorder));
 
@@ -2479,7 +2500,7 @@ mod tests {
             system_transaction::transfer(&mint_keypair, &pubkey1, 1, genesis_config.hash()),
             system_transaction::transfer(&mint_keypair, &pubkey2, 1, genesis_config.hash()),
         ];
-        let (poh_simulator, exit) = simulate_poh(record_receiver, &poh_recorder);
+        let poh_simulator = simulate_poh(record_receiver, &poh_recorder);
 
         (
             transactions,
@@ -2487,7 +2508,6 @@ mod tests {
             poh_recorder,
             entry_receiver,
             poh_simulator,
-            exit,
         )
     }
 
@@ -2495,7 +2515,7 @@ mod tests {
     fn test_consume_buffered_packets() {
         let ledger_path = get_tmp_ledger_path!();
         {
-            let (transactions, bank, poh_recorder, _entry_receiver, poh_simulator, exit) =
+            let (transactions, bank, poh_recorder, _entry_receiver, poh_simulator) =
                 setup_conflicting_transactions(&ledger_path);
             let recorder = poh_recorder.lock().unwrap().recorder();
             let num_conflicting_transactions = transactions.len();
@@ -2549,7 +2569,11 @@ mod tests {
                     assert_eq!(buffered_packets[0].1.len(), num_expected_unprocessed);
                 }
             }
-            exit.store(true, Ordering::Relaxed);
+            poh_recorder
+                .lock()
+                .unwrap()
+                .is_exited
+                .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
         }
         Blockstore::destroy(&ledger_path).unwrap();
@@ -2559,7 +2583,7 @@ mod tests {
     fn test_consume_buffered_packets_interrupted() {
         let ledger_path = get_tmp_ledger_path!();
         {
-            let (transactions, bank, poh_recorder, _entry_receiver, poh_simulator, exit) =
+            let (transactions, bank, poh_recorder, _entry_receiver, poh_simulator) =
                 setup_conflicting_transactions(&ledger_path);
             let num_conflicting_transactions = transactions.len();
             let packets_vec = to_packets_chunked(&transactions, 1);
@@ -2636,7 +2660,11 @@ mod tests {
             }
 
             t_consume.join().unwrap();
-            exit.store(true, Ordering::Relaxed);
+            poh_recorder
+                .lock()
+                .unwrap()
+                .is_exited
+                .store(true, Ordering::Relaxed);
             let _ = poh_simulator.join();
         }
         Blockstore::destroy(&ledger_path).unwrap();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1435,10 +1435,7 @@ mod tests {
     use std::{
         net::SocketAddr,
         path::Path,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            mpsc::Receiver,
-        },
+        sync::atomic::{AtomicBool, Ordering},
         thread::sleep,
     };
 
@@ -2129,7 +2126,7 @@ mod tests {
     }
 
     fn simulate_poh(
-        record_receiver: Receiver<Record>,
+        record_receiver: CrossbeamReceiver<Record>,
         poh_recorder: &Arc<Mutex<PohRecorder>>,
     ) -> (JoinHandle<()>, Arc<AtomicBool>) {
         let exit = Arc::new(AtomicBool::new(false));

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -382,6 +382,8 @@ mod tests {
                 target_tick_duration,
                 target_tick_count: None,
             });
+            let exit = Arc::new(AtomicBool::new(false));
+
             let (poh_recorder, entry_receiver, record_receiver) = PohRecorder::new(
                 bank.tick_height(),
                 prev_hash,
@@ -392,9 +394,9 @@ mod tests {
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &poh_config,
+                exit.clone(),
             );
             let poh_recorder = Arc::new(Mutex::new(poh_recorder));
-            let exit = Arc::new(AtomicBool::new(false));
             let start = Arc::new(Instant::now());
             let working_bank = WorkingBank {
                 bank: bank.clone(),

--- a/core/src/poh_service.rs
+++ b/core/src/poh_service.rs
@@ -1,11 +1,12 @@
 //! The `poh_service` module implements a service that records the passing of
 //! "ticks", a measure of time in the PoH stream
 use crate::poh_recorder::{PohRecorder, Record};
+use crossbeam_channel::Receiver;
 use solana_ledger::poh::Poh;
 use solana_measure::measure::Measure;
 use solana_sdk::poh_config::PohConfig;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc::Receiver, Arc, Mutex};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, sleep, Builder, JoinHandle};
 use std::time::{Duration, Instant};
 

--- a/core/src/send_transaction_service.rs
+++ b/core/src/send_transaction_service.rs
@@ -331,7 +331,7 @@ mod test {
         system_program, system_transaction,
         timing::timestamp,
     };
-    use std::sync::mpsc::channel;
+    use std::sync::{atomic::AtomicBool, mpsc::channel};
 
     #[test]
     fn service_exit() {
@@ -811,6 +811,7 @@ mod test {
                 &Arc::new(blockstore),
                 &Arc::new(LeaderScheduleCache::new_from_bank(&bank)),
                 &Arc::new(PohConfig::default()),
+                Arc::new(AtomicBool::default()),
             );
 
             let node_keypair = Arc::new(Keypair::new());

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -510,6 +510,7 @@ impl Validator {
                 blockstore.new_shreds_signals.first().cloned(),
                 &leader_schedule_cache,
                 &poh_config,
+                exit.clone(),
             );
         if config.snapshot_config.is_some() {
             poh_recorder.set_bank(&bank);


### PR DESCRIPTION
#### Problem
`test_consume_buffered_packets_interrupted()` flaky with channel `recv_timeout()` panic that looks like:

```
thread 'solana-simulate_poh' panicked at 'assertion failed: `(left == right)`
--
  | left: `140256846311424`,
  | right: `0`', /rustc/152f6609246558be5e2582e67376194815e6ba0d/library/std/src/sync/mpsc/shared.rs:251:13
```

#### Summary of Changes
Looks like it could potentially be issue: https://github.com/rust-lang/rust/issues/39364, where the recommendation is to switch to crossbeam channels. 

Can't currently repro the failure locally, testing on CI.

Fixes #
