### PR TITLE
program-test: Add large bootstrap stake for realistic warmups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,6 +4941,7 @@ dependencies = [
 name = "solana-program-test"
 version = "1.7.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "base64 0.12.3",
  "bincode",

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -28,4 +28,5 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
+assert_matches = "1.3.0"
 solana-stake-program = { path = "../programs/stake", version = "=1.7.0" }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -672,7 +672,8 @@ impl ProgramTest {
         let rent = Rent::default();
         let fee_rate_governor = FeeRateGovernor::default();
         let bootstrap_validator_pubkey = Pubkey::new_unique();
-        let bootstrap_validator_stake_lamports = rent.minimum_balance(VoteState::size_of());
+        let bootstrap_validator_stake_lamports =
+            rent.minimum_balance(VoteState::size_of()) + sol_to_lamports(1_000_000.0);
 
         let mint_keypair = Keypair::new();
         let voting_keypair = Keypair::new();


### PR DESCRIPTION
#### Problem

When testing stake warmup and cooldown in program-test, we're reduced to doing huge amounts of warps just to get small stakes to activate, leading to gross stuff like this: https://github.com/solana-labs/solana-program-library/blob/08c4cb530a83edc8a4c7707522b52b80414d988f/stake-pool/program/tests/update_validator_list_balance.rs#L80

This would normally be fine, but with the new changes on the account db bitvec, we're limited to how far we can warp to roughly 500k slots, which caused the break in the downstream build.  The offending stake pool tests are ignored for the moment, and once this is merged we can reduce the amount of warps in the tests.

#### Summary of Changes

Add a big bootstrap stake!

Fixes #
