### PR TITLE
Deprecate RpcClient methods, RpcRequest variants

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1234,8 +1234,8 @@ pub fn process_supply(
 }
 
 pub fn process_total_supply(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {
-    let total_supply = rpc_client.total_supply()?;
-    Ok(format!("{} SOL", lamports_to_sol(total_supply)))
+    let supply = rpc_client.supply()?.value;
+    Ok(format!("{} SOL", lamports_to_sol(supply.total)))
 }
 
 pub fn process_get_transaction_count(rpc_client: &RpcClient, _config: &CliConfig) -> ProcessResult {

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -458,10 +458,17 @@ impl RpcClient {
         )
     }
 
+    #[deprecated(since = "1.5.19", note = "Please use RpcClient::supply() instead")]
+    #[allow(deprecated)]
     pub fn total_supply(&self) -> ClientResult<u64> {
         self.total_supply_with_commitment(self.commitment_config)
     }
 
+    #[deprecated(
+        since = "1.5.19",
+        note = "Please use RpcClient::supply_with_commitment() instead"
+    )]
+    #[allow(deprecated)]
     pub fn total_supply_with_commitment(
         &self,
         commitment_config: CommitmentConfig,
@@ -611,6 +618,11 @@ impl RpcClient {
         )
     }
 
+    #[deprecated(
+        since = "1.5.19",
+        note = "Please use RpcClient::get_confirmed_signatures_for_address2() instead"
+    )]
+    #[allow(deprecated)]
     pub fn get_confirmed_signatures_for_address(
         &self,
         address: &Pubkey,

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -16,7 +16,13 @@ pub enum RpcRequest {
     GetConfirmedBlock,
     GetConfirmedBlocks,
     GetConfirmedBlocksWithLimit,
+
+    #[deprecated(
+        since = "1.5.19",
+        note = "Please use RpcRequest::GetConfirmedSignaturesForAddress2 instead"
+    )]
     GetConfirmedSignaturesForAddress,
+
     GetConfirmedSignaturesForAddress2,
     GetConfirmedTransaction,
     GetEpochInfo,
@@ -55,7 +61,10 @@ pub enum RpcRequest {
     GetTokenAccountsByDelegate,
     GetTokenAccountsByOwner,
     GetTokenSupply,
+
+    #[deprecated(since = "1.5.19", note = "Please use RpcRequest::GetSupply instead")]
     GetTotalSupply,
+
     GetTransactionCount,
     GetVersion,
     GetVoteAccounts,
@@ -67,6 +76,7 @@ pub enum RpcRequest {
     SignVote,
 }
 
+#[allow(deprecated)]
 impl fmt::Display for RpcRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let method = match self {


### PR DESCRIPTION
#### Problem
5 rpc endpoints have been deprecated for a while, and are now obsolete and slated for removal (https://github.com/solana-labs/solana/pull/16500). A couple of these are still supported in RpcRequest, and have associated RpcClient methods.

#### Summary of Changes
Use deprecated attribute to alert downstream users about `getTotalSupply` and `getConfirmedSignaturesForAddress`.
The v1.5/v1.6 backports are the main thrust of this pr; plan to remove these variants/methods in v1.7
