### PR TITLE
uses timeouts based on stake for filtering pull responses

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -4765,7 +4765,8 @@ mod tests {
         })
         .take(NO_ENTRIES)
         .collect();
-        let timeouts = cluster_info.gossip.read().unwrap().make_timeouts_test();
+        let mut timeouts = HashMap::new();
+        timeouts.insert(Pubkey::default(), CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS * 2);
         assert_eq!(
             (0, 0, NO_ENTRIES),
             cluster_info.handle_pull_response(&entrypoint_pubkey, data, &timeouts)


### PR DESCRIPTION
#### Problem
filter_pull_responses is using default timeout when discarding pull
responses (except for ContactInfo):
https://github.com/solana-labs/solana/blob/f804ce63c/core/src/crds_gossip_pull.rs#L349-L350

But purging code uses timeouts based on stake:
https://github.com/solana-labs/solana/blob/f804ce63c/core/src/cluster_info.rs#L1867-L1870

So the crds value will not be purged from the sender's table and will be
sent again over the next pull request.

#### Summary of Changes
* Use timeouts based on stake when discarding pull responses.