### PR TITLE
account.lamports -=

### DIFF
--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -685,7 +685,9 @@ pub fn withdraw<S: std::hash::BuildHasher>(
         }
         _ => (),
     }
-    vote_account.try_account_ref_mut()?.lamports -= lamports;
+    vote_account
+        .try_account_ref_mut()?
+        .checked_sub_lamports(lamports)?;
     to_account
         .try_account_ref_mut()?
         .checked_add_lamports(lamports)?;


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to return Results and use checked_sub_lamports.
Fixes #