### PR TITLE
web3.js: deprecate getTotalSupply and getConfirmedSignaturesForAddress

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2308,15 +2308,16 @@ export class Connection {
 
   /**
    * Fetch the current total currency supply of the cluster in lamports
+   * @deprecated Deprecated since v1.2.8. Use `Connection.getSupply()` instead.
    */
   async getTotalSupply(commitment?: Commitment): Promise<number> {
     const args = this._buildArgs([], commitment);
-    const unsafeRes = await this._rpcRequest('getTotalSupply', args);
-    const res = create(unsafeRes, jsonRpcResult(number()));
+    const unsafeRes = await this._rpcRequest('getSupply', args);
+    const res = create(unsafeRes, GetSupplyRpcResult);
     if ('error' in res) {
       throw new Error('failed to get total supply: ' + res.error.message);
     }
-    return res.result;
+    return res.result.value.total;
   }
 
   /**

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -492,9 +492,15 @@ describe('Connection', () => {
 
   it('get total supply', async () => {
     await mockRpcResponse({
-      method: 'getTotalSupply',
+      method: 'getSupply',
       params: [],
-      value: 1000000,
+      value: {
+        total: 1000000,
+        circulating: 100000,
+        nonCirculating: 900000,
+        nonCirculatingAccounts: [new Account().publicKey.toBase58()],
+      },
+      withContext: true,
     });
 
     const count = await connection.getTotalSupply();


### PR DESCRIPTION
#### Problem
The rpc endpoints `getTotalSupply` and `getConfirmedSignaturesForAddress` have been deprecated for quite a stretch, and we are removing them from solana master: https://github.com/solana-labs/solana/pull/16500
But they have not yet been deprecated in solana-web3.js

#### Summary of Changes
- Deprecate `getTotalSupply` by using `getSupply` under the hood
- Deprecate `getConfirmedSignaturesForAddress` by getting blocks to find before/until signatures, and using `getConfirmedSignaturesForAddress2`
  - As part of this, add `Connection.getConfirmedBlockSignatures` helper using `getConfirmedBlock` config options to save having to get all transaction and rewards data in the response. This is a bit of a shortcut; `Connection.getConfirmedBlock` ought to be updated to support the extended config options. But that needs to be done carefully, since making the `transactions` field optional breaks type assumptions.
