### PR TITLE
Remove unwrap

### DIFF
--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -108,7 +108,7 @@ pub enum InstructionError {
     AccountBorrowFailed,
 
     /// Account data has an outstanding reference after a program's execution
-    #[error("instruction left account with an outstanding reference borrowed")]
+    #[error("instruction left account with an outstanding borrowed reference")]
     AccountBorrowOutstanding,
 
     /// The same account was multiply passed to an on-chain program's entrypoint, but the program

--- a/sdk/src/transaction.rs
+++ b/sdk/src/transaction.rs
@@ -94,6 +94,10 @@ pub enum TransactionError {
 
     #[error("Transactions are currently disabled due to cluster maintenance")]
     ClusterMaintenance,
+
+    /// Transaction processing left an account with an outstanding borrowed reference
+    #[error("Transaction processing left an account with an outstanding borrowed reference")]
+    AccountBorrowOutstanding,
 }
 
 pub type Result<T> = result::Result<T, TransactionError>;

--- a/storage-proto/proto/solana.storage.transaction_by_addr.rs
+++ b/storage-proto/proto/solana.storage.transaction_by_addr.rs
@@ -66,6 +66,7 @@ pub enum TransactionErrorType {
     InvalidProgramForExecution = 13,
     SanitizeFailure = 14,
     ClusterMaintenance = 15,
+    AccountBorrowOutstanding = 16,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -529,6 +529,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
             13 => TransactionError::InvalidProgramForExecution,
             14 => TransactionError::SanitizeFailure,
             15 => TransactionError::ClusterMaintenance,
+            16 => TransactionError::AccountBorrowOutstanding,
             _ => return Err("Invalid TransactionError"),
         })
     }
@@ -583,6 +584,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                 }
                 TransactionError::InstructionError(_, _) => {
                     tx_by_addr::TransactionErrorType::InstructionError
+                }
+                TransactionError::AccountBorrowOutstanding => {
+                    tx_by_addr::TransactionErrorType::AccountBorrowOutstanding
                 }
             } as i32,
             instruction_error: match transaction_error {


### PR DESCRIPTION
#### Problem

Account references are managed by the runtime and in its current form cannot panic on `unwrap`, but that could change over time as the code evolves.

#### Summary of Changes

Remove the `unwrap` and exit gracefully

Fixes #
