### PR TITLE
ReadableAccount.data returns slice

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -421,7 +421,7 @@ mod tests {
             assert_eq!(key, *account_info.key);
             let account = account.borrow();
             assert_eq!(account.lamports, account_info.lamports());
-            assert_eq!(&account.data()[..], &account_info.data.borrow()[..]);
+            assert_eq!(&account.data(), &account_info.data.borrow()[..]);
             assert_eq!(&account.owner, account_info.owner);
             assert_eq!(account.executable, account_info.executable);
             assert_eq!(account.rent_epoch, account_info.rent_epoch);
@@ -461,7 +461,7 @@ mod tests {
             let account = account.borrow();
             assert_eq!(account.lamports, de_keyed_account.lamports().unwrap());
             assert_eq!(
-                &account.data()[..],
+                &account.data(),
                 &de_keyed_account.try_account_ref().unwrap().data()[..]
             );
             assert_eq!(account.owner, de_keyed_account.owner().unwrap());
@@ -487,7 +487,7 @@ mod tests {
             assert_eq!(key, *account_info.key);
             let account = account.borrow();
             assert_eq!(account.lamports, account_info.lamports());
-            assert_eq!(&account.data()[..], &account_info.data.borrow()[..]);
+            assert_eq!(&account.data(), &account_info.data.borrow()[..]);
             assert_eq!(&account.owner, account_info.owner);
             assert_eq!(account.executable, account_info.executable);
             assert_eq!(account.rent_epoch, account_info.rent_epoch);
@@ -520,7 +520,7 @@ mod tests {
             let account = account.borrow();
             assert_eq!(account.lamports, de_keyed_account.lamports().unwrap());
             assert_eq!(
-                &account.data()[..],
+                &account.data(),
                 &de_keyed_account.try_account_ref().unwrap().data()[..]
             );
             assert_eq!(account.owner, de_keyed_account.owner().unwrap());

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -421,7 +421,7 @@ mod tests {
             assert_eq!(key, *account_info.key);
             let account = account.borrow();
             assert_eq!(account.lamports, account_info.lamports());
-            assert_eq!(&account.data(), &account_info.data.borrow()[..]);
+            assert_eq!(account.data(), &account_info.data.borrow()[..]);
             assert_eq!(&account.owner, account_info.owner);
             assert_eq!(account.executable, account_info.executable);
             assert_eq!(account.rent_epoch, account_info.rent_epoch);
@@ -461,7 +461,7 @@ mod tests {
             let account = account.borrow();
             assert_eq!(account.lamports, de_keyed_account.lamports().unwrap());
             assert_eq!(
-                &account.data(),
+                account.data(),
                 &de_keyed_account.try_account_ref().unwrap().data()[..]
             );
             assert_eq!(account.owner, de_keyed_account.owner().unwrap());
@@ -487,7 +487,7 @@ mod tests {
             assert_eq!(key, *account_info.key);
             let account = account.borrow();
             assert_eq!(account.lamports, account_info.lamports());
-            assert_eq!(&account.data(), &account_info.data.borrow()[..]);
+            assert_eq!(account.data(), &account_info.data.borrow()[..]);
             assert_eq!(&account.owner, account_info.owner);
             assert_eq!(account.executable, account_info.executable);
             assert_eq!(account.rent_epoch, account_info.rent_epoch);
@@ -520,7 +520,7 @@ mod tests {
             let account = account.borrow();
             assert_eq!(account.lamports, de_keyed_account.lamports().unwrap());
             assert_eq!(
-                &account.data(),
+                account.data(),
                 &de_keyed_account.try_account_ref().unwrap().data()[..]
             );
             assert_eq!(account.owner, de_keyed_account.owner().unwrap());

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -462,7 +462,7 @@ mod tests {
             assert_eq!(account.lamports, de_keyed_account.lamports().unwrap());
             assert_eq!(
                 account.data(),
-                &de_keyed_account.try_account_ref().unwrap().data()[..]
+                de_keyed_account.try_account_ref().unwrap().data()
             );
             assert_eq!(account.owner, de_keyed_account.owner().unwrap());
             assert_eq!(account.executable, de_keyed_account.executable().unwrap());
@@ -521,7 +521,7 @@ mod tests {
             assert_eq!(account.lamports, de_keyed_account.lamports().unwrap());
             assert_eq!(
                 account.data(),
-                &de_keyed_account.try_account_ref().unwrap().data()[..]
+                de_keyed_account.try_account_ref().unwrap().data()
             );
             assert_eq!(account.owner, de_keyed_account.owner().unwrap());
             assert_eq!(account.executable, de_keyed_account.executable().unwrap());

--- a/runtime/benches/append_vec.rs
+++ b/runtime/benches/append_vec.rs
@@ -51,7 +51,7 @@ fn append_vec_sequential_read(bencher: &mut Bencher) {
         println!("reading pos {} {}", sample, pos);
         let (account, _next) = vec.get_account(pos).unwrap();
         let (_meta, test) = create_test_account(sample);
-        assert_eq!(account.data, test.data().as_slice());
+        assert_eq!(account.data, test.data());
         indexes.push((sample, pos));
     });
 }
@@ -66,7 +66,7 @@ fn append_vec_random_read(bencher: &mut Bencher) {
         let (sample, pos) = &indexes[random_index];
         let (account, _next) = vec.get_account(*pos).unwrap();
         let (_meta, test) = create_test_account(*sample);
-        assert_eq!(account.data, test.data().as_slice());
+        assert_eq!(account.data, test.data());
     });
 }
 
@@ -95,7 +95,7 @@ fn append_vec_concurrent_append_read(bencher: &mut Bencher) {
         let (sample, pos) = *indexes.lock().unwrap().get(random_index).unwrap();
         let (account, _next) = vec.get_account(pos).unwrap();
         let (_meta, test) = create_test_account(sample);
-        assert_eq!(account.data, test.data().as_slice());
+        assert_eq!(account.data, test.data());
     });
 }
 
@@ -115,7 +115,7 @@ fn append_vec_concurrent_read_append(bencher: &mut Bencher) {
         let (sample, pos) = *indexes1.lock().unwrap().get(random_index % len).unwrap();
         let (account, _next) = vec1.get_account(pos).unwrap();
         let (_meta, test) = create_test_account(sample);
-        assert_eq!(account.data, test.data().as_slice());
+        assert_eq!(account.data, test.data());
     });
     bencher.iter(|| {
         let sample: usize = thread_rng().gen_range(0, 256);

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -520,7 +520,7 @@ impl<'a> InvokeContext for ThisInvokeContext<'a> {
             result = self
                 .account_db
                 .load_with_fixed_root(self.ancestors, id)
-                .map(|(account, _)| Rc::new(account.data().clone()));
+                .map(|(account, _)| Rc::new(account.data().to_vec()));
             // Cache it
             self.sysvars.push((*id, result.clone()));
         }
@@ -919,7 +919,7 @@ impl MessageProcessor {
                     dst_keyed_account.try_account_ref_mut()?.owner = src_keyed_account.owner;
                     dst_keyed_account
                         .try_account_ref_mut()?
-                        .set_data(src_keyed_account.data().clone());
+                        .set_data(src_keyed_account.data().to_vec());
                 }
             }
         }

--- a/runtime/src/native_loader.rs
+++ b/runtime/src/native_loader.rs
@@ -154,7 +154,7 @@ impl NativeLoader {
             // still exists even after invoke_context.remove_first_keyed_account() is called
             (
                 *program.unsigned_key(),
-                &program.try_account_ref()?.data().clone(),
+                &program.try_account_ref()?.data().to_vec(),
             )
         };
 

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -94,7 +94,7 @@ pub trait WritableAccount: ReadableAccount {
 
 pub trait ReadableAccount: Sized {
     fn lamports(&self) -> u64;
-    fn data(&self) -> &Vec<u8>;
+    fn data(&self) -> &[u8];
     fn owner(&self) -> &Pubkey;
     fn executable(&self) -> bool;
     fn rent_epoch(&self) -> Epoch;
@@ -104,7 +104,7 @@ impl ReadableAccount for Account {
     fn lamports(&self) -> u64 {
         self.lamports
     }
-    fn data(&self) -> &Vec<u8> {
+    fn data(&self) -> &[u8] {
         &self.data
     }
     fn owner(&self) -> &Pubkey {
@@ -189,7 +189,7 @@ impl ReadableAccount for AccountSharedData {
     fn lamports(&self) -> u64 {
         self.lamports
     }
-    fn data(&self) -> &Vec<u8> {
+    fn data(&self) -> &[u8] {
         &self.data
     }
     fn owner(&self) -> &Pubkey {
@@ -207,7 +207,7 @@ impl ReadableAccount for Ref<'_, AccountSharedData> {
     fn lamports(&self) -> u64 {
         self.lamports
     }
-    fn data(&self) -> &Vec<u8> {
+    fn data(&self) -> &[u8] {
         &self.data
     }
     fn owner(&self) -> &Pubkey {
@@ -225,7 +225,7 @@ impl ReadableAccount for Ref<'_, Account> {
     fn lamports(&self) -> u64 {
         self.lamports
     }
-    fn data(&self) -> &Vec<u8> {
+    fn data(&self) -> &[u8] {
         &self.data
     }
     fn owner(&self) -> &Pubkey {


### PR DESCRIPTION
#### Problem
returning a &Vec<u8> requires the internal implementation to have a Vec it can return a reference to. Callers of data() are happy with &[u8], which current and future implementations of ReadableAccount should have no problem returning.

#### Summary of Changes
data() returns &[u8] instead of &Vec<u8>

Fixes #
