### PR TITLE
distribute_rent_to_validators checked_add_lamports unwrap

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3386,16 +3386,17 @@ impl Bank {
                             rent_to_be_paid as usize
                         );
                     }
-
-                    self.store_account(&pubkey, &account);
-                    rewards.push((
-                        pubkey,
-                        RewardInfo {
-                            reward_type: RewardType::Rent,
-                            lamports: rent_to_be_paid as i64,
-                            post_balance: account.lamports(),
-                        },
-                    ));
+                    else {
+                        self.store_account(&pubkey, &account);
+                        rewards.push((
+                            pubkey,
+                            RewardInfo {
+                                reward_type: RewardType::Rent,
+                                lamports: rent_to_be_paid as i64,
+                                post_balance: account.lamports(),
+                            },
+                        ));
+                    }
                 }
             });
         self.rewards.write().unwrap().append(&mut rewards);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3374,7 +3374,8 @@ impl Bank {
                     let mut account = self
                         .get_account_with_fixed_root(&pubkey)
                         .unwrap_or_default();
-                    account.lamports += rent_to_be_paid;
+                    // unwrap since no straightforward ability to do something useful with error
+                    account.checked_add_lamports(rent_to_be_paid).unwrap();
                     self.store_account(&pubkey, &account);
                     rewards.push((
                         pubkey,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3385,8 +3385,7 @@ impl Bank {
                             "bank-burned_rent_lamports",
                             rent_to_be_paid as usize
                         );
-                    }
-                    else {
+                    } else {
                         self.store_account(&pubkey, &account);
                         rewards.push((
                             pubkey,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3378,11 +3378,11 @@ impl Bank {
                         // overflow adding lamports
                         self.capitalization.fetch_sub(rent_to_be_paid, Relaxed);
                         error!(
-                            "Incinerated {} rent lamports instead of sending to {}",
+                            "Burned {} rent lamports instead of sending to {}",
                             rent_to_be_paid, pubkey
                         );
                         inc_new_counter_error!(
-                            "bank-incinerated_rent_lamports",
+                            "bank-burned_rent_lamports",
                             rent_to_be_paid as usize
                         );
                     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3377,7 +3377,10 @@ impl Bank {
                     if account.checked_add_lamports(rent_to_be_paid).is_err() {
                         // overflow adding lamports
                         self.capitalization.fetch_sub(rent_to_be_paid, Relaxed);
-                        error!("Incinerated {} rent lamports", rent_to_be_paid);
+                        error!(
+                            "Incinerated {} rent lamports instead of sending to {}",
+                            rent_to_be_paid, pubkey
+                        );
                         inc_new_counter_error!(
                             "bank-incinerated_rent_lamports",
                             rent_to_be_paid as usize


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to use checked_add_lamports.
Fixes #