### PR TITLE
Documentation typo for langauge

### DIFF
--- a/docs/src/proposals/embedding-move.md
+++ b/docs/src/proposals/embedding-move.md
@@ -1,5 +1,5 @@
 ---
-title: Embedding the Move Langauge
+title: Embedding the Move Language
 ---
 
 ## Problem


### PR DESCRIPTION
#### Problem
The title was "Embedding the Move Langauge"

#### Summary of Changes
Fixes the typo in langauge.