### PR TITLE
checked_sub_lamports

### DIFF
--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -1158,7 +1158,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
             split
                 .try_account_ref_mut()?
                 .checked_add_lamports(lamports)?;
-            self.try_account_ref_mut()?.lamports -= lamports;
+            self.try_account_ref_mut()?.checked_sub_lamports(lamports)?;
             Ok(())
         } else {
             Err(InstructionError::InvalidAccountData)
@@ -1204,7 +1204,9 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
 
         // Drain the source stake account
         let lamports = source_account.lamports()?;
-        source_account.try_account_ref_mut()?.lamports -= lamports;
+        source_account
+            .try_account_ref_mut()?
+            .checked_sub_lamports(lamports)?;
         self.try_account_ref_mut()?.checked_add_lamports(lamports)?;
         Ok(())
     }
@@ -1285,7 +1287,7 @@ impl<'a> StakeAccount for KeyedAccount<'a> {
             self.set_state(&StakeState::Uninitialized)?;
         }
 
-        self.try_account_ref_mut()?.lamports -= lamports;
+        self.try_account_ref_mut()?.checked_sub_lamports(lamports)?;
         to.try_account_ref_mut()?.checked_add_lamports(lamports)?;
         Ok(())
     }

--- a/runtime/src/system_instruction_processor.rs
+++ b/runtime/src/system_instruction_processor.rs
@@ -189,7 +189,7 @@ fn transfer_verified(
         return Err(SystemError::ResultWithNegativeLamports.into());
     }
 
-    from.try_account_ref_mut()?.lamports -= lamports;
+    from.try_account_ref_mut()?.checked_sub_lamports(lamports)?;
     to.try_account_ref_mut()?.checked_add_lamports(lamports)?;
     Ok(())
 }


### PR DESCRIPTION
Problem
Working towards abstracting AccountSharedData to other implementations. Moving callers to use Readable/WritableAccount methods. We recently added checked_add_lamports and checked_sub_lamports to WritableAccount.

Summary of Changes
Modify code to return Results and use checked_sub_lamports.
Fixes #