### PR TITLE
fix an assertion that might cause panic in debug build

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -148,7 +148,7 @@ fn main() {
             Arg::with_name("num_threads")
                 .long("num-threads")
                 .takes_value(true)
-                .help("Number of iterations"),
+                .help("Number of threads"),
         )
         .get_matches();
 
@@ -169,7 +169,7 @@ fn main() {
 
     let (verified_sender, verified_receiver) = unbounded();
     let (vote_sender, vote_receiver) = unbounded();
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, replay_vote_receiver) = unbounded();
     let bank0 = Bank::new(&genesis_config);
     let mut bank_forks = BankForks::new(bank0);
     let mut bank = bank_forks.working_bank();
@@ -302,7 +302,7 @@ fn main() {
                     bank.transaction_count(),
                     txs_processed
                 );
-                assert!(txs_processed < bank.transaction_count());
+                assert!(txs_processed <= bank.transaction_count());
                 txs_processed = bank.transaction_count();
                 tx_total_us += duration_as_us(&now.elapsed());
 

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -169,7 +169,7 @@ fn main() {
 
     let (verified_sender, verified_receiver) = unbounded();
     let (vote_sender, vote_receiver) = unbounded();
-    let (replay_vote_sender, replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
     let bank0 = Bank::new(&genesis_config);
     let mut bank_forks = BankForks::new(bank0);
     let mut bank = bank_forks.working_bank();


### PR DESCRIPTION
#### Problem
`banking-bench` panics in debug build when running on macBook: 
```% cargo run
   Compiling solana-banking-bench v1.7.0 (/Users/taozhu/Solana/repo/solana/banking-bench)
    Finished dev [unoptimized + debuginfo] target(s) in 31.76s
     Running `/Users/taozhu/Solana/repo/solana/target/debug/solana-banking-bench`
thread 'main' panicked at 'assertion failed: txs_processed < bank.transaction_count()', banking-bench/src/main.rs:305:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It runs fine in release build on same laptop. 

#### Summary of Changes
The issue is likely due to debug build runs much slower, resulting no new transactions being added to bank during some iteration. Should add this as acceptable condition.

Fixes #
To assert processed transaction count should be less *or equal* to bank transaction count.
