### PR TITLE
Deprecate "confirmed" RpcClient methods

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -28,7 +28,7 @@ use solana_client::{
     nonce_utils,
     rpc_client::RpcClient,
     rpc_config::{
-        RpcConfirmedTransactionConfig, RpcLargestAccountsFilter, RpcSendTransactionConfig,
+        RpcLargestAccountsFilter, RpcSendTransactionConfig, RpcTransactionConfig,
         RpcTransactionLogsFilter,
     },
     rpc_response::RpcKeyedAccount,
@@ -1035,7 +1035,7 @@ fn process_confirm(
                 if config.verbose {
                     match rpc_client.get_transaction_with_config(
                         signature,
-                        RpcConfirmedTransactionConfig {
+                        RpcTransactionConfig {
                             encoding: Some(UiTransactionEncoding::Base64),
                             commitment: Some(CommitmentConfig::confirmed()),
                         },

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1033,7 +1033,7 @@ fn process_confirm(
                 let mut transaction = None;
                 let mut get_transaction_error = None;
                 if config.verbose {
-                    match rpc_client.get_confirmed_transaction_with_config(
+                    match rpc_client.get_transaction_with_config(
                         signature,
                         RpcConfirmedTransactionConfig {
                             encoding: Some(UiTransactionEncoding::Base64),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -975,7 +975,7 @@ pub fn process_get_block(
     };
 
     let encoded_confirmed_block = rpc_client
-        .get_confirmed_block_with_config(
+        .get_block_with_config(
             slot,
             RpcConfirmedBlockConfig {
                 encoding: Some(UiTransactionEncoding::Base64),
@@ -1108,7 +1108,7 @@ pub fn process_show_block_production(
         "Fetching confirmed blocks between slots {} and {}...",
         start_slot, end_slot
     ));
-    let confirmed_blocks = rpc_client.get_confirmed_blocks(start_slot, Some(end_slot))?;
+    let confirmed_blocks = rpc_client.get_blocks(start_slot, Some(end_slot))?;
 
     let start_slot_index = (start_slot - first_slot_in_epoch) as usize;
     let end_slot_index = (end_slot - first_slot_in_epoch) as usize;
@@ -1829,7 +1829,7 @@ pub fn process_transaction_history(
     limit: usize,
     show_transactions: bool,
 ) -> ProcessResult {
-    let results = rpc_client.get_confirmed_signatures_for_address2_with_config(
+    let results = rpc_client.get_signatures_for_address_with_config(
         address,
         GetConfirmedSignaturesForAddress2Config {
             before,
@@ -1868,7 +1868,7 @@ pub fn process_transaction_history(
 
         if show_transactions {
             if let Ok(signature) = result.signature.parse::<Signature>() {
-                match rpc_client.get_confirmed_transaction_with_config(
+                match rpc_client.get_transaction_with_config(
                     &signature,
                     RpcConfirmedTransactionConfig {
                         encoding: Some(UiTransactionEncoding::Base64),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -24,9 +24,9 @@ use solana_client::{
     pubsub_client::PubsubClient,
     rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient},
     rpc_config::{
-        RpcAccountInfoConfig, RpcConfirmedBlockConfig, RpcConfirmedTransactionConfig,
-        RpcLargestAccountsConfig, RpcLargestAccountsFilter, RpcProgramAccountsConfig,
-        RpcTransactionLogsConfig, RpcTransactionLogsFilter,
+        RpcAccountInfoConfig, RpcBlockConfig, RpcLargestAccountsConfig, RpcLargestAccountsFilter,
+        RpcProgramAccountsConfig, RpcTransactionConfig, RpcTransactionLogsConfig,
+        RpcTransactionLogsFilter,
     },
     rpc_filter,
     rpc_response::SlotInfo,
@@ -977,10 +977,10 @@ pub fn process_get_block(
     let encoded_confirmed_block = rpc_client
         .get_block_with_config(
             slot,
-            RpcConfirmedBlockConfig {
+            RpcBlockConfig {
                 encoding: Some(UiTransactionEncoding::Base64),
                 commitment: Some(CommitmentConfig::confirmed()),
-                ..RpcConfirmedBlockConfig::default()
+                ..RpcBlockConfig::default()
             },
         )?
         .into();
@@ -1870,7 +1870,7 @@ pub fn process_transaction_history(
             if let Ok(signature) = result.signature.parse::<Signature>() {
                 match rpc_client.get_transaction_with_config(
                     &signature,
-                    RpcConfirmedTransactionConfig {
+                    RpcTransactionConfig {
                         encoding: Some(UiTransactionEncoding::Base64),
                         commitment: Some(CommitmentConfig::confirmed()),
                     },

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rpc_cache;
 pub mod rpc_client;
 pub mod rpc_config;
 pub mod rpc_custom_error;
+pub mod rpc_deprecated_config;
 pub mod rpc_filter;
 pub mod rpc_request;
 pub mod rpc_response;

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1,3 +1,8 @@
+#[allow(deprecated)]
+use crate::rpc_deprecated_config::{
+    RpcConfirmedBlockConfig, RpcConfirmedTransactionConfig,
+    RpcGetConfirmedSignaturesForAddress2Config,
+};
 use {
     crate::{
         client_error::{ClientError, ClientErrorKind, Result as ClientResult},
@@ -5,10 +10,9 @@ use {
         mock_sender::{MockSender, Mocks},
         rpc_config::RpcAccountInfoConfig,
         rpc_config::{
-            RpcConfirmedBlockConfig, RpcConfirmedTransactionConfig, RpcEpochConfig,
-            RpcGetConfirmedSignaturesForAddress2Config, RpcLargestAccountsConfig,
-            RpcProgramAccountsConfig, RpcRequestAirdropConfig, RpcSendTransactionConfig,
-            RpcSimulateTransactionConfig, RpcTokenAccountsFilter,
+            RpcBlockConfig, RpcEpochConfig, RpcLargestAccountsConfig, RpcProgramAccountsConfig,
+            RpcRequestAirdropConfig, RpcSendTransactionConfig, RpcSignaturesForAddressConfig,
+            RpcSimulateTransactionConfig, RpcTokenAccountsFilter, RpcTransactionConfig,
         },
         rpc_request::{RpcError, RpcRequest, RpcResponseErrorData, TokenAccountsFilter},
         rpc_response::*,
@@ -536,7 +540,7 @@ impl RpcClient {
     pub fn get_block_with_config(
         &self,
         slot: Slot,
-        config: RpcConfirmedBlockConfig,
+        config: RpcBlockConfig,
     ) -> ClientResult<UiConfirmedBlock> {
         self.send(RpcRequest::GetBlock, json!([slot, config]))
     }
@@ -703,7 +707,7 @@ impl RpcClient {
         address: &Pubkey,
         config: GetConfirmedSignaturesForAddress2Config,
     ) -> ClientResult<Vec<RpcConfirmedTransactionStatusWithSignature>> {
-        let config = RpcGetConfirmedSignaturesForAddress2Config {
+        let config = RpcSignaturesForAddressConfig {
             before: config.before.map(|signature| signature.to_string()),
             until: config.until.map(|signature| signature.to_string()),
             limit: config.limit,
@@ -772,7 +776,7 @@ impl RpcClient {
     pub fn get_transaction_with_config(
         &self,
         signature: &Signature,
-        config: RpcConfirmedTransactionConfig,
+        config: RpcTransactionConfig,
     ) -> ClientResult<EncodedConfirmedTransaction> {
         self.send(
             RpcRequest::GetTransaction,

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -458,27 +458,6 @@ impl RpcClient {
         )
     }
 
-    #[deprecated(since = "1.5.19", note = "Please use RpcClient::supply() instead")]
-    #[allow(deprecated)]
-    pub fn total_supply(&self) -> ClientResult<u64> {
-        self.total_supply_with_commitment(self.commitment_config)
-    }
-
-    #[deprecated(
-        since = "1.5.19",
-        note = "Please use RpcClient::supply_with_commitment() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn total_supply_with_commitment(
-        &self,
-        commitment_config: CommitmentConfig,
-    ) -> ClientResult<u64> {
-        self.send(
-            RpcRequest::GetTotalSupply,
-            json!([self.maybe_map_commitment(commitment_config)?]),
-        )
-    }
-
     pub fn get_largest_accounts_with_config(
         &self,
         config: RpcLargestAccountsConfig,
@@ -616,33 +595,6 @@ impl RpcClient {
                 self.maybe_map_commitment(commitment_config)?
             ]),
         )
-    }
-
-    #[deprecated(
-        since = "1.5.19",
-        note = "Please use RpcClient::get_confirmed_signatures_for_address2() instead"
-    )]
-    #[allow(deprecated)]
-    pub fn get_confirmed_signatures_for_address(
-        &self,
-        address: &Pubkey,
-        start_slot: Slot,
-        end_slot: Slot,
-    ) -> ClientResult<Vec<Signature>> {
-        let signatures_base58_str: Vec<String> = self.send(
-            RpcRequest::GetConfirmedSignaturesForAddress,
-            json!([address.to_string(), start_slot, end_slot]),
-        )?;
-
-        let mut signatures = vec![];
-        for signature_base58_str in signatures_base58_str {
-            signatures.push(
-                signature_base58_str.parse::<Signature>().map_err(|err| {
-                    Into::<ClientError>::into(RpcError::ParseError(err.to_string()))
-                })?,
-            );
-        }
-        Ok(signatures)
     }
 
     pub fn get_confirmed_signatures_for_address2(

--- a/client/src/rpc_deprecated_config.rs
+++ b/client/src/rpc_deprecated_config.rs
@@ -1,0 +1,120 @@
+#![allow(deprecated)]
+use {
+    crate::rpc_config::{
+        EncodingConfig, RpcBlockConfig, RpcEncodingConfigWrapper, RpcTransactionConfig,
+    },
+    solana_sdk::{clock::Slot, commitment_config::CommitmentConfig},
+    solana_transaction_status::{TransactionDetails, UiTransactionEncoding},
+};
+
+#[deprecated(
+    since = "1.7.0",
+    note = "Please use RpcSignaturesForAddressConfig instead"
+)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcGetConfirmedSignaturesForAddress2Config {
+    pub before: Option<String>, // Signature as base-58 string
+    pub until: Option<String>,  // Signature as base-58 string
+    pub limit: Option<usize>,
+    #[serde(flatten)]
+    pub commitment: Option<CommitmentConfig>,
+}
+
+#[deprecated(since = "1.7.0", note = "Please use RpcBlockConfig instead")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcConfirmedBlockConfig {
+    pub encoding: Option<UiTransactionEncoding>,
+    pub transaction_details: Option<TransactionDetails>,
+    pub rewards: Option<bool>,
+    #[serde(flatten)]
+    pub commitment: Option<CommitmentConfig>,
+}
+
+impl EncodingConfig for RpcConfirmedBlockConfig {
+    fn new_with_encoding(encoding: &Option<UiTransactionEncoding>) -> Self {
+        Self {
+            encoding: *encoding,
+            ..Self::default()
+        }
+    }
+}
+
+impl RpcConfirmedBlockConfig {
+    pub fn rewards_only() -> Self {
+        Self {
+            transaction_details: Some(TransactionDetails::None),
+            ..Self::default()
+        }
+    }
+
+    pub fn rewards_with_commitment(commitment: Option<CommitmentConfig>) -> Self {
+        Self {
+            transaction_details: Some(TransactionDetails::None),
+            commitment,
+            ..Self::default()
+        }
+    }
+}
+
+impl From<RpcConfirmedBlockConfig> for RpcEncodingConfigWrapper<RpcConfirmedBlockConfig> {
+    fn from(config: RpcConfirmedBlockConfig) -> Self {
+        RpcEncodingConfigWrapper::Current(Some(config))
+    }
+}
+
+impl From<RpcConfirmedBlockConfig> for RpcBlockConfig {
+    fn from(config: RpcConfirmedBlockConfig) -> Self {
+        Self {
+            encoding: config.encoding,
+            transaction_details: config.transaction_details,
+            rewards: config.rewards,
+            commitment: config.commitment,
+        }
+    }
+}
+
+#[deprecated(since = "1.7.0", note = "Please use RpcTransactionConfig instead")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcConfirmedTransactionConfig {
+    pub encoding: Option<UiTransactionEncoding>,
+    #[serde(flatten)]
+    pub commitment: Option<CommitmentConfig>,
+}
+
+impl EncodingConfig for RpcConfirmedTransactionConfig {
+    fn new_with_encoding(encoding: &Option<UiTransactionEncoding>) -> Self {
+        Self {
+            encoding: *encoding,
+            ..Self::default()
+        }
+    }
+}
+
+impl From<RpcConfirmedTransactionConfig> for RpcTransactionConfig {
+    fn from(config: RpcConfirmedTransactionConfig) -> Self {
+        Self {
+            encoding: config.encoding,
+            commitment: config.commitment,
+        }
+    }
+}
+
+#[deprecated(since = "1.7.0", note = "Please use RpcBlocksConfigWrapper instead")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RpcConfirmedBlocksConfigWrapper {
+    EndSlotOnly(Option<Slot>),
+    CommitmentOnly(Option<CommitmentConfig>),
+}
+
+impl RpcConfirmedBlocksConfigWrapper {
+    pub fn unzip(&self) -> (Option<Slot>, Option<CommitmentConfig>) {
+        match &self {
+            RpcConfirmedBlocksConfigWrapper::EndSlotOnly(end_slot) => (*end_slot, None),
+            RpcConfirmedBlocksConfigWrapper::CommitmentOnly(commitment) => (None, *commitment),
+        }
+    }
+}

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -11,13 +11,32 @@ pub enum RpcRequest {
     DeregisterNode,
     GetAccountInfo,
     GetBalance,
+    GetBlock,
+    GetBlocks,
+    GetBlocksWithLimit,
     GetBlockTime,
     GetClusterNodes,
+
+    #[deprecated(since = "1.7.0", note = "Please use RpcRequest::GetBlock instead")]
     GetConfirmedBlock,
+    #[deprecated(since = "1.7.0", note = "Please use RpcRequest::GetBlocks instead")]
     GetConfirmedBlocks,
+    #[deprecated(
+        since = "1.7.0",
+        note = "Please use RpcRequest::GetBlocksWithLimit instead"
+    )]
     GetConfirmedBlocksWithLimit,
+    #[deprecated(
+        since = "1.7.0",
+        note = "Please use RpcRequest::GetSignaturesForAddress instead"
+    )]
     GetConfirmedSignaturesForAddress2,
+    #[deprecated(
+        since = "1.7.0",
+        note = "Please use RpcRequest::GetTransaction instead"
+    )]
     GetConfirmedTransaction,
+
     GetEpochInfo,
     GetEpochSchedule,
     GetFeeCalculatorForBlockhash,
@@ -40,6 +59,7 @@ pub enum RpcRequest {
     GetRecentBlockhash,
     GetRecentPerformanceSamples,
     GetSnapshotSlot,
+    GetSignaturesForAddress,
     GetSignatureStatuses,
     GetSlot,
     GetSlotLeader,
@@ -54,6 +74,7 @@ pub enum RpcRequest {
     GetTokenAccountsByDelegate,
     GetTokenAccountsByOwner,
     GetTokenSupply,
+    GetTransaction,
     GetTransactionCount,
     GetVersion,
     GetVoteAccounts,
@@ -72,6 +93,9 @@ impl fmt::Display for RpcRequest {
             RpcRequest::DeregisterNode => "deregisterNode",
             RpcRequest::GetAccountInfo => "getAccountInfo",
             RpcRequest::GetBalance => "getBalance",
+            RpcRequest::GetBlock => "getBlock",
+            RpcRequest::GetBlocks => "getBlocks",
+            RpcRequest::GetBlocksWithLimit => "getBlocksWithLimit",
             RpcRequest::GetBlockTime => "getBlockTime",
             RpcRequest::GetClusterNodes => "getClusterNodes",
             RpcRequest::GetConfirmedBlock => "getConfirmedBlock",
@@ -101,6 +125,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetRecentBlockhash => "getRecentBlockhash",
             RpcRequest::GetRecentPerformanceSamples => "getRecentPerformanceSamples",
             RpcRequest::GetSnapshotSlot => "getSnapshotSlot",
+            RpcRequest::GetSignaturesForAddress => "getSignaturesForAddress",
             RpcRequest::GetSignatureStatuses => "getSignatureStatuses",
             RpcRequest::GetSlot => "getSlot",
             RpcRequest::GetSlotLeader => "getSlotLeader",
@@ -115,6 +140,7 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetTokenAccountsByDelegate => "getTokenAccountsByDelegate",
             RpcRequest::GetTokenAccountsByOwner => "getTokenAccountsByOwner",
             RpcRequest::GetTokenSupply => "getTokenSupply",
+            RpcRequest::GetTransaction => "getTransaction",
             RpcRequest::GetTransactionCount => "getTransactionCount",
             RpcRequest::GetVersion => "getVersion",
             RpcRequest::GetVoteAccounts => "getVoteAccounts",

--- a/client/src/rpc_request.rs
+++ b/client/src/rpc_request.rs
@@ -16,13 +16,6 @@ pub enum RpcRequest {
     GetConfirmedBlock,
     GetConfirmedBlocks,
     GetConfirmedBlocksWithLimit,
-
-    #[deprecated(
-        since = "1.5.19",
-        note = "Please use RpcRequest::GetConfirmedSignaturesForAddress2 instead"
-    )]
-    GetConfirmedSignaturesForAddress,
-
     GetConfirmedSignaturesForAddress2,
     GetConfirmedTransaction,
     GetEpochInfo,
@@ -61,10 +54,6 @@ pub enum RpcRequest {
     GetTokenAccountsByDelegate,
     GetTokenAccountsByOwner,
     GetTokenSupply,
-
-    #[deprecated(since = "1.5.19", note = "Please use RpcRequest::GetSupply instead")]
-    GetTotalSupply,
-
     GetTransactionCount,
     GetVersion,
     GetVoteAccounts,
@@ -88,7 +77,6 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetConfirmedBlock => "getConfirmedBlock",
             RpcRequest::GetConfirmedBlocks => "getConfirmedBlocks",
             RpcRequest::GetConfirmedBlocksWithLimit => "getConfirmedBlocksWithLimit",
-            RpcRequest::GetConfirmedSignaturesForAddress => "getConfirmedSignaturesForAddress",
             RpcRequest::GetConfirmedSignaturesForAddress2 => "getConfirmedSignaturesForAddress2",
             RpcRequest::GetConfirmedTransaction => "getConfirmedTransaction",
             RpcRequest::GetEpochInfo => "getEpochInfo",
@@ -127,7 +115,6 @@ impl fmt::Display for RpcRequest {
             RpcRequest::GetTokenAccountsByDelegate => "getTokenAccountsByDelegate",
             RpcRequest::GetTokenAccountsByOwner => "getTokenAccountsByOwner",
             RpcRequest::GetTokenSupply => "getTokenSupply",
-            RpcRequest::GetTotalSupply => "getTotalSupply",
             RpcRequest::GetTransactionCount => "getTransactionCount",
             RpcRequest::GetVersion => "getVersion",
             RpcRequest::GetVoteAccounts => "getVoteAccounts",

--- a/ramp-tps/src/voters.rs
+++ b/ramp-tps/src/voters.rs
@@ -59,7 +59,7 @@ pub fn calculate_leader_records(
     let start_epoch = epoch_schedule.get_epoch(start_slot);
     let end_epoch = epoch_schedule.get_epoch(end_slot);
     let confirmed_blocks: HashSet<_> = rpc_client
-        .get_confirmed_blocks(start_slot, Some(end_slot))?
+        .get_blocks(start_slot, Some(end_slot))?
         .into_iter()
         .collect();
 

--- a/stake-monitor/src/lib.rs
+++ b/stake-monitor/src/lib.rs
@@ -290,12 +290,11 @@ fn load_blocks(
         start_slot, end_slot
     );
 
-    let slots = rpc_client.get_confirmed_blocks(start_slot, Some(end_slot))?;
+    let slots = rpc_client.get_blocks(start_slot, Some(end_slot))?;
 
     let mut blocks = vec![];
     for slot in slots.into_iter() {
-        let block =
-            rpc_client.get_confirmed_block_with_encoding(slot, UiTransactionEncoding::Base64)?;
+        let block = rpc_client.get_block_with_encoding(slot, UiTransactionEncoding::Base64)?;
         blocks.push((slot, block));
     }
     Ok(blocks)


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/16502 deprecated `getConfirmed` rpc endpoints; however, they are still being used in solana-client

#### Summary of Changes
- Remove obsolete RpcClient methods (follows #16516 )
- Deprecate "confirmed" RpcClient methods and replace with new ones
- Rename Confirmed rpc_config structs, using deprecated versions for backward compatibility. I packaged these in a separate module to make them easy to remove with the rpc and client methods in v1.8

Probably easiest to review by commit, as the 3rd commit has a bit of churn.

Completes #16502
