### PR TITLE
clean_dead_slot grabs roots lock once

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1235,30 +1235,28 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
     /// Remove the slot when the storage for the slot is freed
     /// Accounts no longer reference this slot.
     pub fn clean_dead_slot(&self, slot: Slot) -> Option<AccountsIndexRootsStats> {
-        if self.is_root(slot) {
-            let (roots_len, uncleaned_roots_len, previous_uncleaned_roots_len, roots_range) = {
-                let mut w_roots_tracker = self.roots_tracker.write().unwrap();
-                w_roots_tracker.roots.remove(&slot);
-                w_roots_tracker.uncleaned_roots.remove(&slot);
-                w_roots_tracker.previous_uncleaned_roots.remove(&slot);
-                (
-                    w_roots_tracker.roots.len(),
-                    w_roots_tracker.uncleaned_roots.len(),
-                    w_roots_tracker.previous_uncleaned_roots.len(),
-                    w_roots_tracker.roots.range_width(),
-                )
-            };
-            Some(AccountsIndexRootsStats {
-                roots_len,
-                uncleaned_roots_len,
-                previous_uncleaned_roots_len,
-                roots_range,
-                rooted_cleaned_count: 0,
-                unrooted_cleaned_count: 0,
-            })
-        } else {
-            None
-        }
+        let (roots_len, uncleaned_roots_len, previous_uncleaned_roots_len, roots_range) = {
+            let mut w_roots_tracker = self.roots_tracker.write().unwrap();
+            if !w_roots_tracker.roots.remove(&slot) {
+                return None;
+            }
+            w_roots_tracker.uncleaned_roots.remove(&slot);
+            w_roots_tracker.previous_uncleaned_roots.remove(&slot);
+            (
+                w_roots_tracker.roots.len(),
+                w_roots_tracker.uncleaned_roots.len(),
+                w_roots_tracker.previous_uncleaned_roots.len(),
+                w_roots_tracker.roots.range_width(),
+            )
+        };
+        Some(AccountsIndexRootsStats {
+            roots_len,
+            uncleaned_roots_len,
+            previous_uncleaned_roots_len,
+            roots_range,
+            rooted_cleaned_count: 0,
+            unrooted_cleaned_count: 0,
+        })
     }
 
     pub fn reset_uncleaned_roots(&self, max_clean_root: Option<Slot>) -> HashSet<Slot> {


### PR DESCRIPTION
Problem
on clean_dead_slot, we get a read lock to check for root, then we get a write lock to remove the root. If we are a high% of the time finding that the item is a root, then we can improve performance and reduce lock contention by just getting the write lock and removing the root the first time.
#16849 adds metrics to determine the reality.

Summary of Changes
Get root lock once.
Fixes #