### PR TITLE
CLI BIP32 prep: `KeypairUrl` refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4092,6 +4092,7 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "tiny-bip39 0.8.0",
+ "uriparse",
  "url 2.2.0",
 ]
 
@@ -6479,6 +6480,16 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "uriparse"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e515b1ada404168e145ac55afba3c42f04cf972201a8552d42e2abb17c1b7221"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
 
 [[package]]
 name = "url"

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -16,6 +16,7 @@ solana-remote-wallet = { path = "../remote-wallet", version = "=1.7.0" }
 solana-sdk = { path = "../sdk", version = "=1.7.0" }
 thiserror = "1.0.21"
 tiny-bip39 = "0.8.0"
+uriparse = "0.6.3"
 url = "2.1.0"
 chrono = "0.4"
 

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -1,4 +1,4 @@
-use crate::keypair::{parse_keypair_path, KeypairUrl, ASK_KEYWORD};
+use crate::keypair::{parse_signer_source, SignerSource, ASK_KEYWORD};
 use chrono::DateTime;
 use solana_sdk::{
     clock::{Epoch, Slot},
@@ -108,8 +108,8 @@ pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    match parse_keypair_path(string.as_ref()) {
-        KeypairUrl::Filepath(path) => is_keypair(path),
+    match parse_signer_source(string.as_ref()) {
+        SignerSource::Filepath(path) => is_keypair(path),
         _ => Ok(()),
     }
 }

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -133,7 +133,7 @@ impl DefaultSigner {
     }
 }
 
-pub enum SignerSource {
+pub(crate) enum SignerSource {
     Ask,
     Filepath(String),
     Usb(String),
@@ -141,7 +141,7 @@ pub enum SignerSource {
     Pubkey(Pubkey),
 }
 
-pub fn parse_signer_source<S: AsRef<str>>(source: S) -> SignerSource {
+pub(crate) fn parse_signer_source<S: AsRef<str>>(source: S) -> SignerSource {
     if path == "-" {
         SignerSource::Stdin
     } else if path == ASK_KEYWORD {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -150,6 +150,8 @@ pub(crate) fn parse_signer_source<S: AsRef<str>>(source: S) -> SignerSource {
             if let Some(scheme) = uri.scheme() {
                 let scheme = scheme.as_str().to_ascii_lowercase();
                 match scheme.as_str() {
+                    "ask" => SignerSource::Ask,
+                    "file" => SignerSource::Filepath(uri.path().to_string()),
                     "usb" => SignerSource::Usb(source.to_string()),
                     _ => SignerSource::Filepath(source.to_string()),
                 }
@@ -478,5 +480,15 @@ mod tests {
         assert!(Pubkey::from_str(&junk).is_err());
         assert!(matches!(parse_signer_source(&junk), SignerSource::Filepath(j) if j == junk));
 
+        let ask = "ask:".to_string();
+        assert!(matches!(parse_signer_source(&ask), SignerSource::Ask));
+        let path = "/absolute/path".to_string();
+        assert!(
+            matches!(parse_signer_source(&format!("file:{}", path)), SignerSource::Filepath(p) if p == path)
+        );
+        let path = "relative/path".to_string();
+        assert!(
+            matches!(parse_signer_source(&format!("file:{}", path)), SignerSource::Filepath(p) if p == path)
+        );
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2553,7 +2553,7 @@ mod tests {
             }
         );
 
-        // Test ResolveSigner Subcommand, KeypairUrl::Filepath
+        // Test ResolveSigner Subcommand, SignerSource::Filepath
         let test_resolve_signer =
             test_commands
                 .clone()
@@ -2565,7 +2565,7 @@ mod tests {
                 signers: vec![],
             }
         );
-        // Test ResolveSigner Subcommand, KeypairUrl::Pubkey (Presigner)
+        // Test ResolveSigner Subcommand, SignerSource::Pubkey (Presigner)
         let test_resolve_signer =
             test_commands
                 .clone()

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "tiny-bip39",
+ "uriparse",
  "url",
 ]
 
@@ -4243,6 +4244,16 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "uriparse"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e515b1ada404168e145ac55afba3c42f04cf972201a8552d42e2abb17c1b7221"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
 
 [[package]]
 name = "url"


### PR DESCRIPTION
#### Problem

Signer source path parsing is hand coded and doesn't lend itself to the extension necessary to specify BIP32 derivation paths

#### Summary of Changes

Rename
Refactor to use an RPC compliant URI parsing crate
Adds explicit schemes for `file` and `ask` methods

Toward https://github.com/solana-labs/solana/issues/5246