### PR TITLE
lamports = -> set_lamports

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4956,7 +4956,7 @@ impl Bank {
                 self.get_account_with_fixed_root(&inline_spl_token_v2_0::native_mint::id())
             {
                 if existing_native_mint_account.owner() == &solana_sdk::system_program::id() {
-                    native_mint_account.lamports = existing_native_mint_account.lamports;
+                    native_mint_account.set_lamports(existing_native_mint_account.lamports());
                     true
                 } else {
                     false


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods.

Summary of Changes
lamports = -> set_lamports()
Fixes #