### PR TITLE
Clean up "APR" language around inflation rewards

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -1405,24 +1405,28 @@ impl fmt::Display for CliInflation {
         if (self.governor.initial - self.governor.terminal).abs() < f64::EPSILON {
             writeln!(
                 f,
-                "Fixed APR:               {:>5.2}%",
+                "Fixed rate:              {:>5.2}%",
                 self.governor.terminal * 100.
             )?;
         } else {
             writeln!(
                 f,
-                "Initial APR:             {:>5.2}%",
+                "Initial rate:            {:>5.2}%",
                 self.governor.initial * 100.
             )?;
             writeln!(
                 f,
-                "Terminal APR:            {:>5.2}%",
+                "Terminal rate:           {:>5.2}%",
                 self.governor.terminal * 100.
             )?;
             writeln!(
                 f,
                 "Rate reduction per year: {:>5.2}%",
                 self.governor.taper * 100.
+            )?;
+            writeln!(
+                f,
+                "* Rate reduction is derived using the target slot time in genesis config"
             )?;
         }
         if self.governor.foundation_term > 0. {
@@ -1445,17 +1449,17 @@ impl fmt::Display for CliInflation {
         )?;
         writeln!(
             f,
-            "Total APR:               {:>5.2}%",
+            "Total rate:              {:>5.2}%",
             self.current_rate.total * 100.
         )?;
         writeln!(
             f,
-            "Staking APR:             {:>5.2}%",
+            "Staking rate:            {:>5.2}%",
             self.current_rate.validator * 100.
         )?;
         writeln!(
             f,
-            "Foundation APR:          {:>5.2}%",
+            "Foundation rate:         {:>5.2}%",
             self.current_rate.foundation * 100.
         )
     }

--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1135,7 +1135,8 @@ The result field will be a JSON object with the following fields:
 
 - `initial: <f64>`, the initial inflation percentage from time 0
 - `terminal: <f64>`, terminal inflation percentage
-- `taper: <f64>`, rate per year at which inflation is lowered
+- `taper: <f64>`, rate per year at which inflation is lowered.
+   Rate reduction is derived using the target slot time in genesis config
 - `foundation: <f64>`, percentage of total inflation allocated to the foundation
 - `foundationTerm: <f64>`, duration of foundation pool inflation in years
 

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -241,8 +241,10 @@ impl fmt::Display for GenesisConfig {
              Shred version: {}\n\
              Ticks per slot: {:?}\n\
              Hashes per tick: {:?}\n\
+             Target tick duration: {:?}\n\
              Slots per epoch: {}\n\
              Warmup epochs: {}abled\n\
+             Slots per year: {}\n\
              {:?}\n\
              {:?}\n\
              {:?}\n\
@@ -256,12 +258,14 @@ impl fmt::Display for GenesisConfig {
             compute_shred_version(&self.hash(), None),
             self.ticks_per_slot,
             self.poh_config.hashes_per_tick,
+            self.poh_config.target_tick_duration,
             self.epoch_schedule.slots_per_epoch,
             if self.epoch_schedule.warmup {
                 "en"
             } else {
                 "dis"
             },
+            self.slots_per_year(),
             self.inflation,
             self.rent,
             self.fee_rate_governor,


### PR DESCRIPTION
New `solana inflation` output, APR is now removed entirely as it's misleading.  Instead just use rate:
```
$ solana inflation 
Inflation Governor:
Initial rate:             8.00%
Terminal rate:            1.50%
Rate reduction per year: 15.00%
* Rate reduction is derived using the target slot time in genesis config

Inflation for Epoch 172:
Total rate:               7.84%
Staking rate:             7.84%
Foundation rate:          0.00%
```

The `getInflationGovernor` RPC method documentation now uses the same language.

Also updated the output from `solana-ledger-tool genesis` to include the hard-coded target tick duration and slots-per-year values that are used by the Bank to compute inflation. I briefly considered exposing those values over RPC as well, but ultimately decided not to for now since there's no client demand yet.

Fixes #16718