### PR TITLE
Improve net scripts

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -835,8 +835,8 @@ while [[ -n $1 ]]; do
       doBuild=false
       shift 1
     elif [[ $1 = --limit-ledger-size ]]; then
-      maybeLimitLedgerSize="$1"
-      shift 1
+      maybeLimitLedgerSize="$1" "$2"
+      shift 2
     elif [[ $1 = --skip-poh-verify ]]; then
       maybeSkipLedgerVerify="$1"
       shift 1

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -360,6 +360,8 @@ EOF
 
     if [[ $airdropsEnabled != true ]]; then
       args+=(--no-airdrop)
+    else
+      args+=(--rpc-faucet-address "$entrypointIp:9900")
     fi
 
     if [[ -r "$SOLANA_CONFIG_DIR"/bank-hash ]]; then


### PR DESCRIPTION
#### Problem
Attempting to use the `--limit-ledger-size` flag with `/net` fails, because `multinode-demo/bootstrap-validator.sh` and `multinode-demo/validator.sh` both expect it to be an option with value.

#### Summary of Changes
- Convert net.sh `--limit-ledger-size` to an option with value
- Also, when `airdropsEnabled`, pass the faucet-address to the non-bootstrap nodes, so `solana airdrop` works against any rpc in the test cluster
