### PR TITLE
Remove obsolete commitment variants

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -304,11 +304,6 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 "processed",
                 "confirmed",
                 "finalized",
-                "recent", // Deprecated as of v1.5.5
-                "single", // Deprecated as of v1.5.5
-                "singleGossip", // Deprecated as of v1.5.5
-                "root", // Deprecated as of v1.5.5
-                "max", // Deprecated as of v1.5.5
             ])
             .value_name("COMMITMENT_LEVEL")
             .hide_possible_values(true)

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -29,7 +29,7 @@ use {
     solana_sdk::{
         account::Account,
         clock::{Epoch, Slot, UnixTimestamp, DEFAULT_MS_PER_SLOT, MAX_HASH_AGE_IN_SECONDS},
-        commitment_config::{CommitmentConfig, CommitmentLevel},
+        commitment_config::CommitmentConfig,
         epoch_info::EpochInfo,
         epoch_schedule::EpochSchedule,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
@@ -166,26 +166,6 @@ impl RpcClient {
         self.commitment_config
     }
 
-    fn use_deprecated_commitment(&self) -> Result<bool, RpcError> {
-        Ok(self.get_node_version()? < semver::Version::new(1, 5, 5))
-    }
-
-    fn maybe_map_commitment(
-        &self,
-        requested_commitment: CommitmentConfig,
-    ) -> Result<CommitmentConfig, RpcError> {
-        if matches!(
-            requested_commitment.commitment,
-            CommitmentLevel::Finalized | CommitmentLevel::Confirmed | CommitmentLevel::Processed
-        ) && self.use_deprecated_commitment()?
-        {
-            return Ok(CommitmentConfig::use_deprecated_commitment(
-                requested_commitment,
-            ));
-        }
-        Ok(requested_commitment)
-    }
-
     #[allow(deprecated)]
     fn maybe_map_request(&self, mut request: RpcRequest) -> Result<RpcRequest, RpcError> {
         if self.get_node_version()? < semver::Version::new(1, 7, 0) {
@@ -230,10 +210,7 @@ impl RpcClient {
         self.send_transaction_with_config(
             transaction,
             RpcSendTransactionConfig {
-                preflight_commitment: Some(
-                    self.maybe_map_commitment(self.commitment_config)?
-                        .commitment,
-                ),
+                preflight_commitment: Some(self.commitment_config.commitment),
                 ..RpcSendTransactionConfig::default()
             },
         )
@@ -260,7 +237,6 @@ impl RpcClient {
         let preflight_commitment = CommitmentConfig {
             commitment: config.preflight_commitment.unwrap_or_default(),
         };
-        let preflight_commitment = self.maybe_map_commitment(preflight_commitment)?;
         let config = RpcSendTransactionConfig {
             encoding: Some(encoding),
             preflight_commitment: Some(preflight_commitment.commitment),
@@ -338,7 +314,6 @@ impl RpcClient {
             self.default_cluster_transaction_encoding()?
         };
         let commitment = config.commitment.unwrap_or_default();
-        let commitment = self.maybe_map_commitment(commitment)?;
         let config = RpcSimulateTransactionConfig {
             encoding: Some(encoding),
             commitment: Some(commitment),
@@ -424,10 +399,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Slot> {
-        self.send(
-            RpcRequest::GetSlot,
-            json!([self.maybe_map_commitment(commitment_config)?]),
-        )
+        self.send(RpcRequest::GetSlot, json!([commitment_config]))
     }
 
     pub fn get_slot_leaders(&self, start_slot: Slot, limit: u64) -> ClientResult<Vec<Pubkey>> {
@@ -473,10 +445,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> RpcResult<RpcSupply> {
-        self.send(
-            RpcRequest::GetSupply,
-            json!([self.maybe_map_commitment(commitment_config)?]),
-        )
+        self.send(RpcRequest::GetSupply, json!([commitment_config]))
     }
 
     pub fn get_largest_accounts_with_config(
@@ -484,7 +453,6 @@ impl RpcClient {
         config: RpcLargestAccountsConfig,
     ) -> RpcResult<Vec<RpcAccountBalance>> {
         let commitment = config.commitment.unwrap_or_default();
-        let commitment = self.maybe_map_commitment(commitment)?;
         let config = RpcLargestAccountsConfig {
             commitment: Some(commitment),
             ..config
@@ -500,10 +468,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<RpcVoteAccountStatus> {
-        self.send(
-            RpcRequest::GetVoteAccounts,
-            json!([self.maybe_map_commitment(commitment_config)?]),
-        )
+        self.send(RpcRequest::GetVoteAccounts, json!([commitment_config]))
     }
 
     pub fn wait_for_max_stake(
@@ -614,13 +579,9 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
         let json = if end_slot.is_some() {
-            json!([
-                start_slot,
-                end_slot,
-                self.maybe_map_commitment(commitment_config)?
-            ])
+            json!([start_slot, end_slot, commitment_config])
         } else {
-            json!([start_slot, self.maybe_map_commitment(commitment_config)?])
+            json!([start_slot, commitment_config])
         };
         self.send(self.maybe_map_request(RpcRequest::GetBlocks)?, json)
     }
@@ -640,11 +601,7 @@ impl RpcClient {
     ) -> ClientResult<Vec<Slot>> {
         self.send(
             self.maybe_map_request(RpcRequest::GetBlocksWithLimit)?,
-            json!([
-                start_slot,
-                limit,
-                self.maybe_map_commitment(commitment_config)?
-            ]),
+            json!([start_slot, limit, commitment_config]),
         )
     }
 
@@ -673,13 +630,9 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> ClientResult<Vec<Slot>> {
         let json = if end_slot.is_some() {
-            json!([
-                start_slot,
-                end_slot,
-                self.maybe_map_commitment(commitment_config)?
-            ])
+            json!([start_slot, end_slot, commitment_config])
         } else {
-            json!([start_slot, self.maybe_map_commitment(commitment_config)?])
+            json!([start_slot, commitment_config])
         };
         self.send(RpcRequest::GetConfirmedBlocks, json)
     }
@@ -713,11 +666,7 @@ impl RpcClient {
     ) -> ClientResult<Vec<Slot>> {
         self.send(
             RpcRequest::GetConfirmedBlocksWithLimit,
-            json!([
-                start_slot,
-                limit,
-                self.maybe_map_commitment(commitment_config)?
-            ]),
+            json!([start_slot, limit, commitment_config]),
         )
     }
 
@@ -870,10 +819,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<EpochInfo> {
-        self.send(
-            RpcRequest::GetEpochInfo,
-            json!([self.maybe_map_commitment(commitment_config)?]),
-        )
+        self.send(RpcRequest::GetEpochInfo, json!([commitment_config]))
     }
 
     pub fn get_leader_schedule(
@@ -890,7 +836,7 @@ impl RpcClient {
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
         self.send(
             RpcRequest::GetLeaderSchedule,
-            json!([slot, self.maybe_map_commitment(commitment_config)?]),
+            json!([slot, commitment_config]),
         )
     }
 
@@ -1017,7 +963,7 @@ impl RpcClient {
     ) -> RpcResult<Option<Account>> {
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::Base64),
-            commitment: Some(self.maybe_map_commitment(commitment_config)?),
+            commitment: Some(commitment_config),
             data_slice: None,
         };
         let response = self.sender.send(
@@ -1072,7 +1018,7 @@ impl RpcClient {
     ) -> RpcResult<Vec<Option<Account>>> {
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::Base64),
-            commitment: Some(self.maybe_map_commitment(commitment_config)?),
+            commitment: Some(commitment_config),
             data_slice: None,
         };
         let pubkeys: Vec<_> = pubkeys.iter().map(|pubkey| pubkey.to_string()).collect();
@@ -1126,10 +1072,7 @@ impl RpcClient {
     ) -> RpcResult<u64> {
         self.send(
             RpcRequest::GetBalance,
-            json!([
-                pubkey.to_string(),
-                self.maybe_map_commitment(commitment_config)?
-            ]),
+            json!([pubkey.to_string(), commitment_config]),
         )
     }
 
@@ -1153,7 +1096,6 @@ impl RpcClient {
         config: RpcProgramAccountsConfig,
     ) -> ClientResult<Vec<(Pubkey, Account)>> {
         let commitment = config.account_config.commitment.unwrap_or_default();
-        let commitment = self.maybe_map_commitment(commitment)?;
         let account_config = RpcAccountInfoConfig {
             commitment: Some(commitment),
             ..config.account_config
@@ -1178,10 +1120,7 @@ impl RpcClient {
         &self,
         commitment_config: CommitmentConfig,
     ) -> ClientResult<u64> {
-        self.send(
-            RpcRequest::GetTransactionCount,
-            json!([self.maybe_map_commitment(commitment_config)?]),
-        )
+        self.send(RpcRequest::GetTransactionCount, json!([commitment_config]))
     }
 
     pub fn get_recent_blockhash(&self) -> ClientResult<(Hash, FeeCalculator)> {
@@ -1203,11 +1142,9 @@ impl RpcClient {
                     fee_calculator,
                     last_valid_slot,
                 },
-        }) = self
-            .send::<Response<RpcFees>>(
-                RpcRequest::GetFees,
-                json!([self.maybe_map_commitment(commitment_config)?]),
-            ) {
+        }) =
+            self.send::<Response<RpcFees>>(RpcRequest::GetFees, json!([commitment_config]))
+        {
             (context, blockhash, fee_calculator, last_valid_slot)
         } else if let Ok(Response {
             context,
@@ -1218,7 +1155,7 @@ impl RpcClient {
                 },
         }) = self.send::<Response<RpcBlockhashFeeCalculator>>(
             RpcRequest::GetRecentBlockhash,
-            json!([self.maybe_map_commitment(commitment_config)?]),
+            json!([commitment_config]),
         ) {
             (context, blockhash, fee_calculator, 0)
         } else {
@@ -1256,10 +1193,7 @@ impl RpcClient {
     ) -> RpcResult<Option<FeeCalculator>> {
         let Response { context, value } = self.send::<Response<Option<RpcFeeCalculator>>>(
             RpcRequest::GetFeeCalculatorForBlockhash,
-            json!([
-                blockhash.to_string(),
-                self.maybe_map_commitment(commitment_config)?
-            ]),
+            json!([blockhash.to_string(), commitment_config]),
         )?;
 
         Ok(Response {
@@ -1338,7 +1272,7 @@ impl RpcClient {
     ) -> RpcResult<Option<UiTokenAccount>> {
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::JsonParsed),
-            commitment: Some(self.maybe_map_commitment(commitment_config)?),
+            commitment: Some(commitment_config),
             data_slice: None,
         };
         let response = self.sender.send(
@@ -1399,10 +1333,7 @@ impl RpcClient {
     ) -> RpcResult<UiTokenAmount> {
         self.send(
             RpcRequest::GetTokenAccountBalance,
-            json!([
-                pubkey.to_string(),
-                self.maybe_map_commitment(commitment_config)?
-            ]),
+            json!([pubkey.to_string(), commitment_config]),
         )
     }
 
@@ -1435,7 +1366,7 @@ impl RpcClient {
 
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::JsonParsed),
-            commitment: Some(self.maybe_map_commitment(commitment_config)?),
+            commitment: Some(commitment_config),
             data_slice: None,
         };
 
@@ -1474,7 +1405,7 @@ impl RpcClient {
 
         let config = RpcAccountInfoConfig {
             encoding: Some(UiAccountEncoding::JsonParsed),
-            commitment: Some(self.maybe_map_commitment(commitment_config)?),
+            commitment: Some(commitment_config),
             data_slice: None,
         };
 
@@ -1497,10 +1428,7 @@ impl RpcClient {
     ) -> RpcResult<UiTokenAmount> {
         self.send(
             RpcRequest::GetTokenSupply,
-            json!([
-                mint.to_string(),
-                self.maybe_map_commitment(commitment_config)?
-            ]),
+            json!([mint.to_string(), commitment_config]),
         )
     }
 
@@ -1538,7 +1466,6 @@ impl RpcClient {
         config: RpcRequestAirdropConfig,
     ) -> ClientResult<Signature> {
         let commitment = config.commitment.unwrap_or_default();
-        let commitment = self.maybe_map_commitment(commitment)?;
         let config = RpcRequestAirdropConfig {
             commitment: Some(commitment),
             ..config

--- a/core/src/rpc.rs
+++ b/core/src/rpc.rs
@@ -180,23 +180,13 @@ impl JsonRpcRequestProcessor {
             .slot_with_commitment(commitment.commitment);
 
         match commitment.commitment {
-            // Recent variant is deprecated
-            CommitmentLevel::Recent | CommitmentLevel::Processed => {
+            CommitmentLevel::Processed => {
                 debug!("RPC using the heaviest slot: {:?}", slot);
             }
-            // Root variant is deprecated
-            CommitmentLevel::Root => {
-                debug!("RPC using node root: {:?}", slot);
-            }
-            // Single variant is deprecated
-            CommitmentLevel::Single => {
-                debug!("RPC using confirmed slot: {:?}", slot);
-            }
-            // Max variant is deprecated
-            CommitmentLevel::Max | CommitmentLevel::Finalized => {
+            CommitmentLevel::Finalized => {
                 debug!("RPC using block: {:?}", slot);
             }
-            CommitmentLevel::SingleGossip | CommitmentLevel::Confirmed => unreachable!(), // SingleGossip variant is deprecated
+            CommitmentLevel::Confirmed => unreachable!(),
         };
 
         r_bank_forks.get(slot).cloned().unwrap_or_else(|| {
@@ -6677,7 +6667,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_rpc_single_gossip() {
+    fn test_rpc_confirmed() {
         let exit = Arc::new(AtomicBool::new(false));
         let validator_exit = create_validator_exit(&exit);
         let ledger_path = get_tmp_ledger_path!();

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1592,7 +1592,7 @@ fn test_validator_saves_tower() {
         #[allow(deprecated)]
         // This test depends on knowing the immediate root, without any delay from the commitment
         // service, so the deprecated CommitmentConfig::root() is retained
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
+        if let Some(root) = root_in_tower(&ledger_path, &validator_id) {
             trace!("current root: {}", root);
             if root > last_replayed_root + 1 {
                 last_replayed_root = root;
@@ -1617,14 +1617,13 @@ fn test_validator_saves_tower() {
     tower1.save(&validator_identity_keypair).unwrap();
 
     cluster.restart_node(&validator_id, validator_info);
-    let validator_client = cluster.get_validator_client(&validator_id).unwrap();
 
     // Wait for a new root, demonstrating the validator was able to make progress from the older `tower1`
     loop {
         #[allow(deprecated)]
         // This test depends on knowing the immediate root, without any delay from the commitment
         // service, so the deprecated CommitmentConfig::root() is retained
-        if let Ok(root) = validator_client.get_slot_with_commitment(CommitmentConfig::root()) {
+        if let Some(root) = root_in_tower(&ledger_path, &validator_id) {
             trace!(
                 "current root: {}, last_replayed_root: {}",
                 root,

--- a/runtime/src/commitment.rs
+++ b/runtime/src/commitment.rs
@@ -112,13 +112,9 @@ impl BlockCommitmentCache {
     #[allow(deprecated)]
     pub fn slot_with_commitment(&self, commitment_level: CommitmentLevel) -> Slot {
         match commitment_level {
-            CommitmentLevel::Recent | CommitmentLevel::Processed => self.slot(),
-            CommitmentLevel::Root => self.root(),
-            CommitmentLevel::Single => self.highest_confirmed_slot(),
-            CommitmentLevel::SingleGossip | CommitmentLevel::Confirmed => {
-                self.highest_gossip_confirmed_slot()
-            }
-            CommitmentLevel::Max | CommitmentLevel::Finalized => self.highest_confirmed_root(),
+            CommitmentLevel::Processed => self.slot(),
+            CommitmentLevel::Confirmed => self.highest_gossip_confirmed_slot(),
+            CommitmentLevel::Finalized => self.highest_confirmed_root(),
         }
     }
 

--- a/sdk/src/commitment_config.rs
+++ b/sdk/src/commitment_config.rs
@@ -11,56 +11,6 @@ pub struct CommitmentConfig {
 }
 
 impl CommitmentConfig {
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::processed() instead"
-    )]
-    pub fn recent() -> Self {
-        Self {
-            commitment: CommitmentLevel::Recent,
-        }
-    }
-
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::finalized() instead"
-    )]
-    pub fn max() -> Self {
-        Self {
-            commitment: CommitmentLevel::Max,
-        }
-    }
-
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::finalized() instead"
-    )]
-    pub fn root() -> Self {
-        Self {
-            commitment: CommitmentLevel::Root,
-        }
-    }
-
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::confirmed() instead"
-    )]
-    pub fn single() -> Self {
-        Self {
-            commitment: CommitmentLevel::Single,
-        }
-    }
-
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentConfig::confirmed() instead"
-    )]
-    pub fn single_gossip() -> Self {
-        Self {
-            commitment: CommitmentLevel::SingleGossip,
-        }
-    }
-
     pub fn finalized() -> Self {
         Self {
             commitment: CommitmentLevel::Finalized,
@@ -88,37 +38,19 @@ impl CommitmentConfig {
     }
 
     pub fn is_finalized(&self) -> bool {
-        matches!(
-            &self.commitment,
-            CommitmentLevel::Finalized | CommitmentLevel::Max | CommitmentLevel::Root
-        )
+        self.commitment == CommitmentLevel::Finalized
     }
 
     pub fn is_confirmed(&self) -> bool {
-        matches!(
-            &self.commitment,
-            CommitmentLevel::Confirmed | CommitmentLevel::SingleGossip | CommitmentLevel::Single
-        )
+        self.commitment == CommitmentLevel::Confirmed
     }
 
     pub fn is_processed(&self) -> bool {
-        matches!(
-            &self.commitment,
-            CommitmentLevel::Processed | CommitmentLevel::Recent
-        )
+        self.commitment == CommitmentLevel::Processed
     }
 
     pub fn is_at_least_confirmed(&self) -> bool {
         self.is_confirmed() || self.is_finalized()
-    }
-
-    pub fn use_deprecated_commitment(commitment: CommitmentConfig) -> Self {
-        match commitment.commitment {
-            CommitmentLevel::Finalized => CommitmentConfig::max(),
-            CommitmentLevel::Confirmed => CommitmentConfig::single_gossip(),
-            CommitmentLevel::Processed => CommitmentConfig::recent(),
-            _ => commitment,
-        }
     }
 }
 
@@ -137,48 +69,6 @@ impl FromStr for CommitmentConfig {
 /// finalized. When querying the ledger state, use lower levels of commitment to report progress and higher
 /// levels to ensure state changes will not be rolled back.
 pub enum CommitmentLevel {
-    /// (DEPRECATED) The highest slot having reached max vote lockout, as recognized by a supermajority of the cluster.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Finalized instead"
-    )]
-    Max,
-
-    /// (DEPRECATED) The highest slot of the heaviest fork. Ledger state at this slot is not derived from a finalized
-    /// block, but if multiple forks are present, is from the fork the validator believes is most likely
-    /// to finalize.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Processed instead"
-    )]
-    Recent,
-
-    /// (DEPRECATED) The highest slot having reached max vote lockout.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Finalized instead"
-    )]
-    Root,
-
-    /// (DEPRECATED) The highest slot having reached 1 confirmation by supermajority of the cluster.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Confirmed instead"
-    )]
-    Single,
-
-    /// (DEPRECATED) The highest slot that has been voted on by supermajority of the cluster
-    /// This differs from `single` in that:
-    /// 1) It incorporates votes from gossip and replay.
-    /// 2) It does not count votes on descendants of a block, only direct votes on that block.
-    /// 3) This confirmation level also upholds "optimistic confirmation" guarantees in
-    /// release 1.3 and onwards.
-    #[deprecated(
-        since = "1.5.5",
-        note = "Please use CommitmentLevel::Confirmed instead"
-    )]
-    SingleGossip,
-
     /// The highest slot of the heaviest fork processed by the node. Ledger state at this slot is
     /// not derived from a confirmed or finalized block, but if multiple forks are present, is from
     /// the fork the validator believes is most likely to finalize.
@@ -206,11 +96,6 @@ impl FromStr for CommitmentLevel {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "max" => Ok(CommitmentLevel::Max),
-            "recent" => Ok(CommitmentLevel::Recent),
-            "root" => Ok(CommitmentLevel::Root),
-            "single" => Ok(CommitmentLevel::Single),
-            "singleGossip" => Ok(CommitmentLevel::SingleGossip),
             "processed" => Ok(CommitmentLevel::Processed),
             "confirmed" => Ok(CommitmentLevel::Confirmed),
             "finalized" => Ok(CommitmentLevel::Finalized),
@@ -222,11 +107,6 @@ impl FromStr for CommitmentLevel {
 impl std::fmt::Display for CommitmentLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let s = match self {
-            CommitmentLevel::Max => "max",
-            CommitmentLevel::Recent => "recent",
-            CommitmentLevel::Root => "root",
-            CommitmentLevel::Single => "single",
-            CommitmentLevel::SingleGossip => "singleGossip",
             CommitmentLevel::Processed => "processed",
             CommitmentLevel::Confirmed => "confirmed",
             CommitmentLevel::Finalized => "finalized",

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -756,7 +756,7 @@ mod test {
         assert!(!status.satisfies_commitment(CommitmentConfig::confirmed()));
         assert!(status.satisfies_commitment(CommitmentConfig::processed()));
 
-        // Test single_gossip fallback cases
+        // Test confirmed fallback cases
         let status = TransactionStatus {
             slot: 0,
             confirmations: Some(1),


### PR DESCRIPTION
#### Problem
Commitment variants (root, single, singleGossip, recent) were deprecated in v1.5.5. Time to take them out in v1.7.

#### Summary of Changes
Remove obsolete commitment variants from node and client handling
