### PR TITLE
tests: lamports -= to checked_sub

### DIFF
--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -424,7 +424,7 @@ mod tests {
             assert_eq!(account.data(), &account_info.data.borrow()[..]);
             assert_eq!(account.owner(), account_info.owner);
             assert_eq!(account.executable, account_info.executable);
-            assert_eq!(account.rent_epoch, account_info.rent_epoch);
+            assert_eq!(account.rent_epoch(), account_info.rent_epoch);
 
             assert_eq!(
                 (*account_info.lamports.borrow() as *const u64).align_offset(align_of::<u64>()),
@@ -472,7 +472,7 @@ mod tests {
             );
             assert_eq!(*account.owner(), de_keyed_account.owner().unwrap());
             assert_eq!(account.executable, de_keyed_account.executable().unwrap());
-            assert_eq!(account.rent_epoch, de_keyed_account.rent_epoch().unwrap());
+            assert_eq!(account.rent_epoch(), de_keyed_account.rent_epoch().unwrap());
         }
 
         // check serialize_parameters_unaligned
@@ -496,7 +496,7 @@ mod tests {
             assert_eq!(account.data(), &account_info.data.borrow()[..]);
             assert_eq!(account.owner(), account_info.owner);
             assert_eq!(account.executable, account_info.executable);
-            assert_eq!(account.rent_epoch, account_info.rent_epoch);
+            assert_eq!(account.rent_epoch(), account_info.rent_epoch);
         }
 
         let de_accounts = accounts.clone();
@@ -531,7 +531,7 @@ mod tests {
             );
             assert_eq!(*account.owner(), de_keyed_account.owner().unwrap());
             assert_eq!(account.executable, de_keyed_account.executable().unwrap());
-            assert_eq!(account.rent_epoch, de_keyed_account.rent_epoch().unwrap());
+            assert_eq!(account.rent_epoch(), de_keyed_account.rent_epoch().unwrap());
         }
     }
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1356,11 +1356,11 @@ mod tests {
         let key1 = Pubkey::new(&[5u8; 32]);
 
         let mut account = AccountSharedData::new(1, 0, &Pubkey::default());
-        account.rent_epoch = 1;
+        account.set_rent_epoch(1);
         accounts.push((key0, account));
 
         let mut account = AccountSharedData::new(2, 1, &Pubkey::default());
-        account.rent_epoch = 1;
+        account.set_rent_epoch(1);
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
@@ -1568,18 +1568,18 @@ mod tests {
         let key2 = Pubkey::new(&[6u8; 32]);
 
         let mut account = AccountSharedData::new(1, 0, &Pubkey::default());
-        account.rent_epoch = 1;
+        account.set_rent_epoch(1);
         accounts.push((key0, account));
 
         let mut account = AccountSharedData::new(40, 1, &Pubkey::default());
         account.executable = true;
-        account.rent_epoch = 1;
+        account.set_rent_epoch(1);
         account.set_owner(native_loader::id());
         accounts.push((key1, account));
 
         let mut account = AccountSharedData::new(41, 1, &Pubkey::default());
         account.executable = true;
-        account.rent_epoch = 1;
+        account.set_rent_epoch(1);
         account.set_owner(key1);
         accounts.push((key2, account));
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7384,7 +7384,7 @@ pub mod tests {
 
         // Rent epoch may changes to not affect the hash
         let mut account_modified = account.clone();
-        account_modified.rent_epoch += 1;
+        account_modified.set_rent_epoch(account_modified.rent_epoch() + 1);
         assert_eq!(
             hash,
             AccountsDb::hash_frozen_account_data(&account_modified)

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6151,7 +6151,7 @@ pub(crate) mod tests {
         // Rent deducted on store side
         let account8 = bank.get_account(&keypairs[7].pubkey()).unwrap();
         // Epoch should be set correctly.
-        assert_eq!(account8.rent_epoch, bank.epoch + 1);
+        assert_eq!(account8.rent_epoch(), bank.epoch + 1);
         rent_collected += magic_rent_number;
 
         // 49921 - generic_rent_due_for_system_account(Rent) - 929(Transfer)
@@ -6161,7 +6161,7 @@ pub(crate) mod tests {
         let account10 = bank.get_account(&keypairs[9].pubkey()).unwrap();
         // Account was overwritten at load time, since it didn't have sufficient balance to pay rent
         // Then, at store time we deducted `magic_rent_number` rent for the current epoch, once it has balance
-        assert_eq!(account10.rent_epoch, bank.epoch + 1);
+        assert_eq!(account10.rent_epoch(), bank.epoch + 1);
         // account data is blank now
         assert_eq!(account10.data().len(), 0);
         // 10 - 10(Rent) + 929(Transfer) - magic_rent_number(Rent)
@@ -6853,7 +6853,7 @@ pub(crate) mod tests {
             bank.get_account(&rent_due_pubkey).unwrap().lamports,
             little_lamports
         );
-        assert_eq!(bank.get_account(&rent_due_pubkey).unwrap().rent_epoch, 0);
+        assert_eq!(bank.get_account(&rent_due_pubkey).unwrap().rent_epoch(), 0);
         assert_eq!(
             bank.slots_by_pubkey(&rent_due_pubkey, &ancestors),
             vec![genesis_slot]
@@ -6875,12 +6875,15 @@ pub(crate) mod tests {
             bank.get_account(&rent_due_pubkey).unwrap().lamports,
             little_lamports - rent_collected
         );
-        assert_eq!(bank.get_account(&rent_due_pubkey).unwrap().rent_epoch, 6);
+        assert_eq!(bank.get_account(&rent_due_pubkey).unwrap().rent_epoch(), 6);
         assert_eq!(
             bank.get_account(&rent_exempt_pubkey).unwrap().lamports,
             large_lamports
         );
-        assert_eq!(bank.get_account(&rent_exempt_pubkey).unwrap().rent_epoch, 5);
+        assert_eq!(
+            bank.get_account(&rent_exempt_pubkey).unwrap().rent_epoch(),
+            5
+        );
         assert_eq!(
             bank.slots_by_pubkey(&rent_due_pubkey, &ancestors),
             vec![genesis_slot, some_slot]

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1474,8 +1474,8 @@ mod tests {
             self
         }
         pub fn rent_epoch(mut self, pre: u64, post: u64) -> Self {
-            self.pre.account.borrow_mut().rent_epoch = pre;
-            self.post.rent_epoch = post;
+            self.pre.account.borrow_mut().set_rent_epoch(pre);
+            self.post.set_rent_epoch(post);
             self
         }
         pub fn verify(&self) -> Result<(), InstructionError> {

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -148,18 +148,18 @@ mod tests {
             .collect_from_created_account(&solana_sdk::pubkey::new_rand(), &mut created_account);
         assert!(created_account.lamports < old_lamports);
         assert_eq!(created_account.lamports + collected, old_lamports);
-        assert_ne!(created_account.rent_epoch, old_epoch);
+        assert_ne!(created_account.rent_epoch(), old_epoch);
 
         // collect rent on a already-existing account
         let collected = rent_collector
             .collect_from_existing_account(&solana_sdk::pubkey::new_rand(), &mut existing_account);
         assert!(existing_account.lamports < old_lamports);
         assert_eq!(existing_account.lamports + collected, old_lamports);
-        assert_ne!(existing_account.rent_epoch, old_epoch);
+        assert_ne!(existing_account.rent_epoch(), old_epoch);
 
         // newly created account should be collected for less rent; thus more remaining balance
         assert!(created_account.lamports() > existing_account.lamports);
-        assert_eq!(created_account.rent_epoch, existing_account.rent_epoch);
+        assert_eq!(created_account.rent_epoch(), existing_account.rent_epoch());
     }
 
     #[test]
@@ -172,7 +172,7 @@ mod tests {
         let pubkey = solana_sdk::pubkey::new_rand();
 
         account.lamports = huge_lamports;
-        assert_eq!(account.rent_epoch, 0);
+        assert_eq!(account.rent_epoch(), 0);
 
         // create a tested rent collector
         let rent_collector = RentCollector::default().clone_with_epoch(epoch);


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to return Results and use checked_sub_lamports.
Fixes #