### PR TITLE
web3: export `is_on_curve()`

### DIFF
--- a/web3.js/src/publickey.ts
+++ b/web3.js/src/publickey.ts
@@ -150,6 +150,13 @@ export class PublicKey {
     }
     throw new Error(`Unable to find a viable program address nonce`);
   }
+
+  /**
+   * Check that a pubkey is on the ed25519 curve.
+   */
+  static isOnCurve(pubkey: Uint8Array): boolean {
+    return is_on_curve(pubkey) == 1;
+  }
 }
 
 // @ts-ignore

--- a/web3.js/test/publickey.test.ts
+++ b/web3.js/test/publickey.test.ts
@@ -3,6 +3,7 @@ import {Buffer} from 'buffer';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
+import {Account} from '../src/account';
 import {PublicKey, MAX_SEED_LENGTH} from '../src/publickey';
 
 use(chaiAsPromised);
@@ -327,5 +328,18 @@ describe('PublicKey', function () {
         ),
       ),
     ).to.be.true;
+  });
+
+  it('isOnCurve', () => {
+    let onCurve = new Account().publicKey;
+    expect(PublicKey.isOnCurve(onCurve.toBuffer())).to.be.true;
+    // A program address, yanked from one of the above tests. This is a pretty
+    // poor test vector since it was created by the same code it is testing.
+    // Unfortunately, I've been unable to find a golden negative example input
+    // for curve25519 point decompression :/
+    let offCurve = new PublicKey(
+      '12rqwuEgBYiGhBrDJStCiqEtzQpTTiZbh7teNVLuYcFA',
+    );
+    expect(PublicKey.isOnCurve(offCurve.toBuffer())).to.be.false;
   });
 });


### PR DESCRIPTION
#### Problem

I wanna reject off-curve prospective ATA owners, but `is_on_curve()` isn't exported

#### Summary of Changes

Export it