### PR TITLE
Allow SetUpgradeAuthority instruction in CPI calls

### DIFF
--- a/programs/bpf/Cargo.lock
+++ b/programs/bpf/Cargo.lock
@@ -2736,6 +2736,7 @@ dependencies = [
  "itertools 0.10.0",
  "miow 0.2.2",
  "net2",
+ "solana-account-decoder",
  "solana-bpf-loader-program",
  "solana-cli-output",
  "solana-logger 1.7.0",

--- a/programs/bpf/Cargo.toml
+++ b/programs/bpf/Cargo.toml
@@ -33,6 +33,7 @@ solana_rbpf = "=0.2.8"
 solana-runtime = { path = "../../runtime", version = "=1.7.0" }
 solana-sdk = { path = "../../sdk", version = "=1.7.0" }
 solana-transaction-status = { path = "../../transaction-status", version = "=1.7.0" }
+solana-account-decoder = { path = "../../account-decoder", version = "=1.7.0" }
 
 
 [[bench]]

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -2130,7 +2130,7 @@ fn test_program_bpf_set_upgrade_authority_via_cpi() {
         "solana_bpf_rust_upgradeable",
     );
 
-    // Set program upgrade authority via CPI
+    // Set program upgrade authority instruction to invoke via CPI
     let new_upgrade_authority_key = Keypair::new().pubkey();
     let mut set_upgrade_authority_instruction = bpf_loader_upgradeable::set_upgrade_authority(
         &program_id,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1879,7 +1879,8 @@ fn check_authorized_program(
         || bpf_loader::check_id(program_id)
         || bpf_loader_deprecated::check_id(program_id)
         || (bpf_loader_upgradeable::check_id(program_id)
-            && !bpf_loader_upgradeable::is_cpi_authorized_instruction(instruction_data))
+            && !(bpf_loader_upgradeable::is_upgrade_instruction(instruction_data)
+                || bpf_loader_upgradeable::is_set_authority_instruction(instruction_data)))
     {
         return Err(SyscallError::ProgramNotSupported(*program_id).into());
     }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -21,7 +21,8 @@ use solana_sdk::{
     epoch_schedule::EpochSchedule,
     feature_set::{
         cpi_data_cost, cpi_share_ro_and_exec_accounts, demote_sysvar_write_locks,
-        enforce_aligned_host_addrs, ristretto_mul_syscall_enabled, sysvar_via_syscall,
+        enforce_aligned_host_addrs, 
+        ristretto_mul_syscall_enabled, set_upgrade_authority_via_cpi_enabled, sysvar_via_syscall,
     },
     hash::{Hasher, HASH_BYTES},
     ic_msg,
@@ -1874,13 +1875,16 @@ fn check_account_infos(
 fn check_authorized_program(
     program_id: &Pubkey,
     instruction_data: &[u8],
+    invoke_context: &Ref<&mut dyn InvokeContext>,
 ) -> Result<(), EbpfError<BpfError>> {
     if native_loader::check_id(program_id)
         || bpf_loader::check_id(program_id)
         || bpf_loader_deprecated::check_id(program_id)
         || (bpf_loader_upgradeable::check_id(program_id)
             && !(bpf_loader_upgradeable::is_upgrade_instruction(instruction_data)
-                || bpf_loader_upgradeable::is_set_authority_instruction(instruction_data)))
+                || (bpf_loader_upgradeable::is_set_authority_instruction(instruction_data)
+                    && invoke_context
+                        .is_feature_active(&set_upgrade_authority_via_cpi_enabled::id()))))
     {
         return Err(SyscallError::ProgramNotSupported(*program_id).into());
     }
@@ -1995,7 +1999,7 @@ fn call<'a>(
                 }
             })
             .collect::<Vec<bool>>();
-        check_authorized_program(&callee_program_id, &instruction.data)?;
+        check_authorized_program(&callee_program_id, &instruction.data, &invoke_context)?;
         let (accounts, account_refs) = syscall.translate_accounts(
             &message.account_keys,
             &caller_write_privileges,

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1879,7 +1879,7 @@ fn check_authorized_program(
         || bpf_loader::check_id(program_id)
         || bpf_loader_deprecated::check_id(program_id)
         || (bpf_loader_upgradeable::check_id(program_id)
-            && !bpf_loader_upgradeable::is_upgrade_instruction(instruction_data))
+            && !bpf_loader_upgradeable::is_cli_authorized_instruction(instruction_data))
     {
         return Err(SyscallError::ProgramNotSupported(*program_id).into());
     }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -1879,7 +1879,7 @@ fn check_authorized_program(
         || bpf_loader::check_id(program_id)
         || bpf_loader_deprecated::check_id(program_id)
         || (bpf_loader_upgradeable::check_id(program_id)
-            && !bpf_loader_upgradeable::is_cli_authorized_instruction(instruction_data))
+            && !bpf_loader_upgradeable::is_cpi_authorized_instruction(instruction_data))
     {
         return Err(SyscallError::ProgramNotSupported(*program_id).into());
     }

--- a/programs/bpf_loader/src/syscalls.rs
+++ b/programs/bpf_loader/src/syscalls.rs
@@ -21,8 +21,8 @@ use solana_sdk::{
     epoch_schedule::EpochSchedule,
     feature_set::{
         cpi_data_cost, cpi_share_ro_and_exec_accounts, demote_sysvar_write_locks,
-        enforce_aligned_host_addrs, 
-        ristretto_mul_syscall_enabled, set_upgrade_authority_via_cpi_enabled, sysvar_via_syscall,
+        enforce_aligned_host_addrs, ristretto_mul_syscall_enabled,
+        set_upgrade_authority_via_cpi_enabled, sysvar_via_syscall,
     },
     hash::{Hasher, HASH_BYTES},
     ic_msg,

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -192,6 +192,14 @@ pub fn is_upgrade_instruction(instruction_data: &[u8]) -> bool {
     3 == instruction_data[0]
 }
 
+pub fn is_set_authority_instruction(instruction_data: &[u8]) -> bool {
+    4 == instruction_data[0]
+}
+
+pub fn is_cli_authorized_instruction(instruction_data: &[u8]) -> bool {
+    is_upgrade_instruction(instruction_data) || is_set_authority_instruction(instruction_data)
+}
+
 /// Returns the instructions required to set a buffers's authority.
 pub fn set_buffer_authority(
     buffer_address: &Pubkey,
@@ -262,44 +270,106 @@ mod tests {
         );
     }
 
+    fn assert_is_instruction<F>(
+        is_instruction_fn: F,
+        expected_instructions: &[UpgradeableLoaderInstruction],
+    ) where
+        F: Fn(&[u8]) -> bool,
+    {
+        let result = is_instruction_fn(
+            &bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap(),
+        );
+
+        let expected_result = expected_instructions.iter().any(|i| match i {
+            UpgradeableLoaderInstruction::InitializeBuffer => true,
+            _ => false,
+        });
+
+        assert_eq!(expected_result, result);
+
+        let result = is_instruction_fn(
+            &bincode::serialize(&UpgradeableLoaderInstruction::Write {
+                offset: 0,
+                bytes: vec![],
+            })
+            .unwrap(),
+        );
+
+        let expected_result = expected_instructions.iter().any(|i| match i {
+            UpgradeableLoaderInstruction::Write {
+                offset: _,
+                bytes: _,
+            } => true,
+            _ => false,
+        });
+
+        assert_eq!(expected_result, result);
+
+        let result = is_instruction_fn(
+            &bincode::serialize(&UpgradeableLoaderInstruction::DeployWithMaxDataLen {
+                max_data_len: 0,
+            })
+            .unwrap(),
+        );
+
+        let expected_result = expected_instructions.iter().any(|i| match i {
+            UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len: _ } => true,
+            _ => false,
+        });
+
+        assert_eq!(expected_result, result);
+
+        let result =
+            is_instruction_fn(&bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap());
+
+        let expected_result = expected_instructions.iter().any(|i| match i {
+            UpgradeableLoaderInstruction::Upgrade => true,
+            _ => false,
+        });
+        assert_eq!(expected_result, result);
+
+        let result = is_instruction_fn(
+            &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
+        );
+        let expected_result = expected_instructions.iter().any(|i| match i {
+            UpgradeableLoaderInstruction::SetAuthority => true,
+            _ => false,
+        });
+        assert_eq!(expected_result, result);
+
+        let result =
+            is_instruction_fn(&bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap());
+        let expected_result = expected_instructions.iter().any(|i| match i {
+            UpgradeableLoaderInstruction::Close => true,
+            _ => false,
+        });
+        assert_eq!(expected_result, result);
+    }
+
+    #[test]
+    fn test_is_set_authority_instruction() {
+        assert_is_instruction(
+            is_set_authority_instruction,
+            &[UpgradeableLoaderInstruction::SetAuthority {}],
+        );
+    }
+
     #[test]
     fn test_is_upgrade_instruction() {
-        assert_eq!(
-            false,
-            is_upgrade_instruction(
-                &bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap()
-            )
+        assert_is_instruction(
+            is_upgrade_instruction,
+            &[UpgradeableLoaderInstruction::Upgrade {}],
         );
-        assert_eq!(
-            false,
-            is_upgrade_instruction(
-                &bincode::serialize(&UpgradeableLoaderInstruction::Write {
-                    offset: 0,
-                    bytes: vec![],
-                })
-                .unwrap()
-            )
-        );
-        assert_eq!(
-            false,
-            is_upgrade_instruction(
-                &bincode::serialize(&UpgradeableLoaderInstruction::DeployWithMaxDataLen {
-                    max_data_len: 0,
-                })
-                .unwrap()
-            )
-        );
-        assert_eq!(
-            true,
-            is_upgrade_instruction(
-                &bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap()
-            )
-        );
-        assert_eq!(
-            false,
-            is_upgrade_instruction(
-                &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap()
-            )
+    }
+
+    #[test]
+    fn test_is_cli_authorized_instruction() {
+        assert_is_instruction(
+            is_cli_authorized_instruction,
+            &[
+                UpgradeableLoaderInstruction::Upgrade {},
+                UpgradeableLoaderInstruction::SetAuthority {},
+            ],
         );
     }
 }

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -280,10 +280,9 @@ mod tests {
             &bincode::serialize(&UpgradeableLoaderInstruction::InitializeBuffer).unwrap(),
         );
 
-        let expected_result = expected_instructions.iter().any(|i| match i {
-            UpgradeableLoaderInstruction::InitializeBuffer => true,
-            _ => false,
-        });
+        let expected_result = expected_instructions
+            .iter()
+            .any(|i| matches!(i, UpgradeableLoaderInstruction::InitializeBuffer));
 
         assert_eq!(expected_result, result);
 

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -196,7 +196,7 @@ pub fn is_set_authority_instruction(instruction_data: &[u8]) -> bool {
     4 == instruction_data[0]
 }
 
-pub fn is_cli_authorized_instruction(instruction_data: &[u8]) -> bool {
+pub fn is_cpi_authorized_instruction(instruction_data: &[u8]) -> bool {
     is_upgrade_instruction(instruction_data) || is_set_authority_instruction(instruction_data)
 }
 
@@ -363,9 +363,9 @@ mod tests {
     }
 
     #[test]
-    fn test_is_cli_authorized_instruction() {
+    fn test_is_cpi_authorized_instruction() {
         assert_is_instruction(
-            is_cli_authorized_instruction,
+            is_cpi_authorized_instruction,
             &[
                 UpgradeableLoaderInstruction::Upgrade {},
                 UpgradeableLoaderInstruction::SetAuthority {},

--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -295,12 +295,14 @@ mod tests {
             .unwrap(),
         );
 
-        let expected_result = expected_instructions.iter().any(|i| match i {
-            UpgradeableLoaderInstruction::Write {
-                offset: _,
-                bytes: _,
-            } => true,
-            _ => false,
+        let expected_result = expected_instructions.iter().any(|i| {
+            matches!(
+                i,
+                UpgradeableLoaderInstruction::Write {
+                    offset: _,
+                    bytes: _,
+                }
+            )
         });
 
         assert_eq!(expected_result, result);
@@ -312,9 +314,11 @@ mod tests {
             .unwrap(),
         );
 
-        let expected_result = expected_instructions.iter().any(|i| match i {
-            UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len: _ } => true,
-            _ => false,
+        let expected_result = expected_instructions.iter().any(|i| {
+            matches!(
+                i,
+                UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len: _ }
+            )
         });
 
         assert_eq!(expected_result, result);
@@ -322,27 +326,24 @@ mod tests {
         let result =
             is_instruction_fn(&bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap());
 
-        let expected_result = expected_instructions.iter().any(|i| match i {
-            UpgradeableLoaderInstruction::Upgrade => true,
-            _ => false,
-        });
+        let expected_result = expected_instructions
+            .iter()
+            .any(|i| matches!(i, UpgradeableLoaderInstruction::Upgrade));
         assert_eq!(expected_result, result);
 
         let result = is_instruction_fn(
             &bincode::serialize(&UpgradeableLoaderInstruction::SetAuthority).unwrap(),
         );
-        let expected_result = expected_instructions.iter().any(|i| match i {
-            UpgradeableLoaderInstruction::SetAuthority => true,
-            _ => false,
-        });
+        let expected_result = expected_instructions
+            .iter()
+            .any(|i| matches!(i, UpgradeableLoaderInstruction::SetAuthority));
         assert_eq!(expected_result, result);
 
         let result =
             is_instruction_fn(&bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap());
-        let expected_result = expected_instructions.iter().any(|i| match i {
-            UpgradeableLoaderInstruction::Close => true,
-            _ => false,
-        });
+        let expected_result = expected_instructions
+            .iter()
+            .any(|i| matches!(i, UpgradeableLoaderInstruction::Close));
         assert_eq!(expected_result, result);
     }
 

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -75,10 +75,6 @@ pub mod bpf_loader_upgradeable_program {
     solana_sdk::declare_id!("FbhK8HN9qvNHvJcoFVHAEUCNkagHvu7DTWzdnLuVQ5u4");
 }
 
-pub mod set_upgrade_authority_via_cpi_enabled {
-    solana_sdk::declare_id!("GQdjCCptpGECG7QfE35hKTAopB1umGoSrdKfax2VmZWy");
-}
-
 pub mod stake_program_v3 {
     solana_sdk::declare_id!("Ego6nTu7WsBcZBvVqJQKp6Yku2N3mrfG8oYCfaLZkAeK");
 }
@@ -142,6 +138,10 @@ pub mod check_duplicates_by_hash {
 pub mod enforce_aligned_host_addrs {
     solana_sdk::declare_id!("6Qob9Z4RwGdf599FDVCqsjuKjR8ZFR3oVs2ByRLWBsua");
 }
+    
+pub mod set_upgrade_authority_via_cpi_enabled {
+    solana_sdk::declare_id!("GQdjCCptpGECG7QfE35hKTAopB1umGoSrdKfax2VmZWy");
+}
 
 lazy_static! {
     /// Map of feature identifiers to user-visible description
@@ -160,7 +160,6 @@ lazy_static! {
         (rewrite_stake::id(), "rewrite stake"),
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
         (bpf_loader_upgradeable_program::id(), "upgradeable bpf loader"),
-        (set_upgrade_authority_via_cpi_enabled::id(), "set upgrade authority instruction via cpi calls for upgradable programs"),
         (stake_program_v3::id(), "solana_stake_program v3"),
         (turbine_retransmit_peers_patch::id(), "turbine retransmit peers patch #14631"),
         (require_custodian_for_locked_stake_authorize::id(), "require custodian to authorize withdrawer change for locked stake"),
@@ -179,6 +178,7 @@ lazy_static! {
         (sysvar_via_syscall::id(), "provide sysvars via syscalls"),
         (check_duplicates_by_hash::id(), "use transaction message hash for duplicate check"),
         (enforce_aligned_host_addrs::id(), "enforce aligned host addresses"),
+        (set_upgrade_authority_via_cpi_enabled::id(), "set upgrade authority instruction via cpi calls for upgradable programs"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -75,6 +75,10 @@ pub mod bpf_loader_upgradeable_program {
     solana_sdk::declare_id!("FbhK8HN9qvNHvJcoFVHAEUCNkagHvu7DTWzdnLuVQ5u4");
 }
 
+pub mod set_upgrade_authority_via_cpi_enabled {
+    solana_sdk::declare_id!("GQdjCCptpGECG7QfE35hKTAopB1umGoSrdKfax2VmZWy");
+}
+
 pub mod stake_program_v3 {
     solana_sdk::declare_id!("Ego6nTu7WsBcZBvVqJQKp6Yku2N3mrfG8oYCfaLZkAeK");
 }
@@ -156,6 +160,7 @@ lazy_static! {
         (rewrite_stake::id(), "rewrite stake"),
         (filter_stake_delegation_accounts::id(), "filter stake_delegation_accounts #14062"),
         (bpf_loader_upgradeable_program::id(), "upgradeable bpf loader"),
+        (set_upgrade_authority_via_cpi_enabled::id(), "set upgrade authority instruction via cpi calls for upgradable programs"),
         (stake_program_v3::id(), "solana_stake_program v3"),
         (turbine_retransmit_peers_patch::id(), "turbine retransmit peers patch #14631"),
         (require_custodian_for_locked_stake_authorize::id(), "require custodian to authorize withdrawer change for locked stake"),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -138,7 +138,6 @@ pub mod check_duplicates_by_hash {
 pub mod enforce_aligned_host_addrs {
     solana_sdk::declare_id!("6Qob9Z4RwGdf599FDVCqsjuKjR8ZFR3oVs2ByRLWBsua");
 }
-    
 pub mod set_upgrade_authority_via_cpi_enabled {
     solana_sdk::declare_id!("GQdjCCptpGECG7QfE35hKTAopB1umGoSrdKfax2VmZWy");
 }


### PR DESCRIPTION
#### Problem

For Governance program we want to set the upgrade authority of the program we take under governance.
The upgrade authority should be transferred to the Governance Program Derived Address to let it upgrade the governed program and prevent anybody else but governance from doing so.
It also works as a security check ensuring the governance instruction is signed by the current program upgrade authority and prevents from setting governance for somebody's else program.

It's currently not possible to change upgrade authority via CPI and the following error is returned: 
`"Program failed to complete: Program BPFLoaderUpgradeab1e11111111111111111111111 not supported by inner instructions"`


#### Summary of Changes

Add SetAuthority to instructions authorised for CPI invocation
