### PR TITLE
Reduce account index lookups during clean

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1569,8 +1569,7 @@ impl AccountsDb {
                                             self.accounts_index
                                                 .roots_and_ref_count(&locked_entry, max_clean_root),
                                         );
-                                    }
-                                    else {
+                                    } else {
                                         // prune zero_lamport_pubkey set which should contain all 0-lamport
                                         // keys whether rooted or not. A 0-lamport update may become rooted
                                         // in the future.
@@ -1596,7 +1595,6 @@ impl AccountsDb {
                                 }
                                 AccountIndexGetResult::NotFoundOnFork => {
                                     // do nothing - pubkey is in index, but not found in a root slot
-                                    ()
                                 }
                                 AccountIndexGetResult::Missing(lock) => {
                                     // pubkey is missing from index, so remove from zero_lamports_list

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -22,8 +22,8 @@ use crate::{
     accounts_cache::{AccountsCache, CachedAccount, SlotCache},
     accounts_hash::{AccountsHash, CalculateHashIntermediate, HashStats, PreviousPass},
     accounts_index::{
-        AccountIndex, AccountsIndex, AccountsIndexRootsStats, Ancestors, IndexKey, IsCached,
-        SlotList, SlotSlice, ZeroLamport,
+        AccountIndex, AccountIndexGetResult, AccountsIndex, AccountsIndexRootsStats, Ancestors,
+        IndexKey, IsCached, SlotList, SlotSlice, ZeroLamport,
     },
     append_vec::{AppendVec, StoredAccountMeta, StoredMeta},
     contains::Contains,
@@ -1559,47 +1559,52 @@ impl AccountsDb {
                         let mut purges_in_root = Vec::new();
                         let mut purges = HashMap::new();
                         for pubkey in pubkeys {
-                            if let Some((locked_entry, index)) =
-                                self.accounts_index.get(pubkey, None, max_clean_root)
-                            {
-                                let slot_list = locked_entry.slot_list();
-                                let (slot, account_info) = &slot_list[index];
-                                if account_info.lamports == 0 {
-                                    purges.insert(
-                                        *pubkey,
-                                        self.accounts_index
-                                            .roots_and_ref_count(&locked_entry, max_clean_root),
-                                    );
-                                } else {
-                                    // prune zero_lamport_pubkey set which should contain all 0-lamport
-                                    // keys whether rooted or not. A 0-lamport update may become rooted
-                                    // in the future.
-                                    let has_zero_lamport_accounts = slot_list
-                                        .iter()
-                                        .any(|(_slot, account_info)| account_info.lamports == 0);
-                                    if !has_zero_lamport_accounts {
-                                        self.accounts_index.remove_zero_lamport_key(pubkey);
-                                    }
-                                }
+                            let remove_from_zero_lamports_list =
+                                match self.accounts_index.get(pubkey, None, max_clean_root) {
+                                    AccountIndexGetResult::Success(locked_entry, index) => {
+                                        let slot_list = locked_entry.slot_list();
+                                        let (slot, account_info) = &slot_list[index];
+                                        if account_info.lamports == 0 {
+                                            purges.insert(
+                                                *pubkey,
+                                                self.accounts_index.roots_and_ref_count(
+                                                    &locked_entry,
+                                                    max_clean_root,
+                                                ),
+                                            );
+                                        }
+                                        // prune zero_lamport_pubkey set which should contain all 0-lamport
+                                        // keys whether rooted or not. A 0-lamport update may become rooted
+                                        // in the future.
+                                        let remove_from_zero_lamports_list =
+                                            !slot_list.iter().any(|(_slot, account_info)| {
+                                                account_info.lamports == 0
+                                            });
+                                        // Release the lock
+                                        let slot = *slot;
+                                        drop(locked_entry);
 
-                                // Release the lock
-                                let slot = *slot;
-                                drop(locked_entry);
-
-                                if self.accounts_index.is_uncleaned_root(slot) {
-                                    // Assertion enforced by `accounts_index.get()`, the latest slot
-                                    // will not be greater than the given `max_clean_root`
-                                    if let Some(max_clean_root) = max_clean_root {
-                                        assert!(slot <= max_clean_root);
+                                        if self.accounts_index.is_uncleaned_root(slot) {
+                                            // Assertion enforced by `accounts_index.get()`, the latest slot
+                                            // will not be greater than the given `max_clean_root`
+                                            if let Some(max_clean_root) = max_clean_root {
+                                                assert!(slot <= max_clean_root);
+                                            }
+                                            purges_in_root.push(*pubkey);
+                                        }
+                                        remove_from_zero_lamports_list
                                     }
-                                    purges_in_root.push(*pubkey);
-                                }
-                            } else {
-                                let r_accounts_index =
-                                    self.accounts_index.account_maps.read().unwrap();
-                                if !r_accounts_index.contains_key(pubkey) {
-                                    self.accounts_index.remove_zero_lamport_key(pubkey);
-                                }
+                                    AccountIndexGetResult::NoRootFound(_locked_entry) => {
+                                        // do nothing - pubkey is in index, but not found in a root slot
+                                        false
+                                    }
+                                    AccountIndexGetResult::Missing() => {
+                                        // pubkey is missing from index, so remove from zero_lamports_list
+                                        true
+                                    }
+                                };
+                            if remove_from_zero_lamports_list {
+                                self.accounts_index.remove_zero_lamport_key(pubkey);
                             }
                         }
                         (purges, purges_in_root)
@@ -2334,8 +2339,13 @@ impl AccountsDb {
         max_root: Option<Slot>,
         clone_in_lock: bool,
     ) -> Option<(Slot, AppendVecId, usize, Option<LoadedAccountAccessor<'a>>)> {
-        let (lock, index) = self.accounts_index.get(pubkey, Some(ancestors), max_root)?;
-        // Notice the subtle `?` at previous line, we bail out pretty early for missing.
+        let (lock, index) = match self.accounts_index.get(pubkey, Some(ancestors), max_root) {
+            AccountIndexGetResult::Success(lock, index) => (lock, index),
+            // we bail out pretty early for missing.
+            _ => {
+                return None;
+            }
+        };
 
         let slot_list = lock.slot_list();
         let (
@@ -3883,7 +3893,7 @@ impl AccountsDb {
                         let result: Vec<Hash> = pubkeys
                             .iter()
                             .filter_map(|pubkey| {
-                                if let Some((lock, index)) =
+                                if let AccountIndexGetResult::Success(lock, index) =
                                     self.accounts_index.get(pubkey, Some(ancestors), Some(slot))
                                 {
                                     let (slot, account_info) = &lock.slot_list()[index];

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1594,7 +1594,7 @@ impl AccountsDb {
                                         }
                                         remove_from_zero_lamports_list
                                     }
-                                    AccountIndexGetResult::NoRootFound(_locked_entry) => {
+                                    AccountIndexGetResult::NotFoundOnFork(_locked_entry) => {
                                         // do nothing - pubkey is in index, but not found in a root slot
                                         false
                                     }
@@ -2342,7 +2342,10 @@ impl AccountsDb {
         let (lock, index) = match self.accounts_index.get(pubkey, Some(ancestors), max_root) {
             AccountIndexGetResult::Success(lock, index) => (lock, index),
             // we bail out pretty early for missing.
-            _ => {
+            AccountIndexGetResult::NotFoundOnFork(_) => {
+                return None;
+            }
+            AccountIndexGetResult::Missing() => {
                 return None;
             }
         };

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1570,14 +1570,16 @@ impl AccountsDb {
                                                 .roots_and_ref_count(&locked_entry, max_clean_root),
                                         );
                                     }
-                                    // prune zero_lamport_pubkey set which should contain all 0-lamport
-                                    // keys whether rooted or not. A 0-lamport update may become rooted
-                                    // in the future.
-                                    if !slot_list
-                                        .iter()
-                                        .any(|(_slot, account_info)| account_info.lamports == 0)
-                                    {
-                                        self.accounts_index.remove_zero_lamport_key(pubkey);
+                                    else {
+                                        // prune zero_lamport_pubkey set which should contain all 0-lamport
+                                        // keys whether rooted or not. A 0-lamport update may become rooted
+                                        // in the future.
+                                        if !slot_list
+                                            .iter()
+                                            .any(|(_slot, account_info)| account_info.lamports == 0)
+                                        {
+                                            self.accounts_index.remove_zero_lamport_key(pubkey);
+                                        }
                                     }
                                     // Release the lock
                                     let slot = *slot;

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -87,7 +87,7 @@ impl<T> AccountMapEntryInner<T> {
 
 pub enum AccountIndexGetResult<T: 'static> {
     Success(ReadAccountMapEntry<T>, usize),
-    NoRootFound(ReadAccountMapEntry<T>),
+    NotFoundOnFork(ReadAccountMapEntry<T>),
     Missing(),
 }
 
@@ -951,7 +951,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
                 let found_index = self.latest_slot(ancestors, slot_list, max_root);
                 match found_index {
                     Some(found_index) => AccountIndexGetResult::Success(locked_entry, found_index),
-                    None => AccountIndexGetResult::NoRootFound(locked_entry),
+                    None => AccountIndexGetResult::NotFoundOnFork(locked_entry),
                 }
             }
             None => AccountIndexGetResult::Missing(),

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1340,7 +1340,7 @@ pub mod tests {
         account_indexes
     }
 
-    impl<T: 'static> AccountIndexGetResult<T> {
+    impl<'a, T: 'static, U> AccountIndexGetResult<'a, T, U> {
         pub fn unwrap(self) -> (ReadAccountMapEntry<T>, usize) {
             match self {
                 AccountIndexGetResult::Found(lock, size) => (lock, size),
@@ -1358,7 +1358,7 @@ pub mod tests {
             matches!(self, AccountIndexGetResult::Found(_lock, _size))
         }
 
-        pub fn map<U, F: FnOnce((ReadAccountMapEntry<T>, usize)) -> U>(self, f: F) -> Option<U> {
+        pub fn map<V, F: FnOnce((ReadAccountMapEntry<T>, usize)) -> V>(self, f: F) -> Option<V> {
             match self {
                 AccountIndexGetResult::Found(lock, size) => Some(f((lock, size))),
                 _ => None,


### PR DESCRIPTION
#### Problem
For some code paths in clean, we end up searching the account index for the same pubkey twice. This is not duplicate pubkeys in the stores - this is due to: if the key isn't doesn't match the fork then we call contains_key to search again.

#### Summary of Changes
Return more information from get. Specifically, whether the pubkey was found in the index at all - even if it wasn't in a rooted or ancestor slot less than the specified max.
Fixes #
