### PR TITLE
account.lamports +=

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -421,7 +421,9 @@ fn process_loader_upgradeable_instruction(
             program.try_account_ref_mut()?.executable = true;
 
             // Drain the Buffer account back to the payer
-            payer.try_account_ref_mut()?.lamports += buffer.lamports()?;
+            payer
+                .try_account_ref_mut()?
+                .checked_add_lamports(buffer.lamports()?)?;
             buffer.try_account_ref_mut()?.lamports = 0;
 
             ic_logger_msg!(logger, "Deployed program {:?}", program.unsigned_key());
@@ -547,9 +549,10 @@ fn process_loader_upgradeable_instruction(
 
             // Fund ProgramData to rent-exemption, spill the rest
 
-            spill.try_account_ref_mut()?.lamports += (programdata.lamports()?
-                + buffer.lamports()?)
-            .saturating_sub(programdata_balance_required);
+            spill.try_account_ref_mut()?.checked_add_lamports(
+                (programdata.lamports()? + buffer.lamports()?)
+                    .saturating_sub(programdata_balance_required),
+            )?;
             buffer.try_account_ref_mut()?.lamports = 0;
             programdata.try_account_ref_mut()?.lamports = programdata_balance_required;
 
@@ -640,7 +643,9 @@ fn process_loader_upgradeable_instruction(
                     return Err(InstructionError::MissingRequiredSignature);
                 }
 
-                recipient_account.try_account_ref_mut()?.lamports += close_account.lamports()?;
+                recipient_account
+                    .try_account_ref_mut()?
+                    .checked_add_lamports(close_account.lamports()?)?;
                 close_account.try_account_ref_mut()?.lamports = 0;
                 for elt in close_account.try_account_ref_mut()?.data_as_mut_slice() {
                     *elt = 0;

--- a/programs/budget/src/budget_processor.rs
+++ b/programs/budget/src/budget_processor.rs
@@ -49,7 +49,9 @@ fn apply_signature(
         }
         budget_state.pending_budget = None;
         contract_keyed_account.try_account_ref_mut()?.lamports -= payment.lamports;
-        to_keyed_account.try_account_ref_mut()?.lamports += payment.lamports;
+        to_keyed_account
+            .try_account_ref_mut()?
+            .checked_add_lamports(payment.lamports)?;
     }
     Ok(())
 }
@@ -80,7 +82,9 @@ fn apply_timestamp(
         }
         budget_state.pending_budget = None;
         contract_keyed_account.try_account_ref_mut()?.lamports -= payment.lamports;
-        to_keyed_account.try_account_ref_mut()?.lamports += payment.lamports;
+        to_keyed_account
+            .try_account_ref_mut()?
+            .checked_add_lamports(payment.lamports)?;
     }
     Ok(())
 }
@@ -111,7 +115,9 @@ fn apply_account_data(
         }
         budget_state.pending_budget = None;
         contract_keyed_account.try_account_ref_mut()?.lamports -= payment.lamports;
-        to_keyed_account.try_account_ref_mut()?.lamports += payment.lamports;
+        to_keyed_account
+            .try_account_ref_mut()?
+            .checked_add_lamports(payment.lamports)?;
     }
     Ok(())
 }
@@ -135,7 +141,9 @@ pub fn process_instruction(
                 let to_keyed_account = contract_keyed_account;
                 let contract_keyed_account = keyed_account_at_index(keyed_accounts, 1)?;
                 contract_keyed_account.try_account_ref_mut()?.lamports = 0;
-                to_keyed_account.try_account_ref_mut()?.lamports += payment.lamports;
+                to_keyed_account
+                    .try_account_ref_mut()?
+                    .checked_add_lamports(payment.lamports)?;
                 return Ok(());
             }
             let existing =


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to return Results and use checked_add_lamports.
Fixes #