### PR TITLE
private AccountSharedData.owner

### DIFF
--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -984,7 +984,7 @@ fn test_program_bpf_invoke_sanity() {
 
         assert_eq!(43, bank.get_balance(&derived_key1));
         let account = bank.get_account(&derived_key1).unwrap();
-        assert_eq!(invoke_program_id, account.owner);
+        assert_eq!(&invoke_program_id, account.owner());
         assert_eq!(
             MAX_PERMITTED_DATA_INCREASE,
             bank.get_account(&derived_key1).unwrap().data().len()

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1038,7 +1038,7 @@ pub fn create_test_accounts(
     for t in 0..num {
         let pubkey = solana_sdk::pubkey::new_rand();
         let account =
-            AccountSharedData::new((t + 1) as u64, 0, &AccountSharedData::default().owner());
+            AccountSharedData::new((t + 1) as u64, 0, AccountSharedData::default().owner());
         accounts.store_slow_uncached(slot, &pubkey, &account);
         pubkeys.push(pubkey);
     }
@@ -1049,7 +1049,7 @@ pub fn create_test_accounts(
 pub fn update_accounts_bench(accounts: &Accounts, pubkeys: &[Pubkey], slot: u64) {
     for pubkey in pubkeys {
         let amount = thread_rng().gen_range(0, 10);
-        let account = AccountSharedData::new(amount, 0, &AccountSharedData::default().owner());
+        let account = AccountSharedData::new(amount, 0, AccountSharedData::default().owner());
         accounts.store_slow_uncached(slot, &pubkey, &account);
     }
 }

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -35,7 +35,7 @@ pub struct AccountSharedData {
     /// data held in this account
     data: Arc<Vec<u8>>,
     /// the program that owns this account. If executable, the program that loads this account.
-    pub owner: Pubkey,
+    owner: Pubkey,
     /// this account's data contains a loaded program (and is now read-only)
     pub executable: bool,
     /// the epoch at which this account will next owe rent


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations.
All callers to owner now use trait methods.

Summary of Changes
make AccountSharedData.owner private to force new code to use trait methods.
Fixes #