### PR TITLE
cargo-install-all.sh: on Mac OS X, use greadlink instead of readlink

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -3,7 +3,14 @@
 # |cargo install| of the top-level crate will not install binaries for
 # other workspace crates or native program crates.
 here="$(dirname "$0")"
-cargo="$(readlink -f "${here}/../cargo")"
+
+# Mac OS X's version of `readlink` does not support the -f option.
+# But `greadlink` does, which you can get with `brew install coreutils`
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Darwin*)    cargo="$(greadlink -f "${here}/../cargo")";;
+    *)          cargo="$(readlink -f "${here}/../cargo")"
+esac
 
 set -e
 

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
-
+#
+# |cargo install| of the top-level crate will not install binaries for
+# other workspace crates or native program crates.
+here="$(dirname "$0")"
 readlink_cmd="readlink"
 if [[ $OSTYPE == darwin* ]]; then
   # Mac OS X's version of `readlink` does not support the -f option,
   # But `greadlink` does, which you can get with `brew install coreutils`
   readlink_cmd="greadlink"
 fi
-
-# |cargo install| of the top-level crate will not install binaries for
-# other workspace crates or native program crates.
-here="$(dirname "$0")"
 cargo="$("${readlink_cmd}" -f "${here}/../cargo")"
 
 set -e

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
-#
+
+readlink_cmd="readlink"
+if [[ $OSTYPE == darwin* ]]; then
+  # Mac OS X's version of `readlink` does not support the -f option,
+  # But `greadlink` does, which you can get with `brew install coreutils`
+  readlink_cmd="greadlink"
+fi
+
 # |cargo install| of the top-level crate will not install binaries for
 # other workspace crates or native program crates.
 here="$(dirname "$0")"
-
-# Mac OS X's version of `readlink` does not support the -f option.
-# But `greadlink` does, which you can get with `brew install coreutils`
-unameOut="$(uname -s)"
-case "${unameOut}" in
-    Darwin*)    cargo="$(greadlink -f "${here}/../cargo")";;
-    *)          cargo="$(readlink -f "${here}/../cargo")"
-esac
+cargo="$("${readlink_cmd}" -f "${here}/../cargo")"
 
 set -e
 


### PR DESCRIPTION
#### Problem
Installing the Solana CLI from source on Mac fails because Mac's version of `readlink` does not support the `-f` flag

#### Summary of Changes
On Macs, use `greadlink`, which is a tool that directly mirrors Linux `readlink` functionality on Mac. Building `v1.6.6` works locally using the script after this change

Fixes #
No issues, this is just a minor thing I came across when building from source
