### PR TITLE
AccountSharedData.executable becomes private

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -37,7 +37,7 @@ pub struct AccountSharedData {
     /// the program that owns this account. If executable, the program that loads this account.
     owner: Pubkey,
     /// this account's data contains a loaded program (and is now read-only)
-    pub executable: bool,
+    executable: bool,
     /// the epoch at which this account will next owe rent
     pub rent_epoch: Epoch,
 }


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods.

Summary of Changes
Make executable private to prevent further uses from appearing.
Fixes #