### PR TITLE
Tests: AccountSharedData.set_executable()

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1024,7 +1024,7 @@ mod tests {
         let keyed_accounts = invoke_context.get_keyed_accounts().unwrap();
         assert!(keyed_accounts[0].account.borrow().executable);
 
-        program_account.borrow_mut().executable = false; // Un-finalize the account
+        program_account.borrow_mut().set_executable(false); // Un-finalize the account
 
         // Case: Finalize
         program_account.borrow_mut().data_as_mut_slice()[0] = 0; // bad elf
@@ -1050,7 +1050,7 @@ mod tests {
         file.read_to_end(&mut elf).unwrap();
         let program_account = AccountSharedData::new_ref(1, 0, &program_id);
         program_account.borrow_mut().set_data(elf);
-        program_account.borrow_mut().executable = true;
+        program_account.borrow_mut().set_executable(true);
 
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
 
@@ -1071,7 +1071,7 @@ mod tests {
         );
 
         // Case: Account not a program
-        keyed_accounts[0].account.borrow_mut().executable = false;
+        keyed_accounts[0].account.borrow_mut().set_executable(false);
         assert_eq!(
             Err(InstructionError::InvalidInstructionData),
             process_instruction(
@@ -1080,7 +1080,7 @@ mod tests {
                 &mut MockInvokeContext::new(keyed_accounts.clone())
             )
         );
-        keyed_accounts[0].account.borrow_mut().executable = true;
+        keyed_accounts[0].account.borrow_mut().set_executable(true);
 
         // Case: With program and parameter account
         let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
@@ -1143,7 +1143,7 @@ mod tests {
         file.read_to_end(&mut elf).unwrap();
         let program_account = AccountSharedData::new_ref(1, 0, &program_id);
         program_account.borrow_mut().set_data(elf);
-        program_account.borrow_mut().executable = true;
+        program_account.borrow_mut().set_executable(true);
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
 
         // Case: With program and parameter account
@@ -1185,7 +1185,7 @@ mod tests {
         file.read_to_end(&mut elf).unwrap();
         let program_account = AccountSharedData::new_ref(1, 0, &program_id);
         program_account.borrow_mut().set_data(elf);
-        program_account.borrow_mut().executable = true;
+        program_account.borrow_mut().set_executable(true);
         let mut keyed_accounts = vec![KeyedAccount::new(&program_key, false, &program_account)];
 
         // Case: With program and parameter account
@@ -2239,7 +2239,7 @@ mod tests {
                 UpgradeableLoaderState::program_len().unwrap(),
                 &bpf_loader_upgradeable::id(),
             );
-            program_account.borrow_mut().executable = true;
+            program_account.borrow_mut().set_executable(true);
             program_account
                 .borrow_mut()
                 .set_state(&UpgradeableLoaderState::Program {
@@ -2429,7 +2429,7 @@ mod tests {
             min_program_balance,
             min_programdata_balance,
         );
-        program_account.borrow_mut().executable = false;
+        program_account.borrow_mut().set_executable(false);
         let keyed_accounts = vec![
             KeyedAccount::new(&programdata_address, false, &programdata_account),
             KeyedAccount::new(&program_address, false, &program_account),
@@ -3332,7 +3332,7 @@ mod tests {
             |bytes: &mut [u8]| {
                 let program_account = AccountSharedData::new_ref(1, 0, &program_id);
                 program_account.borrow_mut().set_data(bytes.to_vec());
-                program_account.borrow_mut().executable = true;
+                program_account.borrow_mut().set_executable(true);
 
                 let parameter_account = AccountSharedData::new_ref(1, 0, &program_id);
                 let keyed_accounts = vec![

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1405,32 +1405,32 @@ mod tests {
         accounts.push((key0, account));
 
         let mut account = AccountSharedData::new(40, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         account.set_owner(native_loader::id());
         accounts.push((key1, account));
 
         let mut account = AccountSharedData::new(41, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         account.set_owner(key1);
         accounts.push((key2, account));
 
         let mut account = AccountSharedData::new(42, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         account.set_owner(key2);
         accounts.push((key3, account));
 
         let mut account = AccountSharedData::new(43, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         account.set_owner(key3);
         accounts.push((key4, account));
 
         let mut account = AccountSharedData::new(44, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         account.set_owner(key4);
         accounts.push((key5, account));
 
         let mut account = AccountSharedData::new(45, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         account.set_owner(key5);
         accounts.push((key6, account));
 
@@ -1466,7 +1466,7 @@ mod tests {
         accounts.push((key0, account));
 
         let mut account = AccountSharedData::new(40, 1, &native_loader::id());
-        account.executable = true;
+        account.set_executable(true);
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(0, &(), vec![0])];
@@ -1501,7 +1501,7 @@ mod tests {
         accounts.push((key0, account));
 
         let mut account = AccountSharedData::new(40, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         accounts.push((key1, account));
 
         let instructions = vec![CompiledInstruction::new(1, &(), vec![0])];
@@ -1572,13 +1572,13 @@ mod tests {
         accounts.push((key0, account));
 
         let mut account = AccountSharedData::new(40, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         account.set_rent_epoch(1);
         account.set_owner(native_loader::id());
         accounts.push((key1, account));
 
         let mut account = AccountSharedData::new(41, 1, &Pubkey::default());
-        account.executable = true;
+        account.set_executable(true);
         account.set_rent_epoch(1);
         account.set_owner(key1);
         accounts.push((key2, account));

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7430,7 +7430,7 @@ pub mod tests {
 
         // Executable may not be modified
         let mut account_modified = account;
-        account_modified.executable = true;
+        account_modified.set_executable(true);
         assert_ne!(
             hash,
             AccountsDb::hash_frozen_account_data(&account_modified)
@@ -7588,7 +7588,7 @@ pub mod tests {
         db.store_uncached(some_slot, &[(&key, &account)]);
         let mut account = db.load_without_fixed_root(&ancestors, &key).unwrap().0;
         account.checked_sub_lamports(1).unwrap();
-        account.executable = true;
+        account.set_executable(true);
         db.store_uncached(some_slot, &[(&key, &account)]);
         db.add_root(some_slot);
 

--- a/runtime/src/append_vec.rs
+++ b/runtime/src/append_vec.rs
@@ -570,7 +570,7 @@ pub mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use rand::{thread_rng, Rng};
-    use solana_sdk::timing::duration_as_ms;
+    use solana_sdk::{account::WritableAccount, timing::duration_as_ms};
     use std::time::Instant;
 
     impl AppendVec {
@@ -856,7 +856,7 @@ pub mod tests {
         av.append_account_test(&create_test_account(10)).unwrap();
         {
             let mut executable_account = create_test_account(10);
-            executable_account.1.executable = true;
+            executable_account.1.set_executable(true);
             av.append_account_test(&executable_account).unwrap();
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5993,7 +5993,7 @@ pub(crate) mod tests {
         let account_balance = 1;
         let mut account =
             AccountSharedData::new(account_balance, 0, &solana_sdk::pubkey::new_rand());
-        account.executable = true;
+        account.set_executable(true);
         bank.store_account(&account_pubkey, &account);
 
         let transfer_lamports = 1;
@@ -10380,7 +10380,7 @@ pub(crate) mod tests {
         // Add a new program owned by the first
         let program2_pubkey = solana_sdk::pubkey::new_rand();
         let mut program2_account = AccountSharedData::new(42, 1, &program1_pubkey);
-        program2_account.executable = true;
+        program2_account.set_executable(true);
         bank.store_account(&program2_pubkey, &program2_account);
 
         let instruction = Instruction::new_with_bincode(program2_pubkey, &10, vec![]);

--- a/runtime/src/message_processor.rs
+++ b/runtime/src/message_processor.rs
@@ -1455,8 +1455,8 @@ mod tests {
             self
         }
         pub fn executable(mut self, pre: bool, post: bool) -> Self {
-            self.pre.account.borrow_mut().executable = pre;
-            self.post.executable = post;
+            self.pre.account.borrow_mut().set_executable(pre);
+            self.post.set_executable(post);
             self
         }
         pub fn lamports(mut self, pre: u64, post: u64) -> Self {
@@ -2187,7 +2187,7 @@ mod tests {
         let callee_program_id = solana_sdk::pubkey::new_rand();
 
         let mut program_account = AccountSharedData::new(1, 0, &native_loader::id());
-        program_account.executable = true;
+        program_account.set_executable(true);
         let executable_accounts = vec![(
             callee_program_id,
             Rc::new(RefCell::new(program_account.clone())),


### PR DESCRIPTION
#### Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods.
#### Summary of Changes
Make executable private to prevent further uses from appearing.
Fixes #
