### PR TITLE
write: &AccountSharedData -> &impl ReadableAccount

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3325,7 +3325,7 @@ impl AccountsDb {
         slot: Slot,
         hashes: &[impl Borrow<Hash>],
         mut storage_finder: F,
-        accounts_and_meta_to_store: &[(StoredMeta, Option<&AccountSharedData>)],
+        accounts_and_meta_to_store: &[(StoredMeta, Option<&impl ReadableAccount>)],
     ) -> Vec<AccountInfo> {
         assert_eq!(hashes.len(), accounts_and_meta_to_store.len());
         let mut infos: Vec<AccountInfo> = Vec::with_capacity(accounts_and_meta_to_store.len());
@@ -3712,7 +3712,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         hashes: Option<&[impl Borrow<Hash>]>,
-        accounts_and_meta_to_store: &[(StoredMeta, Option<&AccountSharedData>)],
+        accounts_and_meta_to_store: &[(StoredMeta, Option<&impl ReadableAccount>)],
     ) -> Vec<AccountInfo> {
         let len = accounts_and_meta_to_store.len();
         let hashes = hashes.map(|hashes| {
@@ -3726,8 +3726,9 @@ impl AccountsDb {
             .map(|(i, (meta, account))| {
                 let hash = hashes.map(|hashes| hashes[i].borrow());
 
-                let account = account.cloned().unwrap_or_default();
-
+                let account = account
+                    .map(|account| account.to_account_shared_data())
+                    .unwrap_or_default();
                 let account_info = AccountInfo {
                     store_id: CACHE_VIRTUAL_STORAGE_ID,
                     offset: CACHE_VIRTUAL_OFFSET,
@@ -3754,13 +3755,13 @@ impl AccountsDb {
     >(
         &self,
         slot: Slot,
-        accounts: &[(&Pubkey, &AccountSharedData)],
+        accounts: &[(&Pubkey, &impl ReadableAccount)],
         hashes: Option<&[impl Borrow<Hash>]>,
         storage_finder: F,
         mut write_version_producer: P,
         is_cached_store: bool,
     ) -> Vec<AccountInfo> {
-        let accounts_and_meta_to_store: Vec<(StoredMeta, Option<&AccountSharedData>)> = accounts
+        let accounts_and_meta_to_store: Vec<_> = accounts
             .iter()
             .map(|(pubkey, account)| {
                 self.read_only_accounts_cache.remove(pubkey, slot);
@@ -4309,7 +4310,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         infos: Vec<AccountInfo>,
-        accounts: &[(&Pubkey, &AccountSharedData)],
+        accounts: &[(&Pubkey, &impl ReadableAccount)],
     ) -> SlotList<AccountInfo> {
         let mut reclaims = SlotList::<AccountInfo>::with_capacity(infos.len() * 2);
         for (info, pubkey_account) in infos.into_iter().zip(accounts.iter()) {
@@ -4722,7 +4723,7 @@ impl AccountsDb {
     fn store_accounts_frozen<'a>(
         &'a self,
         slot: Slot,
-        accounts: &[(&Pubkey, &AccountSharedData)],
+        accounts: &[(&Pubkey, &impl ReadableAccount)],
         hashes: Option<&[impl Borrow<Hash>]>,
         storage_finder: Option<StorageFinder<'a>>,
         write_version_producer: Option<Box<dyn Iterator<Item = u64>>>,
@@ -4746,7 +4747,7 @@ impl AccountsDb {
     fn store_accounts_custom<'a>(
         &'a self,
         slot: Slot,
-        accounts: &[(&Pubkey, &AccountSharedData)],
+        accounts: &[(&Pubkey, &impl ReadableAccount)],
         hashes: Option<&[impl Borrow<Hash>]>,
         storage_finder: Option<StorageFinder<'a>>,
         write_version_producer: Option<Box<dyn Iterator<Item = u64>>>,

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -462,7 +462,7 @@ impl AppendVec {
     /// and will be available to other threads.
     pub fn append_accounts(
         &self,
-        accounts: &[(StoredMeta, Option<&AccountSharedData>)],
+        accounts: &[(StoredMeta, Option<&impl ReadableAccount>)],
         hashes: &[impl Borrow<Hash>],
     ) -> Vec<usize> {
         let _lock = self.append_lock.lock().unwrap();

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -116,6 +116,15 @@ pub trait ReadableAccount: Sized {
     fn owner(&self) -> &Pubkey;
     fn executable(&self) -> bool;
     fn rent_epoch(&self) -> Epoch;
+    fn to_account_shared_data(&self) -> AccountSharedData {
+        AccountSharedData::create(
+            self.lamports(),
+            self.data().to_vec(),
+            *self.owner(),
+            self.executable(),
+            self.rent_epoch(),
+        )
+    }
 }
 
 impl ReadableAccount for Account {
@@ -666,6 +675,17 @@ pub mod tests {
         let key = Pubkey::new_unique();
         let (_account1, mut account2) = make_two_accounts(&key);
         account2.serialize_data(&"hello world").unwrap();
+    }
+
+    #[test]
+    fn test_to_account_shared_data() {
+        let key = Pubkey::new_unique();
+        let (account1, account2) = make_two_accounts(&key);
+        assert!(accounts_equal(&account1, &account2));
+        let account3 = account1.to_account_shared_data();
+        let account4 = account2.to_account_shared_data();
+        assert!(accounts_equal(&account1, &account3));
+        assert!(accounts_equal(&account1, &account4));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. There will [soon be a new ReadableAccount impl for a stored account](https://github.com/solana-labs/solana/pull/16690/commits/95261a4f74b5aed97e96cf11a0f9b791565a3c23#r621561972). 

#### Summary of Changes
Make the write path that uses &AccountSharedData instead use &impl ReadableAccount

Fixes #
