### PR TITLE
Wrap derivation_path::DerivationPath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivation-path"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193388a8c8c75a490b604ff61775e236541b8975e98e5ca1f6ea97d122b7e2db"
+dependencies = [
+ "failure",
+]
+
+[[package]]
 name = "derivative"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5071,6 +5080,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "curve25519-dalek 2.1.0",
+ "derivation-path",
  "digest 0.9.0",
  "ed25519-dalek",
  "generic-array 0.14.3",

--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -677,6 +677,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivation-path"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193388a8c8c75a490b604ff61775e236541b8975e98e5ca1f6ea97d122b7e2db"
+dependencies = [
+ "failure",
+]
+
+[[package]]
 name = "derivative"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +852,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.6",
+ "syn 1.0.67",
+ "synstructure",
 ]
 
 [[package]]
@@ -3416,6 +3446,7 @@ dependencies = [
  "bv",
  "byteorder 1.3.4",
  "chrono",
+ "derivation-path",
  "digest 0.9.0",
  "ed25519-dalek",
  "generic-array 0.14.3",

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -6,7 +6,7 @@ use {
     log::*,
     parking_lot::{Mutex, RwLock},
     solana_sdk::{
-        derivation_path::{DerivationPath, DerivationPathError},
+        derivation_path::{DerivationPath, DerivationPathError, Solana},
         pubkey::Pubkey,
         signature::{Signature, SignerError},
     },
@@ -291,7 +291,7 @@ impl RemoteWalletInfo {
                         if key_path.ends_with('/') {
                             key_path.pop();
                         }
-                        derivation_path = DerivationPath::from_key_str(key_path)?;
+                        derivation_path = DerivationPath::from_key_str(key_path, Solana)?;
                     } else {
                         return Err(DerivationPathError::InvalidDerivationPath(format!(
                             "invalid query string `{}={}`, only `key` supported",
@@ -364,7 +364,7 @@ mod tests {
         }));
         assert_eq!(
             derivation_path,
-            DerivationPath::new_bip44_solana(Some(1), Some(2))
+            DerivationPath::new_bip44(Solana, Some(1), Some(2))
         );
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1'/2'", pubkey)).unwrap();
@@ -378,7 +378,7 @@ mod tests {
         }));
         assert_eq!(
             derivation_path,
-            DerivationPath::new_bip44_solana(Some(1), Some(2))
+            DerivationPath::new_bip44(Solana, Some(1), Some(2))
         );
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1\'/2\'", pubkey)).unwrap();
@@ -392,7 +392,7 @@ mod tests {
         }));
         assert_eq!(
             derivation_path,
-            DerivationPath::new_bip44_solana(Some(1), Some(2))
+            DerivationPath::new_bip44(Solana, Some(1), Some(2))
         );
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1/2/", pubkey)).unwrap();
@@ -406,7 +406,7 @@ mod tests {
         }));
         assert_eq!(
             derivation_path,
-            DerivationPath::new_bip44_solana(Some(1), Some(2))
+            DerivationPath::new_bip44(Solana, Some(1), Some(2))
         );
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1/", pubkey)).unwrap();
@@ -420,7 +420,7 @@ mod tests {
         }));
         assert_eq!(
             derivation_path,
-            DerivationPath::new_bip44_solana(Some(1), None)
+            DerivationPath::new_bip44(Solana, Some(1), None)
         );
 
         // Test that wallet id need not be complete for key derivation to work
@@ -436,7 +436,7 @@ mod tests {
         }));
         assert_eq!(
             derivation_path,
-            DerivationPath::new_bip44_solana(Some(1), None)
+            DerivationPath::new_bip44(Solana, Some(1), None)
         );
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path("usb://ledger/?key=1/2".to_string()).unwrap();
@@ -450,7 +450,7 @@ mod tests {
         }));
         assert_eq!(
             derivation_path,
-            DerivationPath::new_bip44_solana(Some(1), Some(2))
+            DerivationPath::new_bip44(Solana, Some(1), Some(2))
         );
 
         // Failure cases

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -6,7 +6,7 @@ use {
     log::*,
     parking_lot::{Mutex, RwLock},
     solana_sdk::{
-        derivation_path::{DerivationPath, DerivationPathError, Solana},
+        derivation_path::{DerivationPath, DerivationPathError},
         pubkey::Pubkey,
         signature::{Signature, SignerError},
     },
@@ -291,7 +291,7 @@ impl RemoteWalletInfo {
                         if key_path.ends_with('/') {
                             key_path.pop();
                         }
-                        derivation_path = DerivationPath::from_key_str(key_path, Solana)?;
+                        derivation_path = DerivationPath::from_key_str(key_path)?;
                     } else {
                         return Err(DerivationPathError::InvalidDerivationPath(format!(
                             "invalid query string `{}={}`, only `key` supported",
@@ -362,10 +362,7 @@ mod tests {
             pubkey,
             error: None,
         }));
-        assert_eq!(
-            derivation_path,
-            DerivationPath::new_bip44(Solana, Some(1), Some(2))
-        );
+        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), Some(2)));
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1'/2'", pubkey)).unwrap();
         assert!(wallet_info.matches(&RemoteWalletInfo {
@@ -376,10 +373,7 @@ mod tests {
             pubkey,
             error: None,
         }));
-        assert_eq!(
-            derivation_path,
-            DerivationPath::new_bip44(Solana, Some(1), Some(2))
-        );
+        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), Some(2)));
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1\'/2\'", pubkey)).unwrap();
         assert!(wallet_info.matches(&RemoteWalletInfo {
@@ -390,10 +384,7 @@ mod tests {
             pubkey,
             error: None,
         }));
-        assert_eq!(
-            derivation_path,
-            DerivationPath::new_bip44(Solana, Some(1), Some(2))
-        );
+        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), Some(2)));
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1/2/", pubkey)).unwrap();
         assert!(wallet_info.matches(&RemoteWalletInfo {
@@ -404,10 +395,7 @@ mod tests {
             pubkey,
             error: None,
         }));
-        assert_eq!(
-            derivation_path,
-            DerivationPath::new_bip44(Solana, Some(1), Some(2))
-        );
+        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), Some(2)));
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path(format!("usb://ledger/{:?}?key=1/", pubkey)).unwrap();
         assert!(wallet_info.matches(&RemoteWalletInfo {
@@ -418,10 +406,7 @@ mod tests {
             pubkey,
             error: None,
         }));
-        assert_eq!(
-            derivation_path,
-            DerivationPath::new_bip44(Solana, Some(1), None)
-        );
+        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), None));
 
         // Test that wallet id need not be complete for key derivation to work
         let (wallet_info, derivation_path) =
@@ -434,10 +419,7 @@ mod tests {
             pubkey: Pubkey::default(),
             error: None,
         }));
-        assert_eq!(
-            derivation_path,
-            DerivationPath::new_bip44(Solana, Some(1), None)
-        );
+        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), None));
         let (wallet_info, derivation_path) =
             RemoteWalletInfo::parse_path("usb://ledger/?key=1/2".to_string()).unwrap();
         assert!(wallet_info.matches(&RemoteWalletInfo {
@@ -448,10 +430,7 @@ mod tests {
             pubkey: Pubkey::default(),
             error: None,
         }));
-        assert_eq!(
-            derivation_path,
-            DerivationPath::new_bip44(Solana, Some(1), Some(2))
-        );
+        assert_eq!(derivation_path, DerivationPath::new_bip44(Some(1), Some(2)));
 
         // Failure cases
         assert!(

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -43,6 +43,7 @@ bv = { version = "0.11.1", features = ["serde"] }
 byteorder = { version = "1.3.4", optional = true }
 chrono = { version = "0.4", optional = true }
 curve25519-dalek = { version = "2.1.0", optional = true }
+derivation-path = { version = "0.1.3", default-features = false }
 generic-array = { version = "0.14.3", default-features = false, features = ["serde", "more_lengths"], optional = true }
 hex = "0.4.2"
 hmac = "0.10.1"

--- a/sdk/src/derivation_path.rs
+++ b/sdk/src/derivation_path.rs
@@ -1,7 +1,13 @@
 use {
-    std::{fmt, str::FromStr},
+    derivation_path::{ChildIndex, DerivationPath as DerivationPathInner},
+    std::fmt,
     thiserror::Error,
 };
+
+const BIP_44_PURPOSE: u32 = 44; // not yet hardened
+const BIP_44_COIN_SOL: u32 = 501; // not yet hardened
+const ACCOUNT_INDEX: usize = 2;
+const CHANGE_INDEX: usize = 3;
 
 /// Derivation path error.
 #[derive(Error, Debug, Clone)]
@@ -10,85 +16,64 @@ pub enum DerivationPathError {
     InvalidDerivationPath(String),
 }
 
-#[derive(Clone, Default, PartialEq)]
-pub struct DerivationPathComponent(u32);
+#[derive(PartialEq)]
+pub struct DerivationPath(DerivationPathInner);
 
-impl DerivationPathComponent {
-    pub const HARDENED_BIT: u32 = 1 << 31;
-
-    pub fn as_u32(&self) -> u32 {
-        self.0
-    }
-}
-
-impl From<u32> for DerivationPathComponent {
-    fn from(n: u32) -> Self {
-        Self(n | Self::HARDENED_BIT)
-    }
-}
-
-impl FromStr for DerivationPathComponent {
-    type Err = DerivationPathError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let index_str = if let Some(stripped) = s.strip_suffix('\'') {
-            stripped
-        } else {
-            s
-        };
-        index_str.parse::<u32>().map(|ki| ki.into()).map_err(|_| {
-            DerivationPathError::InvalidDerivationPath(format!(
-                "failed to parse path component: {:?}",
-                s
-            ))
-        })
-    }
-}
-
-impl std::fmt::Display for DerivationPathComponent {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let hardened = if (self.0 & Self::HARDENED_BIT) == 0 {
-            ""
-        } else {
-            "'"
-        };
-        let index = self.0 & !Self::HARDENED_BIT;
-        write!(fmt, "{}{}", index, hardened)
-    }
-}
-
-impl std::fmt::Debug for DerivationPathComponent {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(self, fmt)
-    }
-}
-
-#[derive(Default, PartialEq, Clone)]
-pub struct DerivationPath {
-    pub account: Option<DerivationPathComponent>,
-    pub change: Option<DerivationPathComponent>,
-}
-
-impl fmt::Debug for DerivationPath {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let account = if let Some(account) = &self.account {
-            format!("/{:?}", account)
-        } else {
-            "".to_string()
-        };
-        let change = if let Some(change) = &self.change {
-            format!("/{:?}", change)
-        } else {
-            "".to_string()
-        };
-        write!(f, "m/44'/501'{}{}", account, change)
+impl Default for DerivationPath {
+    fn default() -> Self {
+        Self::new_bip44_solana(None, None)
     }
 }
 
 impl DerivationPath {
+    fn new<P: Into<Box<[ChildIndex]>>>(path: P) -> Self {
+        Self(DerivationPathInner::new(path))
+    }
+
+    pub fn from_key_str(path: &str) -> Result<Self, DerivationPathError> {
+        let mut indexes = bip44_solana_indexes();
+        let mut parts = path.split('/');
+        if let Some(account) = parts.next() {
+            indexes.push(child_index_from_str(account)?);
+        }
+        if let Some(change) = parts.next() {
+            indexes.push(child_index_from_str(change)?);
+        }
+        if parts.next().is_some() {
+            return Err(DerivationPathError::InvalidDerivationPath(format!(
+                "key path `{}` too deep, only <account>/<change> supported",
+                path
+            )));
+        }
+        Ok(Self::new(indexes))
+    }
+
+    pub fn new_bip44_solana(account: Option<u32>, change: Option<u32>) -> Self {
+        let mut indexes = bip44_solana_indexes();
+        if let Some(account) = account {
+            indexes.push(ChildIndex::Hardened(account));
+            if let Some(change) = change {
+                indexes.push(ChildIndex::Hardened(change));
+            }
+        }
+        Self::new(indexes)
+    }
+
+    pub fn account(&self) -> Option<&ChildIndex> {
+        self.0.path().get(ACCOUNT_INDEX)
+    }
+
+    pub fn change(&self) -> Option<&ChildIndex> {
+        self.0.path().get(CHANGE_INDEX)
+    }
+
+    pub fn path(&self) -> &[ChildIndex] {
+        self.0.path()
+    }
+
     pub fn get_query(&self) -> String {
-        if let Some(account) = &self.account {
-            if let Some(change) = &self.change {
+        if let Some(account) = &self.account() {
+            if let Some(change) = &self.change() {
                 format!("?key={}/{}", account, change)
             } else {
                 format!("?key={}", account)
@@ -99,65 +84,112 @@ impl DerivationPath {
     }
 }
 
+impl fmt::Debug for DerivationPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "m")?;
+        for index in self.0.path() {
+            write!(f, "/{}", index)?;
+        }
+        Ok(())
+    }
+}
+
+fn bip44_solana_indexes() -> Vec<ChildIndex> {
+    vec![
+        ChildIndex::Hardened(BIP_44_PURPOSE),
+        ChildIndex::Hardened(BIP_44_COIN_SOL),
+    ]
+}
+
+fn child_index_from_str(s: &str) -> Result<ChildIndex, DerivationPathError> {
+    let index_str = if let Some(stripped) = s.strip_suffix('\'') {
+        stripped
+    } else {
+        s
+    };
+    let index = index_str.parse::<u32>().map_err(|_| {
+        DerivationPathError::InvalidDerivationPath(format!(
+            "failed to parse path component: {:?}",
+            s
+        ))
+    })?;
+    Ok(ChildIndex::Hardened(index))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
+    fn test_from_key_str() {
+        let s = "1/2";
+        assert_eq!(
+            DerivationPath::from_key_str(s).unwrap(),
+            DerivationPath::new_bip44_solana(Some(1), Some(2))
+        );
+        let s = "1'/2'";
+        assert_eq!(
+            DerivationPath::from_key_str(s).unwrap(),
+            DerivationPath::new_bip44_solana(Some(1), Some(2))
+        );
+        let s = "1\'/2\'";
+        assert_eq!(
+            DerivationPath::from_key_str(s).unwrap(),
+            DerivationPath::new_bip44_solana(Some(1), Some(2))
+        );
+        let s = "1";
+        assert_eq!(
+            DerivationPath::from_key_str(s).unwrap(),
+            DerivationPath::new_bip44_solana(Some(1), None)
+        );
+        let s = "1'";
+        assert_eq!(
+            DerivationPath::from_key_str(s).unwrap(),
+            DerivationPath::new_bip44_solana(Some(1), None)
+        );
+        let s = "1\'";
+        assert_eq!(
+            DerivationPath::from_key_str(s).unwrap(),
+            DerivationPath::new_bip44_solana(Some(1), None)
+        );
+
+        assert!(DerivationPath::from_key_str("other").is_err());
+        assert!(DerivationPath::from_key_str("1o").is_err());
+    }
+
+    #[test]
     fn test_get_query() {
-        let derivation_path = DerivationPath {
-            account: None,
-            change: None,
-        };
+        let derivation_path = DerivationPath::new_bip44_solana(None, None);
         assert_eq!(derivation_path.get_query(), "".to_string());
-        let derivation_path = DerivationPath {
-            account: Some(1.into()),
-            change: None,
-        };
-        assert_eq!(
-            derivation_path.get_query(),
-            format!("?key={}", DerivationPathComponent::from(1))
-        );
-        let derivation_path = DerivationPath {
-            account: Some(1.into()),
-            change: Some(2.into()),
-        };
-        assert_eq!(
-            derivation_path.get_query(),
-            format!(
-                "?key={}/{}",
-                DerivationPathComponent::from(1),
-                DerivationPathComponent::from(2)
-            )
-        );
+        let derivation_path = DerivationPath::new_bip44_solana(Some(1), None);
+        assert_eq!(derivation_path.get_query(), "?key=1'".to_string());
+        let derivation_path = DerivationPath::new_bip44_solana(Some(1), Some(2));
+        assert_eq!(derivation_path.get_query(), "?key=1'/2'".to_string());
     }
 
     #[test]
     fn test_derivation_path_debug() {
-        let mut path = DerivationPath::default();
+        let path = DerivationPath::default();
         assert_eq!(format!("{:?}", path), "m/44'/501'".to_string());
 
-        path.account = Some(1.into());
+        let path = DerivationPath::new_bip44_solana(Some(1), None);
         assert_eq!(format!("{:?}", path), "m/44'/501'/1'".to_string());
 
-        path.change = Some(2.into());
+        let path = DerivationPath::new_bip44_solana(Some(1), Some(2));
         assert_eq!(format!("{:?}", path), "m/44'/501'/1'/2'".to_string());
     }
 
     #[test]
-    fn test_derivation_path_component() {
-        let f = DerivationPathComponent::from(1);
-        assert_eq!(f.as_u32(), 1 | DerivationPathComponent::HARDENED_BIT);
-
-        let fs = DerivationPathComponent::from_str("1").unwrap();
-        assert_eq!(fs, f);
-
-        let fs = DerivationPathComponent::from_str("1'").unwrap();
-        assert_eq!(fs, f);
-
-        assert!(DerivationPathComponent::from_str("-1").is_err());
-
-        assert_eq!(format!("{}", f), "1'".to_string());
-        assert_eq!(format!("{:?}", f), "1'".to_string());
+    fn test_child_index_from_str() {
+        let s = "1";
+        assert_eq!(child_index_from_str(s).unwrap(), ChildIndex::Hardened(1));
+        let s = "1\'";
+        assert_eq!(child_index_from_str(s).unwrap(), ChildIndex::Hardened(1));
+        let s = "1/";
+        assert!(child_index_from_str(s).is_err());
+        let s = "e";
+        assert!(child_index_from_str(s).is_err());
+        let s = "m";
+        assert!(child_index_from_str(s).is_err());
     }
 }


### PR DESCRIPTION
#### Problem
Sdk/remote-wallet uses a hand-rolled DerivationPath, which makes future integration with ed25519-dalek-bip32 difficult.

#### Summary of Changes
Replace DerivationPath with one that wraps `derivation_path::DerivationPath`
Add helpers for solana bip44 derivation, and derivations from query value strings

Toward #5246 
