### PR TITLE
RpcClient: Compress account data by default

### DIFF
--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1026,7 +1026,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Option<Account>> {
         let config = RpcAccountInfoConfig {
-            encoding: Some(UiAccountEncoding::Base64),
+            encoding: Some(UiAccountEncoding::Base64Zstd),
             commitment: Some(self.maybe_map_commitment(commitment_config)?),
             data_slice: None,
         };
@@ -1081,7 +1081,7 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Vec<Option<Account>>> {
         let config = RpcAccountInfoConfig {
-            encoding: Some(UiAccountEncoding::Base64),
+            encoding: Some(UiAccountEncoding::Base64Zstd),
             commitment: Some(self.maybe_map_commitment(commitment_config)?),
             data_slice: None,
         };
@@ -1149,7 +1149,7 @@ impl RpcClient {
             RpcProgramAccountsConfig {
                 filters: None,
                 account_config: RpcAccountInfoConfig {
-                    encoding: Some(UiAccountEncoding::Base64),
+                    encoding: Some(UiAccountEncoding::Base64Zstd),
                     commitment: Some(self.commitment_config),
                     ..RpcAccountInfoConfig::default()
                 },


### PR DESCRIPTION
`UiAccountEncoding::Base64` -> `UiAccountEncoding::Base64Zstd` to speed up responses for larger accounts.  