### PR TITLE
limits to data_header.size when combining shreds' payloads

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2948,6 +2948,8 @@ pub(crate) mod tests {
             let gibberish = [0xa5u8; PACKET_DATA_SIZE];
             let mut data_header = DataShredHeader::default();
             data_header.flags |= DATA_COMPLETE_SHRED;
+            // Need to provide the right size for Shredder::deshred.
+            data_header.size = SIZE_OF_DATA_SHRED_PAYLOAD as u16;
             let mut shred = Shred::new_empty_from_header(
                 ShredCommonHeader::default(),
                 data_header,


### PR DESCRIPTION
#### Problem
deshred is ignoring `data_header.size` when combining shreds' payloads:
https://github.com/solana-labs/solana/blob/37b8587d4/ledger/src/shred.rs#L940-L961

#### Summary of Changes
* limit the payload to `data_header.size`.
* also more sanity checks on the given shreds indices.