### PR TITLE
reclaim unrefs accounts from index

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1724,7 +1724,9 @@ impl AccountsDb {
         // Don't reset from clean, since the pubkeys in those stores may need to be unref'ed
         // and those stores may be used for background hashing.
         let reset_accounts = false;
-        self.handle_reclaims(&reclaims, None, false, None, reset_accounts);
+        let mut reclaim_result = ReclaimResult::default();
+        let reclaim_result = Some(&mut reclaim_result);
+        self.handle_reclaims(&reclaims, None, false, reclaim_result, reset_accounts);
 
         reclaims_time.stop();
 


### PR DESCRIPTION
#### Problem
I've been chasing a problem where really old (-2m slots) 0-lamport accounts are not getting cleaned. There is at least 1 validator on mnb that is generating snapshots like this. My research indicates that the problem is that we are cleaning, but after removing a store, we aren't updating the accounts index to deref the accounts that are present in the store.

Without this change, we load a snapshot with this data:
roots: 460977, min: 71500402, max: 73790273, range: 2289871
the first non-zero lamport account is:
slot: 73358273, previous # of ZERO lamport accounts: 156880

after 1st clean, we end up with:
roots: 460977, min: 71500402, max: 73790273, range: 2,289,871 < in snapshot, before clean
roots: 391303, min: 71999188, max: 73790273, range: 1,791,085 < after 1st clean

subsequent cleans do nothing to remove additional accounts.

WITH this change, the following progression is observed:
roots: 460977, min: 71500402, max: 73790273, range: 2,289,871 < in snapshot, before clean
roots: 391303, min: 71999188, max: 73790273, range: 1,791,085 < after 1st clean
roots: 387969, min: 73358273, max: 73790273, range: 432,000 < after 2nd clean (no further changes after this)

I believe this is now expected behavior for range of active slots.

It is very possible there is a better way to fix this problem. I am unsure yet if reclaim_result needs to be used for further processing. This finding seemed to be a good stopping point to circle back and discuss the demonstrated problem and a potential 'solution'.

#### Summary of Changes

Fixes #
