### PR TITLE
Explorer: avoid passing along additionalSignatures as an option to getConfirmedSignaturesForAddress2

### DIFF
--- a/explorer/src/providers/accounts/history.tsx
+++ b/explorer/src/providers/accounts/history.tsx
@@ -130,9 +130,9 @@ async function fetchAccountHistory(
   options: {
     before?: TransactionSignature;
     limit: number;
-    additionalSignatures?: string[];
   },
-  fetchTransactions?: boolean
+  fetchTransactions?: boolean,
+  additionalSignatures?: string[]
 ) {
   dispatch({
     type: ActionType.Update,
@@ -166,7 +166,7 @@ async function fetchAccountHistory(
     try {
       const signatures = history.fetched
         .map((signature) => signature.signature)
-        .concat(options.additionalSignatures || []);
+        .concat(additionalSignatures || []);
       transactionMap = await fetchParsedTransactions(url, signatures);
     } catch (error) {
       if (cluster !== Cluster.Custom) {
@@ -256,9 +256,9 @@ export function useFetchAccountHistory() {
           {
             before: oldest,
             limit: 25,
-            additionalSignatures,
           },
-          fetchTransactions
+          fetchTransactions,
+          additionalSignatures
         );
       } else {
         fetchAccountHistory(


### PR DESCRIPTION
#### Problem
`additionalSignatures` is not a valid parameter for `getConfirmedSignaturesForAddress2` and we should avoid passing this forward. 

#### Summary of Changes
Passes `additionalSignatures` through a standalone argument, instead of the options object, of the fetchAccountHistory function
