### PR TITLE
Trim extra shred bytes in blockstore

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2944,7 +2944,6 @@ pub(crate) mod tests {
     fn test_dead_fork_entry_deserialize_failure() {
         // Insert entry that causes deserialization failure
         let res = check_dead_fork(|_, _| {
-            let payload_len = SIZE_OF_DATA_SHRED_PAYLOAD;
             let gibberish = [0xa5u8; PACKET_DATA_SIZE];
             let mut data_header = DataShredHeader::default();
             data_header.flags |= DATA_COMPLETE_SHRED;
@@ -2957,7 +2956,7 @@ pub(crate) mod tests {
             );
             bincode::serialize_into(
                 &mut shred.payload[SIZE_OF_COMMON_SHRED_HEADER + SIZE_OF_DATA_SHRED_HEADER..],
-                &gibberish[..payload_len],
+                &gibberish[..SIZE_OF_DATA_SHRED_PAYLOAD],
             )
             .unwrap();
             vec![shred]

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -939,6 +939,7 @@ mod tests {
             assert_eq!(shreds[0].slot(), 1);
             assert_eq!(shreds[0].index(), 0);
             shreds[0].payload.push(10);
+            shreds[0].data_header.size = shreds[0].payload.len() as u16;
             blockstore
                 .insert_shreds(shreds, None, false)
                 .expect("Expect successful ledger write");

--- a/core/src/serve_repair.rs
+++ b/core/src/serve_repair.rs
@@ -611,9 +611,7 @@ mod tests {
     use solana_ledger::{
         blockstore::make_many_slot_entries,
         blockstore_processor::fill_blockstore_slot_with_ticks,
-        shred::{
-            max_ticks_per_n_shreds, CodingShredHeader, DataShredHeader, Shred, ShredCommonHeader,
-        },
+        shred::{max_ticks_per_n_shreds, Shred},
     };
     use solana_perf::packet::Packet;
     use solana_sdk::{hash::Hash, pubkey::Pubkey, timing::timestamp};
@@ -726,23 +724,10 @@ mod tests {
                 nonce,
             );
             assert!(rv.is_none());
-            let common_header = ShredCommonHeader {
-                slot,
-                index: 1,
-                ..ShredCommonHeader::default()
-            };
-            let data_header = DataShredHeader {
-                parent_offset: 1,
-                ..DataShredHeader::default()
-            };
-            let shred_info = Shred::new_empty_from_header(
-                common_header,
-                data_header,
-                CodingShredHeader::default(),
-            );
+            let shred = Shred::new_from_data(slot, 1, 1, None, false, false, 0, 2, 0);
 
             blockstore
-                .insert_shreds(vec![shred_info], None, false)
+                .insert_shreds(vec![shred], None, false)
                 .expect("Expect successful ledger write");
 
             let index = 1;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1290,6 +1290,10 @@ impl Blockstore {
             false
         };
 
+        if shred.data_header.size == 0 {
+            return false;
+        }
+
         // Check that we do not receive shred_index >= than the last_index
         // for the slot
         let last_index = slot_meta.last_index;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1447,9 +1447,9 @@ impl Blockstore {
     pub fn get_data_shred(&self, slot: Slot, index: u64) -> Result<Option<Vec<u8>>> {
         use crate::shred::SHRED_PAYLOAD_SIZE;
         self.data_shred_cf.get_bytes((slot, index)).map(|data| {
-            data.and_then(|mut d| {
+            data.map(|mut d| {
                 d.resize(cmp::max(d.len(), SHRED_PAYLOAD_SIZE), 0);
-                Some(d)
+                d
             })
         })
     }
@@ -2829,9 +2829,14 @@ impl Blockstore {
                 .expect("fetch from DuplicateSlots column family failed")
         };
 
-        let new_shred = Shred::new_from_serialized_shred(new_shred_raw.to_vec()).unwrap();
+        let mut payload = new_shred_raw.to_vec();
+        payload.resize(
+            std::cmp::max(new_shred_raw.len(), crate::shred::SHRED_PAYLOAD_SIZE),
+            0,
+        );
+        let new_shred = Shred::new_from_serialized_shred(payload).unwrap();
         res.map(|existing_shred| {
-            if existing_shred != new_shred.payload[..new_shred.data_header.size as usize] {
+            if existing_shred != new_shred.payload {
                 Some(existing_shred)
             } else {
                 None
@@ -7505,7 +7510,7 @@ pub mod tests {
                         .get_data_shred(s.slot(), s.index() as u64)
                         .unwrap()
                         .unwrap(),
-                    buf[..s.data_header.size as usize]
+                    buf
                 );
             }
 
@@ -7736,7 +7741,7 @@ pub mod tests {
                     &duplicate_shred.payload,
                     duplicate_shred.is_data()
                 ),
-                Some(shred.payload[..shred.data_header.size as usize].to_vec())
+                Some(shred.payload.to_vec())
             );
             assert!(blockstore
                 .is_shred_duplicate(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1410,7 +1410,10 @@ impl Blockstore {
 
         // Commit step: commit all changes to the mutable structures at once, or none at all.
         // We don't want only a subset of these changes going through.
-        write_batch.put_bytes::<cf::ShredData>((slot, index), &shred.payload)?;
+        write_batch.put_bytes::<cf::ShredData>(
+            (slot, index),
+            &shred.payload[..shred.data_header.size as usize],
+        )?;
         data_index.set_present(index, true);
         let newly_completed_data_sets = update_slot_meta(
             last_in_slot,
@@ -1438,7 +1441,13 @@ impl Blockstore {
     }
 
     pub fn get_data_shred(&self, slot: Slot, index: u64) -> Result<Option<Vec<u8>>> {
-        self.data_shred_cf.get_bytes((slot, index))
+        use crate::shred::SHRED_PAYLOAD_SIZE;
+        self.data_shred_cf.get_bytes((slot, index)).map(|data| {
+            data.and_then(|mut d| {
+                d.resize(cmp::max(d.len(), SHRED_PAYLOAD_SIZE), 0);
+                Some(d)
+            })
+        })
     }
 
     pub fn get_data_shreds_for_slot(
@@ -2805,7 +2814,7 @@ impl Blockstore {
         &self,
         slot: u64,
         index: u32,
-        new_shred: &[u8],
+        new_shred_raw: &[u8],
         is_data: bool,
     ) -> Option<Vec<u8>> {
         let res = if is_data {
@@ -2816,8 +2825,9 @@ impl Blockstore {
                 .expect("fetch from DuplicateSlots column family failed")
         };
 
+        let new_shred = Shred::new_from_serialized_shred(new_shred_raw.to_vec()).unwrap();
         res.map(|existing_shred| {
-            if existing_shred != new_shred {
+            if existing_shred != new_shred.payload[..new_shred.data_header.size as usize] {
                 Some(existing_shred)
             } else {
                 None
@@ -7491,7 +7501,7 @@ pub mod tests {
                         .get_data_shred(s.slot(), s.index() as u64)
                         .unwrap()
                         .unwrap(),
-                    buf
+                    buf[..s.data_header.size as usize]
                 );
             }
 
@@ -7722,7 +7732,7 @@ pub mod tests {
                     &duplicate_shred.payload,
                     duplicate_shred.is_data()
                 ),
-                Some(shred.payload.clone())
+                Some(shred.payload[..shred.data_header.size as usize].to_vec())
             );
             assert!(blockstore
                 .is_shred_duplicate(

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -398,7 +398,6 @@ impl Shred {
                 &data_header,
             )
             .expect("Failed to write data header into shred buffer");
-            assert!(data_header.size as usize >= start);
         } else if common_header.shred_type == ShredType(CODING_SHRED) {
             Self::serialize_obj_into(
                 &mut start,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -319,11 +319,10 @@ impl Shred {
             Self::deserialize_obj(&mut start, SIZE_OF_COMMON_SHRED_HEADER, &payload)?;
 
         let slot = common_header.slot;
-        let expected_data_size = SHRED_PAYLOAD_SIZE;
         // Shreds should be padded out to SHRED_PAYLOAD_SIZE
         // so that erasure generation/recovery works correctly
         // But only the data_header.size is stored in blockstore.
-        payload.resize(expected_data_size, 0);
+        payload.resize(SHRED_PAYLOAD_SIZE, 0);
         let shred = if common_header.shred_type == ShredType(CODING_SHRED) {
             let coding_header: CodingShredHeader =
                 Self::deserialize_obj(&mut start, SIZE_OF_CODING_SHRED_HEADER, &payload)?;

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -407,6 +407,7 @@ impl Shred {
             )
             .expect("Failed to write data header into shred buffer");
         }
+        assert!(data_header.size as usize >= start);
         Shred {
             common_header,
             data_header,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -398,6 +398,7 @@ impl Shred {
                 &data_header,
             )
             .expect("Failed to write data header into shred buffer");
+            assert!(data_header.size as usize >= start);
         } else if common_header.shred_type == ShredType(CODING_SHRED) {
             Self::serialize_obj_into(
                 &mut start,
@@ -407,7 +408,6 @@ impl Shred {
             )
             .expect("Failed to write data header into shred buffer");
         }
-        assert!(data_header.size as usize >= start);
         Shred {
             common_header,
             data_header,

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -216,11 +216,12 @@ impl Shred {
     where
         T: Deserialize<'de>,
     {
+        let end = std::cmp::min(*index + size, buf.len());
         let ret = bincode::options()
             .with_limit(PACKET_DATA_SIZE as u64)
             .with_fixint_encoding()
             .allow_trailing_bytes()
-            .deserialize(&buf[*index..*index + size])?;
+            .deserialize(&buf[*index..end])?;
         *index += size;
         Ok(ret)
     }
@@ -319,14 +320,10 @@ impl Shred {
 
         let slot = common_header.slot;
         let expected_data_size = SHRED_PAYLOAD_SIZE;
-        // Safe because any payload from the network must have passed through
-        // window service,  which implies payload wll be of size
-        // PACKET_DATA_SIZE, and `expected_data_size` <= PACKET_DATA_SIZE.
-        //
-        // On the other hand, if this function is called locally, the payload size should match
-        // the `expected_data_size`.
-        assert!(payload.len() >= expected_data_size);
-        payload.truncate(expected_data_size);
+        // Shreds should be padded out to SHRED_PAYLOAD_SIZE
+        // so that erasure generation/recovery works correctly
+        // But only the data_header.size is stored in blockstore.
+        payload.resize(expected_data_size, 0);
         let shred = if common_header.shred_type == ShredType(CODING_SHRED) {
             let coding_header: CodingShredHeader =
                 Self::deserialize_obj(&mut start, SIZE_OF_CODING_SHRED_HEADER, &payload)?;


### PR DESCRIPTION
#### Problem
Data shred bytestreams are currently inserted into the blockstore with padded 0's. Every data shred has at least some padded 0's due to there being a "restricted" section at the end of a data shred's payload:
https://github.com/solana-labs/solana/blob/master/ledger/src/shred.rs#L44-L50

Furthermore, data shreds that are not filled to capacity with data will have additional 0-padding to get to fill up the packet.

The result of these two items is that the blockstore is getting bloated with extraneous bytes.

#### Summary of Changes
Trim the extra padding bytes off of the shred on insertion; "re-expand" the bytestream when retrieving from the blockstore to avoid breaking the erasure coding algorithm (which requires that coding and data shreds are of same length).

Fixes #16236
