### PR TITLE
Remove blake3 from bpf program dependencies

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ codecov = { repository = "solana-labs/solana", branch = "master", service = "git
 ahash = "0.6.1"
 base64 = "0.12.3"
 bincode = "1.3.1"
-blake3 = "0.3.6"
+blake3 = "0.3.7"
 bv = { version = "0.11.1", features = ["serde"] }
 bs58 = "0.3.1"
 byteorder = "1.3.4"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 arrayref = "0.3.6"
 bincode = "1.3.1"
-blake3 = "0.3.6"
+blake3 = "0.3.7"
 bv = { version = "0.11.1", features = ["serde"] }
 byteorder = "1.3.4"
 bzip2 = "0.3.3"

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.3.1"
-blake3 = "0.3.7"
 borsh = "0.8.1"
 borsh-derive = "0.8.1"
 bs58 = "0.3.1"
@@ -33,7 +32,7 @@ solana-sdk-macro = { path = "../macro", version = "=1.7.0" }
 thiserror = "1.0"
 
 [target.'cfg(not(target_arch = "bpf"))'.dependencies]
-blake3 = "0.3.6"
+blake3 = "0.3.7"
 curve25519-dalek = "2.1.0"
 rand = "0.7.0"
 solana-logger = { path = "../../logger", version = "=1.7.0" }


### PR DESCRIPTION
#### Problem
Unnecessary dependency bloat for bpf programs

#### Summary of Changes
- Conditionally compile message hash functions
- Bump blake3 version

Fixes #
