### PR TITLE
write Option<AccountSharedData>

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3749,6 +3749,9 @@ impl AccountsDb {
             .iter()
             .map(|(pubkey, account)| {
                 self.read_only_accounts_cache.remove(pubkey, slot);
+                // this is the source of Some(Account) or None.
+                // Some(Account) = store 'Account'
+                // None = store a default/empty account with 0 lamports
                 let (account, data_len) = if account.lamports() == 0 {
                     (None, 0)
                 } else {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -3310,7 +3310,7 @@ impl AccountsDb {
         slot: Slot,
         hashes: &[impl Borrow<Hash>],
         mut storage_finder: F,
-        accounts_and_meta_to_store: &[(StoredMeta, &AccountSharedData)],
+        accounts_and_meta_to_store: &[(StoredMeta, Option<&AccountSharedData>)],
     ) -> Vec<AccountInfo> {
         assert_eq!(hashes.len(), accounts_and_meta_to_store.len());
         let mut infos: Vec<AccountInfo> = Vec::with_capacity(accounts_and_meta_to_store.len());
@@ -3318,7 +3318,10 @@ impl AccountsDb {
         let mut total_storage_find_us = 0;
         while infos.len() < accounts_and_meta_to_store.len() {
             let mut storage_find = Measure::start("storage_finder");
-            let data_len = accounts_and_meta_to_store[infos.len()].1.data().len();
+            let data_len = accounts_and_meta_to_store[infos.len()]
+                .1
+                .map(|account| account.data().len())
+                .unwrap_or_default();
             let storage = storage_finder(slot, data_len + STORE_META_OVERHEAD);
             storage_find.stop();
             total_storage_find_us += storage_find.as_us();
@@ -3364,7 +3367,9 @@ impl AccountsDb {
                     store_id: storage.append_vec_id(),
                     offset: offsets[0],
                     stored_size,
-                    lamports: account.lamports(),
+                    lamports: account
+                        .map(|account| account.lamports())
+                        .unwrap_or_default(),
                 });
             }
             // restore the state to available
@@ -3692,7 +3697,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         hashes: Option<&[impl Borrow<Hash>]>,
-        accounts_and_meta_to_store: &[(StoredMeta, &AccountSharedData)],
+        accounts_and_meta_to_store: &[(StoredMeta, Option<&AccountSharedData>)],
     ) -> Vec<AccountInfo> {
         let len = accounts_and_meta_to_store.len();
         let hashes = hashes.map(|hashes| {
@@ -3705,9 +3710,17 @@ impl AccountsDb {
             .enumerate()
             .map(|(i, (meta, account))| {
                 let hash = hashes.map(|hashes| hashes[i].borrow());
-                let cached_account =
-                    self.accounts_cache
-                        .store(slot, &meta.pubkey, (*account).clone(), hash);
+
+                let account = account.cloned().unwrap_or_default();
+
+                let account_info = AccountInfo {
+                    store_id: CACHE_VIRTUAL_STORAGE_ID,
+                    offset: CACHE_VIRTUAL_OFFSET,
+                    stored_size: CACHE_VIRTUAL_STORED_SIZE,
+                    lamports: account.lamports(),
+                };
+
+                let cached_account = self.accounts_cache.store(slot, &meta.pubkey, account, hash);
                 // hash this account in the bg
                 match &self.sender_bg_hasher {
                     Some(ref sender) => {
@@ -3715,13 +3728,7 @@ impl AccountsDb {
                     }
                     None => (),
                 };
-
-                AccountInfo {
-                    store_id: CACHE_VIRTUAL_STORAGE_ID,
-                    offset: CACHE_VIRTUAL_OFFSET,
-                    stored_size: CACHE_VIRTUAL_STORED_SIZE,
-                    lamports: account.lamports(),
-                }
+                account_info
             })
             .collect()
     }
@@ -3738,17 +3745,15 @@ impl AccountsDb {
         mut write_version_producer: P,
         is_cached_store: bool,
     ) -> Vec<AccountInfo> {
-        let default_account = AccountSharedData::default();
-        let accounts_and_meta_to_store: Vec<(StoredMeta, &AccountSharedData)> = accounts
+        let accounts_and_meta_to_store: Vec<(StoredMeta, Option<&AccountSharedData>)> = accounts
             .iter()
             .map(|(pubkey, account)| {
                 self.read_only_accounts_cache.remove(pubkey, slot);
-                let account = if account.lamports() == 0 {
-                    &default_account
+                let (account, data_len) = if account.lamports() == 0 {
+                    (None, 0)
                 } else {
-                    *account
+                    (Some(*account), account.data().len() as u64)
                 };
-                let data_len = account.data().len() as u64;
                 let meta = StoredMeta {
                     write_version: write_version_producer.next().unwrap(),
                     pubkey: **pubkey,
@@ -5809,7 +5814,7 @@ pub mod tests {
         };
         storages[0][0]
             .accounts
-            .append_accounts(&[(sm, &acc)], &[&Hash::default()]);
+            .append_accounts(&[(sm, Some(&acc))], &[&Hash::default()]);
 
         let calls = AtomicU64::new(0);
         let result = AccountsDb::scan_account_storage_no_bank(


### PR DESCRIPTION
#### Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. There will [soon be a new ReadableAccount impl for a stored account](https://github.com/solana-labs/solana/pull/16690/commits/95261a4f74b5aed97e96cf11a0f9b791565a3c23#r621561972). This does not have a good default. So, AccountSharedData::default() doesn't work well.

#### Summary of Changes
Make the write path that uses AccountSharedData::default() instead use Option<AccountSharedData>

Fixes #
