### PR TITLE
RPC: use finalized as default pubsub commitment level

### DIFF
--- a/core/src/rpc_subscriptions.rs
+++ b/core/src/rpc_subscriptions.rs
@@ -630,9 +630,7 @@ impl RpcSubscriptions {
         subscriber: Subscriber<Response<UiAccount>>,
     ) {
         let config = config.unwrap_or_default();
-        let commitment = config
-            .commitment
-            .unwrap_or_else(CommitmentConfig::confirmed);
+        let commitment = config.commitment.unwrap_or_default();
 
         let slot = if commitment.is_finalized() {
             self.block_commitment_cache
@@ -703,10 +701,7 @@ impl RpcSubscriptions {
         subscriber: Subscriber<Response<RpcKeyedAccount>>,
     ) {
         let config = config.unwrap_or_default();
-        let commitment = config
-            .account_config
-            .commitment
-            .unwrap_or_else(CommitmentConfig::confirmed);
+        let commitment = config.account_config.commitment.unwrap_or_default();
 
         let mut subscriptions = if commitment.is_confirmed() {
             self.subscriptions
@@ -753,7 +748,7 @@ impl RpcSubscriptions {
         sub_id: SubscriptionId,
         subscriber: Subscriber<Response<RpcLogsResponse>>,
     ) {
-        let commitment = commitment.unwrap_or_else(CommitmentConfig::confirmed);
+        let commitment = commitment.unwrap_or_default();
 
         {
             let mut subscriptions = if commitment.is_confirmed() {
@@ -864,7 +859,7 @@ impl RpcSubscriptions {
             .map(|config| (config.commitment, config.enable_received_notification))
             .unwrap_or_default();
 
-        let commitment = commitment.unwrap_or_else(CommitmentConfig::confirmed);
+        let commitment = commitment.unwrap_or_default();
 
         let mut subscriptions = if commitment.is_confirmed() {
             self.subscriptions

--- a/core/tests/rpc.rs
+++ b/core/tests/rpc.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value};
 use solana_account_decoder::UiAccount;
 use solana_client::{
     rpc_client::RpcClient,
+    rpc_config::{RpcAccountInfoConfig, RpcSignatureSubscribeConfig},
     rpc_response::{Response, RpcSignatureResult, SlotUpdate},
 };
 use solana_core::{rpc_pubsub::gen_client::Client as PubsubClient, test_validator::TestValidator};
@@ -262,7 +263,13 @@ fn test_rpc_subscriptions() {
         for sig in signature_set_clone {
             let status_sender = status_sender.clone();
             let mut sig_sub = client
-                .signature_subscribe(sig.clone(), None)
+                .signature_subscribe(
+                    sig.clone(),
+                    Some(RpcSignatureSubscribeConfig {
+                        commitment: Some(CommitmentConfig::confirmed()),
+                        ..RpcSignatureSubscribeConfig::default()
+                    }),
+                )
                 .unwrap_or_else(|err| panic!("sig sub err: {:#?}", err));
 
             tokio_02::spawn(async move {
@@ -277,7 +284,13 @@ fn test_rpc_subscriptions() {
         for pubkey in account_set {
             let account_sender = account_sender.clone();
             let mut client_sub = client
-                .account_subscribe(pubkey, None)
+                .account_subscribe(
+                    pubkey,
+                    Some(RpcAccountInfoConfig {
+                        commitment: Some(CommitmentConfig::confirmed()),
+                        ..RpcAccountInfoConfig::default()
+                    }),
+                )
                 .unwrap_or_else(|err| panic!("acct sub err: {:#?}", err));
             tokio_02::spawn(async move {
                 let response = client_sub.next().await.unwrap();

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -3050,7 +3050,7 @@ After connecting to the RPC PubSub websocket at `ws://<ADDRESS>/`:
 
 - Submit subscription requests to the websocket using the methods below
 - Multiple subscriptions may be active at once
-- Many subscriptions take the optional [`commitment` parameter](jsonrpc-api.md#configuring-state-commitment), defining how finalized a change should be to trigger a notification. For subscriptions, if commitment is unspecified, the default value is `"confirmed"`.
+- Many subscriptions take the optional [`commitment` parameter](jsonrpc-api.md#configuring-state-commitment), defining how finalized a change should be to trigger a notification. For subscriptions, if commitment is unspecified, the default value is `"finalized"`.
 
 ### accountSubscribe
 


### PR DESCRIPTION
#### Problem
The default commitment for pubsub and http requests are different which can cause consistency issues in downstream clients.

#### Summary of Changes
Change the default commitment of pubsub subscriptions from confirmed to finalized

Fixes https://github.com/solana-labs/solana/issues/16596
