### PR TITLE
lamports += to checked_add

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -686,7 +686,9 @@ pub fn withdraw<S: std::hash::BuildHasher>(
         _ => (),
     }
     vote_account.try_account_ref_mut()?.lamports -= lamports;
-    to_account.try_account_ref_mut()?.lamports += lamports;
+    to_account
+        .try_account_ref_mut()?
+        .checked_add_lamports(lamports)?;
     Ok(())
 }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5449,7 +5449,10 @@ pub(crate) mod tests {
         if let Ok(instruction) = bincode::deserialize(data) {
             match instruction {
                 MockInstruction::Deduction => {
-                    keyed_accounts[1].account.borrow_mut().lamports += 1;
+                    keyed_accounts[1]
+                        .account
+                        .borrow_mut()
+                        .checked_add_lamports(1)?;
                     keyed_accounts[2].account.borrow_mut().lamports -= 1;
                     Ok(())
                 }
@@ -9868,7 +9871,7 @@ pub(crate) mod tests {
                 let mut to_account = keyed_accounts[1].try_account_ref_mut()?;
                 let mut dup_account = keyed_accounts[2].try_account_ref_mut()?;
                 dup_account.lamports -= lamports;
-                to_account.lamports += lamports;
+                to_account.checked_add_lamports(lamports).unwrap();
             }
             keyed_accounts[0]
                 .try_account_ref_mut()?
@@ -10359,7 +10362,7 @@ pub(crate) mod tests {
             let keyed_accounts = invoke_context.get_keyed_accounts()?;
             assert_eq!(42, keyed_accounts[0].lamports().unwrap());
             let mut account = keyed_accounts[0].try_account_ref_mut()?;
-            account.lamports += 1;
+            account.checked_add_lamports(1)?;
             Ok(())
         }
 

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1828,7 +1828,10 @@ mod tests {
                     MockSystemInstruction::Correct => Ok(()),
                     MockSystemInstruction::AttemptCredit { lamports } => {
                         keyed_accounts[0].account.borrow_mut().lamports -= lamports;
-                        keyed_accounts[1].account.borrow_mut().lamports += lamports;
+                        keyed_accounts[1]
+                            .account
+                            .borrow_mut()
+                            .checked_add_lamports(lamports)?;
                         Ok(())
                     }
                     // Change data in a read-only account
@@ -2005,11 +2008,13 @@ mod tests {
                             let mut to_account = keyed_accounts[1].try_account_ref_mut()?;
                             let mut dup_account = keyed_accounts[2].try_account_ref_mut()?;
                             dup_account.lamports -= lamports;
-                            to_account.lamports += lamports;
+                            to_account.checked_add_lamports(lamports)?;
                             dup_account.set_data(vec![data]);
                         }
                         keyed_accounts[0].try_account_ref_mut()?.lamports -= lamports;
-                        keyed_accounts[1].try_account_ref_mut()?.lamports += lamports;
+                        keyed_accounts[1]
+                            .try_account_ref_mut()?
+                            .checked_add_lamports(lamports)?;
                         Ok(())
                     }
                 }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -190,7 +190,7 @@ fn transfer_verified(
     }
 
     from.try_account_ref_mut()?.lamports -= lamports;
-    to.try_account_ref_mut()?.lamports += lamports;
+    to.try_account_ref_mut()?.checked_add_lamports(lamports)?;
     Ok(())
 }
 


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to use checked_add_lamports.
Fixes #