### PR TITLE
removes first_coding_index from erasure recovery code

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -152,9 +152,8 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
             coding_shreds[..].to_vec(),
             symbol_count,
             symbol_count,
-            0,
-            0,
-            1,
+            0, // first index
+            1, // slot
         )
         .unwrap();
     })

--- a/core/src/cluster_info.rs
+++ b/core/src/cluster_info.rs
@@ -3516,7 +3516,6 @@ mod tests {
     use itertools::izip;
     use rand::{seq::SliceRandom, SeedableRng};
     use rand_chacha::ChaChaRng;
-    use serial_test::serial;
     use solana_ledger::shred::Shredder;
     use solana_sdk::signature::{Keypair, Signer};
     use solana_vote_program::{vote_instruction, vote_state::Vote};
@@ -4787,8 +4786,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
-    #[ignore]
+    #[ignore] // TODO: debug why this is flaky on buildkite!
     fn test_pull_request_time_pruning() {
         let node = Node::new_localhost();
         let cluster_info = Arc::new(ClusterInfo::new_with_invalid_keypair(node.info));

--- a/ledger/tests/shred.rs
+++ b/ledger/tests/shred.rs
@@ -76,7 +76,6 @@ fn test_multi_fec_block_coding() {
             MAX_DATA_SHREDS_PER_FEC_BLOCK as usize,
             MAX_DATA_SHREDS_PER_FEC_BLOCK as usize,
             shred_start_index,
-            shred_start_index,
             slot,
         )
         .unwrap();
@@ -121,6 +120,7 @@ fn test_multi_fec_block_different_size_coding() {
     for (fec_data_shreds, fec_coding_shreds) in fec_data.values().zip(fec_coding.values()) {
         let first_data_index = fec_data_shreds.first().unwrap().index() as usize;
         let first_code_index = fec_coding_shreds.first().unwrap().index() as usize;
+        assert_eq!(first_data_index, first_code_index);
         let num_data = fec_data_shreds.len();
         let num_coding = fec_coding_shreds.len();
         let all_shreds: Vec<Shred> = fec_data_shreds
@@ -129,17 +129,9 @@ fn test_multi_fec_block_different_size_coding() {
             .chain(fec_coding_shreds.iter().step_by(2))
             .cloned()
             .collect();
-
-        let recovered_data = Shredder::try_recovery(
-            all_shreds,
-            num_data,
-            num_coding,
-            first_data_index,
-            first_code_index,
-            slot,
-        )
-        .unwrap();
-
+        let recovered_data =
+            Shredder::try_recovery(all_shreds, num_data, num_coding, first_data_index, slot)
+                .unwrap();
         // Necessary in order to ensure the last shred in the slot
         // is part of the recovered set, and that the below `index`
         // calcuation in the loop is correct


### PR DESCRIPTION
#### Problem
`first_coding_index` is the same as the `set_index` and is so redundant:
https://github.com/solana-labs/solana/blob/37b8587d4/ledger/src/blockstore_meta.rs#L49-L60

#### Summary of Changes
* removed `first_coding_index`