### PR TITLE
temporarily disable readonly cache due to lru problem

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -8854,21 +8854,22 @@ pub mod tests {
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports, 1);
-        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        let expected = 0;
+        assert_eq!(db.read_only_accounts_cache.cache_len(), expected);
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports, 1);
-        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_eq!(db.read_only_accounts_cache.cache_len(), expected);
         db.store_cached(2, &[(&account_key, &zero_lamport_account)]);
-        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_eq!(db.read_only_accounts_cache.cache_len(), expected);
         let account = db
             .load_with_fixed_root(&Ancestors::default(), &account_key)
             .map(|(account, _)| account)
             .unwrap();
         assert_eq!(account.lamports, 0);
-        assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+        assert_eq!(db.read_only_accounts_cache.cache_len(), expected);
     }
 
     #[test]

--- a/runtime/src/read_only_accounts_cache.rs
+++ b/runtime/src/read_only_accounts_cache.rs
@@ -203,7 +203,7 @@ pub mod tests {
         let per_account_size = ReadOnlyAccountsCache::per_account_size();
         let data_size = 100;
         let max = data_size + per_account_size;
-        let cache = ReadOnlyAccountsCache::new(max);
+        let mut cache = ReadOnlyAccountsCache::new(max);
         cache.disabled = false;
         let slot = 0;
         assert!(cache.load(&Pubkey::default(), slot).is_none());
@@ -239,7 +239,7 @@ pub mod tests {
 
         // can store 2 items, 3rd item kicks oldest item out
         let max = (data_size + per_account_size) * 2;
-        let cache = ReadOnlyAccountsCache::new(max);
+        let mut cache = ReadOnlyAccountsCache::new(max);
         cache.disabled = false;
         cache.store(&key1, slot, &account1);
         assert_eq!(100 + per_account_size, cache.data_size());


### PR DESCRIPTION
#### Problem
tps is messed up due to bad lru cleanup of readonly cache
#### Summary of Changes
disable store in read only cache to disable the cache.
Fixes #
