### PR TITLE
checked_sub_lamports with unwrap

### DIFF
--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -96,7 +96,7 @@ impl RentCollector {
                                 1
                             },
                     );
-                    account.lamports -= rent_due;
+                    account.checked_sub_lamports(rent_due).unwrap(); // will not fail. We check above.
                     rent_due
                 } else {
                     let rent_charged = account.lamports();

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -96,7 +96,7 @@ impl RentCollector {
                                 1
                             },
                     );
-                    account.checked_sub_lamports(rent_due).unwrap(); // will not fail. We check above.
+                    let _ = account.checked_sub_lamports(rent_due); // will not fail. We check above.
                     rent_due
                 } else {
                     let rent_charged = account.lamports();


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to return Results and use checked_sub_lamports.
Fixes #