### PR TITLE
Fix instruction validation for parsed memo instructions

### DIFF
--- a/explorer/src/components/account/history/TokenInstructionsCard.tsx
+++ b/explorer/src/components/account/history/TokenInstructionsCard.tsx
@@ -185,11 +185,15 @@ function isRelevantInstruction(
         account.equals(pubkey) ||
         mintMap.get(account.toBase58())?.mint === address
     );
-  } else {
+  } else if (
+    typeof instruction.parsed === "object" &&
+    "info" in instruction.parsed
+  ) {
     return Object.entries(instruction.parsed.info).some(
       ([key, value]) =>
         value === address ||
         (typeof value === "string" && mintMap.get(value)?.mint === address)
     );
   }
+  return false;
 }

--- a/explorer/src/utils/instruction.ts
+++ b/explorer/src/utils/instruction.ts
@@ -47,7 +47,11 @@ export class InstructionContainer {
     this.instructions = parsedTransaction.transaction.message.instructions.map(
       (instruction) => {
         if ("parsed" in instruction) {
-          instruction.parsed = create(instruction.parsed, ParsedInfo);
+          if (typeof instruction.parsed === "object") {
+            instruction.parsed = create(instruction.parsed, ParsedInfo);
+          } else if (typeof instruction.parsed !== "string") {
+            throw new Error("Unexpected parsed response");
+          }
         }
 
         return {


### PR DESCRIPTION
#### Problem
The `parsed` field in memo instructions is not an object but was expected to be one

#### Summary of Changes

Fixes #
