### PR TITLE
tests: lamports -= to checked_sub

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7376,7 +7376,7 @@ pub mod tests {
 
         // Lamports changes to not affect the hash
         let mut account_modified = account.clone();
-        account_modified.lamports -= 1;
+        account_modified.checked_sub_lamports(1).unwrap();
         assert_eq!(
             hash,
             AccountsDb::hash_frozen_account_data(&account_modified)
@@ -7464,7 +7464,7 @@ pub mod tests {
         db.freeze_accounts(&ancestors, &[frozen_pubkey]);
 
         // Store with a decrease below the frozen amount of lamports is not ok
-        account.lamports -= 1;
+        account.checked_sub_lamports(1).unwrap();
         db.store_uncached(0, &[(&frozen_pubkey, &account)]);
     }
 
@@ -7566,7 +7566,7 @@ pub mod tests {
 
         db.store_uncached(some_slot, &[(&key, &account)]);
         let mut account = db.load_without_fixed_root(&ancestors, &key).unwrap().0;
-        account.lamports -= 1;
+        account.checked_sub_lamports(1).unwrap();
         account.executable = true;
         db.store_uncached(some_slot, &[(&key, &account)]);
         db.add_root(some_slot);

--- a/runtime/tests/accounts.rs
+++ b/runtime/tests/accounts.rs
@@ -6,7 +6,11 @@ use solana_runtime::{
     accounts_index::Ancestors,
 };
 use solana_sdk::genesis_config::ClusterType;
-use solana_sdk::{account::AccountSharedData, clock::Slot, pubkey::Pubkey};
+use solana_sdk::{
+    account::{AccountSharedData, WritableAccount},
+    clock::Slot,
+    pubkey::Pubkey,
+};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -47,7 +51,7 @@ fn test_shrink_and_clean() {
             alive_accounts.retain(|(_pubkey, account)| account.lamports >= 1);
 
             for (pubkey, account) in alive_accounts.iter_mut() {
-                account.lamports -= 1;
+                account.checked_sub_lamports(1).unwrap();
                 accounts.store_uncached(current_slot, &[(&pubkey, &account)]);
             }
             accounts.add_root(current_slot);


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to use checked_sub_lamports.
Fixes #