### PR TITLE
dl-utils: use `wide_msg` everywhere for truncation on narrow terminals

### DIFF
--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -74,15 +74,12 @@ pub fn download_file(
         progress_bar.set_length(download_size);
         progress_bar.set_style(
             ProgressStyle::default_bar()
-                .template(&format!(
-                    "{}{}Downloading {} {}",
-                    "{spinner:.green} ",
-                    TRUCK,
-                    url,
-                    "[{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})"
-                ))
+                .template(
+                    "{spinner:.green}{msg_wide}[{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})",
+                )
                 .progress_chars("=> "),
         );
+        progress_bar.set_message(&format!("{}Downloading~ {}", TRUCK, url));
     } else {
         info!("Downloading {} bytes from {}", download_size, url);
     }

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -109,14 +109,12 @@ fn download_to_temp(
     progress_bar.set_length(download_size);
     progress_bar.set_style(
         ProgressStyle::default_bar()
-            .template(&format!(
-                "{}{}{}",
-                "{spinner:.green} ",
-                TRUCK,
-                "Downloading [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})"
-            ))
+            .template(
+                "{spinner:.green}{wide_msg} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})",
+            )
             .progress_chars("=> "),
     );
+    progress_bar.set_message(&format!("{}Downloading", TRUCK));
 
     struct DownloadProgress<R> {
         progress_bar: ProgressBar,
@@ -824,14 +822,10 @@ pub fn gc(config_file: &str) -> Result<(), String> {
             progress_bar.set_length(old_releases.len() as u64);
             progress_bar.set_style(
                 ProgressStyle::default_bar()
-                    .template(&format!(
-                        "{}{}{}",
-                        "{spinner:.green} ",
-                        RECYCLING,
-                        "Removing old releases [{bar:40.cyan/blue}] {pos}/{len} ({eta})"
-                    ))
+                    .template("{spinner:.green}{wide_msg} [{bar:40.cyan/blue}] {pos}/{len} ({eta})")
                     .progress_chars("=> "),
             );
+            progress_bar.set_message(&format!("{}Removing old releases", RECYCLING));
             for (release, _modified_type) in old_releases {
                 progress_bar.inc(1);
                 let _ = fs::remove_dir_all(&release);


### PR DESCRIPTION
#### Problem

Download progress bars don't support truncation, resulting in line wrap induced terminal spam on narrow terminals

#### Summary of Changes

Use `wide_msg` in the download progress bar style and separately `set_message()` the message.  This works well so long as the terminal is wider than `bar`. Unfortunately `wide_bar` doesn't play nice with `wide_msg`

Still looks gross if you resize the terminal while it's animating

Fixes #16449
