### PR TITLE
Add --sort argument to `solana validators`

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -378,12 +378,9 @@ impl fmt::Display for CliValidators {
         }
 
         let padding = ((self.validators.len() + 1) as f64).log10().floor() as usize + 1;
-        write!(f, "{:padding$}", " ", padding = padding)?;
-        writeln!(
-            f,
-            "{}",
-            style(format!(
-                "  {:<44}  {:<38}  {}  {}  {} {:>11} {:^7}  {}",
+        let header = style(format!(
+                "{:padding$}  {:<44}  {:<38}  {}  {}  {} {:>11} {:^7}  {}",
+                " ",
                 "Identity",
                 "Vote Account",
                 "Commission",
@@ -392,9 +389,10 @@ impl fmt::Display for CliValidators {
                 "Epoch Credits",
                 "Version",
                 "Active Stake",
+                padding = padding
             ))
-            .bold()
-        )?;
+            .bold();
+        writeln!(f, "{}", header)?;
 
         let mut sorted_validators = self.validators.clone();
         match self.validators_sort_order {
@@ -436,6 +434,11 @@ impl fmt::Display for CliValidators {
                 self.total_active_stake,
                 self.use_lamports_unit,
             )?;
+        }
+
+        // The actual header has long scrolled away.  Print the header once more as a footer
+        if self.validators.len() > 100 {
+            writeln!(f, "{}", header)?;
         }
 
         writeln!(f)?;

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -376,6 +376,9 @@ impl fmt::Display for CliValidators {
                 },
             )
         }
+
+        let padding = ((self.validators.len() + 1) as f64).log10().floor() as usize + 1;
+        write!(f, "{:padding$}", " ", padding = padding)?;
         writeln!(
             f,
             "{}",
@@ -425,7 +428,8 @@ impl fmt::Display for CliValidators {
             sorted_validators.reverse();
         }
 
-        for validator in &sorted_validators {
+        for (i, validator) in sorted_validators.iter().enumerate() {
+            write!(f, "{:padding$}", i + 1, padding = padding)?;
             write_vote_account(
                 f,
                 validator,

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -326,6 +326,8 @@ pub struct CliValidators {
     pub validators_sort_order: CliValidatorsSortOrder,
     #[serde(skip_serializing)]
     pub validators_reverse_sort: bool,
+    #[serde(skip_serializing)]
+    pub number_validators: bool,
     pub stake_by_version: BTreeMap<String, CliValidatorsStakeByVersion>,
     #[serde(skip_serializing)]
     pub use_lamports_unit: bool,
@@ -377,21 +379,25 @@ impl fmt::Display for CliValidators {
             )
         }
 
-        let padding = ((self.validators.len() + 1) as f64).log10().floor() as usize + 1;
+        let padding = if self.number_validators {
+            ((self.validators.len() + 1) as f64).log10().floor() as usize + 1
+        } else {
+            0
+        };
         let header = style(format!(
-                "{:padding$}  {:<44}  {:<38}  {}  {}  {} {:>11} {:^7}  {}",
-                " ",
-                "Identity",
-                "Vote Account",
-                "Commission",
-                "Last Vote",
-                "Root Block",
-                "Epoch Credits",
-                "Version",
-                "Active Stake",
-                padding = padding
-            ))
-            .bold();
+            "{:padding$} {:<44}  {:<38}  {}  {}  {} {:>11} {:^7}  {}",
+            " ",
+            "Identity",
+            "Vote Account",
+            "Commission",
+            "Last Vote",
+            "Root Block",
+            "Epoch Credits",
+            "Version",
+            "Active Stake",
+            padding = padding + 1
+        ))
+        .bold();
         writeln!(f, "{}", header)?;
 
         let mut sorted_validators = self.validators.clone();
@@ -427,7 +433,9 @@ impl fmt::Display for CliValidators {
         }
 
         for (i, validator) in sorted_validators.iter().enumerate() {
-            write!(f, "{:padding$}", i + 1, padding = padding)?;
+            if padding > 0 {
+                write!(f, "{:padding$}", i + 1, padding = padding)?;
+            }
             write_vote_account(
                 f,
                 validator,

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -358,7 +358,7 @@ impl fmt::Display for CliValidators {
                 if validator.delinquent {
                     WARNING.to_string()
                 } else {
-                    " ".to_string()
+                    "\u{a0}".to_string()
                 },
                 validator.identity_pubkey,
                 validator.vote_account_pubkey,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -133,6 +133,7 @@ pub enum CliCommand {
         use_lamports_unit: bool,
         sort_order: CliValidatorsSortOrder,
         reverse_sort: bool,
+        number_validators: bool,
     },
     Supply {
         print_accounts: bool,
@@ -1385,12 +1386,14 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
             use_lamports_unit,
             sort_order,
             reverse_sort,
+            number_validators,
         } => process_show_validators(
             &rpc_client,
             config,
             *use_lamports_unit,
             *sort_order,
             *reverse_sort,
+            *number_validators,
         ),
         CliCommand::Supply { print_accounts } => {
             process_supply(&rpc_client, config, *print_accounts)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -20,7 +20,8 @@ use solana_clap_utils::{
 use solana_cli_output::{
     display::{build_balance_message, println_name_value},
     return_signers_with_config, CliAccount, CliSignature, CliSignatureVerificationStatus,
-    CliTransaction, CliTransactionConfirmation, OutputFormat, ReturnSignersConfig,
+    CliTransaction, CliTransactionConfirmation, CliValidatorsSortOrder, OutputFormat,
+    ReturnSignersConfig,
 };
 use solana_client::{
     blockhash_query::BlockhashQuery,
@@ -130,6 +131,8 @@ pub enum CliCommand {
     },
     ShowValidators {
         use_lamports_unit: bool,
+        sort_order: CliValidatorsSortOrder,
+        reverse_sort: bool,
     },
     Supply {
         print_accounts: bool,
@@ -1378,9 +1381,17 @@ pub fn process_command(config: &CliConfig) -> ProcessResult {
         CliCommand::WaitForMaxStake { max_stake_percent } => {
             process_wait_for_max_stake(&rpc_client, config, *max_stake_percent)
         }
-        CliCommand::ShowValidators { use_lamports_unit } => {
-            process_show_validators(&rpc_client, config, *use_lamports_unit)
-        }
+        CliCommand::ShowValidators {
+            use_lamports_unit,
+            sort_order,
+            reverse_sort,
+        } => process_show_validators(
+            &rpc_client,
+            config,
+            *use_lamports_unit,
+            *sort_order,
+            *reverse_sort,
+        ),
         CliCommand::Supply { print_accounts } => {
             process_supply(&rpc_client, config, *print_accounts)
         }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -351,6 +351,13 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .help("Display balance in lamports instead of SOL"),
                 )
                 .arg(
+                    Arg::with_name("number")
+                        .long("number")
+                        .short("n")
+                        .takes_value(false)
+                        .help("Number the validators"),
+                )
+                .arg(
                     Arg::with_name("reverse")
                         .long("reverse")
                         .short("r")
@@ -606,6 +613,7 @@ pub fn parse_show_stakes(
 
 pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommandInfo, CliError> {
     let use_lamports_unit = matches.is_present("lamports");
+    let number_validators = matches.is_present("number");
     let reverse_sort = matches.is_present("reverse");
 
     let sort_order = match value_t_or_exit!(matches, "sort", String).as_str() {
@@ -625,6 +633,7 @@ pub fn parse_show_validators(matches: &ArgMatches<'_>) -> Result<CliCommandInfo,
             use_lamports_unit,
             sort_order,
             reverse_sort,
+            number_validators,
         },
         signers: vec![],
     })
@@ -1773,6 +1782,7 @@ pub fn process_show_validators(
     use_lamports_unit: bool,
     validators_sort_order: CliValidatorsSortOrder,
     validators_reverse_sort: bool,
+    number_validators: bool,
 ) -> ProcessResult {
     let epoch_info = rpc_client.get_epoch_info()?;
     let vote_accounts = rpc_client.get_vote_accounts()?;
@@ -1859,6 +1869,7 @@ pub fn process_show_validators(
             .collect(),
         validators_sort_order,
         validators_reverse_sort,
+        number_validators,
         stake_by_version,
         use_lamports_unit,
     };


### PR DESCRIPTION
`solana validators` sorts only based on the active stake.  Add all the sorts:
```
        --sort <sort>                      Sort order [default: stake]  [possible values: delinquent, commission,
                                           credits, identity, last-vote, root, stake, vote-account]
```
and:
```
    -r, --reverse                        Reverse order while sorting
```


Note: this PR changes the default behaviour of `solana validators` to list from lowest to highest staked nodes instead.  