### PR TITLE
some ReadableAccount changes

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -635,8 +635,8 @@ pub struct BankHashStats {
 }
 
 impl BankHashStats {
-    pub fn update(&mut self, account: &AccountSharedData) {
-        if account.lamports == 0 {
+    pub fn update<T: ReadableAccount>(&mut self, account: &T) {
+        if account.lamports() == 0 {
             self.num_removed_accounts += 1;
         } else {
             self.num_updated_accounts += 1;
@@ -644,10 +644,10 @@ impl BankHashStats {
         self.total_data_len = self
             .total_data_len
             .wrapping_add(account.data().len() as u64);
-        if account.executable {
+        if account.executable() {
             self.num_executable_accounts += 1;
         }
-        self.num_lamports_stored = self.num_lamports_stored.wrapping_add(account.lamports);
+        self.num_lamports_stored = self.num_lamports_stored.wrapping_add(account.lamports());
     }
 
     pub fn merge(&mut self, other: &BankHashStats) {
@@ -3232,13 +3232,13 @@ impl AccountsDb {
         )
     }
 
-    pub fn hash_account(slot: Slot, account: &AccountSharedData, pubkey: &Pubkey) -> Hash {
+    pub fn hash_account<T: ReadableAccount>(slot: Slot, account: &T, pubkey: &Pubkey) -> Hash {
         Self::hash_account_data(
             slot,
-            account.lamports,
-            &account.owner,
-            account.executable,
-            account.rent_epoch,
+            account.lamports(),
+            &account.owner(),
+            account.executable(),
+            account.rent_epoch(),
             &account.data(),
             pubkey,
         )
@@ -3361,7 +3361,7 @@ impl AccountsDb {
                     store_id: storage.append_vec_id(),
                     offset: offsets[0],
                     stored_size,
-                    lamports: account.lamports,
+                    lamports: account.lamports(),
                 });
             }
             // restore the state to available
@@ -3717,7 +3717,7 @@ impl AccountsDb {
                     store_id: CACHE_VIRTUAL_STORAGE_ID,
                     offset: CACHE_VIRTUAL_OFFSET,
                     stored_size: CACHE_VIRTUAL_STORED_SIZE,
-                    lamports: account.lamports,
+                    lamports: account.lamports(),
                 }
             })
             .collect()
@@ -3740,7 +3740,7 @@ impl AccountsDb {
             .iter()
             .map(|(pubkey, account)| {
                 self.read_only_accounts_cache.remove(pubkey, slot);
-                let account = if account.lamports == 0 {
+                let account = if account.lamports() == 0 {
                     &default_account
                 } else {
                     *account
@@ -4291,7 +4291,7 @@ impl AccountsDb {
             self.accounts_index.upsert(
                 slot,
                 pubkey,
-                &pubkey_account.1.owner,
+                &pubkey_account.1.owner(),
                 &pubkey_account.1.data(),
                 &self.account_indexes,
                 info,
@@ -4533,7 +4533,7 @@ impl AccountsDb {
         let mut total_data = 0;
         accounts.iter().for_each(|(_pubkey, account)| {
             total_data += account.data().len();
-            stats.update(account);
+            stats.update(*account);
         });
 
         self.stats

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -57,13 +57,13 @@ pub struct AccountMeta {
     pub rent_epoch: Epoch,
 }
 
-impl<'a> From<&'a AccountSharedData> for AccountMeta {
-    fn from(account: &'a AccountSharedData) -> Self {
+impl<'a, T: ReadableAccount> From<&'a T> for AccountMeta {
+    fn from(account: &'a T) -> Self {
         Self {
-            lamports: account.lamports,
-            owner: account.owner,
-            executable: account.executable,
-            rent_epoch: account.rent_epoch,
+            lamports: account.lamports(),
+            owner: *account.owner(),
+            executable: account.executable(),
+            rent_epoch: account.rent_epoch(),
         }
     }
 }

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -117,7 +117,7 @@ fn test_bad_bank_hash() {
             assert_eq!(
                 db.load_account_hash(&ancestors, &key, None, LoadHint::Unspecified)
                     .unwrap(),
-                AccountsDb::hash_account(some_slot, &account, &key)
+                AccountsDb::hash_account(some_slot, *account, &key)
             );
         }
         existing.clear();


### PR DESCRIPTION
#### Problem
There will likely be new implementations of an account that can implement ReadableAccount without data copies required to create an AccountSharedData.

#### Summary of Changes
A few code paths now support the more general ReadableAccount trait instead of specifically AccountSharedData. This allows other implementations of ReadableAccount to share the code path with no changes.

Fixes #
