### PR TITLE
stretchy roots tracker

### DIFF
--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1675,16 +1675,16 @@ pub mod tests {
         for width in [16, 4194304].iter() {
             let width = *width;
             let mut tester = setup_empty(width);
-            for start in [0, width * 5].iter().map(|x| *x) {
+            for start in [0, width * 5].iter().cloned() {
                 // recreate means create empty bitfield with each iteration, otherwise re-use
-                for recreate in [false, true].iter().map(|x| *x) {
+                for recreate in [false, true].iter().cloned() {
                     let max = start + 3;
                     // first root to add
                     for slot in start..max {
                         // subsequent roots to add
                         for slot2 in (slot + 1)..max {
                             // reverse_slots = 1 means add slots in reverse order (max to min). This causes us to add second and later slots to excess.
-                            for reverse_slots in [false, true].iter().map(|x| *x) {
+                            for reverse_slots in [false, true].iter().cloned() {
                                 let maybe_reverse = |slot| {
                                     if reverse_slots {
                                         max - slot

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1780,6 +1780,7 @@ pub mod tests {
                     max = std::cmp::max(max, item);
                 }
             }
+            assert_eq!(bitfield.get_all().len(), hashset.len());
             // range isn't tracked for excess items
             if bitfield.excess.len() != bitfield.len() {
                 let width = if bitfield.is_empty() {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1687,7 +1687,7 @@ pub mod tests {
                 for slot in start..max {
                     // subsequent roots to add
                     for slot2 in (slot + 1)..max {
-                        // revers_slots = 1 means add slots in reverse order (max to min). This causes us to add second and later slots to excess.
+                        // reverse_slots = 1 means add slots in reverse order (max to min). This causes us to add second and later slots to excess.
                         for reverse_slots in 0..2 {
                             let reverse_slots = reverse_slots == 1;
                             let maybe_reverse = |slot| {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1685,8 +1685,7 @@ pub mod tests {
                         // subsequent roots to add
                         for slot2 in (slot + 1)..max {
                             // reverse_slots = 1 means add slots in reverse order (max to min). This causes us to add second and later slots to excess.
-                            for reverse_slots in 0..2 {
-                                let reverse_slots = reverse_slots == 1;
+                            for reverse_slots in [false, true].iter().map(|x| *x) {
                                 let maybe_reverse = |slot| {
                                     if reverse_slots {
                                         max - slot

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1681,8 +1681,8 @@ pub mod tests {
             let (mut bitfield, mut hash_set) = setup_empty(width);
             for start in [0, width * 5].iter() {
                 let start = *start;
-                // recreate = 1 means create empty bitfield with each iteration, otherwise re-use
-                for recreate in 0..2 {
+                // recreate means create empty bitfield with each iteration, otherwise re-use
+                for recreate in [false, true].iter().map(|x| *x) {
                     let max = start + 3;
                     // first root to add
                     for slot in start..max {
@@ -1698,7 +1698,7 @@ pub mod tests {
                                         slot
                                     }
                                 };
-                                if recreate == 1 {
+                                if recreate {
                                     let recreated = setup_empty(width);
                                     bitfield = recreated.0;
                                     hash_set = recreated.1;

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1675,8 +1675,7 @@ pub mod tests {
         for width in [16, 4194304].iter() {
             let width = *width;
             let mut tester = setup_empty(width);
-            for start in [0, width * 5].iter() {
-                let start = *start;
+            for start in [0, width * 5].iter().map(|x| *x) {
                 // recreate means create empty bitfield with each iteration, otherwise re-use
                 for recreate in [false, true].iter().map(|x| *x) {
                     let max = start + 3;


### PR DESCRIPTION
#### Problem
I've been chasing a problem where really old (-2m slots) 0-lamport accounts are not getting cleaned. There is at least 1 validator on mnb that is generating snapshots like this. My research indicates that the problem is that we are cleaning, but after removing a store, we aren't updating the accounts index to deref the accounts that are present in the store.

We can load a snapshot with this data:
roots: 460977, min: 71500402, max: 73790273, range: 2289871
the first non-zero lamport account is:
slot: 73358273, previous # of ZERO lamport accounts: 156880

This panics because a range of 2M is too large for the previously hardcoded range.
There is a problem apparently where old accounts are not being cleaned correctly. I'm working on that separately.

This PR will prevent us from asserting and instead we will silently handle the behavior with some minor performance penalty. The previous implementation of RootsTracker WAS a HashSet.

#### Summary of Changes
Adapt the RootsTracker to allow it to stretch to accommodate really old roots while maintaining high performance lookups on the most recent set of roots. Code inspection seems to indicate minor performance impact. We call is_root many times during account load and many other operations.

Fixes #
