### PR TITLE
docs: getInflationReward rpc output fields should be in lower camel case

### DIFF
--- a/docs/src/developing/clients/jsonrpc-api.md
+++ b/docs/src/developing/clients/jsonrpc-api.md
@@ -1209,10 +1209,10 @@ Returns the inflation reward for a list of addresses for an epoch
 
 The result field will be a JSON array with the following fields:
 
-- `epoch: <u64>`, epoch
-- `effective_slot: <u64>`, the slot in which the rewards are effective
+- `epoch: <u64>`, epoch for which reward occured
+- `effectiveSlot: <u64>`, the slot in which the rewards are effective
 - `amount: <u64>`, reward amount in lamports
-- `post_balance: <u64>`, post balance of the account in lamports
+- `postBalance: <u64>`, post balance of the account in lamports
 
 #### Example
 


### PR DESCRIPTION
#### Problem
The `getInflationReward` output fields description in the JSON-RPC documentation should be lower camel case.

#### Summary of Changes
Make fields `effectiveSlot` and `postBalance` lower camel case.