### PR TITLE
Bump scripts to current commitment variants

### DIFF
--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -24,7 +24,7 @@ done
 snapshot_slot=1
 
 # wait a bit longer than snapshot_slot
-while [[ $($solana_cli --url http://localhost:8899 slot --commitment recent) -le $((snapshot_slot + 1)) ]]; do
+while [[ $($solana_cli --url http://localhost:8899 slot --commitment processed) -le $((snapshot_slot + 1)) ]]; do
   sleep 1
   echo "Checking slot"
 done

--- a/scripts/wallet-sanity.sh
+++ b/scripts/wallet-sanity.sh
@@ -21,7 +21,7 @@ node_readiness=false
 timeout=60
 while [[ $timeout -gt 0 ]]; do
   set +e
-  output=$($solana_cli "${args[@]}" transaction-count --commitment max)
+  output=$($solana_cli "${args[@]}" transaction-count --commitment finalized)
   rc=$?
   set -e
   if [[ $rc -eq 0 && -n $output ]]; then


### PR DESCRIPTION
#### Problem
A couple scripts are using deprecated commitment values, which will prevent removing handling for those variants.

#### Summary of Changes
Update them
