### PR TITLE
stats on clean for removing roots

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -951,6 +951,8 @@ struct LatestAccountsIndexRootsStats {
     uncleaned_roots_len: AtomicUsize,
     previous_uncleaned_roots_len: AtomicUsize,
     roots_range: AtomicU64,
+    cleaned_roots: AtomicUsize,
+    not_a_root_cleaned: AtomicUsize,
 }
 
 impl LatestAccountsIndexRootsStats {
@@ -967,6 +969,12 @@ impl LatestAccountsIndexRootsStats {
         );
         self.roots_range
             .store(accounts_index_roots_stats.roots_range, Ordering::Relaxed);
+        self.cleaned_roots
+            .store(accounts_index_roots_stats.cleaned_roots, Ordering::Relaxed);
+        self.not_a_root_cleaned.store(
+            accounts_index_roots_stats.not_a_root_cleaned,
+            Ordering::Relaxed,
+        );
     }
 
     fn report(&self) {
@@ -990,6 +998,16 @@ impl LatestAccountsIndexRootsStats {
             (
                 "roots_range_width",
                 self.roots_range.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "not_a_root_cleaned",
+                self.not_a_root_cleaned.load(Ordering::Relaxed) as i64,
+                i64
+            ),
+            (
+                "cleaned_roots",
+                self.cleaned_roots.load(Ordering::Relaxed) as i64,
                 i64
             ),
         );
@@ -4425,16 +4443,24 @@ impl AccountsDb {
         }
 
         let mut accounts_index_root_stats = AccountsIndexRootsStats::default();
+        let mut not_a_root_count = 0;
+        let mut dead_slots_count = 0;
         let dead_slots: Vec<_> = dead_slots_iter
             .clone()
             .map(|slot| {
+                dead_slots_count += 1;
                 if let Some(latest) = self.accounts_index.clean_dead_slot(*slot) {
                     accounts_index_root_stats = latest;
+                } else {
+                    not_a_root_count += 1;
                 }
                 *slot
             })
             .collect();
         info!("finalize_dead_slot_removal: slots {:?}", dead_slots);
+
+        accounts_index_root_stats.cleaned_roots += dead_slots_count;
+        accounts_index_root_stats.not_a_root_cleaned += not_a_root_count;
 
         self.clean_accounts_stats
             .latest_accounts_index_roots_stats

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -969,11 +969,11 @@ impl LatestAccountsIndexRootsStats {
         );
         self.roots_range
             .store(accounts_index_roots_stats.roots_range, Ordering::Relaxed);
-        self.rooted_cleaned_count.store(
+        self.rooted_cleaned_count.fetch_add(
             accounts_index_roots_stats.rooted_cleaned_count,
             Ordering::Relaxed,
         );
-        self.unrooted_cleaned_count.store(
+        self.unrooted_cleaned_count.fetch_add(
             accounts_index_roots_stats.unrooted_cleaned_count,
             Ordering::Relaxed,
         );
@@ -1004,12 +1004,12 @@ impl LatestAccountsIndexRootsStats {
             ),
             (
                 "unrooted_cleaned_count",
-                self.unrooted_cleaned_count.load(Ordering::Relaxed) as i64,
+                self.unrooted_cleaned_count.swap(0, Ordering::Relaxed) as i64,
                 i64
             ),
             (
                 "rooted_cleaned_count",
-                self.rooted_cleaned_count.load(Ordering::Relaxed) as i64,
+                self.rooted_cleaned_count.swap(0, Ordering::Relaxed) as i64,
                 i64
             ),
         );

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -347,8 +347,8 @@ pub struct AccountsIndexRootsStats {
     pub uncleaned_roots_len: usize,
     pub previous_uncleaned_roots_len: usize,
     pub roots_range: u64,
-    pub cleaned_roots: usize,
-    pub not_a_root_cleaned: usize,
+    pub rooted_cleaned_count: usize,
+    pub unrooted_cleaned_count: usize,
 }
 
 pub struct AccountsIndexIterator<'a, T> {
@@ -1253,8 +1253,8 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
                 uncleaned_roots_len,
                 previous_uncleaned_roots_len,
                 roots_range,
-                cleaned_roots: 0,
-                not_a_root_cleaned: 0,
+                rooted_cleaned_count: 0,
+                unrooted_cleaned_count: 0,
             })
         } else {
             None

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -347,6 +347,8 @@ pub struct AccountsIndexRootsStats {
     pub uncleaned_roots_len: usize,
     pub previous_uncleaned_roots_len: usize,
     pub roots_range: u64,
+    pub cleaned_roots: usize,
+    pub not_a_root_cleaned: usize,
 }
 
 pub struct AccountsIndexIterator<'a, T> {
@@ -1251,6 +1253,8 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
                 uncleaned_roots_len,
                 previous_uncleaned_roots_len,
                 roots_range,
+                cleaned_roots: 0,
+                not_a_root_cleaned: 0,
             })
         } else {
             None


### PR DESCRIPTION
#### Problem
on clean_dead_slot, we get a read lock to check for root, then we get a write lock to remove the root. If we are a high% of the time finding that the item is a root, then we can improve performance and reduce lock contention by just getting the write lock and [removing the root the first time](https://github.com/solana-labs/solana/pull/16829).

#### Summary of Changes
log metrics on how often we try to clean_dead_slot on a slot that isn't a root.
Fixes #
