### PR TITLE
increase scan passes to 16 to see if it helps kin simulation

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -4136,7 +4136,7 @@ impl AccountsDb {
             // higher passes = slower total time, lower dynamic memory usage
             // lower passes = faster total time, higher dynamic memory usage
             // passes=2 cuts dynamic memory usage in approximately half.
-            let num_scan_passes: usize = 2;
+            let num_scan_passes: usize = 16;
 
             let bins_per_pass = PUBKEY_BINS_FOR_CALCULATING_HASHES / num_scan_passes;
             assert_eq!(


### PR DESCRIPTION
#### Problem
non-index scan can use bins to calculate hash values. Higher bin count means longer time, but less dynamic mem usage. Current builds of master against mnb are running out of mem on 64G machines.
#### Summary of Changes
increase bins from 2 to 16
Fixes #
