### PR TITLE
explorer: downgrade nodejs version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
 
       language: node_js
       node_js:
-        - "node"
+        - "lts/*"
 
       cache:
         directories:

--- a/explorer/.travis.yml
+++ b/explorer/.travis.yml
@@ -1,9 +1,14 @@
 language: node_js
+
+# "node" (v16) is not supported by node-sass yet
+# https://github.com/sass/node-sass/pull/3090
 node_js:
-  - "node"
+  - "lts/*"
+
 branches:
   only:
     - master
+
 script:
   - npm run build
   - npm run test


### PR DESCRIPTION
#### Problem
Travis CI latest Node.js version is v16 as of 4/20 and this is not supported by node-sass yet

#### Summary of Changes
Use LTS node

Fixes #
