### PR TITLE
rpc_client: `solana leader-schedule -um` works again

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -876,7 +876,7 @@ impl RpcClient {
         &self,
         slot: Option<Slot>,
     ) -> ClientResult<Option<RpcLeaderSchedule>> {
-        self.get_leader_schedule_with_config(slot, RpcLeaderScheduleConfig::default())
+        self.get_leader_schedule_with_commitment(slot, self.commitment_config)
     }
 
     pub fn get_leader_schedule_with_commitment(


### PR DESCRIPTION
Problem:
```
$ solana --version
solana-cli 1.7.0 (src:559d3d8f; feat:1280983886)
$ solana leader-schedule -um
Error: RPC request error: Failed to deserialize RPC error response: {"code":-32602,"message":"Invalid params: missing field `commitment`."} [missing field `data`]
```