### PR TITLE
Add allowed-IP list to faucet

### DIFF
--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -1,5 +1,5 @@
 use {
-    clap::{crate_description, crate_name, App, Arg},
+    clap::{crate_description, crate_name, values_t, App, Arg},
     log::*,
     solana_clap_utils::input_parsers::{lamports_of_sol, value_of},
     solana_faucet::{
@@ -8,7 +8,8 @@ use {
     },
     solana_sdk::signature::read_keypair_file,
     std::{
-        net::{Ipv4Addr, SocketAddr},
+        collections::HashSet,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
         sync::{Arc, Mutex},
         thread,
     },
@@ -55,6 +56,17 @@ async fn main() {
                 .takes_value(true)
                 .help("Request limit for a single request, in SOL"),
         )
+        .arg(
+            Arg::with_name("allowed_ip")
+                .long("allow-ip")
+                .value_name("IP_ADDRESS")
+                .takes_value(true)
+                .multiple(true)
+                .help(
+                    "Allow requests from a particular IP address without request limit; \
+                    recipient address will be used to check request limits instead",
+                ),
+        )
         .get_matches();
 
     let faucet_keypair = read_keypair_file(matches.value_of("keypair").unwrap())
@@ -64,13 +76,19 @@ async fn main() {
     let per_time_cap = lamports_of_sol(&matches, "per_time_cap");
     let per_request_cap = lamports_of_sol(&matches, "per_request_cap");
 
+    let allowed_ips: HashSet<_> = values_t!(matches.values_of("allowed_ip"), IpAddr)
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+
     let faucet_addr = socketaddr!(0, FAUCET_PORT);
 
-    let faucet = Arc::new(Mutex::new(Faucet::new(
+    let faucet = Arc::new(Mutex::new(Faucet::new_with_allowed_ips(
         faucet_keypair,
         time_slice,
         per_time_cap,
         per_request_cap,
+        allowed_ips,
     )));
 
     let faucet1 = faucet.clone();


### PR DESCRIPTION
#### Problem
Follow-up to https://github.com/solana-labs/solana/pull/16487
Airdrop requests sent to the same rpc node appear to the faucet with the same source IP address, regardless of the IP that sent the rpc request. If this IP is not the loopback address (as in the case of load-balanced api nodes remote from the faucet), airdrop requests will be overly limited by a faucet running with a per-time-cap, limiting all users together instead of per IP as intended.

#### Summary of Changes
Add allowed-IP list to faucet; IPs listed are excluded from ip limiting (address limits still checked/applied)

cc @joeaba 
