### PR TITLE
Clean unrooted dropped banks (#16580)

### DIFF
--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1609,8 +1609,12 @@ impl AccountsDb {
                                     }
                                 }
                                 AccountIndexGetResult::NotFoundOnFork => {
-                                    // pubkey is in the index but not in a root slot, so clean it
-                                    // up by adding it to the to-be-purged list
+                                    // This pubkey is in the index but not in a root slot, so clean
+                                    // it up by adding it to the to-be-purged list.
+                                    //
+                                    // Also, this pubkey must have been touched by some slot since
+                                    // it was in the dirty list, so we assume that the slot it was
+                                    // touched in must be unrooted.
                                     purges_unrooted.push(*pubkey);
                                 }
                                 AccountIndexGetResult::Missing(lock) => {

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -1270,12 +1270,12 @@ impl AccountsDb {
     }
 
     // Reclaim older states of rooted accounts for AccountsDb bloat mitigation
-    fn clean_old_rooted_accounts(
+    fn clean_purgeable_accounts(
         &self,
-        purges_in_root: Vec<Pubkey>,
+        purges: Vec<Pubkey>,
         max_clean_root: Option<Slot>,
     ) -> ReclaimResult {
-        if purges_in_root.is_empty() {
+        if purges.is_empty() {
             return (HashMap::new(), HashMap::new());
         }
         // This number isn't carefully chosen; just guessed randomly such that
@@ -1283,21 +1283,20 @@ impl AccountsDb {
         const INDEX_CLEAN_BULK_COUNT: usize = 4096;
 
         let mut clean_rooted = Measure::start("clean_old_root-ms");
-        let reclaim_vecs =
-            purges_in_root
-                .par_chunks(INDEX_CLEAN_BULK_COUNT)
-                .map(|pubkeys: &[Pubkey]| {
-                    let mut reclaims = Vec::new();
-                    for pubkey in pubkeys {
-                        self.accounts_index.clean_rooted_entries(
-                            &pubkey,
-                            &mut reclaims,
-                            max_clean_root,
-                            &self.account_indexes,
-                        );
-                    }
-                    reclaims
-                });
+        let reclaim_vecs = purges
+            .par_chunks(INDEX_CLEAN_BULK_COUNT)
+            .map(|pubkeys: &[Pubkey]| {
+                let mut reclaims = Vec::new();
+                for pubkey in pubkeys {
+                    self.accounts_index.clean_rooted_entries(
+                        &pubkey,
+                        &mut reclaims,
+                        max_clean_root,
+                        &self.account_indexes,
+                    );
+                }
+                reclaims
+            });
         let reclaims: Vec<_> = reclaim_vecs.flatten().collect();
         clean_rooted.stop();
         inc_new_counter_info!("clean-old-root-par-clean-ms", clean_rooted.as_ms() as usize);
@@ -1643,7 +1642,7 @@ impl AccountsDb {
         let mut clean_old_rooted = Measure::start("clean_old_roots");
         let purges = [purges_rooted, purges_unrooted].concat();
         let (purged_account_slots, removed_accounts) =
-            self.clean_old_rooted_accounts(purges, max_clean_root);
+            self.clean_purgeable_accounts(purges, max_clean_root);
 
         if self.caching_enabled {
             self.do_reset_uncleaned_roots(max_clean_root);
@@ -1672,7 +1671,7 @@ impl AccountsDb {
                     return false;
                 }
                 // Check if this update in `slot` to the account with `key` was reclaimed earlier by
-                // `clean_old_rooted_accounts()`
+                // `clean_purgeable_accounts()`
                 let was_reclaimed = removed_accounts
                     .get(&account_info.store_id)
                     .map(|store_removed| store_removed.contains(&account_info.offset))
@@ -2502,7 +2501,7 @@ impl AccountsDb {
         //        purge_slot_cache_pubkeys()      | (removes existing store_id, offset for caches)
         //      OR                                |
         //    clean_accounts()/                   |
-        //        clean_old_rooted_accounts()     | (removes existing store_id, offset for stores)
+        //        clean_purgeable_accounts()      | (removes existing store_id, offset for stores)
         //                                        V
         //
         // Remarks for purger: So, for any reading operations, it's a race condition

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1185,7 +1185,7 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         max_clean_root: Option<Slot>,
         account_indexes: &HashSet<AccountIndex>,
     ) {
-        let mut empty_key = false;
+        let mut is_slot_list_empty = false;
         if let Some(mut locked_entry) = self.get_account_write_entry(pubkey) {
             locked_entry.slot_list_mut(|slot_list| {
                 self.purge_older_root_entries(
@@ -1195,10 +1195,10 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
                     max_clean_root,
                     account_indexes,
                 );
-                empty_key = slot_list.is_empty();
+                is_slot_list_empty = slot_list.is_empty();
             });
         }
-        if empty_key {
+        if is_slot_list_empty {
             let mut w_maps = self.account_maps.write().unwrap();
             if let Some(x) = w_maps.get(pubkey) {
                 if x.slot_list.read().unwrap().is_empty() {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1212,7 +1212,21 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         }
     }
 
+    /// When can an entry be purged?
+    ///
+    /// If we get a slot update where slot != max_cleanable_root for an account where slot <
+    /// max_clean_root, then we know it's safe to delete because:
+    ///
+    /// a) If s < max_cleanable_root_in_slot_list, then we know the update is outdated by a later
+    /// rooted update, namely the one in max_cleanable_root_in_slot_list
+    ///
+    /// b) If s > max_cleanable_root_in_slot_list, then because s < max_clean_root and we know
+    /// there are no roots in the slot list between max_cleanable_root_in_slot_list and
+    /// max_clean_root, (otherwise there would be a bigger max_cleanable_root_in_slot_list, which
+    /// is a contradiction), then we know s must be an unrooted slot less than max_clean_root and
+    /// thus safe to clean as well.
     fn can_purge_older_entries(max_clean_root: Slot, max_cleanable_root: Slot, slot: Slot) -> bool {
+        assert!(max_cleanable_root < max_clean_root);
         slot < max_clean_root && slot != max_cleanable_root
     }
 

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1200,6 +1200,11 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
                 is_slot_list_empty = slot_list.is_empty();
             });
         }
+
+        // If the slot list is empty, remove the pubkey from `account_maps`.  Make sure to grab the
+        // lock and double check the slot list is still empty, because another writer could have
+        // locked and inserted the pubkey inbetween when `is_slot_list_empty=true` and the call to
+        // remove() below.
         if is_slot_list_empty {
             let mut w_maps = self.account_maps.write().unwrap();
             if let Some(x) = w_maps.get(pubkey) {

--- a/runtime/src/accounts_index.rs
+++ b/runtime/src/accounts_index.rs
@@ -1227,7 +1227,6 @@ impl<T: 'static + Clone + IsCached + ZeroLamport> AccountsIndex<T> {
         newest_root_in_slot_list: Slot,
         slot: Slot,
     ) -> bool {
-        assert!(newest_root_in_slot_list < max_clean_root);
         slot < max_clean_root && slot != newest_root_in_slot_list
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -12468,4 +12468,54 @@ pub(crate) mod tests {
             ))
         );
     }
+
+    #[test]
+    fn test_clean_unrooted_dropped_banks() {
+        //! Test that unrooted banks are cleaned up properly
+        //!
+        //! slot 0:       bank0 (rooted)
+        //!               /   \
+        //! slot 1:      /   bank1 (unrooted and dropped)
+        //!             /
+        //! slot 2:  bank2 (rooted)
+        //!
+        //! In the scenario above, when `clean_accounts()` is called on bank2, the keys that exist
+        //! _only_ in bank1 should be cleaned up, since those keys are unreachable.
+        //
+        solana_logger::setup();
+
+        let (genesis_config, mint_keypair) = create_genesis_config(100);
+        let bank0 = Arc::new(Bank::new(&genesis_config));
+
+        let collector = Pubkey::new_unique();
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        bank0.transfer(2, &mint_keypair, &pubkey2).unwrap();
+        bank0.freeze();
+
+        let slot = 1;
+        let bank1 = Bank::new_from_parent(&bank0, &collector, slot);
+        bank1.transfer(3, &mint_keypair, &pubkey1).unwrap();
+        bank1.freeze();
+
+        let slot = slot + 1;
+        let bank2 = Bank::new_from_parent(&bank0, &collector, slot);
+        bank2.transfer(4, &mint_keypair, &pubkey2).unwrap();
+        bank2.freeze(); // the freeze here is not strictly necessary, but more for illustration
+        bank2.squash();
+
+        drop(bank1);
+
+        bank2.clean_accounts(false);
+        assert_eq!(
+            bank2
+                .rc
+                .accounts
+                .accounts_db
+                .accounts_index
+                .ref_count_from_storage(&pubkey1),
+            0
+        );
+    }
 }


### PR DESCRIPTION
 Clean unrooted dropped banks (#16580)

In a scenario where a bank is unrooted and dropped, any keys that exist
_only_ in that bank are now cleaned up.

This work was originally based on PR #15106.