### PR TITLE
Fixup rpc-endpoints

### DIFF
--- a/docs/src/cluster/rpc-endpoints.md
+++ b/docs/src/cluster/rpc-endpoints.md
@@ -1,6 +1,10 @@
-# Solana Cluster RPC Endpoints
+---
+title: Solana Cluster RPC Endpoints
+---
 
-Solana maintains dedicated api nodes to fulfill [JSON-RPC](https://docs.solana.com/developing/clients/jsonrpc-api) requests for each public cluster, and third parties may as well. Here are the public RPC endpoints currently available and recommended for each public cluster with their specific rate limits:
+Solana maintains dedicated api nodes to fulfill [JSON-RPC](developing/clients/jsonrpc-api.md)
+requests for each public cluster, and third parties may as well. Here are the
+public RPC endpoints currently available and recommended for each public cluster:
 
 ## Devnet
 
@@ -37,7 +41,7 @@ Solana maintains dedicated api nodes to fulfill [JSON-RPC](https://docs.solana.c
 - `https://api.mainnet-beta.solana.com` - Solana-hosted api node cluster, backed by a load balancer; rate-limited
 - `https://solana-api.projectserum.com` - Project Serum-hosted api node
 
-Rate Limits 
+#### Rate Limits
 
 - Maximum number of requests per 10 seconds per IP: 100
 - Maximum number of requests per 10 seconds per IP for a single RPC: 40


### PR DESCRIPTION
#### Problem
Line-wrapping and dynamic linking lost on rpc-endpoints page.

#### Summary of Changes
Fix it, and also add missing header markdown
