### PR TITLE
Add port and gossip options to solana-test-validator

### DIFF
--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
-pub use solana_core::test_validator;
+pub use solana_core::{cluster_info::MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, test_validator};
 use {
     console::style,
     indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle},
@@ -73,6 +73,22 @@ pub fn port_validator(port: String) -> Result<(), String> {
     port.parse::<u16>()
         .map(|_| ())
         .map_err(|e| format!("{:?}", e))
+}
+
+pub fn port_range_validator(port_range: String) -> Result<(), String> {
+    if let Some((start, end)) = solana_net_utils::parse_port_range(&port_range) {
+        if end - start < MINIMUM_VALIDATOR_PORT_RANGE_WIDTH {
+            Err(format!(
+                "Port range is too small.  Try --dynamic-port-range {}-{}",
+                start,
+                start + MINIMUM_VALIDATOR_PORT_RANGE_WIDTH
+            ))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Invalid port range".to_string())
+    }
 }
 
 /// Creates a new process bar for processing that will take an unknown amount of time

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -21,9 +21,7 @@ use {
         DEFAULT_MAX_LEDGER_SHREDS, DEFAULT_MIN_MAX_LEDGER_SHREDS,
     },
     solana_core::{
-        cluster_info::{
-            ClusterInfo, Node, MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE,
-        },
+        cluster_info::{ClusterInfo, Node, VALIDATOR_PORT_RANGE},
         contact_info::ContactInfo,
         gossip_service::GossipService,
         poh_service,
@@ -294,22 +292,6 @@ fn wait_for_restart_window(
     drop(progress_bar);
     println!("{}", style("Ready to restart").green());
     Ok(())
-}
-
-fn port_range_validator(port_range: String) -> Result<(), String> {
-    if let Some((start, end)) = solana_net_utils::parse_port_range(&port_range) {
-        if end - start < MINIMUM_VALIDATOR_PORT_RANGE_WIDTH {
-            Err(format!(
-                "Port range is too small.  Try --dynamic-port-range {}-{}",
-                start,
-                start + MINIMUM_VALIDATOR_PORT_RANGE_WIDTH
-            ))
-        } else {
-            Ok(())
-        }
-    } else {
-        Err("Invalid port range".to_string())
-    }
 }
 
 fn hash_validator(hash: String) -> Result<(), String> {
@@ -1298,7 +1280,7 @@ pub fn main() {
                 .value_name("MIN_PORT-MAX_PORT")
                 .takes_value(true)
                 .default_value(default_dynamic_port_range)
-                .validator(port_range_validator)
+                .validator(solana_validator::port_range_validator)
                 .help("Range to use for dynamically assigned ports"),
         )
         .arg(


### PR DESCRIPTION
#### Problem
`solana-test-validator` is a convenient way to spin up a node, but can only realistically be used locally. Users testing more complete workflows need to be able to do things like deploy programs from remote nodes.

#### Summary of Changes
Add `--gossip-port`, `--gossip-host`, `--dynamic-port-range`, and `--bind-address` options to `solana-test-validator`
