### PR TITLE
CLI: Make `pay` subcommand a proper alias of `transfer`

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -848,7 +848,7 @@ pub fn parse_command(
                 signers: vec![],
             })
         }
-        ("pay", Some(matches)) | ("transfer", Some(matches)) => {
+        ("transfer", Some(matches)) => {
             let amount = SpendAmount::new_from_matches(matches, "amount");
             let to = pubkey_of_signer(matches, "to", wallet_manager)?.unwrap();
             let sign_only = matches.is_present(SIGN_ONLY_ARG.name);
@@ -2150,28 +2150,6 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
                 ),
         )
         .subcommand(
-            SubCommand::with_name("pay")
-                .about("Deprecated alias for the transfer command")
-                .arg(
-                    pubkey!(Arg::with_name("to")
-                        .index(1)
-                        .value_name("RECIPIENT_ADDRESS")
-                        .required(true),
-                        "The account address of recipient. "),
-                )
-                .arg(
-                    Arg::with_name("amount")
-                        .index(2)
-                        .value_name("AMOUNT")
-                        .takes_value(true)
-                        .validator(is_amount_or_all)
-                        .required(true)
-                        .help("The amount to send, in SOL; accepts keyword ALL"),
-                )
-                .offline_args()
-                .nonce_args(false)
-        )
-        .subcommand(
             SubCommand::with_name("resolve-signer")
                 .about("Checks that a signer is valid, and returns its specific path; useful for signers that may be specified generally, eg. usb://ledger")
                 .arg(
@@ -2187,6 +2165,7 @@ pub fn app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> App<'ab, '
         .subcommand(
             SubCommand::with_name("transfer")
                 .about("Transfer funds between system accounts")
+                .alias("pay")
                 .arg(
                     pubkey!(Arg::with_name("to")
                         .index(1)


### PR DESCRIPTION
#### Problem

CLI's `pay` subcommand purports to be an alias of `transfer`, yet lacks feature parity

#### Summary of Changes

Make `pay` subcommand a proper alias of `transfer`

Fixes #16706


```
$ solana -ud pay 5G1W4yDDVbVGKdKGWZKtvuuizsXUDGBfbrfEaKA6ZMhY 1
Error: The recipient address (5G1W4yDDVbVGKdKGWZKtvuuizsXUDGBfbrfEaKA6ZMhY) is not funded. Add `--allow-unfunded-recipient` to complete the transfer
```
```
$ solana -ud pay 5G1W4yDDVbVGKdKGWZKtvuuizsXUDGBfbrfEaKA6ZMhY 1 --allow-unfunded-recipient

Signature: 5MTFj5EDDVLKxdKLfdcxX8JE7Z2h5e3u9sQBCDe6sK9y4qoCGfo29weC4qzszGRAhhDC5xQdH1UWcS1EKKHkZbTn
```
```
$ solana --help | grep -A2 -B2 pay
    transaction-count              Get current transaction count
    transaction-history            Show historical transactions affecting the given address from newest to oldest
    transfer                       Transfer funds between system accounts [aliases: pay]
    validator-info                 Publish/get Validator info on Solana
    validators                     Show summary information about the current validators
```
