### PR TITLE
AccountSharedData.set_executable

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -17,7 +17,7 @@ use solana_ledger::{
 };
 use solana_runtime::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE;
 use solana_sdk::{
-    account::{Account, AccountSharedData},
+    account::{Account, AccountSharedData, WritableAccount},
     clock,
     epoch_schedule::EpochSchedule,
     fee_calculator::FeeRateGovernor,
@@ -91,7 +91,7 @@ pub fn load_genesis_accounts(file: &str, genesis_config: &mut GenesisConfig) -> 
                 })?,
             );
         }
-        account.executable = account_details.executable;
+        account.set_executable(account_details.executable);
         lamports += account.lamports;
         genesis_config.add_account(pubkey, account);
     }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -418,7 +418,7 @@ fn process_loader_upgradeable_instruction(
             program.set_state(&UpgradeableLoaderState::Program {
                 programdata_address: *programdata.unsigned_key(),
             })?;
-            program.try_account_ref_mut()?.executable = true;
+            program.try_account_ref_mut()?.set_executable(true);
 
             // Drain the Buffer account back to the payer
             payer.try_account_ref_mut()?.lamports += buffer.lamports()?;
@@ -690,7 +690,7 @@ fn process_loader_instruction(
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             let program = keyed_account_at_index(keyed_accounts, 0)?;
             invoke_context.add_executor(program.unsigned_key(), executor);
-            program.try_account_ref_mut()?.executable = true;
+            program.try_account_ref_mut()?.set_executable(true);
             ic_msg!(
                 invoke_context,
                 "Finalized account {:?}",


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods.

Summary of Changes
use .set_executable()
Fixes #