### PR TITLE
Avoid full-range compactions with periodic filtered b.g. ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,26 +261,21 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.54.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
+checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
- "clap",
- "env_logger 0.7.1",
  "lazy_static",
  "lazycell",
- "log 0.4.11",
  "peeking_take_while",
  "proc-macro2 1.0.24",
  "quote 1.0.6",
  "regex",
  "rustc-hash",
  "shlex",
- "which",
 ]
 
 [[package]]
@@ -583,13 +578,13 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "853eda514c284c2287f4bf20ae614f8781f40a81d32ecda6e91449304dfe077c"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.5.2",
+ "libloading 0.7.0",
 ]
 
 [[package]]
@@ -1200,25 +1195,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime 1.3.0",
- "log 0.4.11",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
- "humantime 2.0.1",
+ "humantime",
  "log 0.4.11",
  "regex",
  "termcolor",
@@ -1780,15 +1762,6 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
@@ -2186,16 +2159,6 @@ checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-dependencies = [
- "cc",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "libloading"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cadb8e769f070c45df05c78c7520eb4cd17061d4ab262e43cfc68b4d00ac71c"
@@ -2204,10 +2167,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "librocksdb-sys"
-version = "6.11.4"
+name = "libloading"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b56f651c204634b936be2f92dbb42c36867e00ff7fe2405591f3b9fa66f09"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "6.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da125e1c0f22c7cae785982115523a0738728498547f415c9054cb17c7e89f9"
 dependencies = [
  "bindgen",
  "cc",
@@ -3060,12 +3033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d83c02c429044d58474eaf5ae31e062d0de894e21125b47437ec0edc1397e6"
+checksum = "c749134fda8bfc90d0de643d59bfc841dcb3ac8a1062e12b6754bd60235c48b3"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -4180,7 +4147,7 @@ dependencies = [
  "criterion-stats",
  "ctrlc",
  "dirs-next",
- "humantime 2.0.1",
+ "humantime",
  "indicatif",
  "log 0.4.11",
  "num-traits",
@@ -4234,7 +4201,7 @@ dependencies = [
  "base64 0.13.0",
  "chrono",
  "console 0.14.1",
- "humantime 2.0.1",
+ "humantime",
  "indicatif",
  "serde",
  "serde_derive",
@@ -4811,7 +4778,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fa7bddd7b89c26c6e3ef4af9b47d6bc8d60888559affb5160f5ade18c0cd058"
 dependencies = [
- "env_logger 0.8.3",
+ "env_logger",
  "lazy_static",
  "log 0.4.11",
 ]
@@ -4820,7 +4787,7 @@ dependencies = [
 name = "solana-logger"
 version = "1.8.0"
 dependencies = [
- "env_logger 0.8.3",
+ "env_logger",
  "lazy_static",
  "log 0.4.11",
 ]
@@ -4861,7 +4828,7 @@ dependencies = [
 name = "solana-metrics"
 version = "1.8.0"
 dependencies = [
- "env_logger 0.8.3",
+ "env_logger",
  "gethostname",
  "lazy_static",
  "log 0.4.11",
@@ -5555,7 +5522,7 @@ name = "solana-watchtower"
 version = "1.8.0"
 dependencies = [
  "clap",
- "humantime 2.0.1",
+ "humantime",
  "log 0.4.11",
  "solana-clap-utils",
  "solana-cli-config",
@@ -5803,7 +5770,7 @@ dependencies = [
  "anyhow",
  "fnv",
  "futures 0.3.8",
- "humantime 2.0.1",
+ "humantime",
  "log 0.4.11",
  "pin-project 1.0.1",
  "rand 0.7.3",
@@ -6847,15 +6814,6 @@ dependencies = [
  "tokio-io",
  "tokio-tcp",
  "tokio-tls",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -212,6 +212,8 @@ impl LedgerCleanupService {
                         lowest_cleanup_slot,
                         PurgeType::PrimaryIndex,
                     );
+                    // update only after purge operation
+                    blockstore.set_last_purged_slot(lowest_cleanup_slot);
                     purge_time.stop();
                     info!("{}", purge_time);
 

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -214,18 +214,16 @@ impl LedgerCleanupService {
                         PurgeType::CompactionFilter,
                     );
                     // Update only after purge operation.
-                    // Safety: This value can be used by compaction_filters
-                    // shared via Arc<AtomicU64>. Compactions are async and run as a multi-threaded
-                    // background job. However, this shouldn't cause consistency issues
-                    // for iterators and getters
-                    // because we have already expired all affected keys (older than or
-                    // equal to lowest_cleanup_slot) by the above `purge_slots`.
-                    // According to the general RocksDB design where SST files are immutable, even
-                    // running iterators aren't affected; the database grabs a snapshot of the
-                    // live set of sst files at iterator's creation.
-                    // Also, we passed the PurgeType::CompactionFilter, meaning no delete_range
-                    // for transaction_status and address_signatures CFs. These are fine because
-                    // they don't require strong consistent view for their operation.
+                    // Safety: This value can be used by compaction_filters shared via Arc<AtomicU64>.
+                    // Compactions are async and run as a multi-threaded background job. However, this
+                    // shouldn't cause consistency issues for iterators and getters because we have
+                    // already expired all affected keys (older than or equal to lowest_cleanup_slot)
+                    // by the above `purge_slots`. According to the general RocksDB design where SST
+                    // files are immutable, even running iterators aren't affected; the database grabs
+                    // a snapshot of the live set of sst files at iterator's creation.
+                    // Also, we passed the PurgeType::CompactionFilter, meaning no delete_range for
+                    // transaction_status and address_signatures CFs. These are fine because they
+                    // don't require strong consistent view for their operation.
                     blockstore.set_max_expired_slot(lowest_cleanup_slot);
 
                     purge_time.stop();

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -226,7 +226,7 @@ impl LedgerCleanupService {
                     // Also, we passed the PurgeType::CompactionFilter, meaning no delete_range
                     // for transaction_status and address_signatures CFs. These are fine because
                     // they don't require strong consistent view for their operation.
-                    blockstore.expire_upto_slot_for_compaction_filter(lowest_cleanup_slot);
+                    blockstore.set_max_expired_slot(lowest_cleanup_slot);
 
                     purge_time.stop();
                     info!("{}", purge_time);

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -211,7 +211,7 @@ impl LedgerCleanupService {
                     blockstore.purge_slots(
                         purge_first_slot,
                         lowest_cleanup_slot,
-                        PurgeType::PrimaryIndex,
+                        PurgeType::CompactionFilter,
                     );
                     // update only after purge operation
                     // safety: Firstly, this value can thereafter be used by compaction_filters

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -213,20 +213,19 @@ impl LedgerCleanupService {
                         lowest_cleanup_slot,
                         PurgeType::CompactionFilter,
                     );
-                    // update only after purge operation
-                    // safety: Firstly, this value can thereafter be used by compaction_filters
-                    // shared via Arc<AtomicU64>. Compactions are async and run in multi-threaded
-                    // as a background job. Sounds racy? ;) But this shouldn't cause consistency issues,
-                    // from higher layer's view point like iterators and getters.
-                    // That's because we have already shadowed all affected keys (older than or
+                    // Update only after purge operation.
+                    // Safety: This value can be used by compaction_filters
+                    // shared via Arc<AtomicU64>. Compactions are async and run as a multi-threaded
+                    // background job. However, this shouldn't cause consistency issues
+                    // for iterators and getters
+                    // because we have already expired all affected keys (older than or
                     // equal to lowest_cleanup_slot) by the above `purge_slots`.
-                    // According to the general RocksDB design where SST files and immutable, even
-                    // running iterators aren't affected; it grabs implicitly-created snapshot of
+                    // According to the general RocksDB design where SST files are immutable, even
+                    // running iterators aren't affected; the database grabs a snapshot of the
                     // live set of sst files at iterator's creation.
                     // Also, we passed the PurgeType::CompactionFilter, meaning no delete_range
                     // for transaction_status and address_signatures CFs. These are fine because
-                    // they don't require strong consistent view for workings.
-                    // so, with those enough bla bla, it can be said SAFU.
+                    // they don't require strong consistent view for their operation.
                     blockstore.expire_upto_slot_for_compaction_filter(lowest_cleanup_slot);
 
                     purge_time.stop();

--- a/core/src/ledger_cleanup_service.rs
+++ b/core/src/ledger_cleanup_service.rs
@@ -224,10 +224,10 @@ impl LedgerCleanupService {
                     // running iterators aren't affected; it grabs implicitly-created snapshot of
                     // live set of sst files at iterator's creation.
                     // Also, we passed the PurgeType::CompactionFilter, meaning no delete_range
-                    // for transaction_status and address_signatures CFs.  These are fine because
+                    // for transaction_status and address_signatures CFs. These are fine because
                     // they don't require strong consistent view for workings.
                     // so, with those enough bla bla, it can be said SAFU.
-                    blockstore.set_last_purged_slot(lowest_cleanup_slot);
+                    blockstore.expire_upto_slot_for_compaction_filter(lowest_cleanup_slot);
 
                     purge_time.stop();
                     info!("{}", purge_time);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1640,7 +1640,7 @@ mod tests {
             backup_and_clear_blockstore(&blockstore_path, 5, 2);
 
             let blockstore = Blockstore::open(&blockstore_path).unwrap();
-            // assert that slots less than 5 isn't affected
+            // assert that slots less than 5 aren't affected
             assert!(blockstore.meta(4).unwrap().unwrap().next_slots.is_empty());
             for i in 5..10 {
                 assert!(blockstore

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1636,9 +1636,11 @@ mod tests {
             }
             drop(blockstore);
 
+            // this purges and compacts all slots greater than or equal to 5
             backup_and_clear_blockstore(&blockstore_path, 5, 2);
 
             let blockstore = Blockstore::open(&blockstore_path).unwrap();
+            // assert that slots less than 5 isn't affected
             assert!(blockstore.meta(4).unwrap().unwrap().next_slots.is_empty());
             for i in 5..10 {
                 assert!(blockstore

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -39,6 +39,7 @@ mod tests {
         pub cleanup_blockstore: bool,
         pub emit_cpu_info: bool,
         pub assert_compaction: bool,
+        pub compaction_interval: Option<u64>,
         pub no_compaction: bool,
     }
 
@@ -155,6 +156,10 @@ mod tests {
         let emit_cpu_info = read_env("EMIT_CPU_INFO", true);
         // set default to `true` once compaction is merged
         let assert_compaction = read_env("ASSERT_COMPACTION", false);
+        let compaction_interval = match read_env("COMPACTION_INTERVAL", 0) {
+            maybe_zero if maybe_zero == 0 => None,
+            non_zero => Some(non_zero),
+        };
         let no_compaction = read_env("NO_COMPACTION", false);
 
         BenchmarkConfig {
@@ -168,6 +173,7 @@ mod tests {
             cleanup_blockstore,
             emit_cpu_info,
             assert_compaction,
+            compaction_interval,
             no_compaction,
         }
     }
@@ -231,6 +237,8 @@ mod tests {
         let stop_size_bytes = config.stop_size_bytes;
         let stop_size_iterations = config.stop_size_iterations;
         let pre_generate_data = config.pre_generate_data;
+        let compaction_interval = config.compaction_interval;
+
         let batches = benchmark_slots / batch_size;
 
         let (sender, receiver) = channel();
@@ -240,7 +248,7 @@ mod tests {
             blockstore.clone(),
             max_ledger_shreds,
             &exit,
-            None,
+            compaction_interval,
             None,
         );
 

--- a/core/tests/ledger_cleanup.rs
+++ b/core/tests/ledger_cleanup.rs
@@ -39,6 +39,7 @@ mod tests {
         pub cleanup_blockstore: bool,
         pub emit_cpu_info: bool,
         pub assert_compaction: bool,
+        pub no_compaction: bool,
     }
 
     #[derive(Clone, Copy, Debug)]
@@ -154,6 +155,7 @@ mod tests {
         let emit_cpu_info = read_env("EMIT_CPU_INFO", true);
         // set default to `true` once compaction is merged
         let assert_compaction = read_env("ASSERT_COMPACTION", false);
+        let no_compaction = read_env("NO_COMPACTION", false);
 
         BenchmarkConfig {
             benchmark_slots,
@@ -166,6 +168,7 @@ mod tests {
             cleanup_blockstore,
             emit_cpu_info,
             assert_compaction,
+            no_compaction,
         }
     }
 
@@ -211,8 +214,13 @@ mod tests {
     fn test_ledger_cleanup_compaction() {
         solana_logger::setup();
         let blockstore_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(Blockstore::open(&blockstore_path).unwrap());
+        let mut blockstore = Blockstore::open(&blockstore_path).unwrap();
         let config = get_benchmark_config();
+        if config.no_compaction {
+            blockstore.set_no_compaction(true);
+        }
+        let blockstore = Arc::new(blockstore);
+
         eprintln!("BENCHMARK CONFIG: {:?}", config);
         eprintln!("LEDGER_PATH: {:?}", &blockstore_path);
 

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -59,7 +59,7 @@ trees = "0.2.1"
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts
 # when also using the bzip2 crate
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
 features = ["lz4"]
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -6736,6 +6736,7 @@ pub mod tests {
                 log_messages: Some(vec![]),
                 pre_token_balances: Some(vec![]),
                 post_token_balances: Some(vec![]),
+                rewards: Some(vec![]),
             }
             .into();
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2063,7 +2063,7 @@ impl Blockstore {
         signature: Signature,
         confirmed_unrooted_slots: &[Slot],
     ) -> Result<(Option<(Slot, TransactionStatusMeta)>, u64)> {
-        // transaction_status doesn't employ strong read consystency with slot-based
+        // transaction_status_cf doesn't employ strong read consystency with slot-based
         // delete_range via LedgerCleanupService, because of inefficiency.
         // so, ensure consistent result by using lowest_cleanup_slot as the lower bound
         // for reading
@@ -2217,7 +2217,7 @@ impl Blockstore {
         start_slot: Slot,
         end_slot: Slot,
     ) -> Result<Vec<(Slot, Signature)>> {
-        // transaction_status doesn't employ strong read consystency with slot-based
+        // adress_signatures_cf doesn't employ strong read consystency with slot-based
         // delete_range via LedgerCleanupService, because of inefficiency.
         // so, ensure consistent result by using lowest_cleanup_slot as the lower bound
         // for reading
@@ -2255,7 +2255,7 @@ impl Blockstore {
         pubkey: Pubkey,
         slot: Slot,
     ) -> Result<Vec<(Slot, Signature)>> {
-        // transaction_status doesn't employ strong read consystency with slot-based
+        // address_signatures_cf doesn't employ strong read consystency with slot-based
         // delete_range via LedgerCleanupService, because of inefficiency.
         // so, ensure consistent result by using lowest_cleanup_slot as the lower bound
         // for reading

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2060,7 +2060,7 @@ impl Blockstore {
     fn ensure_lowest_cleanup_slot(&self) -> (std::sync::RwLockReadGuard<Slot>, Slot) {
         // Ensures consistent result by using lowest_cleanup_slot as the lower bound
         // for reading columns that do not employ strong read consistency with slot-based
-        // delete_range 
+        // delete_range
         let lowest_cleanup_slot = self.lowest_cleanup_slot.read().unwrap();
         let lowest_available_slot = (*lowest_cleanup_slot)
             .checked_add(1)
@@ -6833,7 +6833,7 @@ pub mod tests {
             assert_existing_always();
 
             if simulate_compaction {
-                blockstore.expire_upto_slot_for_compaction_filter(lowest_cleanup_slot);
+                blockstore.set_max_expired_slot(lowest_cleanup_slot);
                 // force compaction filters to run across whole key range.
                 blockstore
                     .compact_storage(Slot::min_value(), Slot::max_value())

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -92,6 +92,7 @@ type CompletedRanges = Vec<(u32, u32)>;
 pub enum PurgeType {
     Exact,
     PrimaryIndex,
+    CompactionFilter,
 }
 
 #[derive(Error, Debug)]

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1959,13 +1959,13 @@ impl Blockstore {
         } else {
             let purge_target_primary_index = if index0.frozen && to_slot > index0.max_slot {
                 info!(
-                    "Pruning expired primary index 0 at slot {} (requested: {})",
+                    "Pruning expired primary index 0 up to slot {} (max requested: {})",
                     index0.max_slot, to_slot
                 );
                 Some(0)
             } else if index1.frozen && to_slot > index1.max_slot {
                 info!(
-                    "Pruning expired primary index 1 at slot {} (requested: {})",
+                    "Pruning expired primary index 1 up to slot {} (max requested: {})",
                     index1.max_slot, to_slot
                 );
                 Some(1)
@@ -2063,7 +2063,7 @@ impl Blockstore {
         signature: Signature,
         confirmed_unrooted_slots: &[Slot],
     ) -> Result<(Option<(Slot, TransactionStatusMeta)>, u64)> {
-        // transaction_status_cf doesn't employ strong read consystency with slot-based
+        // transaction_status_cf doesn't employ strong read consistency with slot-based
         // delete_range via LedgerCleanupService, because of inefficiency.
         // so, ensure consistent result by using lowest_cleanup_slot as the lower bound
         // for reading
@@ -2217,7 +2217,7 @@ impl Blockstore {
         start_slot: Slot,
         end_slot: Slot,
     ) -> Result<Vec<(Slot, Signature)>> {
-        // adress_signatures_cf doesn't employ strong read consystency with slot-based
+        // address_signatures_cf doesn't employ strong read consistency with slot-based
         // delete_range via LedgerCleanupService, because of inefficiency.
         // so, ensure consistent result by using lowest_cleanup_slot as the lower bound
         // for reading
@@ -2255,7 +2255,7 @@ impl Blockstore {
         pubkey: Pubkey,
         slot: Slot,
     ) -> Result<Vec<(Slot, Signature)>> {
-        // address_signatures_cf doesn't employ strong read consystency with slot-based
+        // address_signatures_cf doesn't employ strong read consistency with slot-based
         // delete_range via LedgerCleanupService, because of inefficiency.
         // so, ensure consistent result by using lowest_cleanup_slot as the lower bound
         // for reading

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1957,10 +1957,16 @@ impl Blockstore {
             Ok(None)
         } else {
             let result = if index0.frozen && to_slot > index0.max_slot {
-                debug!("Pruning transaction index 0 at slot {}", index0.max_slot);
+                info!(
+                    "Pruning expired primary index 0 at slot {} (requested: {})",
+                    index0.max_slot, to_slot
+                );
                 Some(0)
             } else if index1.frozen && to_slot > index1.max_slot {
-                debug!("Pruning transaction index 1 at slot {}", index1.max_slot);
+                info!(
+                    "Pruning expired primary index 1 at slot {} (requested: {})",
+                    index1.max_slot, to_slot
+                );
                 Some(1)
             } else {
                 None

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -38,7 +38,7 @@ impl Blockstore {
     /// can also be used to purge *future* slots for --hard-fork thing, preserving older
     /// slots. It'd be quite dangerous to purge older slots in that case.
     /// So, current legal user of this function is LedgerCleanupService.
-    pub fn expire_upto_slot_for_compaction_filter(&self, to_slot: Slot) {
+    pub fn set_max_expired_slot(&self, to_slot: Slot) {
         // convert here from inclusive purged range end to inclusive alive range start to align
         // with Slot::default() for initial compaction filter behavior consistency
         let to_slot = to_slot.checked_add(1).unwrap();

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -33,7 +33,7 @@ impl Blockstore {
     }
 
     /// Usually this is paired with .purge_slots() but we can't internally call this in
-    /// that function unconditionally. That's because expire_upto_slot_for_compaction_filter()
+    /// that function unconditionally. That's because set_max_expired_slot()
     /// expects to purge older slots by the successive chronological order, while .purge_slots()
     /// can also be used to purge *future* slots for --hard-fork thing, preserving older
     /// slots. It'd be quite dangerous to purge older slots in that case.

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -16,6 +16,8 @@ impl Blockstore {
         let mut purge_stats = PurgeStats::default();
         let purge_result =
             self.run_purge_with_stats(from_slot, to_slot, purge_type, &mut purge_stats);
+        // update only after purge operation
+        crate::blockstore_db::LAST_PURGE_SLOT.store(to_slot, std::sync::atomic::Ordering::Relaxed);
 
         datapoint_info!(
             "blockstore-purge",

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -32,6 +32,12 @@ impl Blockstore {
         }
     }
 
+    /// Usually this is paired with .purge_slots() but we can't internally call this in
+    /// that function unconditionally. That's because set_last_purged_slot expects to
+    /// purge older slots by the successive chronological order, while .purge_slots()
+    /// can also be used to purge *future* slots for --hard-fork thing, preserving older
+    /// slots. It'd be quite dangerous to purge older slots in that case.
+    /// So, current legal user of this function is LedgerCleanupService.
     pub fn set_last_purged_slot(&self, to_slot: Slot) {
         // convert here from inclusive purged range end to inclusive alive range start to align
         // with Slot::default() for initial compaction filter behavior consistency

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -191,7 +191,7 @@ impl Blockstore {
                 // this purge type completely and indefinitely relies on the proper working of compaction
                 // filter for those speical column families, never toggling the primary index from the
                 // current one. Overall, this enables well uniformly distributed writes, resulting
-                // in no spiky periodic compaction for them.
+                // in no spiky periodic huge delete_range for them.
             }
         }
         delete_range_timer.stop();

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -187,6 +187,12 @@ impl Blockstore {
                     to_slot,
                 )?;
             }
+            PurgeType::CompactionFilter => {
+                // this purge type completely and indefinitely relies on the proper working of compaction
+                // filter for those speical column families, never toggling the primary index from the
+                // current one. Overall, this enables well uniformly distributed writes, resulting
+                // in no spiky periodic compaction for them.
+            }
         }
         delete_range_timer.stop();
         let mut write_timer = Measure::start("write_batch");

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -33,12 +33,12 @@ impl Blockstore {
     }
 
     /// Usually this is paired with .purge_slots() but we can't internally call this in
-    /// that function unconditionally. That's because set_last_purged_slot expects to
-    /// purge older slots by the successive chronological order, while .purge_slots()
+    /// that function unconditionally. That's because expire_upto_slot_for_compaction_filter()
+    /// expects to purge older slots by the successive chronological order, while .purge_slots()
     /// can also be used to purge *future* slots for --hard-fork thing, preserving older
     /// slots. It'd be quite dangerous to purge older slots in that case.
     /// So, current legal user of this function is LedgerCleanupService.
-    pub fn set_last_purged_slot(&self, to_slot: Slot) {
+    pub fn expire_upto_slot_for_compaction_filter(&self, to_slot: Slot) {
         // convert here from inclusive purged range end to inclusive alive range start to align
         // with Slot::default() for initial compaction filter behavior consistency
         let to_slot = to_slot.checked_add(1).unwrap();

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -33,8 +33,8 @@ impl Blockstore {
     }
 
     pub fn set_last_purged_slot(&self, to_slot: Slot) {
-        // convert here from inclusive puraged range end to inclusive alive range start to align
-        // with Slot::defualt() for initial compaction filter behavior consistency
+        // convert here from inclusive purged range end to inclusive alive range start to align
+        // with Slot::default() for initial compaction filter behavior consistency
         let to_slot = to_slot.checked_add(1).unwrap();
         self.db.set_oldest_slot(to_slot);
     }
@@ -188,9 +188,10 @@ impl Blockstore {
                 )?;
             }
             PurgeType::CompactionFilter => {
-                // this purge type completely and indefinitely relies on the proper working of compaction
-                // filter for those speical column families, never toggling the primary index from the
-                // current one. Overall, this enables well uniformly distributed writes, resulting
+                // No explicit action is required here because this purge type completely and
+                // indefinitely relies on the proper working of compaction filter for those
+                // special column families, never toggling the primary index from the current
+                // one. Overall, this enables well uniformly distributed writes, resulting
                 // in no spiky periodic huge delete_range for them.
             }
         }

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -448,8 +448,7 @@ impl Rocks {
                     db.cf_handle(cf_name),
                     &[(
                         "periodic_compaction_seconds",
-                        &std::env::var("SOLANA_ROCKSDB_PERIODIC_COMPACTION_SECONDS")
-                            .unwrap_or(format!("{}", PERIODIC_COMPACTION_SECONDS)),
+                        &format!("{}", PERIODIC_COMPACTION_SECONDS),
                     )],
                 )
                 .unwrap();

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -231,7 +231,7 @@ struct OldestSlot(Arc<AtomicU64>);
 impl OldestSlot {
     pub fn set(&self, oldest_slot: Slot) {
         // this is independently used for compaction_filter without any data dependency.
-        // also, compaction_fileters are created via its factories, creating short-lived copies of
+        // also, compaction_filters are created via its factories, creating short-lived copies of
         // this atomic value for the single job of compaction. So, Relaxed store can be justified
         // in total
         self.0.store(oldest_slot, Ordering::Relaxed);

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -1199,7 +1199,7 @@ impl<C: Column + ColumnName> CompactionFilter for PurgedSlotFilter<C> {
         use rocksdb::CompactionDecision::*;
 
         let slot_in_key = C::slot(C::index(key));
-        // Refer to a comment about periodic_compaction_seconds, especially regarding implict
+        // Refer to a comment about periodic_compaction_seconds, especially regarding implicit
         // periodic execution of compaction_filters
         if slot_in_key >= self.oldest_slot {
             Keep

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -338,7 +338,7 @@ impl Rocks {
         );
         let block_height_cf_descriptor = ColumnFamilyDescriptor::new(
             BlockHeight::NAME,
-            get_cf_options::<BlockHeight>(&access_type)
+            get_cf_options::<BlockHeight>(&access_type, &oldest_slot),
         );
 
         let cfs = vec![

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -323,16 +323,20 @@ impl Rocks {
                 }
             }
         };
-        for cf_name in cf_names {
-            db.0.set_options_cf(
-                db.cf_handle(cf_name),
-                &[(
-                    "ttl",
-                    &std::env::var("SOLANA_ROCKSDB_COMPACTION_TTL")
-                        .unwrap_or(format!("{}", 60 * 60 * 24 * 3)),
-                )],
-            )
-            .unwrap();
+        if db.1 == ActualAccessType::Primary {
+            // Setting ttl only makes sense for primary access mode; and forcing so causes
+            // hard-errors from RocksDB
+            for cf_name in cf_names {
+                db.0.set_options_cf(
+                    db.cf_handle(cf_name),
+                    &[(
+                        "ttl",
+                        &std::env::var("SOLANA_ROCKSDB_COMPACTION_TTL")
+                            .unwrap_or(format!("{}", 60 * 60 * 24 * 3)),
+                    )],
+                )
+                .unwrap();
+            }
         }
 
         Ok(db)

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -324,8 +324,8 @@ impl Rocks {
             }
         };
         if db.1 == ActualAccessType::Primary {
-            // Setting ttl only makes sense for primary access mode; and forcing so causes
-            // hard-errors from RocksDB
+            // Setting ttl only makes sense for primary access mode; and forcing so with secondary
+            // access causes hard-errors from RocksDB...
             for cf_name in cf_names {
                 db.0.set_options_cf(
                     db.cf_handle(cf_name),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1500,14 +1500,7 @@ pub fn main() {
             Arg::with_name("no_rocksdb_compaction")
                 .long("no-rocksdb-compaction")
                 .takes_value(false)
-                .help("Disable manual compaction of the ledger database.")
-        )
-        .arg(
-            Arg::with_name("rocksdb_compaction")
-                .long("rocksdb-compaction")
-                .takes_value(false)
-                .conflicts_with("no_rocksdb_compaction")
-                .help("Enable manual compaction of the ledger database.")
+                .help("Disable manual compaction of the ledger database (this is ignored).")
         )
         .arg(
             Arg::with_name("rocksdb_compaction_interval")
@@ -2023,17 +2016,7 @@ pub fn main() {
 
     let private_rpc = matches.is_present("private_rpc");
     let no_port_check = matches.is_present("no_port_check");
-    let rocksdb_compaction = match (
-        matches.is_present("rocksdb_compaction"),
-        matches.is_present("no_rocksdb_compaction"),
-    ) {
-        (true, true) => unreachable!(),
-        (true, false) => true,
-        (false, true) => false,
-        (false, false) => false, // no MANUAL compaction as default behavior
-    };
-    let no_rocksdb_compaction = !rocksdb_compaction;
-
+    let no_rocksdb_compaction = false;
     let rocksdb_compaction_interval = value_t!(matches, "rocksdb_compaction_interval", u64).ok();
     let rocksdb_max_compaction_jitter =
         value_t!(matches, "rocksdb_max_compaction_jitter", u64).ok();

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -2016,7 +2016,7 @@ pub fn main() {
 
     let private_rpc = matches.is_present("private_rpc");
     let no_port_check = matches.is_present("no_port_check");
-    let no_rocksdb_compaction = false;
+    let no_rocksdb_compaction = true;
     let rocksdb_compaction_interval = value_t!(matches, "rocksdb_compaction_interval", u64).ok();
     let rocksdb_max_compaction_jitter =
         value_t!(matches, "rocksdb_max_compaction_jitter", u64).ok();

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1500,7 +1500,13 @@ pub fn main() {
             Arg::with_name("no_rocksdb_compaction")
                 .long("no-rocksdb-compaction")
                 .takes_value(false)
-                .help("Disable manual compaction of the ledger database. May increase storage requirements.")
+                .help("Disable manual compaction of the ledger database.")
+        )
+        .arg(
+            Arg::with_name("rocksdb_compaction")
+                .long("rocksdb-compaction")
+                .takes_value(false)
+                .help("Enable manual compaction of the ledger database.")
         )
         .arg(
             Arg::with_name("rocksdb_compaction_interval")
@@ -2016,7 +2022,17 @@ pub fn main() {
 
     let private_rpc = matches.is_present("private_rpc");
     let no_port_check = matches.is_present("no_port_check");
-    let no_rocksdb_compaction = matches.is_present("no_rocksdb_compaction");
+    let rocksdb_compaction = match (
+        matches.is_present("rocksdb_compaction"),
+        matches.is_present("no_rocksdb_compaction"),
+    ) {
+        (true, true) => panic!("conflicting options are supplied!"),
+        (true, false) => true,
+        (false, true) => false,
+        (false, false) => false, // no MANUAL compaction as default behavior
+    };
+    let no_rocksdb_compaction = !rocksdb_compaction;
+
     let rocksdb_compaction_interval = value_t!(matches, "rocksdb_compaction_interval", u64).ok();
     let rocksdb_max_compaction_jitter =
         value_t!(matches, "rocksdb_max_compaction_jitter", u64).ok();

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1506,6 +1506,7 @@ pub fn main() {
             Arg::with_name("rocksdb_compaction")
                 .long("rocksdb-compaction")
                 .takes_value(false)
+                .conflicts_with("no_rocksdb_compaction")
                 .help("Enable manual compaction of the ledger database.")
         )
         .arg(
@@ -2026,7 +2027,7 @@ pub fn main() {
         matches.is_present("rocksdb_compaction"),
         matches.is_present("no_rocksdb_compaction"),
     ) {
-        (true, true) => panic!("conflicting options are supplied!"),
+        (true, true) => unreachable!(),
         (true, false) => true,
         (false, true) => false,
         (false, false) => false, // no MANUAL compaction as default behavior


### PR DESCRIPTION
~here's the result from 1-day investigation. this is still needs to be tested. I'm 50% certain for this fix at this moment...~ now I'm certain for the effectiveness of this.  :)

#### Problem

manual compaction is bad. it causes stalls. but it was needed to avoid unbounded ledger dir size bloating.
it seems the ultimate problem was older blocks aren't compacted via the background compaction. but I think it's tunable.

That's partly due to our rather unusual write pattern: we seldom dirties the older keys, as we only write things with newer slot number under normal operation. So, my hypothesis is that compaction only focus on the newer sst files even if we submit delete_range over older slots.

at least, manual compaction has succeeded in keeping the ledger size under controll, so there should be no reason we can make it possible with background compaction, avoiding stalls.



#### Summary of Changes

Avoid manual compaction by making sure every sst files are periodically scanned for deletion via compaction_filter.

Also, update rocksdb to use the new api: `set_options_cf()` (For the update, I test binary compatibility of forward- backward- update of rocksdb 0.11.4 <=> 0.17.0 also checked `rust-rocksdb` and `rocksdb`'s changelogs to check there is no serious regression or breaking changes..)
Maybe this may increase disk write but, I think it's tolerable. we're already notorious as ssd killer.
Also, it should be no significant difference regarding total write sum of amplification due to compactions between from manual compaction and from background compaction.

Fixes https://github.com/solana-labs/solana/issues/14586
