### PR TITLE
Fix sanity test flakiness by prebuilding binaries

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -70,7 +70,7 @@ done
 
 source ci/upload-ci-artifact.sh
 source scripts/configure-metrics.sh
-source multinode-demo/common.sh
+source multinode-demo/common.sh --prebuild
 
 nodes=(
   "multinode-demo/bootstrap-validator.sh \

--- a/frozen-abi/src/lib.rs
+++ b/frozen-abi/src/lib.rs
@@ -9,7 +9,6 @@ extern crate self as solana_frozen_abi;
 pub mod abi_digester;
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 pub mod abi_example;
-
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
 mod hash;
 

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -10,6 +10,13 @@
 # shellcheck source=net/common.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. || exit 1; pwd)"/net/common.sh
 
+skip_build=true
+case "$1" in
+  --prebuild)
+    skip_build=
+    ;;
+esac
+
 if [[ $(uname) != Linux ]]; then
   # Protect against unsupported configurations to prevent non-obvious errors
   # later. Arguably these should be fatal errors but for now prefer tolerance.
@@ -44,11 +51,13 @@ else
     fi
 
     # Prebuild binaries so that CI sanity check timeout doesn't include build time
-    (
-      set -x
-      # shellcheck disable=SC2086 # Don't want to double quote
-      cargo $CARGO_TOOLCHAIN build $maybe_release --bin $program
-    )
+    if [[ -z $skip_build ]]; then
+      (
+        set -x
+        # shellcheck disable=SC2086 # Don't want to double quote
+        cargo $CARGO_TOOLCHAIN build $maybe_release --bin $program
+      )
+    fi
 
     printf "cargo $CARGO_TOOLCHAIN run $maybe_release  --bin %s %s -- " "$program"
   }

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -10,12 +10,10 @@
 # shellcheck source=net/common.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. || exit 1; pwd)"/net/common.sh
 
-skip_build=true
-case "$1" in
-  --prebuild)
-    skip_build=
-    ;;
-esac
+prebuild=
+if [[ $1 = "--prebuild" ]]; then
+  prebuild=true
+fi
 
 if [[ $(uname) != Linux ]]; then
   # Protect against unsupported configurations to prevent non-obvious errors
@@ -51,7 +49,7 @@ else
     fi
 
     # Prebuild binaries so that CI sanity check timeout doesn't include build time
-    if [[ -z $skip_build ]]; then
+    if [[ $prebuild ]]; then
       (
         set -x
         # shellcheck disable=SC2086 # Don't want to double quote
@@ -62,6 +60,7 @@ else
     printf "cargo $CARGO_TOOLCHAIN run $maybe_release  --bin %s %s -- " "$program"
   }
 fi
+
 solana_bench_tps=$(solana_program bench-tps)
 solana_faucet=$(solana_program faucet)
 solana_validator=$(solana_program validator)

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -39,17 +39,20 @@ else
       program="solana-$program"
     fi
 
-    if [[ -r "$SOLANA_ROOT/$crate"/Cargo.toml ]]; then
-      maybe_package="--package solana-$crate"
-    fi
     if [[ -n $NDEBUG ]]; then
       maybe_release=--release
     fi
-    declare manifest_path="--manifest-path=$SOLANA_ROOT/$crate/Cargo.toml"
-    printf "cargo $CARGO_TOOLCHAIN run $manifest_path $maybe_release $maybe_package --bin %s %s -- " "$program"
+
+    (
+      set -x
+      # Prebuild local binaries so that CI sanity check doesn't include build time
+      # in the check timeout
+      cargo $CARGO_TOOLCHAIN build $maybe_release --bin $program
+    )
+
+    printf "cargo $CARGO_TOOLCHAIN run $maybe_release  --bin %s %s -- " "$program"
   }
 fi
-
 solana_bench_tps=$(solana_program bench-tps)
 solana_faucet=$(solana_program faucet)
 solana_validator=$(solana_program validator)

--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -43,10 +43,10 @@ else
       maybe_release=--release
     fi
 
+    # Prebuild binaries so that CI sanity check timeout doesn't include build time
     (
       set -x
-      # Prebuild local binaries so that CI sanity check doesn't include build time
-      # in the check timeout
+      # shellcheck disable=SC2086 # Don't want to double quote
       cargo $CARGO_TOOLCHAIN build $maybe_release --bin $program
     )
 


### PR DESCRIPTION
#### Problem
https://buildkite.com/solana-labs/solana/builds/44091#3b501072-5bcb-4347-8776-4db10ffd4887 seems to have timed out early due to long-ish build times being included in the sanity test timeout duration

#### Summary of Changes
- Prebuild local binaries before using multidemo scripts in sanity tests
- Remove `--manifest-path` and `--package` from build commands to reduce feature thrashing

Fixes #
