### PR TITLE
pass &Pubkey through account storage, slot clean code to reduce copies

### DIFF
--- a/runtime/src/accounts_cache.rs
+++ b/runtime/src/accounts_cache.rs
@@ -51,7 +51,7 @@ impl SlotCacheInner {
         &self,
         pubkey: &Pubkey,
         account: AccountSharedData,
-        hash: Option<Hash>,
+        hash: Option<&Hash>,
         slot: Slot,
     ) -> CachedAccount {
         if self.cache.contains_key(pubkey) {
@@ -64,7 +64,7 @@ impl SlotCacheInner {
         }
         let item = Arc::new(CachedAccountInner {
             account,
-            hash: RwLock::new(hash),
+            hash: RwLock::new(hash.copied()),
             slot,
             pubkey: *pubkey,
         });
@@ -169,7 +169,7 @@ impl AccountsCache {
         slot: Slot,
         pubkey: &Pubkey,
         account: AccountSharedData,
-        hash: Option<Hash>,
+        hash: Option<&Hash>,
     ) -> CachedAccount {
         let slot_cache = self.slot_cache(slot).unwrap_or_else(||
             // DashMap entry.or_insert() returns a RefMut, essentially a write lock,
@@ -283,7 +283,7 @@ pub mod tests {
             inserted_slot,
             &Pubkey::new_unique(),
             AccountSharedData::new(1, 0, &Pubkey::default()),
-            Some(Hash::default()),
+            Some(&Hash::default()),
         );
         // If the cache is told the size limit is 0, it should return the one slot
         let removed = cache.remove_slots_le(0);
@@ -301,7 +301,7 @@ pub mod tests {
             inserted_slot,
             &Pubkey::new_unique(),
             AccountSharedData::new(1, 0, &Pubkey::default()),
-            Some(Hash::default()),
+            Some(&Hash::default()),
         );
 
         // If the cache is told the size limit is 0, it should return nothing because there's only

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3650,7 +3650,6 @@ impl AccountsDb {
                 // will be able to find the account in storage
                 let flushed_store =
                     self.create_and_insert_store(slot, aligned_total_size, "flush_slot_cache");
-                //let hashes_refs = hashes.iter().collect::<Vec<_>>();
                 self.store_accounts_frozen(
                     slot,
                     &accounts,

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -453,7 +453,7 @@ impl AppendVec {
     pub fn append_accounts(
         &self,
         accounts: &[(StoredMeta, &AccountSharedData)],
-        hashes: &[Hash],
+        hashes: &[&Hash],
     ) -> Vec<usize> {
         let _lock = self.append_lock.lock().unwrap();
         let mut offset = self.len();
@@ -494,7 +494,7 @@ impl AppendVec {
         account: &AccountSharedData,
         hash: Hash,
     ) -> Option<usize> {
-        let res = self.append_accounts(&[(storage_meta, account)], &[hash]);
+        let res = self.append_accounts(&[(storage_meta, account)], &[&hash]);
         if res.len() == 1 {
             None
         } else {

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -1,6 +1,7 @@
 //! Persistent storage for accounts. For more information, see:
 //! https://docs.solana.com/implemented-proposals/persistent-account-storage
 
+use crate::accounts_db::GetHash;
 use log::*;
 use memmap2::MmapMut;
 use serde::{Deserialize, Serialize};
@@ -450,10 +451,10 @@ impl AppendVec {
     /// Return the starting offset of each account metadata.
     /// After each account is appended, the internal `current_len` is updated
     /// and will be available to other threads.
-    pub fn append_accounts(
+    pub fn append_accounts<T: GetHash>(
         &self,
         accounts: &[(StoredMeta, &AccountSharedData)],
-        hashes: &[&Hash],
+        hashes: &[T],
     ) -> Vec<usize> {
         let _lock = self.append_lock.lock().unwrap();
         let mut offset = self.len();
@@ -464,7 +465,7 @@ impl AppendVec {
             let account_meta_ptr = &account_meta as *const AccountMeta;
             let data_len = stored_meta.data_len as usize;
             let data_ptr = account.data().as_ptr();
-            let hash_ptr = hash.as_ref().as_ptr();
+            let hash_ptr = hash.get_hash().as_ref().as_ptr();
             let ptrs = [
                 (meta_ptr as *const u8, mem::size_of::<StoredMeta>()),
                 (account_meta_ptr as *const u8, mem::size_of::<AccountMeta>()),


### PR DESCRIPTION
#### Problem
Cleaning up snapshots makes an unnecessary copy of each pubkey when rewriting storage.

#### Summary of Changes
allow callers to pass pubkeys by ref or value.

Fixes #
