### PR TITLE
bank.withdraw uses checked_sub_lamports

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4030,6 +4030,10 @@ impl Bank {
                     _ => 0,
                 };
 
+                lamports
+                    .checked_add(min_balance)
+                    .filter(|required_balance| *required_balance <= account.lamports())
+                    .ok_or(TransactionError::InsufficientFundsForFee)?;
                 account
                     .checked_sub_lamports(lamports)
                     .or_else(|_| Err(TransactionError::InsufficientFundsForFee))?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4030,12 +4030,9 @@ impl Bank {
                     _ => 0,
                 };
 
-                lamports
-                    .checked_add(min_balance)
-                    .filter(|required_balance| *required_balance <= account.lamports())
-                    .ok_or(TransactionError::InsufficientFundsForFee)?;
-
-                account.lamports -= lamports;
+                account
+                    .checked_sub_lamports(lamports)
+                    .or_else(|_| Err(TransactionError::InsufficientFundsForFee))?;
                 self.store_account(pubkey, &account);
 
                 Ok(())

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4036,7 +4036,7 @@ impl Bank {
                     .ok_or(TransactionError::InsufficientFundsForFee)?;
                 account
                     .checked_sub_lamports(lamports)
-                    .or_else(|_| Err(TransactionError::InsufficientFundsForFee))?;
+                    .map_err(|_| TransactionError::InsufficientFundsForFee)?;
                 self.store_account(pubkey, &account);
 
                 Ok(())


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to use checked_sub_lamports.
Fixes #
