### PR TITLE
redo: deprecate getTotalSupply and getConfirmedSignaturesForAddress 

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -2308,15 +2308,16 @@ export class Connection {
 
   /**
    * Fetch the current total currency supply of the cluster in lamports
+   * @deprecated Deprecated since v1.2.8. Use `Connection.getSupply()` instead.
    */
   async getTotalSupply(commitment?: Commitment): Promise<number> {
     const args = this._buildArgs([], commitment);
-    const unsafeRes = await this._rpcRequest('getTotalSupply', args);
-    const res = create(unsafeRes, jsonRpcResult(number()));
+    const unsafeRes = await this._rpcRequest('getSupply', args);
+    const res = create(unsafeRes, GetSupplyRpcResult);
     if ('error' in res) {
       throw new Error('failed to get total supply: ' + res.error.message);
     }
-    return res.result;
+    return res.result.value.total;
   }
 
   /**

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -492,9 +492,15 @@ describe('Connection', () => {
 
   it('get total supply', async () => {
     await mockRpcResponse({
-      method: 'getTotalSupply',
+      method: 'getSupply',
       params: [],
-      value: 1000000,
+      value: {
+        total: 1000000,
+        circulating: 100000,
+        nonCirculating: 900000,
+        nonCirculatingAccounts: [new Account().publicKey.toBase58()],
+      },
+      withContext: true,
     });
 
     const count = await connection.getTotalSupply();


### PR DESCRIPTION
Redo of #16534 to keep separate commits
