### PR TITLE
Retry latest vote if expired

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -1363,7 +1363,7 @@ impl BankingStage {
 
 pub(crate) fn next_leader_tpu(
     cluster_info: &ClusterInfo,
-    poh_recorder: &Arc<Mutex<PohRecorder>>,
+    poh_recorder: &Mutex<PohRecorder>,
 ) -> Option<std::net::SocketAddr> {
     if let Some(leader_pubkey) = poh_recorder
         .lock()

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -382,7 +382,7 @@ impl Tower {
         self.last_vote_tx_blockhash
     }
 
-    fn last_voted_slot_in_bank(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {
+    pub fn last_voted_slot_in_bank(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {
         let (_stake, vote_account) = bank.get_vote_account(vote_account_pubkey)?;
         let slot = vote_account.vote_state().as_ref().ok()?.last_voted_slot();
         slot
@@ -461,7 +461,7 @@ impl Tower {
 
     #[cfg(test)]
     pub fn record_vote(&mut self, slot: Slot, hash: Hash) -> Option<Slot> {
-        self.record_bank_vote_and_update_lockouts(slot, hash, None)
+        self.record_bank_vote_and_update_lockouts(slot, hash, self.last_voted_slot())
     }
 
     pub fn last_voted_slot(&self) -> Option<Slot> {
@@ -2592,10 +2592,12 @@ pub mod test {
         } else {
             vec![]
         };
-        let expected = Vote::new(slots, Hash::default());
+        let mut expected = Vote::new(slots, Hash::default());
         for i in 0..num_votes {
             tower.record_vote(i as u64, Hash::default());
         }
+
+        expected.timestamp = tower.last_vote.timestamp;
         assert_eq!(expected, tower.last_vote)
     }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -427,7 +427,7 @@ impl Tower {
         self.record_bank_vote_and_update_lockouts(bank.slot(), bank.hash(), last_voted_slot_in_bank)
     }
 
-    pub fn record_bank_vote_and_update_lockouts(
+    fn record_bank_vote_and_update_lockouts(
         &mut self,
         vote_slot: Slot,
         vote_hash: Hash,

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -109,6 +109,7 @@ pub struct Tower {
     threshold_size: f64,
     lockouts: VoteState,
     last_vote: Vote,
+    #[serde(skip)]
     // The blockhash used in the last vote transaction, may or may not equal the
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
     // For instance, a vote for slot 5, may be refreshed/resubmitted for inclusion in

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1238,7 +1238,7 @@ impl SavedTower {
     pub fn new<T: Signer>(tower: &Tower, keypair: &Arc<T>) -> Result<Self> {
         let data = bincode::serialize(tower)?;
         let signature = keypair.sign_message(&data);
-        Ok(Self { data, signature })
+        Ok(Self { signature, data })
     }
 
     pub fn verify(&self, pubkey: &Pubkey) -> bool {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -225,7 +225,7 @@ impl Tower {
     }
 
     pub(crate) fn collect_vote_lockouts<F>(
-        node_pubkey: &Pubkey,
+        vote_account_pubkey: &Pubkey,
         bank_slot: Slot,
         vote_accounts: F,
         ancestors: &HashMap<Slot, HashSet<Slot>>,
@@ -247,7 +247,7 @@ impl Tower {
             if voted_stake == 0 {
                 continue;
             }
-            trace!("{} {} with stake {}", node_pubkey, key, voted_stake);
+            trace!("{} {} with stake {}", vote_account_pubkey, key, voted_stake);
             let mut vote_state = match account.vote_state().as_ref() {
                 Err(_) => {
                     datapoint_warn!(
@@ -269,7 +269,7 @@ impl Tower {
                     .push((vote.slot, key));
             }
 
-            if key == *node_pubkey || vote_state.node_pubkey == *node_pubkey {
+            if key == *vote_account_pubkey {
                 my_latest_landed_vote = vote_state.nth_recent_vote(0).map(|v| v.slot).unwrap_or(0);
                 debug!("vote state {:?}", vote_state);
                 debug!(

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -259,6 +259,7 @@ pub(crate) struct ForkStats {
     pub(crate) computed: bool,
     pub(crate) lockout_intervals: LockoutIntervals,
     pub(crate) bank_hash: Option<Hash>,
+    pub(crate) my_latest_landed_vote: Slot,
 }
 
 #[derive(Clone, Default)]
@@ -530,6 +531,12 @@ impl ProgressMap {
                 // this confirmation on `S` is irrelevant to them.
             }
         }
+    }
+
+    pub fn my_latest_landed_vote(&self, slot: Slot) -> Option<Slot> {
+        self.progress_map
+            .get(&slot)
+            .map(|s| s.fork_stats.my_latest_landed_vote)
     }
 
     pub fn set_supermajority_confirmed_slot(&mut self, slot: Slot) {

--- a/core/src/progress_map.rs
+++ b/core/src/progress_map.rs
@@ -259,7 +259,7 @@ pub(crate) struct ForkStats {
     pub(crate) computed: bool,
     pub(crate) lockout_intervals: LockoutIntervals,
     pub(crate) bank_hash: Option<Hash>,
-    pub(crate) my_latest_landed_vote: Slot,
+    pub(crate) my_latest_landed_vote: Option<Slot>,
 }
 
 #[derive(Clone, Default)]
@@ -536,7 +536,7 @@ impl ProgressMap {
     pub fn my_latest_landed_vote(&self, slot: Slot) -> Option<Slot> {
         self.progress_map
             .get(&slot)
-            .map(|s| s.fork_stats.my_latest_landed_vote)
+            .and_then(|s| s.fork_stats.my_latest_landed_vote)
     }
 
     pub fn set_supermajority_confirmed_slot(&mut self, slot: Slot) {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1494,14 +1494,13 @@ impl ReplayStage {
         // Refresh the vote if our latest vote hasn't landed, and the recent blockhash of the
         // last attempt at a vote transaction has expired
         let last_voted_slot = last_voted_slot.unwrap();
-        let is_landed_greater_than_last_voted_slot = my_latest_landed_vote >= last_voted_slot;
-        if is_landed_greater_than_last_voted_slot
+        if my_latest_landed_vote > last_voted_slot
             && last_vote_refresh_time.last_print_time.elapsed().as_secs() >= 1
         {
             last_vote_refresh_time.last_print_time = Instant::now();
             info!("Last landed vote for slot {} in bank {} is greater than the current last vote for slot: {} tracked by Tower", my_latest_landed_vote, heaviest_bank_on_same_fork.slot(), last_voted_slot);
         }
-        if is_landed_greater_than_last_voted_slot
+        if my_latest_landed_vote >= last_voted_slot
             || heaviest_bank_on_same_fork
                 .check_hash_age(&tower.last_vote_tx_blockhash(), MAX_PROCESSING_AGE)
                 .unwrap_or(false)

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1509,9 +1509,16 @@ impl ReplayStage {
         );
 
         if let Some(vote_tx) = vote_tx {
-            tower.refresh_last_vote_tx_blockhash(vote_tx.message.recent_blockhash);
+            let recent_blockhash = vote_tx.message.recent_blockhash;
+            tower.refresh_last_vote_tx_blockhash(recent_blockhash);
 
             // Send the votes to the TPU and gossip for network propagation
+            info!(
+                "refreshing vote for slot {}, for target slot {}, hash {}",
+                last_voted_slot,
+                heaviest_bank_on_same_fork.slot(),
+                recent_blockhash
+            );
             let _ = cluster_info.send_vote(
                 &vote_tx,
                 crate::banking_stage::next_leader_tpu(cluster_info, poh_recorder),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1489,7 +1489,7 @@ impl ReplayStage {
             || heaviest_bank_on_same_fork
                 .check_hash_age(&tower.last_vote_tx_blockhash(), MAX_PROCESSING_AGE)
                 .unwrap_or(false)
-            // In order to avoid voting on multiple forks all past MAX_PROCESSING_AGE that don't 
+            // In order to avoid voting on multiple forks all past MAX_PROCESSING_AGE that don't
             // include the last voted blockhash
             || last_vote_refresh_time.elapsed().as_millis() < 5000
         {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1464,6 +1464,7 @@ impl ReplayStage {
         Some(vote_tx)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn refresh_last_vote(
         tower: &mut Tower,
         cluster_info: &ClusterInfo,
@@ -1513,11 +1514,12 @@ impl ReplayStage {
             tower.refresh_last_vote_tx_blockhash(recent_blockhash);
 
             // Send the votes to the TPU and gossip for network propagation
-            info!(
-                "refreshing vote for slot {}, for target slot {}, hash {}",
-                last_voted_slot,
-                heaviest_bank_on_same_fork.slot(),
-                recent_blockhash
+            let hash_string = format!("{}", recent_blockhash);
+            datapoint_info!(
+                "refresh_vote",
+                ("last_voted_slot", last_voted_slot, i64),
+                ("target_bank_slot", heaviest_bank_on_same_fork.slot(), i64),
+                ("target_bank_hash", hash_string, String),
             );
             let _ = cluster_info.send_vote(
                 &vote_tx,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -457,7 +457,7 @@ impl ReplayStage {
 
                     let mut compute_bank_stats_time = Measure::start("compute_bank_stats");
                     let newly_computed_slot_stats = Self::compute_bank_stats(
-                        &my_pubkey,
+                        &vote_account,
                         &ancestors,
                         &mut frozen_banks,
                         &tower,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -713,7 +713,7 @@ fn test_kill_partition_switch_threshold_progress() {
 // 6) Resolve the partition so that the 2% repairs the other fork, and tries to switch,
 // stalling the network.
 
-fn test_fork_choice_ingest_votes_from_gossip() {
+fn test_fork_choice_refresh_old_votes() {
     solana_logger::setup_with_default(RUST_LOG_FILTER);
     let max_switch_threshold_failure_pct = 1.0 - 2.0 * SWITCH_FORK_THRESHOLD;
     let total_stake = 100;

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -1634,6 +1634,7 @@ fn test_fail_entry_verification_leader() {
 
 #[test]
 #[allow(unused_attributes)]
+#[ignore]
 fn test_fake_shreds_broadcast_leader() {
     test_faulty_node(BroadcastStageType::BroadcastFakeShreds);
 }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -689,7 +689,6 @@ fn test_kill_partition_switch_threshold_progress() {
 
 #[test]
 #[serial]
-#[ignore]
 // Steps in this test:
 // We want to create a situation like:
 /*


### PR DESCRIPTION
#### Problem
Follow-up to problem as described in https://github.com/solana-labs/solana/pull/16560. The issue with that solution is 
if people selectively rewrite votes in gossip, they may be able to influence fork choice.

#### Summary of Changes
1. Periodically refresh the latest vote `V` if it's expired, using the recent blockhash of the heaviest bank on the same fork as that last vote `V`
2. Add ability in `cluster_info` to "refresh" a vote, i.e. emplace a vote for the same slot with a newer one (use the same vote index in gossip)
2. Re-enable local cluster test showing issue is resolved
Fixes #
