### PR TITLE
web3.js: introduce getInflationReward to connection

### DIFF
--- a/web3.js/src/connection.ts
+++ b/web3.js/src/connection.ts
@@ -322,6 +322,36 @@ const GetInflationGovernorResult = pick({
 });
 
 /**
+ * The inflation reward for an epoch
+ */
+export type InflationReward = {
+  /** epoch for which the reward occurs */
+  epoch: number;
+  /** the slot in which the rewards are effective */
+  effectiveSlot: number;
+  /** reward amount in lamports */
+  amount: number;
+  /** post balance of the account in lamports */
+  postBalance: number;
+};
+
+/**
+ * Expected JSON RPC response for the "getInflationReward" message
+ */
+const GetInflationRewardResult = jsonRpcResult(
+  array(
+    nullable(
+      pick({
+        epoch: number(),
+        effectiveSlot: number(),
+        amount: number(),
+        postBalance: number(),
+      }),
+    ),
+  ),
+);
+
+/**
  * Information about the current epoch
  */
 export type EpochInfo = {
@@ -2438,6 +2468,30 @@ export class Connection {
     const res = create(unsafeRes, GetInflationGovernorRpcResult);
     if ('error' in res) {
       throw new Error('failed to get inflation: ' + res.error.message);
+    }
+    return res.result;
+  }
+
+  /**
+   * Fetch the inflation reward for a list of addresses for an epoch
+   */
+  async getInflationReward(
+    addresses: PublicKey[],
+    epoch?: number,
+    commitment?: Commitment,
+  ): Promise<(InflationReward | null)[]> {
+    const args = this._buildArgs(
+      [addresses.map(pubkey => pubkey.toBase58())],
+      commitment,
+      undefined,
+      {
+        epoch,
+      },
+    );
+    const unsafeRes = await this._rpcRequest('getInflationReward', args);
+    const res = create(unsafeRes, GetInflationRewardResult);
+    if ('error' in res) {
+      throw new Error('failed to get inflation reward: ' + res.error.message);
     }
     return res.result;
   }

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -545,6 +545,51 @@ describe('Connection', () => {
     }
   });
 
+  it('get inflation reward', async () => {
+    await mockRpcResponse({
+      method: 'getInflationReward',
+      params: [
+        [
+          '7GHnTRB8Rz14qZQhDXf8ox1Kfu7mPcPLpKaBJJirmYj2',
+          'CrinLuHjVGDDcQfrEoCmM4k31Ni9sMoTCEEvNSUSh7Jg',
+        ],
+        {
+          epoch: 0,
+        },
+      ],
+      value: [
+        {
+          amount: 3646143,
+          effectiveSlot: 432000,
+          epoch: 0,
+          postBalance: 30504783,
+        },
+        null,
+      ],
+    });
+
+    let inflationReward;
+    try {
+      inflationReward = await connection.getInflationReward(
+        [
+          new PublicKey('7GHnTRB8Rz14qZQhDXf8ox1Kfu7mPcPLpKaBJJirmYj2'),
+          new PublicKey('CrinLuHjVGDDcQfrEoCmM4k31Ni9sMoTCEEvNSUSh7Jg'),
+        ],
+        0,
+      );
+    } catch (error) {
+      // a live server needs to have slots up to 432000
+      // in order to have rewards for epoch 0
+      if (!mockServer && error.message.match(/Block not available/)) {
+        return;
+      }
+
+      throw error;
+    }
+
+    expect(inflationReward).to.have.lengthOf(2);
+  });
+
   it('get epoch info', async () => {
     await mockRpcResponse({
       method: 'getEpochInfo',

--- a/web3.js/test/connection.test.ts
+++ b/web3.js/test/connection.test.ts
@@ -546,48 +546,39 @@ describe('Connection', () => {
   });
 
   it('get inflation reward', async () => {
-    await mockRpcResponse({
-      method: 'getInflationReward',
-      params: [
-        [
-          '7GHnTRB8Rz14qZQhDXf8ox1Kfu7mPcPLpKaBJJirmYj2',
-          'CrinLuHjVGDDcQfrEoCmM4k31Ni9sMoTCEEvNSUSh7Jg',
+    if (mockServer) {
+      await mockRpcResponse({
+        method: 'getInflationReward',
+        params: [
+          [
+            '7GHnTRB8Rz14qZQhDXf8ox1Kfu7mPcPLpKaBJJirmYj2',
+            'CrinLuHjVGDDcQfrEoCmM4k31Ni9sMoTCEEvNSUSh7Jg',
+          ],
+          {
+            epoch: 0,
+          },
         ],
-        {
-          epoch: 0,
-        },
-      ],
-      value: [
-        {
-          amount: 3646143,
-          effectiveSlot: 432000,
-          epoch: 0,
-          postBalance: 30504783,
-        },
-        null,
-      ],
-    });
+        value: [
+          {
+            amount: 3646143,
+            effectiveSlot: 432000,
+            epoch: 0,
+            postBalance: 30504783,
+          },
+          null,
+        ],
+      });
 
-    let inflationReward;
-    try {
-      inflationReward = await connection.getInflationReward(
+      const inflationReward = await connection.getInflationReward(
         [
           new PublicKey('7GHnTRB8Rz14qZQhDXf8ox1Kfu7mPcPLpKaBJJirmYj2'),
           new PublicKey('CrinLuHjVGDDcQfrEoCmM4k31Ni9sMoTCEEvNSUSh7Jg'),
         ],
         0,
       );
-    } catch (error) {
-      // a live server needs to have slots up to 432000
-      // in order to have rewards for epoch 0
-      if (!mockServer && error.message.match(/Block not available/)) {
-        return;
-      }
 
-      throw error;
+      expect(inflationReward).to.have.lengthOf(2);
     }
-
-    expect(inflationReward).to.have.lengthOf(2);
   });
 
   it('get epoch info', async () => {


### PR DESCRIPTION
#### Problem
Web3.js needs to support the `getInflationReward` RPC call.

#### Summary of Changes
Add `getInflationReward` support to Connection object. 
