### PR TITLE
Rpc: Rework `getLeaderSchedule` options

### DIFF
--- a/client/src/rpc_config.rs
+++ b/client/src/rpc_config.rs
@@ -49,6 +49,22 @@ pub struct RpcLeaderScheduleConfig {
     pub commitment: Option<CommitmentConfig>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RpcLeaderScheduleConfigWrapper {
+    SlotOnly(Option<Slot>),
+    ConfigOnly(Option<RpcLeaderScheduleConfig>),
+}
+
+impl RpcLeaderScheduleConfigWrapper {
+    pub fn unzip(&self) -> (Option<Slot>, Option<RpcLeaderScheduleConfig>) {
+        match &self {
+            RpcLeaderScheduleConfigWrapper::SlotOnly(slot) => (*slot, None),
+            RpcLeaderScheduleConfigWrapper::ConfigOnly(config) => (None, config.clone()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum RpcLargestAccountsFilter {


### PR DESCRIPTION
#### Problem
The parameters in `getLeaderSchedule` are not truly optional. In order to use `commitment` or `identity`, a slot must be provided.

#### Summary of Changes
Rework `getLeaderSchedule` options so that slot is truly optional, even with config options included

Fixes https://github.com/solana-labs/solana/pull/16723#discussion_r617960638