### PR TITLE
Tests: AccountSharedData.executable()

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1022,7 +1022,7 @@ mod tests {
             process_instruction(&bpf_loader::id(), &instruction_data, &mut invoke_context)
         );
         let keyed_accounts = invoke_context.get_keyed_accounts().unwrap();
-        assert!(keyed_accounts[0].account.borrow().executable);
+        assert!(keyed_accounts[0].account.borrow().executable());
 
         program_account.borrow_mut().executable = false; // Un-finalize the account
 

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -423,7 +423,7 @@ mod tests {
             assert_eq!(account.lamports, account_info.lamports());
             assert_eq!(account.data(), &account_info.data.borrow()[..]);
             assert_eq!(account.owner(), account_info.owner);
-            assert_eq!(account.executable, account_info.executable);
+            assert_eq!(account.executable(), account_info.executable);
             assert_eq!(account.rent_epoch(), account_info.rent_epoch);
 
             assert_eq!(
@@ -471,7 +471,7 @@ mod tests {
                 de_keyed_account.try_account_ref().unwrap().data()
             );
             assert_eq!(*account.owner(), de_keyed_account.owner().unwrap());
-            assert_eq!(account.executable, de_keyed_account.executable().unwrap());
+            assert_eq!(account.executable(), de_keyed_account.executable().unwrap());
             assert_eq!(account.rent_epoch(), de_keyed_account.rent_epoch().unwrap());
         }
 
@@ -495,7 +495,7 @@ mod tests {
             assert_eq!(account.lamports, account_info.lamports());
             assert_eq!(account.data(), &account_info.data.borrow()[..]);
             assert_eq!(account.owner(), account_info.owner);
-            assert_eq!(account.executable, account_info.executable);
+            assert_eq!(account.executable(), account_info.executable);
             assert_eq!(account.rent_epoch(), account_info.rent_epoch);
         }
 
@@ -530,7 +530,7 @@ mod tests {
                 de_keyed_account.try_account_ref().unwrap().data()
             );
             assert_eq!(*account.owner(), de_keyed_account.owner().unwrap());
-            assert_eq!(account.executable, de_keyed_account.executable().unwrap());
+            assert_eq!(account.executable(), de_keyed_account.executable().unwrap());
             assert_eq!(account.rent_epoch(), de_keyed_account.rent_epoch().unwrap());
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -9993,7 +9993,7 @@ pub(crate) mod tests {
         assert_eq!(result, Ok(()));
         let account = bank.get_account(&solana_vote_program::id()).unwrap();
         info!("account: {:?}", account);
-        assert!(account.executable);
+        assert!(account.executable());
     }
 
     #[test]
@@ -10298,7 +10298,7 @@ pub(crate) mod tests {
             }
             for (key, name) in &program_keys {
                 let account = bank.get_account(key).unwrap();
-                assert!(account.executable);
+                assert!(account.executable());
                 assert_eq!(account.data(), name);
             }
             info!("result: {:?}", result);


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods.

Summary of Changes
executable uses executable()
Fixes #