### PR TITLE
replay_stage: send votes to next leader's TPU instead of our TPU

### DIFF
--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -1182,8 +1182,8 @@ impl ClusterInfo {
             .process_push_message(&self_pubkey, vec![vote], now);
     }
 
-    pub fn send_vote(&self, vote: &Transaction) -> Result<()> {
-        let tpu = self.my_contact_info().tpu;
+    pub fn send_vote(&self, vote: &Transaction, tpu: Option<SocketAddr>) -> Result<()> {
+        let tpu = tpu.unwrap_or_else(|| self.my_contact_info().tpu);
         let buf = serialize(vote)?;
         self.socket.send_to(&buf, &tpu)?;
         Ok(())

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -526,6 +526,7 @@ impl ReplayStage {
 
                         Self::handle_votable_bank(
                             &vote_bank,
+                            &poh_recorder,
                             switch_fork_decision,
                             &bank_forks,
                             &mut tower,
@@ -1250,6 +1251,7 @@ impl ReplayStage {
     #[allow(clippy::too_many_arguments)]
     fn handle_votable_bank(
         bank: &Arc<Bank>,
+        poh_recorder: &Arc<Mutex<PohRecorder>>,
         switch_fork_decision: &SwitchForkDecision,
         bank_forks: &Arc<RwLock<BankForks>>,
         tower: &mut Tower,
@@ -1350,6 +1352,7 @@ impl ReplayStage {
         Self::push_vote(
             cluster_info,
             bank,
+            poh_recorder,
             vote_account_pubkey,
             authorized_voter_keypairs,
             last_vote,
@@ -1360,9 +1363,11 @@ impl ReplayStage {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn push_vote(
         cluster_info: &ClusterInfo,
         bank: &Arc<Bank>,
+        poh_recorder: &Arc<Mutex<PohRecorder>>,
         vote_account_pubkey: &Pubkey,
         authorized_voter_keypairs: &[Arc<Keypair>],
         vote: Vote,
@@ -1452,7 +1457,10 @@ impl ReplayStage {
             vote_signatures.clear();
         }
 
-        let _ = cluster_info.send_vote(&vote_tx);
+        let _ = cluster_info.send_vote(
+            &vote_tx,
+            crate::banking_stage::next_leader_tpu(cluster_info, poh_recorder),
+        );
         cluster_info.push_vote(tower, vote_tx);
     }
 


### PR DESCRIPTION
ReplayStage currently sends votes to the node's TPU, which in almost all cases guarantees that the vote will need to be forwarded by BankingStage to the next leader.  Avoid this hop and send votes directly at the next leader from ReplayStage