### PR TITLE
Retain alloc'd and updated data in cpi

### DIFF
--- a/programs/bpf/rust/invoked/src/instruction.rs
+++ b/programs/bpf/rust/invoked/src/instruction.rs
@@ -17,6 +17,7 @@ pub const VERIFY_PRIVILEGE_DEESCALATION: u8 = 8;
 pub const VERIFY_PRIVILEGE_DEESCALATION_ESCALATION_SIGNER: u8 = 9;
 pub const VERIFY_PRIVILEGE_DEESCALATION_ESCALATION_WRITABLE: u8 = 10;
 pub const WRITE_ACCOUNT: u8 = 11;
+pub const CREATE_AND_INIT: u8 = 12;
 
 pub fn create_instruction(
     program_id: Pubkey,

--- a/programs/bpf/tests/programs.rs
+++ b/programs/bpf/tests/programs.rs
@@ -876,6 +876,8 @@ fn test_program_bpf_invoke_sanity() {
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
                 invoked_program_id.clone(),
+                invoked_program_id.clone(),
+                solana_sdk::system_program::id(),
             ],
         };
         assert_eq!(invoked_programs.len(), expected_invoked_programs.len());

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -126,8 +126,13 @@ pub mod check_duplicates_by_hash {
 pub mod enforce_aligned_host_addrs {
     solana_sdk::declare_id!("6Qob9Z4RwGdf599FDVCqsjuKjR8ZFR3oVs2ByRLWBsua");
 }
+
 pub mod set_upgrade_authority_via_cpi_enabled {
     solana_sdk::declare_id!("GQdjCCptpGECG7QfE35hKTAopB1umGoSrdKfax2VmZWy");
+}
+
+pub mod update_data_on_realloc {
+    solana_sdk::declare_id!("BkPcYCrwHXBoTsv9vMhiRF9gteZmDj3Uwisz9CDjoMKp");
 }
 
 lazy_static! {
@@ -163,6 +168,7 @@ lazy_static! {
         (check_duplicates_by_hash::id(), "use transaction message hash for duplicate check"),
         (enforce_aligned_host_addrs::id(), "enforce aligned host addresses"),
         (set_upgrade_authority_via_cpi_enabled::id(), "set upgrade authority instruction via cpi calls for upgradable programs"),
+        (update_data_on_realloc::id(), "Retain updated data values modified after realloc via CPI"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

If an invoked program both creates an account (via the system program) and then updates that account's data the data values will be lost and most likely the transaction will fail to verify

#### Summary of Changes

Retain the updated data values

Fixes #16825
