### PR TITLE
rename threads: 15 char limit

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -43,7 +43,7 @@ impl AccountsHashVerifier {
         let exit = exit.clone();
         let cluster_info = cluster_info.clone();
         let t_accounts_hash_verifier = Builder::new()
-            .name("solana-accounts-hash".to_string())
+            .name("solana-hash-accounts".to_string())
             .spawn(move || {
                 let mut hashes = vec![];
                 let mut thread_pool_storage = None;

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -295,7 +295,7 @@ impl AccountsBackgroundService {
         let mut total_remove_slots_time = 0;
         let mut last_expiration_check_time = Instant::now();
         let t_background = Builder::new()
-            .name("solana-accounts-background".to_string())
+            .name("solana-bg-accounts".to_string())
             .spawn(move || loop {
                 if exit.load(Ordering::Relaxed) {
                     break;

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1050,7 +1050,7 @@ pub fn make_min_priority_thread_pool() -> ThreadPool {
     // Use lower thread count to reduce priority.
     let num_threads = std::cmp::max(2, num_cpus::get() / 4);
     rayon::ThreadPoolBuilder::new()
-        .thread_name(|i| format!("solana-accounts-cleanup-{}", i))
+        .thread_name(|i| format!("solana-cleanup-accounts-{}", i))
         .num_threads(num_threads)
         .build()
         .unwrap()
@@ -1096,7 +1096,7 @@ impl Default for AccountsDb {
             file_size: DEFAULT_FILE_SIZE,
             thread_pool: rayon::ThreadPoolBuilder::new()
                 .num_threads(num_threads)
-                .thread_name(|i| format!("solana-accounts-db-{}", i))
+                .thread_name(|i| format!("solana-db-accounts-{}", i))
                 .build()
                 .unwrap(),
             thread_pool_clean: make_min_priority_thread_pool(),
@@ -1337,7 +1337,7 @@ impl AccountsDb {
     fn start_background_hasher(&mut self) {
         let (sender, receiver) = unbounded();
         Builder::new()
-            .name("solana-accounts-db-store-hasher".to_string())
+            .name("solana-db-store-hasher-accounts".to_string())
             .spawn(move || {
                 Self::background_hasher(receiver);
             })


### PR DESCRIPTION
#### Problem
It appears linux has a 15 char limit on thread names. Tools like htop and ps both indicate this to be true. The result is many types of account threads appear as solana-accounts. This loses unique information.

#### Summary of Changes
Reorder words in the thread names.

Fixes #
