### PR TITLE
Revert #16534

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -584,22 +584,6 @@ export type ConfirmedBlock = {
 };
 
 /**
- * A ConfirmedBlock on the ledger with signatures only
- */
-export type ConfirmedBlockSignatures = {
-  /** Blockhash of this block */
-  blockhash: Blockhash;
-  /** Blockhash of this block's parent */
-  previousBlockhash: Blockhash;
-  /** Slot index of this block's parent */
-  parentSlot: number;
-  /** Vector of signatures */
-  signatures: Array<string>;
-  /** The unix timestamp of when the block was processed */
-  blockTime: number | null;
-};
-
-/**
  * A performance sample
  */
 export type PerfSample = {
@@ -932,6 +916,13 @@ const StakeActivationResult = pick({
 });
 
 /**
+ * Expected JSON RPC response for the "getConfirmedSignaturesForAddress" message
+ */
+const GetConfirmedSignaturesForAddressRpcResult = jsonRpcResult(
+  array(string()),
+);
+
+/**
  * Expected JSON RPC response for the "getConfirmedSignaturesForAddress2" message
  */
 
@@ -1235,21 +1226,6 @@ const GetConfirmedBlockRpcResult = jsonRpcResult(
           }),
         ),
       ),
-      blockTime: nullable(number()),
-    }),
-  ),
-);
-
-/**
- * Expected JSON RPC response for the "getConfirmedBlockSignatures" message
- */
-const GetConfirmedBlockSignaturesRpcResult = jsonRpcResult(
-  nullable(
-    pick({
-      blockhash: string(),
-      previousBlockhash: string(),
-      parentSlot: number(),
-      signatures: array(string()),
       blockTime: nullable(number()),
     }),
   ),
@@ -2308,16 +2284,15 @@ export class Connection {
 
   /**
    * Fetch the current total currency supply of the cluster in lamports
-   * @deprecated Deprecated since v1.2.8. Use `Connection.getSupply()` instead.
    */
   async getTotalSupply(commitment?: Commitment): Promise<number> {
     const args = this._buildArgs([], commitment);
-    const unsafeRes = await this._rpcRequest('getSupply', args);
-    const res = create(unsafeRes, GetSupplyRpcResult);
+    const unsafeRes = await this._rpcRequest('getTotalSupply', args);
+    const res = create(unsafeRes, jsonRpcResult(number()));
     if ('error' in res) {
       throw new Error('failed to get total supply: ' + res.error.message);
     }
-    return res.result.value.total;
+    return res.result;
   }
 
   /**
@@ -2503,27 +2478,6 @@ export class Connection {
   }
 
   /**
-   * Fetch a list of Signatures from the cluster for a confirmed block, excluding rewards
-   */
-  async getConfirmedBlockSignatures(
-    slot: number,
-  ): Promise<ConfirmedBlockSignatures> {
-    const unsafeRes = await this._rpcRequest('getConfirmedBlock', [
-      slot,
-      {transactionDetails: 'signatures', rewards: false},
-    ]);
-    const res = create(unsafeRes, GetConfirmedBlockSignaturesRpcResult);
-    if ('error' in res) {
-      throw new Error('failed to get confirmed block: ' + res.error.message);
-    }
-    const result = res.result;
-    if (!result) {
-      throw new Error('Confirmed block ' + slot + ' not found');
-    }
-    return result;
-  }
-
-  /**
    * Fetch a transaction details for a confirmed transaction
    */
   async getConfirmedTransaction(
@@ -2590,7 +2544,6 @@ export class Connection {
   /**
    * Fetch a list of all the confirmed signatures for transactions involving an address
    * within a specified slot range. Max range allowed is 10,000 slots.
-   * @deprecated Deprecated since v1.3. Use `Connection.getConfirmedSignaturesForAddress2()` instead.
    *
    * @param address queried address
    * @param startSlot start slot, inclusive
@@ -2601,59 +2554,17 @@ export class Connection {
     startSlot: number,
     endSlot: number,
   ): Promise<Array<TransactionSignature>> {
-    let options: any = {};
-
-    let firstAvailableBlock = await this.getFirstAvailableBlock();
-    while (!('until' in options)) {
-      startSlot--;
-      if (startSlot <= 0 || startSlot < firstAvailableBlock) {
-        break;
-      }
-
-      try {
-        const block = await this.getConfirmedBlockSignatures(startSlot);
-        if (block.signatures.length > 0) {
-          options.until = block.signatures[
-            block.signatures.length - 1
-          ].toString();
-        }
-      } catch (err) {
-        if (err.message.includes('skipped')) {
-          continue;
-        } else {
-          throw err;
-        }
-      }
-    }
-
-    let highestConfirmedRoot = await this.getSlot('finalized');
-    while (!('before' in options)) {
-      endSlot++;
-      if (endSlot > highestConfirmedRoot) {
-        break;
-      }
-
-      try {
-        const block = await this.getConfirmedBlockSignatures(endSlot);
-        if (block.signatures.length > 0) {
-          options.before = block.signatures[
-            block.signatures.length - 1
-          ].toString();
-        }
-      } catch (err) {
-        if (err.message.includes('skipped')) {
-          continue;
-        } else {
-          throw err;
-        }
-      }
-    }
-
-    const confirmedSignatureInfo = await this.getConfirmedSignaturesForAddress2(
-      address,
-      options,
+    const unsafeRes = await this._rpcRequest(
+      'getConfirmedSignaturesForAddress',
+      [address.toBase58(), startSlot, endSlot],
     );
-    return confirmedSignatureInfo.map(info => info.signature);
+    const res = create(unsafeRes, GetConfirmedSignaturesForAddressRpcResult);
+    if ('error' in res) {
+      throw new Error(
+        'failed to get confirmed signatures for address: ' + res.error.message,
+      );
+    }
+    return res.result;
   }
 
   /**

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -492,15 +492,9 @@ describe('Connection', () => {
 
   it('get total supply', async () => {
     await mockRpcResponse({
-      method: 'getSupply',
+      method: 'getTotalSupply',
       params: [],
-      value: {
-        total: 1000000,
-        circulating: 100000,
-        nonCirculating: 900000,
-        nonCirculatingAccounts: [new Account().publicKey.toBase58()],
-      },
-      withContext: true,
+      value: 1000000,
     });
 
     const count = await connection.getTotalSupply();
@@ -603,50 +597,9 @@ describe('Connection', () => {
 
     // getConfirmedSignaturesForAddress tests...
     await mockRpcResponse({
-      method: 'getFirstAvailableBlock',
-      params: [],
-      value: 0,
-    });
-    const mockSignature =
-      '5SHZ9NwpnS9zYnauN7pnuborKf39zGMr11XpMC59VvRSeDJNcnYLecmdxXCVuBFPNQLdCBBjyZiNCL4KoHKr3tvz';
-    await mockRpcResponse({
-      method: 'getConfirmedBlock',
-      params: [slot, {transactionDetails: 'signatures', rewards: false}],
-      value: {
-        blockTime: 1614281964,
-        blockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
-        previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
-        parentSlot: 1,
-        signatures: [mockSignature],
-      },
-    });
-    await mockRpcResponse({
-      method: 'getSlot',
-      params: [],
-      value: 123,
-    });
-    await mockRpcResponse({
-      method: 'getConfirmedBlock',
-      params: [slot + 2, {transactionDetails: 'signatures', rewards: false}],
-      value: {
-        blockTime: 1614281964,
-        blockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
-        previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
-        parentSlot: 1,
-        signatures: [mockSignature],
-      },
-    });
-    await mockRpcResponse({
-      method: 'getConfirmedSignaturesForAddress2',
-      params: [address.toBase58(), {before: mockSignature}],
-      value: [
-        {
-          signature: expectedSignature,
-          slot,
-          err: null,
-          memo: null,
-        },
-      ],
+      method: 'getConfirmedSignaturesForAddress',
+      params: [address.toBase58(), slot, slot + 1],
+      value: [expectedSignature],
     });
 
     const confirmedSignatures = await connection.getConfirmedSignaturesForAddress(
@@ -658,17 +611,17 @@ describe('Connection', () => {
 
     const badSlot = Number.MAX_SAFE_INTEGER - 1;
     await mockRpcResponse({
-      method: 'getConfirmedBlock',
-      params: [badSlot - 1, {transactionDetails: 'signatures', rewards: false}],
-      error: {message: 'Block not available for slot ' + badSlot},
+      method: 'getConfirmedSignaturesForAddress',
+      params: [address.toBase58(), badSlot, badSlot + 1],
+      value: [],
     });
-    expect(
-      connection.getConfirmedSignaturesForAddress(
-        address,
-        badSlot,
-        badSlot + 1,
-      ),
-    ).to.be.rejected;
+
+    const emptySignatures = await connection.getConfirmedSignaturesForAddress(
+      address,
+      badSlot,
+      badSlot + 1,
+    );
+    expect(emptySignatures).to.have.length(0);
 
     // getConfirmedSignaturesForAddress2 tests...
     await mockRpcResponse({
@@ -1330,94 +1283,6 @@ describe('Connection', () => {
     });
     await expect(
       connection.getConfirmedBlock(Number.MAX_SAFE_INTEGER),
-    ).to.be.rejectedWith(
-      `Block not available for slot ${Number.MAX_SAFE_INTEGER}`,
-    );
-  });
-
-  it('get confirmed block signatures', async () => {
-    await mockRpcResponse({
-      method: 'getSlot',
-      params: [],
-      value: 1,
-    });
-
-    while ((await connection.getSlot()) <= 0) {
-      continue;
-    }
-
-    await mockRpcResponse({
-      method: 'getConfirmedBlock',
-      params: [
-        0,
-        {
-          transactionDetails: 'signatures',
-          rewards: false,
-        },
-      ],
-      value: {
-        blockTime: 1614281964,
-        blockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
-        previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
-        parentSlot: 0,
-        signatures: [],
-      },
-    });
-
-    // Block 0 never has any transactions in test validator
-    const block0 = await connection.getConfirmedBlockSignatures(0);
-    const blockhash0 = block0.blockhash;
-    expect(block0.signatures).to.have.length(0);
-    expect(blockhash0).not.to.be.null;
-    expect(block0.previousBlockhash).not.to.be.null;
-    expect(block0.parentSlot).to.eq(0);
-    expect(block0).to.not.have.property('rewards');
-
-    await mockRpcResponse({
-      method: 'getConfirmedBlock',
-      params: [
-        1,
-        {
-          transactionDetails: 'signatures',
-          rewards: false,
-        },
-      ],
-      value: {
-        blockTime: 1614281964,
-        blockhash: '57zQNBZBEiHsCZFqsaY6h176ioXy5MsSLmcvHkEyaLGy',
-        previousBlockhash: 'H5nJ91eGag3B5ZSRHZ7zG5ZwXJ6ywCt2hyR8xCsV7xMo',
-        parentSlot: 0,
-        signatures: [
-          'w2Zeq8YkpyB463DttvfzARD7k9ZxGEwbsEw4boEK7jDp3pfoxZbTdLFSsEPhzXhpCcjGi2kHtHFobgX49MMhbWt',
-          '4oCEqwGrMdBeMxpzuWiukCYqSfV4DsSKXSiVVCh1iJ6pS772X7y219JZP3mgqBz5PhsvprpKyhzChjYc3VSBQXzG',
-        ],
-      },
-    });
-
-    // Find a block that has a transaction, usually Block 1
-    let x = 1;
-    while (x < 10) {
-      const block1 = await connection.getConfirmedBlockSignatures(x);
-      if (block1.signatures.length >= 1) {
-        expect(block1.previousBlockhash).to.eq(blockhash0);
-        expect(block1.blockhash).not.to.be.null;
-        expect(block1.parentSlot).to.eq(0);
-        expect(block1.signatures[0]).not.to.be.null;
-        expect(block1).to.not.have.property('rewards');
-        break;
-      }
-      x++;
-    }
-
-    await mockRpcResponse({
-      method: 'getConfirmedBlock',
-      params: [Number.MAX_SAFE_INTEGER],
-      error: {
-        message: `Block not available for slot ${Number.MAX_SAFE_INTEGER}`,
-      },
-    });
-    await expect(
-      connection.getConfirmedBlockSignatures(Number.MAX_SAFE_INTEGER),
     ).to.be.rejectedWith(
       `Block not available for slot ${Number.MAX_SAFE_INTEGER}`,
     );


### PR DESCRIPTION
#### Problem
I foolishly used `automerge` on #16534 , which squashed the commits and prevented the release automation in solana-web3.js repo.

#### Summary of Changes
Revert squashed commit, to be redone and rebased-and-merged (doing separately, since CI is confused by the 0 changeset)
